### PR TITLE
Docs: Outline methods section

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,6 +11,7 @@ BUILDDIR      = _build
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	./fix_github_links.py "$(BUILDDIR)"
 
 .PHONY: help Makefile
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,4 +31,12 @@ add_module_names = False
 
 # https://myst-parser.readthedocs.io/en/v0.16.1/syntax/optional.html#syntax-header-anchors
 
+html_context = {
+    "display_github": True,
+    "github_user": "cp2k",
+    "github_repo": "cp2k",
+    "github_version": "master",
+    "conf_py_path": "/docs/",
+}
+
 # EOF

--- a/docs/fix_github_links.py
+++ b/docs/fix_github_links.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# author: Ole Schuett
+
+import sys
+from pathlib import Path
+import re
+
+LINK_PATTERN = re.compile('<a .*? class="fa fa-github"> Edit on GitHub</a>')
+
+
+# ======================================================================================
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("fix_github_links.py <build_dir>")
+        sys.exit(1)
+
+    print("Fixing GitHub links...")
+    build_dir = Path(sys.argv[1])
+
+    replace(build_dir / "bibliography.html", newlink("src/common/bibliography.F"))
+    replace(build_dir / "units.html", newlink("src/common/cp_units.F"))
+
+    message = "This page was generated. Please use the smaller [Edit on GitHub] links to see the original location of each string."
+    replace(build_dir / "CP2K_INPUT.html", alert(message))
+    cp2k_input_dir = build_dir / "CP2K_INPUT"
+    for fn in cp2k_input_dir.rglob("*.html"):
+        replace(fn, alert(message))
+
+
+# ======================================================================================
+def replace(filename: Path, replacement: str) -> None:
+    orig_content = filename.read_text()
+    new_content, count = LINK_PATTERN.subn(replacement, orig_content)
+    assert count == 1
+    filename.write_text(new_content)
+
+
+# ======================================================================================
+def newlink(src_file: str) -> str:
+    github_url = f"https://github.com/cp2k/cp2k/blob/master/{src_file}"
+    return f'<a href="{github_url}" class="fa fa-github"> Edit on GitHub</a>'
+
+
+# ======================================================================================
+def alert(message: str) -> str:
+    return f'<a onclick="alert(\'{message}\')" class="fa fa-github"> Edit on GitHub</a>'
+
+
+# ======================================================================================
+main()
+
+# EOF

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,23 @@
 
 % TODO: `{toctree} % :caption: Get started % % get-started/installation % get-started/tutorials % `
 
+```{toctree}
+:caption: Methods
+:titlesonly:
+:maxdepth: 1
+
+methods/dft
+methods/post_hartree_fock
+methods/semiempiricals
+methods/machine_learning
+methods/embedding
+methods/qm_mm
+methods/sampling
+methods/optimization
+methods/spectroscopy
+methods/other_properties
+```
+
 % TODO: `{toctree} % :caption: How-to guides % % dummy % `
 
 ```{toctree}

--- a/docs/methods/basis_sets.md
+++ b/docs/methods/basis_sets.md
@@ -1,0 +1,10 @@
+# Basis Sets
+
+Unfortunately no one has gotten around to writing this page yet :-(
+
+In the meantime, the following links might be helpful:
+
+- <https://en.wikipedia.org/wiki/Gaussian_orbital>
+- <https://www.cp2k.org/basis_sets>
+- <https://www.cp2k.org/tools:cp2k-basis>
+- [](#VandeVondele2007)

--- a/docs/methods/dft.md
+++ b/docs/methods/dft.md
@@ -1,0 +1,15 @@
+# Density Functional Theory
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+gpw
+gapw
+hfx
+Local Resolution of Identity <https://www.cp2k.org/howto:lrigpw>
+Constrained DFT <https://www.cp2k.org/howto:cdft>
+ls-dft
+basis_sets
+pseudopotentials
+```

--- a/docs/methods/dftb.md
+++ b/docs/methods/dftb.md
@@ -1,0 +1,3 @@
+# Density Functional Tight Binding
+
+Unfortunately, nobody has gotten around to writing this page yet :-(

--- a/docs/methods/ehrenfest.md
+++ b/docs/methods/ehrenfest.md
@@ -1,0 +1,3 @@
+# Ehrenfest Dynamics
+
+Unfortunately, nobody has gotten around to writing this page yet :-(

--- a/docs/methods/embedding.md
+++ b/docs/methods/embedding.md
@@ -1,0 +1,9 @@
+# Embedding
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Kim-Gordon <https://www.cp2k.org/howto:kg>
+qm_qm
+```

--- a/docs/methods/gapw.md
+++ b/docs/methods/gapw.md
@@ -1,0 +1,8 @@
+# Gaussian Augmented Plane Waves
+
+Unfortunately no one has gotten around to writing this page yet :-(
+
+In the meantime, the following links might be helpful:
+
+- [](#Lippert1999)
+- [](#VandeVondele2006)

--- a/docs/methods/gpw.md
+++ b/docs/methods/gpw.md
@@ -1,0 +1,9 @@
+# Gaussian Plane Wave
+
+Unfortunately no one has gotten around to writing this page yet :-(
+
+In the meantime, the following links might be helpful:
+
+- <https://www.cp2k.org/gpw>
+- <https://www.cp2k.org/quickstep>
+- [](#VandeVondele2005)

--- a/docs/methods/hfx.md
+++ b/docs/methods/hfx.md
@@ -1,0 +1,8 @@
+# Hartree-Fock eXchange
+
+Unfortunately no one has gotten around to writing this page yet :-(
+
+In the meantime, the following links might be helpful:
+
+- [](#Guidon2009)
+- [](#Guidon2010)

--- a/docs/methods/implicit_solvation.md
+++ b/docs/methods/implicit_solvation.md
@@ -1,0 +1,3 @@
+# Implicit Solvation
+
+Unfortunately, nobody has gotten around to writing this page yet :-(

--- a/docs/methods/ls-dft.md
+++ b/docs/methods/ls-dft.md
@@ -1,0 +1,7 @@
+# Linear Scaling DFT
+
+Unfortunately no one has gotten around to writing this page yet :-(
+
+In the meantime, the following links might be helpful:
+
+- [](#VandeVondele2012)

--- a/docs/methods/machine_learning.md
+++ b/docs/methods/machine_learning.md
@@ -1,0 +1,10 @@
+# Machine Learning
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Nequip / Allegro <https://www.cp2k.org/howto:allegro>
+Neural Network Potentials <https://www.cp2k.org/tools:aml>
+pao-ml
+```

--- a/docs/methods/metadynamics.md
+++ b/docs/methods/metadynamics.md
@@ -1,0 +1,3 @@
+# Metadynamics
+
+Unfortunately, nobody has gotten around to writing this page yet :-(

--- a/docs/methods/neb.md
+++ b/docs/methods/neb.md
@@ -1,0 +1,3 @@
+# Nudged Elastic Band
+
+Unfortunately, nobody has gotten around to writing this page yet :-(

--- a/docs/methods/nmr.md
+++ b/docs/methods/nmr.md
@@ -1,0 +1,3 @@
+# Nuclear Magnetic Resonance
+
+Unfortunately, nobody has gotten around to writing this page yet :-(

--- a/docs/methods/optimization.md
+++ b/docs/methods/optimization.md
@@ -1,0 +1,9 @@
+# Optimization
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Geometry Optimization <https://www.cp2k.org/howto:geometry_optimisation>
+neb
+```

--- a/docs/methods/other_properties.md
+++ b/docs/methods/other_properties.md
@@ -1,0 +1,10 @@
+# Other Properties
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+STM images <https://www.cp2k.org/howto:stm>
+Electron transport <https://www.cp2k.org/howto:cp2k_omen>
+RESP charges <https://www.cp2k.org/howto:resp>
+```

--- a/docs/methods/pao-ml.md
+++ b/docs/methods/pao-ml.md
@@ -1,0 +1,235 @@
+# PAO-ML
+
+PAO-ML stands for Polarized Atomic Orbitals from Machine Learning. It
+uses machine learning to generate geometry adopted small basis sets. It
+also provides exact ionic forces. The scheme can serve as an almost
+drop-in replacement for conventional basis sets to speedup otherwise
+standard DFT calculations. The method is similar to semi-empirical
+models based on minimal basis sets, but offers improved accuracy and
+quasi-automatic parameterization. However, the method is still in an
+early stage - so use with caution. For more information see:
+[10.1021/acs.jctc.8b00378](https://dx.doi.org/10.1021/acs.jctc.8b00378).
+
+## Step 1: Obtain training structures
+
+The PAO-ML scheme takes a set of training structures as input. For each
+of these structures, the variational PAO basis is determined via an
+explicit optimization. The training structures should be much smaller
+than the target system, but large enough to contain all the *motifs* of
+the larger system. For liquids a good way to obtain structures is to run
+an MD of a smaller box.
+
+## Step 2: Calculate reference data in primary basis
+
+Choose a primary basis set, e.g. `DZVP-MOLOPT-GTH` and perform a full
+[LS_SCF](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF)
+optimization. You should also enable
+[RESTART_WRITE](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.RESTART_WRITE)
+to save the final density matrix. It can be used to speed up the next
+step significantly.
+
+## Step 3: Optimize PAO basis for training structures
+
+Choose a
+[PAO_BASIS_SIZE](#CP2K_INPUT.FORCE_EVAL.SUBSYS.KIND.PAO_BASIS_SIZE)
+for each atomic kind. Good results can already be optained with a
+minimal basis sets. Slightly larger-than-minimal PAO basis sets can
+significantly increase the accuracy. However, they are also tougher to
+optimize and machine learn.
+
+Most of the PAO settings are in the
+[PAO](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.PAO)
+sections:
+
+```
+&PAO
+  EPS_PAO    1.0E-7                    ! convergence threshold of PAO optimization
+  MAX_PAO    10000                     ! minimal PAO basis usually converge withing 2000 steps.
+  
+  MAX_CYCLES 500                       ! tunning parameter for PAO optimization scheme
+  MIXING     0.5                       ! tunning parameter for PAO optimization scheme
+  PREOPT_DM_FILE primay_basis.dm       ! restart DM from primary basis for great speedup
+  
+  LINPOT_REGULARIZATION_DELTA 1E-6     !!!! Critical parameter for accuracy vs learnability trade-off !!!!
+  
+  LINPOT_REGULARIZATION_STRENGTH 1E-3  ! rather insensitive parameter, 1e-3 works usually
+  REGULARIZATION 1.0E-3                ! rather insensitive parameter, 1e-3 works usually
+  
+  PRECONDITION YES                     ! not important, don't touch 
+  LINPOT_PRECONDITION_DELTA 0.01       ! not important, don't touch 
+  LINPOT_INITGUESS_DELTA 1E+10         ! not important, don't touch
+
+  &PRINT
+    &RESTART
+      BACKUP_COPIES 1                  ! write restart files, just in case
+    &END RESTART
+  &END PRINT
+&END PAO
+```
+
+Settings for individual atomic kinds are in the
+[KIND](#CP2K_INPUT.FORCE_EVAL.SUBSYS.KIND)
+section:
+
+```
+&KIND H
+  PAO_BASIS_SIZE 1    ! set this to at least the minimal basis size
+  &PAO_POTENTIAL
+    MAXL 4            ! 4 works usually
+    BETA 2.0          ! 2 work usually, but is worth exploring in case of accuracy or learnability issues.
+  &END PAO_POTENTIAL
+&END KIND
+```
+
+### Tuning the PAO Optimization
+
+Finding the optimal PAO basis poses an intricate minimization problem,
+because the rotation matrix U and the Kohn-Sham matrix H have to be
+optimized in a self-consistent manner. In order to speedup the
+optimization, the Kohn-Sham matrix is only updated occasionally while
+most time is spend on optimizing U. This alternating scheme is
+controlled by two input parameters:
+
+- The frequency with which H is recalculated is determined by
+  [MAX_CYCLES](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.PAO.MAX_CYCLES).
+- Overshooting during the U optimization is damped via
+  [MIXING](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.PAO.MIXING).
+
+The progress of the PAO optimization can be tracked from lines that
+start with `PAO| step`. The columns have the following meaning:
+
+```
+             step-num             energy          conv-crit. step-length   time
+ PAO| step   1121                 -186.164843303  0.227E-06  0.120E+01     1.440
+```
+
+- The step number counts the number of energy evaluation, ie. the
+  number of U matrices probed. It can increase with different
+  intervals, when the
+  [ADAPTive](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.PAO.LINE_SEARCH.METHOD)
+  line-search method is used. When the step number reaches
+  [MAX_PAO](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.PAO.MAX_PAO)
+  then the optimization is terminated prematurely.
+- The energy is the quantity that is optimized. It contains **only the
+  first order term** of the total energy, ie. $Tr\[HP\]$, but shares
+  the same variational minima. It furthermore contains the
+  contributions from the various regularization terms.
+- The convergence criterion is the norm of the gradient normalized by
+  system size. It is compared against
+  [EPS_PAO](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.PAO.EPS_PAO)
+  to decided if the PAO optimization has converged. The overall
+  optimization is terminated if this convergence criterion is reached
+  within two steps after updating the Kohn-Sham matrix.
+- The step length is the outcome of the line search. It should be of
+  order 1. If it starts to behave erratically towards the end of the
+  optimization, this indicates that further optimization is hindered
+  by numerical accuracy e.g. from
+  [EPS_FILTER](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.EPS_FILTER)
+  or
+  [EPS_SCF](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.EPS_SCF).
+- The time is the time spend on this optimization step in seconds.
+  This number can varry accordingly to the number of performed lines
+  search steps.
+
+## Step 4: Optimize machine learning hyper-parameters
+
+For the simulation of larger systems the PAO-ML scheme infers new PAO
+basis sets from the training data. For this two heuristics are employed:
+A [descriptor](<https://en.wikipedia.org/wiki/Feature_(machine_learning)>)
+and an inference algorithm. Currently, only one simple descriptor and
+[Gaussian processes](https://en.wikipedia.org/wiki/Gaussian_process) are
+implemented. However, this part offers great opportunities for future
+research.
+
+In order to obtain good results from the learning machinery a small
+number of so-called
+[hyperparameters](https://en.wikipedia.org/wiki/Hyperparameter) have to
+be carefully tuned for each application. For the current implementation
+this includes the
+[GP_SCALE](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.PAO.MACHINE_LEARNING.GP_SCALE)
+and the descriptor's
+[BETA](#CP2K_INPUT.FORCE_EVAL.SUBSYS.KIND.PAO_DESCRIPTOR.BETA)
+and
+[SCREENING](#CP2K_INPUT.FORCE_EVAL.SUBSYS.KIND.PAO_DESCRIPTOR.SCREENING).
+
+For the optimization of the hyper-parameter exists no gradient, hence
+one has to use a derivative-free method like the one by
+[Powell](https://en.wikipedia.org/wiki/Powell%27s_method). A versatile
+implementation is e.g. the
+[scriptmini](https://github.com/cp2k/cp2k/tree/master/tools/scriptmini)
+tool. A good optimization criterion is the variance of the energy
+difference wrt. the primary basis across the training set.
+Alternatively, atomic forces could be compared. Despite the missing
+gradients, this optimization is rather quick because it only performs
+calculations in the small PAO basis set.
+
+## Step 5: Run simulation with PAO-ML
+
+Most of the PAO-ML settings are in the
+[PAO/MACHINE_LEARNING](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.PAO.MACHINE_LEARNING)
+sections:
+
+```
+&PAO
+  MAX_PAO 0                  ! use PAO basis as predicted by ML, required for correct forces
+  PENALTY_STRENGTH 0.0       ! disable penalty, required for correct forces
+  
+  &MACHINE_LEARNING
+    GP_SCALE 0.46            !!! critical tuning parameter - depends also on descriptor settings !!!
+    GP_NOISE_VAR 0.0001      ! insensitive parameter
+
+
+    METHOD GAUSSIAN_PROCESS  ! only implemented method - opportunity for future research
+    DESCRIPTOR OVERLAP       ! only implemented method - opportunity for future research
+    PRIOR MEAN               ! try once ZERO - makes usually no difference
+    TOLERANCE 1000.0         ! disable check for max variance of GP prediction
+    
+    &TRAINING_SET
+          ../training/Frame0000/calc_pao_ref-1_0.pao
+          ../training/Frame0100/calc_pao_ref-1_0.pao
+          ../training/Frame0200/calc_pao_ref-1_0.pao
+          ! add more ...
+    &END TRAINING_SET
+  &END MACHINE_LEARNING
+&END PAO
+```
+
+Settings for individual atomic kinds are again in the
+[KIND](#CP2K_INPUT.FORCE_EVAL.SUBSYS.KIND)
+section:
+
+```
+&KIND H
+  PAO_BASIS_SIZE 1      ! use same settings as for training
+  &PAO_POTENTIAL
+    MAXL 4              ! use same settings as for training
+    BETA 2.0            ! use same settings as for training
+  &END PAO_POTENTIAL
+  
+  &PAO_DESCRIPTOR
+     BETA   0.16        !!! important ML hyper-parameter !!!
+     SCREENING 0.66     !!! important ML hyper-parameter !!!
+     WEIGHT 1.0         ! usually not needed when BETA and SCREENING are choose properly
+  &END PAO_DESCRIPTOR
+&END KIND
+```
+
+## Debugging accuracy vs learnability trade-off
+
+When optimizing the PAO reference data in Step 3 one has to make a
+trade-off between accuracy and learnability. Good learnability means
+that similar structures leads to similar PAO parameters. In other words
+the PAO parameters should depend smoothly on the atomic positions. In
+general, the settings presented above should yield good results.
+However, if problems arise in the later machine learning steps, this
+might be the culprit.
+
+Unfortunately, there is not yet a simple way to assess learnability. One
+way to investigate is to create a set of structures along a reaction
+coordinate, e.g. a dimer dissociation. One can then plot the numbers
+from the `Xblock` in the `.pao` files vs. the reaction coordinate.
+
+The most critical parameters for learnability are
+[LINPOT_REGULARIZATION_DELTA](#CP2K_INPUT.FORCE_EVAL.DFT.LS_SCF.PAO.LINPOT_REGULARIZATION_DELTA)
+and the potential's
+[BETA](#CP2K_INPUT.FORCE_EVAL.SUBSYS.KIND.PAO_POTENTIAL.BETA).

--- a/docs/methods/path_integrals.md
+++ b/docs/methods/path_integrals.md
@@ -1,0 +1,3 @@
+# Path Integrals
+
+Unfortunately, nobody has gotten around to writing this page yet :-(

--- a/docs/methods/polarizable_ff.md
+++ b/docs/methods/polarizable_ff.md
@@ -1,0 +1,7 @@
+# Polarizable Force-Fields
+
+Unfortunately no one has gotten around to writing this page yet :-(
+
+In the meantime, the following links might be helpful:
+
+- [](#Devynck2012)

--- a/docs/methods/post_hartree_fock.md
+++ b/docs/methods/post_hartree_fock.md
@@ -1,0 +1,10 @@
+# Post Hartree-Fock
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Møller–Plesset perturbation theory <https://www.cp2k.org/howto:mp2>
+rpa
+GW approximation <https://www.cp2k.org/howto:gw>
+```

--- a/docs/methods/pseudopotentials.md
+++ b/docs/methods/pseudopotentials.md
@@ -1,0 +1,12 @@
+# Pseudopotentials
+
+Unfortunately no one has gotten around to writing this page yet :-(
+
+In the meantime, the following links might be helpful:
+
+- <https://en.wikipedia.org/wiki/Pseudopotential>
+- <https://cp2k.org/static/potentials/>
+- <https://www.cp2k.org/tools:cp2k-basis>
+- [](#Goedecker1996)
+- [](#Hartwigsen1998)
+- [](#Krack2005)

--- a/docs/methods/qm_mm.md
+++ b/docs/methods/qm_mm.md
@@ -1,0 +1,13 @@
+# QM/MM
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+QM/MM with built-in force-field <https://www.cp2k.org/howto:biochem_qmmm>
+QM/MM with Gromacs <https://www.cp2k.org/tools:gromacs>
+polarizable_ff
+implicit_solvation
+Image charges <https://www.cp2k.org/howto:ic-qmmm>
+
+```

--- a/docs/methods/qm_qm.md
+++ b/docs/methods/qm_qm.md
@@ -1,0 +1,7 @@
+# Quantum Embedding Theories
+
+Unfortunately no one has gotten around to writing this page yet :-(
+
+In the meantime, the following links might be helpful:
+
+- <https://www.cp2k.org/_media/events:2017_dev_meeting:rybkin_cp2kdev-meeting_zurich2017-7.pdf>

--- a/docs/methods/raman.md
+++ b/docs/methods/raman.md
@@ -1,0 +1,3 @@
+# Raman
+
+Unfortunately, nobody has gotten around to writing this page yet :-(

--- a/docs/methods/rpa.md
+++ b/docs/methods/rpa.md
@@ -1,0 +1,3 @@
+# Random Phase Approximation
+
+Unfortunately, nobody has gotten around to writing this page yet :-(

--- a/docs/methods/sampling.md
+++ b/docs/methods/sampling.md
@@ -1,0 +1,15 @@
+# Sampling
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+Molecular Dynamics <https://www.cp2k.org/howto:md>
+metadynamics
+path_integrals
+Surface Hopping with NEWTON-X <https://www.cp2k.org/howto:newtonx>
+i-PI <https://www.cp2k.org/howto:ipi>
+Gibbs Ensemble Monte Carlo <https://www.cp2k.org/howto:gemc>
+Langevin Dynamics <https://www.cp2k.org/howto:langevin_regions>
+ehrenfest
+```

--- a/docs/methods/semiempiricals.md
+++ b/docs/methods/semiempiricals.md
@@ -1,0 +1,9 @@
+# Semi-Empiricals
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+eXtended Tight Binding  <https://www.cp2k.org/howto:gfn1xtb>
+dftb
+```

--- a/docs/methods/spectroscopy.md
+++ b/docs/methods/spectroscopy.md
@@ -1,0 +1,12 @@
+# Spectroscopy
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+X-Ray <https://www.cp2k.org/howto:xas_tdp>
+Optical <https://www.cp2k.org/howto:tddft>
+Infrared <https://brehm-research.de/spectroscopy>
+raman
+nmr
+```

--- a/tools/docker/scripts/test_manual.sh
+++ b/tools/docker/scripts/test_manual.sh
@@ -43,6 +43,7 @@ set +e # disable error trapping for remainder of script
   /opt/cp2k/docs/generate_input_reference.py ./cp2k_input.xml ./references.html
   echo ""
   sphinx-build /opt/cp2k/docs/ /workspace/artifacts/manual -W -n --keep-going --jobs 16
+  /opt/cp2k/docs/fix_github_links.py /workspace/artifacts/manual
 )
 EXIT_CODE=$?
 if ((EXIT_CODE)); then

--- a/tools/docker/scripts/test_misc.sh
+++ b/tools/docker/scripts/test_misc.sh
@@ -43,6 +43,7 @@ run_test mypy --strict ./tools/docker/generate_dockerfiles.py
 run_test mypy --strict ./tools/apptainer/generate_apptainer_def_files.py
 run_test mypy --strict ./tools/conventions/analyze_gfortran_ast.py
 run_test mypy --strict ./docs/generate_input_reference.py
+run_test mypy --strict ./docs/fix_github_links.py
 
 # TODO: Find a way to test generate_dashboard.py without git repository.
 #


### PR DESCRIPTION
This PR adds an initial outline for our documentation. I've keep the file hierarchy flat to allow for easy restructuring.

The section pages are intended as navigation aid. Besides a brief introduction they should explain how the individual methods relate and compare to each other. 

The leaf pages cover individual methods. For many methods we already have great wiki pages. I'll migrate those over the coming weeks.

Later we could harmonize the method pages so that they each contain the four categories of the [documentation system](https://documentation.divio.com/).
