### PR TITLE
Use routines in pw_methods for some standard grid operations

### DIFF
--- a/src/ewald_methods_tb.F
+++ b/src/ewald_methods_tb.F
@@ -32,7 +32,10 @@ MODULE ewald_methods_tb
    USE pw_methods,                      ONLY: pw_copy,&
                                               pw_derive,&
                                               pw_integral_a2b,&
-                                              pw_transfer
+                                              pw_multiply,&
+                                              pw_multiply_with,&
+                                              pw_transfer,&
+                                              pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_rebuild,&
                                               pw_poisson_solve
    USE pw_poisson_types,                ONLY: greens_fn_type,&
@@ -178,7 +181,7 @@ CONTAINS
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
       ! update charge function
-      rhob_g%cc = rhob_g%cc*green%p3m_charge%cr
+      CALL pw_multiply_with(rhob_g, green%p3m_charge)
 
       !-------------- ELECTROSTATIC CALCULATION -----------
 
@@ -206,7 +209,8 @@ CONTAINS
             IF (atprop%stress .AND. use_virial) THEN
 
                CALL rs_grid_zero(rpot)
-               rhob_g%cc = phi_g%cc*green%p3m_charge%cr
+               CALL pw_zero(rhob_g)
+               CALL pw_multiply(rhob_g, phi_g, green%p3m_charge)
                CALL pw_transfer(rhob_g, rhob_r)
                CALL transfer_pw2rs(rpot, rhob_r)
                ipart = 0
@@ -239,7 +243,7 @@ CONTAINS
                      nd(j) = 1
                      CALL pw_copy(phib_g, rhob_g)
                      CALL pw_derive(rhob_g, nd)
-                     rhob_g%cc = rhob_g%cc*green%p3m_charge%cr
+                     CALL pw_multiply_with(rhob_g, green%p3m_charge)
                      CALL pw_transfer(rhob_g, rhob_r)
                      CALL transfer_pw2rs(rpot, rhob_r)
 
@@ -269,7 +273,7 @@ CONTAINS
       DEALLOCATE (rhob_g)
 
       CALL rs_grid_zero(rpot)
-      phi_g%cc = phi_g%cc*green%p3m_charge%cr
+      CALL pw_multiply_with(phi_g, green%p3m_charge)
       CALL pw_transfer(phi_g, rhob_r)
       CALL pw_pool_give_back_pw(pw_pool, phi_g)
       DEALLOCATE (phi_g)
@@ -299,7 +303,7 @@ CONTAINS
          DO i = 1, 3
             CALL rs_grid_create(drpot(i), rs_desc)
             CALL rs_grid_set_box(grid_spme, rs=drpot(i))
-            dphi_g(i)%cc = dphi_g(i)%cc*green%p3m_charge%cr
+            CALL pw_multiply_with(dphi_g(i), green%p3m_charge)
             CALL pw_transfer(dphi_g(i), rhob_r)
             CALL pw_pool_give_back_pw(pw_pool, dphi_g(i))
             CALL transfer_pw2rs(drpot(i), rhob_r)
@@ -521,7 +525,7 @@ CONTAINS
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
       ! update charge function
-      rhob_g%cc = rhob_g%cc*green%p3m_charge%cr
+      CALL pw_multiply_with(rhob_g, green%p3m_charge)
 
       !-------------- ELECTROSTATIC CALCULATION -----------
 
@@ -543,7 +547,7 @@ CONTAINS
       DEALLOCATE (rhob_g)
 
       CALL rs_grid_zero(rpot)
-      phi_g%cc = phi_g%cc*green%p3m_charge%cr
+      CALL pw_multiply_with(phi_g, green%p3m_charge)
       CALL pw_transfer(phi_g, rhob_r)
       CALL pw_pool_give_back_pw(pw_pool, phi_g)
       DEALLOCATE (phi_g)
@@ -556,7 +560,7 @@ CONTAINS
       DO i = 1, 3
          CALL rs_grid_create(drpot(i), rs_desc)
          CALL rs_grid_set_box(grid_spme, rs=drpot(i))
-         dphi_g(i)%cc = dphi_g(i)%cc*green%p3m_charge%cr
+         CALL pw_multiply_with(dphi_g(i), green%p3m_charge)
          CALL pw_transfer(dphi_g(i), rhob_r)
          CALL pw_pool_give_back_pw(pw_pool, dphi_g(i))
          CALL transfer_pw2rs(drpot(i), rhob_r)

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -127,7 +127,8 @@ MODULE force_env_methods
    USE physcon,                         ONLY: debye
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_methods,                      ONLY: pw_copy,&
+   USE pw_methods,                      ONLY: pw_axpy,&
+                                              pw_copy,&
                                               pw_integral_ab,&
                                               pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
@@ -1677,12 +1678,12 @@ CONTAINS
 
       ! Check the preliminary density differences
       DO i_spin = 1, nspins
-         diff_rho_r%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :) - rho_r_ref(i_spin)%cr3d(:, :, :)
+         CALL pw_axpy(rho_r_ref(i_spin), diff_rho_r, -1.0_dp)
       END DO
       IF (opt_embed%open_shell_embed) THEN ! Spin part
          IF (nspins .EQ. 2) THEN ! Reference systems has an open shell, else the reference diff_rho_spin is zero
-            diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) - rho_r_ref(1)%cr3d(:, :, :) &
-                                          + rho_r_ref(2)%cr3d(:, :, :)
+            CALL pw_axpy(rho_r_ref(1), diff_rho_spin, -1.0_dp)
+            CALL pw_axpy(rho_r_ref(2), diff_rho_spin, 1.0_dp)
          END IF
       END IF
 
@@ -1694,18 +1695,18 @@ CONTAINS
          ! Add subsystem densities
          CALL qs_rho_get(rho_struct=subsys_rho, rho_r=rho_r_subsys)
          DO i_spin = 1, nspins_subsys
-            diff_rho_r%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :) + rho_r_subsys(i_spin)%cr3d(:, :, :)
+            CALL pw_axpy(rho_r_subsys(i_spin), diff_rho_r, allow_noncompatible_grids=.TRUE.)
          END DO
          IF (opt_embed%open_shell_embed) THEN ! Spin part
             IF (nspins_subsys .EQ. 2) THEN ! The subsystem makes contribution if it is spin-polarized
                ! We may need to change spin ONLY FOR THE SECOND SUBSYSTEM: that's the internal convention
                IF ((i_force_eval .EQ. 2) .AND. (opt_embed%change_spin)) THEN
-                  diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) - &
-                                                rho_r_subsys(1)%cr3d(:, :, :) + rho_r_subsys(2)%cr3d(:, :, :)
+                  CALL pw_axpy(rho_r_subsys(1), diff_rho_spin, -1.0_dp, allow_noncompatible_grids=.TRUE.)
+                  CALL pw_axpy(rho_r_subsys(2), diff_rho_spin, 1.0_dp, allow_noncompatible_grids=.TRUE.)
                ELSE
                   ! First subsystem (always) and second subsystem (without spin change)
-                  diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) + &
-                                                rho_r_subsys(1)%cr3d(:, :, :) - rho_r_subsys(2)%cr3d(:, :, :)
+                  CALL pw_axpy(rho_r_subsys(1), diff_rho_spin, 1.0_dp, allow_noncompatible_grids=.TRUE.)
+                  CALL pw_axpy(rho_r_subsys(2), diff_rho_spin, -1.0_dp, allow_noncompatible_grids=.TRUE.)
                END IF
             END IF
          END IF
@@ -1738,17 +1739,17 @@ CONTAINS
                                   force_env%sub_force_env(i_force_eval)%force_env%qs_env, nforce_eval, i_force_eval, opt_embed%eta)
             END IF
          END DO
-         embed_pot%cr3d(:, :, :) = embed_pot%cr3d(:, :, :) + opt_embed%pot_diff%cr3d(:, :, :)
+         CALL pw_axpy(opt_embed%pot_diff, embed_pot)
          IF (.NOT. opt_embed%grid_opt) CALL pw_copy(embed_pot, opt_embed%const_pot)
 
       END IF
 
       ! Difference guess
       IF (opt_embed%diff_guess) THEN
-         embed_pot%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :)
+         CALL pw_copy(diff_rho_r, embed_pot)
          IF (.NOT. opt_embed%grid_opt) CALL pw_copy(embed_pot, opt_embed%const_pot)
          ! Open shell
-         IF (opt_embed%open_shell_embed) spin_embed_pot%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :)
+         IF (opt_embed%open_shell_embed) CALL pw_copy(diff_rho_spin, spin_embed_pot)
       END IF
 
       ! Calculate subsystems with trial embedding potential
@@ -1760,13 +1761,13 @@ CONTAINS
          CALL get_qs_env(force_env%sub_force_env(ref_subsys_number)%force_env%qs_env, dft_control=dft_control)
          nspins = dft_control%nspins
          DO i_spin = 1, nspins
-            diff_rho_r%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :) - rho_r_ref(i_spin)%cr3d(:, :, :)
+            CALL pw_axpy(rho_r_ref(i_spin), diff_rho_r, -1.0_dp)
          END DO
          IF (opt_embed%open_shell_embed) THEN ! Spin part
             CALL pw_zero(diff_rho_spin)
             IF (nspins .EQ. 2) THEN ! Reference systems has an open shell, else the reference diff_rho_spin is zero
-               diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) - rho_r_ref(1)%cr3d(:, :, :) &
-                                             + rho_r_ref(2)%cr3d(:, :, :)
+               CALL pw_axpy(rho_r_ref(1), diff_rho_spin, -1.0_dp)
+               CALL pw_axpy(rho_r_ref(2), diff_rho_spin, 1.0_dp)
             END IF
          END IF
 
@@ -1786,11 +1787,6 @@ CONTAINS
                                           embed_pot, embed_pot_subsys, spin_embed_pot, spin_embed_pot_subsys, &
                                           opt_embed%open_shell_embed, .FALSE.)
             END IF
-
-            ! Subtract Coulomb potential difference if needed
-            !  IF ((i_force_eval .EQ. 2) .AND. (opt_embed%Coulomb_guess)) THEN
-            !     embed_pot_subsys%cr3d(:, :, :) = embed_pot_subsys%cr3d(:, :, :)-opt_embed%pot_diff%cr3d(:, :, :)
-            !  ENDIF
 
             ! Switch on external potential in the subsystems
             dft_control%apply_embed_pot = .TRUE.
@@ -1828,18 +1824,18 @@ CONTAINS
             ! Add subsystem densities
             CALL qs_rho_get(rho_struct=subsys_rho, rho_r=rho_r_subsys)
             DO i_spin = 1, nspins_subsys
-               diff_rho_r%cr3d(:, :, :) = diff_rho_r%cr3d(:, :, :) + rho_r_subsys(i_spin)%cr3d(:, :, :)
+               CALL pw_axpy(rho_r_subsys(i_spin), diff_rho_r, allow_noncompatible_grids=.TRUE.)
             END DO
             IF (opt_embed%open_shell_embed) THEN ! Spin part
                IF (nspins_subsys .EQ. 2) THEN ! The subsystem makes contribution if it is spin-polarized
                   ! We may need to change spin ONLY FOR THE SECOND SUBSYSTEM: that's the internal convention
                   IF ((i_force_eval .EQ. 2) .AND. (opt_embed%change_spin)) THEN
-                     diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) - &
-                                                   rho_r_subsys(1)%cr3d(:, :, :) + rho_r_subsys(2)%cr3d(:, :, :)
+                     CALL pw_axpy(rho_r_subsys(1), diff_rho_spin, -1.0_dp, allow_noncompatible_grids=.TRUE.)
+                     CALL pw_axpy(rho_r_subsys(2), diff_rho_spin, 1.0_dp, allow_noncompatible_grids=.TRUE.)
                   ELSE
                      ! First subsystem (always) and second subsystem (without spin change)
-                     diff_rho_spin%cr3d(:, :, :) = diff_rho_spin%cr3d(:, :, :) + &
-                                                   rho_r_subsys(1)%cr3d(:, :, :) - rho_r_subsys(2)%cr3d(:, :, :)
+                     CALL pw_axpy(rho_r_subsys(1), diff_rho_spin, 1.0_dp, allow_noncompatible_grids=.TRUE.)
+                     CALL pw_axpy(rho_r_subsys(2), diff_rho_spin, -1.0_dp, allow_noncompatible_grids=.TRUE.)
                   END IF
                END IF
             END IF
@@ -1938,7 +1934,7 @@ CONTAINS
                                     opt_embed%open_shell_embed, opt_embed%change_spin)
 
          IF (opt_embed%Coulomb_guess) THEN
-            embed_pot_subsys%cr3d(:, :, :) = embed_pot_subsys%cr3d(:, :, :) - opt_embed%pot_diff%cr3d(:, :, :)
+            CALL pw_axpy(opt_embed%pot_diff, embed_pot_subsys, -1.0_dp, allow_noncompatible_grids=.TRUE.)
          END IF
 
          CALL set_qs_env(force_env%sub_force_env(ref_subsys_number + 1)%force_env%qs_env, embed_pot=embed_pot_subsys)

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -40,7 +40,9 @@ MODULE hfx_pw_methods
    USE pw_env_types,                    ONLY: pw_env_type
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_methods,                      ONLY: pw_copy,&
-                                              pw_transfer
+                                              pw_multiply,&
+                                              pw_transfer,&
+                                              pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
@@ -233,7 +235,8 @@ CONTAINS
                         IF (jorb < iorb) CYCLE
 
                         ! compute the pair density
-                        rho_r%cr3d = rho_i(iloc)%cr3d*rho_j(jloc)%cr3d
+                        CALL pw_zero(rho_r)
+                        CALL pw_multiply(rho_r, rho_i(iloc), rho_j(jloc))
 
                         ! go the g-space and compute hartree energy
                         CALL pw_transfer(rho_r, rho_g)

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -295,7 +295,7 @@ CONTAINS
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r, rho_r_valid=rho_r_valid)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm, use_data=REALDATA3D)
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm, use_data=REALDATA3D, in_space=REALSPACE)
       ! loop over spins
       DO is = 1, SIZE(rho_r)
          IF (rho_r_valid) THEN
@@ -383,7 +383,7 @@ CONTAINS
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r, rho_r_valid=rho_r_valid)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm, use_data=REALDATA3D)
+      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm, use_data=REALDATA3D, in_space=REALSPACE)
       !
       DO iloop = 1, maxloop
 
@@ -524,8 +524,7 @@ CONTAINS
          DEALLOCATE (fnorm)
       END IF
       ALLOCATE (fnorm)
-      CALL pw_pool_create_pw(auxbas_pw_pool, fnorm, use_data=REALDATA3D)
-      fnorm%in_space = REALSPACE
+      CALL pw_pool_create_pw(auxbas_pw_pool, fnorm, use_data=REALDATA3D, in_space=REALSPACE)
       CALL set_hirshfeld_info(hirshfeld_env, fnorm=fnorm)
 
       CALL transfer_rs2pw(rs_rho, fnorm)

--- a/src/kg_correction.F
+++ b/src/kg_correction.F
@@ -474,7 +474,7 @@ CONTAINS
          CPABORT(" KG with meta-kinetic energy functionals not implemented")
       END IF
       DO ispin = 1, nspins
-         vxc_rho(ispin)%cr3d = vxc_rho(ispin)%cr3d*vxc_rho(ispin)%pw_grid%dvol
+         CALL pw_scale(vxc_rho(ispin), vxc_rho(ispin)%pw_grid%dvol)
          lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
          CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, lri_v_int, calc_force, "LRI_AUX")
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin))
@@ -501,7 +501,7 @@ CONTAINS
          ekin_mol = ekin_mol + ekin_imol
 
          DO ispin = 1, nspins
-            vxc_rho(ispin)%cr3d = -vxc_rho(ispin)%cr3d*vxc_rho(ispin)%pw_grid%dvol
+            CALL pw_scale(vxc_rho(ispin), -vxc_rho(ispin)%pw_grid%dvol)
             lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
             CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, &
                                                lri_v_int, calc_force, &

--- a/src/library_tests.F
+++ b/src/library_tests.F
@@ -744,8 +744,7 @@ CONTAINS
       CALL pw_grid_setup(box%hmat, grid, grid_span=FULLSPACE, npts=np, fft_usage=.TRUE., iounit=iw)
       no = grid%npts
 
-      CALL pw_create(ca, grid, REALDATA3D)
-      ca%in_space = REALSPACE
+      CALL pw_create(ca, grid, REALDATA3D, REALSPACE)
       CALL pw_zero(ca)
 
       ! .. rs input setting type
@@ -941,15 +940,14 @@ CONTAINS
             ! note that the number of grid points might be different from what the user requested (fft-able needed)
             no = grid%npts
 
-            CALL pw_create(ca, grid, COMPLEXDATA1D)
-            CALL pw_create(cb, grid, COMPLEXDATA3D)
-            CALL pw_create(cc, grid, COMPLEXDATA1D)
+            CALL pw_create(ca, grid, COMPLEXDATA1D, RECIPROCALSPACE)
+            CALL pw_create(cb, grid, COMPLEXDATA3D, REALSPACE)
+            CALL pw_create(cc, grid, COMPLEXDATA1D, RECIPROCALSPACE)
 
             ! initialize data
             CALL pw_zero(ca)
             CALL pw_zero(cb)
             CALL pw_zero(cc)
-            ca%in_space = RECIPROCALSPACE
             nn = SIZE(ca%cc)
             DO ig = 1, nn
                gsq = grid%gsq(ig)

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -92,7 +92,9 @@ MODULE mixed_cdft_methods
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_methods,                      ONLY: pw_scale
+   USE pw_methods,                      ONLY: pw_copy,&
+                                              pw_scale,&
+                                              pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_give_back_pw,&
                                               pw_pool_type
@@ -653,7 +655,7 @@ CONTAINS
       ALLOCATE (cdft_control_target%group(1)%weight)
       CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control_target%group(1)%weight, &
                              use_data=REALDATA3D, in_space=REALSPACE)
-      cdft_control_target%group(1)%weight%cr3d = 0.0_dp
+      CALL pw_zero(cdft_control_target%group(1)%weight)
       ! Assemble the recved slices
       DO j = 1, SIZE(mixed_cdft%source_list)
          cdft_control_target%group(1)%weight%cr3d(recvbuffer(j)%imap(1):recvbuffer(j)%imap(2), &
@@ -949,7 +951,7 @@ CONTAINS
                                       cdft_control_target%group(igroup)%weight, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                ! We have ensured that the grids are consistent => no danger in using explicit copy
-               cdft_control_target%group(igroup)%weight%cr3d = cdft_control_source%group(igroup)%weight%cr3d
+               CALL pw_copy(cdft_control_source%group(igroup)%weight, cdft_control_target%group(igroup)%weight)
                CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%group(igroup)%weight)
                DEALLOCATE (cdft_control_source%group(igroup)%weight)
             END DO
@@ -958,8 +960,7 @@ CONTAINS
                IF (cdft_control_source%becke_control%cavity_confine) THEN
                   CALL pw_pool_create_pw(auxbas_pw_pool_target, cdft_control_target%becke_control%cavity, &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  cdft_control_target%becke_control%cavity%cr3d(:, :, :) = &
-                     cdft_control_source%becke_control%cavity%cr3d
+                  CALL pw_copy(cdft_control_source%becke_control%cavity, cdft_control_target%becke_control%cavity)
                   CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%becke_control%cavity)
                END IF
             END IF
@@ -989,7 +990,7 @@ CONTAINS
                   CALL pw_pool_create_pw(auxbas_pw_pool_target, &
                                          cdft_control_target%charge(iatom), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  cdft_control_target%charge(iatom)%cr3d = cdft_control_source%charge(iatom)%cr3d
+                  CALL pw_copy(cdft_control_source%charge(iatom), cdft_control_target%charge(iatom))
                   CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%charge(iatom))
                END DO
             END IF

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -40,6 +40,7 @@ MODULE mp2_eri_gpw
                                               pw_env_type
    USE pw_methods,                      ONLY: &
         pw_compl_gauss_damp, pw_copy, pw_derive, pw_gauss_damp, pw_gauss_damp_mix, pw_integral_ab, &
+        pw_log_deriv_compl_gauss, pw_log_deriv_gauss, pw_log_deriv_mix_cl, pw_log_deriv_trunc, &
         pw_scale, pw_transfer, pw_truncated, pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
@@ -761,12 +762,8 @@ CONTAINS
 !> \param potential_parameter parameters of potential V(g)
 ! **************************************************************************************************
    SUBROUTINE factor_virial_gpw(pw, potential_parameter)
-      TYPE(pw_type), INTENT(IN)                          :: pw
+      TYPE(pw_type), INTENT(INOUT)                       :: pw
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
-
-      INTEGER                                            :: i
-      REAL(KIND=dp)                                      :: omega_2, rchalf, scale_coul, scale_long, &
-                                                            tmp
 
       IF (.NOT. (pw%in_space == RECIPROCALSPACE .AND. pw%in_use == COMPLEXDATA1D)) &
          CPABORT("pw in wrong space or wrong data type")
@@ -774,51 +771,16 @@ CONTAINS
       CASE (do_potential_coulomb)
          RETURN
       CASE (do_potential_long)
-         omega_2 = 1.0_dp/(2.0_dp*potential_parameter%omega)**2
-!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw,potential_parameter,omega_2)
-         pw%cc(:) = pw%cc(:)*(1.0_dp + omega_2*pw%pw_grid%gsq(:))
-!$OMP END PARALLEL WORKSHARE
+         CALL pw_log_deriv_gauss(pw, potential_parameter%omega)
       CASE (do_potential_short)
-         omega_2 = 1.0_dp/(2.0_dp*potential_parameter%omega)**2
-!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i,tmp) &
-!$OMP             SHARED(pw,omega_2)
-         DO i = 1, SIZE(pw%cc)
-            tmp = omega_2*pw%pw_grid%gsq(i)
-            ! For too small arguments, use the Taylor polynomial to prevent division by zero
-            IF (ABS(tmp) >= 0.003_dp) THEN
-               pw%cc(i) = pw%cc(i)*(1.0_dp - tmp*EXP(-tmp)/(1.0_dp - EXP(-tmp)))
-            ELSE
-               pw%cc(i) = pw%cc(i)*(0.5_dp*tmp - tmp**2/12.0_dp)
-            END IF
-         END DO
-!$OMP END PARALLEL DO
+         CALL pw_log_deriv_compl_gauss(pw, potential_parameter%omega)
       CASE (do_potential_mix_cl)
-         omega_2 = 1.0_dp/(2.0_dp*potential_parameter%omega)**2
-         scale_coul = potential_parameter%scale_coulomb
-         scale_long = potential_parameter%scale_longrange
-!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i,tmp) &
-!$OMP             SHARED(pw,omega_2,scale_long,scale_coul)
-         DO i = 1, SIZE(pw%cc)
-            tmp = omega_2*pw%pw_grid%gsq(i)
-            pw%cc(i) = pw%cc(i)*(1.0_dp + scale_long*tmp*EXP(-tmp)/(scale_coul + scale_long*EXP(-tmp)))
-         END DO
-!$OMP END PARALLEL DO
+         CALL pw_log_deriv_mix_cl(pw, potential_parameter%omega, &
+                                  potential_parameter%scale_coulomb, potential_parameter%scale_longrange)
       CASE (do_potential_truncated)
-         rchalf = 0.5_dp*potential_parameter%cutoff_radius
-!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i,tmp) &
-!$OMP             SHARED(pw,rchalf)
-         DO i = 1, SIZE(pw%cc)
-            tmp = rchalf*SQRT(pw%pw_grid%gsq(i))
-            ! For too small arguments, use the Taylor polynomial to prevent division by zero
-            IF (ABS(tmp) >= 0.0001_dp) THEN
-               pw%cc(i) = pw%cc(i)*(1.0_dp - tmp/TAN(tmp))
-            ELSE
-               pw%cc(i) = pw%cc(i)*tmp**2*(1.0_dp + tmp**2/15.0_dp)/3.0_dp
-            END IF
-         END DO
-!$OMP END PARALLEL DO
+         CALL pw_log_deriv_trunc(pw, potential_parameter%cutoff_radius)
       CASE (do_potential_id)
-         pw%cc = 0.0_dp
+         CALL pw_zero(pw)
       CASE DEFAULT
          CPABORT("Unknown potential type")
       END SELECT

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -1042,7 +1042,7 @@ CONTAINS
                              in_space=REALSPACE)
 
       ! run the FFT once, to set up buffers and to take into account the memory
-      rho_r%cr3d = 0.0D0
+      CALL pw_zero(rho_r)
       CALL pw_transfer(rho_r, rho_g)
 
       CALL timestop(handle)

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -42,7 +42,9 @@ MODULE mp2_gpw_method
                                               prepare_gpw
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_type
-   USE pw_methods,                      ONLY: pw_transfer
+   USE pw_methods,                      ONLY: pw_multiply,&
+                                              pw_transfer,&
+                                              pw_zero
    USE pw_poisson_types,                ONLY: pw_poisson_type
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_type
@@ -412,7 +414,8 @@ CONTAINS
             i_counter = i_counter + 1
 
             ! potential
-            rho_r%cr3d = psi_i(i)%cr3d*psi_a%cr3d
+            CALL pw_zero(rho_r)
+            CALL pw_multiply(rho_r, psi_i(i), psi_a)
             CALL pw_transfer(rho_r, rho_g)
             CALL calc_potential_gpw(rho_r, rho_g, poisson_env, pot_g, qs_env%mp2_env%potential_parameter)
 

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -1027,7 +1027,7 @@ CONTAINS
       CALL pw_scale(v_resp_rspace, normalize_factor)
 
       ! Hard copy potential
-      v_rspace%cr3d(:, :, :) = v_resp_rspace%cr3d(:, :, :)
+      CALL pw_copy(v_resp_rspace, v_rspace)
 
       ! Release plane waves
       CALL pw_release(v_resp_gspace)
@@ -1079,7 +1079,7 @@ CONTAINS
                              in_space=REALSPACE)
 
       ! Hard copy the grid
-      embed_pot_subsys%cr3d(:, :, :) = embed_pot%cr3d(:, :, :)
+      CALL pw_copy(embed_pot, embed_pot_subsys)
 
       IF (open_shell_embed) THEN
          NULLIFY (spin_embed_pot_subsys)
@@ -1089,9 +1089,9 @@ CONTAINS
                                 in_space=REALSPACE)
          ! Hard copy the grid
          IF (change_spin_sign) THEN
-            spin_embed_pot_subsys%cr3d(:, :, :) = -spin_embed_pot%cr3d(:, :, :)
+            CALL pw_axpy(spin_embed_pot, spin_embed_pot_subsys, -1.0_dp, 0.0_dp, allow_noncompatible_grids=.TRUE.)
          ELSE
-            spin_embed_pot_subsys%cr3d(:, :, :) = spin_embed_pot%cr3d(:, :, :)
+            CALL pw_copy(spin_embed_pot, spin_embed_pot_subsys)
          END IF
       END IF
 
@@ -3535,8 +3535,8 @@ CONTAINS
       i_dens_start = SUM(opt_embed%all_nspins(1:subsys_num)) - nspins + 1
 
       DO i_spin = 1, nspins
-         opt_embed%prev_subsys_dens(i_dens_start + i_spin - 1)%cr3d(:, :, :) = &
-            rho_r(i_spin)%cr3d(:, :, :) - opt_embed%prev_subsys_dens(i_dens_start + i_spin - 1)%cr3d(:, :, :)
+         CALL pw_axpy(rho_r(i_spin), opt_embed%prev_subsys_dens(i_dens_start + i_spin - 1), 1.0_dp, -1.0_dp, &
+                      allow_noncompatible_grids=.TRUE.)
          opt_embed%max_subsys_dens_diff(i_dens_start + i_spin - 1) = &
             max_dens_diff(opt_embed%prev_subsys_dens(i_dens_start + i_spin - 1))
       END DO

--- a/src/pme.F
+++ b/src/pme.F
@@ -168,9 +168,9 @@ CONTAINS
       END IF
 
       CALL pw_pool_create_pw(pw_small_pool, rhos1, &
-                             use_data=REALDATA3D)
+                             use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_pool_create_pw(pw_small_pool, rhos2, &
-                             use_data=REALDATA3D)
+                             use_data=REALDATA3D, in_space=REALSPACE)
 
       ALLOCATE (rden)
       CALL rs_grid_create(rden, rs_desc)

--- a/src/pw/dg_rho0_types.F
+++ b/src/pw/dg_rho0_types.F
@@ -19,6 +19,7 @@ MODULE dg_rho0_types
                                               do_ewald_pme,&
                                               do_ewald_spme
    USE pw_types,                        ONLY: REALDATA3D,&
+                                              REALSPACE,&
                                               pw_create,&
                                               pw_release,&
                                               pw_type
@@ -170,10 +171,10 @@ CONTAINS
       END IF
       SELECT CASE (dg_rho0%type)
       CASE (do_ewald_ewald)
-         CALL pw_create(dg_rho0%density, pw_grid, REALDATA3D)
+         CALL pw_create(dg_rho0%density, pw_grid, REALDATA3D, REALSPACE)
          CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
       CASE (do_ewald_pme)
-         CALL pw_create(dg_rho0%density, pw_grid, REALDATA3D)
+         CALL pw_create(dg_rho0%density, pw_grid, REALDATA3D, REALSPACE)
          CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
       CASE (do_ewald_spme)
          CPABORT('SPME type not implemented')

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -2039,15 +2039,17 @@ CONTAINS
 !>      JGH (14-Mar-2001) : Parallel sum and some tests, HALFSPACE case
 !> \author apsi
 ! **************************************************************************************************
-   FUNCTION pw_integral_ab(pw1, pw2, sumtype) RESULT(integral_value)
+   FUNCTION pw_integral_ab(pw1, pw2, sumtype, just_sum) RESULT(integral_value)
 
       TYPE(pw_type), INTENT(IN)                          :: pw1, pw2
       INTEGER, INTENT(IN), OPTIONAL                      :: sumtype
       REAL(KIND=dp)                                      :: integral_value
+      LOGICAL, OPTIONAL, INTENT(IN)                      :: just_sum
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_integral_ab'
 
       INTEGER                                            :: handle, loc_sumtype
+      LOGICAL                                            :: my_just_sum
 
       CALL timeset(routineN, handle)
 
@@ -2058,6 +2060,10 @@ CONTAINS
          CPABORT("Grids incompatible")
       END IF
 
+      my_just_sum = .FALSE.
+      IF (PRESENT(just_sum)) my_just_sum = just_sum
+
+      ! do standard sum
       IF (loc_sumtype == do_standard_sum) THEN
 
          ! Do standard sum
@@ -2149,10 +2155,12 @@ CONTAINS
 
       END IF
 
-      IF (pw1%in_use == REALDATA3D .OR. pw1%in_use == COMPLEXDATA3D) THEN
-         integral_value = integral_value*pw1%pw_grid%dvol
-      ELSE
-         integral_value = integral_value*pw1%pw_grid%vol
+      IF (.NOT. my_just_sum) THEN
+         IF (pw1%in_use == REALDATA3D .OR. pw1%in_use == COMPLEXDATA3D) THEN
+            integral_value = integral_value*pw1%pw_grid%dvol
+         ELSE
+            integral_value = integral_value*pw1%pw_grid%vol
+         END IF
       END IF
 
       IF (pw1%in_use == COMPLEXDATA1D) THEN

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -257,7 +257,7 @@ CONTAINS
 
                pw2%in_space = RECIPROCALSPACE
 
-            ELSE IF (pw1%in_use == REALDATA3D .AND. pw1%in_use==pw2%in_use .AND. &
+            ELSE IF (pw1%in_use == REALDATA3D .AND. pw1%in_use == pw2%in_use .AND. &
                      pw1%in_space == REALSPACE) THEN
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2)
                pw2%cr3d(:, :, :) = pw1%cr3d(:, :, :)
@@ -917,6 +917,7 @@ CONTAINS
 !> \param pw2 ...
 !> \param alpha ...
 !> \param beta ...
+!> \param allow_noncompatible_grids ...
 !> \par History
 !>      JGH (21-Feb-2003) : added reference grid functionality
 !>      JGH (01-Dec-2007) : rename and remove complex alpha
@@ -925,15 +926,17 @@ CONTAINS
 !>      Currently only summing up of respective types allowed,
 !>      in order to avoid errors
 ! **************************************************************************************************
-   SUBROUTINE pw_axpy(pw1, pw2, alpha, beta)
+   SUBROUTINE pw_axpy(pw1, pw2, alpha, beta, allow_noncompatible_grids)
 
       TYPE(pw_type), INTENT(IN)                          :: pw1
       TYPE(pw_type), INTENT(INOUT)                       :: pw2
       REAL(KIND=dp), INTENT(in), OPTIONAL                :: alpha, beta
+      LOGICAL, INTENT(IN), OPTIONAL                      :: allow_noncompatible_grids
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_axpy'
 
       INTEGER                                            :: handle, i, j, ng, ng1, ng2, out_unit
+      LOGICAL                                            :: my_allow_noncompatible_grids
       REAL(KIND=dp)                                      :: my_alpha, my_beta
 
       CALL timeset(routineN, handle)
@@ -945,6 +948,9 @@ CONTAINS
 
       my_beta = 1.0_dp
       IF (PRESENT(beta)) my_beta = beta
+
+      my_allow_noncompatible_grids = .FALSE.
+      IF (PRESENT(allow_noncompatible_grids)) my_allow_noncompatible_grids = allow_noncompatible_grids
 
       IF (my_beta /= 1.0_dp) THEN
          IF (my_beta == 0.0_dp) THEN
@@ -1028,7 +1034,7 @@ CONTAINS
             CPABORT("No suitable data field")
          END IF
 
-      ELSE IF (pw_compatible(pw1%pw_grid, pw2%pw_grid)) THEN
+      ELSE IF (pw_compatible(pw1%pw_grid, pw2%pw_grid) .OR. my_allow_noncompatible_grids) THEN
 
          IF (pw1%in_use == COMPLEXDATA1D .AND. &
              pw2%in_use == COMPLEXDATA1D .AND. &
@@ -1138,6 +1144,24 @@ CONTAINS
                END IF
                CPABORT("Grids not compatible")
 
+            END IF
+
+         ELSE IF (pw1%in_use == REALDATA3D .AND. &
+                  pw2%in_use == REALDATA3D .AND. &
+                  pw1%in_space == REALSPACE .AND. &
+                  pw2%in_space == REALSPACE) THEN
+
+            IF (ANY(SHAPE(pw1%cr3d) /= SHAPE(pw2%cr3d))) &
+               CPABORT("Noncommensurate grids not implemented for real-valued grids!")
+
+            IF (my_alpha == 1.0_dp) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2)
+               pw2%cr3d(:, :, :) = pw2%cr3d(:, :, :) + pw1%cr3d(:, :, :)
+!$OMP END PARALLEL WORKSHARE
+            ELSE
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2,my_alpha)
+               pw2%cr3d(:, :, :) = pw2%cr3d(:, :, :) + my_alpha*pw1%cr3d(:, :, :)
+!$OMP END PARALLEL WORKSHARE
             END IF
          ELSE
             CPABORT("No suitable data field")

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -67,7 +67,7 @@ MODULE pw_methods
    PUBLIC :: pw_copy, pw_axpy, pw_transfer, pw_scale
    PUBLIC :: pw_gauss_damp, pw_compl_gauss_damp, pw_derive, pw_laplace, pw_dr2, pw_write, pw_multiply
    PUBLIC :: pw_log_deriv_gauss, pw_log_deriv_compl_gauss, pw_log_deriv_mix_cl, pw_log_deriv_trunc
-   PUBLIC :: pw_gauss_damp_mix
+   PUBLIC :: pw_gauss_damp_mix, pw_multiply_with
    PUBLIC :: pw_integral_ab, pw_integral_a2b
    PUBLIC :: pw_dr2_gg, pw_integrate_function
    PUBLIC :: pw_set, pw_truncated
@@ -1427,6 +1427,18 @@ CONTAINS
                pw_out%cc = pw_out%cc + my_alpha*pw1%cc*pw2%cc
 !$OMP END PARALLEL WORKSHARE
             END IF
+         ELSE IF (pw1%in_use == COMPLEXDATA1D .AND. &
+                  pw2%in_use == REALDATA1D .AND. &
+                  pw_out%in_use == COMPLEXDATA1D) THEN
+            IF (my_alpha == 1.0_dp) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw_out, pw1, pw2)
+               pw_out%cc = pw_out%cc + pw1%cc*pw2%cr
+!$OMP END PARALLEL WORKSHARE
+            ELSE
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw_out, pw1, pw2, my_alpha)
+               pw_out%cc = pw_out%cc + my_alpha*pw1%cc*pw2%cr
+!$OMP END PARALLEL WORKSHARE
+            END IF
          ELSE IF (pw1%in_use == REALDATA3D .AND. pw2%in_use == REALDATA3D .AND. &
                   pw_out%in_use == REALDATA3D) THEN
             IF (my_alpha == 1.0_dp) THEN
@@ -1448,6 +1460,18 @@ CONTAINS
             ELSE
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(my_alpha, pw_out, pw1, pw2)
                pw_out%cc3d = pw_out%cc3d + my_alpha*pw1%cc3d*pw2%cc3d
+!$OMP END PARALLEL WORKSHARE
+            END IF
+         ELSE IF (pw1%in_use == COMPLEXDATA3D .AND. &
+                  pw2%in_use == REALDATA3D .AND. &
+                  pw_out%in_use == COMPLEXDATA3D) THEN
+            IF (my_alpha == 1.0_dp) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw_out, pw1, pw2)
+               pw_out%cc3d = pw_out%cc3d + pw1%cc3d*pw2%cr3d
+!$OMP END PARALLEL WORKSHARE
+            ELSE
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw_out, pw1, pw2, my_alpha)
+               pw_out%cc3d = pw_out%cc3d + my_alpha*pw1%cc3d*pw2%cr3d
 !$OMP END PARALLEL WORKSHARE
             END IF
          ELSE
@@ -2660,5 +2684,55 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE pw_set_value
+
+! **************************************************************************************************
+!> \brief ...
+!> \param pw1 ...
+!> \param pw2 ...
+! **************************************************************************************************
+   SUBROUTINE pw_multiply_with(pw1, pw2)
+      TYPE(pw_type), INTENT(IN)                          :: pw1, pw2
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'pw_multiply_with'
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      IF (pw1%in_space /= pw2%in_space .OR. pw1%in_space == NOSPACE) &
+         CPABORT("Invalid space combination!")
+      IF (.NOT. pw_compatible(pw1%pw_grid, pw2%pw_grid)) &
+         CPABORT("Incompatible grids!")
+
+      IF (pw1%in_use == REALDATA1D .AND. pw2%in_use == REALDATA1D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2)
+         pw1%cr = pw1%cr*pw2%cr
+!$OMP END PARALLEL WORKSHARE
+      ELSE IF (pw1%in_use == REALDATA3D .AND. pw2%in_use == REALDATA3D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2)
+         pw1%cr3d = pw1%cr3d*pw2%cr3d
+!$OMP END PARALLEL WORKSHARE
+      ELSE IF (pw1%in_use == COMPLEXDATA1D .AND. pw2%in_use == COMPLEXDATA1D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2)
+         pw1%cc = pw1%cc*pw2%cc
+!$OMP END PARALLEL WORKSHARE
+      ELSE IF (pw1%in_use == COMPLEXDATA1D .AND. pw2%in_use == REALDATA1D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2)
+         pw1%cc = pw1%cc*pw2%cr
+!$OMP END PARALLEL WORKSHARE
+      ELSE IF (pw1%in_use == COMPLEXDATA3D .AND. pw2%in_use == COMPLEXDATA3D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2)
+         pw1%cc3d = pw1%cc3d*pw2%cc3d
+!$OMP END PARALLEL WORKSHARE
+      ELSE IF (pw1%in_use == COMPLEXDATA3D .AND. pw2%in_use == REALDATA3D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2)
+         pw1%cc3d = pw1%cc3d*pw2%cr3d
+!$OMP END PARALLEL WORKSHARE
+      ELSE
+         CPABORT("Invalid combination of grids!")
+      END IF
+      CALL timestop(handle)
+
+   END SUBROUTINE pw_multiply_with
 
 END MODULE pw_methods

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -84,6 +84,10 @@ MODULE pw_methods
       MODULE PROCEDURE pw_scatter_s, pw_scatter_p
    END INTERFACE
 
+   INTERFACE pw_set
+      MODULE PROCEDURE pw_set_value, pw_set_array
+   END INTERFACE
+
 CONTAINS
 
 ! **************************************************************************************************
@@ -2094,27 +2098,31 @@ CONTAINS
 !> \param pw2 ...
 !> \param sumtype ...
 !> \param just_sum ...
+!> \param local_only ...
 !> \return ...
 !> \par History
 !>      JGH (14-Mar-2001) : Parallel sum and some tests, HALFSPACE case
 !> \author apsi
 ! **************************************************************************************************
-   FUNCTION pw_integral_ab(pw1, pw2, sumtype, just_sum) RESULT(integral_value)
+   FUNCTION pw_integral_ab(pw1, pw2, sumtype, just_sum, local_only) RESULT(integral_value)
 
       TYPE(pw_type), INTENT(IN)                          :: pw1, pw2
       INTEGER, INTENT(IN), OPTIONAL                      :: sumtype
-      LOGICAL, INTENT(IN), OPTIONAL                      :: just_sum
+      LOGICAL, INTENT(IN), OPTIONAL                      :: just_sum, local_only
       REAL(KIND=dp)                                      :: integral_value
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_integral_ab'
 
       INTEGER                                            :: handle, loc_sumtype
-      LOGICAL                                            :: my_just_sum
+      LOGICAL                                            :: my_just_sum, my_local_only
 
       CALL timeset(routineN, handle)
 
       loc_sumtype = do_accurate_sum
       IF (PRESENT(sumtype)) loc_sumtype = sumtype
+
+      my_local_only = .FALSE.
+      IF (PRESENT(local_only)) my_local_only = local_only
 
       IF (.NOT. ASSOCIATED(pw1%pw_grid, pw2%pw_grid)) THEN
          CPABORT("Grids incompatible")
@@ -2231,7 +2239,7 @@ CONTAINS
          END IF
       END IF
 
-      IF (pw1%pw_grid%para%mode == PW_MODE_DISTRIBUTED) &
+      IF (.NOT. my_local_only .AND. pw1%pw_grid%para%mode == PW_MODE_DISTRIBUTED) &
          CALL pw1%pw_grid%para%group%sum(integral_value)
       CALL timestop(handle)
 
@@ -2400,13 +2408,13 @@ CONTAINS
 !>      Created 12.2016
 !> \author Nico Holmberg
 ! **************************************************************************************************
-   SUBROUTINE pw_set(pw, values)
+   SUBROUTINE pw_set_array(pw, values)
 
       TYPE(pw_type), INTENT(INOUT)                       :: pw
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN), &
          POINTER                                         :: values
 
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_set'
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_set_array'
 
       INTEGER                                            :: handle, i, j, k
       LOGICAL                                            :: is_match
@@ -2441,6 +2449,32 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE pw_set
+   END SUBROUTINE pw_set_array
+
+! **************************************************************************************************
+!> \brief ...
+!> \param pw ...
+!> \param value ...
+! **************************************************************************************************
+   SUBROUTINE pw_set_value(pw, value)
+      TYPE(pw_type), INTENT(IN)                          :: pw
+      REAL(KIND=dp), INTENT(IN)                          :: value
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_set_value'
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      IF (pw%in_use == REALDATA3D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw,value)
+         pw%cr3d = value
+!$OMP END PARALLEL WORKSHARE
+      ELSE
+         CPABORT("Illegal pw type, should be REALDATA3D.")
+      END IF
+      CALL timestop(handle)
+
+   END SUBROUTINE pw_set_value
 
 END MODULE pw_methods

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -906,11 +906,12 @@ CONTAINS
    END SUBROUTINE pw_transfer
 
 ! **************************************************************************************************
-!> \brief pw2 = alpha*pw1 + pw2
-!>      alpha defaults to 1
+!> \brief pw2 = alpha*pw1 + beta*pw2
+!>      alpha defaults to 1, beta defaults to 1
 !> \param pw1 ...
 !> \param pw2 ...
 !> \param alpha ...
+!> \param beta ...
 !> \par History
 !>      JGH (21-Feb-2003) : added reference grid functionality
 !>      JGH (01-Dec-2007) : rename and remove complex alpha
@@ -919,16 +920,16 @@ CONTAINS
 !>      Currently only summing up of respective types allowed,
 !>      in order to avoid errors
 ! **************************************************************************************************
-   SUBROUTINE pw_axpy(pw1, pw2, alpha)
+   SUBROUTINE pw_axpy(pw1, pw2, alpha, beta)
 
       TYPE(pw_type), INTENT(IN)                          :: pw1
       TYPE(pw_type), INTENT(INOUT)                       :: pw2
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: alpha
+      REAL(KIND=dp), INTENT(in), OPTIONAL                :: alpha, beta
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_axpy'
 
       INTEGER                                            :: handle, i, j, ng, ng1, ng2, out_unit
-      REAL(KIND=dp)                                      :: my_alpha
+      REAL(KIND=dp)                                      :: my_alpha, my_beta
 
       CALL timeset(routineN, handle)
 
@@ -936,6 +937,35 @@ CONTAINS
 
       my_alpha = 1.0_dp
       IF (PRESENT(alpha)) my_alpha = alpha
+
+      my_beta = 1.0_dp
+      IF (PRESENT(beta)) my_beta = beta
+
+      IF (my_beta /= 1.0_dp) THEN
+         IF (my_beta == 0.0_dp) THEN
+            CALL pw_zero(pw2)
+         ELSE
+            IF (pw2%in_use == REALDATA1D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw2,my_beta)
+               pw2%cr = pw2%cr*my_beta
+!$OMP END PARALLEL WORKSHARE
+            ELSE IF (pw2%in_use == REALDATA3D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw2,my_beta)
+               pw2%cr3d = pw2%cr3d*my_beta
+!$OMP END PARALLEL WORKSHARE
+            ELSE IF (pw2%in_use == COMPLEXDATA1D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw2,my_beta)
+               pw2%cc = pw2%cc*my_beta
+!$OMP END PARALLEL WORKSHARE
+            ELSE IF (pw2%in_use == COMPLEXDATA3D) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw2,my_beta)
+               pw2%cc3d = pw2%cc3d*my_beta
+!$OMP END PARALLEL WORKSHARE
+            ELSE
+               CPABORT("Unknown array type in use for PW!")
+            END IF
+         END IF
+      END IF
 
       IF (ASSOCIATED(pw1%pw_grid, pw2%pw_grid)) THEN
 
@@ -946,8 +976,8 @@ CONTAINS
                   pw2%cr(i) = pw2%cr(i) + pw1%cr(i)
                END DO
 !$OMP END PARALLEL DO
-            ELSE
-!$OMP PARALLEL DO PRIVATE(i) DEFAULT(NONE) SHARED(my_alpha, pw1, pw2)
+            ELSE IF (my_alpha /= 0.0_dp) THEN
+!$OMP PARALLEL DO PRIVATE(i) DEFAULT(NONE) SHARED(pw2,pw1,my_alpha)
                DO i = 1, SIZE(pw2%cr)
                   pw2%cr(i) = pw2%cr(i) + my_alpha*pw1%cr(i)
                END DO
@@ -961,8 +991,8 @@ CONTAINS
                   pw2%cc(i) = pw2%cc(i) + pw1%cc(i)
                END DO
 !$OMP END PARALLEL DO
-            ELSE
-!$OMP PARALLEL DO PRIVATE(i) DEFAULT(NONE) SHARED(my_alpha, pw1, pw2)
+            ELSE IF (my_alpha /= 0.0_dp) THEN
+!$OMP PARALLEL DO PRIVATE(i) DEFAULT(NONE) SHARED(pw2,my_alpha,pw1)
                DO i = 1, SIZE(pw2%cc)
                   pw2%cc(i) = pw2%cc(i) + my_alpha*pw1%cc(i)
                END DO
@@ -973,8 +1003,8 @@ CONTAINS
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1, pw2)
                pw2%cr3d = pw2%cr3d + pw1%cr3d
 !$OMP END PARALLEL WORKSHARE
-            ELSE
-!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(my_alpha, pw1, pw2)
+            ELSE IF (my_alpha /= 0.0_dp) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1, pw2, my_alpha)
                pw2%cr3d = pw2%cr3d + my_alpha*pw1%cr3d
 !$OMP END PARALLEL WORKSHARE
             END IF
@@ -984,8 +1014,8 @@ CONTAINS
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1, pw2)
                pw2%cc3d = pw2%cc3d + pw1%cc3d
 !$OMP END PARALLEL WORKSHARE
-            ELSE
-!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(my_alpha, pw1, pw2)
+            ELSE IF (my_alpha /= 0.0_dp) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1, pw2, my_alpha)
                pw2%cc3d = pw2%cc3d + my_alpha*pw1%cc3d
 !$OMP END PARALLEL WORKSHARE
             END IF
@@ -1012,8 +1042,8 @@ CONTAINS
                      pw2%cc(i) = pw2%cc(i) + pw1%cc(i)
                   END DO
 !$OMP END PARALLEL DO
-               ELSE
-!$OMP PARALLEL DO PRIVATE(i) DEFAULT(NONE) SHARED(my_alpha, ng, pw1, pw2)
+               ELSE IF (my_alpha /= 0.0_dp) THEN
+!$OMP PARALLEL DO PRIVATE(i) DEFAULT(NONE) SHARED(pw2,pw1,my_alpha,ng)
                   DO i = 1, ng
                      pw2%cc(i) = pw2%cc(i) + my_alpha*pw1%cc(i)
                   END DO
@@ -1038,7 +1068,7 @@ CONTAINS
                      END DO
 !$OMP END PARALLEL DO
                   END IF
-               ELSE
+               ELSE IF (my_alpha /= 0.0_dp) THEN
                   IF (ng1 >= ng2) THEN
 !$OMP PARALLEL DO PRIVATE(i,j) DEFAULT(NONE) SHARED(my_alpha, ng2, pw1, pw2)
                      DO i = 1, ng2
@@ -1073,7 +1103,7 @@ CONTAINS
                      END DO
 !$OMP END PARALLEL DO
                   END IF
-               ELSE
+               ELSE IF (my_alpha /= 0.0_dp) THEN
                   IF (ng1 >= ng2) THEN
 !$OMP PARALLEL DO PRIVATE(i,j) DEFAULT(NONE) SHARED(my_alpha, ng2, pw1, pw2)
                      DO i = 1, ng2
@@ -2034,6 +2064,7 @@ CONTAINS
 !> \param pw1 ...
 !> \param pw2 ...
 !> \param sumtype ...
+!> \param just_sum ...
 !> \return ...
 !> \par History
 !>      JGH (14-Mar-2001) : Parallel sum and some tests, HALFSPACE case
@@ -2043,8 +2074,8 @@ CONTAINS
 
       TYPE(pw_type), INTENT(IN)                          :: pw1, pw2
       INTEGER, INTENT(IN), OPTIONAL                      :: sumtype
+      LOGICAL, INTENT(IN), OPTIONAL                      :: just_sum
       REAL(KIND=dp)                                      :: integral_value
-      LOGICAL, OPTIONAL, INTENT(IN)                      :: just_sum
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_integral_ab'
 

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -66,6 +66,7 @@ MODULE pw_methods
    PUBLIC :: pw_zero, pw_structure_factor, pw_smoothing
    PUBLIC :: pw_copy, pw_axpy, pw_transfer, pw_scale
    PUBLIC :: pw_gauss_damp, pw_compl_gauss_damp, pw_derive, pw_laplace, pw_dr2, pw_write, pw_multiply
+   PUBLIC :: pw_log_deriv_gauss, pw_log_deriv_compl_gauss, pw_log_deriv_mix_cl, pw_log_deriv_trunc
    PUBLIC :: pw_gauss_damp_mix
    PUBLIC :: pw_integral_ab, pw_integral_a2b
    PUBLIC :: pw_dr2_gg, pw_integrate_function
@@ -406,7 +407,8 @@ CONTAINS
 
       IF (pw%in_space == RECIPROCALSPACE .AND. &
           pw%in_use == COMPLEXDATA1D) THEN
-!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(omega_2, pw)
+
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw,omega_2)
          pw%cc(:) = pw%cc(:)*EXP(-pw%pw_grid%gsq(:)*omega_2)
 !$OMP END PARALLEL WORKSHARE
       ELSE
@@ -416,6 +418,46 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE pw_gauss_damp
+
+! **************************************************************************************************
+!> \brief Multiply all data points with the logarithmic derivative of a Gaussian
+!> \param pw ...
+!> \param omega ...
+!> \note
+!>      Performs a Gaussian damping
+!>      PW has to be in RECIPROCALSPACE and data in use is COMPLEXDATA1D
+! **************************************************************************************************
+   SUBROUTINE pw_log_deriv_gauss(pw, omega)
+
+      TYPE(pw_type), INTENT(IN)                          :: pw
+      REAL(KIND=dp), INTENT(IN)                          :: omega
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'pw_log_deriv_gauss'
+
+      INTEGER                                            :: handle
+      REAL(KIND=dp)                                      :: omega_2
+
+      CALL timeset(routineN, handle)
+      CPASSERT(omega >= 0)
+
+      omega_2 = omega*omega
+      omega_2 = 0.25_dp/omega_2
+
+      IF (pw%in_space == RECIPROCALSPACE .AND. &
+          pw%in_use == COMPLEXDATA1D) THEN
+
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw,omega_2)
+         pw%cc(:) = pw%cc(:)*(1.0_dp + omega_2*pw%pw_grid%gsq(:))
+!$OMP END PARALLEL WORKSHARE
+
+      ELSE
+
+         CPABORT("No suitable data field")
+
+      END IF
+
+      CALL timestop(handle)
+   END SUBROUTINE pw_log_deriv_gauss
 
 ! **************************************************************************************************
 !> \brief Multiply all data points with a Gaussian damping factor
@@ -473,6 +515,54 @@ CONTAINS
    END SUBROUTINE pw_compl_gauss_damp
 
 ! **************************************************************************************************
+!> \brief Multiply all data points with the logarithmic derivative of the complementary Gaussian damping factor
+!> \param pw ...
+!> \param omega ...
+!> \note
+!>      PW has to be in RECIPROCALSPACE and data in use is COMPLEXDATA1D
+! **************************************************************************************************
+   SUBROUTINE pw_log_deriv_compl_gauss(pw, omega)
+
+      TYPE(pw_type), INTENT(IN)                          :: pw
+      REAL(KIND=dp), INTENT(IN)                          :: omega
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'pw_log_deriv_compl_gauss'
+
+      INTEGER                                            :: handle, i
+      REAL(KIND=dp)                                      :: omega_2, tmp
+
+      CALL timeset(routineN, handle)
+
+      omega_2 = omega*omega
+      omega_2 = 0.25_dp/omega_2
+
+      IF (pw%in_space == RECIPROCALSPACE .AND. &
+          pw%in_use == COMPLEXDATA1D) THEN
+
+!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i,tmp) &
+!$OMP             SHARED(pw,omega_2)
+         DO i = 1, SIZE(pw%cc)
+            tmp = omega_2*pw%pw_grid%gsq(i)
+            ! For too small arguments, use the Taylor polynomial to prevent division by zero
+            IF (ABS(tmp) >= 0.003_dp) THEN
+               pw%cc(i) = pw%cc(i)*(1.0_dp - tmp*EXP(-tmp)/(1.0_dp - EXP(-tmp)))
+            ELSE
+               pw%cc(i) = pw%cc(i)*(0.5_dp*tmp - tmp**2/12.0_dp)
+            END IF
+         END DO
+!$OMP END PARALLEL DO
+
+      ELSE
+
+         CPABORT("No suitable data field")
+
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE pw_log_deriv_compl_gauss
+
+! **************************************************************************************************
 !> \brief Multiply all data points with a Gaussian damping factor and mixes it with the original function
 !>        Needed for mixed longrange/Coulomb potential
 !>        V(\vec r)=(a+b*erf(omega*r))/r
@@ -519,6 +609,52 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE pw_gauss_damp_mix
+
+! **************************************************************************************************
+!> \brief Multiply all data points with the logarithmic derivative of the mixed longrange/Coulomb potential
+!>        Needed for mixed longrange/Coulomb potential
+!> \param pw ...
+!> \param omega ...
+!> \param scale_coul ...
+!> \param scale_long ...
+!> \note
+!>      PW has to be in RECIPROCALSPACE and data in use is COMPLEXDATA1D
+! **************************************************************************************************
+   SUBROUTINE pw_log_deriv_mix_cl(pw, omega, scale_coul, scale_long)
+
+      TYPE(pw_type), INTENT(IN)                          :: pw
+      REAL(KIND=dp), INTENT(IN)                          :: omega, scale_coul, scale_long
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'pw_log_deriv_mix_cl'
+
+      INTEGER                                            :: handle, i
+      REAL(KIND=dp)                                      :: omega_2, tmp
+
+      CALL timeset(routineN, handle)
+
+      omega_2 = omega*omega
+      omega_2 = 0.25_dp/omega_2
+
+      IF (pw%in_space == RECIPROCALSPACE .AND. &
+          pw%in_use == COMPLEXDATA1D) THEN
+
+!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i,tmp) &
+!$OMP             SHARED(pw,omega_2,scale_long,scale_coul)
+         DO i = 1, SIZE(pw%cc)
+            tmp = omega_2*pw%pw_grid%gsq(i)
+            pw%cc(i) = pw%cc(i)*(1.0_dp + scale_long*tmp*EXP(-tmp)/(scale_coul + scale_long*EXP(-tmp)))
+         END DO
+!$OMP END PARALLEL DO
+
+      ELSE
+
+         CPABORT("No suitable data field")
+
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE pw_log_deriv_mix_cl
 
 ! **************************************************************************************************
 !> \brief Multiply all data points with a complementary cosine
@@ -572,6 +708,54 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE pw_truncated
+
+! **************************************************************************************************
+!> \brief Multiply all data points with the logarithmic derivative of the complementary cosine
+!>        This function is needed for virials using truncated Coulomb potentials
+!> \param pw ...
+!> \param rcutoff ...
+!> \note
+!>      PW has to be in RECIPROCALSPACE and data in use is COMPLEXDATA1D
+! **************************************************************************************************
+   SUBROUTINE pw_log_deriv_trunc(pw, rcutoff)
+
+      TYPE(pw_type), INTENT(IN)                          :: pw
+      REAL(KIND=dp), INTENT(IN)                          :: rcutoff
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'pw_log_deriv_trunc'
+
+      INTEGER                                            :: handle, i
+      REAL(KIND=dp)                                      :: rchalf, tmp
+
+      CALL timeset(routineN, handle)
+      CPASSERT(rcutoff >= 0)
+
+      IF (pw%in_space == RECIPROCALSPACE .AND. &
+          pw%in_use == COMPLEXDATA1D) THEN
+
+         rchalf = 0.5_dp*rcutoff
+!$OMP PARALLEL DO DEFAULT(NONE) PRIVATE(i,tmp) &
+!$OMP             SHARED(pw,rchalf)
+         DO i = 1, SIZE(pw%cc)
+            tmp = rchalf*SQRT(pw%pw_grid%gsq(i))
+            ! For too small arguments, use the Taylor polynomial to prevent division by zero
+            IF (ABS(tmp) >= 0.0001_dp) THEN
+               pw%cc(i) = pw%cc(i)*(1.0_dp - tmp/TAN(tmp))
+            ELSE
+               pw%cc(i) = pw%cc(i)*tmp**2*(1.0_dp + tmp**2/15.0_dp)/3.0_dp
+            END IF
+         END DO
+!$OMP END PARALLEL DO
+
+      ELSE
+
+         CPABORT("No suitable data field")
+
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE pw_log_deriv_trunc
 
 ! **************************************************************************************************
 !> \brief Calculate the derivative of a plane wave vector

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -199,13 +199,13 @@ CONTAINS
          ELSE IF (.NOT. (pw1%pw_grid%spherical .OR. &
                          pw2%pw_grid%spherical)) THEN
 
-            ng1 = SIZE(pw1%cc)
-            ng2 = SIZE(pw2%cc)
-            ns = 2*MAX(ng1, ng2)
-
             IF (pw1%in_use == COMPLEXDATA1D .AND. &
                 pw2%in_use == COMPLEXDATA1D .AND. &
                 pw1%in_space == RECIPROCALSPACE) THEN
+
+               ng1 = SIZE(pw1%cc)
+               ng2 = SIZE(pw2%cc)
+               ns = 2*MAX(ng1, ng2)
 
                IF ((pw1%pw_grid%id_nr == pw2%pw_grid%reference)) THEN
                   IF (ng1 >= ng2) THEN
@@ -255,11 +255,16 @@ CONTAINS
                   CALL pw_copy_match(pw1, pw2)
                END IF
 
+               pw2%in_space = RECIPROCALSPACE
+
+            ELSE IF (pw1%in_use == REALDATA3D .AND. pw1%in_use==pw2%in_use .AND. &
+                     pw1%in_space == REALSPACE) THEN
+!$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw1,pw2)
+               pw2%cr3d(:, :, :) = pw1%cr3d(:, :, :)
+!$OMP END PARALLEL WORKSHARE
             ELSE
                CPABORT("No suitable data field")
             END IF
-
-            pw2%in_space = RECIPROCALSPACE
 
          ELSE
 

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -2691,7 +2691,8 @@ CONTAINS
 !> \param pw2 ...
 ! **************************************************************************************************
    SUBROUTINE pw_multiply_with(pw1, pw2)
-      TYPE(pw_type), INTENT(IN)                          :: pw1, pw2
+      TYPE(pw_type), INTENT(INOUT)                       :: pw1
+      TYPE(pw_type), INTENT(IN)                          :: pw2
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'pw_multiply_with'
 

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -51,7 +51,6 @@ MODULE pw_methods
                                               pw_grid_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               COMPLEXDATA3D,&
-                                              NOSPACE,&
                                               REALDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -2260,8 +2259,6 @@ CONTAINS
       END SELECT
 
       SELECT CASE (pw%in_space)
-      CASE (NOSPACE)
-         WRITE (unit=unit_nr, fmt="(a)", iostat=iostatus) " in_space=NOSPACE"
       CASE (REALSPACE)
          WRITE (unit=unit_nr, fmt="(a)", iostat=iostatus) " in_space=REALSPACE"
       CASE (RECIPROCALSPACE)
@@ -2700,7 +2697,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      IF (pw1%in_space /= pw2%in_space .OR. pw1%in_space == NOSPACE) &
+      IF (pw1%in_space /= pw2%in_space) &
          CPABORT("Invalid space combination!")
       IF (.NOT. pw_compatible(pw1%pw_grid, pw2%pw_grid)) &
          CPABORT("Incompatible grids!")

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -265,8 +265,7 @@ CONTAINS
    SUBROUTINE pw_pool_create_pw(pool, pw, use_data, in_space)
       TYPE(pw_pool_type), INTENT(IN)                     :: pool
       TYPE(pw_type), INTENT(OUT)                         :: pw
-      INTEGER, INTENT(in)                                :: use_data
-      INTEGER, INTENT(in)                                :: in_space
+      INTEGER, INTENT(in)                                :: use_data, in_space
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_pool_create_pw'
 

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -266,7 +266,7 @@ CONTAINS
       TYPE(pw_pool_type), INTENT(IN)                     :: pool
       TYPE(pw_type), INTENT(OUT)                         :: pw
       INTEGER, INTENT(in)                                :: use_data
-      INTEGER, INTENT(in), OPTIONAL                      :: in_space
+      INTEGER, INTENT(in)                                :: in_space
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_pool_create_pw'
 
@@ -302,14 +302,12 @@ CONTAINS
 
       IF (.NOT. ASSOCIATED(el)) THEN
          CALL pw_create(pw, pool%pw_grid, use_data=use_data, &
-                        cr3d_ptr=cr3d_ptr)
+                        in_space=in_space, cr3d_ptr=cr3d_ptr)
       ELSE
          pw = el
          DEALLOCATE (el)
+         pw%in_space = in_space
       END IF
-
-      pw%in_space = 0
-      IF (PRESENT(in_space)) pw%in_space = in_space
 
       CALL timestop(handle)
 

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -97,6 +97,7 @@ CONTAINS
          CPABORT("unknown data type "//cp_to_string(pw%in_use))
       END SELECT
       CALL pw_grid_release(pw%pw_grid)
+      pw%in_space = NOSPACE
    END SUBROUTINE pw_release
 
 ! **************************************************************************************************
@@ -115,7 +116,7 @@ CONTAINS
       TYPE(pw_type), INTENT(OUT)                         :: pw
       TYPE(pw_grid_type), INTENT(IN), POINTER            :: pw_grid
       INTEGER, INTENT(in)                                :: use_data
-      INTEGER, INTENT(in), OPTIONAL                      :: in_space
+      INTEGER, INTENT(in)                                :: in_space
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(IN), OPTIONAL, POINTER                   :: cr3d_ptr
 
@@ -146,7 +147,6 @@ CONTAINS
       pw%in_use = use_data
       pw%pw_grid => pw_grid
       CALL pw_grid_retain(pw%pw_grid)
-      pw%in_space = NOSPACE
       bounds => pw%pw_grid%bounds_local
 
       SELECT CASE (use_data)
@@ -182,7 +182,7 @@ CONTAINS
       CASE default
          CPABORT("unknown data type")
       END SELECT
-      IF (PRESENT(in_space)) pw%in_space = in_space
+      pw%in_space = in_space
       CALL timestop(handle)
    END SUBROUTINE pw_create
 

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -115,8 +115,7 @@ CONTAINS
    SUBROUTINE pw_create(pw, pw_grid, use_data, in_space, cr3d_ptr)
       TYPE(pw_type), INTENT(OUT)                         :: pw
       TYPE(pw_grid_type), INTENT(IN), POINTER            :: pw_grid
-      INTEGER, INTENT(in)                                :: use_data
-      INTEGER, INTENT(in)                                :: in_space
+      INTEGER, INTENT(in)                                :: use_data, in_space
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(IN), OPTIONAL, POINTER                   :: cr3d_ptr
 

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -137,6 +137,9 @@ CONTAINS
          CALL print_stack(cp_logger_get_default_unit_nr(logger))
       END IF
 
+      IF (in_space /= REALSPACE .AND. in_space /= RECIPROCALSPACE) &
+         CPABORT("Choose a proper space in which the grid lives!")
+
       IF (PRESENT(cr3d_ptr)) THEN
          IF (ASSOCIATED(cr3d_ptr)) THEN
             CPASSERT(use_data == REALDATA3D)

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -41,12 +41,15 @@ MODULE pw_types
    PUBLIC :: pw_release, pw_create
 
    ! Flags for the structure member 'in_use'
+   ! NODATA only for internal use, we enforce a certain data type
    INTEGER, PARAMETER, PUBLIC :: REALDATA1D = 301, COMPLEXDATA1D = 302
-   INTEGER, PARAMETER, PUBLIC :: REALDATA3D = 303, COMPLEXDATA3D = 304, NODATA = 305
+   INTEGER, PARAMETER, PUBLIC :: REALDATA3D = 303, COMPLEXDATA3D = 304
+   INTEGER, PARAMETER         :: NODATA = 305
 
    ! Flags for the structure member 'in_space'
-   INTEGER, PARAMETER, PUBLIC :: NOSPACE = 371, REALSPACE = 372, RECIPROCALSPACE = 373
-   INTEGER, PUBLIC, PARAMETER :: SQUARE = 391, SQUAREROOT = 392
+   ! NOSPACE only for internal usage, we enforce the choice of a proper space
+   INTEGER, PARAMETER :: NOSPACE = 371
+   INTEGER, PARAMETER, PUBLIC :: REALSPACE = 372, RECIPROCALSPACE = 373
 
 ! **************************************************************************************************
    TYPE pw_type
@@ -93,11 +96,13 @@ CONTAINS
       CASE (COMPLEXDATA3D)
          IF (ASSOCIATED(pw%cc3d)) DEALLOCATE (pw%cc3d)
       CASE (NODATA)
+         ! Only, if the pw grid was never created
       CASE default
          CPABORT("unknown data type "//cp_to_string(pw%in_use))
       END SELECT
       CALL pw_grid_release(pw%pw_grid)
       pw%in_space = NOSPACE
+      pw%in_use = NODATA
    END SUBROUTINE pw_release
 
 ! **************************************************************************************************
@@ -181,6 +186,7 @@ CONTAINS
                    bounds(1, 2):bounds(2, 2), &
                    bounds(1, 3):bounds(2, 3)))
       CASE (NODATA)
+         CPABORT("Choose a proper data type!")
       CASE default
          CPABORT("unknown data type")
       END SELECT

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -945,7 +945,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE add_image_pot_to_hartree_pot(v_hartree, v_metal, qs_env)
 
-      TYPE(pw_type), INTENT(IN)                          :: v_hartree, v_metal
+      TYPE(pw_type), INTENT(INOUT)                       :: v_hartree
+      TYPE(pw_type), INTENT(IN)                          :: v_metal
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(len=*), PARAMETER :: routineN = 'add_image_pot_to_hartree_pot'

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -43,7 +43,8 @@ MODULE qmmm_image_charge
    USE message_passing,                 ONLY: mp_para_env_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_methods,                      ONLY: pw_integral_ab,&
+   USE pw_methods,                      ONLY: pw_axpy,&
+                                              pw_integral_ab,&
                                               pw_scale,&
                                               pw_transfer,&
                                               pw_zero
@@ -959,7 +960,7 @@ CONTAINS
       logger => cp_get_default_logger()
 
       !add image charge potential
-      v_hartree%cr3d = v_hartree%cr3d + v_metal%cr3d
+      CALL pw_axpy(v_metal, v_hartree)
 
       ! print info
       CALL get_qs_env(qs_env=qs_env, &

--- a/src/qs_2nd_kernel_ao.F
+++ b/src/qs_2nd_kernel_ao.F
@@ -38,6 +38,7 @@ MODULE qs_2nd_kernel_ao
    USE kinds,                           ONLY: dp
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
+   USE pw_methods,                      ONLY: pw_scale
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
                                               pw_pool_type
    USE pw_types,                        ONLY: pw_type
@@ -337,13 +338,13 @@ CONTAINS
 
          CALL cp_fm_get_info(admm_env%A, nrow_global=nao_aux, ncol_global=nao)
          DO ispin = 1, nspins
-            v_xc(ispin)%cr3d = v_xc(ispin)%cr3d*v_xc(ispin)%pw_grid%dvol
+            CALL pw_scale(v_xc(ispin), v_xc(ispin)%pw_grid%dvol)
             CALL dbcsr_set(work_hmat%matrix, 0.0_dp)
             CALL integrate_v_rspace(v_rspace=v_xc(ispin), hmat=work_hmat, qs_env=qs_env, &
                                     calculate_forces=my_calc_forces, basis_type="AUX_FIT", &
                                     task_list_external=task_list_aux_fit, pmat=rho_ao_aux(ispin))
             IF (ASSOCIATED(v_xc_tau)) THEN
-               v_xc_tau(ispin)%cr3d = v_xc_tau(ispin)%cr3d*v_xc_tau(ispin)%pw_grid%dvol
+               CALL pw_scale(v_xc_tau(ispin), v_xc_tau(ispin)%pw_grid%dvol)
                CALL integrate_v_rspace(v_rspace=v_xc_tau(ispin), hmat=work_hmat, qs_env=qs_env, &
                                        compute_tau=.TRUE., &
                                        calculate_forces=my_calc_forces, basis_type="AUX_FIT", &

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -27,9 +27,12 @@ MODULE qs_active_space_methods
    USE cp_dbcsr_operations, ONLY: cp_dbcsr_plus_fm_fm_t, &
                                   cp_dbcsr_sm_fm_multiply, &
                                   dbcsr_allocate_matrix_set
+   USE cp_external_control, ONLY: external_control
    USE cp_files, ONLY: close_file, &
                        file_exists, &
                        open_file
+   USE cp_fm_basic_linalg, ONLY: cp_fm_column_scale
+   USE cp_fm_diag, ONLY: cp_fm_syevd
    USE cp_fm_struct, ONLY: cp_fm_struct_create, &
                            cp_fm_struct_release, &
                            cp_fm_struct_type
@@ -78,7 +81,8 @@ MODULE qs_active_space_methods
                            pw_env_release, &
                            pw_env_type
    USE pw_methods, ONLY: pw_integrate_function, &
-                         pw_transfer
+                         pw_transfer, &
+                         pw_zero
    USE pw_poisson_methods, ONLY: pw_poisson_rebuild, &
                                  pw_poisson_solve
    USE pw_poisson_types, ONLY: ANALYTIC0D, &
@@ -1364,7 +1368,7 @@ CONTAINS
       CALL pw_pool_create_pw(auxbas_pw_pool, pot_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! run the FFT once, to set up buffers and to take into account the memory
-      rho_r%cr3d = 0.0D0
+      CALL pw_zero(rho_r)
       CALL pw_transfer(rho_r, rho_g)
       dvol = rho_r%pw_grid%dvol
       CALL mp_group%set_handle(eri_env%eri(1)%csr_mat%mp_group%get_handle())

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -81,6 +81,8 @@ MODULE qs_active_space_methods
                            pw_env_release, &
                            pw_env_type
    USE pw_methods, ONLY: pw_integrate_function, &
+                         pw_multiply, &
+                         pw_multiply_with, &
                          pw_transfer, &
                          pw_zero
    USE pw_poisson_methods, ONLY: pw_poisson_rebuild, &
@@ -1400,7 +1402,8 @@ CONTAINS
                   CPABORT("")
                END IF
                ! calculate charge distribution and potential
-               rho_r%cr3d = wfn1%cr3d*wfn2%cr3d
+               CALL pw_zero(rho_r)
+               CALL pw_multiply(rho_r, wfn1, wfn2)
                IF (print2 .AND. iw > 0) THEN
                   ! TODO: this call hangs in parallel
                   erint = pw_integrate_function(rho_r)/dvol
@@ -1440,7 +1443,9 @@ CONTAINS
                            ELSE
                               CPABORT("")
                            END IF
-                           wfn_r%cr3d = rho_r%cr3d*wfn3%cr3d*wfn4%cr3d
+                           CALL pw_zero(wfn_r)
+                           CALL pw_multiply(wfn_r, rho_r, wfn3)
+                           CALL pw_multiply_with(wfn_r, wfn4)
                            erint = pw_integrate_function(wfn_r)
                            IF (ABS(erint) > eri_env%eps_integral) THEN
                               intcount = intcount + 1

--- a/src/qs_cdft_methods.F
+++ b/src/qs_cdft_methods.F
@@ -43,7 +43,10 @@ MODULE qs_cdft_methods
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_copy,&
-                                              pw_integrate_function
+                                              pw_integral_ab,&
+                                              pw_integrate_function,&
+                                              pw_set,&
+                                              pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_give_back_pw,&
                                               pw_pool_type
@@ -751,22 +754,22 @@ CONTAINS
          END IF
 
          ! Setup pw
-         cdft_control%group(igroup)%weight%cr3d = 0.0_dp
+         CALL pw_zero(cdft_control%group(igroup)%weight)
 
          CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total_constraint, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
-         cdft_control%group(igroup)%hw_rho_total_constraint%cr3d = 1.0_dp
+         CALL pw_set(cdft_control%group(igroup)%hw_rho_total_constraint, 1.0_dp)
 
          IF (igroup == 1) THEN
             CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total, &
                                    use_data=REALDATA3D, in_space=REALSPACE)
-            cdft_control%group(igroup)%hw_rho_total%cr3d = 1.0_dp
+            CALL pw_set(cdft_control%group(igroup)%hw_rho_total, 1.0_dp)
 
             IF (hirshfeld_control%print_density) THEN
                DO iatom = 1, cdft_control%natoms
                   CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic(iatom), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  cdft_control%group(igroup)%hw_rho_atomic(iatom)%cr3d = 1.0_dp
+                  CALL pw_set(cdft_control%group(igroup)%hw_rho_atomic(iatom), 1.0_dp)
                END DO
             END IF
          END IF
@@ -786,7 +789,7 @@ CONTAINS
             DO iatom = 1, cdft_control%natoms
                CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic_charge(iatom), &
                                       use_data=REALDATA3D, in_space=REALSPACE)
-               cdft_control%group(igroup)%hw_rho_atomic_charge(iatom)%cr3d = 1.0_dp
+               CALL pw_set(cdft_control%group(igroup)%hw_rho_atomic_charge(iatom), 1.0_dp)
             END DO
          END IF
 
@@ -974,7 +977,7 @@ CONTAINS
                DO i = 1, num_species
                   CALL pw_pool_create_pw(auxbas_pw_pool, pw_single_dr(i), use_data=REALDATA3D, &
                                          in_space=REALSPACE)
-                  pw_single_dr(i)%cr3d(:, :, :) = 0.0_dp
+                  CALL pw_zero(pw_single_dr(i))
                END DO
 
                atoms_memory_num = SIZE((/(j, j=1, num_species, atoms_memory)/))
@@ -1236,12 +1239,12 @@ CONTAINS
                dE(igroup) = dE(igroup) + sign*accurate_dot_product(group(igroup)%weight%cr3d, rho_r(i)%cr3d, &
                                                                    becke_control%cavity_mat, eps_cavity)*dvol
             ELSE
-               dE(igroup) = dE(igroup) + sign*accurate_dot_product(group(igroup)%weight%cr3d, rho_r(i)%cr3d)*dvol
+               dE(igroup) = dE(igroup) + sign*pw_integral_ab(group(igroup)%weight, rho_r(i), local_only=.TRUE.)
             END IF
          END DO
          IF (cdft_control%atomic_charges) THEN
             DO iatom = 1, cdft_control%natoms
-               electronic_charge(iatom, i) = accurate_dot_product(charge(iatom)%cr3d, rho_r(i)%cr3d)*dvol
+               electronic_charge(iatom, i) = pw_integral_ab(charge(iatom), rho_r(i), local_only=.TRUE.)
             END DO
          END IF
       END DO
@@ -1716,7 +1719,7 @@ CONTAINS
                                                                becke_control%cavity_mat, becke_control%eps_cavity)*dvol
          ELSE
             cdft_control%target(igroup) = cdft_control%target(igroup) + &
-                                          accurate_dot_product(group(igroup)%weight%cr3d, rho_frag(i)%cr3d)*dvol
+                                          pw_integral_ab(group(igroup)%weight, rho_frag(i), local_only=.TRUE.)
          END IF
       END DO
       CALL para_env%sum(cdft_control%target)
@@ -1726,7 +1729,7 @@ CONTAINS
          DO i = 1, nfrag_spins
             DO iatom = 1, cdft_control%natoms
                cdft_control%charges_fragment(iatom, i) = &
-                  accurate_dot_product(cdft_control%charge(iatom)%cr3d, rho_frag(i)%cr3d)*dvol
+                  pw_integral_ab(cdft_control%charge(iatom), rho_frag(i), local_only=.TRUE.)
             END DO
          END DO
          CALL para_env%sum(cdft_control%charges_fragment)

--- a/src/qs_cdft_utils.F
+++ b/src/qs_cdft_utils.F
@@ -54,6 +54,7 @@ MODULE qs_cdft_utils
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
+   USE pw_methods,                      ONLY: pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
@@ -198,11 +199,11 @@ CONTAINS
       END IF
       ! Zero weight functions
       DO igroup = 1, SIZE(group)
-         group(igroup)%weight%cr3d = 0.0_dp
+         CALL pw_zero(group(igroup)%weight)
       END DO
       IF (cdft_control%atomic_charges) THEN
          DO iatom = 1, cdft_control%natoms
-            cdft_control%charge(iatom)%cr3d = 0.0_dp
+            CALL pw_zero(cdft_control%charge(iatom))
          END DO
       END IF
       ! Allocate storage for cell adjustment coefficients and needed distance vectors

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -287,11 +287,9 @@ CONTAINS
 
       DO ispin = 1, dcdr_env%nspins
          CALL dbcsr_set(dcdr_env%matrix_apply_op_constant(ispin)%matrix, 0.0_dp)
+         CALL pw_axpy(v_hartree_rspace, v_rspace_new(ispin))
          IF (dcdr_env%nspins == 1) THEN
-            v_rspace_new(1)%cr3d = 2.0_dp*v_rspace_new(1)%cr3d + 2.0_dp*v_hartree_rspace%cr3d
-         ELSE IF (dcdr_env%nspins == 2) THEN
-            v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d + &
-                                       v_hartree_rspace%cr3d
+            CALL pw_scale(v_rspace_new(1), 2.0_dp)
          END IF
 
          CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -248,8 +248,7 @@ CONTAINS
                ALLOCATE (rho_core)
                CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_core, &
-                                      use_data=COMPLEXDATA1D)
-               rho_core%in_space = RECIPROCALSPACE
+                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                CALL set_ks_env(ks_env, rho_core=rho_core)
             END IF
             CALL get_qs_env(qs_env=qs_env, rho0_mpole=rho0_mpole)
@@ -281,8 +280,7 @@ CONTAINS
             ALLOCATE (rho_core)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_core, &
-                                   use_data=COMPLEXDATA1D)
-            rho_core%in_space = RECIPROCALSPACE
+                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL set_ks_env(ks_env, rho_core=rho_core)
          END IF
 
@@ -296,8 +294,7 @@ CONTAINS
                ALLOCATE (vppl)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, vppl, use_data=REALDATA3D)
-            vppl%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, vppl, use_data=REALDATA3D, in_space=REALSPACE)
             CALL set_ks_env(ks_env, vppl=vppl)
          END IF
 
@@ -314,8 +311,7 @@ CONTAINS
                ALLOCATE (rho_nlcc)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc, use_data=REALDATA3D)
-            rho_nlcc%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc, REALDATA3D, REALSPACE)
             CALL set_ks_env(ks_env, rho_nlcc=rho_nlcc)
             ! the g-space version
             NULLIFY (rho_nlcc_g)
@@ -326,8 +322,7 @@ CONTAINS
                ALLOCATE (rho_nlcc_g)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc_g, use_data=COMPLEXDATA1D)
-            rho_nlcc_g%in_space = RECIPROCALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc_g, COMPLEXDATA1D, RECIPROCALSPACE)
             CALL set_ks_env(ks_env, rho_nlcc_g=rho_nlcc_g)
          END IF
 
@@ -341,8 +336,7 @@ CONTAINS
             END IF
             ALLOCATE (vee)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, vee, use_data=REALDATA3D)
-            vee%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, vee, REALDATA3D, REALSPACE)
             CALL set_ks_env(ks_env, vee=vee)
             dft_control%eval_external_potential = .TRUE.
          END IF
@@ -357,8 +351,7 @@ CONTAINS
                ALLOCATE (external_vxc)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, external_vxc, use_data=REALDATA3D)
-            external_vxc%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, external_vxc, REALDATA3D, REALSPACE)
             CALL set_qs_env(qs_env, external_vxc=external_vxc)
             dft_control%read_external_vxc = .TRUE.
          END IF
@@ -373,8 +366,7 @@ CONTAINS
                ALLOCATE (embed_pot)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot, use_data=REALDATA3D)
-            embed_pot%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot, REALDATA3D, REALSPACE)
             CALL set_qs_env(qs_env, embed_pot=embed_pot)
 
             NULLIFY (spin_embed_pot)
@@ -386,8 +378,7 @@ CONTAINS
                ALLOCATE (spin_embed_pot)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot, use_data=REALDATA3D)
-            spin_embed_pot%in_space = REALSPACE
+            CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot, REALDATA3D, REALSPACE)
             CALL set_qs_env(qs_env, spin_embed_pot=spin_embed_pot)
          END IF
 
@@ -400,7 +391,7 @@ CONTAINS
          CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
          ALLOCATE (v_hartree_rspace)
          CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+                                REALDATA3D, REALSPACE)
          CALL set_ks_env(ks_env, v_hartree_rspace=v_hartree_rspace)
       END IF
 

--- a/src/qs_external_potential.F
+++ b/src/qs_external_potential.F
@@ -32,8 +32,8 @@ MODULE qs_external_potential
    USE maxwell_solver_interface,        ONLY: maxwell_solver
    USE message_passing,                 ONLY: mp_comm_type
    USE particle_types,                  ONLY: particle_type
-USE pw_methods, ONLY: pw_zero
    USE pw_grid_types,                   ONLY: PW_MODE_LOCAL
+   USE pw_methods,                      ONLY: pw_zero
    USE pw_types,                        ONLY: pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&

--- a/src/qs_external_potential.F
+++ b/src/qs_external_potential.F
@@ -32,6 +32,7 @@ MODULE qs_external_potential
    USE maxwell_solver_interface,        ONLY: maxwell_solver
    USE message_passing,                 ONLY: mp_comm_type
    USE particle_types,                  ONLY: particle_type
+USE pw_methods, ONLY: pw_zero
    USE pw_grid_types,                   ONLY: PW_MODE_LOCAL
    USE pw_types,                        ONLY: pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
@@ -96,7 +97,7 @@ CONTAINS
 
                dr = v_ee%pw_grid%dr
                dvol = v_ee%pw_grid%dvol
-               v_ee%cr3d = 0.0_dp
+               CALL pw_zero(v_ee)
 
                bo_local = v_ee%pw_grid%bounds_local
                bo_global = v_ee%pw_grid%bounds

--- a/src/qs_gamma2kp.F
+++ b/src/qs_gamma2kp.F
@@ -25,6 +25,7 @@ MODULE qs_gamma2kp
    USE kpoint_types,                    ONLY: kpoint_create,&
                                               kpoint_type
    USE message_passing,                 ONLY: mp_para_env_type
+USE pw_methods, ONLY: pw_copy
    USE pw_types,                        ONLY: pw_type
    USE qs_energy_init,                  ONLY: qs_energies_init
    USE qs_environment,                  ONLY: qs_init
@@ -123,8 +124,8 @@ CONTAINS
       CALL qs_rho_get(rho, rho_ao_kp=rho_ao_kp, rho_r=rho_r_kp, rho_g=rho_g_kp)
 
       DO ispin = 1, SIZE(rho_r_gamma)
-         rho_r_kp(ispin)%cr3d(:, :, :) = rho_r_gamma(ispin)%cr3d(:, :, :)
-         rho_g_kp(ispin)%cc(:) = rho_g_gamma(ispin)%cc(:)
+         CALL pw_copy(rho_r_gamma(ispin), rho_r_kp(ispin))
+         CALL pw_copy(rho_g_gamma(ispin), rho_g_kp(ispin))
          CALL dbcsr_add(matrix_a=rho_ao_kp(ispin, 1)%matrix, alpha_scalar=0.0_dp, &
                         matrix_b=rho_ao_kp_gamma(ispin, 1)%matrix, beta_scalar=1.0_dp)
       END DO

--- a/src/qs_gamma2kp.F
+++ b/src/qs_gamma2kp.F
@@ -25,7 +25,7 @@ MODULE qs_gamma2kp
    USE kpoint_types,                    ONLY: kpoint_create,&
                                               kpoint_type
    USE message_passing,                 ONLY: mp_para_env_type
-USE pw_methods, ONLY: pw_copy
+   USE pw_methods,                      ONLY: pw_copy
    USE pw_types,                        ONLY: pw_type
    USE qs_energy_init,                  ONLY: qs_energies_init
    USE qs_environment,                  ONLY: qs_init

--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -100,7 +100,7 @@ CONTAINS
          nspin = SIZE(rho_g, 1)
          nimg = dft_control%nimages
          ng = SIZE(rho_g(1)%pw_grid%gsq)
-         CPASSERT((ng == SIZE(mixing_store%rhoin(1)%cc)))
+         CPASSERT(ng == SIZE(mixing_store%rhoin(1)%cc))
 
          alpha = mixing_store%alpha
          gapw = dft_control%qs_control%gapw
@@ -331,8 +331,8 @@ CONTAINS
       ALLOCATE (cc_mix(ng))
 
       IF (nspin == 2) THEN
+         CALL pw_axpy(rho_g(1), rho_g(2), 1.0_dp, -1.0_dp)
          DO ig = 1, ng
-            rho_g(2)%cc(ig) = rho_g(1)%cc(ig) - rho_g(2)%cc(ig)
             mixing_store%rhoin(2)%cc(ig) = mixing_store%rhoin(1)%cc(ig) - mixing_store%rhoin(2)%cc(ig)
          END DO
          IF (gapw .AND. mixing_store%gmix_p) THEN
@@ -527,8 +527,8 @@ CONTAINS
       DEALLOCATE (cc_mix)
 
       IF (nspin == 2) THEN
+         CALL pw_axpy(rho_g(1), rho_g(2), 1.0_dp, -1.0_dp)
          DO ig = 1, ng
-            rho_g(2)%cc(ig) = rho_g(1)%cc(ig) - rho_g(2)%cc(ig)
             mixing_store%rhoin(2)%cc(ig) = mixing_store%rhoin(1)%cc(ig) - mixing_store%rhoin(2)%cc(ig)
          END DO
          IF (gapw .AND. mixing_store%gmix_p) THEN
@@ -623,8 +623,8 @@ CONTAINS
       END IF
 
       IF (nspin == 2) THEN
+         CALL pw_axpy(rho_g(1), rho_g(2), 1.0_dp, -1.0_dp)
          DO ig = 1, ng
-            rho_g(2)%cc(ig) = rho_g(1)%cc(ig) - rho_g(2)%cc(ig)
             mixing_store%rhoin(2)%cc(ig) = mixing_store%rhoin(1)%cc(ig) - mixing_store%rhoin(2)%cc(ig)
          END DO
          IF (gapw .AND. mixing_store%gmix_p) THEN
@@ -850,8 +850,8 @@ CONTAINS
 
       END DO ! ispin
       IF (nspin == 2) THEN
+         CALL pw_axpy(rho_g(1), rho_g(2), 1.0_dp, -1.0_dp)
          DO ig = 1, ng
-            rho_g(2)%cc(ig) = rho_g(1)%cc(ig) - rho_g(2)%cc(ig)
             mixing_store%rhoin(2)%cc(ig) = mixing_store%rhoin(1)%cc(ig) - mixing_store%rhoin(2)%cc(ig)
          END DO
          IF (gapw .AND. mixing_store%gmix_p) THEN

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -434,7 +434,7 @@ CONTAINS
 
                ! add hartree only for SINGLETS
                IF (.NOT. do_triplet) THEN
-                  v_rspace_new(1)%cr3d = v_hartree_rspace%cr3d
+                  CALL pw_copy(v_hartree_rspace, v_rspace_new(1))
 
                   CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
                                           pmat=rho_ao(ispin), &
@@ -458,7 +458,7 @@ CONTAINS
                                           calculate_forces=my_calc_forces, gapw=gapw_xc)
                END IF
 
-               v_rspace_new(ispin)%cr3d = v_hartree_rspace%cr3d
+               CALL pw_copy(v_hartree_rspace, v_rspace_new(ispin))
                CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
                                        pmat=rho_ao(ispin), &
                                        hmat=p_env%kpp1_env%v_ao(ispin), &
@@ -472,12 +472,10 @@ CONTAINS
 
                ! add hartree only for SINGLETS
                IF (.NOT. do_triplet) THEN
-                  v_rspace_new(1)%cr3d = v_rspace_new(1)%cr3d + &
-                                         v_hartree_rspace%cr3d
+                  CALL pw_axpy(v_hartree_rspace, v_rspace_new(1))
                END IF
             ELSE
-               v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d + &
-                                          v_hartree_rspace%cr3d
+               CALL pw_axpy(v_hartree_rspace, v_rspace_new(ispin))
             END IF
 
             IF (lrigpw) THEN
@@ -609,8 +607,8 @@ CONTAINS
       DO ispin = 1, SIZE(k_p_p1)
          CALL dbcsr_add(rho_ao(ispin)%matrix, rho1_ao(ispin)%matrix, &
                         alpha_scalar=1.0_dp, beta_scalar=my_diff)
-         rho_r(ispin)%cr3d = rho_r(ispin)%cr3d + my_diff*rho1_r(ispin)%cr3d
-         rho_g(ispin)%cc = rho_g(ispin)%cc + my_diff*rho1_g(ispin)%cc
+         CALL pw_axpy(rho1_r(ispin), rho_r(ispin), my_diff)
+         CALL pw_axpy(rho1_g(ispin), rho_g(ispin), my_diff)
       END DO
 
       CALL qs_ks_build_kohn_sham_matrix(qs_env, &
@@ -630,8 +628,8 @@ CONTAINS
       DO ispin = 1, nspins
          CALL dbcsr_add(rho_ao(ispin)%matrix, rho1_ao(ispin)%matrix, &
                         alpha_scalar=1.0_dp, beta_scalar=my_diff)
-         rho_r(ispin)%cr3d = rho_r(ispin)%cr3d + my_diff*rho1_r(ispin)%cr3d
-         rho_g(ispin)%cc = rho_g(ispin)%cc + my_diff*rho1_g(ispin)%cc
+         CALL pw_axpy(rho1_r(ispin), rho_r(ispin), my_diff)
+         CALL pw_axpy(rho1_g(ispin), rho_g(ispin), my_diff)
       END DO
 
       CALL qs_ks_build_kohn_sham_matrix(qs_env, &
@@ -644,8 +642,8 @@ CONTAINS
       DO ispin = 1, nspins
          CALL dbcsr_add(rho_ao(ispin)%matrix, rho1_ao(ispin)%matrix, &
                         alpha_scalar=1.0_dp, beta_scalar=my_diff)
-         rho_r(ispin)%cr3d = rho_r(ispin)%cr3d + my_diff*rho1_r(ispin)%cr3d
-         rho_g(ispin)%cc = rho_g(ispin)%cc + my_diff*rho1_g(ispin)%cc
+         CALL pw_axpy(rho1_r(ispin), rho_r(ispin), my_diff)
+         CALL pw_axpy(rho1_g(ispin), rho_g(ispin), my_diff)
       END DO
 
 ! k_p_p1=(H(rho0+h/2 rho1)-H(rho0-h/2 rho1))/h
@@ -716,14 +714,14 @@ CONTAINS
             DO ispin = 1, 2
                CALL pw_pool_create_pw(auxbas_pw_pool, my_rho_r(ispin), &
                                       use_data=rho_r(1)%in_use, in_space=rho_r(1)%in_space)
-               my_rho_r(ispin)%cr3d = 0.5_dp*rho_r(1)%cr3d
+               CALL pw_axpy(rho_r(1), my_rho_r(ispin), 0.5_dp, 0.0_dp)
             END DO
             IF (dft_control%use_kinetic_energy_density) THEN
                ALLOCATE (my_tau_r(2))
                DO ispin = 1, 2
                   CALL pw_pool_create_pw(auxbas_pw_pool, my_tau_r(ispin), &
                                          use_data=tau_r(1)%in_use, in_space=tau_r(1)%in_space)
-                  my_tau_r(ispin)%cr3d = 0.5_dp*tau_r(1)%cr3d
+                  CALL pw_axpy(tau_r(1), my_tau_r(ispin), 0.5_dp, 0.0_dp)
                END DO
             END IF
          ELSE

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -856,10 +856,8 @@ CONTAINS
          ! update core energy for grid based local pseudopotential
          ecore_ppl = 0._dp
          DO ispin = 1, nspins
-            ecore_ppl = ecore_ppl + &
-                        SUM(vppl_rspace%cr3d*rho_r(ispin)%cr3d)*vppl_rspace%pw_grid%dvol
+            ecore_ppl = ecore_ppl + pw_integral_ab(vppl_rspace, rho_r(ispin))
          END DO
-         CALL para_env%sum(ecore_ppl)
          energy%core = energy%core + ecore_ppl
       END IF
 

--- a/src/qs_ks_qmmm_methods.F
+++ b/src/qs_ks_qmmm_methods.F
@@ -23,7 +23,8 @@ MODULE qs_ks_qmmm_methods
    USE kinds,                           ONLY: dp
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_retain
-   USE pw_methods,                      ONLY: pw_integral_ab,pw_axpy
+   USE pw_methods,                      ONLY: pw_axpy,&
+                                              pw_integral_ab
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_p_type,&
                                               pw_pool_type
@@ -198,7 +199,8 @@ CONTAINS
 !> \author Teodoro Laino
 ! **************************************************************************************************
    SUBROUTINE qmmm_modify_hartree_pot(v_hartree, v_qmmm, scale)
-      TYPE(pw_type), INTENT(IN)                          :: v_hartree, v_qmmm
+      TYPE(pw_type), INTENT(INOUT)                       :: v_hartree
+      TYPE(pw_type), INTENT(IN)                          :: v_qmmm
       REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CALL pw_axpy(v_qmmm, v_hartree, v_qmmm%pw_grid%dvol*scale)

--- a/src/qs_ks_qmmm_methods.F
+++ b/src/qs_ks_qmmm_methods.F
@@ -23,7 +23,7 @@ MODULE qs_ks_qmmm_methods
    USE kinds,                           ONLY: dp
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_retain
-   USE pw_methods,                      ONLY: pw_integral_ab
+   USE pw_methods,                      ONLY: pw_integral_ab,pw_axpy
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_p_type,&
                                               pw_pool_type
@@ -201,17 +201,8 @@ CONTAINS
       TYPE(pw_type), INTENT(IN)                          :: v_hartree, v_qmmm
       REAL(KIND=dp), INTENT(IN)                          :: scale
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'qmmm_modify_hartree_pot'
+      CALL pw_axpy(v_qmmm, v_hartree, v_qmmm%pw_grid%dvol*scale)
 
-      INTEGER                                            :: handle
-      REAL(KIND=dp)                                      :: fac
-
-      CALL timeset(routineN, handle)
-
-      fac = v_qmmm%pw_grid%dvol*scale
-      v_hartree%cr3d = v_hartree%cr3d + fac*v_qmmm%cr3d
-
-      CALL timestop(handle)
    END SUBROUTINE qmmm_modify_hartree_pot
 
 END MODULE qs_ks_qmmm_methods

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -711,8 +711,7 @@ CONTAINS
                                    rho_g=rho_g, tau=tau, vxc_tau=vxc_tau, exc=exc, xc_section=xc_section, &
                                    pw_pool=xc_pw_pool, compute_virial=compute_virial, virial_xc=virial_xc_tmp)
             ! add to the existing work_v_rspace
-            work_v_rspace%cr3d = work_v_rspace%cr3d - &
-                                 dft_control%sic_scaling_b*vxc(1)%pw_grid%dvol*vxc(1)%cr3d
+            CALL pw_axpy(vxc(1), work_v_rspace, -dft_control%sic_scaling_b*vxc(1)%pw_grid%dvol)
          END IF
          energy%exc = energy%exc - dft_control%sic_scaling_b*exc
 
@@ -1350,9 +1349,7 @@ CONTAINS
                ! SIC not implemented (or at least not tested)
                CPASSERT(dft_control%sic_method_id == sic_none)
                !Only the xc potential, because it has to be integrated with the soft basis
-               v_rspace_new(ispin)%cr3d = &
-                  v_rspace_new(ispin)%pw_grid%dvol* &
-                  v_rspace_new(ispin)%cr3d
+               CALL pw_scale(v_rspace_new(ispin), v_rspace_new(ispin)%pw_grid%dvol)
 
                ! add the xc  part due to v_rspace soft
                rho_ao => rho_ao_kp(ispin, :)
@@ -1364,7 +1361,7 @@ CONTAINS
                                        gapw=gapw_xc)
 
                ! Now the Hartree potential to be integrated with the full basis
-               v_rspace_new(ispin)%cr3d = v_rspace%cr3d
+               CALL pw_copy(v_rspace, v_rspace_new(ispin))
             ELSE
                ! Add v_hartree + v_xc = v_rspace_new
                v_rspace_new(ispin)%cr3d = &
@@ -1374,15 +1371,12 @@ CONTAINS
             IF (dft_control%qs_control%ddapc_explicit_potential) THEN
                IF (dft_control%qs_control%ddapc_restraint_is_spin) THEN
                   IF (ispin == 1) THEN
-                     v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d &
-                                                + v_spin_ddapc_rest_r%cr3d
+                     CALL pw_axpy(v_spin_ddapc_rest_r, v_rspace_new(ispin), 1.0_dp)
                   ELSE
-                     v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d &
-                                                - v_spin_ddapc_rest_r%cr3d
+                     CALL pw_axpy(v_spin_ddapc_rest_r, v_rspace_new(ispin), -1.0_dp)
                   END IF
                ELSE
-                  v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d &
-                                             + v_spin_ddapc_rest_r%cr3d
+                  CALL pw_axpy(v_spin_ddapc_rest_r, v_rspace_new(ispin), 1.0_dp)
                END IF
             END IF
             ! CDFT constraint contribution
@@ -1406,9 +1400,8 @@ CONTAINS
                   CASE DEFAULT
                      CPABORT("Unknown constraint type.")
                   END SELECT
-                  v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d &
-                                             + csign*cdft_control%group(igroup)%weight%cr3d* &
-                                             cdft_control%strength(igroup)
+                  CALL pw_axpy(cdft_control%group(igroup)%weight, v_rspace_new(ispin), &
+                  csign*cdft_control%strength(igroup))
                END DO
             END IF
             ! functional derivative of the Hartree energy wrt the density in the presence of dielectric

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -83,9 +83,9 @@ MODULE qs_ks_utils
                                               PERIODIC_BC
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_grid_types,                   ONLY: PW_MODE_DISTRIBUTED
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_copy,&
+                                              pw_integral_ab,&
                                               pw_integrate_function,&
                                               pw_scale,&
                                               pw_transfer,&
@@ -386,8 +386,7 @@ CONTAINS
             DO ispin = 1, Nspin
                CALL dbcsr_set(matrix_h(ispin)%matrix, 0.0_dp)
                ! use a work_v_rspace
-               work_v_rspace%cr3d = (energy_scaling(iterm)*vxc(ispin)%pw_grid%dvol)* &
-                                    vxc(ispin)%cr3d
+               CALL pw_axpy(vxc(ispin), work_v_rspace, energy_scaling(iterm)*vxc(ispin)%pw_grid%dvol, 0.0_dp)
                CALL integrate_v_rspace(v_rspace=work_v_rspace, pmat=matrix_p(ispin), hmat=matrix_h(ispin), &
                                        qs_env=qs_env, calculate_forces=calculate_forces)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc(ispin))
@@ -1364,9 +1363,7 @@ CONTAINS
                CALL pw_copy(v_rspace, v_rspace_new(ispin))
             ELSE
                ! Add v_hartree + v_xc = v_rspace_new
-               v_rspace_new(ispin)%cr3d = &
-                  v_rspace_new(ispin)%pw_grid%dvol* &
-                  v_rspace_new(ispin)%cr3d + v_rspace%cr3d
+               CALL pw_axpy(v_rspace, v_rspace_new(ispin), 1.0_dp, v_rspace_new(ispin)%pw_grid%dvol)
             END IF ! gapw_xc
             IF (dft_control%qs_control%ddapc_explicit_potential) THEN
                IF (dft_control%qs_control%ddapc_restraint_is_spin) THEN
@@ -1401,7 +1398,7 @@ CONTAINS
                      CPABORT("Unknown constraint type.")
                   END SELECT
                   CALL pw_axpy(cdft_control%group(igroup)%weight, v_rspace_new(ispin), &
-                  csign*cdft_control%strength(igroup))
+                               csign*cdft_control%strength(igroup))
                END DO
             END IF
             ! functional derivative of the Hartree energy wrt the density in the presence of dielectric
@@ -1409,13 +1406,11 @@ CONTAINS
             ! of the charge density
             IF (poisson_env%parameters%solver .EQ. pw_poisson_implicit) THEN
                dvol = poisson_env%implicit_env%v_eps%pw_grid%dvol
-               v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d + &
-                                          poisson_env%implicit_env%v_eps%cr3d*dvol
+               CALL pw_axpy(poisson_env%implicit_env%v_eps, v_rspace_new(ispin), dvol)
             END IF
             ! Add SCCS contribution
             IF (dft_control%do_sccs) THEN
-               v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d + &
-                                          v_sccs_rspace%cr3d
+               CALL pw_axpy(v_sccs_rspace, v_rspace_new(ispin))
             END IF
             ! External electrostatic potential
             IF (dft_control%apply_external_potential) THEN
@@ -1424,8 +1419,7 @@ CONTAINS
             END IF
             IF (do_ppl) THEN
                CPASSERT(.NOT. gapw)
-               v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d + &
-                                          vppl_rspace%cr3d*vppl_rspace%pw_grid%dvol
+               CALL pw_axpy(vppl_rspace, v_rspace_new(ispin), vppl_rspace%pw_grid%dvol)
             END IF
             ! the electrostatic sic contribution
             SELECT CASE (dft_control%sic_method_id)
@@ -1433,22 +1427,18 @@ CONTAINS
                !
             CASE (sic_mauri_us, sic_mauri_spz)
                IF (ispin == 1) THEN
-                  v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d - &
-                                             v_sic_rspace%cr3d
+                  CALL pw_axpy(v_sic_rspace, v_rspace_new(ispin), -1.0_dp)
                ELSE
-                  v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d + &
-                                             v_sic_rspace%cr3d
+                  CALL pw_axpy(v_sic_rspace, v_rspace_new(ispin), 1.0_dp)
                END IF
             CASE (sic_ad)
-               v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d - v_sic_rspace%cr3d
+               CALL pw_axpy(v_sic_rspace, v_rspace_new(ispin), -1.0_dp)
             CASE (sic_eo)
                ! NOTHING TO BE DONE
             END SELECT
             ! DFT embedding
             IF (dft_control%apply_embed_pot) THEN
-               v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d + &
-                                          v_rspace_embed(ispin)%pw_grid%dvol* &
-                                          v_rspace_embed(ispin)%cr3d
+               CALL pw_axpy(v_rspace_embed(ispin), v_rspace_new(ispin), v_rspace_embed(ispin)%pw_grid%dvol)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_embed(ispin))
             END IF
             IF (lrigpw) THEN
@@ -1511,17 +1501,15 @@ CONTAINS
             ! extra contribution attributed to the dependency of the dielectric constant to the charge density
             IF (poisson_env%parameters%solver .EQ. pw_poisson_implicit) THEN
                dvol = poisson_env%implicit_env%v_eps%pw_grid%dvol
-               v_rspace%cr3d = v_rspace%cr3d + poisson_env%implicit_env%v_eps%cr3d*dvol
+               CALL pw_axpy(poisson_env%implicit_env%v_eps, v_rspace, dvol)
             END IF
             ! Add SCCS contribution
             IF (dft_control%do_sccs) THEN
-               v_rspace%cr3d = v_rspace%cr3d + v_sccs_rspace%cr3d
+               CALL pw_axpy(v_sccs_rspace, v_rspace)
             END IF
             ! DFT embedding
             IF (dft_control%apply_embed_pot) THEN
-               v_rspace%cr3d = v_rspace%cr3d + &
-                               v_rspace_embed(ispin)%pw_grid%dvol* &
-                               v_rspace_embed(ispin)%cr3d
+               CALL pw_axpy(v_rspace_embed(ispin), v_rspace, v_rspace_embed(ispin)%pw_grid%dvol)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_embed(ispin))
             END IF
             IF (lrigpw) THEN
@@ -1599,9 +1587,7 @@ CONTAINS
             CPABORT("LRIGPW/RIGPW not implemented for meta-GGAs")
          END IF
          DO ispin = 1, nspins
-            v_tau_rspace(ispin)%cr3d = &
-               v_tau_rspace(ispin)%pw_grid%dvol* &
-               v_tau_rspace(ispin)%cr3d
+            CALL pw_scale(v_tau_rspace(ispin), v_tau_rspace(ispin)%pw_grid%dvol)
 
             rho_ao => rho_ao_kp(ispin, :)
             ksmat => ks_matrix(ispin, :)
@@ -1624,9 +1610,7 @@ CONTAINS
          IF (ASSOCIATED(v_rspace_new_aux_fit)) THEN
             DO ispin = 1, nspins
                ! Calculate the xc potential
-               v_rspace_new_aux_fit(ispin)%cr3d = &
-                  v_rspace_new_aux_fit(ispin)%pw_grid%dvol* &
-                  v_rspace_new_aux_fit(ispin)%cr3d
+               CALL pw_scale(v_rspace_new_aux_fit(ispin), v_rspace_new_aux_fit(ispin)%pw_grid%dvol)
 
                ! set matrix_ks_aux_fit_dft = matrix_ks_aux_fit(k_HF)
                CALL dbcsr_copy(matrix_ks_aux_fit_dft(ispin)%matrix, matrix_ks_aux_fit(ispin)%matrix, &
@@ -1752,7 +1736,6 @@ CONTAINS
       do_zmp_read = dft_control%apply_external_vxc
       IF (do_zmp_read) THEN
          CALL pw_copy(qs_env%external_vxc, v_rspace_new(1))
-         exc = 0.0_dp
          exc = accurate_dot_product(v_rspace_new(1)%cr3d, rho_r(1)%cr3d)* &
                v_rspace_new(1)%pw_grid%dvol
       ELSE
@@ -1793,14 +1776,8 @@ CONTAINS
             CALL pw_copy(v_rspace_new(1), v_xc_rspace)
 
             exc = 0.0_dp
-            exc = accurate_sum(v_rspace_new(1)%cr3d*rho_r(1)%cr3d)* &
-                  v_rspace_new(1)%pw_grid%dvol
-            IF (v_rspace_new(1)%pw_grid%para%mode == PW_MODE_DISTRIBUTED) THEN
-               CALL v_rspace_new(1)%pw_grid%para%group%sum(exc)
-            END IF
+            exc = pw_integral_ab(v_rspace_new(1), rho_r(1))
 
-!     IF (v_rspace_new(1)%pw_grid%para%my_pos==0) &
-!           WRITE(*,FMT="(T3,A,T61,F20.10)") "ZMP| Integral of (electron density)*(v_xc):    " , exc
 !Note that this is not the xc energy but \int(\rho*v_xc)
 !Vxc---> v_rspace_new
 !Exc---> energy%exc
@@ -1837,7 +1814,7 @@ CONTAINS
 
       CHARACTER(*), PARAMETER :: routineN = 'get_embed_potential_energy'
 
-      INTEGER                                            :: handle, ispin, ns1, ns2
+      INTEGER                                            :: handle, ispin
       REAL(KIND=dp)                                      :: embed_corr_local
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
@@ -1862,29 +1839,17 @@ CONTAINS
          CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_rspace_embed(ispin), &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(v_rspace_embed(ispin))
-         ns1 = SIZE(qs_env%embed_pot%cr3d)
-         ns2 = SIZE(v_rspace_embed(ispin)%cr3d)
-         IF (ns1 .NE. ns2) CPABORT("Subsystem grids must be identical")
 
-         v_rspace_embed(ispin)%cr3d(:, :, :) = qs_env%embed_pot%cr3d
+         CALL pw_copy(qs_env%embed_pot, v_rspace_embed(ispin))
          embed_corr_local = 0.0_dp
 
          ! Spin embedding potential in open-shell case
          IF (dft_control%nspins .EQ. 2) THEN
-            ns1 = SIZE(qs_env%spin_embed_pot%cr3d)
-            IF (ns1 .NE. ns2) CPABORT("Subsystem grids must be identical")
-            IF (ispin .EQ. 1) v_rspace_embed(ispin)%cr3d(:, :, :) = &
-               v_rspace_embed(ispin)%cr3d(:, :, :) + qs_env%spin_embed_pot%cr3d
-            IF (ispin .EQ. 2) v_rspace_embed(ispin)%cr3d(:, :, :) = &
-               v_rspace_embed(ispin)%cr3d(:, :, :) - qs_env%spin_embed_pot%cr3d
+            IF (ispin .EQ. 1) CALL pw_axpy(qs_env%spin_embed_pot, v_rspace_embed(ispin), 1.0_dp)
+            IF (ispin .EQ. 2) CALL pw_axpy(qs_env%spin_embed_pot, v_rspace_embed(ispin), -1.0_dp)
          END IF
          ! Integrate the density*potential
-         embed_corr_local = accurate_dot_product(v_rspace_embed(ispin)%cr3d, rho_r(ispin)%cr3d)* &
-                            v_rspace_embed(ispin)%pw_grid%dvol
-
-         IF (v_rspace_embed(ispin)%pw_grid%para%mode == PW_MODE_DISTRIBUTED) THEN
-            CALL v_rspace_embed(ispin)%pw_grid%para%group%sum(embed_corr_local)
-         END IF
+         embed_corr_local = pw_integral_ab(v_rspace_embed(ispin), rho_r(ispin))
 
          embed_corr = embed_corr + embed_corr_local
 

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -373,8 +373,8 @@ CONTAINS
             IF (nspins == 1) THEN
 
                IF (.NOT. (lr_triplet)) THEN
-                  v_rspace_new(1)%cr3d = 2.0_dp*v_rspace_new(1)%cr3d
-                  IF (ASSOCIATED(v_xc_tau)) v_xc_tau(1)%cr3d = 2.0_dp*v_xc_tau(1)%cr3d
+                  CALL pw_scale(v_rspace_new(1), 2.0_dp)
+                  IF (ASSOCIATED(v_xc_tau)) CALL pw_scale(v_xc_tau(1), 2.0_dp)
                END IF
                CALL qs_rho_get(rho1, rho_ao=rho1_ao)
                ! remove kpp1_env%v_ao and work directly on k_p_p1 ?
@@ -432,18 +432,16 @@ CONTAINS
 
             IF (nspins == 1) THEN
                IF (.NOT. (lr_triplet)) THEN
-                  v_rspace_new(1)%cr3d = 2.0_dp*v_rspace_new(1)%cr3d
-                  IF (ASSOCIATED(v_xc_tau)) v_xc_tau(1)%cr3d = 2.0_dp*v_xc_tau(1)%cr3d
+                  CALL pw_scale(v_rspace_new(1), 2.0_dp)
+                  IF (ASSOCIATED(v_xc_tau)) CALL pw_scale(v_xc_tau(1), 2.0_dp)
                END IF
                ! add hartree only for SINGLETS
                !IF (res_etype == tddfpt_singlet) THEN
                IF (.NOT. lr_triplet) THEN
-                  v_rspace_new(1)%cr3d = v_rspace_new(1)%cr3d + &
-                                         2.0_dp*v_hartree_rspace%cr3d
+                  CALL pw_axpy(v_hartree_rspace, v_rspace_new(1), 2.0_dp)
                END IF
             ELSE
-               v_rspace_new(ispin)%cr3d = v_rspace_new(ispin)%cr3d + &
-                                          v_hartree_rspace%cr3d
+               CALL pw_axpy(v_hartree_rspace, v_rspace_new(ispin), 1.0_dp)
             END IF
 
             IF (lrigpw) THEN
@@ -933,7 +931,7 @@ CONTAINS
             IF (nspins == 1) alpha = 2.0_dp
 
             DO ispin = 1, nspins
-               v_xc(ispin)%cr3d = v_xc(ispin)%cr3d*v_xc(ispin)%pw_grid%dvol
+               CALL pw_scale(v_xc(ispin), v_xc(ispin)%pw_grid%dvol)
                CALL dbcsr_copy(xcmat%matrix, matrix_s(1)%matrix)
                CALL dbcsr_set(xcmat%matrix, 0.0_dp)
                CALL integrate_v_rspace(v_rspace=v_xc(ispin), hmat=xcmat, qs_env=qs_env, &

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -395,7 +395,7 @@ CONTAINS
 
                ! add hartree only for SINGLETS
                IF (.NOT. lr_triplet) THEN
-                  v_rspace_new(1)%cr3d = 2.0_dp*v_hartree_rspace%cr3d
+                  CALL pw_axpy(v_hartree_rspace, v_rspace_new(1), 2.0_dp, 0.0_dp)
 
                   CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
                                           pmat=rho_ao(ispin), &
@@ -420,7 +420,7 @@ CONTAINS
                                           calculate_forces=.FALSE., gapw=gapw_xc)
                END IF
 
-               v_rspace_new(ispin)%cr3d = v_hartree_rspace%cr3d
+               CALL pw_copy(v_hartree_rspace, v_rspace_new(ispin))
                CALL integrate_v_rspace(v_rspace=v_rspace_new(ispin), &
                                        pmat=rho_ao(ispin), &
                                        hmat=kpp1_env%v_ao(ispin), &

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -32,7 +32,7 @@ MODULE qs_rho0_ggrid
                                               pw_copy,&
                                               pw_integrate_function,&
                                               pw_transfer,&
-                                              pw_zero
+                                              pw_zero,pw_scale
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_give_back_pw,&
                                               pw_pool_p_type,&
@@ -457,7 +457,7 @@ CONTAINS
          CALL pw_pool_create_pw(pw_aux, coeff_raux, use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          fscale = coeff_rspace%pw_grid%dvol/coeff_raux%pw_grid%dvol
-         coeff_rspace%cr3d = fscale*coeff_rspace%cr3d
+         CALL pw_scale(coeff_rspace, fscale)
          CALL pw_pool_give_back_pw(pw_aux, coeff_raux)
       ELSE
 

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -31,8 +31,9 @@ MODULE qs_rho0_ggrid
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_copy,&
                                               pw_integrate_function,&
+                                              pw_scale,&
                                               pw_transfer,&
-                                              pw_zero,pw_scale
+                                              pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_give_back_pw,&
                                               pw_pool_p_type,&

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -300,8 +300,7 @@ CONTAINS
          ALLOCATE (rho0_mpole%rho0_s_gs)
       END IF
       CALL pw_pool_create_pw(auxbas_pw_pool, rho0_mpole%rho0_s_gs, &
-                             use_data=COMPLEXDATA1D)
-      rho0_mpole%rho0_s_gs%in_space = RECIPROCALSPACE
+                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! Find the grid level suitable for rho0_soft
       rho0_mpole%igrid_zet0_s = gaussian_gridlevel(pw_env%gridlevel_info, 2.0_dp*rho0_mpole%zet0_h)

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -906,14 +906,15 @@ CONTAINS
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_out(i), &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
-               rho_g_out(i)%cc(:) = rho_g_in(1)%cc(:)*ospin
+               CALL pw_copy(rho_g_in(1), rho_g_out(i))
+               CALL pw_scale(rho_g_out(i), ospin)
             END DO
          ELSE
             DO i = 1, nspins
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_out(i), &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
-               rho_g_out(i)%cc(:) = rho_g_in(i)%cc(:)
+               CALL pw_copy(rho_g_in(i), rho_g_out(i))
             END DO
          END IF
       END IF
@@ -965,7 +966,8 @@ CONTAINS
                   CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j), &
                                          use_data=COMPLEXDATA1D, &
                                          in_space=RECIPROCALSPACE)
-                  drho_g_out(i, j)%cc(:) = drho_g_in(i, 1)%cc(:)*ospin
+                  CALL pw_copy(drho_g_in(i, 1), drho_g_out(i, j))
+                  CALL pw_scale(drho_g_out(i, j), ospin)
                END DO
             END DO
          ELSE
@@ -974,7 +976,7 @@ CONTAINS
                   CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j), &
                                          use_data=COMPLEXDATA1D, &
                                          in_space=RECIPROCALSPACE)
-                  drho_g_out(i, j)%cc(:) = drho_g_in(i, j)%cc(:)
+                  CALL pw_copy(drho_g_in(i, j), drho_g_out(i, j))
                END DO
             END DO
          END IF
@@ -1013,14 +1015,15 @@ CONTAINS
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_g_out(i), &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
-               tau_g_out(i)%cc(:) = tau_g_in(1)%cc(:)*ospin
+               CALL pw_copy(tau_g_in(1), tau_g_out(i))
+               CALL pw_scale(tau_g_out(i), ospin)
             END DO
          ELSE
             DO i = 1, nspins
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_g_out(i), &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
-               tau_g_out(i)%cc(:) = tau_g_in(i)%cc(:)
+               CALL pw_copy(tau_g_in(i), tau_g_out(i))
             END DO
          END IF
       END IF

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -33,7 +33,10 @@ MODULE qs_rho_methods
    USE message_passing,                 ONLY: mp_para_env_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_methods,                      ONLY: pw_zero, pw_scale, pw_copy
+   USE pw_methods,                      ONLY: pw_axpy,&
+                                              pw_copy,&
+                                              pw_scale,&
+                                              pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
@@ -1153,7 +1156,7 @@ CONTAINS
          nspinb = SIZE(rho_ao_b)
          nspins = MIN(nspina, nspinb)
          DO i = 1, nspins
-            rho_r_a(i)%cr3d(:, :, :) = alpha*rho_r_a(i)%cr3d(:, :, :) + beta*rho_r_b(i)%cr3d(:, :, :)
+            CALL pw_axpy(rho_r_b(i), rho_r_a(i), beta, alpha)
          END DO
       END IF
 
@@ -1163,13 +1166,13 @@ CONTAINS
          nspinb = SIZE(rho_ao_b)
          nspins = MIN(nspina, nspinb)
          DO i = 1, nspins
-            rho_g_a(i)%cc(:) = alpha*rho_g_a(i)%cc(:) + beta*rho_g_b(i)%cc(:)
+            CALL pw_axpy(rho_g_b(i), rho_g_a(i), beta, alpha)
          END DO
       END IF
 
       ! SCCS
       IF (ASSOCIATED(rho_r_sccs_a) .AND. ASSOCIATED(rho_r_sccs_b)) THEN
-         rho_r_sccs_a%cr3d(:, :, :) = alpha*rho_r_sccs_a%cr3d(:, :, :) + beta*rho_r_sccs_b%cr3d(:, :, :)
+         CALL pw_axpy(rho_r_sccs_b, rho_r_sccs_a, beta, alpha)
       END IF
 
       ! drho_r
@@ -1177,7 +1180,7 @@ CONTAINS
          CPASSERT(ALL(SHAPE(drho_r_a) == SHAPE(drho_r_b))) ! not implemented
          DO j = 1, SIZE(drho_r_a, 2)
             DO i = 1, SIZE(drho_r_a, 1)
-               drho_r_a(i, j)%cr3d(:, :, :) = alpha*drho_r_a(i, j)%cr3d(:, :, :) + beta*drho_r_b(i, j)%cr3d(:, :, :)
+               CALL pw_axpy(drho_r_b(i, j), drho_r_a(i, j), beta, alpha)
             END DO
          END DO
       END IF
@@ -1187,7 +1190,7 @@ CONTAINS
          CPASSERT(ALL(SHAPE(drho_g_a) == SHAPE(drho_g_b))) ! not implemented
          DO j = 1, SIZE(drho_g_a, 2)
             DO i = 1, SIZE(drho_g_a, 1)
-               drho_g_a(i, j)%cc(:) = alpha*drho_g_a(i, j)%cc(:) + beta*drho_g_b(i, j)%cc(:)
+               CALL pw_axpy(drho_g_b(i, j), drho_g_a(i, j), beta, alpha)
             END DO
          END DO
       END IF
@@ -1198,7 +1201,7 @@ CONTAINS
          nspinb = SIZE(rho_ao_b)
          nspins = MIN(nspina, nspinb)
          DO i = 1, nspins
-            tau_r_a(i)%cr3d(:, :, :) = alpha*tau_r_a(i)%cr3d(:, :, :) + beta*tau_r_b(i)%cr3d(:, :, :)
+            CALL pw_axpy(tau_r_b(i), tau_r_a(i), beta, alpha)
          END DO
       END IF
 
@@ -1208,7 +1211,7 @@ CONTAINS
          nspinb = SIZE(rho_ao_b)
          nspins = MIN(nspina, nspinb)
          DO i = 1, nspins
-            tau_g_a(i)%cc(:) = alpha*tau_g_a(i)%cc(:) + beta*tau_g_b(i)%cc(:)
+            CALL pw_axpy(tau_g_b(i), tau_g_a(i), beta, alpha)
          END DO
       END IF
 

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -33,7 +33,7 @@ MODULE qs_rho_methods
    USE message_passing,                 ONLY: mp_para_env_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_methods,                      ONLY: pw_zero
+   USE pw_methods,                      ONLY: pw_zero, pw_scale, pw_copy
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
@@ -880,13 +880,14 @@ CONTAINS
             DO i = 1, mspin
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_out(i), &
                                       use_data=REALDATA3D, in_space=REALSPACE)
-               rho_r_out(i)%cr3d(:, :, :) = rho_r_in(1)%cr3d(:, :, :)*ospin
+               CALL pw_copy(rho_r_in(1), rho_r_out(i))
+               CALL pw_scale(rho_r_out(i), ospin)
             END DO
          ELSE
             DO i = 1, nspins
                CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_out(i), &
                                       use_data=REALDATA3D, in_space=REALSPACE)
-               rho_r_out(i)%cr3d(:, :, :) = rho_r_in(i)%cr3d(:, :, :)
+               CALL pw_copy(rho_r_in(i), rho_r_out(i))
             END DO
          END IF
       END IF
@@ -920,7 +921,7 @@ CONTAINS
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out, &
                                 in_space=REALSPACE, &
                                 use_data=REALDATA3D)
-         rho_r_sccs_out%cr3d(:, :, :) = rho_r_sccs_in%cr3d(:, :, :)
+         CALL pw_copy(rho_r_sccs_in, rho_r_sccs_out)
       END IF
 
       ! drho_r
@@ -934,7 +935,8 @@ CONTAINS
                DO i = 1, 3
                   CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  drho_r_out(i, j)%cr3d(:, :, :) = drho_r_in(i, 1)%cr3d(:, :, :)*ospin
+                  CALL pw_copy(drho_r_in(i, 1), drho_r_out(i, j))
+                  CALL pw_scale(drho_r_out(i, j), ospin)
                END DO
             END DO
          ELSE
@@ -942,7 +944,7 @@ CONTAINS
                DO i = 1, 3
                   CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  drho_r_out(i, j)%cr3d(:, :, :) = drho_r_in(i, j)%cr3d(:, :, :)
+                  CALL pw_copy(drho_r_in(i, j), drho_r_out(i, j))
                END DO
             END DO
          END IF
@@ -985,13 +987,14 @@ CONTAINS
             DO i = 1, mspin
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_r_out(i), &
                                       use_data=REALDATA3D, in_space=REALSPACE)
-               tau_r_out(i)%cr3d(:, :, :) = tau_r_in(1)%cr3d(:, :, :)*ospin
+               CALL pw_copy(tau_r_in(1), tau_r_out(i))
+               CALL pw_scale(tau_r_out(i), ospin)
             END DO
          ELSE
             DO i = 1, nspins
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_r_out(i), &
                                       use_data=REALDATA3D, in_space=REALSPACE)
-               tau_r_out(i)%cr3d(:, :, :) = tau_r_in(i)%cr3d(:, :, :)
+               CALL pw_copy(tau_r_in(i), tau_r_out(i))
             END DO
          END IF
       END IF
@@ -1338,7 +1341,7 @@ CONTAINS
          DO i = 1, nspins
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_out(i), &
                                    use_data=REALDATA3D, in_space=REALSPACE)
-            rho_r_out(i)%cr3d(:, :, :) = rho_r_in(i)%cr3d(:, :, :)
+            CALL pw_copy(rho_r_in(i), rho_r_out(i))
          END DO
       END IF
 
@@ -1350,7 +1353,7 @@ CONTAINS
             CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_out(i), &
                                    use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
-            rho_g_out(i)%cc(:) = rho_g_in(i)%cc(:)
+            CALL pw_copy(rho_g_in(i), rho_g_out(i))
          END DO
       END IF
 
@@ -1360,7 +1363,7 @@ CONTAINS
          CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out, &
                                 in_space=REALSPACE, &
                                 use_data=REALDATA3D)
-         rho_r_sccs_out%cr3d(:, :, :) = rho_r_sccs_in%cr3d(:, :, :)
+         CALL pw_copy(rho_r_sccs_in, rho_r_sccs_out)
       END IF
 
       ! drho_r and drho_g are only needed if calculated by collocation
@@ -1373,7 +1376,7 @@ CONTAINS
                DO i = 1, 3
                   CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j), &
                                          use_data=REALDATA3D, in_space=REALSPACE)
-                  drho_r_out(i, j)%cr3d(:, :, :) = drho_r_in(i, j)%cr3d(:, :, :)
+                  CALL pw_copy(drho_r_in(i, j), drho_r_out(i, j))
                END DO
             END DO
          END IF
@@ -1387,7 +1390,7 @@ CONTAINS
                   CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j), &
                                          use_data=COMPLEXDATA1D, &
                                          in_space=RECIPROCALSPACE)
-                  drho_g_out(i, j)%cc(:) = drho_g_in(i, j)%cc(:)
+                  CALL pw_copy(drho_g_in(i, j), drho_g_out(i, j))
                END DO
             END DO
          END IF
@@ -1404,7 +1407,7 @@ CONTAINS
             DO i = 1, nspins
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_r_out(i), &
                                       use_data=REALDATA3D, in_space=REALSPACE)
-               tau_r_out(i)%cr3d(:, :, :) = tau_r_in(i)%cr3d(:, :, :)
+               CALL pw_copy(tau_r_in(i), tau_r_out(i))
             END DO
          END IF
 
@@ -1416,7 +1419,7 @@ CONTAINS
                CALL pw_pool_create_pw(auxbas_pw_pool, tau_g_out(i), &
                                       use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
-               tau_g_out(i)%cc(:) = tau_g_in(i)%cc(:)
+               CALL pw_copy(tau_g_in(i), tau_g_out(i))
             END DO
          END IF
       END IF

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -68,7 +68,7 @@ MODULE qs_sccs
                                               pw_derive,&
                                               pw_integral_ab,&
                                               pw_transfer,&
-                                              pw_zero
+                                              pw_zero,pw_integrate_function
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_analytic,&
                                               pw_poisson_mt,&
@@ -288,8 +288,7 @@ CONTAINS
          DO ispin = 2, nspin
             CALL pw_axpy(rho_pw_r(ispin), rho_elec)
          END DO
-         tot_rho_elec = accurate_sum(rho_elec%cr3d)*dvol
-         CALL para_env%sum(tot_rho_elec)
+         tot_rho_elec = pw_integrate_function(rho_elec)
 
          ! Calculate the dielectric (smoothed) function of rho_elec in r-space
          CALL pw_pool_create_pw(auxbas_pw_pool, &
@@ -370,8 +369,7 @@ CONTAINS
                   END DO
                END DO
 !$OMP    END PARALLEL DO
-               cavity_volume = accurate_sum(theta%cr3d)*dvol
-               CALL para_env%sum(cavity_volume)
+               cavity_volume = pw_integrate_function(theta)
 
                ! Calculate the derivative of the electronic density in r-space
                ! TODO: Could be retrieved from the QS environment
@@ -448,8 +446,7 @@ CONTAINS
                CASE DEFAULT
                   CPABORT("Invalid method specified for SCCS model")
                END SELECT
-               cavity_surface = accurate_sum(theta%cr3d)*dvol
-               CALL para_env%sum(cavity_surface)
+               cavity_surface = pw_integrate_function(theta)
 
                ! Release storage
                CALL pw_pool_give_back_pw(auxbas_pw_pool, theta)
@@ -473,8 +470,7 @@ CONTAINS
                                 in_space=REALSPACE)
          CALL pw_zero(rho_solute)
          CALL pw_transfer(rho_tot_gspace, rho_solute)
-         tot_rho_solute = accurate_sum(rho_solute%cr3d)*dvol
-         CALL para_env%sum(tot_rho_solute)
+         tot_rho_solute = pw_integrate_function(rho_solute)
 
          ! Check total charge
          IF (ABS(tot_rho_solute) >= 1.0E-6_dp) THEN
@@ -763,8 +759,7 @@ CONTAINS
          ! Calculate the polarisation charge (store it in rho_tot)
          ! rho_pol = rho_tot - rho_solute
          CALL pw_axpy(rho_solute, rho_tot, alpha=-1.0_dp)
-         polarisation_charge = accurate_sum(rho_tot%cr3d)*dvol
-         CALL para_env%sum(polarisation_charge)
+         polarisation_charge = pw_integrate_function(rho_tot)
 
          ! Optional output of the SCCS polarisation charge in cube file format
          filename = "POLARISATION_CHARGE_DENSITY"

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -52,7 +52,6 @@ MODULE qs_sccs
                                               section_get_lval,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type
-   USE kahan_sum,                       ONLY: accurate_sum
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
                                               dp,&
@@ -67,8 +66,9 @@ MODULE qs_sccs
                                               pw_copy,&
                                               pw_derive,&
                                               pw_integral_ab,&
+                                              pw_integrate_function,&
                                               pw_transfer,&
-                                              pw_zero,pw_integrate_function
+                                              pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_analytic,&
                                               pw_poisson_mt,&

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -325,7 +325,7 @@ CONTAINS
             IF (do_adiabatic_rescaling) THEN
                IF (ASSOCIATED(my_vxc_rho)) THEN
                   DO ispin = 1, SIZE(my_vxc_rho)
-                     my_vxc_rho(ispin)%cr3d = my_vxc_rho(ispin)%cr3d*my_adiabatic_rescale_factor
+                     CALL pw_scale(my_vxc_rho(ispin), my_adiabatic_rescale_factor)
                   END DO
                END IF
             END IF
@@ -335,12 +335,12 @@ CONTAINS
             exc = exc*my_scaling
             IF (ASSOCIATED(my_vxc_rho)) THEN
                DO ispin = 1, SIZE(my_vxc_rho)
-                  my_vxc_rho(ispin)%cr3d = my_vxc_rho(ispin)%cr3d*my_scaling
+                  CALL pw_scale(my_vxc_rho(ispin), my_scaling)
                END DO
             END IF
             IF (ASSOCIATED(my_vxc_tau)) THEN
                DO ispin = 1, SIZE(my_vxc_tau)
-                  my_vxc_tau(ispin)%cr3d = my_vxc_tau(ispin)%cr3d*my_scaling
+                  CALL pw_scale(my_vxc_tau(ispin), my_scaling)
                END DO
             END IF
          END IF
@@ -410,10 +410,8 @@ CONTAINS
 
             ! and take care of the potential only vxc_rho is taken into account
             IF (.NOT. my_just_energy) THEN
-               vxc_rho(1)%cr3d = vxc_rho(1)%cr3d - dft_control%sic_scaling_b* &
-                                 my_vxc_rho(1)%cr3d
-               vxc_rho(2)%cr3d = vxc_rho(2)%cr3d + dft_control%sic_scaling_b* &
-                                 my_vxc_rho(1)%cr3d ! 1=m
+               CALL pw_axpy(my_vxc_rho(1), vxc_rho(1), -dft_control%sic_scaling_b)
+               CALL pw_axpy(my_vxc_rho(1), vxc_rho(2), dft_control%sic_scaling_b)
                CALL pw_release(my_vxc_rho(1))
                CALL pw_release(my_vxc_rho(2))
                DEALLOCATE (my_vxc_rho)
@@ -477,8 +475,7 @@ CONTAINS
 
                ! and take care of the potential only vxc_rho is taken into account
                IF (.NOT. my_just_energy) THEN
-                  vxc_rho(ispin)%cr3d = vxc_rho(ispin)%cr3d - dft_control%sic_scaling_b* &
-                                        my_vxc_rho(1)%cr3d
+                  CALL pw_axpy(my_vxc_rho(1), vxc_rho(ispin), -dft_control%sic_scaling_b)
                   CALL pw_release(my_vxc_rho(1))
                   CALL pw_release(my_vxc_rho(2))
                   DEALLOCATE (my_vxc_rho)
@@ -525,8 +522,7 @@ CONTAINS
             ! and take care of the potential
             IF (.NOT. my_just_energy) THEN
                ! both go to minority spin
-               vxc_rho(2)%cr3d = vxc_rho(2)%cr3d + &
-                                 2.0_dp*dft_control%sic_scaling_b*my_vxc_rho(1)%cr3d
+               CALL pw_axpy(my_vxc_rho(1), vxc_rho(2), 2.0_dp*dft_control%sic_scaling_b)
                CALL pw_release(my_vxc_rho(1))
                CALL pw_release(my_vxc_rho(2))
                DEALLOCATE (my_vxc_rho)

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -105,8 +105,10 @@ MODULE rpa_gw
    USE physcon,                         ONLY: evolt
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_methods,                      ONLY: pw_scale,&
-                                              pw_zero,pw_copy,pw_axpy
+   USE pw_methods,                      ONLY: pw_axpy,&
+                                              pw_copy,&
+                                              pw_scale,&
+                                              pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_give_back_pw,&
                                               pw_pool_type

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -105,6 +105,8 @@ MODULE rpa_gw
    USE physcon,                         ONLY: evolt
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
+   USE pw_methods,                      ONLY: pw_scale,&
+                                              pw_zero,pw_copy,pw_axpy
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_give_back_pw,&
                                               pw_pool_type
@@ -113,7 +115,6 @@ MODULE rpa_gw
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_type
-   USE pw_methods, ONLY: pw_zero, pw_scale
    USE qs_band_structure,               ONLY: calculate_kp_orbitals
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -2380,7 +2381,8 @@ CONTAINS
       CALL pw_scale(E_VBM_rspace, evolt)
       CALL pw_scale(E_CBM_rspace, evolt)
 
-      E_gap_rspace%cr3d(:, :, :) = E_CBM_rspace%cr3d(:, :, :) - E_VBM_rspace%cr3d(:, :, :)
+      CALL pw_copy(E_CBM_rspace, E_gap_rspace)
+      CALL pw_axpy(E_VBM_rspace, E_gap_rspace, -1.0_dp)
 
       gw_section => section_vals_get_subs_vals(qs_env%input, "DFT%XC%WF_CORRELATION%RI_RPA%GW")
       CALL qs_subsys_get(subsys, particles=particles)

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -113,6 +113,7 @@ MODULE rpa_gw
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
                                               pw_type
+   USE pw_methods, ONLY: pw_zero, pw_scale
    USE qs_band_structure,               ONLY: calculate_kp_orbitals
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -2337,8 +2338,8 @@ CONTAINS
       n_z_start = LBOUND(LDOS(1)%cr3d, 3)
       n_z_end = UBOUND(LDOS(1)%cr3d, 3)
 
-      E_VBM_rspace%cr3d(:, :, :) = 0.0_dp
-      E_CBM_rspace%cr3d(:, :, :) = 0.0_dp
+      CALL pw_zero(E_VBM_rspace)
+      CALL pw_zero(E_CBM_rspace)
 
       DO i_x = n_x_start, n_x_end
          DO i_y = n_y_start, n_y_end
@@ -2376,8 +2377,8 @@ CONTAINS
          END DO
       END DO
 
-      E_VBM_rspace%cr3d(:, :, :) = E_VBM_rspace%cr3d(:, :, :)*evolt
-      E_CBM_rspace%cr3d(:, :, :) = E_CBM_rspace%cr3d(:, :, :)*evolt
+      CALL pw_scale(E_VBM_rspace, evolt)
+      CALL pw_scale(E_CBM_rspace, evolt)
 
       E_gap_rspace%cr3d(:, :, :) = E_CBM_rspace%cr3d(:, :, :) - E_VBM_rspace%cr3d(:, :, :)
 

--- a/src/spme.F
+++ b/src/spme.F
@@ -36,6 +36,7 @@ MODULE spme
    USE pw_methods,                      ONLY: pw_copy,&
                                               pw_derive,&
                                               pw_integral_a2b,&
+                                              pw_multiply_with,&
                                               pw_transfer
    USE pw_poisson_methods,              ONLY: pw_poisson_rebuild,&
                                               pw_poisson_solve
@@ -232,7 +233,7 @@ CONTAINS
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
       ! update charge function
-      rhob_g%cc = rhob_g%cc*green%p3m_charge%cr
+      CALL pw_multiply_with(rhob_g, green%p3m_charge)
 
       !-------------- ELECTROSTATIC CALCULATION -----------
       ! allocate intermediate arrays
@@ -255,7 +256,7 @@ CONTAINS
          ALLOCATE (rpot)
          CALL rs_grid_create(rpot, rs_desc)
          CALL rs_grid_set_box(grid_spme, rs=rpot)
-         phi_g%cc = phi_g%cc*green%p3m_charge%cr
+         CALL pw_multiply_with(phi_g, green%p3m_charge)
          CALL pw_transfer(phi_g, rhob_r)
          CALL transfer_pw2rs(rpot, rhob_r)
          ipart = 0
@@ -319,7 +320,7 @@ CONTAINS
                   nd(j) = 1
                   CALL pw_copy(phi_g, rhob_g)
                   CALL pw_derive(rhob_g, nd)
-                  rhob_g%cc = rhob_g%cc*green%p3m_charge%cr
+                  CALL pw_multiply_with(rhob_g, green%p3m_charge)
                   CALL pw_transfer(rhob_g, rhob_r)
                   CALL transfer_pw2rs(rpot, rhob_r)
 
@@ -365,7 +366,7 @@ CONTAINS
       DO i = 1, 3
          CALL rs_grid_create(drpot(i), rs_desc)
          CALL rs_grid_set_box(grid_spme, rs=drpot(i))
-         dphi_g(i)%cc = dphi_g(i)%cc*green%p3m_charge%cr
+         CALL pw_multiply_with(dphi_g(i), green%p3m_charge)
          CALL pw_transfer(dphi_g(i), rhob_r)
          CALL pw_pool_give_back_pw(pw_pool, dphi_g(i))
          CALL transfer_pw2rs(drpot(i), rhob_r)
@@ -557,7 +558,7 @@ CONTAINS
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
       ! update charge function
-      rhob_g%cc = rhob_g%cc*green%p3m_charge%cr
+      CALL pw_multiply_with(rhob_g, green%p3m_charge)
 
       !-------------- ELECTROSTATIC CALCULATION -----------
       ! allocate intermediate arrays
@@ -573,7 +574,7 @@ CONTAINS
       ALLOCATE (center(3, npart_b), delta(3, npart_b))
       CALL get_center(particle_set_b, box, center, delta, npts, n)
       rpot => rden
-      phi_g%cc = phi_g%cc*green%p3m_charge%cr
+      CALL pw_multiply_with(phi_g, green%p3m_charge)
       CALL pw_transfer(phi_g, rhob_r)
       CALL transfer_pw2rs(rpot, rhob_r)
       ipart = 0
@@ -706,7 +707,7 @@ CONTAINS
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
       ! update charge function
-      rhob_g%cc = rhob_g%cc*green%p3m_charge%cr
+      CALL pw_multiply_with(rhob_g, green%p3m_charge)
 
       !-------------- ELECTROSTATIC CALCULATION -----------
       ! allocate intermediate arrays
@@ -728,7 +729,7 @@ CONTAINS
       DO i = 1, 3
          CALL rs_grid_create(drpot(i), rs_desc)
          CALL rs_grid_set_box(grid_spme, rs=drpot(i))
-         dphi_g(i)%cc = dphi_g(i)%cc*green%p3m_charge%cr
+         CALL pw_multiply_with(dphi_g(i), green%p3m_charge)
          CALL pw_transfer(dphi_g(i), rhob_r)
          CALL pw_pool_give_back_pw(pw_pool, dphi_g(i))
          CALL transfer_pw2rs(drpot(i), rhob_r)

--- a/src/surface_dipole.F
+++ b/src/surface_dipole.F
@@ -10,8 +10,7 @@ MODULE surface_dipole
 
    USE cell_types,                      ONLY: cell_type
    USE cp_control_types,                ONLY: dft_control_type
-   USE kahan_sum,                       ONLY: accurate_dot_product,&
-                                              accurate_sum
+   USE kahan_sum,                       ONLY: accurate_sum
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: pi
    USE physcon,                         ONLY: bohr
@@ -19,6 +18,8 @@ MODULE surface_dipole
                                               pw_env_type
    USE pw_grid_types,                   ONLY: PW_MODE_LOCAL
    USE pw_methods,                      ONLY: pw_axpy,&
+                                              pw_integral_ab,&
+                                              pw_scale,&
                                               pw_transfer,&
                                               pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
@@ -147,7 +148,7 @@ CONTAINS
       bo => wf_r%pw_grid%bounds_local
       dh = wf_r%pw_grid%dh
 
-      wf_r%cr3d = wf_r%cr3d*wf_r%pw_grid%vol
+      CALL pw_scale(wf_r, wf_r%pw_grid%vol)
       IF (idir_surfdip == 3) THEN
          isurf = 1
          jsurf = 2
@@ -171,7 +172,7 @@ CONTAINS
             rhoavsurf(i) = accurate_sum(wf_r%cr3d(i, bo(1, 2):bo(2, 2), bo(1, 3):bo(2, 3)))
          END DO
       END IF
-      wf_r%cr3d = wf_r%cr3d/wf_r%pw_grid%vol
+      CALL pw_scale(wf_r, 1.0_dp/wf_r%pw_grid%vol)
       rhoavsurf = rhoavsurf/wf_r%pw_grid%vol
 
       surfarea = cell%hmat(isurf, isurf)*cell%hmat(jsurf, jsurf) - &
@@ -263,13 +264,10 @@ CONTAINS
       END DO
 
 !    Dipole correction contribution to the energy
-      energy%surf_dipole = 0.5_dp*accurate_dot_product(vdip_r%cr3d, wf_r%cr3d)
-      IF (wf_r%pw_grid%para%mode /= PW_MODE_LOCAL) THEN
-         CALL wf_r%pw_grid%para%group%sum(energy%surf_dipole)
-      END IF
+      energy%surf_dipole = 0.5_dp*pw_integral_ab(vdip_r, wf_r, just_sum=.TRUE.)
 
 !    Add the dipole potential to the hartree potential on the realspace grid
-      v_hartree_rspace%cr3d = v_hartree_rspace%cr3d + vdip_r%cr3d
+      CALL pw_axpy(vdip_r, v_hartree_rspace)
 
       CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
       CALL pw_pool_give_back_pw(auxbas_pw_pool, vdip_r)

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -129,14 +129,11 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          NULLIFY (vtip)
          ALLOCATE (vtip)
-         CALL pw_pool_create_pw(auxbas_pw_pool, vtip, use_data=REALDATA3D)
-         vtip%in_space = REALSPACE
+         CALL pw_pool_create_pw(auxbas_pw_pool, vtip, REALDATA3D, REALSPACE)
          CALL pw_zero(vtip)
-         CALL pw_pool_create_pw(auxbas_pw_pool, vref, use_data=COMPLEXDATA1D)
-         vref%in_space = RECIPROCALSPACE
+         CALL pw_pool_create_pw(auxbas_pw_pool, vref, COMPLEXDATA1D, RECIPROCALSPACE)
          CALL pw_zero(vref)
-         CALL pw_pool_create_pw(auxbas_pw_pool, sf, use_data=COMPLEXDATA1D)
-         sf%in_space = RECIPROCALSPACE
+         CALL pw_pool_create_pw(auxbas_pw_pool, sf, COMPLEXDATA1D, RECIPROCALSPACE)
 
          ! get the reference tip potential and store it in reciprocal space (vref)
          CALL pw_transfer(scan_env%tip_pw_g, vref)

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -43,7 +43,10 @@ MODULE xc_pot_saop
    USE message_passing,                 ONLY: mp_para_env_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_methods,                      ONLY: pw_zero
+   USE pw_methods,                      ONLY: pw_axpy,&
+                                              pw_copy,&
+                                              pw_scale,&
+                                              pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
                                               pw_pool_give_back_pw,&
                                               pw_pool_type
@@ -142,7 +145,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: coeff_col
       REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_xc_tmp
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
-      REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: dummy, e_uniform
+      REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: e_uniform
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: single_mo_coeff
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: orbital_density_matrix, rho_struct_ao
@@ -168,7 +171,7 @@ CONTAINS
       NULLIFY (rho_g, rho_r, tau, rho_struct, e_uniform)
       NULLIFY (vxc_LB, vxc_tmp, vxc_tau)
       NULLIFY (mo_eigenvalues, deriv, rho_struct_r, rho_struct_ao)
-      NULLIFY (orbital_density_matrix, dummy, xc_section_tmp, xc_fun_section_tmp)
+      NULLIFY (orbital_density_matrix, xc_section_tmp, xc_fun_section_tmp)
 
       CALL get_qs_env(qs_env, &
                       ks_env=ks_env, &
@@ -270,15 +273,13 @@ CONTAINS
                              compute_virial=.FALSE., virial_xc=virial_xc_tmp)
 
       DO ispin = 1, nspins
-         vxc_LB(ispin)%cr3d = vxc_LB(ispin)%cr3d + alpha*vxc_tmp(ispin)%cr3d
+         CALL pw_axpy(vxc_tmp(ispin), vxc_LB(ispin), alpha)
       END DO
 
       DO ispin = 1, nspins
-         dummy => vxc_tmp(ispin)%cr3d
-         CALL add_lb_pot(dummy, rho_set, lsd, ispin)
-         vxc_LB(ispin)%cr3d = vxc_LB(ispin)%cr3d - vxc_tmp(ispin)%cr3d
+         CALL add_lb_pot(vxc_tmp(ispin)%cr3d, rho_set, lsd, ispin)
+         CALL pw_axpy(vxc_tmp(ispin), vxc_LB(ispin), -1.0_dp)
       END DO
-      NULLIFY (dummy)
 
       !-----------------------------------------------------------------------------------!
       ! Construct 2 times PBE one particle density from the PZ correlation energy density !
@@ -301,10 +302,8 @@ CONTAINS
       END DO
 
       DO ispin = 1, nspins
-         dummy => vxc_GLLB(ispin)%cr3d
-         CALL calc_2excpbe(dummy, rho_set, e_uniform, lsd)
+         CALL calc_2excpbe(vxc_GLLB(ispin)%cr3d, rho_set, e_uniform, lsd)
       END DO
-      NULLIFY (dummy)
 
       CALL xc_dset_release(deriv_set)
 
@@ -352,8 +351,7 @@ CONTAINS
                                     rho=orbital, rho_gspace=orbital_g, &
                                     ks_env=ks_env)
 
-            vxc_tmp(ispin)%cr3d = vxc_tmp(ispin)%cr3d + &
-                                  efac*orbital%cr3d
+            CALL pw_axpy(orbital, vxc_tmp(ispin), efac)
 
          END DO
          DEALLOCATE (coeff_col)
@@ -371,7 +369,7 @@ CONTAINS
             END DO
          END DO
 
-         vxc_GLLB(ispin)%cr3d = vxc_GLLB(ispin)%cr3d + vxc_tmp(ispin)%cr3d
+         CALL pw_axpy(vxc_tmp(ispin), vxc_GLLB(ispin), 1.0_dp)
 
       END DO
 
@@ -456,11 +454,11 @@ CONTAINS
       DO ispin = 1, nspins
 
          IF (oe_corr == oe_lb) THEN
-            vxc_SAOP(ispin)%cr3d = vxc_LB(ispin)%cr3d
+            CALL pw_copy(vxc_LB(ispin), vxc_SAOP(ispin))
          ELSE IF (oe_corr == oe_gllb) THEN
-            vxc_SAOP(ispin)%cr3d = vxc_GLLB(ispin)%cr3d
+            CALL pw_copy(vxc_GLLB(ispin), vxc_SAOP(ispin))
          END IF
-         vxc_SAOP(ispin)%cr3d = vxc_SAOP(ispin)%cr3d*vxc_SAOP(ispin)%pw_grid%dvol
+         CALL pw_scale(vxc_SAOP(ispin), vxc_SAOP(ispin)%pw_grid%dvol)
 
          CALL integrate_v_rspace(v_rspace=vxc_SAOP(ispin), pmat=rho_struct_ao(ispin), &
                                  hmat=ks_matrix(ispin), qs_env=qs_env, &


### PR DESCRIPTION
This PR prepares later improvement steps for the OpenMP parallelization.

EDIT: This PR enforces the developer to provide proper spaces and data types when a PW grid is created. In that regard, there are also some inconsistencies within the PW methods.