### PR TITLE
Fix TDDFPT restart

### DIFF
--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -882,6 +882,8 @@ CONTAINS
 
       ! reuse Ritz vectors from the previous calculation if available
       IF (tddfpt_control%is_restart .AND. .NOT. do_soc) THEN
+         CALL get_qs_env(qs_env, blacs_env=blacs_env)
+
          nstates_read = tddfpt_read_restart( &
                         evects=evects, &
                         evals=evals, &

--- a/tests/QS/regtest-tddfpt/H2O_tddfpt_NTO_restart.inp
+++ b/tests/QS/regtest-tddfpt/H2O_tddfpt_NTO_restart.inp
@@ -1,0 +1,72 @@
+&GLOBAL
+  PROJECT test
+  RUN_TYPE ENERGY
+  PRINT_LEVEL LOW
+&END GLOBAL
+&FORCE_EVAL
+  METHOD Quickstep
+  &PROPERTIES
+    &TDDFPT
+       RESTART      T
+       NSTATES      3
+       MAX_ITER    10
+       MAX_KV      10
+       CONVERGENCE 1.0e-5
+       &XC
+         &XC_FUNCTIONAL PBE
+         &END XC_FUNCTIONAL
+         &XC_GRID
+            XC_DERIV SPLINE2_SMOOTH
+         &END XC_GRID
+       &END XC
+       &PRINT
+          &NTO_ANALYSIS
+             CUBE_FILES
+             THRESHOLD  0.99
+             INTENSITY_THRESHOLD 0.02
+             STATE_LIST 1 3
+          &END
+          &MOS_MOLDEN
+          &END
+       &END
+    &END TDDFPT
+  &END PROPERTIES
+
+  &DFT
+    CHARGE 1
+    LSD
+    BASIS_SET_FILE_NAME BASIS_SET
+    POTENTIAL_FILE_NAME POTENTIAL
+    &MGRID
+      CUTOFF 100
+    &END MGRID
+    &QS
+    &END QS
+    &SCF
+      MAX_SCF 10
+      SCF_GUESS atomic
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 5.0 5.0 5.0
+    &END CELL
+    &COORD
+    O   0.000000    0.000000   -0.065587 H2O
+    H   0.000000   -0.757136    0.520545 H2O
+    H   0.000000    0.757136    0.520545 H2O
+    &END COORD
+    &KIND H
+      BASIS_SET DZVP-GTH-PADE
+      POTENTIAL GTH-PADE-q1
+    &END KIND
+    &KIND O
+      BASIS_SET DZVP-GTH-PADE
+      POTENTIAL GTH-PADE-q6
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-tddfpt/TEST_FILES
+++ b/tests/QS/regtest-tddfpt/TEST_FILES
@@ -16,5 +16,6 @@ NO_tddfpt-s-3.inp                                     37    4.0E-06             
 NO_tddfpt-t-3.inp                                     37    4.0E-06                   0.358683E+00
 H2O_tddfpt_NTO.inp                                    37    4.0E-06                   0.542432E+00
 H2O_tddfpt_NTO_slist.inp                              37    4.0E-06                   0.542432E+00
+H2O_tddfpt_NTO_restart.inp                            37    4.0E-06                   0.542432E+00
 #
 #EOF


### PR DESCRIPTION
Fixes #2923.

This PR fixes the TDDFPT restart functionality which is broken since PR #2859 .

Adds a regtests testing the restart functionality.

@oschuett Is it possible to add this PR to version 2023.2?