### PR TITLE
Darwin: libint2 requires -lstdc++ flag

### DIFF
--- a/arch/Darwin-gfortran.psmp
+++ b/arch/Darwin-gfortran.psmp
@@ -15,4 +15,4 @@ FCFLAGS  = -I $(LIBXC_INCLUDE_DIR) -I $(LIBINT_INCLUDE_DIR) -fopenmp -O2 -g \
 LDFLAGS  = $(FCFLAGS)
 LIBS     = -framework Accelerate -lscalapack \
            -L$(LIBXC_LIB_DIR) -lxcf03 -lxc \
-           -L$(LIBINT_LIB_DIR) -lint2
+           -L$(LIBINT_LIB_DIR) -lint2 -lstdc++

--- a/arch/Darwin-gfortran.ssmp
+++ b/arch/Darwin-gfortran.ssmp
@@ -13,4 +13,4 @@ FCFLAGS  = -I $(LIBXC_INCLUDE_DIR) -I $(LIBINT_INCLUDE_DIR) -fopenmp -funroll-lo
 LDFLAGS  = $(FCFLAGS)
 LIBS     = -framework Accelerate \
            -L$(LIBXC_LIB_DIR) -lxcf03 -lxc \
-           -L$(LIBINT_LIB_DIR) -lint2
+           -L$(LIBINT_LIB_DIR) -lint2 -lstdc++


### PR DESCRIPTION
In order to build, this is required. Homebrew currently adds it manually,
and other Darwin/macOS arch files have it.
