### PR TITLE
RI-HFX for K-points (with gradients and ADMM)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,6 +220,7 @@ list(
   hfx_pair_list_methods.F
   hfx_pw_methods.F
   hfx_ri.F
+  hfx_ri_kp.F
   hfx_screening_methods.F
   hfx_types.F
   hirshfeld_methods.F

--- a/src/admm_methods.F
+++ b/src/admm_methods.F
@@ -19,11 +19,25 @@ MODULE admm_methods
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE bibliography,                    ONLY: Merlot2014,&
                                               cite_reference
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_cholesky_decompose,&
+                                              cp_cfm_cholesky_invert,&
+                                              cp_cfm_scale,&
+                                              cp_cfm_scale_and_add,&
+                                              cp_cfm_scale_and_add_fm,&
+                                              cp_cfm_transpose
+   USE cp_cfm_types,                    ONLY: cp_cfm_create,&
+                                              cp_cfm_get_info,&
+                                              cp_cfm_release,&
+                                              cp_cfm_to_fm,&
+                                              cp_cfm_type,&
+                                              cp_fm_to_cfm
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               copy_fm_to_dbcsr,&
-                                              cp_dbcsr_plus_fm_fm_t
+                                              cp_dbcsr_plus_fm_fm_t,&
+                                              dbcsr_allocate_matrix_set,&
+                                              dbcsr_deallocate_matrix_set
    USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
    USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
                                               cp_fm_scale,&
@@ -35,15 +49,16 @@ MODULE admm_methods
                                               cp_fm_cholesky_reduce,&
                                               cp_fm_cholesky_restore
    USE cp_fm_diag,                      ONLY: cp_fm_syevd
-   USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_get_info,&
-                                              cp_fm_release,&
-                                              cp_fm_set_all,&
-                                              cp_fm_set_element,&
-                                              cp_fm_to_fm,&
-                                              cp_fm_type
+   USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
+                                              cp_fm_struct_release,&
+                                              cp_fm_struct_type
+   USE cp_fm_types,                     ONLY: &
+        copy_info_type, cp_fm_cleanup_copy_general, cp_fm_create, cp_fm_finish_copy_general, &
+        cp_fm_get_info, cp_fm_release, cp_fm_set_all, cp_fm_set_element, cp_fm_start_copy_general, &
+        cp_fm_to_fm, cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
-                                              cp_logger_type
+                                              cp_logger_type,&
+                                              cp_to_string
    USE cp_output_handling,              ONLY: cp_p_file,&
                                               cp_print_key_finished_output,&
                                               cp_print_key_should_output,&
@@ -52,8 +67,8 @@ MODULE admm_methods
         dbcsr_add, dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_desymmetrize, &
         dbcsr_dot, dbcsr_get_block_p, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
         dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_p_type, &
-        dbcsr_release, dbcsr_scale, dbcsr_set, dbcsr_type, dbcsr_type_no_symmetry, &
-        dbcsr_type_symmetric
+        dbcsr_release, dbcsr_scale, dbcsr_set, dbcsr_type, dbcsr_type_antisymmetric, &
+        dbcsr_type_no_symmetry, dbcsr_type_symmetric
    USE input_constants,                 ONLY: do_admm_purify_cauchy,&
                                               do_admm_purify_cauchy_subspace,&
                                               do_admm_purify_mo_diag,&
@@ -63,6 +78,16 @@ MODULE admm_methods
                                               section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
+   USE kpoint_methods,                  ONLY: kpoint_density_matrices,&
+                                              kpoint_density_transform,&
+                                              rskp_transform
+   USE kpoint_types,                    ONLY: get_kpoint_env,&
+                                              get_kpoint_info,&
+                                              kpoint_env_type,&
+                                              kpoint_type
+   USE mathconstants,                   ONLY: gaussi,&
+                                              z_one,&
+                                              z_zero
    USE message_passing,                 ONLY: mp_para_env_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE pw_types,                        ONLY: pw_type
@@ -87,6 +112,7 @@ MODULE admm_methods
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_set,&
                                               qs_rho_type
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
    USE qs_vxc,                          ONLY: qs_vxc_create
    USE qs_vxc_atom,                     ONLY: calculate_vxc_atom
    USE task_list_types,                 ONLY: task_list_type
@@ -96,6 +122,7 @@ MODULE admm_methods
    PRIVATE
 
    PUBLIC :: admm_mo_calc_rho_aux, &
+             admm_mo_calc_rho_aux_kp, &
              admm_mo_merge_ks_matrix, &
              admm_mo_merge_derivs, &
              admm_aux_response_density, &
@@ -105,7 +132,9 @@ MODULE admm_methods
              admm_update_ks_atom, &
              calc_admm_mo_derivatives, &
              calc_admm_ovlp_forces, &
-             admm_projection_derivative
+             calc_admm_ovlp_forces_kp, &
+             admm_projection_derivative, &
+             kpoint_calc_admm_matrices
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'admm_methods'
 
@@ -247,6 +276,434 @@ CONTAINS
    END SUBROUTINE admm_mo_calc_rho_aux
 
 ! **************************************************************************************************
+!> \brief ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE admm_mo_calc_rho_aux_kp(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'admm_mo_calc_rho_aux_kp'
+
+      CHARACTER(LEN=default_string_length)               :: basis_type
+      INTEGER                                            :: handle, i, igroup, ik, ikp, img, indx, &
+                                                            ispin, kplocal, nao_aux_fit, nao_orb, &
+                                                            natom, nkp, nkp_groups, nmo, nspins
+      INTEGER, DIMENSION(2)                              :: kp_range
+      INTEGER, DIMENSION(:, :), POINTER                  :: kp_dist
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: gapw, my_kpgrp, pmat_from_rs, &
+                                                            use_real_wfn
+      REAL(dp)                                           :: maxval_mos, nelec_aux(2), nelec_orb(2), &
+                                                            tmp
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: occ_num, occ_num_aux, tot_rho_r_aux
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(copy_info_type), ALLOCATABLE, DIMENSION(:, :) :: info
+      TYPE(cp_cfm_type)                                  :: cA, cmo_coeff, cmo_coeff_aux_fit, &
+                                                            cpmatrix, cwork_aux_aux, cwork_aux_orb
+      TYPE(cp_fm_struct_type), POINTER                   :: mo_struct, mo_struct_aux_fit, &
+                                                            struct_aux_aux, struct_aux_orb, &
+                                                            struct_orb_orb
+      TYPE(cp_fm_type)                                   :: fmdummy, work_aux_orb, work_orb_orb, &
+                                                            work_orb_orb2
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s, matrix_s_aux_fit, rho_ao_aux, &
+                                                            rho_ao_orb
+      TYPE(dbcsr_type)                                   :: pmatrix_tmp
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: pmatrix
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_env_type), POINTER                     :: kp
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos, mos_aux_fit
+      TYPE(mo_set_type), DIMENSION(:, :), POINTER        :: mos_aux_fit_kp, mos_kp
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_aux_fit, sab_kp
+      TYPE(pw_type), DIMENSION(:), POINTER               :: rho_g_aux, rho_r_aux
+      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+      TYPE(qs_rho_type), POINTER                         :: rho_aux_fit, rho_orb
+      TYPE(qs_scf_env_type), POINTER                     :: scf_env
+      TYPE(task_list_type), POINTER                      :: task_list
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (ks_env, admm_env, mos, mos_aux_fit, matrix_s, rho_orb, &
+               matrix_s_aux_fit, rho_aux_fit, rho_ao_orb, &
+               para_env, rho_g_aux, rho_r_aux, rho_ao_aux, tot_rho_r_aux, &
+               kpoints, sab_aux_fit, sab_kp, kp, &
+               struct_orb_orb, struct_aux_orb, struct_aux_aux, mo_struct, mo_struct_aux_fit)
+
+      CALL get_qs_env(qs_env, &
+                      ks_env=ks_env, &
+                      admm_env=admm_env, &
+                      dft_control=dft_control, &
+                      kpoints=kpoints, &
+                      natom=natom, &
+                      scf_env=scf_env, &
+                      matrix_s_kp=matrix_s, &
+                      rho=rho_orb)
+      CALL get_admm_env(admm_env, &
+                        rho_aux_fit=rho_aux_fit, &
+                        matrix_s_aux_fit_kp=matrix_s_aux_fit, &
+                        sab_aux_fit=sab_aux_fit)
+      gapw = admm_env%do_gapw
+
+      CALL qs_rho_get(rho_aux_fit, &
+                      rho_ao_kp=rho_ao_aux, &
+                      rho_g=rho_g_aux, &
+                      rho_r=rho_r_aux, &
+                      tot_rho_r=tot_rho_r_aux)
+
+      CALL qs_rho_get(rho_orb, rho_ao_kp=rho_ao_orb)
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, use_real_wfn=use_real_wfn, kp_range=kp_range, &
+                           nkp_groups=nkp_groups, kp_dist=kp_dist, &
+                           cell_to_index=cell_to_index, sab_nl=sab_kp)
+
+      ! the temporary DBCSR matrices for the rskp_transform we have to manually allocate
+      ! index 1 => real, index 2 => imaginary
+      ALLOCATE (pmatrix(2))
+      CALL dbcsr_create(pmatrix(1), template=matrix_s(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_symmetric)
+      CALL dbcsr_create(pmatrix(2), template=matrix_s(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_antisymmetric)
+      CALL dbcsr_create(pmatrix_tmp, template=matrix_s(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+      CALL cp_dbcsr_alloc_block_from_nbl(pmatrix(1), sab_kp)
+      CALL cp_dbcsr_alloc_block_from_nbl(pmatrix(2), sab_kp)
+
+      nao_aux_fit = admm_env%nao_aux_fit
+      nao_orb = admm_env%nao_orb
+      nspins = dft_control%nspins
+
+      !Create fm and cfm work matrices, for each KP subgroup
+      CALL cp_fm_struct_create(struct_orb_orb, context=kpoints%blacs_env, para_env=kpoints%para_env_kp, &
+                               nrow_global=nao_orb, ncol_global=nao_orb)
+      CALL cp_fm_create(work_orb_orb, struct_orb_orb)
+      CALL cp_fm_create(work_orb_orb2, struct_orb_orb)
+
+      CALL cp_fm_struct_create(struct_aux_aux, context=kpoints%blacs_env, para_env=kpoints%para_env_kp, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_aux_fit)
+
+      CALL cp_fm_struct_create(struct_aux_orb, context=kpoints%blacs_env, para_env=kpoints%para_env_kp, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_orb)
+      CALL cp_fm_create(work_aux_orb, struct_orb_orb)
+
+      IF (.NOT. use_real_wfn) THEN
+         CALL cp_cfm_create(cpmatrix, struct_orb_orb)
+
+         CALL cp_cfm_create(cwork_aux_aux, struct_aux_aux)
+
+         CALL cp_cfm_create(cA, struct_aux_orb)
+         CALL cp_cfm_create(cwork_aux_orb, struct_aux_orb)
+
+         CALL get_kpoint_env(kpoints%kp_env(1)%kpoint_env, mos=mos_kp)
+         mos => mos_kp(1, :)
+         CALL get_mo_set(mos(1), mo_coeff=mo_coeff)
+         CALL cp_fm_get_info(mo_coeff, matrix_struct=mo_struct)
+         CALL cp_cfm_create(cmo_coeff, mo_struct)
+
+         CALL get_kpoint_env(kpoints%kp_aux_env(1)%kpoint_env, mos=mos_aux_fit_kp)
+         mos => mos_aux_fit_kp(1, :)
+         CALL get_mo_set(mos(1), mo_coeff=mo_coeff_aux_fit)
+         CALL cp_fm_get_info(mo_coeff_aux_fit, matrix_struct=mo_struct_aux_fit)
+         CALL cp_cfm_create(cmo_coeff_aux_fit, mo_struct_aux_fit)
+      END IF
+
+      CALL cp_fm_struct_release(struct_orb_orb)
+      CALL cp_fm_struct_release(struct_aux_aux)
+      CALL cp_fm_struct_release(struct_aux_orb)
+
+      para_env => kpoints%blacs_env_all%para_env
+      kplocal = kp_range(2) - kp_range(1) + 1
+
+      !We querry the maximum absolute value of the KP MOs to see if they are populated at all. If not, we
+      !need to get the KP Pmat from the RS ones (happens at first SCF step, for example)
+      maxval_mos = 0.0_dp
+      indx = 0
+      DO ikp = 1, kplocal
+         DO ispin = 1, nspins
+            DO igroup = 1, nkp_groups
+               ! number of current kpoint
+               ik = kp_dist(1, igroup) + ikp - 1
+               my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+               indx = indx + 1
+
+               CALL get_kpoint_env(kpoints%kp_env(ikp)%kpoint_env, mos=mos_kp)
+               mos => mos_kp(1, :)
+               CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
+               maxval_mos = MAX(maxval_mos, MAXVAL(ABS(mo_coeff%local_data)))
+
+               IF (.NOT. use_real_wfn) THEN
+                  mos => mos_kp(2, :)
+                  CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
+                  maxval_mos = MAX(maxval_mos, MAXVAL(ABS(mo_coeff%local_data)))
+               END IF
+            END DO
+         END DO
+      END DO
+      CALL para_env%sum(maxval_mos) !I think para_env is the global one
+
+      pmat_from_rs = .FALSE.
+      IF (maxval_mos < EPSILON(0.0_dp)) pmat_from_rs = .TRUE.
+
+      !TODO: issue a warning when doing ADMM with ATOMIC guess. If small number of K-points => leads to bad things
+
+      ALLOCATE (info(kplocal*nspins*nkp_groups, 2))
+      !Start communication: only P matrix, and only if required
+      indx = 0
+      IF (pmat_from_rs) THEN
+         DO ikp = 1, kplocal
+            DO ispin = 1, nspins
+               DO igroup = 1, nkp_groups
+                  ! number of current kpoint
+                  ik = kp_dist(1, igroup) + ikp - 1
+                  my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+                  indx = indx + 1
+
+                  ! FT of matrices P if required, then transfer to FM type
+                  IF (use_real_wfn) THEN
+                     CALL dbcsr_set(pmatrix(1), 0.0_dp)
+                     CALL rskp_transform(rmatrix=pmatrix(1), rsmat=rho_ao_orb, ispin=ispin, &
+                                         xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_kp)
+                     CALL dbcsr_desymmetrize(pmatrix(1), pmatrix_tmp)
+                     CALL copy_dbcsr_to_fm(pmatrix_tmp, admm_env%work_orb_orb)
+                  ELSE
+                     CALL dbcsr_set(pmatrix(1), 0.0_dp)
+                     CALL dbcsr_set(pmatrix(2), 0.0_dp)
+                     CALL rskp_transform(rmatrix=pmatrix(1), cmatrix=pmatrix(2), rsmat=rho_ao_orb, ispin=ispin, &
+                                         xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_kp)
+                     CALL dbcsr_desymmetrize(pmatrix(1), pmatrix_tmp)
+                     CALL copy_dbcsr_to_fm(pmatrix_tmp, admm_env%work_orb_orb)
+                     CALL dbcsr_desymmetrize(pmatrix(2), pmatrix_tmp)
+                     CALL copy_dbcsr_to_fm(pmatrix_tmp, admm_env%work_orb_orb2)
+                  END IF
+
+                  IF (my_kpgrp) THEN
+                     CALL cp_fm_start_copy_general(admm_env%work_orb_orb, work_orb_orb, para_env, info(indx, 1))
+                     IF (.NOT. use_real_wfn) THEN
+                        CALL cp_fm_start_copy_general(admm_env%work_orb_orb2, work_orb_orb2, para_env, info(indx, 2))
+                     END IF
+                  ELSE
+                     CALL cp_fm_start_copy_general(admm_env%work_orb_orb, fmdummy, para_env, info(indx, 1))
+                     IF (.NOT. use_real_wfn) THEN
+                        CALL cp_fm_start_copy_general(admm_env%work_orb_orb2, fmdummy, para_env, info(indx, 2))
+                     END IF
+                  END IF !my_kpgrp
+               END DO
+            END DO
+         END DO
+      END IF !pmat_from_rs
+
+      indx = 0
+      DO ikp = 1, kplocal
+         DO ispin = 1, nspins
+            DO igroup = 1, nkp_groups
+               ! number of current kpoint
+               ik = kp_dist(1, igroup) + ikp - 1
+               my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+               indx = indx + 1
+               IF (my_kpgrp .AND. pmat_from_rs) THEN
+                  CALL cp_fm_finish_copy_general(work_orb_orb, info(indx, 1))
+                  IF (.NOT. use_real_wfn) THEN
+                     CALL cp_fm_finish_copy_general(work_orb_orb2, info(indx, 2))
+                     CALL cp_fm_to_cfm(work_orb_orb, work_orb_orb2, cpmatrix)
+                  END IF
+               END IF
+            END DO
+
+            IF (use_real_wfn) THEN
+
+               nmo = admm_env%nmo(ispin)
+               !! Each kpoint group has now information on a kpoint for which to calculate the MOS_aux
+               CALL get_kpoint_env(kpoints%kp_env(ikp)%kpoint_env, mos=mos_kp)
+               CALL get_kpoint_env(kpoints%kp_aux_env(ikp)%kpoint_env, mos=mos_aux_fit_kp)
+               mos => mos_kp(1, :)
+               mos_aux_fit => mos_aux_fit_kp(1, :)
+
+               CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, occupation_numbers=occ_num)
+               CALL get_mo_set(mos_aux_fit(ispin), mo_coeff=mo_coeff_aux_fit, &
+                               occupation_numbers=occ_num_aux)
+
+               kp => kpoints%kp_aux_env(ikp)%kpoint_env
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nmo, nao_orb, 1.0_dp, kp%amat(1, 1), &
+                                  mo_coeff, 0.0_dp, mo_coeff_aux_fit)
+
+               occ_num_aux(1:nmo) = occ_num(1:nmo)
+
+               IF (pmat_from_rs) THEN
+                  !We project on the AUX basis: P_aux = A * P *A^T
+                  CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_orb, 1.0_dp, kp%amat(1, 1), &
+                                     work_orb_orb, 0.0_dp, work_aux_orb)
+                  CALL parallel_gemm('N', 'T', nao_aux_fit, nao_aux_fit, nao_orb, 1.0_dp, work_aux_orb, &
+                                     kp%amat(1, 1), 0.0_dp, kpoints%kp_aux_env(ikp)%kpoint_env%pmat(1, ispin))
+               END IF
+
+            ELSE !complex wfn
+
+               !construct the ORB MOs in complex format
+               nmo = admm_env%nmo(ispin)
+               CALL get_kpoint_env(kpoints%kp_env(ikp)%kpoint_env, mos=mos_kp)
+               mos => mos_kp(1, :) !real
+               CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
+               CALL cp_cfm_scale_and_add_fm(z_zero, cmo_coeff, z_one, mo_coeff)
+               mos => mos_kp(2, :) !complex
+               CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
+               CALL cp_cfm_scale_and_add_fm(z_one, cmo_coeff, gaussi, mo_coeff)
+
+               !project
+               kp => kpoints%kp_aux_env(ikp)%kpoint_env
+               CALL cp_fm_to_cfm(kp%amat(1, 1), kp%amat(2, 1), cA)
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nmo, nao_orb, &
+                                  z_one, cA, cmo_coeff, z_zero, cmo_coeff_aux_fit)
+
+               !write result back to KP MOs
+               CALL get_kpoint_env(kpoints%kp_aux_env(ikp)%kpoint_env, mos=mos_aux_fit_kp)
+               mos_aux_fit => mos_aux_fit_kp(1, :)
+               CALL get_mo_set(mos_aux_fit(ispin), mo_coeff=mo_coeff_aux_fit)
+               CALL cp_cfm_to_fm(cmo_coeff_aux_fit, mtargetr=mo_coeff_aux_fit)
+               mos_aux_fit => mos_aux_fit_kp(2, :)
+               CALL get_mo_set(mos_aux_fit(ispin), mo_coeff=mo_coeff_aux_fit)
+               CALL cp_cfm_to_fm(cmo_coeff_aux_fit, mtargeti=mo_coeff_aux_fit)
+
+               DO i = 1, 2
+                  mos => mos_kp(i, :)
+                  CALL get_mo_set(mos(ispin), occupation_numbers=occ_num)
+                  mos_aux_fit => mos_aux_fit_kp(i, :)
+                  CALL get_mo_set(mos_aux_fit(ispin), occupation_numbers=occ_num_aux)
+                  occ_num_aux(:) = occ_num(:)
+               END DO
+
+               IF (pmat_from_rs) THEN
+                  CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_orb, z_one, cA, &
+                                     cpmatrix, z_zero, cwork_aux_orb)
+                  CALL parallel_gemm('N', 'C', nao_aux_fit, nao_aux_fit, nao_orb, z_one, cwork_aux_orb, &
+                                     cA, z_zero, cwork_aux_aux)
+
+                  CALL cp_cfm_to_fm(cwork_aux_aux, mtargetr=kpoints%kp_aux_env(ikp)%kpoint_env%pmat(1, ispin), &
+                                    mtargeti=kpoints%kp_aux_env(ikp)%kpoint_env%pmat(2, ispin))
+               END IF
+            END IF
+
+         END DO
+      END DO
+
+      !Clean-up communication
+      IF (pmat_from_rs) THEN
+         indx = 0
+         DO ikp = 1, kplocal
+            DO ispin = 1, nspins
+               DO igroup = 1, nkp_groups
+                  ! number of current kpoint
+                  ik = kp_dist(1, igroup) + ikp - 1
+                  my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+                  indx = indx + 1
+
+                  CALL cp_fm_cleanup_copy_general(info(indx, 1))
+                  IF (.NOT. use_real_wfn) CALL cp_fm_cleanup_copy_general(info(indx, 2))
+               END DO
+            END DO
+         END DO
+      END IF
+
+      DEALLOCATE (info)
+      CALL dbcsr_release(pmatrix(1))
+      CALL dbcsr_release(pmatrix(2))
+      CALL dbcsr_release(pmatrix_tmp)
+
+      CALL cp_fm_release(work_orb_orb)
+      CALL cp_fm_release(work_orb_orb2)
+      CALL cp_fm_release(work_aux_orb)
+      IF (.NOT. use_real_wfn) THEN
+         CALL cp_cfm_release(cpmatrix)
+         CALL cp_cfm_release(cwork_aux_aux)
+         CALL cp_cfm_release(cwork_aux_orb)
+         CALL cp_cfm_release(cA)
+         CALL cp_cfm_release(cmo_coeff)
+         CALL cp_cfm_release(cmo_coeff_aux_fit)
+      END IF
+
+      IF (.NOT. pmat_from_rs) CALL kpoint_density_matrices(kpoints, for_aux_fit=.TRUE.)
+      CALL kpoint_density_transform(kpoints, rho_ao_aux, .FALSE., &
+                                    matrix_s_aux_fit(1, 1)%matrix, sab_aux_fit, &
+                                    admm_env%scf_work_aux_fit, for_aux_fit=.TRUE.)
+
+      !ADMMQ, ADMMP, ADMMS
+      IF (admm_env%do_admmq .OR. admm_env%do_admmp .OR. admm_env%do_admms) THEN
+
+         CALL cite_reference(Merlot2014)
+
+         nelec_orb = 0.0_dp
+         nelec_aux = 0.0_dp
+         admm_env%n_large_basis = 0.0_dp
+         !Note: we can take the trace of the symmetric-typed matrices as P_mu^0,nu^b = P_nu^0,mu^-b
+         !      and because of the sum over all images, all atomic blocks are accounted for
+         DO img = 1, dft_control%nimages
+            DO ispin = 1, dft_control%nspins
+               CALL dbcsr_dot(rho_ao_orb(ispin, img)%matrix, matrix_s(1, img)%matrix, tmp)
+               nelec_orb(ispin) = nelec_orb(ispin) + tmp
+               CALL dbcsr_dot(rho_ao_aux(ispin, img)%matrix, matrix_s_aux_fit(1, img)%matrix, tmp)
+               nelec_aux(ispin) = nelec_aux(ispin) + tmp
+            END DO
+         END DO
+
+         DO ispin = 1, dft_control%nspins
+            admm_env%n_large_basis(ispin) = nelec_orb(ispin)
+            admm_env%gsi(ispin) = nelec_orb(ispin)/nelec_aux(ispin)
+         END DO
+
+         IF (admm_env%charge_constrain) THEN
+            DO img = 1, dft_control%nimages
+               DO ispin = 1, dft_control%nspins
+                  CALL dbcsr_scale(rho_ao_aux(ispin, img)%matrix, admm_env%gsi(ispin))
+               END DO
+            END DO
+         END IF
+
+         IF (dft_control%nspins == 1) THEN
+            admm_env%gsi(3) = admm_env%gsi(1)
+         ELSE
+            admm_env%gsi(3) = (admm_env%gsi(1) + admm_env%gsi(2))/2.0_dp
+         END IF
+      END IF
+
+      basis_type = "AUX_FIT"
+      task_list => admm_env%task_list_aux_fit
+      IF (gapw) THEN
+         basis_type = "AUX_FIT_SOFT"
+         task_list => admm_env%admm_gapw_env%task_list
+      END IF
+
+      DO ispin = 1, nspins
+         rho_ao => rho_ao_aux(ispin, :)
+         CALL calculate_rho_elec(ks_env=ks_env, &
+                                 matrix_p_kp=rho_ao, &
+                                 rho=rho_r_aux(ispin), &
+                                 rho_gspace=rho_g_aux(ispin), &
+                                 total_rho=tot_rho_r_aux(ispin), &
+                                 soft_valid=.FALSE., &
+                                 basis_type=basis_type, &
+                                 task_list_external=task_list)
+      END DO
+
+      IF (gapw) THEN
+         CALL calculate_rho_atom_coeff(qs_env, rho_ao_aux, &
+                                       rho_atom_set=admm_env%admm_gapw_env%local_rho_set%rho_atom_set, &
+                                       qs_kind_set=admm_env%admm_gapw_env%admm_kind_set, &
+                                       oce=admm_env%admm_gapw_env%oce, &
+                                       sab=admm_env%sab_aux_fit, para_env=para_env)
+
+         CALL prepare_gapw_den(qs_env, local_rho_set=admm_env%admm_gapw_env%local_rho_set, &
+                               do_rho0=.FALSE., kind_set_external=admm_env%admm_gapw_env%admm_kind_set)
+      END IF
+
+      CALL qs_rho_set(rho_aux_fit, rho_r_valid=.TRUE., rho_g_valid=.TRUE.)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE admm_mo_calc_rho_aux_kp
+
+! **************************************************************************************************
 !> \brief Adds the GAPW exchange contribution to the aux_fit ks matrices
 !> \param qs_env ...
 !> \param calculate_forces ...
@@ -258,10 +715,10 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'admm_update_ks_atom'
 
-      INTEGER                                            :: handle, ispin
+      INTEGER                                            :: handle, img, ispin
       REAL(dp)                                           :: force_fac(2)
       TYPE(admm_type), POINTER                           :: admm_env
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_aux_fit, &
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_aux_fit, &
                                                             matrix_ks_aux_fit_dft, &
                                                             matrix_ks_aux_fit_hfx, rho_ao_aux
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -273,10 +730,10 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, admm_env=admm_env, dft_control=dft_control)
-      CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit, matrix_ks_aux_fit=matrix_ks_aux_fit, &
-                        matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft, &
-                        matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
-      CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux)
+      CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit, matrix_ks_aux_fit_kp=matrix_ks_aux_fit, &
+                        matrix_ks_aux_fit_dft_kp=matrix_ks_aux_fit_dft, &
+                        matrix_ks_aux_fit_hfx_kp=matrix_ks_aux_fit_hfx)
+      CALL qs_rho_get(rho_aux_fit, rho_ao_kp=rho_ao_aux)
 
       !In case of ADMMS or ADMMP, need to scale the forces stemming from DFT exchagne correction
       force_fac = 1.0_dp
@@ -297,9 +754,13 @@ CONTAINS
                           sab_external=admm_env%sab_aux_fit, fscale=force_fac)
 
       !Following the logic of sum_up_and_integrate to recover the pure DFT exchange contribution
-      DO ispin = 1, dft_control%nspins
-         CALL dbcsr_add(matrix_ks_aux_fit_dft(ispin)%matrix, matrix_ks_aux_fit(ispin)%matrix, 0.0_dp, -1.0_dp)
-         CALL dbcsr_add(matrix_ks_aux_fit_dft(ispin)%matrix, matrix_ks_aux_fit_hfx(ispin)%matrix, 1.0_dp, 1.0_dp)
+      DO img = 1, dft_control%nimages
+         DO ispin = 1, dft_control%nspins
+            CALL dbcsr_add(matrix_ks_aux_fit_dft(ispin, img)%matrix, matrix_ks_aux_fit(ispin, img)%matrix, &
+                           0.0_dp, -1.0_dp)
+            CALL dbcsr_add(matrix_ks_aux_fit_dft(ispin, img)%matrix, matrix_ks_aux_fit_hfx(ispin, img)%matrix, &
+                           1.0_dp, 1.0_dp)
+         END DO
       END DO
 
       CALL timestop(handle)
@@ -317,11 +778,12 @@ CONTAINS
 
       INTEGER                                            :: handle
       TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(dft_control_type), POINTER                    :: dft_control
 
       CALL timeset(routineN, handle)
       NULLIFY (admm_env)
 
-      CALL get_qs_env(qs_env, admm_env=admm_env)
+      CALL get_qs_env(qs_env, admm_env=admm_env, dft_control=dft_control)
 
       SELECT CASE (admm_env%purification_method)
       CASE (do_admm_purify_cauchy)
@@ -331,7 +793,11 @@ CONTAINS
          CALL merge_ks_matrix_cauchy_subspace(qs_env)
 
       CASE (do_admm_purify_none)
-         CALL merge_ks_matrix_none(qs_env)
+         IF (dft_control%nimages > 1) THEN
+            CALL merge_ks_matrix_none_kp(qs_env)
+         ELSE
+            CALL merge_ks_matrix_none(qs_env)
+         END IF
 
       CASE (do_admm_purify_mo_diag, do_admm_purify_mo_no_diag)
          !do nothing
@@ -410,9 +876,9 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL fit_mo_coeffs(admm_env, matrix_s_aux_fit, matrix_s_mixed, &
-                         mos, geometry_did_change, &
-                         blocked=admm_env%block_fit)
+      IF (geometry_did_change) THEN
+         CALL fit_mo_coeffs(admm_env, matrix_s_aux_fit, matrix_s_mixed)
+      END IF
 
       SELECT CASE (admm_env%purification_method)
       CASE (do_admm_purify_mo_no_diag, do_admm_purify_cauchy_subspace)
@@ -430,25 +896,19 @@ CONTAINS
    END SUBROUTINE admm_fit_mo_coeffs
 
 ! **************************************************************************************************
-!> \brief ...
+!> \brief Calculate S^-1, Q, B full-matrices given sparse S_tilde and Q
 !> \param admm_env ...
 !> \param matrix_s_aux_fit ...
 !> \param matrix_s_mixed ...
-!> \param mos ...
-!> \param geometry_did_change ...
-!> \param blocked ...
 ! **************************************************************************************************
-   SUBROUTINE fit_mo_coeffs(admm_env, matrix_s_aux_fit, matrix_s_mixed, &
-                            mos, geometry_did_change, blocked)
+   SUBROUTINE fit_mo_coeffs(admm_env, matrix_s_aux_fit, matrix_s_mixed)
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit, matrix_s_mixed
-      TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
-      LOGICAL, INTENT(IN)                                :: geometry_did_change, blocked
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'fit_mo_coeffs'
 
       INTEGER                                            :: blk, handle, iatom, jatom, nao_aux_fit, &
-                                                            nao_orb, nspins
+                                                            nao_orb
       REAL(dp), DIMENSION(:, :), POINTER                 :: sparse_block
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_type), POINTER                          :: matrix_s_tilde
@@ -457,59 +917,56 @@ CONTAINS
 
       nao_aux_fit = admm_env%nao_aux_fit
       nao_orb = admm_env%nao_orb
-      nspins = SIZE(mos)
 
       ! *** This part only depends on overlap matrices ==> needs only to be calculated if the geometry changed
 
-      IF (geometry_did_change) THEN
-         IF (.NOT. blocked) THEN
-            CALL copy_dbcsr_to_fm(matrix_s_aux_fit(1)%matrix, admm_env%S_inv)
-         ELSE
-            NULLIFY (matrix_s_tilde)
-            ALLOCATE (matrix_s_tilde)
-            CALL dbcsr_create(matrix_s_tilde, template=matrix_s_aux_fit(1)%matrix, &
-                              name='MATRIX s_tilde', &
-                              matrix_type=dbcsr_type_symmetric)
+      IF (.NOT. admm_env%block_fit) THEN
+         CALL copy_dbcsr_to_fm(matrix_s_aux_fit(1)%matrix, admm_env%S_inv)
+      ELSE
+         NULLIFY (matrix_s_tilde)
+         ALLOCATE (matrix_s_tilde)
+         CALL dbcsr_create(matrix_s_tilde, template=matrix_s_aux_fit(1)%matrix, &
+                           name='MATRIX s_tilde', &
+                           matrix_type=dbcsr_type_symmetric)
 
-            CALL dbcsr_copy(matrix_s_tilde, matrix_s_aux_fit(1)%matrix)
+         CALL dbcsr_copy(matrix_s_tilde, matrix_s_aux_fit(1)%matrix)
 
-            CALL dbcsr_iterator_start(iter, matrix_s_tilde)
-            DO WHILE (dbcsr_iterator_blocks_left(iter))
-               CALL dbcsr_iterator_next_block(iter, iatom, jatom, sparse_block, blk)
-               IF (admm_env%block_map(iatom, jatom) == 0) THEN
-                  sparse_block = 0.0_dp
-               END IF
-            END DO
-            CALL dbcsr_iterator_stop(iter)
-            CALL copy_dbcsr_to_fm(matrix_s_tilde, admm_env%S_inv)
-            CALL dbcsr_deallocate_matrix(matrix_s_tilde)
-         END IF
+         CALL dbcsr_iterator_start(iter, matrix_s_tilde)
+         DO WHILE (dbcsr_iterator_blocks_left(iter))
+            CALL dbcsr_iterator_next_block(iter, iatom, jatom, sparse_block, blk)
+            IF (admm_env%block_map(iatom, jatom) == 0) THEN
+               sparse_block = 0.0_dp
+            END IF
+         END DO
+         CALL dbcsr_iterator_stop(iter)
+         CALL copy_dbcsr_to_fm(matrix_s_tilde, admm_env%S_inv)
+         CALL dbcsr_deallocate_matrix(matrix_s_tilde)
+      END IF
 
-         CALL cp_fm_upper_to_full(admm_env%S_inv, admm_env%work_aux_aux)
-         CALL cp_fm_to_fm(admm_env%S_inv, admm_env%S)
+      CALL cp_fm_upper_to_full(admm_env%S_inv, admm_env%work_aux_aux)
+      CALL cp_fm_to_fm(admm_env%S_inv, admm_env%S)
 
-         CALL copy_dbcsr_to_fm(matrix_s_mixed(1)%matrix, admm_env%Q)
+      CALL copy_dbcsr_to_fm(matrix_s_mixed(1)%matrix, admm_env%Q)
 
-         !! Calculate S'_inverse
-         CALL cp_fm_cholesky_decompose(admm_env%S_inv)
-         CALL cp_fm_cholesky_invert(admm_env%S_inv)
-         !! Symmetrize the guy
-         CALL cp_fm_upper_to_full(admm_env%S_inv, admm_env%work_aux_aux)
+      !! Calculate S'_inverse
+      CALL cp_fm_cholesky_decompose(admm_env%S_inv)
+      CALL cp_fm_cholesky_invert(admm_env%S_inv)
+      !! Symmetrize the guy
+      CALL cp_fm_upper_to_full(admm_env%S_inv, admm_env%work_aux_aux)
 
-         !! Calculate A=S'^(-1)*Q
-         IF (blocked) THEN
-            CALL cp_fm_set_all(admm_env%A, 0.0_dp, 1.0_dp)
-         ELSE
-            CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, &
-                               1.0_dp, admm_env%S_inv, admm_env%Q, 0.0_dp, &
-                               admm_env%A)
+      !! Calculate A=S'^(-1)*Q
+      IF (admm_env%block_fit) THEN
+         CALL cp_fm_set_all(admm_env%A, 0.0_dp, 1.0_dp)
+      ELSE
+         CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, &
+                            1.0_dp, admm_env%S_inv, admm_env%Q, 0.0_dp, &
+                            admm_env%A)
 
-            ! this multiplication is apparent not need for purify_none
-            !! B=Q^(T)*A
-            CALL parallel_gemm('T', 'N', nao_orb, nao_orb, nao_aux_fit, &
-                               1.0_dp, admm_env%Q, admm_env%A, 0.0_dp, &
-                               admm_env%B)
-         END IF
+         ! this multiplication is apparent not need for purify_none
+         !! B=Q^(T)*A
+         CALL parallel_gemm('T', 'N', nao_orb, nao_orb, nao_aux_fit, &
+                            1.0_dp, admm_env%Q, admm_env%A, 0.0_dp, &
+                            admm_env%B)
       END IF
 
       CALL timestop(handle)
@@ -1476,14 +1933,448 @@ CONTAINS
    END SUBROUTINE merge_ks_matrix_none
 
 ! **************************************************************************************************
-!> \brief Calculate exchange correction energy (Merlot2014 Eqs. 32, 33) for every spin
+!> \brief ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE merge_ks_matrix_none_kp(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'merge_ks_matrix_none_kp'
+
+      COMPLEX(dp)                                        :: fac, fac2
+      INTEGER                                            :: handle, i, igroup, ik, ikp, img, indx, &
+                                                            ispin, kplocal, nao_aux_fit, nao_orb, &
+                                                            natom, nkp, nkp_groups, nspins
+      INTEGER, DIMENSION(2)                              :: kp_range
+      INTEGER, DIMENSION(:, :), POINTER                  :: kp_dist
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: my_kpgrp, use_real_wfn
+      REAL(dp)                                           :: ener_k(2), ener_x(2), ener_x1(2), tmp, &
+                                                            trace_tmp, trace_tmp_two
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(copy_info_type), ALLOCATABLE, DIMENSION(:, :) :: info
+      TYPE(cp_cfm_type)                                  :: cA, cK, cS, cwork_aux_aux, &
+                                                            cwork_aux_orb, cwork_orb_orb
+      TYPE(cp_fm_struct_type), POINTER                   :: struct_aux_aux, struct_aux_orb, &
+                                                            struct_orb_orb
+      TYPE(cp_fm_type)                                   :: fmdummy, work_aux_aux, work_aux_aux2, &
+                                                            work_aux_orb
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fmwork
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :, :)  :: fm_ks
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER :: matrix_k_tilde, matrix_ks_aux_fit, &
+         matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, matrix_ks_kp, matrix_s, matrix_s_aux_fit, &
+         rho_ao_aux
+      TYPE(dbcsr_type)                                   :: tmpmatrix_ks
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: ksmatrix
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_env_type), POINTER                     :: kp
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_aux_fit, sab_kp
+      TYPE(qs_energy_type), POINTER                      :: energy
+      TYPE(qs_rho_type), POINTER                         :: rho_aux_fit
+      TYPE(qs_scf_env_type), POINTER                     :: scf_env
+
+      CALL timeset(routineN, handle)
+      NULLIFY (admm_env, rho_ao_aux, rho_aux_fit, &
+               matrix_s_aux_fit, energy, &
+               para_env, kpoints, sab_aux_fit, &
+               matrix_k_tilde, matrix_ks_kp, matrix_ks_aux_fit, scf_env, &
+               struct_orb_orb, struct_aux_orb, struct_aux_aux, kp, &
+               matrix_ks_aux_fit_hfx, matrix_ks_aux_fit_dft)
+
+      CALL get_qs_env(qs_env, &
+                      admm_env=admm_env, &
+                      dft_control=dft_control, &
+                      matrix_ks_kp=matrix_ks_kp, &
+                      matrix_s_kp=matrix_s, &
+                      para_env=para_env, &
+                      scf_env=scf_env, &
+                      natom=natom, &
+                      kpoints=kpoints, &
+                      energy=energy)
+
+      CALL get_admm_env(admm_env, &
+                        matrix_ks_aux_fit_kp=matrix_ks_aux_fit, &
+                        matrix_ks_aux_fit_hfx_kp=matrix_ks_aux_fit_hfx, &
+                        matrix_ks_aux_fit_dft_kp=matrix_ks_aux_fit_dft, &
+                        matrix_s_aux_fit_kp=matrix_s_aux_fit, &
+                        sab_aux_fit=sab_aux_fit, &
+                        rho_aux_fit=rho_aux_fit)
+      CALL qs_rho_get(rho_aux_fit, rho_ao_kp=rho_ao_aux)
+
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, use_real_wfn=use_real_wfn, kp_range=kp_range, &
+                           nkp_groups=nkp_groups, kp_dist=kp_dist, sab_nl=sab_kp, &
+                           cell_to_index=cell_to_index)
+
+      nao_aux_fit = admm_env%nao_aux_fit
+      nao_orb = admm_env%nao_orb
+      nspins = dft_control%nspins
+
+      !Case study on ADMMQ, ADMMS and ADMMP
+
+      !ADMMQ: calculate lamda as in Merlot eq (28)
+      IF (admm_env%do_admmq) THEN
+         admm_env%lambda_merlot = 0.0_dp
+         DO img = 1, dft_control%nimages
+            DO ispin = 1, nspins
+               CALL dbcsr_dot(matrix_ks_aux_fit(ispin, img)%matrix, rho_ao_aux(ispin, img)%matrix, trace_tmp)
+               admm_env%lambda_merlot(ispin) = admm_env%lambda_merlot(ispin) + trace_tmp/admm_env%n_large_basis(ispin)
+            END DO
+         END DO
+      END IF
+
+      !ADMMP: calculate lamda as in Merlot eq (34)
+      IF (admm_env%do_admmp) THEN
+         IF (nspins == 1) THEN
+            admm_env%lambda_merlot(1) = 2.0_dp*(admm_env%gsi(1))**2* &
+                                        (energy%ex + energy%exc_aux_fit + energy%exc1_aux_fit) &
+                                        /(admm_env%n_large_basis(1))
+         ELSE
+            DO ispin = 1, nspins
+               CALL calc_spin_dep_aux_exch_ener(qs_env=qs_env, admm_env=admm_env, &
+                                                ener_k_ispin=ener_k(ispin), ener_x_ispin=ener_x(ispin), &
+                                                ener_x1_ispin=ener_x1(ispin), ispin=ispin)
+               admm_env%lambda_merlot(ispin) = 2.0_dp*(admm_env%gsi(ispin))**2* &
+                                               (ener_k(ispin) + ener_x(ispin) + ener_x1(ispin))/ &
+                                               (admm_env%n_large_basis(ispin))
+            END DO
+         END IF
+      END IF
+
+      !ADMMS: calculate lambda as in Merlot eq (36)
+      IF (admm_env%do_admms) THEN
+         IF (nspins == 1) THEN
+            trace_tmp = 0.0_dp
+            trace_tmp_two = 0.0_dp
+            DO img = 1, dft_control%nimages
+               CALL dbcsr_dot(matrix_ks_aux_fit_hfx(1, img)%matrix, rho_ao_aux(1, img)%matrix, tmp)
+               trace_tmp = trace_tmp + tmp
+               CALL dbcsr_dot(matrix_ks_aux_fit_dft(1, img)%matrix, rho_ao_aux(1, img)%matrix, tmp)
+               trace_tmp_two = trace_tmp_two + tmp
+            END DO
+            admm_env%lambda_merlot(1) = (trace_tmp + (admm_env%gsi(1))**(2.0_dp/3.0_dp)* &
+                                         (2.0_dp/3.0_dp*(energy%exc_aux_fit + energy%exc1_aux_fit) - &
+                                          trace_tmp_two))/(admm_env%n_large_basis(1))
+         ELSE
+
+            DO ispin = 1, nspins
+               trace_tmp = 0.0_dp
+               trace_tmp_two = 0.0_dp
+               DO img = 1, dft_control%nimages
+                  CALL dbcsr_dot(matrix_ks_aux_fit_hfx(ispin, img)%matrix, rho_ao_aux(ispin, img)%matrix, tmp)
+                  trace_tmp = trace_tmp + tmp
+                  CALL dbcsr_dot(matrix_ks_aux_fit_dft(ispin, img)%matrix, rho_ao_aux(ispin, img)%matrix, tmp)
+                  trace_tmp_two = trace_tmp_two + tmp
+               END DO
+
+               CALL calc_spin_dep_aux_exch_ener(qs_env=qs_env, admm_env=admm_env, &
+                                                ener_k_ispin=ener_k(ispin), ener_x_ispin=ener_x(ispin), &
+                                                ener_x1_ispin=ener_x1(ispin), ispin=ispin)
+
+               admm_env%lambda_merlot(ispin) = &
+                  (trace_tmp + 2.0_dp/3.0_dp*((admm_env%gsi(ispin))**(2.0_dp/3.0_dp))* &
+                   (ener_x(ispin) + ener_x1(ispin)) - ((admm_env%gsi(ispin))**(2.0_dp/3.0_dp))* &
+                   trace_tmp_two)/(admm_env%n_large_basis(ispin))
+            END DO
+         END IF
+
+         !Here we buld the KS matrix: KS_hfx = gsi^2/3*KS_dft, the we then pass as the ususal KS_aux_fit
+         NULLIFY (matrix_ks_aux_fit)
+         ALLOCATE (matrix_ks_aux_fit(nspins, dft_control%nimages))
+         DO img = 1, dft_control%nimages
+            DO ispin = 1, nspins
+               NULLIFY (matrix_ks_aux_fit(ispin, img)%matrix)
+               ALLOCATE (matrix_ks_aux_fit(ispin, img)%matrix)
+               CALL dbcsr_create(matrix_ks_aux_fit(ispin, img)%matrix, template=matrix_s_aux_fit(1, 1)%matrix)
+               CALL dbcsr_copy(matrix_ks_aux_fit(ispin, img)%matrix, matrix_ks_aux_fit_hfx(ispin, img)%matrix)
+               CALL dbcsr_add(matrix_ks_aux_fit(ispin, img)%matrix, matrix_ks_aux_fit_dft(ispin, img)%matrix, &
+                              1.0_dp, -admm_env%gsi(ispin)**(2.0_dp/3.0_dp))
+            END DO
+         END DO
+      END IF
+
+      ! the temporary DBCSR matrices for the rskp_transform we have to manually allocate
+      ALLOCATE (ksmatrix(2))
+      CALL dbcsr_create(ksmatrix(1), template=matrix_ks_aux_fit(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_symmetric)
+      CALL dbcsr_create(ksmatrix(2), template=matrix_ks_aux_fit(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_antisymmetric)
+      CALL dbcsr_create(tmpmatrix_ks, template=matrix_ks_aux_fit(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_symmetric)
+      CALL cp_dbcsr_alloc_block_from_nbl(ksmatrix(1), sab_aux_fit)
+      CALL cp_dbcsr_alloc_block_from_nbl(ksmatrix(2), sab_aux_fit)
+
+      kplocal = kp_range(2) - kp_range(1) + 1
+      para_env => kpoints%blacs_env_all%para_env
+
+      CALL cp_fm_struct_create(struct_aux_aux, context=kpoints%blacs_env, para_env=kpoints%para_env_kp, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_aux_fit)
+      CALL cp_fm_create(work_aux_aux, struct_aux_aux)
+      CALL cp_fm_create(work_aux_aux2, struct_aux_aux)
+
+      CALL cp_fm_struct_create(struct_aux_orb, context=kpoints%blacs_env, para_env=kpoints%para_env_kp, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_orb)
+      CALL cp_fm_create(work_aux_orb, struct_aux_orb)
+
+      CALL cp_fm_struct_create(struct_orb_orb, context=kpoints%blacs_env, para_env=kpoints%para_env_kp, &
+                               nrow_global=nao_orb, ncol_global=nao_orb)
+
+      !Create cfm work matrices
+      IF (.NOT. use_real_wfn) THEN
+         CALL cp_cfm_create(cS, struct_aux_aux)
+         CALL cp_cfm_create(cK, struct_aux_aux)
+         CALL cp_cfm_create(cwork_aux_aux, struct_aux_aux)
+
+         CALL cp_cfm_create(cA, struct_aux_orb)
+         CALL cp_cfm_create(cwork_aux_orb, struct_aux_orb)
+
+         CALL cp_cfm_create(cwork_orb_orb, struct_orb_orb)
+      END IF
+
+      !We create the fms in which we store the KS ORB matrix at each kp
+      ALLOCATE (fm_ks(kplocal, 2, nspins))
+      DO ispin = 1, nspins
+         DO i = 1, 2
+            DO ikp = 1, kplocal
+               CALL cp_fm_create(fm_ks(ikp, i, ispin), struct_orb_orb)
+            END DO
+         END DO
+      END DO
+
+      CALL cp_fm_struct_release(struct_aux_aux)
+      CALL cp_fm_struct_release(struct_aux_orb)
+      CALL cp_fm_struct_release(struct_orb_orb)
+
+      ALLOCATE (info(kplocal*nspins*nkp_groups, 2))
+      indx = 0
+      DO ikp = 1, kplocal
+         DO ispin = 1, nspins
+            DO igroup = 1, nkp_groups
+               ! number of current kpoint
+               ik = kp_dist(1, igroup) + ikp - 1
+               my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+               indx = indx + 1
+
+               IF (use_real_wfn) THEN
+                  CALL dbcsr_set(ksmatrix(1), 0.0_dp)
+                  CALL rskp_transform(rmatrix=ksmatrix(1), rsmat=matrix_ks_aux_fit, ispin=ispin, &
+                                      xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_aux_fit)
+                  CALL dbcsr_desymmetrize(ksmatrix(1), tmpmatrix_ks)
+                  CALL copy_dbcsr_to_fm(tmpmatrix_ks, admm_env%work_aux_aux)
+               ELSE
+                  CALL dbcsr_set(ksmatrix(1), 0.0_dp)
+                  CALL dbcsr_set(ksmatrix(2), 0.0_dp)
+                  CALL rskp_transform(rmatrix=ksmatrix(1), cmatrix=ksmatrix(2), rsmat=matrix_ks_aux_fit, ispin=ispin, &
+                                      xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_aux_fit)
+                  CALL dbcsr_desymmetrize(ksmatrix(1), tmpmatrix_ks)
+                  CALL copy_dbcsr_to_fm(tmpmatrix_ks, admm_env%work_aux_aux)
+                  CALL dbcsr_desymmetrize(ksmatrix(2), tmpmatrix_ks)
+                  CALL copy_dbcsr_to_fm(tmpmatrix_ks, admm_env%work_aux_aux2)
+               END IF
+
+               IF (my_kpgrp) THEN
+                  CALL cp_fm_start_copy_general(admm_env%work_aux_aux, work_aux_aux, para_env, info(indx, 1))
+                  IF (.NOT. use_real_wfn) &
+                     CALL cp_fm_start_copy_general(admm_env%work_aux_aux2, work_aux_aux2, &
+                                                   para_env, info(indx, 2))
+               ELSE
+                  CALL cp_fm_start_copy_general(admm_env%work_aux_aux, fmdummy, para_env, info(indx, 1))
+                  IF (.NOT. use_real_wfn) &
+                     CALL cp_fm_start_copy_general(admm_env%work_aux_aux2, fmdummy, para_env, info(indx, 2))
+               END IF
+            END DO
+         END DO
+      END DO
+
+      indx = 0
+      DO ikp = 1, kplocal
+         DO ispin = 1, nspins
+            DO igroup = 1, nkp_groups
+               ! number of current kpoint
+               ik = kp_dist(1, igroup) + ikp - 1
+               my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+               indx = indx + 1
+               IF (my_kpgrp) THEN
+                  CALL cp_fm_finish_copy_general(work_aux_aux, info(indx, 1))
+                  IF (.NOT. use_real_wfn) THEN
+                     CALL cp_fm_finish_copy_general(work_aux_aux2, info(indx, 2))
+                     CALL cp_fm_to_cfm(work_aux_aux, work_aux_aux2, cK)
+                  END IF
+               END IF
+            END DO
+
+            kp => kpoints%kp_aux_env(ikp)%kpoint_env
+            IF (use_real_wfn) THEN
+
+               !! K*A
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, &
+                                  1.0_dp, work_aux_aux, kp%amat(1, 1), 0.0_dp, &
+                                  work_aux_orb)
+               !! A^T*K*A
+               CALL parallel_gemm('T', 'N', nao_orb, nao_orb, nao_aux_fit, &
+                                  1.0_dp, kp%amat(1, 1), work_aux_orb, 0.0_dp, &
+                                  fm_ks(ikp, 1, ispin))
+            ELSE
+
+               IF (admm_env%do_admmq .OR. admm_env%do_admms) THEN
+                  CALL cp_fm_to_cfm(kp%smat(1, 1), kp%smat(2, 1), cS)
+
+                  !Need to subdtract lambda* S_aux to K_aux, and scale the whole thing by gsi
+                  fac = CMPLX(-admm_env%lambda_merlot(ispin), 0.0_dp, dp)
+                  CALL cp_cfm_scale_and_add(z_one, cK, fac, cS)
+                  CALL cp_cfm_scale(admm_env%gsi(ispin), cK)
+               END IF
+
+               IF (admm_env%do_admmp) THEN
+                  CALL cp_fm_to_cfm(kp%smat(1, 1), kp%smat(2, 1), cS)
+
+                  !Need to substract labda*gsi*S_aux to gsi**2*K_aux
+                  fac = CMPLX(-admm_env%gsi(ispin)*admm_env%lambda_merlot(ispin), 0.0_dp, dp)
+                  fac2 = CMPLX(admm_env%gsi(ispin)**2, 0.0_dp, dp)
+                  CALL cp_cfm_scale_and_add(fac2, cK, fac, cS)
+               END IF
+
+               CALL cp_fm_to_cfm(kp%amat(1, 1), kp%amat(2, 1), cA)
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, &
+                                  z_one, cK, cA, z_zero, cwork_aux_orb)
+
+               CALL parallel_gemm('C', 'N', nao_orb, nao_orb, nao_aux_fit, &
+                                  z_one, cA, cwork_aux_orb, z_zero, cwork_orb_orb)
+
+               CALL cp_cfm_to_fm(cwork_orb_orb, mtargetr=fm_ks(ikp, 1, ispin), mtargeti=fm_ks(ikp, 2, ispin))
+            END IF
+         END DO
+      END DO
+
+      indx = 0
+      DO ikp = 1, kplocal
+         DO ispin = 1, nspins
+            DO igroup = 1, nkp_groups
+               ! number of current kpoint
+               ik = kp_dist(1, igroup) + ikp - 1
+               my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+               indx = indx + 1
+               CALL cp_fm_cleanup_copy_general(info(indx, 1))
+               IF (.NOT. use_real_wfn) CALL cp_fm_cleanup_copy_general(info(indx, 2))
+            END DO
+         END DO
+      END DO
+
+      DEALLOCATE (info)
+      CALL dbcsr_release(ksmatrix(1))
+      CALL dbcsr_release(ksmatrix(2))
+      CALL dbcsr_release(tmpmatrix_ks)
+
+      CALL cp_fm_release(work_aux_aux)
+      CALL cp_fm_release(work_aux_aux2)
+      CALL cp_fm_release(work_aux_orb)
+      IF (.NOT. use_real_wfn) THEN
+         CALL cp_cfm_release(cS)
+         CALL cp_cfm_release(cK)
+         CALL cp_cfm_release(cwork_aux_aux)
+         CALL cp_cfm_release(cA)
+         CALL cp_cfm_release(cwork_aux_orb)
+         CALL cp_cfm_release(cwork_orb_orb)
+      END IF
+
+      NULLIFY (matrix_k_tilde)
+
+      CALL dbcsr_allocate_matrix_set(matrix_k_tilde, dft_control%nspins, dft_control%nimages)
+
+      DO ispin = 1, nspins
+         DO img = 1, dft_control%nimages
+            ALLOCATE (matrix_k_tilde(ispin, img)%matrix)
+            CALL dbcsr_create(matrix=matrix_k_tilde(ispin, img)%matrix, template=matrix_ks_kp(1, 1)%matrix, &
+                              name='MATRIX K_tilde '//TRIM(ADJUSTL(cp_to_string(ispin)))//'_'//TRIM(ADJUSTL(cp_to_string(img))), &
+                              matrix_type=dbcsr_type_symmetric, nze=0)
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_k_tilde(ispin, img)%matrix, sab_kp)
+            CALL dbcsr_set(matrix_k_tilde(ispin, img)%matrix, 0.0_dp)
+         END DO
+      END DO
+
+      CALL cp_fm_get_info(admm_env%work_orb_orb, matrix_struct=struct_orb_orb)
+      ALLOCATE (fmwork(2))
+      CALL cp_fm_create(fmwork(1), struct_orb_orb)
+      CALL cp_fm_create(fmwork(2), struct_orb_orb)
+
+      ! reuse the density transform to FT the KS matrix
+      CALL kpoint_density_transform(kpoints, matrix_k_tilde, .FALSE., &
+                                    matrix_k_tilde(1, 1)%matrix, sab_kp, &
+                                    fmwork, for_aux_fit=.FALSE., pmat_ext=fm_ks)
+      CALL cp_fm_release(fmwork(1))
+      CALL cp_fm_release(fmwork(2))
+
+      DO ispin = 1, nspins
+         DO i = 1, 2
+            DO ikp = 1, kplocal
+               CALL cp_fm_release(fm_ks(ikp, i, ispin))
+            END DO
+         END DO
+      END DO
+
+      DO ispin = 1, nspins
+         DO img = 1, dft_control%nimages
+            CALL dbcsr_add(matrix_ks_kp(ispin, img)%matrix, matrix_k_tilde(ispin, img)%matrix, 1.0_dp, 1.0_dp)
+            IF (admm_env%do_admmq .OR. admm_env%do_admmp .OR. admm_env%do_admms) THEN
+               !In ADMMQ and ADMMP, need to add lambda*S_orb (Merlot eq 27)
+               CALL dbcsr_add(matrix_ks_kp(ispin, img)%matrix, matrix_s(1, img)%matrix, &
+                              1.0_dp, admm_env%lambda_merlot(ispin))
+            END IF
+         END DO
+      END DO
+
+      !Scale the energies
+      IF (admm_env%do_admmp) THEN
+         IF (nspins == 1) THEN
+            energy%exc_aux_fit = (admm_env%gsi(1))**2.0_dp*energy%exc_aux_fit
+            energy%exc1_aux_fit = (admm_env%gsi(1))**2.0_dp*energy%exc1_aux_fit
+            energy%ex = (admm_env%gsi(1))**2.0_dp*energy%ex
+         ELSE
+            energy%exc_aux_fit = 0.0_dp
+            energy%exc1_aux_fit = 0.0_dp
+            energy%ex = 0.0_dp
+            DO ispin = 1, dft_control%nspins
+               energy%exc_aux_fit = energy%exc_aux_fit + (admm_env%gsi(ispin))**2.0_dp*ener_x(ispin)
+               energy%exc1_aux_fit = energy%exc1_aux_fit + (admm_env%gsi(ispin))**2.0_dp*ener_x1(ispin)
+               energy%ex = energy%ex + (admm_env%gsi(ispin))**2.0_dp*ener_k(ispin)
+            END DO
+         END IF
+      END IF
+
+      !Scale the energies and clean-up
+      IF (admm_env%do_admms) THEN
+         IF (nspins == 1) THEN
+            energy%exc_aux_fit = (admm_env%gsi(1))**(2.0_dp/3.0_dp)*energy%exc_aux_fit
+            energy%exc1_aux_fit = (admm_env%gsi(1))**(2.0_dp/3.0_dp)*energy%exc1_aux_fit
+         ELSE
+            energy%exc_aux_fit = 0.0_dp
+            energy%exc1_aux_fit = 0.0_dp
+            DO ispin = 1, nspins
+               energy%exc_aux_fit = energy%exc_aux_fit + (admm_env%gsi(ispin))**(2.0_dp/3.0_dp)*ener_x(ispin)
+               energy%exc1_aux_fit = energy%exc1_aux_fit + (admm_env%gsi(ispin))**(2.0_dp/3.0_dp)*ener_x1(ispin)
+            END DO
+         END IF
+
+         CALL dbcsr_deallocate_matrix_set(matrix_ks_aux_fit)
+      END IF
+
+      CALL dbcsr_deallocate_matrix_set(matrix_k_tilde)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE merge_ks_matrix_none_kp
+
+! **************************************************************************************************
+!> \brief Calculate exchange correction energy (Merlot2014 Eqs. 32, 33) for every spin, for KP
 !> \param qs_env ...
 !> \param admm_env ...
 !> \param ener_k_ispin exact ispin (Fock) exchange in auxiliary basis
 !> \param ener_x_ispin ispin DFT exchange in auxiliary basis
 !> \param ener_x1_ispin ispin DFT exchange in auxiliary basis, due to the GAPW atomic contributions
 !> \param ispin ...
-!> \author Jan Wilhelm, 12/2014
 ! **************************************************************************************************
    SUBROUTINE calc_spin_dep_aux_exch_ener(qs_env, admm_env, ener_k_ispin, ener_x_ispin, &
                                           ener_x1_ispin, ispin)
@@ -1495,12 +2386,14 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_spin_dep_aux_exch_ener'
 
       CHARACTER(LEN=default_string_length)               :: basis_type
-      INTEGER                                            :: handle, myspin
+      INTEGER                                            :: handle, img, myspin, nimg
       LOGICAL                                            :: gapw
+      REAL(dp)                                           :: tmp
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_r
       TYPE(admm_gapw_type), POINTER                      :: admm_gapw_env
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_aux_fit_hfx, rho_ao_aux, &
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: rho_ao
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_aux_fit_hfx, rho_ao_aux, &
                                                             rho_ao_aux_buffer
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(local_rho_type), POINTER                      :: local_rho_buffer
@@ -1514,35 +2407,36 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (ks_env, rho_aux_fit, rho_aux_fit_buffer, &
+      NULLIFY (ks_env, rho_aux_fit, rho_aux_fit_buffer, rho_ao, &
                xc_section_aux, v_rspace_dummy, v_tau_rspace_dummy, &
                rho_ao_aux, rho_ao_aux_buffer, dft_control, &
                matrix_ks_aux_fit_hfx, task_list, local_rho_buffer, admm_gapw_env)
 
       NULLIFY (rho_g, rho_r, tot_rho_r)
 
-      CALL get_qs_env(qs_env, &
-                      ks_env=ks_env, &
-                      dft_control=dft_control)
+      CALL get_qs_env(qs_env, ks_env=ks_env, dft_control=dft_control)
       CALL get_admm_env(admm_env, rho_aux_fit=rho_aux_fit, rho_aux_fit_buffer=rho_aux_fit_buffer, &
-                        matrix_ks_aux_fit_hfx=matrix_ks_aux_fit_hfx)
+                        matrix_ks_aux_fit_hfx_kp=matrix_ks_aux_fit_hfx)
 
       CALL qs_rho_get(rho_aux_fit, &
-                      rho_ao=rho_ao_aux)
+                      rho_ao_kp=rho_ao_aux)
 
       CALL qs_rho_get(rho_aux_fit_buffer, &
-                      rho_ao=rho_ao_aux_buffer, &
+                      rho_ao_kp=rho_ao_aux_buffer, &
                       rho_g=rho_g, &
                       rho_r=rho_r, &
                       tot_rho_r=tot_rho_r)
 
       gapw = admm_env%do_gapw
+      nimg = dft_control%nimages
 
 !   Calculate rho_buffer = rho_aux(ispin) to get exchange of ispin electrons
-      CALL dbcsr_set(rho_ao_aux_buffer(1)%matrix, 0.0_dp)
-      CALL dbcsr_set(rho_ao_aux_buffer(2)%matrix, 0.0_dp)
-      CALL dbcsr_add(rho_ao_aux_buffer(ispin)%matrix, &
-                     rho_ao_aux(ispin)%matrix, 0.0_dp, 1.0_dp)
+      DO img = 1, nimg
+         CALL dbcsr_set(rho_ao_aux_buffer(1, img)%matrix, 0.0_dp)
+         CALL dbcsr_set(rho_ao_aux_buffer(2, img)%matrix, 0.0_dp)
+         CALL dbcsr_add(rho_ao_aux_buffer(ispin, img)%matrix, &
+                        rho_ao_aux(ispin, img)%matrix, 0.0_dp, 1.0_dp)
+      END DO
 
       ! By default use standard AUX_FIT basis and task_list. IF GAPW use the soft ones
       basis_type = "AUX_FIT"
@@ -1555,8 +2449,9 @@ CONTAINS
       ! integration for getting the spin dependent density has to done for both spins!
       DO myspin = 1, dft_control%nspins
 
+         rho_ao => rho_ao_aux_buffer(myspin, :)
          CALL calculate_rho_elec(ks_env=ks_env, &
-                                 matrix_p=rho_ao_aux_buffer(myspin)%matrix, &
+                                 matrix_p_kp=rho_ao, &
                                  rho=rho_r(myspin), &
                                  rho_gspace=rho_g(myspin), &
                                  total_rho=tot_rho_r(myspin), &
@@ -1610,8 +2505,10 @@ CONTAINS
       ener_k_ispin = 0.0_dp
 
       !! ** Calculate the exchange energy
-      CALL dbcsr_dot(matrix_ks_aux_fit_hfx(ispin)%matrix, rho_ao_aux_buffer(ispin)%matrix, &
-                     ener_k_ispin)
+      DO img = 1, nimg
+         CALL dbcsr_dot(matrix_ks_aux_fit_hfx(ispin, img)%matrix, rho_ao_aux_buffer(ispin, img)%matrix, tmp)
+         ener_k_ispin = ener_k_ispin + tmp
+      END DO
 
       ! Divide exchange for indivivual spin by two, since the ener_k_ispin originally is total
       ! exchange of alpha and beta
@@ -1886,6 +2783,447 @@ CONTAINS
       END IF
 
    END SUBROUTINE calc_admm_ovlp_forces
+
+! **************************************************************************************************
+!> \brief Calculate the forces due to the AUX/ORB basis overlap in ADMM, in the KP case
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE calc_admm_ovlp_forces_kp(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'calc_admm_ovlp_forces_kp'
+
+      COMPLEX(dp)                                        :: fac, fac2
+      INTEGER                                            :: handle, i, igroup, ik, ikp, img, indx, &
+                                                            ispin, kplocal, nao_aux_fit, nao_orb, &
+                                                            natom, nimg, nkp, nkp_groups, nspins
+      INTEGER, DIMENSION(2)                              :: kp_range
+      INTEGER, DIMENSION(:, :), POINTER                  :: kp_dist
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: gapw, my_kpgrp, use_real_wfn
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: admm_force
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(copy_info_type), ALLOCATABLE, DIMENSION(:, :) :: info
+      TYPE(cp_cfm_type)                                  :: cA, ckmatrix, cpmatrix, cQ, cS, cS_inv, &
+                                                            cwork_aux_aux, cwork_aux_orb, &
+                                                            cwork_aux_orb2
+      TYPE(cp_fm_struct_type), POINTER                   :: struct_aux_aux, struct_aux_orb, &
+                                                            struct_orb_orb
+      TYPE(cp_fm_type)                                   :: fmdummy, S_inv, work_aux_aux, &
+                                                            work_aux_aux2, work_aux_aux3, &
+                                                            work_aux_orb
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :, :)  :: fm_skap, fm_skapa
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fmwork
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER :: matrix_ks_aux_fit, matrix_ks_aux_fit_dft, &
+         matrix_ks_aux_fit_hfx, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, matrix_skap, &
+         matrix_skapa, rho_ao_orb
+      TYPE(dbcsr_type)                                   :: kmatrix_tmp
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: kmatrix
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_env_type), POINTER                     :: kp
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_aux_fit, sab_aux_fit_asymm, &
+                                                            sab_aux_fit_vs_orb, sab_kp
+      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+      TYPE(qs_rho_type), POINTER                         :: rho
+
+      CALL timeset(routineN, handle)
+
+      !Note: we only treat the case with purification none, there the overlap forces read as:
+      !F = 2*Tr[P * A^T * K_aux * S^-1_aux * Q^(x)] - 2*Tr[A * P * A^T * K_aux * S^-1_aux *S_aux^(x)]
+      !where P is the density matrix in the ORB basis. As a strategy, we FT all relevant matrices
+      !from real space to KP, calculate the matrix products, back FT to real space, and calculate the
+      !overlap forces
+
+      NULLIFY (ks_env, admm_env, matrix_ks_aux_fit, &
+               matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, rho, force, &
+               para_env, atomic_kind_set, kpoints, sab_aux_fit, &
+               sab_aux_fit_vs_orb, sab_aux_fit_asymm, struct_orb_orb, &
+               struct_aux_orb, struct_aux_aux)
+
+      CALL get_qs_env(qs_env, &
+                      ks_env=ks_env, &
+                      admm_env=admm_env, &
+                      dft_control=dft_control, &
+                      kpoints=kpoints, &
+                      natom=natom, &
+                      atomic_kind_set=atomic_kind_set, &
+                      force=force, &
+                      rho=rho)
+      nimg = dft_control%nimages
+      CALL get_admm_env(admm_env, &
+                        matrix_s_aux_fit_kp=matrix_s_aux_fit, &
+                        matrix_s_aux_fit_vs_orb_kp=matrix_s_aux_fit_vs_orb, &
+                        sab_aux_fit=sab_aux_fit, &
+                        sab_aux_fit_vs_orb=sab_aux_fit_vs_orb, &
+                        sab_aux_fit_asymm=sab_aux_fit_asymm, &
+                        matrix_ks_aux_fit_kp=matrix_ks_aux_fit, &
+                        matrix_ks_aux_fit_dft_kp=matrix_ks_aux_fit_dft, &
+                        matrix_ks_aux_fit_hfx_kp=matrix_ks_aux_fit_hfx)
+
+      gapw = admm_env%do_gapw
+      nao_aux_fit = admm_env%nao_aux_fit
+      nao_orb = admm_env%nao_orb
+      nspins = dft_control%nspins
+
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, use_real_wfn=use_real_wfn, kp_range=kp_range, &
+                           nkp_groups=nkp_groups, kp_dist=kp_dist, &
+                           cell_to_index=cell_to_index, sab_nl=sab_kp)
+
+      !Case study on ADMMQ, ADMMS and ADMMP
+      IF (admm_env%do_admms) THEN
+         !Here we buld the KS matrix: KS_hfx = gsi^2/3*KS_dft, the we then pass as the ususal KS_aux_fit
+         NULLIFY (matrix_ks_aux_fit)
+         ALLOCATE (matrix_ks_aux_fit(nspins, dft_control%nimages))
+         DO img = 1, dft_control%nimages
+            DO ispin = 1, nspins
+               NULLIFY (matrix_ks_aux_fit(ispin, img)%matrix)
+               ALLOCATE (matrix_ks_aux_fit(ispin, img)%matrix)
+               CALL dbcsr_create(matrix_ks_aux_fit(ispin, img)%matrix, template=matrix_s_aux_fit(1, 1)%matrix)
+               CALL dbcsr_copy(matrix_ks_aux_fit(ispin, img)%matrix, matrix_ks_aux_fit_hfx(ispin, img)%matrix)
+               CALL dbcsr_add(matrix_ks_aux_fit(ispin, img)%matrix, matrix_ks_aux_fit_dft(ispin, img)%matrix, &
+                              1.0_dp, -admm_env%gsi(ispin)**(2.0_dp/3.0_dp))
+            END DO
+         END DO
+      END IF
+
+      ! the temporary DBCSR matrices for the rskp_transform we have to manually allocate
+      ! index 1 => real, index 2 => imaginary
+      ALLOCATE (kmatrix(2))
+      CALL dbcsr_create(kmatrix(1), template=matrix_ks_aux_fit(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_symmetric)
+      CALL dbcsr_create(kmatrix(2), template=matrix_ks_aux_fit(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_antisymmetric)
+      CALL dbcsr_create(kmatrix_tmp, template=matrix_ks_aux_fit(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+      CALL cp_dbcsr_alloc_block_from_nbl(kmatrix(1), sab_aux_fit)
+      CALL cp_dbcsr_alloc_block_from_nbl(kmatrix(2), sab_aux_fit)
+
+      kplocal = kp_range(2) - kp_range(1) + 1
+      para_env => kpoints%blacs_env_all%para_env
+      ALLOCATE (info(kplocal*nspins*nkp_groups, 2))
+
+      CALL cp_fm_struct_create(struct_aux_aux, context=kpoints%blacs_env, para_env=kpoints%para_env_kp, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_aux_fit)
+      CALL cp_fm_create(work_aux_aux, struct_aux_aux)
+      CALL cp_fm_create(work_aux_aux2, struct_aux_aux)
+      CALL cp_fm_create(work_aux_aux3, struct_aux_aux)
+      CALL cp_fm_create(s_inv, struct_aux_aux)
+
+      CALL cp_fm_struct_create(struct_aux_orb, context=kpoints%blacs_env, para_env=kpoints%para_env_kp, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_orb)
+      CALL cp_fm_create(work_aux_orb, struct_aux_orb)
+
+      CALL cp_fm_struct_create(struct_orb_orb, context=kpoints%blacs_env, para_env=kpoints%para_env_kp, &
+                               nrow_global=nao_orb, ncol_global=nao_orb)
+
+      !Create cfm work matrices
+      IF (.NOT. use_real_wfn) THEN
+         CALL cp_cfm_create(cpmatrix, struct_orb_orb)
+
+         CALL cp_cfm_create(cS_inv, struct_aux_aux)
+         CALL cp_cfm_create(cS, struct_aux_aux)
+         CALL cp_cfm_create(cwork_aux_aux, struct_aux_aux)
+         CALL cp_cfm_create(ckmatrix, struct_aux_aux)
+
+         CALL cp_cfm_create(cA, struct_aux_orb)
+         CALL cp_cfm_create(cQ, struct_aux_orb)
+         CALL cp_cfm_create(cwork_aux_orb, struct_aux_orb)
+         CALL cp_cfm_create(cwork_aux_orb2, struct_aux_orb)
+      END IF
+
+      !We create the fms in which we store the KP matrix products
+      ALLOCATE (fm_skap(kplocal, 2, nspins), fm_skapa(kplocal, 2, nspins))
+      DO ispin = 1, nspins
+         DO i = 1, 2
+            DO ikp = 1, kplocal
+               CALL cp_fm_create(fm_skap(ikp, i, ispin), struct_aux_orb)
+               CALL cp_fm_create(fm_skapa(ikp, i, ispin), struct_aux_aux)
+            END DO
+         END DO
+      END DO
+
+      CALL cp_fm_struct_release(struct_aux_aux)
+      CALL cp_fm_struct_release(struct_aux_orb)
+      CALL cp_fm_struct_release(struct_orb_orb)
+
+      indx = 0
+      DO ikp = 1, kplocal
+         DO ispin = 1, nspins
+            DO igroup = 1, nkp_groups
+               ! number of current kpoint
+               ik = kp_dist(1, igroup) + ikp - 1
+               my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+               indx = indx + 1
+
+               ! FT of matrices KS, then transfer to FM type
+               IF (use_real_wfn) THEN
+                  CALL dbcsr_set(kmatrix(1), 0.0_dp)
+                  CALL rskp_transform(rmatrix=kmatrix(1), rsmat=matrix_ks_aux_fit, ispin=ispin, &
+                                      xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_aux_fit)
+                  CALL dbcsr_desymmetrize(kmatrix(1), kmatrix_tmp)
+                  CALL copy_dbcsr_to_fm(kmatrix_tmp, admm_env%work_aux_aux)
+               ELSE
+                  CALL dbcsr_set(kmatrix(1), 0.0_dp)
+                  CALL dbcsr_set(kmatrix(2), 0.0_dp)
+                  CALL rskp_transform(rmatrix=kmatrix(1), cmatrix=kmatrix(2), rsmat=matrix_ks_aux_fit, ispin=ispin, &
+                                      xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_aux_fit)
+                  CALL dbcsr_desymmetrize(kmatrix(1), kmatrix_tmp)
+                  CALL copy_dbcsr_to_fm(kmatrix_tmp, admm_env%work_aux_aux)
+                  CALL dbcsr_desymmetrize(kmatrix(2), kmatrix_tmp)
+                  CALL copy_dbcsr_to_fm(kmatrix_tmp, admm_env%work_aux_aux2)
+               END IF
+
+               IF (my_kpgrp) THEN
+                  CALL cp_fm_start_copy_general(admm_env%work_aux_aux, work_aux_aux, para_env, info(indx, 1))
+                  IF (.NOT. use_real_wfn) &
+                     CALL cp_fm_start_copy_general(admm_env%work_aux_aux2, work_aux_aux2, para_env, info(indx, 2))
+               ELSE
+                  CALL cp_fm_start_copy_general(admm_env%work_aux_aux, fmdummy, para_env, info(indx, 1))
+                  IF (.NOT. use_real_wfn) &
+                     CALL cp_fm_start_copy_general(admm_env%work_aux_aux2, fmdummy, para_env, info(indx, 2))
+               END IF
+            END DO
+         END DO
+      END DO
+
+      indx = 0
+      DO ikp = 1, kplocal
+         DO ispin = 1, nspins
+            DO igroup = 1, nkp_groups
+               ! number of current kpoint
+               ik = kp_dist(1, igroup) + ikp - 1
+               my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+               indx = indx + 1
+               IF (my_kpgrp) THEN
+                  CALL cp_fm_finish_copy_general(work_aux_aux, info(indx, 1))
+                  IF (.NOT. use_real_wfn) THEN
+                     CALL cp_fm_finish_copy_general(work_aux_aux2, info(indx, 2))
+                     CALL cp_fm_to_cfm(work_aux_aux, work_aux_aux2, ckmatrix)
+                  END IF
+               END IF
+            END DO
+            kp => kpoints%kp_aux_env(ikp)%kpoint_env
+
+            IF (use_real_wfn) THEN
+
+               !! Calculate S'_inverse
+               CALL cp_fm_to_fm(kp%smat(1, 1), S_inv)
+               CALL cp_fm_cholesky_decompose(S_inv)
+               CALL cp_fm_cholesky_invert(S_inv)
+               !! Symmetrize the guy
+               CALL cp_fm_upper_to_full(S_inv, work_aux_aux3)
+
+               !We need to calculate S^-1*K*A*P and S^-1*K*A*P*A^T
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nao_aux_fit, nao_aux_fit, 1.0_dp, S_inv, &
+                                  work_aux_aux, 0.0_dp, work_aux_aux3) ! S^-1 * K
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, 1.0_dp, work_aux_aux3, &
+                                  kp%amat(1, 1), 0.0_dp, work_aux_orb) ! S^-1 * K * A
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_orb, 1.0_dp, work_aux_orb, &
+                                  kpoints%kp_env(ikp)%kpoint_env%pmat(1, ispin), 0.0_dp, &
+                                  fm_skap(ikp, 1, ispin)) ! S^-1 * K * A * P
+               CALL parallel_gemm('N', 'T', nao_aux_fit, nao_aux_fit, nao_orb, 1.0_dp, fm_skap(ikp, 1, ispin), &
+                                  kp%amat(1, 1), 0.0_dp, fm_skapa(ikp, 1, ispin))
+
+            ELSE !complex wfn
+
+               IF (admm_env%do_admmq .OR. admm_env%do_admms) THEN
+                  CALL cp_fm_to_cfm(kp%smat(1, 1), kp%smat(2, 1), cS)
+
+                  !Need to subdtract lambda* S_aux to K_aux, and scale the whole thing by gsi
+                  fac = CMPLX(-admm_env%lambda_merlot(ispin), 0.0_dp, dp)
+                  CALL cp_cfm_scale_and_add(z_one, ckmatrix, fac, cS)
+                  CALL cp_cfm_scale(admm_env%gsi(ispin), ckmatrix)
+               END IF
+
+               IF (admm_env%do_admmp) THEN
+                  CALL cp_fm_to_cfm(kp%smat(1, 1), kp%smat(2, 1), cS)
+
+                  !Need to substract labda*gsi*S_aux to gsi**2*K_aux
+                  fac = CMPLX(-admm_env%gsi(ispin)*admm_env%lambda_merlot(ispin), 0.0_dp, dp)
+                  fac2 = CMPLX(admm_env%gsi(ispin)**2, 0.0_dp, dp)
+                  CALL cp_cfm_scale_and_add(fac2, ckmatrix, fac, cS)
+               END IF
+
+               CALL cp_fm_to_cfm(kp%smat(1, 1), kp%smat(2, 1), cS_inv)
+               CALL cp_cfm_cholesky_decompose(cS_inv)
+               CALL cp_cfm_cholesky_invert(cS_inv)
+               CALL own_cfm_upper_to_full(cS_inv, cwork_aux_aux)
+
+               !Take the ORB density matrix from the kp_env
+               CALL cp_fm_to_cfm(kpoints%kp_env(ikp)%kpoint_env%pmat(1, ispin), &
+                                 kpoints%kp_env(ikp)%kpoint_env%pmat(2, ispin), &
+                                 cpmatrix)
+
+               !Do the same thing as in the real case
+               !We need to calculate S^-1*K*A*P and S^-1*K*A*P*A^T
+               CALL cp_fm_to_cfm(kp%amat(1, 1), kp%amat(2, 1), cA)
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nao_aux_fit, nao_aux_fit, z_one, cS_inv, &
+                                  ckmatrix, z_zero, cwork_aux_aux) ! S^-1 * K
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, z_one, cwork_aux_aux, &
+                                  cA, z_zero, cwork_aux_orb) ! S^-1 * K * A
+               CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_orb, z_one, cwork_aux_orb, &
+                                  cpmatrix, z_zero, cwork_aux_orb2) ! S^-1 * K * A * P
+               CALL parallel_gemm('N', 'C', nao_aux_fit, nao_aux_fit, nao_orb, z_one, cwork_aux_orb2, &
+                                  cA, z_zero, cwork_aux_aux)
+
+               IF (admm_env%do_admmq .OR. admm_env%do_admmp .OR. admm_env%do_admms) THEN
+                  !In ADMMQ, ADMMS, and ADMMP, there is an extra lambda*Tq *P* Tq^T matrix to contract with S_aux^(x)
+                  !we calculate it and add it to fm_skapa (aka cwork_aux_aux)
+
+                  !factor 0.5 because later multiplied by 2
+                  fac = CMPLX(0.5_dp*admm_env%lambda_merlot(ispin)*admm_env%gsi(ispin), 0.0_dp, dp)
+                  CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_orb, z_one, cA, cpmatrix, &
+                                     z_zero, cwork_aux_orb)
+                  CALL parallel_gemm('N', 'C', nao_aux_fit, nao_aux_fit, nao_orb, fac, cwork_aux_orb, &
+                                     cA, z_one, cwork_aux_aux)
+               END IF
+
+               CALL cp_cfm_to_fm(cwork_aux_orb2, mtargetr=fm_skap(ikp, 1, ispin), mtargeti=fm_skap(ikp, 2, ispin))
+               CALL cp_cfm_to_fm(cwork_aux_aux, mtargetr=fm_skapa(ikp, 1, ispin), mtargeti=fm_skapa(ikp, 2, ispin))
+
+            END IF
+
+         END DO
+      END DO
+
+      indx = 0
+      DO ikp = 1, kplocal
+         DO ispin = 1, nspins
+            DO igroup = 1, nkp_groups
+               ! number of current kpoint
+               ik = kp_dist(1, igroup) + ikp - 1
+               my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+               indx = indx + 1
+               CALL cp_fm_cleanup_copy_general(info(indx, 1))
+               IF (.NOT. use_real_wfn) CALL cp_fm_cleanup_copy_general(info(indx, 2))
+            END DO
+         END DO
+      END DO
+
+      DEALLOCATE (info)
+      CALL dbcsr_release(kmatrix(1))
+      CALL dbcsr_release(kmatrix(2))
+      CALL dbcsr_release(kmatrix_tmp)
+
+      CALL cp_fm_release(work_aux_aux)
+      CALL cp_fm_release(work_aux_aux2)
+      CALL cp_fm_release(work_aux_aux3)
+      CALL cp_fm_release(S_inv)
+      CALL cp_fm_release(work_aux_orb)
+      IF (.NOT. use_real_wfn) THEN
+         CALL cp_cfm_release(ckmatrix)
+         CALL cp_cfm_release(cpmatrix)
+         CALL cp_cfm_release(cS_inv)
+         CALL cp_cfm_release(cS)
+         CALL cp_cfm_release(cwork_aux_aux)
+         CALL cp_cfm_release(cwork_aux_orb)
+         CALL cp_cfm_release(cwork_aux_orb2)
+         CALL cp_cfm_release(cA)
+         CALL cp_cfm_release(cQ)
+      END IF
+
+      !Back FT to real space
+      ALLOCATE (matrix_skap(nspins, nimg), matrix_skapa(nspins, nimg))
+      DO img = 1, nimg
+         DO ispin = 1, nspins
+            ALLOCATE (matrix_skap(ispin, img)%matrix)
+            CALL dbcsr_create(matrix_skap(ispin, img)%matrix, template=matrix_s_aux_fit_vs_orb(1, 1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry)
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_skap(ispin, img)%matrix, sab_aux_fit_vs_orb)
+
+            ALLOCATE (matrix_skapa(ispin, img)%matrix)
+            CALL dbcsr_create(matrix_skapa(ispin, img)%matrix, template=matrix_s_aux_fit(1, 1)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry)
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_skapa(ispin, img)%matrix, sab_aux_fit_asymm)
+         END DO
+      END DO
+
+      ALLOCATE (fmwork(2))
+      CALL cp_fm_get_info(admm_env%work_aux_orb, matrix_struct=struct_aux_orb)
+      CALL cp_fm_create(fmwork(1), struct_aux_orb)
+      CALL cp_fm_create(fmwork(2), struct_aux_orb)
+      CALL kpoint_density_transform(kpoints, matrix_skap, .FALSE., &
+                                    matrix_s_aux_fit_vs_orb(1, 1)%matrix, sab_aux_fit_vs_orb, &
+                                    fmwork, for_aux_fit=.TRUE., pmat_ext=fm_skap)
+      CALL cp_fm_release(fmwork(1))
+      CALL cp_fm_release(fmwork(2))
+
+      CALL cp_fm_get_info(admm_env%work_aux_aux, matrix_struct=struct_aux_aux)
+      CALL cp_fm_create(fmwork(1), struct_aux_aux)
+      CALL cp_fm_create(fmwork(2), struct_aux_aux)
+      CALL kpoint_density_transform(kpoints, matrix_skapa, .FALSE., &
+                                    matrix_s_aux_fit(1, 1)%matrix, sab_aux_fit_asymm, &
+                                    fmwork, for_aux_fit=.TRUE., pmat_ext=fm_skapa)
+      CALL cp_fm_release(fmwork(1))
+      CALL cp_fm_release(fmwork(2))
+      DEALLOCATE (fmwork)
+
+      DO img = 1, nimg
+         DO ispin = 1, nspins
+            CALL dbcsr_scale(matrix_skap(ispin, img)%matrix, -2.0_dp)
+            CALL dbcsr_scale(matrix_skapa(ispin, img)%matrix, 2.0_dp)
+         END DO
+         IF (nspins == 2) THEN
+            CALL dbcsr_add(matrix_skap(1, img)%matrix, matrix_skap(2, img)%matrix, 1.0_dp, 1.0_dp)
+            CALL dbcsr_add(matrix_skapa(1, img)%matrix, matrix_skapa(2, img)%matrix, 1.0_dp, 1.0_dp)
+         END IF
+      END DO
+
+      ALLOCATE (admm_force(3, natom))
+      admm_force = 0.0_dp
+
+      IF (admm_env%do_admmq .OR. admm_env%do_admmp .OR. admm_env%do_admms) THEN
+         CALL qs_rho_get(rho, rho_ao_kp=rho_ao_orb)
+         DO img = 1, nimg
+            DO ispin = 1, nspins
+               CALL dbcsr_scale(rho_ao_orb(ispin, img)%matrix, -admm_env%lambda_merlot(ispin))
+            END DO
+            IF (nspins == 2) CALL dbcsr_add(rho_ao_orb(1, img)%matrix, rho_ao_orb(2, img)%matrix, 1.0_dp, 1.0_dp)
+         END DO
+
+         !In ADMMQ, ADMMS and ADMMP, there is an extra contribution from lambda*P_orb*S^(x)
+         CALL build_overlap_force(qs_env%ks_env, admm_force, basis_type_a="ORB", basis_type_b="ORB", &
+                                  sab_nl=sab_kp, matrixkp_p=rho_ao_orb(1, :))
+         DO img = 1, nimg
+            IF (nspins == 2) CALL dbcsr_add(rho_ao_orb(1, img)%matrix, rho_ao_orb(2, img)%matrix, 1.0_dp, -1.0_dp)
+            DO ispin = 1, nspins
+               CALL dbcsr_scale(rho_ao_orb(ispin, img)%matrix, -1.0_dp/admm_env%lambda_merlot(ispin))
+            END DO
+         END DO
+      END IF
+
+      CALL build_overlap_force(qs_env%ks_env, admm_force, basis_type_a="AUX_FIT", basis_type_b="ORB", &
+                               sab_nl=sab_aux_fit_vs_orb, matrixkp_p=matrix_skap(1, :))
+      CALL build_overlap_force(qs_env%ks_env, admm_force, basis_type_a="AUX_FIT", basis_type_b="AUX_FIT", &
+                               sab_nl=sab_aux_fit_asymm, matrixkp_p=matrix_skapa(1, :))
+
+      CALL add_qs_force(admm_force, force, "overlap_admm", atomic_kind_set)
+      DEALLOCATE (admm_force)
+
+      DO ispin = 1, nspins
+         DO i = 1, 2
+            DO ikp = 1, kplocal
+               CALL cp_fm_release(fm_skap(ikp, i, ispin))
+               CALL cp_fm_release(fm_skapa(ikp, i, ispin))
+            END DO
+         END DO
+      END DO
+      CALL dbcsr_deallocate_matrix_set(matrix_skap)
+      CALL dbcsr_deallocate_matrix_set(matrix_skapa)
+
+      IF (admm_env%do_admms) THEN
+         CALL dbcsr_deallocate_matrix_set(matrix_ks_aux_fit)
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE calc_admm_ovlp_forces_kp
 
 ! **************************************************************************************************
 !> \brief Calculate derivatives terms from overlap matrices
@@ -2508,5 +3846,328 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE admm_aux_response_density
+
+! **************************************************************************************************
+!> \brief Fill the ADMM overlp and basis change  matrices in the KP env based on the real-space array
+!> \param qs_env ...
+!> \param calculate_forces ...
+! **************************************************************************************************
+   SUBROUTINE kpoint_calc_admm_matrices(qs_env, calculate_forces)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      LOGICAL                                            :: calculate_forces
+
+      INTEGER                                            :: ic, igroup, ik, ikp, indx, kplocal, &
+                                                            nao_aux_fit, nao_orb, nc, nkp, &
+                                                            nkp_groups
+      INTEGER, DIMENSION(2)                              :: kp_range
+      INTEGER, DIMENSION(:, :), POINTER                  :: kp_dist
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: my_kpgrp, use_real_wfn
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(copy_info_type), ALLOCATABLE, DIMENSION(:, :) :: info
+      TYPE(cp_cfm_type)                                  :: cmat_aux_fit, cmat_aux_fit_vs_orb, &
+                                                            cwork_aux_fit, cwork_aux_fit_vs_orb
+      TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct_aux_fit, &
+                                                            matrix_struct_aux_fit_vs_orb
+      TYPE(cp_fm_type)                                   :: fmdummy, imat_aux_fit, &
+                                                            imat_aux_fit_vs_orb, rmat_aux_fit, &
+                                                            rmat_aux_fit_vs_orb, work_aux_fit
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fmwork
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: dbcsr_aux_fit, dbcsr_aux_fit_vs_orb
+      TYPE(kpoint_env_type), POINTER                     :: kp
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(mp_para_env_type), POINTER                    :: para_env_global, para_env_local
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_aux_fit, sab_aux_fit_vs_orb
+
+      NULLIFY (xkp, kp_dist, para_env_local, cell_to_index, admm_env, kp, &
+               kpoints, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, sab_aux_fit, sab_aux_fit_vs_orb, &
+               para_env_global, matrix_struct_aux_fit, matrix_struct_aux_fit_vs_orb)
+
+      CALL get_qs_env(qs_env, kpoints=kpoints, admm_env=admm_env)
+
+      CALL get_admm_env(admm_env, matrix_s_aux_fit_kp=matrix_s_aux_fit, &
+                        matrix_s_aux_fit_vs_orb_kp=matrix_s_aux_fit_vs_orb, &
+                        sab_aux_fit=sab_aux_fit, &
+                        sab_aux_fit_vs_orb=sab_aux_fit_vs_orb)
+
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, use_real_wfn=use_real_wfn, kp_range=kp_range, &
+                           nkp_groups=nkp_groups, kp_dist=kp_dist, cell_to_index=cell_to_index)
+      kplocal = kp_range(2) - kp_range(1) + 1
+      nc = 1
+      IF (.NOT. use_real_wfn) nc = 2
+
+      ALLOCATE (dbcsr_aux_fit(3))
+      CALL dbcsr_create(dbcsr_aux_fit(1), template=matrix_s_aux_fit(1, 1)%matrix, matrix_type=dbcsr_type_symmetric)
+      CALL dbcsr_create(dbcsr_aux_fit(2), template=matrix_s_aux_fit(1, 1)%matrix, matrix_type=dbcsr_type_antisymmetric)
+      CALL dbcsr_create(dbcsr_aux_fit(3), template=matrix_s_aux_fit(1, 1)%matrix, matrix_type=dbcsr_type_no_symmetry)
+      CALL cp_dbcsr_alloc_block_from_nbl(dbcsr_aux_fit(1), sab_aux_fit)
+      CALL cp_dbcsr_alloc_block_from_nbl(dbcsr_aux_fit(2), sab_aux_fit)
+
+      ALLOCATE (dbcsr_aux_fit_vs_orb(2))
+      CALL dbcsr_create(dbcsr_aux_fit_vs_orb(1), template=matrix_s_aux_fit_vs_orb(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+      CALL dbcsr_create(dbcsr_aux_fit_vs_orb(2), template=matrix_s_aux_fit_vs_orb(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
+      CALL cp_dbcsr_alloc_block_from_nbl(dbcsr_aux_fit_vs_orb(1), sab_aux_fit_vs_orb)
+      CALL cp_dbcsr_alloc_block_from_nbl(dbcsr_aux_fit_vs_orb(2), sab_aux_fit_vs_orb)
+
+      !Create global work fm
+      nao_aux_fit = admm_env%nao_aux_fit
+      nao_orb = admm_env%nao_orb
+      para_env_global => kpoints%blacs_env_all%para_env
+
+      ALLOCATE (fmwork(4))
+      CALL cp_fm_struct_create(matrix_struct_aux_fit, context=kpoints%blacs_env_all, para_env=para_env_global, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_aux_fit)
+      CALL cp_fm_create(fmwork(1), matrix_struct_aux_fit)
+      CALL cp_fm_create(fmwork(2), matrix_struct_aux_fit)
+      CALL cp_fm_struct_release(matrix_struct_aux_fit)
+
+      CALL cp_fm_struct_create(matrix_struct_aux_fit_vs_orb, context=kpoints%blacs_env_all, para_env=para_env_global, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_orb)
+      CALL cp_fm_create(fmwork(3), matrix_struct_aux_fit_vs_orb)
+      CALL cp_fm_create(fmwork(4), matrix_struct_aux_fit_vs_orb)
+      CALL cp_fm_struct_release(matrix_struct_aux_fit_vs_orb)
+
+      !Create fm local to the KP groups
+      nao_aux_fit = admm_env%nao_aux_fit
+      nao_orb = admm_env%nao_orb
+      para_env_local => kpoints%blacs_env%para_env
+
+      CALL cp_fm_struct_create(matrix_struct_aux_fit, context=kpoints%blacs_env, para_env=para_env_local, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_aux_fit)
+      CALL cp_fm_create(rmat_aux_fit, matrix_struct_aux_fit)
+      CALL cp_fm_create(imat_aux_fit, matrix_struct_aux_fit)
+      CALL cp_fm_create(work_aux_fit, matrix_struct_aux_fit)
+      CALL cp_cfm_create(cwork_aux_fit, matrix_struct_aux_fit)
+      CALL cp_cfm_create(cmat_aux_fit, matrix_struct_aux_fit)
+
+      CALL cp_fm_struct_create(matrix_struct_aux_fit_vs_orb, context=kpoints%blacs_env, para_env=para_env_local, &
+                               nrow_global=nao_aux_fit, ncol_global=nao_orb)
+      CALL cp_fm_create(rmat_aux_fit_vs_orb, matrix_struct_aux_fit_vs_orb)
+      CALL cp_fm_create(imat_aux_fit_vs_orb, matrix_struct_aux_fit_vs_orb)
+      CALL cp_cfm_create(cwork_aux_fit_vs_orb, matrix_struct_aux_fit_vs_orb)
+      CALL cp_cfm_create(cmat_aux_fit_vs_orb, matrix_struct_aux_fit_vs_orb)
+
+      ALLOCATE (info(kplocal*nkp_groups, 4))
+
+      ! Steup and start all the communication
+      indx = 0
+      DO ikp = 1, kplocal
+         DO igroup = 1, nkp_groups
+            ik = kp_dist(1, igroup) + ikp - 1
+            my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+            indx = indx + 1
+
+            IF (use_real_wfn) THEN
+               !AUX-AUX overlap
+               CALL dbcsr_set(dbcsr_aux_fit(1), 0.0_dp)
+               CALL rskp_transform(rmatrix=dbcsr_aux_fit(1), rsmat=matrix_s_aux_fit, ispin=1, &
+                                   xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_aux_fit)
+               CALL dbcsr_desymmetrize(dbcsr_aux_fit(1), dbcsr_aux_fit(3))
+               CALL copy_dbcsr_to_fm(dbcsr_aux_fit(3), fmwork(1))
+
+               !AUX-ORB overlap
+               CALL dbcsr_set(dbcsr_aux_fit_vs_orb(1), 0.0_dp)
+               CALL rskp_transform(rmatrix=dbcsr_aux_fit_vs_orb(1), rsmat=matrix_s_aux_fit_vs_orb, ispin=1, &
+                                   xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_aux_fit_vs_orb)
+               CALL copy_dbcsr_to_fm(dbcsr_aux_fit_vs_orb(1), fmwork(3))
+            ELSE
+               !AUX-AUX overlap
+               CALL dbcsr_set(dbcsr_aux_fit(1), 0.0_dp)
+               CALL dbcsr_set(dbcsr_aux_fit(2), 0.0_dp)
+               CALL rskp_transform(rmatrix=dbcsr_aux_fit(1), cmatrix=dbcsr_aux_fit(2), rsmat=matrix_s_aux_fit, &
+                                   ispin=1, xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_aux_fit)
+               CALL dbcsr_desymmetrize(dbcsr_aux_fit(1), dbcsr_aux_fit(3))
+               CALL copy_dbcsr_to_fm(dbcsr_aux_fit(3), fmwork(1))
+               CALL dbcsr_desymmetrize(dbcsr_aux_fit(2), dbcsr_aux_fit(3))
+               CALL copy_dbcsr_to_fm(dbcsr_aux_fit(3), fmwork(2))
+
+               !AUX-ORB overlap
+               CALL dbcsr_set(dbcsr_aux_fit_vs_orb(1), 0.0_dp)
+               CALL dbcsr_set(dbcsr_aux_fit_vs_orb(2), 0.0_dp)
+               CALL rskp_transform(rmatrix=dbcsr_aux_fit_vs_orb(1), cmatrix=dbcsr_aux_fit_vs_orb(2), &
+                                   rsmat=matrix_s_aux_fit_vs_orb, ispin=1, xkp=xkp(1:3, ik), &
+                                   cell_to_index=cell_to_index, sab_nl=sab_aux_fit_vs_orb)
+               CALL copy_dbcsr_to_fm(dbcsr_aux_fit_vs_orb(1), fmwork(3))
+               CALL copy_dbcsr_to_fm(dbcsr_aux_fit_vs_orb(2), fmwork(4))
+            END IF
+
+            IF (my_kpgrp) THEN
+               CALL cp_fm_start_copy_general(fmwork(1), rmat_aux_fit, para_env_global, info(indx, 1))
+               CALL cp_fm_start_copy_general(fmwork(3), rmat_aux_fit_vs_orb, para_env_global, info(indx, 3))
+               IF (.NOT. use_real_wfn) THEN
+                  CALL cp_fm_start_copy_general(fmwork(2), imat_aux_fit, para_env_global, info(indx, 2))
+                  CALL cp_fm_start_copy_general(fmwork(4), imat_aux_fit_vs_orb, para_env_global, info(indx, 4))
+               END IF
+            ELSE
+               CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env_global, info(indx, 1))
+               CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env_global, info(indx, 3))
+               IF (.NOT. use_real_wfn) THEN
+                  CALL cp_fm_start_copy_general(fmwork(2), fmdummy, para_env_global, info(indx, 2))
+                  CALL cp_fm_start_copy_general(fmwork(4), fmdummy, para_env_global, info(indx, 4))
+               END IF
+            END IF
+
+         END DO
+      END DO
+
+      ! Finish communication and store
+      indx = 0
+      DO ikp = 1, kplocal
+         DO igroup = 1, nkp_groups
+            ik = kp_dist(1, igroup) + ikp - 1
+            my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+            indx = indx + 1
+
+            IF (my_kpgrp) THEN
+               CALL cp_fm_finish_copy_general(rmat_aux_fit, info(indx, 1))
+               CALL cp_fm_finish_copy_general(rmat_aux_fit_vs_orb, info(indx, 3))
+               IF (.NOT. use_real_wfn) THEN
+                  CALL cp_fm_finish_copy_general(imat_aux_fit, info(indx, 2))
+                  CALL cp_fm_finish_copy_general(imat_aux_fit_vs_orb, info(indx, 4))
+               END IF
+            END IF
+         END DO
+
+         kp => kpoints%kp_aux_env(ikp)%kpoint_env
+
+         !Allocate local KP matrices
+         CALL cp_fm_release(kp%amat)
+         ALLOCATE (kp%amat(nc, 1))
+         DO ic = 1, nc
+            CALL cp_fm_create(kp%amat(ic, 1), matrix_struct_aux_fit_vs_orb)
+         END DO
+
+         !Only need the overlap in case of ADMMP, ADMMQ or ADMMS, or for forces
+         IF (admm_env%do_admmp .OR. admm_env%do_admmq .OR. admm_env%do_admms .OR. calculate_forces) THEN
+            CALL cp_fm_release(kp%smat)
+            ALLOCATE (kp%smat(nc, 1))
+            DO ic = 1, nc
+               CALL cp_fm_create(kp%smat(ic, 1), matrix_struct_aux_fit)
+            END DO
+            CALL cp_fm_to_fm(rmat_aux_fit, kp%smat(1, 1))
+            IF (.NOT. use_real_wfn) CALL cp_fm_to_fm(imat_aux_fit, kp%smat(2, 1))
+         END IF
+
+         IF (use_real_wfn) THEN
+            !Invert S_aux
+            CALL cp_fm_cholesky_decompose(rmat_aux_fit)
+            CALL cp_fm_cholesky_invert(rmat_aux_fit)
+            CALL cp_fm_upper_to_full(rmat_aux_fit, work_aux_fit)
+
+            !A = S^-1 * Q
+            CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, 1.0_dp, &
+                               rmat_aux_fit, rmat_aux_fit_vs_orb, 0.0_dp, kp%amat(1, 1))
+         ELSE
+
+            !Invert S_aux
+            CALL cp_fm_to_cfm(rmat_aux_fit, imat_aux_fit, cmat_aux_fit)
+            CALL cp_cfm_cholesky_decompose(cmat_aux_fit)
+            CALL cp_cfm_cholesky_invert(cmat_aux_fit)
+            CALL own_cfm_upper_to_full(cmat_aux_fit, cwork_aux_fit)
+
+            !A = S^-1 * Q
+            CALL cp_fm_to_cfm(rmat_aux_fit_vs_orb, imat_aux_fit_vs_orb, cmat_aux_fit_vs_orb)
+            CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, z_one, &
+                               cmat_aux_fit, cmat_aux_fit_vs_orb, z_zero, cwork_aux_fit_vs_orb)
+            CALL cp_cfm_to_fm(cwork_aux_fit_vs_orb, kp%amat(1, 1), kp%amat(2, 1))
+         END IF
+      END DO
+
+      ! Clean up communication
+      indx = 0
+      DO ikp = 1, kplocal
+         DO igroup = 1, nkp_groups
+            ik = kp_dist(1, igroup) + ikp - 1
+            my_kpgrp = (ik >= kpoints%kp_range(1) .AND. ik <= kpoints%kp_range(2))
+            indx = indx + 1
+
+            IF (my_kpgrp) THEN
+               CALL cp_fm_cleanup_copy_general(info(indx, 1))
+               CALL cp_fm_cleanup_copy_general(info(indx, 3))
+               IF (.NOT. use_real_wfn) THEN
+                  CALL cp_fm_cleanup_copy_general(info(indx, 2))
+                  CALL cp_fm_cleanup_copy_general(info(indx, 4))
+               END IF
+            END IF
+
+         END DO
+      END DO
+
+      CALL cp_fm_release(rmat_aux_fit)
+      CALL cp_fm_release(imat_aux_fit)
+      CALL cp_fm_release(work_aux_fit)
+      CALL cp_cfm_release(cwork_aux_fit)
+      CALL cp_cfm_release(cmat_aux_fit)
+      CALL cp_fm_release(rmat_aux_fit_vs_orb)
+      CALL cp_fm_release(imat_aux_fit_vs_orb)
+      CALL cp_cfm_release(cwork_aux_fit_vs_orb)
+      CALL cp_cfm_release(cmat_aux_fit_vs_orb)
+      CALL cp_fm_struct_release(matrix_struct_aux_fit)
+      CALL cp_fm_struct_release(matrix_struct_aux_fit_vs_orb)
+
+      CALL cp_fm_release(fmwork(1))
+      CALL cp_fm_release(fmwork(2))
+      CALL cp_fm_release(fmwork(3))
+      CALL cp_fm_release(fmwork(4))
+
+      CALL dbcsr_release(dbcsr_aux_fit(1))
+      CALL dbcsr_release(dbcsr_aux_fit(2))
+      CALL dbcsr_release(dbcsr_aux_fit(3))
+      CALL dbcsr_release(dbcsr_aux_fit_vs_orb(1))
+      CALL dbcsr_release(dbcsr_aux_fit_vs_orb(2))
+
+   END SUBROUTINE kpoint_calc_admm_matrices
+
+! **************************************************************************************************
+!> \brief ...
+!> \param cfm_mat_Q ...
+!> \param cfm_mat_work ...
+! **************************************************************************************************
+   SUBROUTINE own_cfm_upper_to_full(cfm_mat_Q, cfm_mat_work)
+
+      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q, cfm_mat_work
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'own_cfm_upper_to_full'
+
+      INTEGER                                            :: handle, i_global, iiB, j_global, jjB, &
+                                                            ncol_local, nrow_local
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
+
+      CALL timeset(routineN, handle)
+
+      !TODO: routine cpoied from rpa_gw_kpoints_util.F => put it somewhere centralized?
+
+      ! get info of fm_mat_Q
+      CALL cp_cfm_get_info(matrix=cfm_mat_Q, &
+                           nrow_local=nrow_local, &
+                           ncol_local=ncol_local, &
+                           row_indices=row_indices, &
+                           col_indices=col_indices)
+
+      DO jjB = 1, ncol_local
+         j_global = col_indices(jjB)
+         DO iiB = 1, nrow_local
+            i_global = row_indices(iiB)
+            IF (j_global < i_global) THEN
+               cfm_mat_Q%local_data(iiB, jjB) = z_zero
+            END IF
+            IF (j_global == i_global) THEN
+               cfm_mat_Q%local_data(iiB, jjB) = cfm_mat_Q%local_data(iiB, jjB)/(2.0_dp, 0.0_dp)
+            END IF
+         END DO
+      END DO
+
+      CALL cp_cfm_transpose(cfm_mat_Q, 'C', cfm_mat_work)
+
+      CALL cp_cfm_scale_and_add(z_one, cfm_mat_Q, z_one, cfm_mat_work)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE
 
 END MODULE admm_methods

--- a/src/admm_types.F
+++ b/src/admm_types.F
@@ -17,6 +17,7 @@ MODULE admm_types
                                               admm_dm_type
    USE bibliography,                    ONLY: Guidon2010,&
                                               cite_reference
+   USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: admm_control_type
    USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
@@ -36,6 +37,12 @@ MODULE admm_types
    USE input_section_types,             ONLY: section_vals_release,&
                                               section_vals_type
    USE kinds,                           ONLY: dp
+   USE kpoint_transitional,             ONLY: get_1d_pointer,&
+                                              get_2d_pointer,&
+                                              kpoint_transitional_release,&
+                                              kpoint_transitional_type,&
+                                              set_1d_pointer,&
+                                              set_2d_pointer
    USE message_passing,                 ONLY: mp_para_env_type
    USE qs_kind_types,                   ONLY: deallocate_qs_kind_set,&
                                               qs_kind_type
@@ -150,7 +157,8 @@ MODULE admm_types
                                                    lambda_inv2 => Null(), &
                                                    C_hat => Null(), &
                                                    P_tilde => Null(), &
-                                                   ks_to_be_merged => Null()
+                                                   ks_to_be_merged => Null(), &
+                                                   scf_work_aux_fit => Null()
       TYPE(eigvals_p_type), DIMENSION(:), &
          POINTER                                :: eigvals_lambda => Null(), &
                                                    eigvals_P_to_be_purified => Null()
@@ -179,9 +187,12 @@ MODULE admm_types
       TYPE(neighbor_list_set_p_type), &
          DIMENSION(:), POINTER                 :: sab_aux_fit => NULL(), sab_aux_fit_asymm => NULL(), sab_aux_fit_vs_orb => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:), &
-         POINTER                               :: matrix_ks_aux_fit => NULL(), matrix_ks_aux_fit_im => NULL(), &
-                                                  matrix_ks_aux_fit_dft => NULL(), matrix_ks_aux_fit_hfx => NULL(), &
-                                                  matrix_s_aux_fit => NULL(), matrix_s_aux_fit_vs_orb => NULL()
+         POINTER                               :: matrix_ks_aux_fit_im => Null()
+      TYPE(kpoint_transitional_type)           :: matrix_ks_aux_fit, &
+                                                  matrix_ks_aux_fit_dft, &
+                                                  matrix_ks_aux_fit_hfx, &
+                                                  matrix_s_aux_fit, &
+                                                  matrix_s_aux_fit_vs_orb
       TYPE(qs_rho_type), POINTER               :: rho_aux_fit => NULL(), rho_aux_fit_buffer => NULL()
       TYPE(task_list_type), POINTER            :: task_list_aux_fit => NULL()
       TYPE(cp_fm_type), DIMENSION(:), &
@@ -200,22 +211,25 @@ CONTAINS
 !> \param para_env The parallel env
 !> \param natoms ...
 !> \param nao_aux_fit ...
+!> \param blacs_env_ext ...
 !> \par History
 !>      05.2008 created [Manuel Guidon]
 !> \author Manuel Guidon
 ! **************************************************************************************************
-   SUBROUTINE admm_env_create(admm_env, admm_control, mos, para_env, natoms, nao_aux_fit)
+   SUBROUTINE admm_env_create(admm_env, admm_control, mos, para_env, natoms, nao_aux_fit, blacs_env_ext)
 
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(admm_control_type), POINTER                   :: admm_control
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
       TYPE(mp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: natoms, nao_aux_fit
+      TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env_ext
 
       INTEGER                                            :: i, iatom, iblock, ispin, j, jatom, &
                                                             nao_orb, nmo, nspins
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER :: fm_struct_aux_aux, fm_struct_aux_nmo, fm_struct_aux_orb, &
-         fm_struct_nmo_nmo, fm_struct_orb_aux, fm_struct_orb_nmo, fm_struct_orb_orb
+         fm_struct_nmo_nmo, fm_struct_orb_nmo, fm_struct_orb_orb
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
 
       CALL cite_reference(Guidon2010)
@@ -224,26 +238,24 @@ CONTAINS
 
       nspins = SIZE(mos)
       CALL get_mo_set(mos(1), mo_coeff=mo_coeff, nmo=nmo, nao=nao_orb)
+      blacs_env => mo_coeff%matrix_struct%context
+      IF (PRESENT(blacs_env_ext)) blacs_env => blacs_env_ext
+
       admm_env%nmo = 0
       admm_env%nao_aux_fit = nao_aux_fit
       admm_env%nao_orb = nao_orb
       CALL cp_fm_struct_create(fm_struct_aux_aux, &
-                               context=mo_coeff%matrix_struct%context, &
+                               context=blacs_env, &
                                nrow_global=nao_aux_fit, &
                                ncol_global=nao_aux_fit, &
                                para_env=para_env)
       CALL cp_fm_struct_create(fm_struct_aux_orb, &
-                               context=mo_coeff%matrix_struct%context, &
+                               context=blacs_env, &
                                nrow_global=nao_aux_fit, &
                                ncol_global=nao_orb, &
                                para_env=para_env)
-      CALL cp_fm_struct_create(fm_struct_orb_aux, &
-                               context=mo_coeff%matrix_struct%context, &
-                               nrow_global=nao_orb, &
-                               ncol_global=nao_aux_fit, &
-                               para_env=para_env)
       CALL cp_fm_struct_create(fm_struct_orb_orb, &
-                               context=mo_coeff%matrix_struct%context, &
+                               context=blacs_env, &
                                nrow_global=nao_orb, &
                                ncol_global=nao_orb, &
                                para_env=para_env)
@@ -304,17 +316,17 @@ CONTAINS
          CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
          admm_env%nmo(ispin) = nmo
          CALL cp_fm_struct_create(fm_struct_aux_nmo, &
-                                  context=mo_coeff%matrix_struct%context, &
+                                  context=blacs_env, &
                                   nrow_global=nao_aux_fit, &
                                   ncol_global=nmo, &
                                   para_env=para_env)
          CALL cp_fm_struct_create(fm_struct_orb_nmo, &
-                                  context=mo_coeff%matrix_struct%context, &
+                                  context=blacs_env, &
                                   nrow_global=nao_orb, &
                                   ncol_global=nmo, &
                                   para_env=para_env)
          CALL cp_fm_struct_create(fm_struct_nmo_nmo, &
-                                  context=mo_coeff%matrix_struct%context, &
+                                  context=blacs_env, &
                                   nrow_global=nmo, &
                                   ncol_global=nmo, &
                                   para_env=para_env)
@@ -355,7 +367,6 @@ CONTAINS
 
       CALL cp_fm_struct_release(fm_struct_aux_aux)
       CALL cp_fm_struct_release(fm_struct_aux_orb)
-      CALL cp_fm_struct_release(fm_struct_orb_aux)
       CALL cp_fm_struct_release(fm_struct_orb_orb)
 
       ! Copy settings from admm_control
@@ -398,8 +409,7 @@ CONTAINS
       admm_env%do_gapw = .FALSE.
 
       NULLIFY (admm_env%mos_aux_fit, admm_env%sab_aux_fit, admm_env%sab_aux_fit_asymm, admm_env%sab_aux_fit_vs_orb)
-      NULLIFY (admm_env%matrix_ks_aux_fit, admm_env%matrix_ks_aux_fit_im, admm_env%matrix_ks_aux_fit_dft)
-      NULLIFY (admm_env%matrix_ks_aux_fit_hfx, admm_env%matrix_s_aux_fit, admm_env%matrix_s_aux_fit_vs_orb)
+      NULLIFY (admm_env%matrix_ks_aux_fit_im)
       NULLIFY (admm_env%rho_aux_fit, admm_env%rho_aux_fit_buffer, admm_env%task_list_aux_fit, admm_env%mo_derivs_aux_fit)
 
    END SUBROUTINE admm_env_create
@@ -492,16 +502,21 @@ CONTAINS
       END IF
       CALL cp_fm_release(admm_env%mo_derivs_aux_fit)
 
+      IF (ASSOCIATED(admm_env%scf_work_aux_fit)) THEN
+         CALL cp_fm_release(admm_env%scf_work_aux_fit)
+      END IF
+
       IF (ASSOCIATED(admm_env%sab_aux_fit)) CALL release_neighbor_list_sets(admm_env%sab_aux_fit)
       IF (ASSOCIATED(admm_env%sab_aux_fit_vs_orb)) CALL release_neighbor_list_sets(admm_env%sab_aux_fit_vs_orb)
       IF (ASSOCIATED(admm_env%sab_aux_fit_asymm)) CALL release_neighbor_list_sets(admm_env%sab_aux_fit_asymm)
 
-      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit)
+      CALL kpoint_transitional_release(admm_env%matrix_ks_aux_fit)
+      CALL kpoint_transitional_release(admm_env%matrix_ks_aux_fit_dft)
+      CALL kpoint_transitional_release(admm_env%matrix_ks_aux_fit_hfx)
+      CALL kpoint_transitional_release(admm_env%matrix_s_aux_fit)
+      CALL kpoint_transitional_release(admm_env%matrix_s_aux_fit_vs_orb)
+
       IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_im)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_im)
-      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_dft)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_dft)
-      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_hfx)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_hfx)
-      IF (ASSOCIATED(admm_env%matrix_s_aux_fit)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_s_aux_fit)
-      IF (ASSOCIATED(admm_env%matrix_s_aux_fit_vs_orb)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_s_aux_fit_vs_orb)
 
       IF (ASSOCIATED(admm_env%rho_aux_fit)) THEN
          CALL qs_rho_release(admm_env%rho_aux_fit)
@@ -555,20 +570,25 @@ CONTAINS
 !> \param sab_aux_fit_asymm ...
 !> \param sab_aux_fit_vs_orb ...
 !> \param matrix_s_aux_fit ...
+!> \param matrix_s_aux_fit_kp ...
 !> \param matrix_s_aux_fit_vs_orb ...
+!> \param matrix_s_aux_fit_vs_orb_kp ...
 !> \param task_list_aux_fit ...
 !> \param matrix_ks_aux_fit ...
+!> \param matrix_ks_aux_fit_kp ...
 !> \param matrix_ks_aux_fit_im ...
 !> \param matrix_ks_aux_fit_dft ...
 !> \param matrix_ks_aux_fit_hfx ...
+!> \param matrix_ks_aux_fit_dft_kp ...
+!> \param matrix_ks_aux_fit_hfx_kp ...
 !> \param rho_aux_fit ...
 !> \param rho_aux_fit_buffer ...
 !> \param admm_dm ...
 ! **************************************************************************************************
    SUBROUTINE get_admm_env(admm_env, mo_derivs_aux_fit, mos_aux_fit, sab_aux_fit, sab_aux_fit_asymm, &
-                           sab_aux_fit_vs_orb, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
-                           task_list_aux_fit, matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
-                           matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, rho_aux_fit, &
+                   sab_aux_fit_vs_orb, matrix_s_aux_fit, matrix_s_aux_fit_kp, matrix_s_aux_fit_vs_orb, matrix_s_aux_fit_vs_orb_kp, &
+                           task_list_aux_fit, matrix_ks_aux_fit, matrix_ks_aux_fit_kp, matrix_ks_aux_fit_im, &
+                    matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, matrix_ks_aux_fit_dft_kp, matrix_ks_aux_fit_hfx_kp, rho_aux_fit, &
                            rho_aux_fit_buffer, admm_dm)
 
       TYPE(admm_type), INTENT(IN), POINTER               :: admm_env
@@ -578,12 +598,25 @@ CONTAINS
          OPTIONAL, POINTER                               :: sab_aux_fit, sab_aux_fit_asymm, &
                                                             sab_aux_fit_vs_orb
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
+         POINTER                                         :: matrix_s_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: matrix_s_aux_fit_kp
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_s_aux_fit_vs_orb
+      TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: matrix_s_aux_fit_vs_orb_kp
       TYPE(task_list_type), OPTIONAL, POINTER            :: task_list_aux_fit
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
+         POINTER                                         :: matrix_ks_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: matrix_ks_aux_fit_kp
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_ks_aux_fit_im, &
                                                             matrix_ks_aux_fit_dft, &
                                                             matrix_ks_aux_fit_hfx
+      TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: matrix_ks_aux_fit_dft_kp, &
+                                                            matrix_ks_aux_fit_hfx_kp
       TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho_aux_fit, rho_aux_fit_buffer
       TYPE(admm_dm_type), OPTIONAL, POINTER              :: admm_dm
 
@@ -594,17 +627,22 @@ CONTAINS
       IF (PRESENT(sab_aux_fit)) sab_aux_fit => admm_env%sab_aux_fit
       IF (PRESENT(sab_aux_fit_asymm)) sab_aux_fit_asymm => admm_env%sab_aux_fit_asymm
       IF (PRESENT(sab_aux_fit_vs_orb)) sab_aux_fit_vs_orb => admm_env%sab_aux_fit_vs_orb
-      IF (PRESENT(matrix_s_aux_fit)) matrix_s_aux_fit => admm_env%matrix_s_aux_fit
-      IF (PRESENT(matrix_s_aux_fit_vs_orb)) matrix_s_aux_fit_vs_orb => admm_env%matrix_s_aux_fit_vs_orb
       IF (PRESENT(task_list_aux_fit)) task_list_aux_fit => admm_env%task_list_aux_fit
-      IF (PRESENT(matrix_ks_aux_fit)) matrix_ks_aux_fit => admm_env%matrix_ks_aux_fit
       IF (PRESENT(matrix_ks_aux_fit_im)) matrix_ks_aux_fit_im => admm_env%matrix_ks_aux_fit_im
-      IF (PRESENT(matrix_ks_aux_fit_dft)) matrix_ks_aux_fit_dft => admm_env%matrix_ks_aux_fit_dft
-      IF (PRESENT(matrix_ks_aux_fit_hfx)) matrix_ks_aux_fit_hfx => admm_env%matrix_ks_aux_fit_hfx
       IF (PRESENT(rho_aux_fit)) rho_aux_fit => admm_env%rho_aux_fit
       IF (PRESENT(rho_aux_fit_buffer)) rho_aux_fit_buffer => admm_env%rho_aux_fit_buffer
       IF (PRESENT(admm_dm)) admm_dm => admm_env%admm_dm
 
+      IF (PRESENT(matrix_ks_aux_fit)) matrix_ks_aux_fit => get_1d_pointer(admm_env%matrix_ks_aux_fit)
+      IF (PRESENT(matrix_ks_aux_fit_kp)) matrix_ks_aux_fit_kp => get_2d_pointer(admm_env%matrix_ks_aux_fit)
+      IF (PRESENT(matrix_ks_aux_fit_dft)) matrix_ks_aux_fit_dft => get_1d_pointer(admm_env%matrix_ks_aux_fit_dft)
+      IF (PRESENT(matrix_ks_aux_fit_dft_kp)) matrix_ks_aux_fit_dft_kp => get_2d_pointer(admm_env%matrix_ks_aux_fit_dft)
+      IF (PRESENT(matrix_ks_aux_fit_hfx)) matrix_ks_aux_fit_hfx => get_1d_pointer(admm_env%matrix_ks_aux_fit_hfx)
+      IF (PRESENT(matrix_ks_aux_fit_hfx_kp)) matrix_ks_aux_fit_hfx_kp => get_2d_pointer(admm_env%matrix_ks_aux_fit_hfx)
+      IF (PRESENT(matrix_s_aux_fit)) matrix_s_aux_fit => get_1d_pointer(admm_env%matrix_s_aux_fit)
+      IF (PRESENT(matrix_s_aux_fit_kp)) matrix_s_aux_fit_kp => get_2d_pointer(admm_env%matrix_s_aux_fit)
+      IF (PRESENT(matrix_s_aux_fit_vs_orb)) matrix_s_aux_fit_vs_orb => get_1d_pointer(admm_env%matrix_s_aux_fit_vs_orb)
+      IF (PRESENT(matrix_s_aux_fit_vs_orb_kp)) matrix_s_aux_fit_vs_orb_kp => get_2d_pointer(admm_env%matrix_s_aux_fit_vs_orb)
    END SUBROUTINE get_admm_env
 
 ! **************************************************************************************************
@@ -616,20 +654,25 @@ CONTAINS
 !> \param sab_aux_fit_asymm ...
 !> \param sab_aux_fit_vs_orb ...
 !> \param matrix_s_aux_fit ...
+!> \param matrix_s_aux_fit_kp ...
 !> \param matrix_s_aux_fit_vs_orb ...
+!> \param matrix_s_aux_fit_vs_orb_kp ...
 !> \param task_list_aux_fit ...
 !> \param matrix_ks_aux_fit ...
+!> \param matrix_ks_aux_fit_kp ...
 !> \param matrix_ks_aux_fit_im ...
 !> \param matrix_ks_aux_fit_dft ...
 !> \param matrix_ks_aux_fit_hfx ...
+!> \param matrix_ks_aux_fit_dft_kp ...
+!> \param matrix_ks_aux_fit_hfx_kp ...
 !> \param rho_aux_fit ...
 !> \param rho_aux_fit_buffer ...
 !> \param admm_dm ...
 ! **************************************************************************************************
    SUBROUTINE set_admm_env(admm_env, mo_derivs_aux_fit, mos_aux_fit, sab_aux_fit, sab_aux_fit_asymm, &
-                           sab_aux_fit_vs_orb, matrix_s_aux_fit, matrix_s_aux_fit_vs_orb, &
-                           task_list_aux_fit, matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
-                           matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, rho_aux_fit, &
+                   sab_aux_fit_vs_orb, matrix_s_aux_fit, matrix_s_aux_fit_kp, matrix_s_aux_fit_vs_orb, matrix_s_aux_fit_vs_orb_kp, &
+                           task_list_aux_fit, matrix_ks_aux_fit, matrix_ks_aux_fit_kp, matrix_ks_aux_fit_im, &
+                    matrix_ks_aux_fit_dft, matrix_ks_aux_fit_hfx, matrix_ks_aux_fit_dft_kp, matrix_ks_aux_fit_hfx_kp, rho_aux_fit, &
                            rho_aux_fit_buffer, admm_dm)
 
       TYPE(admm_type), INTENT(INOUT), POINTER            :: admm_env
@@ -639,12 +682,25 @@ CONTAINS
          OPTIONAL, POINTER                               :: sab_aux_fit, sab_aux_fit_asymm, &
                                                             sab_aux_fit_vs_orb
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: matrix_s_aux_fit, matrix_s_aux_fit_vs_orb
+         POINTER                                         :: matrix_s_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: matrix_s_aux_fit_kp
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_s_aux_fit_vs_orb
+      TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: matrix_s_aux_fit_vs_orb_kp
       TYPE(task_list_type), OPTIONAL, POINTER            :: task_list_aux_fit
       TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: matrix_ks_aux_fit, matrix_ks_aux_fit_im, &
+         POINTER                                         :: matrix_ks_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: matrix_ks_aux_fit_kp
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_ks_aux_fit_im, &
                                                             matrix_ks_aux_fit_dft, &
                                                             matrix_ks_aux_fit_hfx
+      TYPE(dbcsr_p_type), DIMENSION(:, :), OPTIONAL, &
+         POINTER                                         :: matrix_ks_aux_fit_dft_kp, &
+                                                            matrix_ks_aux_fit_hfx_kp
       TYPE(qs_rho_type), OPTIONAL, POINTER               :: rho_aux_fit, rho_aux_fit_buffer
       TYPE(admm_dm_type), OPTIONAL, POINTER              :: admm_dm
 
@@ -655,16 +711,22 @@ CONTAINS
       IF (PRESENT(sab_aux_fit)) admm_env%sab_aux_fit => sab_aux_fit
       IF (PRESENT(sab_aux_fit_asymm)) admm_env%sab_aux_fit_asymm => sab_aux_fit_asymm
       IF (PRESENT(sab_aux_fit_vs_orb)) admm_env%sab_aux_fit_vs_orb => sab_aux_fit_vs_orb
-      IF (PRESENT(matrix_s_aux_fit)) admm_env%matrix_s_aux_fit => matrix_s_aux_fit
-      IF (PRESENT(matrix_s_aux_fit_vs_orb)) admm_env%matrix_s_aux_fit_vs_orb => matrix_s_aux_fit_vs_orb
       IF (PRESENT(task_list_aux_fit)) admm_env%task_list_aux_fit => task_list_aux_fit
-      IF (PRESENT(matrix_ks_aux_fit)) admm_env%matrix_ks_aux_fit => matrix_ks_aux_fit
       IF (PRESENT(matrix_ks_aux_fit_im)) admm_env%matrix_ks_aux_fit_im => matrix_ks_aux_fit_im
-      IF (PRESENT(matrix_ks_aux_fit_dft)) admm_env%matrix_ks_aux_fit_dft => matrix_ks_aux_fit_dft
-      IF (PRESENT(matrix_ks_aux_fit_hfx)) admm_env%matrix_ks_aux_fit_hfx => matrix_ks_aux_fit_hfx
       IF (PRESENT(rho_aux_fit)) admm_env%rho_aux_fit => rho_aux_fit
       IF (PRESENT(rho_aux_fit_buffer)) admm_env%rho_aux_fit_buffer => rho_aux_fit_buffer
       IF (PRESENT(admm_dm)) admm_env%admm_dm => admm_dm
+
+      IF (PRESENT(matrix_ks_aux_fit)) CALL set_1d_pointer(admm_env%matrix_ks_aux_fit, matrix_ks_aux_fit)
+      IF (PRESENT(matrix_ks_aux_fit_kp)) CALL set_2d_pointer(admm_env%matrix_ks_aux_fit, matrix_ks_aux_fit_kp)
+      IF (PRESENT(matrix_ks_aux_fit_dft)) CALL set_1d_pointer(admm_env%matrix_ks_aux_fit_dft, matrix_ks_aux_fit_dft)
+      IF (PRESENT(matrix_ks_aux_fit_dft_kp)) CALL set_2d_pointer(admm_env%matrix_ks_aux_fit_dft, matrix_ks_aux_fit_dft_kp)
+      IF (PRESENT(matrix_ks_aux_fit_hfx)) CALL set_1d_pointer(admm_env%matrix_ks_aux_fit_hfx, matrix_ks_aux_fit)
+      IF (PRESENT(matrix_ks_aux_fit_hfx_kp)) CALL set_2d_pointer(admm_env%matrix_ks_aux_fit_hfx, matrix_ks_aux_fit_hfx_kp)
+      IF (PRESENT(matrix_s_aux_fit)) CALL set_1d_pointer(admm_env%matrix_s_aux_fit, matrix_s_aux_fit)
+      IF (PRESENT(matrix_s_aux_fit_kp)) CALL set_2d_pointer(admm_env%matrix_s_aux_fit, matrix_s_aux_fit_kp)
+      IF (PRESENT(matrix_s_aux_fit_vs_orb)) CALL set_1d_pointer(admm_env%matrix_s_aux_fit_vs_orb, matrix_s_aux_fit_vs_orb)
+      IF (PRESENT(matrix_s_aux_fit_vs_orb_kp)) CALL set_2d_pointer(admm_env%matrix_s_aux_fit_vs_orb, matrix_s_aux_fit_vs_orb_kp)
 
    END SUBROUTINE set_admm_env
 

--- a/src/hfx_admm_utils.F
+++ b/src/hfx_admm_utils.F
@@ -16,11 +16,13 @@
 ! **************************************************************************************************
 MODULE hfx_admm_utils
    USE admm_dm_types,                   ONLY: admm_dm_create
-   USE admm_methods,                    ONLY: scale_dm
+   USE admm_methods,                    ONLY: kpoint_calc_admm_matrices,&
+                                              scale_dm
    USE admm_types,                      ONLY: admm_env_create,&
                                               admm_gapw_type,&
                                               admm_type,&
-                                              get_admm_env
+                                              get_admm_env,&
+                                              set_admm_env
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE basis_set_container_types,       ONLY: add_basis_set_to_container
    USE basis_set_types,                 ONLY: copy_gto_basis_set,&
@@ -32,8 +34,8 @@ MODULE hfx_admm_utils
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: cp_dbcsr_m_by_n_from_row_template,&
-                                              dbcsr_allocate_matrix_set,&
-                                              dbcsr_deallocate_matrix_set
+                                              dbcsr_allocate_matrix_set
+   USE cp_fm_pool_types,                ONLY: cp_fm_pool_p_type
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
@@ -60,14 +62,18 @@ MODULE hfx_admm_utils
    USE hfx_pw_methods,                  ONLY: pw_hfx
    USE hfx_ri,                          ONLY: hfx_ri_update_forces,&
                                               hfx_ri_update_ks
+   USE hfx_ri_kp,                       ONLY: hfx_ri_update_forces_kp,&
+                                              hfx_ri_update_ks_kp
    USE hfx_types,                       ONLY: hfx_type
    USE input_constants,                 ONLY: &
         do_admm_aux_exch_func_bee, do_admm_aux_exch_func_bee_libxc, do_admm_aux_exch_func_default, &
         do_admm_aux_exch_func_default_libxc, do_admm_aux_exch_func_none, &
         do_admm_aux_exch_func_opt, do_admm_aux_exch_func_opt_libxc, do_admm_aux_exch_func_pbex, &
-        do_admm_aux_exch_func_pbex_libxc, do_admm_aux_exch_func_sx_libxc, do_potential_coulomb, &
-        do_potential_long, do_potential_mix_cl, do_potential_mix_cl_trunc, do_potential_short, &
-        do_potential_truncated, xc_funct_no_shortcut, xc_none
+        do_admm_aux_exch_func_pbex_libxc, do_admm_aux_exch_func_sx_libxc, &
+        do_admm_basis_projection, do_admm_charge_constrained_projection, do_admm_purify_none, &
+        do_potential_coulomb, do_potential_id, do_potential_long, do_potential_mix_cl, &
+        do_potential_mix_cl_trunc, do_potential_short, do_potential_truncated, &
+        xc_funct_no_shortcut, xc_none
    USE input_section_types,             ONLY: section_vals_duplicate,&
                                               section_vals_get,&
                                               section_vals_get_subs_vals,&
@@ -77,7 +83,13 @@ MODULE hfx_admm_utils
                                               section_vals_val_get,&
                                               section_vals_val_set
    USE kinds,                           ONLY: dp
-   USE kpoint_types,                    ONLY: kpoint_type
+   USE kpoint_methods,                  ONLY: kpoint_initialize_mos
+   USE kpoint_transitional,             ONLY: kpoint_transitional_release,&
+                                              set_2d_pointer
+   USE kpoint_types,                    ONLY: get_kpoint_info,&
+                                              kpoint_type
+   USE libint_2c_3c,                    ONLY: cutoff_screen_factor
+   USE mathlib,                         ONLY: erfc_cutoff
    USE message_passing,                 ONLY: mp_para_env_type
    USE molecule_types,                  ONLY: molecule_type
    USE particle_types,                  ONLY: particle_type
@@ -100,6 +112,7 @@ MODULE hfx_admm_utils
                                               qs_kind_type
    USE qs_ks_types,                     ONLY: qs_ks_env_type
    USE qs_local_rho_types,              ONLY: local_rho_set_create
+   USE qs_matrix_pools,                 ONLY: mpools_get
    USE qs_mo_types,                     ONLY: allocate_mo_set,&
                                               get_mo_set,&
                                               init_mo_set,&
@@ -134,7 +147,7 @@ MODULE hfx_admm_utils
    PRIVATE
 
    ! *** Public subroutines ***
-   PUBLIC :: hfx_ks_matrix, hfx_admm_init, create_admm_xc_section, tddft_hfx_matrix
+   PUBLIC :: hfx_ks_matrix, hfx_admm_init, create_admm_xc_section, tddft_hfx_matrix, hfx_ks_matrix_kp
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'hfx_admm_utils'
 
@@ -143,34 +156,38 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param qs_env ...
+!> \param calculate_forces ...
 ! **************************************************************************************************
-   SUBROUTINE hfx_admm_init(qs_env)
+   SUBROUTINE hfx_admm_init(qs_env, calculate_forces)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
+      LOGICAL, INTENT(IN), OPTIONAL                      :: calculate_forces
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'hfx_admm_init'
 
       INTEGER                                            :: handle, ispin, n_rep_hf, nao_aux_fit, &
                                                             natoms, nelectron, nmo
-      LOGICAL                                            :: s_mstruct_changed, use_virial
+      LOGICAL                                            :: calc_forces, do_kpoints, &
+                                                            s_mstruct_changed, use_virial
       REAL(dp)                                           :: maxocc
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER                   :: aux_fit_fm_struct
       TYPE(cp_fm_type), POINTER                          :: mo_coeff_aux_fit
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_aux_fit_kp
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_b
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos, mos_aux_fit
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
-      TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(section_vals_type), POINTER                   :: hfx_sections, input, xc_section
       TYPE(virial_type), POINTER                         :: virial
 
       CALL timeset(routineN, handle)
+
       NULLIFY (admm_env, hfx_sections, mos, mos_aux_fit, para_env, virial, &
-               mo_coeff_aux_fit, xc_section, rho, ks_env, dft_control, input, &
+               mo_coeff_aux_fit, xc_section, ks_env, dft_control, input, &
                qs_kind_set, mo_coeff_b, aux_fit_fm_struct, blacs_env)
 
       CALL get_qs_env(qs_env, &
@@ -179,11 +196,14 @@ CONTAINS
                       para_env=para_env, &
                       blacs_env=blacs_env, &
                       s_mstruct_changed=s_mstruct_changed, &
-                      rho=rho, &
                       ks_env=ks_env, &
                       dft_control=dft_control, &
                       input=input, &
-                      virial=virial)
+                      virial=virial, &
+                      do_kpoints=do_kpoints)
+
+      calc_forces = .FALSE.
+      IF (PRESENT(calculate_forces)) calc_forces = .TRUE.
 
       hfx_sections => section_vals_get_subs_vals(input, "DFT%XC%HF")
 
@@ -247,8 +267,9 @@ CONTAINS
             IF (.NOT. ASSOCIATED(mo_coeff_b)) THEN
                CALL cp_fm_get_info(mos_aux_fit(ispin)%mo_coeff, ncol_global=nmo)
                CALL dbcsr_init_p(mos_aux_fit(ispin)%mo_coeff_b)
+               CALL get_admm_env(admm_env, matrix_s_aux_fit_kp=matrix_s_aux_fit_kp)
                CALL cp_dbcsr_m_by_n_from_row_template(mos_aux_fit(ispin)%mo_coeff_b, &
-                                                      template=admm_env%matrix_s_aux_fit(1)%matrix, &
+                                                      template=matrix_s_aux_fit_kp(1, 1)%matrix, &
                                                       n=nmo, sym=dbcsr_type_no_symmetry)
             END IF
          END DO
@@ -261,11 +282,80 @@ CONTAINS
             END DO
          END IF
 
+         IF (do_kpoints) THEN
+            BLOCK
+               TYPE(kpoint_type), POINTER :: kpoints
+               TYPE(mo_set_type), DIMENSION(:, :), POINTER           :: mos_aux_fit_kp
+               TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER        :: ao_mo_fm_pools_aux_fit
+               TYPE(cp_fm_struct_type), POINTER                      :: ao_ao_fm_struct
+               INTEGER                                               :: ic, ik, ikk, is
+               INTEGER, PARAMETER                                    :: nwork1 = 4
+               LOGICAL                                               :: use_real_wfn
+
+               NULLIFY (ao_mo_fm_pools_aux_fit, mos_aux_fit_kp)
+
+               CALL get_qs_env(qs_env=qs_env, kpoints=kpoints)
+               CALL get_kpoint_info(kpoints, use_real_wfn=use_real_wfn)
+
+               !Test combinations of input values. So far, only ADMM2 is availavle
+               IF (.NOT. admm_env%purification_method == do_admm_purify_none) &
+                  CPABORT("Only ADMM_PURIFICATION_METHOD NONE implemeted for ADMM K-points")
+               IF (.NOT. (dft_control%admm_control%method == do_admm_basis_projection &
+                          .OR. dft_control%admm_control%method == do_admm_charge_constrained_projection)) &
+                  CPABORT("Only BASIS_PROJECTION and CHARGE_CONSTRAINED_PROJECTION implemented for KP")
+               IF (admm_env%do_admms .OR. admm_env%do_admmp .OR. admm_env%do_admmq) THEN
+                  IF (use_real_wfn) CPABORT("Only KP-HFX ADMM2 is implemented with REAL wavefunctions")
+               END IF
+
+               CALL kpoint_initialize_mos(kpoints, admm_env%mos_aux_fit, for_aux_fit=.TRUE.)
+
+               CALL mpools_get(kpoints%mpools_aux_fit, ao_mo_fm_pools=ao_mo_fm_pools_aux_fit)
+               DO ik = 1, SIZE(kpoints%kp_aux_env)
+                  mos_aux_fit_kp => kpoints%kp_aux_env(ik)%kpoint_env%mos
+                  ikk = kpoints%kp_range(1) + ik - 1
+                  DO ispin = 1, SIZE(mos_aux_fit_kp, 2)
+                     DO ic = 1, SIZE(mos_aux_fit_kp, 1)
+                        CALL get_mo_set(mos_aux_fit_kp(ic, ispin), mo_coeff=mo_coeff_aux_fit, mo_coeff_b=mo_coeff_b)
+
+                        ! no sparse matrix representation of kpoint MO vectors
+                        CPASSERT(.NOT. ASSOCIATED(mo_coeff_b))
+
+                        IF (.NOT. ASSOCIATED(mo_coeff_aux_fit)) THEN
+                           CALL init_mo_set(mos_aux_fit_kp(ic, ispin), &
+                                            fm_pool=ao_mo_fm_pools_aux_fit(ispin)%pool, &
+                                            name="kpoints_"//TRIM(ADJUSTL(cp_to_string(ikk)))// &
+                                            "%mo_aux_fit"//TRIM(ADJUSTL(cp_to_string(ispin))))
+                        END IF
+                     END DO
+                  END DO
+               END DO
+
+               ALLOCATE (admm_env%scf_work_aux_fit(nwork1))
+
+               ! create an ao_ao parallel matrix structure
+               CALL cp_fm_struct_create(ao_ao_fm_struct, context=blacs_env, para_env=para_env, &
+                                        nrow_global=nao_aux_fit, &
+                                        ncol_global=nao_aux_fit)
+
+               DO is = 1, nwork1
+                  CALL cp_fm_create(admm_env%scf_work_aux_fit(is), &
+                                    matrix_struct=ao_ao_fm_struct, &
+                                    name="SCF-WORK_MATRIX-AUX-"//TRIM(ADJUSTL(cp_to_string(is))))
+               END DO
+               CALL cp_fm_struct_release(ao_ao_fm_struct)
+
+               ! Create and populate the internal ADMM overlap matrices at each KP
+               CALL kpoint_calc_admm_matrices(qs_env, calc_forces)
+
+            END BLOCK
+         END IF
+
       ELSE IF (s_mstruct_changed) THEN
          CALL admm_init_hamiltonians(admm_env, qs_env)
          CALL admm_update_s_mstruct(admm_env, qs_env)
          CALL admm_alloc_ks_matrices(admm_env, qs_env)
          IF (admm_env%do_gapw) CALL update_admm_gapw(qs_env)
+         IF (do_kpoints) CALL kpoint_calc_admm_matrices(qs_env, calc_forces)
       END IF
 
       IF (admm_env%do_gapw .AND. dft_control%do_admm_dm) THEN
@@ -397,14 +487,17 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'admm_init_hamiltonians'
 
-      INTEGER                                            :: handle, ikind, nkind
-      LOGICAL                                            :: mic, molecule_only
+      INTEGER                                            :: handle, hfx_pot, ikind, nkind
+      LOGICAL                                            :: do_kpoints, mic, molecule_only
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: aux_fit_present, orb_present
-      REAL(dp)                                           :: pdist, subcells
+      REAL(dp)                                           :: eps_schwarz, omega, pdist, roperator, &
+                                                            subcells
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: aux_fit_radius, orb_radius
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: pair_radius
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_aux_fit_kp, &
+                                                            matrix_s_aux_fit_vs_orb_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(distribution_1d_type), POINTER                :: distribution_1d
       TYPE(distribution_2d_type), POINTER                :: distribution_2d
@@ -416,17 +509,17 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
-      TYPE(section_vals_type), POINTER                   :: neighbor_list_section
+      TYPE(section_vals_type), POINTER                   :: hfx_sections, neighbor_list_section
 
       NULLIFY (particle_set, cell, kpoints, distribution_1d, distribution_2d, molecule_set, &
                atomic_kind_set, dft_control, neighbor_list_section, aux_fit_basis_set, orb_basis_set, &
-               ks_env, para_env, qs_kind_set)
+               ks_env, para_env, qs_kind_set, matrix_s_aux_fit_kp, matrix_s_aux_fit_vs_orb_kp)
 
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, nkind=nkind, particle_set=particle_set, cell=cell, kpoints=kpoints, &
                       local_particles=distribution_1d, distribution_2d=distribution_2d, &
-                      molecule_set=molecule_set, atomic_kind_set=atomic_kind_set, &
+                      molecule_set=molecule_set, atomic_kind_set=atomic_kind_set, do_kpoints=do_kpoints, &
                       dft_control=dft_control, para_env=para_env, qs_kind_set=qs_kind_set)
       ALLOCATE (orb_present(nkind), aux_fit_present(nkind))
       ALLOCATE (orb_radius(nkind), aux_fit_radius(nkind), pair_radius(nkind, nkind))
@@ -473,7 +566,30 @@ CONTAINS
                      plane_distance(0, 1, 0, cell), &
                      plane_distance(0, 0, 1, cell))
       END IF
+
+      !In case of K-points, we need to add the HFX potential range to sab_aux_fit, because it is used
+      !to populate AUX density and KS matrices
+      roperator = 0.0_dp
+      IF (do_kpoints) THEN
+         hfx_sections => section_vals_get_subs_vals(qs_env%input, "DFT%XC%HF")
+         CALL section_vals_val_get(hfx_sections, "INTERACTION_POTENTIAL%POTENTIAL_TYPE", i_val=hfx_pot)
+
+         SELECT CASE (hfx_pot)
+         CASE (do_potential_id)
+            roperator = 0.0_dp
+         CASE (do_potential_truncated)
+            CALL section_vals_val_get(hfx_sections, "INTERACTION_POTENTIAL%CUTOFF_RADIUS", r_val=roperator)
+         CASE (do_potential_short)
+            CALL section_vals_val_get(hfx_sections, "INTERACTION_POTENTIAL%OMEGA", r_val=omega)
+            CALL section_vals_val_get(hfx_sections, "SCREENING%EPS_SCHWARZ", r_val=eps_schwarz)
+            CALL erfc_cutoff(eps_schwarz, omega, roperator)
+         CASE DEFAULT
+            CPABORT("HFX potential not available for K-points (NYI)")
+         END SELECT
+      END IF
+
       CALL pair_radius_setup(aux_fit_present, aux_fit_present, aux_fit_radius, aux_fit_radius, pair_radius, pdist)
+      pair_radius = pair_radius + cutoff_screen_factor*roperator
       CALL build_neighbor_lists(admm_env%sab_aux_fit, particle_set, atom2d, cell, pair_radius, &
                                 mic=mic, molecular=molecule_only, subcells=subcells, nlname="sab_aux_fit")
       CALL build_neighbor_lists(admm_env%sab_aux_fit_asymm, particle_set, atom2d, cell, pair_radius, &
@@ -494,18 +610,20 @@ CONTAINS
       !The ADMM overlap matrices (initially in qs_core_hamiltonian.F)
       CALL get_qs_env(qs_env, ks_env=ks_env)
 
-      IF (ASSOCIATED(admm_env%matrix_s_aux_fit)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_s_aux_fit)
-      CALL build_overlap_matrix(ks_env, matrix_s=admm_env%matrix_s_aux_fit, &
+      CALL kpoint_transitional_release(admm_env%matrix_s_aux_fit)
+      CALL build_overlap_matrix(ks_env, matrixkp_s=matrix_s_aux_fit_kp, &
                                 matrix_name="AUX_FIT_OVERLAP", &
                                 basis_type_a="AUX_FIT", &
                                 basis_type_b="AUX_FIT", &
                                 sab_nl=admm_env%sab_aux_fit)
-      IF (ASSOCIATED(admm_env%matrix_s_aux_fit_vs_orb)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_s_aux_fit_vs_orb)
-      CALL build_overlap_matrix(ks_env, matrix_s=admm_env%matrix_s_aux_fit_vs_orb, &
+      CALL set_2d_pointer(admm_env%matrix_s_aux_fit, matrix_s_aux_fit_kp)
+      CALL kpoint_transitional_release(admm_env%matrix_s_aux_fit_vs_orb)
+      CALL build_overlap_matrix(ks_env, matrixkp_s=matrix_s_aux_fit_vs_orb_kp, &
                                 matrix_name="MIXED_OVERLAP", &
                                 basis_type_a="AUX_FIT", &
                                 basis_type_b="ORB", &
                                 sab_nl=admm_env%sab_aux_fit_vs_orb)
+      CALL set_2d_pointer(admm_env%matrix_s_aux_fit_vs_orb, matrix_s_aux_fit_vs_orb_kp)
 
       CALL timestop(handle)
 
@@ -671,50 +789,230 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'admm_alloc_ks_matrices'
 
-      INTEGER                                            :: handle, ispin
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s_aux_fit
+      INTEGER                                            :: handle, ic, ispin
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_aux_fit_dft_kp, &
+                                                            matrix_ks_aux_fit_hfx_kp, &
+                                                            matrix_ks_aux_fit_kp, &
+                                                            matrix_s_aux_fit_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
 
-      NULLIFY (dft_control, matrix_s_aux_fit)
+      NULLIFY (dft_control, matrix_s_aux_fit_kp, matrix_ks_aux_fit_kp, matrix_ks_aux_fit_dft_kp, matrix_ks_aux_fit_hfx_kp)
 
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, dft_control=dft_control)
+      CALL get_admm_env(admm_env, matrix_s_aux_fit_kp=matrix_s_aux_fit_kp)
 
-      matrix_s_aux_fit => admm_env%matrix_s_aux_fit
-      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit)
-      CALL dbcsr_allocate_matrix_set(admm_env%matrix_ks_aux_fit, dft_control%nspins)
+      CALL kpoint_transitional_release(admm_env%matrix_ks_aux_fit)
+      CALL kpoint_transitional_release(admm_env%matrix_ks_aux_fit_dft)
+      CALL kpoint_transitional_release(admm_env%matrix_ks_aux_fit_hfx)
+
+      CALL dbcsr_allocate_matrix_set(matrix_ks_aux_fit_kp, dft_control%nspins, dft_control%nimages)
+      CALL dbcsr_allocate_matrix_set(matrix_ks_aux_fit_dft_kp, dft_control%nspins, dft_control%nimages)
+      CALL dbcsr_allocate_matrix_set(matrix_ks_aux_fit_hfx_kp, dft_control%nspins, dft_control%nimages)
+
       DO ispin = 1, dft_control%nspins
-         ALLOCATE (admm_env%matrix_ks_aux_fit(ispin)%matrix)
-         CALL dbcsr_create(admm_env%matrix_ks_aux_fit(ispin)%matrix, template=matrix_s_aux_fit(1)%matrix, &
-                           name="KOHN-SHAM_MATRIX for ADMM")
-         CALL cp_dbcsr_alloc_block_from_nbl(admm_env%matrix_ks_aux_fit(ispin)%matrix, admm_env%sab_aux_fit)
-         CALL dbcsr_set(admm_env%matrix_ks_aux_fit(ispin)%matrix, 0.0_dp)
+         DO ic = 1, dft_control%nimages
+            ALLOCATE (matrix_ks_aux_fit_kp(ispin, ic)%matrix)
+            CALL dbcsr_create(matrix_ks_aux_fit_kp(ispin, ic)%matrix, template=matrix_s_aux_fit_kp(1, ic)%matrix, &
+                              name="KOHN-SHAM_MATRIX for ADMM")
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_ks_aux_fit_kp(ispin, ic)%matrix, admm_env%sab_aux_fit)
+            CALL dbcsr_set(matrix_ks_aux_fit_kp(ispin, ic)%matrix, 0.0_dp)
+
+            ALLOCATE (matrix_ks_aux_fit_dft_kp(ispin, ic)%matrix)
+            CALL dbcsr_create(matrix_ks_aux_fit_dft_kp(ispin, ic)%matrix, template=matrix_s_aux_fit_kp(1, 1)%matrix, &
+                              name="KOHN-SHAM_MATRIX for ADMM")
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_ks_aux_fit_dft_kp(ispin, ic)%matrix, admm_env%sab_aux_fit)
+            CALL dbcsr_set(matrix_ks_aux_fit_dft_kp(ispin, ic)%matrix, 0.0_dp)
+
+            ALLOCATE (matrix_ks_aux_fit_hfx_kp(ispin, ic)%matrix)
+            CALL dbcsr_create(matrix_ks_aux_fit_hfx_kp(ispin, ic)%matrix, template=matrix_s_aux_fit_kp(1, 1)%matrix, &
+                              name="KOHN-SHAM_MATRIX for ADMM")
+            CALL cp_dbcsr_alloc_block_from_nbl(matrix_ks_aux_fit_hfx_kp(ispin, ic)%matrix, admm_env%sab_aux_fit)
+            CALL dbcsr_set(matrix_ks_aux_fit_hfx_kp(ispin, ic)%matrix, 0.0_dp)
+         END DO
       END DO
 
-      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_dft)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_dft)
-      CALL dbcsr_allocate_matrix_set(admm_env%matrix_ks_aux_fit_dft, dft_control%nspins)
-      DO ispin = 1, dft_control%nspins
-         ALLOCATE (admm_env%matrix_ks_aux_fit_dft(ispin)%matrix)
-         CALL dbcsr_create(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, template=matrix_s_aux_fit(1)%matrix, &
-                           name="KOHN-SHAM_MATRIX for ADMM")
-         CALL cp_dbcsr_alloc_block_from_nbl(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, admm_env%sab_aux_fit)
-         CALL dbcsr_set(admm_env%matrix_ks_aux_fit_dft(ispin)%matrix, 0.0_dp)
-      END DO
-
-      IF (ASSOCIATED(admm_env%matrix_ks_aux_fit_hfx)) CALL dbcsr_deallocate_matrix_set(admm_env%matrix_ks_aux_fit_hfx)
-      CALL dbcsr_allocate_matrix_set(admm_env%matrix_ks_aux_fit_hfx, dft_control%nspins)
-      DO ispin = 1, dft_control%nspins
-         ALLOCATE (admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix)
-         CALL dbcsr_create(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, template=matrix_s_aux_fit(1)%matrix, &
-                           name="KOHN-SHAM_MATRIX for ADMM")
-         CALL cp_dbcsr_alloc_block_from_nbl(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, admm_env%sab_aux_fit)
-         CALL dbcsr_set(admm_env%matrix_ks_aux_fit_hfx(ispin)%matrix, 0.0_dp)
-      END DO
+      CALL set_admm_env(admm_env, &
+                        matrix_ks_aux_fit_kp=matrix_ks_aux_fit_kp, &
+                        matrix_ks_aux_fit_dft_kp=matrix_ks_aux_fit_dft_kp, &
+                        matrix_ks_aux_fit_hfx_kp=matrix_ks_aux_fit_hfx_kp)
 
       CALL timestop(handle)
 
    END SUBROUTINE admm_alloc_ks_matrices
+
+! **************************************************************************************************
+!> \brief Add the HFX K-point contribution to the real-space Hamiltonians
+!> \param qs_env ...
+!> \param matrix_ks ...
+!> \param energy ...
+!> \param calculate_forces ...
+! **************************************************************************************************
+   SUBROUTINE hfx_ks_matrix_kp(qs_env, matrix_ks, energy, calculate_forces)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks
+      TYPE(qs_energy_type), POINTER                      :: energy
+      LOGICAL, INTENT(in)                                :: calculate_forces
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'hfx_ks_matrix_kp'
+
+      INTEGER                                            :: handle, img, irep, ispin, n_rep_hf, &
+                                                            nimages, nspins
+      LOGICAL                                            :: do_adiabatic_rescaling, &
+                                                            s_mstruct_changed, use_virial
+      REAL(dp)                                           :: eh1, ehfx, eold
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: hf_energy
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks_aux_fit_im, matrix_ks_im
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_h, matrix_ks_aux_fit_hfx_kp, &
+                                                            matrix_ks_aux_fit_kp, matrix_ks_orb, &
+                                                            rho_ao_orb
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(hfx_type), DIMENSION(:, :), POINTER           :: x_data
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(pw_env_type), POINTER                         :: pw_env
+      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_pool_type), POINTER                        :: auxbas_pw_pool
+      TYPE(qs_rho_type), POINTER                         :: rho_orb
+      TYPE(section_vals_type), POINTER                   :: adiabatic_rescaling_section, &
+                                                            hfx_sections, input
+      TYPE(virial_type), POINTER                         :: virial
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (auxbas_pw_pool, dft_control, hfx_sections, input, &
+               para_env, poisson_env, pw_env, virial, matrix_ks_im, &
+               matrix_ks_orb, rho_ao_orb, matrix_h, matrix_ks_aux_fit_kp, &
+               matrix_ks_aux_fit_im, matrix_ks_aux_fit_hfx_kp)
+
+      CALL get_qs_env(qs_env=qs_env, &
+                      dft_control=dft_control, &
+                      input=input, &
+                      matrix_h_kp=matrix_h, &
+                      para_env=para_env, &
+                      pw_env=pw_env, &
+                      virial=virial, &
+                      matrix_ks_im=matrix_ks_im, &
+                      s_mstruct_changed=s_mstruct_changed, &
+                      x_data=x_data)
+
+      ! No RTP
+      IF (qs_env%run_rtp) CPABORT("No RTP implementation with K-points HFX")
+
+      ! No adiabatic rescaling
+      adiabatic_rescaling_section => section_vals_get_subs_vals(input, "DFT%XC%ADIABATIC_RESCALING")
+      CALL section_vals_get(adiabatic_rescaling_section, explicit=do_adiabatic_rescaling)
+      IF (do_adiabatic_rescaling) CPABORT("No adiabatic rescaling implementation with K-points HFX")
+
+      IF (dft_control%do_admm) THEN
+         CALL get_admm_env(qs_env%admm_env, matrix_ks_aux_fit_kp=matrix_ks_aux_fit_kp, &
+                           matrix_ks_aux_fit_im=matrix_ks_aux_fit_im, &
+                           matrix_ks_aux_fit_hfx_kp=matrix_ks_aux_fit_hfx_kp)
+      END IF
+
+      nspins = dft_control%nspins
+      nimages = dft_control%nimages
+
+      use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
+      IF (use_virial .AND. calculate_forces) virial%pv_fock_4c = 0.0_dp
+
+      hfx_sections => section_vals_get_subs_vals(input, "DFT%XC%HF")
+      CALL section_vals_get(hfx_sections, n_repetition=n_rep_hf)
+
+      ! *** Initialize the auxiliary ks matrix to zero if required
+      IF (dft_control%do_admm) THEN
+         DO ispin = 1, nspins
+            DO img = 1, nimages
+               CALL dbcsr_set(matrix_ks_aux_fit_kp(ispin, img)%matrix, 0.0_dp)
+            END DO
+         END DO
+      END IF
+      DO ispin = 1, nspins
+         DO img = 1, nimages
+            CALL dbcsr_set(matrix_ks(ispin, img)%matrix, 0.0_dp)
+         END DO
+      END DO
+
+      ALLOCATE (hf_energy(n_rep_hf))
+
+      eold = 0.0_dp
+
+      DO irep = 1, n_rep_hf
+
+         ! fetch the correct matrices for normal HFX or ADMM
+         IF (dft_control%do_admm) THEN
+            CALL get_admm_env(qs_env%admm_env, matrix_ks_aux_fit_kp=matrix_ks_orb, rho_aux_fit=rho_orb)
+         ELSE
+            CALL get_qs_env(qs_env=qs_env, matrix_ks_kp=matrix_ks_orb, rho=rho_orb)
+         END IF
+         CALL qs_rho_get(rho_struct=rho_orb, rho_ao_kp=rho_ao_orb)
+
+         ! Finally the real hfx calulation
+         ehfx = 0.0_dp
+
+         IF (.NOT. x_data(irep, 1)%do_hfx_ri) THEN
+            CPABORT("Only RI-HFX is implemented for K-points")
+         END IF
+
+         CALL hfx_ri_update_ks_kp(qs_env, x_data(irep, 1)%ri_data, matrix_ks_orb, ehfx, &
+                                  rho_ao_orb, s_mstruct_changed, nspins, &
+                                  x_data(irep, 1)%general_parameter%fraction, &
+                                  calculate_forces)
+
+         IF (calculate_forces) THEN
+            !Scale auxiliary density matrix for ADMMP (see Merlot2014) with gsi(ispin) to scale force
+            !Note: scale twice (gsi**2) because the non-scaled density matrix from previous energy call is reused
+            IF (dft_control%do_admm) THEN
+               CALL scale_dm(qs_env, rho_ao_orb, scale_back=.FALSE.)
+               CALL scale_dm(qs_env, rho_ao_orb, scale_back=.FALSE.)
+            END IF
+
+            CALL hfx_ri_update_forces_kp(qs_env, x_data(irep, 1)%ri_data, nspins, &
+                                         x_data(irep, 1)%general_parameter%fraction, &
+                                         rho_ao_orb, use_virial=use_virial)
+
+            IF (dft_control%do_admm) THEN
+               CALL scale_dm(qs_env, rho_ao_orb, scale_back=.TRUE.)
+               CALL scale_dm(qs_env, rho_ao_orb, scale_back=.TRUE.)
+            END IF
+         END IF
+
+         CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, poisson_env=poisson_env)
+         eh1 = ehfx - eold
+         CALL pw_hfx(qs_env, eh1, hfx_sections, poisson_env, auxbas_pw_pool, irep)
+         eold = ehfx
+
+      END DO
+
+      ! *** Set the total HFX energy
+      energy%ex = ehfx
+
+      ! *** Add Core-Hamiltonian-Matrix ***
+      DO ispin = 1, nspins
+         DO img = 1, nimages
+            CALL dbcsr_add(matrix_ks(ispin, img)%matrix, matrix_h(1, img)%matrix, &
+                           1.0_dp, 1.0_dp)
+         END DO
+      END DO
+      IF (use_virial .AND. calculate_forces) THEN
+         virial%pv_exx = virial%pv_exx - virial%pv_fock_4c
+         virial%pv_virial = virial%pv_virial - virial%pv_fock_4c
+         virial%pv_calculate = .FALSE.
+      END IF
+
+      !update the hfx aux_fit matrix
+      IF (dft_control%do_admm) THEN
+         DO ispin = 1, nspins
+            DO img = 1, nimages
+               CALL dbcsr_add(matrix_ks_aux_fit_hfx_kp(ispin, img)%matrix, matrix_ks_aux_fit_kp(ispin, img)%matrix, &
+                              0.0_dp, 1.0_dp)
+            END DO
+         END DO
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE hfx_ks_matrix_kp
 
 ! **************************************************************************************************
 !> \brief Add the hfx contributions to the Hamiltonian
@@ -851,6 +1149,7 @@ CONTAINS
          ehfx = 0.0_dp
 
          IF (x_data(irep, 1)%do_hfx_ri) THEN
+
             CALL hfx_ri_update_ks(qs_env, x_data(irep, 1)%ri_data, matrix_ks_orb, ehfx, &
                                   mo_array, rho_ao_orb, &
                                   s_mstruct_changed, nspins, &

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -100,7 +100,7 @@ CONTAINS
       INTEGER                                            :: blocksize, handle, ig, iloc, iorb, &
                                                             iorb_block, ispin, iw, jloc, jorb, &
                                                             jorb_block, norb, potential_type
-      LOGICAL                                            :: do_pw_hfx, explicit
+      LOGICAL                                            :: do_kpoints, do_pw_hfx, explicit
       REAL(KIND=dp)                                      :: exchange_energy, fraction, g2, g3d, gg, &
                                                             omega, pair_energy, rcut, scaling
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
@@ -128,8 +128,9 @@ CONTAINS
          CALL section_vals_val_get(hfx_section, "PW_HFX_BLOCKSIZE", i_val=blocksize)
 
          CALL get_qs_env(qs_env, mos=mo_array, pw_env=pw_env, dft_control=dft_control, &
-                         cell=cell, particle_set=particle_set, &
+                         cell=cell, particle_set=particle_set, do_kpoints=do_kpoints, &
                          atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set)
+         IF (do_kpoints) CPABORT("PW HFX not implemented with K-points")
 
          ! limit the blocksize by the number of orbitals
          CALL get_mo_set(mo_set=mo_array(1), mo_coeff=mo_coeff)

--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -18,8 +18,7 @@ MODULE hfx_ri
                                               get_atomic_kind_set
    USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
                                               gto_basis_set_type
-   USE cell_types,                      ONLY: cell_type,&
-                                              real_to_scaled
+   USE cell_types,                      ONLY: cell_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_cholesky,               ONLY: cp_dbcsr_cholesky_decompose,&
@@ -111,11 +110,13 @@ MODULE hfx_ri
    USE virial_types,                    ONLY: virial_type
 #include "./base/base_uses.f90"
 
+!$ USE OMP_LIB, ONLY: omp_get_num_threads
+
    IMPLICIT NONE
    PRIVATE
 
    PUBLIC :: hfx_ri_update_ks, hfx_ri_update_forces, get_force_from_3c_trace, get_2c_der_force, &
-             get_idx_to_atom, print_ri_hfx
+             get_idx_to_atom, print_ri_hfx, hfx_ri_pre_scf_calc_tensors, check_inverse
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'hfx_ri'
 CONTAINS
@@ -430,29 +431,37 @@ CONTAINS
 !> v_1 is HF operator, v_2 is RI metric
 !> \param qs_env ...
 !> \param ri_data ...
-!> \param t_2c_int_RI K_2(P, R)
+!> \param t_2c_int_RI K_2(P, R) note: even with k-point, only need on central cell
 !> \param t_2c_int_pot K_1(P, R)
 !> \param t_3c_int int_3c(mu, lambda, P)
+!> \param do_kpoints ...
+!> \notes the integral tensor arrays are already allocated on entry
 ! **************************************************************************************************
-   SUBROUTINE hfx_ri_pre_scf_calc_tensors(qs_env, ri_data, t_2c_int_RI, t_2c_int_pot, t_3c_int)
+   SUBROUTINE hfx_ri_pre_scf_calc_tensors(qs_env, ri_data, t_2c_int_RI, t_2c_int_pot, t_3c_int, do_kpoints)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
-      TYPE(dbcsr_type), DIMENSION(1), INTENT(OUT)        :: t_2c_int_RI, t_2c_int_pot
-      TYPE(dbt_type), DIMENSION(1, 1), INTENT(OUT)       :: t_3c_int
+      TYPE(dbcsr_type), DIMENSION(:), INTENT(OUT)        :: t_2c_int_RI, t_2c_int_pot
+      TYPE(dbt_type), DIMENSION(:, :)                    :: t_3c_int
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_kpoints
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'hfx_ri_pre_scf_calc_tensors'
 
-      INTEGER                                            :: handle, i_mem, ibasis, n_mem, natom, &
-                                                            nkind
-      INTEGER, ALLOCATABLE, DIMENSION(:) :: dist_AO_1, dist_AO_2, dist_RI, &
-         ends_array_mc_block_int, ends_array_mc_int, sizes_AO, sizes_RI, &
-         starts_array_mc_block_int, starts_array_mc_int
+      CHARACTER                                          :: symm
+      INTEGER                                            :: handle, i_img, i_mem, ibasis, j_img, &
+                                                            n_mem, natom, nblks, nimg, nkind, &
+                                                            nthreads
+      INTEGER(int_8)                                     :: nze
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: dist_AO_1, dist_AO_2, dist_RI, dist_RI_ext, &
+         ends_array_mc_block_int, ends_array_mc_int, sizes_AO, sizes_RI, sizes_RI_ext, &
+         sizes_RI_ext_split, starts_array_mc_block_int, starts_array_mc_int
       INTEGER, DIMENSION(3)                              :: pcoord, pdims
       INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
-      LOGICAL                                            :: converged
-      REAL(dp)                                           :: max_ev, min_ev
+      LOGICAL                                            :: converged, do_kpoints_prv
+      REAL(dp)                                           :: max_ev, min_ev, occ, RI_range
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
+      TYPE(dbt_distribution_type)                        :: t_dist
+      TYPE(dbt_pgrid_type)                               :: pgrid
       TYPE(dbt_type)                                     :: t_3c_tmp
       TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_int_batched
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -462,6 +471,7 @@ CONTAINS
          DIMENSION(:), TARGET                            :: basis_set_AO, basis_set_RI
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis, ri_basis
       TYPE(mp_cart_type)                                 :: mp_comm_t3c
+      TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(neighbor_list_3c_type)                        :: nl_3c
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: nl_2c_pot, nl_2c_RI
@@ -471,17 +481,25 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       NULLIFY (col_bsize, row_bsize, dist_2d, nl_2c_pot, nl_2c_RI, &
-               particle_set, qs_kind_set, ks_env)
+               particle_set, qs_kind_set, ks_env, para_env)
 
       CALL get_qs_env(qs_env, natom=natom, nkind=nkind, qs_kind_set=qs_kind_set, particle_set=particle_set, &
-                      distribution_2d=dist_2d, ks_env=ks_env, dft_control=dft_control)
+                      distribution_2d=dist_2d, ks_env=ks_env, dft_control=dft_control, para_env=para_env)
+
+      RI_range = 0.0_dp
+      do_kpoints_prv = .FALSE.
+      IF (PRESENT(do_kpoints)) do_kpoints_prv = do_kpoints
+      nimg = 1
+      IF (do_kpoints_prv) THEN
+         nimg = ri_data%nimg
+         RI_range = ri_data%kp_RI_range
+      END IF
 
       ALLOCATE (sizes_RI(natom), sizes_AO(natom))
       ALLOCATE (basis_set_RI(nkind), basis_set_AO(nkind))
       CALL basis_set_list_setup(basis_set_RI, ri_data%ri_basis_type, qs_kind_set)
       CALL get_particle_set(particle_set, qs_kind_set, nsgf=sizes_RI, basis=basis_set_RI)
       CALL basis_set_list_setup(basis_set_AO, ri_data%orb_basis_type, qs_kind_set)
-
       CALL get_particle_set(particle_set, qs_kind_set, nsgf=sizes_AO, basis=basis_set_AO)
 
       DO ibasis = 1, SIZE(basis_set_AO)
@@ -500,61 +518,151 @@ CONTAINS
 
       DEALLOCATE (starts_array_mc_int, ends_array_mc_int)
 
-      ALLOCATE (t_3c_int_batched(1, 1))
-      CALL create_3c_tensor(t_3c_int_batched(1, 1), dist_RI, dist_AO_1, dist_AO_2, ri_data%pgrid, &
-                            sizes_RI, sizes_AO, sizes_AO, map1=[1], map2=[2, 3], &
-                            name="(RI | AO AO)")
+      !We separate the K-points and standard 3c integrals, because handle quite differently
+      IF (.NOT. do_kpoints_prv) THEN
 
-      CALL get_qs_env(qs_env, nkind=nkind, particle_set=particle_set, atomic_kind_set=atomic_kind_set)
-      CALL dbt_mp_environ_pgrid(ri_data%pgrid, pdims, pcoord)
-      CALL mp_comm_t3c%create(ri_data%pgrid%mp_comm_2d, 3, pdims)
-      CALL distribution_3d_create(dist_3d, dist_RI, dist_AO_1, dist_AO_2, &
-                                  nkind, particle_set, mp_comm_t3c, own_comm=.TRUE.)
-      DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
+         nthreads = 1
+!$       nthreads = omp_get_num_threads()
+         pdims = 0
+         CALL dbt_pgrid_create(para_env, pdims, pgrid, tensor_dims=[MAX(1, natom/(n_mem*nthreads)), natom, natom])
 
-      CALL create_3c_tensor(t_3c_int(1, 1), dist_RI, dist_AO_1, dist_AO_2, ri_data%pgrid, &
-                            ri_data%bsizes_RI_split, ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
-                            map1=[1], map2=[2, 3], &
-                            name="O (RI AO | AO)")
+         ALLOCATE (t_3c_int_batched(1, 1))
+         CALL create_3c_tensor(t_3c_int_batched(1, 1), dist_RI, dist_AO_1, dist_AO_2, pgrid, &
+                               sizes_RI, sizes_AO, sizes_AO, map1=[1], map2=[2, 3], &
+                               name="(RI | AO AO)")
 
-      ! create 3c tensor for storage of ints
+         CALL get_qs_env(qs_env, nkind=nkind, particle_set=particle_set, atomic_kind_set=atomic_kind_set)
+         CALL dbt_mp_environ_pgrid(pgrid, pdims, pcoord)
+         CALL mp_comm_t3c%create(pgrid%mp_comm_2d, 3, pdims)
+         CALL distribution_3d_create(dist_3d, dist_RI, dist_AO_1, dist_AO_2, &
+                                     nkind, particle_set, mp_comm_t3c, own_comm=.TRUE.)
+         DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
 
-      CALL build_3c_neighbor_lists(nl_3c, basis_set_RI, basis_set_AO, basis_set_AO, dist_3d, ri_data%ri_metric, &
-                                   "HFX_3c_nl", qs_env, op_pos=1, sym_jk=.TRUE., own_dist=.TRUE.)
+         CALL create_3c_tensor(t_3c_int(1, 1), dist_RI, dist_AO_1, dist_AO_2, ri_data%pgrid, &
+                               ri_data%bsizes_RI_split, ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
+                               map1=[1], map2=[2, 3], &
+                               name="O (RI AO | AO)")
 
-      DO i_mem = 1, n_mem
-         CALL build_3c_integrals(t_3c_int_batched, ri_data%filter_eps/2, qs_env, nl_3c, &
-                                 basis_set_RI, basis_set_AO, basis_set_AO, &
-                                 ri_data%ri_metric, int_eps=ri_data%eps_schwarz, op_pos=1, &
-                                 desymmetrize=.FALSE., &
-                                 bounds_i=[starts_array_mc_block_int(i_mem), ends_array_mc_block_int(i_mem)])
-         CALL dbt_copy(t_3c_int_batched(1, 1), t_3c_int(1, 1), summation=.TRUE., move_data=.TRUE.)
-         CALL dbt_filter(t_3c_int(1, 1), ri_data%filter_eps/2)
-      END DO
+         CALL build_3c_neighbor_lists(nl_3c, basis_set_RI, basis_set_AO, basis_set_AO, dist_3d, ri_data%ri_metric, &
+                                      "HFX_3c_nl", qs_env, op_pos=1, sym_jk=.TRUE., own_dist=.TRUE.)
 
-      CALL dbt_destroy(t_3c_int_batched(1, 1))
+         DO i_mem = 1, n_mem
+            CALL build_3c_integrals(t_3c_int_batched, ri_data%filter_eps/2, qs_env, nl_3c, &
+                                    basis_set_RI, basis_set_AO, basis_set_AO, &
+                                    ri_data%ri_metric, int_eps=ri_data%eps_schwarz, op_pos=1, &
+                                    desymmetrize=.FALSE., &
+                                    bounds_i=[starts_array_mc_block_int(i_mem), ends_array_mc_block_int(i_mem)])
+            CALL dbt_copy(t_3c_int_batched(1, 1), t_3c_int(1, 1), summation=.TRUE., move_data=.TRUE.)
+            CALL dbt_filter(t_3c_int(1, 1), ri_data%filter_eps/2)
+         END DO
 
-      CALL neighbor_list_3c_destroy(nl_3c)
+         CALL dbt_destroy(t_3c_int_batched(1, 1))
 
-      CALL dbt_create(t_3c_int(1, 1), t_3c_tmp)
+         CALL neighbor_list_3c_destroy(nl_3c)
 
-      IF (ri_data%flavor == ri_pmat) THEN ! desymmetrize
-         ! desymmetrize
-         CALL dbt_copy(t_3c_int(1, 1), t_3c_tmp)
-         CALL dbt_copy(t_3c_tmp, t_3c_int(1, 1), order=[1, 3, 2], summation=.TRUE., move_data=.TRUE.)
+         CALL dbt_create(t_3c_int(1, 1), t_3c_tmp)
 
-         ! For RI-RHO filter_eps_storage is reserved for screening tensor contracted with RI-metric
-         ! with RI metric but not to bare integral tensor
-         CALL dbt_filter(t_3c_int(1, 1), ri_data%filter_eps)
-      ELSE
-         CALL dbt_filter(t_3c_int(1, 1), ri_data%filter_eps_storage/2)
+         IF (ri_data%flavor == ri_pmat) THEN ! desymmetrize
+            ! desymmetrize
+            CALL dbt_copy(t_3c_int(1, 1), t_3c_tmp)
+            CALL dbt_copy(t_3c_tmp, t_3c_int(1, 1), order=[1, 3, 2], summation=.TRUE., move_data=.TRUE.)
+
+            ! For RI-RHO filter_eps_storage is reserved for screening tensor contracted with RI-metric
+            ! with RI metric but not to bare integral tensor
+            CALL dbt_filter(t_3c_int(1, 1), ri_data%filter_eps)
+         ELSE
+            CALL dbt_filter(t_3c_int(1, 1), ri_data%filter_eps_storage/2)
+         END IF
+
+         CALL dbt_destroy(t_3c_tmp)
+
+      ELSE !do_kpoints
+
+         nthreads = 1
+!$       nthreads = omp_get_num_threads()
+         pdims = 0
+         CALL dbt_pgrid_create(para_env, pdims, pgrid, tensor_dims=[natom, natom, MAX(1, natom/(n_mem*nthreads))])
+
+         !In k-points HFX, we stack all images along the RI direction in the same tensors, in order
+         !to avoid storing nimg x ncell_RI different tensors (very memory intensive)
+         nblks = SIZE(ri_data%bsizes_RI_split)
+         ALLOCATE (sizes_RI_ext(natom*ri_data%ncell_RI), sizes_RI_ext_split(nblks*ri_data%ncell_RI))
+         DO i_img = 1, ri_data%ncell_RI
+            sizes_RI_ext((i_img - 1)*natom + 1:i_img*natom) = sizes_RI(:)
+            sizes_RI_ext_split((i_img - 1)*nblks + 1:i_img*nblks) = ri_data%bsizes_RI_split(:)
+         END DO
+
+         CALL create_3c_tensor(t_3c_tmp, dist_AO_1, dist_AO_2, dist_RI, &
+                               pgrid, sizes_AO, sizes_AO, sizes_RI, map1=[1, 2], map2=[3], &
+                               name="(AO AO | RI)")
+         CALL dbt_destroy(t_3c_tmp)
+
+         !For the integrals to work, the distribution along the RI direction must be repeated
+         ALLOCATE (dist_RI_ext(natom*ri_data%ncell_RI))
+         DO i_img = 1, ri_data%ncell_RI
+            dist_RI_ext((i_img - 1)*natom + 1:i_img*natom) = dist_RI(:)
+         END DO
+
+         ALLOCATE (t_3c_int_batched(nimg, 1))
+         CALL dbt_distribution_new(t_dist, pgrid, dist_AO_1, dist_AO_2, dist_RI_ext)
+         CALL dbt_create(t_3c_int_batched(1, 1), "KP_3c_ints", t_dist, [1, 2], [3], &
+                         sizes_AO, sizes_AO, sizes_RI_ext)
+         DO i_img = 2, nimg
+            CALL dbt_create(t_3c_int_batched(1, 1), t_3c_int_batched(i_img, 1))
+         END DO
+         CALL dbt_distribution_destroy(t_dist)
+
+         CALL get_qs_env(qs_env, nkind=nkind, particle_set=particle_set, atomic_kind_set=atomic_kind_set)
+         CALL dbt_mp_environ_pgrid(pgrid, pdims, pcoord)
+         CALL mp_comm_t3c%create(pgrid%mp_comm_2d, 3, pdims)
+         CALL distribution_3d_create(dist_3d, dist_AO_1, dist_AO_2, dist_RI, &
+                                     nkind, particle_set, mp_comm_t3c, own_comm=.TRUE.)
+         DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
+
+         ! create 3c tensor for storage of ints
+         CALL build_3c_neighbor_lists(nl_3c, basis_set_AO, basis_set_AO, basis_set_RI, dist_3d, ri_data%ri_metric, &
+                                      "HFX_3c_nl", qs_env, op_pos=2, sym_ij=.FALSE., own_dist=.TRUE.)
+
+         CALL create_3c_tensor(t_3c_int(1, 1), dist_RI, dist_AO_1, dist_AO_2, ri_data%pgrid, &
+                               sizes_RI_ext_split, ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
+                               map1=[1], map2=[2, 3], &
+                               name="O (RI AO | AO)")
+         DO j_img = 2, nimg
+            CALL dbt_create(t_3c_int(1, 1), t_3c_int(1, j_img))
+         END DO
+
+         CALL dbt_create(t_3c_int(1, 1), t_3c_tmp)
+         DO i_mem = 1, n_mem
+            CALL build_3c_integrals(t_3c_int_batched, ri_data%filter_eps, qs_env, nl_3c, &
+                                    basis_set_AO, basis_set_AO, basis_set_RI, &
+                                    ri_data%ri_metric, int_eps=ri_data%eps_schwarz, op_pos=2, &
+                                    desymmetrize=.FALSE., do_kpoints=.TRUE., do_hfx_kpoints=.TRUE., &
+                                    bounds_k=[starts_array_mc_block_int(i_mem), ends_array_mc_block_int(i_mem)], &
+                                    RI_range=RI_range, img_to_RI_cell=ri_data%img_to_RI_cell)
+
+            DO i_img = 1, nimg
+               !we start with (mu^0 sigma^i | P^j) and finish with (P^i | mu^0 sigma^j)
+               CALL get_tensor_occupancy(t_3c_int_batched(i_img, 1), nze, occ)
+               IF (nze > 0) THEN
+                  CALL dbt_copy(t_3c_int_batched(i_img, 1), t_3c_tmp, order=[3, 2, 1], move_data=.TRUE.)
+                  CALL dbt_filter(t_3c_tmp, ri_data%filter_eps)
+                  CALL dbt_copy(t_3c_tmp, t_3c_int(1, i_img), order=[1, 3, 2], &
+                                summation=.TRUE., move_data=.TRUE.)
+               END IF
+            END DO
+         END DO
+
+         DO i_img = 1, nimg
+            CALL dbt_destroy(t_3c_int_batched(i_img, 1))
+         END DO
+         DEALLOCATE (t_3c_int_batched)
+         CALL neighbor_list_3c_destroy(nl_3c)
+         CALL dbt_destroy(t_3c_tmp)
       END IF
-
-      CALL dbt_destroy(t_3c_tmp)
+      CALL dbt_pgrid_destroy(pgrid)
 
       CALL build_2c_neighbor_lists(nl_2c_pot, basis_set_RI, basis_set_RI, ri_data%hfx_pot, &
-                                   "HFX_2c_nl_pot", &
-                                   qs_env, sym_ij=.TRUE., &
+                                   "HFX_2c_nl_pot", qs_env, sym_ij=.NOT. do_kpoints_prv, &
                                    dist_2d=dist_2d)
 
       CALL cp_dbcsr_dist2d_to_dist(dist_2d, dbcsr_dist)
@@ -563,24 +671,36 @@ CONTAINS
       row_bsize(:) = sizes_RI
       col_bsize(:) = sizes_RI
 
-      CALL dbcsr_create(t_2c_int_pot(1), "(R|P) HFX", dbcsr_dist, dbcsr_type_symmetric, &
-                        row_bsize, col_bsize, reuse_arrays=.TRUE.)
+      !Use non-symmetric nl and matrices for k-points
+      symm = dbcsr_type_symmetric
+      IF (do_kpoints_prv) symm = dbcsr_type_no_symmetry
+
+      CALL dbcsr_create(t_2c_int_pot(1), "(R|P) HFX", dbcsr_dist, symm, row_bsize, col_bsize)
+      DO i_img = 2, nimg
+         CALL dbcsr_create(t_2c_int_pot(i_img), template=t_2c_int_pot(1))
+      END DO
+
+      IF (.NOT. ri_data%same_op) THEN
+         CALL dbcsr_create(t_2c_int_RI(1), "(R|P) HFX", dbcsr_dist, symm, row_bsize, col_bsize)
+         DO i_img = 2, nimg
+            CALL dbcsr_create(t_2c_int_RI(i_img), template=t_2c_int_RI(1))
+         END DO
+      END IF
+      DEALLOCATE (col_bsize, row_bsize)
 
       CALL dbcsr_distribution_release(dbcsr_dist)
 
       CALL build_2c_integrals(t_2c_int_pot, ri_data%filter_eps_2c, qs_env, nl_2c_pot, basis_set_RI, basis_set_RI, &
-                              ri_data%hfx_pot)
+                              ri_data%hfx_pot, do_kpoints=do_kpoints_prv, do_hfx_kpoints=do_kpoints_prv)
       CALL release_neighbor_list_sets(nl_2c_pot)
 
       IF (.NOT. ri_data%same_op) THEN
          CALL build_2c_neighbor_lists(nl_2c_RI, basis_set_RI, basis_set_RI, ri_data%ri_metric, &
-                                      "HFX_2c_nl_RI", &
-                                      qs_env, sym_ij=.TRUE., &
+                                      "HFX_2c_nl_RI", qs_env, sym_ij=.NOT. do_kpoints_prv, &
                                       dist_2d=dist_2d)
 
-         CALL dbcsr_create(t_2c_int_RI(1), template=t_2c_int_pot(1), matrix_type=dbcsr_type_symmetric, name="(R|P) RI")
          CALL build_2c_integrals(t_2c_int_RI, ri_data%filter_eps_2c, qs_env, nl_2c_RI, basis_set_RI, basis_set_RI, &
-                                 ri_data%ri_metric)
+                                 ri_data%ri_metric, do_kpoints=do_kpoints_prv, do_hfx_kpoints=do_kpoints_prv)
 
          CALL release_neighbor_list_sets(nl_2c_RI)
       END IF
@@ -3004,7 +3124,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'precalc_derivatives'
 
-      INTEGER                                            :: handle, i_mem, i_xyz, n_mem, nkind
+      INTEGER                                            :: handle, i_mem, i_xyz, n_mem, natom, &
+                                                            nkind, nthreads
       INTEGER(int_8)                                     :: nze, nze_tot
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2, dist_AO_1, dist_AO_2, &
                                                             dist_RI, dummy_end, dummy_start, &
@@ -3014,6 +3135,7 @@ CONTAINS
       REAL(dp)                                           :: compression_factor, memory, occ
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
       TYPE(dbcsr_type), DIMENSION(1, 3)                  :: t_2c_der_metric_prv, t_2c_der_RI_prv
+      TYPE(dbt_pgrid_type)                               :: pgrid
       TYPE(dbt_type)                                     :: t_2c_template, t_2c_tmp, t_3c_template
       TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :, :)    :: t_3c_der_AO_prv, t_3c_der_RI_prv
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -3031,11 +3153,17 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL get_qs_env(qs_env, nkind=nkind, qs_kind_set=qs_kind_set, distribution_2d=dist_2d, &
+      CALL get_qs_env(qs_env, nkind=nkind, qs_kind_set=qs_kind_set, distribution_2d=dist_2d, natom=natom, &
                       particle_set=particle_set, dft_control=dft_control, para_env=para_env)
 
+      !TODO: is such a pgrid correct?
       !Dealing with the 3c derivatives
-      CALL create_3c_tensor(t_3c_template, dist_RI, dist_AO_1, dist_AO_2, ri_data%pgrid, &
+      nthreads = 1
+!$    nthreads = omp_get_num_threads()
+      pdims = 0
+      CALL dbt_pgrid_create(para_env, pdims, pgrid, tensor_dims=[MAX(1, natom/(ri_data%n_mem*nthreads)), natom, natom])
+
+      CALL create_3c_tensor(t_3c_template, dist_RI, dist_AO_1, dist_AO_2, pgrid, &
                             ri_data%bsizes_RI, ri_data%bsizes_AO, ri_data%bsizes_AO, &
                             map1=[1], map2=[2, 3], &
                             name="der (RI AO | AO)")
@@ -3050,8 +3178,8 @@ CONTAINS
       END IF
       CALL dbt_destroy(t_3c_template)
 
-      CALL dbt_mp_environ_pgrid(ri_data%pgrid, pdims, pcoord)
-      CALL mp_comm_t3c%create(ri_data%pgrid%mp_comm_2d, 3, pdims)
+      CALL dbt_mp_environ_pgrid(pgrid, pdims, pcoord)
+      CALL mp_comm_t3c%create(pgrid%mp_comm_2d, 3, pdims)
       CALL distribution_3d_create(dist_3d, dist_RI, dist_AO_1, dist_AO_2, &
                                   nkind, particle_set, mp_comm_t3c, own_comm=.TRUE.)
 
@@ -3059,7 +3187,8 @@ CONTAINS
                                    "HFX_3c_nl", qs_env, op_pos=1, sym_jk=.TRUE., own_dist=.TRUE.)
 
       IF (PRESENT(nl_3c_out)) THEN
-         CALL mp_comm_t3c_out%create(ri_data%pgrid%mp_comm_2d, 3, pdims)
+         CALL dbt_mp_environ_pgrid(pgrid, pdims, pcoord)
+         CALL mp_comm_t3c_out%create(pgrid%mp_comm_2d, 3, pdims)
          CALL distribution_3d_create(dist_3d_out, dist_RI, dist_AO_1, dist_AO_2, &
                                      nkind, particle_set, mp_comm_t3c_out, own_comm=.TRUE.)
          CALL build_3c_neighbor_lists(nl_3c_out, basis_set_RI, basis_set_AO, basis_set_AO, dist_3d_out, &
@@ -3067,6 +3196,7 @@ CONTAINS
                                       own_dist=.TRUE.)
       END IF
       DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
+      CALL dbt_pgrid_destroy(pgrid)
 
       n_mem = ri_data%n_mem
       CALL create_tensor_batches(ri_data%bsizes_RI, n_mem, dummy_start, dummy_end, &
@@ -3218,24 +3348,17 @@ CONTAINS
 !> \param kind_of ...
 !> \param idx_to_at ...
 !> \param pref ...
-!> \param work_virial ...
-!> \param cell ...
-!> \param particle_set ...
 !> \param do_mp2 ...
 !> \param deriv_dim the dimension of the tensor corresponding to the derivative (by default 1)
 ! **************************************************************************************************
    SUBROUTINE get_force_from_3c_trace(force, t_3c_contr, t_3c_der, atom_of_kind, kind_of, idx_to_at, &
-                                      pref, work_virial, cell, particle_set, do_mp2, deriv_dim)
+                                      pref, do_mp2, deriv_dim)
 
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_contr
       TYPE(dbt_type), DIMENSION(3), INTENT(INOUT)        :: t_3c_der
       INTEGER, DIMENSION(:), INTENT(IN)                  :: atom_of_kind, kind_of, idx_to_at
       REAL(dp), INTENT(IN)                               :: pref
-      REAL(dp), DIMENSION(3, 3), INTENT(INOUT), OPTIONAL :: work_virial
-      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
-      TYPE(particle_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: particle_set
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_mp2
       INTEGER, INTENT(IN), OPTIONAL                      :: deriv_dim
 
@@ -3244,16 +3367,13 @@ CONTAINS
       INTEGER                                            :: deriv_dim_prv, handle, i_xyz, iat, &
                                                             iat_of_kind, ikind, j_xyz
       INTEGER, DIMENSION(3)                              :: ind
-      LOGICAL                                            :: do_mp2_prv, found, use_virial
+      LOGICAL                                            :: do_mp2_prv, found
       REAL(dp)                                           :: new_force
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :), TARGET  :: contr_blk, der_blk
       REAL(dp), DIMENSION(3)                             :: scoord
       TYPE(dbt_iterator_type)                            :: iter
 
       CALL timeset(routineN, handle)
-
-      use_virial = .FALSE.
-      IF (PRESENT(work_virial) .AND. PRESENT(cell) .AND. PRESENT(particle_set)) use_virial = .TRUE.
 
       do_mp2_prv = .FALSE.
       IF (PRESENT(do_mp2)) do_mp2_prv = do_mp2
@@ -3262,8 +3382,7 @@ CONTAINS
       IF (PRESENT(deriv_dim)) deriv_dim_prv = deriv_dim
 
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP SHARED(t_3c_der,t_3c_contr,work_virial,force,use_virial,do_mp2_prv,deriv_dim_prv) &
-!$OMP SHARED(pref,idx_to_at,atom_of_kind,kind_of,particle_set,cell) &
+!$OMP SHARED(t_3c_der,t_3c_contr,force,do_mp2_prv,deriv_dim_prv,pref,idx_to_at,atom_of_kind,kind_of) &
 !$OMP PRIVATE(i_xyz,j_xyz,iter,ind,der_blk,contr_blk,found,new_force,iat,iat_of_kind,ikind,scoord)
       DO i_xyz = 1, 3
          CALL dbt_iterator_start(iter, t_3c_der(i_xyz))
@@ -3294,14 +3413,6 @@ CONTAINS
                                                                  + new_force
                END IF
 
-               IF (use_virial) THEN
-                  CALL real_to_scaled(scoord, particle_set(iat)%r, cell)
-
-                  DO j_xyz = 1, 3
-!$OMP ATOMIC
-                     work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + new_force*scoord(j_xyz)
-                  END DO
-               END IF
                DEALLOCATE (contr_blk)
             END IF
             DEALLOCATE (der_blk)
@@ -3314,95 +3425,6 @@ CONTAINS
    END SUBROUTINE get_force_from_3c_trace
 
 ! **************************************************************************************************
-!> \brief Get the force from a contraction of type SUM_a,beta (a|beta') C_a,beta, where beta is an AO
-!>        and a is a MO
-!> \param force ...
-!> \param t_mo_coeff ...
-!> \param t_2c_MO_AO ...
-!> \param atom_of_kind ...
-!> \param kind_of ...
-!> \param idx_to_at ...
-!> \param pref ...
-!> \param i_xyz ...
-!> \param work_virial ...
-!> \param cell ...
-!> \param particle_set ...
-! **************************************************************************************************
-   SUBROUTINE get_MO_AO_force(force, t_mo_coeff, t_2c_MO_AO, atom_of_kind, kind_of, idx_to_at, &
-                              pref, i_xyz, work_virial, cell, particle_set)
-
-      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
-      TYPE(dbt_type), INTENT(INOUT)                      :: t_mo_coeff, t_2c_MO_AO
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: atom_of_kind, kind_of, idx_to_at
-      REAL(dp), INTENT(IN)                               :: pref
-      INTEGER, INTENT(IN)                                :: i_xyz
-      REAL(dp), DIMENSION(3, 3), INTENT(INOUT), OPTIONAL :: work_virial
-      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
-      TYPE(particle_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: particle_set
-
-      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'get_MO_AO_force'
-
-      INTEGER                                            :: handle, iat, iat_of_kind, ikind, j_xyz
-      INTEGER, DIMENSION(2)                              :: ind
-      LOGICAL                                            :: found, use_virial
-      REAL(dp)                                           :: new_force
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :), TARGET     :: mo_ao_blk, mo_coeff_blk
-      REAL(dp), DIMENSION(3)                             :: scoord
-      TYPE(dbt_iterator_type)                            :: iter
-
-      CALL timeset(routineN, handle)
-
-      use_virial = .FALSE.
-      IF (PRESENT(work_virial) .AND. PRESENT(cell) .AND. PRESENT(particle_set)) use_virial = .TRUE.
-
-!$OMP PARALLEL DEFAULT(NONE) &
-!$OMP SHARED(t_2c_MO_AO,t_mo_coeff,pref,use_virial,particle_set,cell,force,work_virial) &
-!$OMP SHARED(idx_to_at,atom_of_kind,kind_of,i_xyz) &
-!$OMP PRIVATE(iter,ind,mo_ao_blk,mo_coeff_blk,found,new_force,iat,iat_of_kind,ikind,scoord,j_xyz)
-      CALL dbt_iterator_start(iter, t_2c_MO_AO)
-      DO WHILE (dbt_iterator_blocks_left(iter))
-         CALL dbt_iterator_next_block(iter, ind)
-
-         CALL dbt_get_block(t_2c_MO_AO, ind, mo_ao_blk, found)
-         CPASSERT(found)
-         CALL dbt_get_block(t_mo_coeff, ind, mo_coeff_blk, found)
-
-         IF (found) THEN
-
-            new_force = pref*SUM(mo_ao_blk(:, :)*mo_coeff_blk(:, :))
-
-            iat = idx_to_at(ind(2)) !AO index is column index
-            iat_of_kind = atom_of_kind(iat)
-            ikind = kind_of(iat)
-
-!$OMP ATOMIC
-            force(ikind)%fock_4c(i_xyz, iat_of_kind) = force(ikind)%fock_4c(i_xyz, iat_of_kind) &
-                                                       + new_force
-
-            IF (use_virial) THEN
-
-               CALL real_to_scaled(scoord, particle_set(iat)%r, cell)
-
-               DO j_xyz = 1, 3
-!$OMP ATOMIC
-                  work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + new_force*scoord(j_xyz)
-               END DO
-            END IF
-
-            DEALLOCATE (mo_coeff_blk)
-         END IF
-
-         DEALLOCATE (mo_ao_blk)
-      END DO !iter
-      CALL dbt_iterator_stop(iter)
-!$OMP END PARALLEL
-
-      CALL timestop(handle)
-
-   END SUBROUTINE get_MO_AO_force
-
-! **************************************************************************************************
 !> \brief Update the forces due to the derivative of the a 2-center product d/dR (Q|R)
 !> \param force ...
 !> \param t_2c_contr A precontracted tensor containing sum_abcdPS (ab|P)(P|Q)^-1 (R|S)^-1 (S|cd) P_ac P_bd
@@ -3411,25 +3433,18 @@ CONTAINS
 !> \param kind_of ...
 !> \param idx_to_at ...
 !> \param pref ...
-!> \param work_virial ...
-!> \param cell ...
-!> \param particle_set ...
 !> \param do_mp2 ...
 !> \param do_ovlp ...
 !> \note IMPORTANT: t_tc_contr and t_2c_der need to have the same distribution
 ! **************************************************************************************************
    SUBROUTINE get_2c_der_force(force, t_2c_contr, t_2c_der, atom_of_kind, kind_of, idx_to_at, &
-                               pref, work_virial, cell, particle_set, do_mp2, do_ovlp)
+                               pref, do_mp2, do_ovlp)
 
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(dbt_type), INTENT(INOUT)                      :: t_2c_contr
       TYPE(dbt_type), DIMENSION(3), INTENT(INOUT)        :: t_2c_der
       INTEGER, DIMENSION(:), INTENT(IN)                  :: atom_of_kind, kind_of, idx_to_at
       REAL(dp), INTENT(IN)                               :: pref
-      REAL(dp), DIMENSION(3, 3), INTENT(INOUT), OPTIONAL :: work_virial
-      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
-      TYPE(particle_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: particle_set
       LOGICAL, INTENT(IN), OPTIONAL                      :: do_mp2, do_ovlp
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'get_2c_der_force'
@@ -3437,8 +3452,7 @@ CONTAINS
       INTEGER                                            :: handle, i_xyz, iat, iat_of_kind, ikind, &
                                                             j_xyz, jat, jat_of_kind, jkind
       INTEGER, DIMENSION(2)                              :: ind
-      LOGICAL                                            :: do_mp2_prv, do_ovlp_prv, found, &
-                                                            use_virial
+      LOGICAL                                            :: do_mp2_prv, do_ovlp_prv, found
       REAL(dp)                                           :: new_force
       REAL(dp), ALLOCATABLE, DIMENSION(:, :), TARGET     :: contr_blk, der_blk
       REAL(dp), DIMENSION(3)                             :: scoord
@@ -3449,9 +3463,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      use_virial = .FALSE.
-      IF (PRESENT(work_virial) .AND. PRESENT(cell) .AND. PRESENT(particle_set)) use_virial = .TRUE.
-
       do_mp2_prv = .FALSE.
       IF (PRESENT(do_mp2)) do_mp2_prv = do_mp2
 
@@ -3459,8 +3470,7 @@ CONTAINS
       IF (PRESENT(do_ovlp)) do_ovlp_prv = do_ovlp
 
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP SHARED(t_2c_der,t_2c_contr,work_virial,force,use_virial,do_mp2_prv,do_ovlp_prv) &
-!$OMP SHARED(pref,idx_to_at,atom_of_kind,kind_of,particle_set,cell) &
+!$OMP SHARED(t_2c_der,t_2c_contr,force,do_mp2_prv,do_ovlp_prv,pref,idx_to_at,atom_of_kind,kind_of) &
 !$OMP PRIVATE(i_xyz,j_xyz,iter,ind,der_blk,contr_blk,found,new_force) &
 !$OMP PRIVATE(iat,jat,iat_of_kind,jat_of_kind,ikind,jkind,scoord)
       DO i_xyz = 1, 3
@@ -3498,16 +3508,6 @@ CONTAINS
                                                              + new_force
                END IF
 
-               IF (use_virial) THEN
-
-                  CALL real_to_scaled(scoord, particle_set(iat)%r, cell)
-
-                  DO j_xyz = 1, 3
-!$OMP ATOMIC
-                     work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + new_force*scoord(j_xyz)
-                  END DO
-               END IF
-
                jat = idx_to_at(ind(2))
                jat_of_kind = atom_of_kind(jat)
                jkind = kind_of(jat)
@@ -3526,16 +3526,6 @@ CONTAINS
                                                              - new_force
                END IF
 
-               IF (use_virial) THEN
-
-                  CALL real_to_scaled(scoord, particle_set(jat)%r, cell)
-
-                  DO j_xyz = 1, 3
-!$OMP ATOMIC
-                     work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) - new_force*scoord(j_xyz)
-                  END DO
-               END IF
-
                DEALLOCATE (contr_blk)
             END IF
 
@@ -3548,6 +3538,73 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE get_2c_der_force
+
+! **************************************************************************************************
+!> \brief Get the force from a contraction of type SUM_a,beta (a|beta') C_a,beta, where beta is an AO
+!>        and a is a MO
+!> \param force ...
+!> \param t_mo_coeff ...
+!> \param t_2c_MO_AO ...
+!> \param atom_of_kind ...
+!> \param kind_of ...
+!> \param idx_to_at ...
+!> \param pref ...
+!> \param i_xyz ...
+! **************************************************************************************************
+   SUBROUTINE get_MO_AO_force(force, t_mo_coeff, t_2c_MO_AO, atom_of_kind, kind_of, idx_to_at, pref, i_xyz)
+
+      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_mo_coeff, t_2c_MO_AO
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: atom_of_kind, kind_of, idx_to_at
+      REAL(dp), INTENT(IN)                               :: pref
+      INTEGER, INTENT(IN)                                :: i_xyz
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'get_MO_AO_force'
+
+      INTEGER                                            :: handle, iat, iat_of_kind, ikind, j_xyz
+      INTEGER, DIMENSION(2)                              :: ind
+      LOGICAL                                            :: found
+      REAL(dp)                                           :: new_force
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :), TARGET     :: mo_ao_blk, mo_coeff_blk
+      REAL(dp), DIMENSION(3)                             :: scoord
+      TYPE(dbt_iterator_type)                            :: iter
+
+      CALL timeset(routineN, handle)
+
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED(t_2c_MO_AO,t_mo_coeff,pref,force,idx_to_at,atom_of_kind,kind_of,i_xyz) &
+!$OMP PRIVATE(iter,ind,mo_ao_blk,mo_coeff_blk,found,new_force,iat,iat_of_kind,ikind,scoord,j_xyz)
+      CALL dbt_iterator_start(iter, t_2c_MO_AO)
+      DO WHILE (dbt_iterator_blocks_left(iter))
+         CALL dbt_iterator_next_block(iter, ind)
+
+         CALL dbt_get_block(t_2c_MO_AO, ind, mo_ao_blk, found)
+         CPASSERT(found)
+         CALL dbt_get_block(t_mo_coeff, ind, mo_coeff_blk, found)
+
+         IF (found) THEN
+
+            new_force = pref*SUM(mo_ao_blk(:, :)*mo_coeff_blk(:, :))
+
+            iat = idx_to_at(ind(2)) !AO index is column index
+            iat_of_kind = atom_of_kind(iat)
+            ikind = kind_of(iat)
+
+!$OMP ATOMIC
+            force(ikind)%fock_4c(i_xyz, iat_of_kind) = force(ikind)%fock_4c(i_xyz, iat_of_kind) &
+                                                       + new_force
+
+            DEALLOCATE (mo_coeff_blk)
+         END IF
+
+         DEALLOCATE (mo_ao_blk)
+      END DO !iter
+      CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+
+      CALL timestop(handle)
+
+   END SUBROUTINE get_MO_AO_force
 
 ! **************************************************************************************************
 !> \brief Print RI-HFX quantities, as required by the PRINT subsection
@@ -3844,6 +3901,8 @@ CONTAINS
       CALL dbt_create(rho_ao_t_3d, "rho_ao_3d", dist_3d, [1, 2], [3], ri_data%bsizes_AO_split, &
                       ri_data%bsizes_AO_split, [1])
       DEALLOCATE (dist1, dist2, dist3)
+      CALL dbt_pgrid_destroy(pgrid_3d)
+      CALL dbt_distribution_destroy(dist_3d)
 
       ! copy density
       nblks = 0
@@ -3924,20 +3983,25 @@ CONTAINS
       CALL dbt_create(density_coeffs_t, "density_coeffs", dist_2d, [1], [2], ri_data%bsizes_RI_split, [1])
       CALL dbt_create(density_coeffs_t, density_tmp)
       DEALLOCATE (dist1, dist2)
+      CALL dbt_pgrid_destroy(pgrid_2d)
+      CALL dbt_distribution_destroy(dist_2d)
 
       CALL dbt_get_info(ri_data%t_3c_int_ctr_3(1, 1), nfull_total=dims_3c)
 
       ! The 3c integrals tensor, in case we compute them here
+      pdims_3d = 0
+      CALL dbt_pgrid_create(para_env, pdims_3d, pgrid_3d, tensor_dims=[MAX(1, natom/n_mem), natom, natom])
       ALLOCATE (t_3c_int_batched(1, 1))
-      CALL create_3c_tensor(t_3c_int_batched(1, 1), dist1, dist2, dist3, ri_data%pgrid, &
+      CALL create_3c_tensor(t_3c_int_batched(1, 1), dist1, dist2, dist3, pgrid_3d, &
                             ri_data%bsizes_RI, ri_data%bsizes_AO, ri_data%bsizes_AO, map1=[1], map2=[2, 3], &
                             name="(RI | AO AO)")
 
-      CALL dbt_mp_environ_pgrid(ri_data%pgrid, pdims_3d, pcoord_3d)
-      CALL mp_comm_t3c%create(ri_data%pgrid%mp_comm_2d, 3, pdims_3d)
+      CALL dbt_mp_environ_pgrid(pgrid_3d, pdims_3d, pcoord_3d)
+      CALL mp_comm_t3c%create(pgrid_3d%mp_comm_2d, 3, pdims_3d)
       CALL distribution_3d_create(dist_nl3c, dist1, dist2, dist3, nkind, particle_set, &
                                   mp_comm_t3c, own_comm=.TRUE.)
       DEALLOCATE (dist1, dist2, dist3)
+      CALL dbt_pgrid_destroy(pgrid_3d)
 
       CALL build_3c_neighbor_lists(nl_3c, basis_set_RI, basis_set_AO, basis_set_AO, dist_nl3c, ri_data%ri_metric, &
                                    "HFX_3c_nl", qs_env, op_pos=1, sym_jk=.TRUE., own_dist=.TRUE.)
@@ -4022,10 +4086,6 @@ CONTAINS
       CALL dbt_destroy(rho_ao_t_3d)
       CALL dbt_destroy(density_coeffs_t)
       CALL dbt_destroy(t_3c_int_batched(1, 1))
-      CALL dbt_pgrid_destroy(pgrid_2d)
-      CALL dbt_distribution_destroy(dist_2d)
-      CALL dbt_pgrid_destroy(pgrid_3d)
-      CALL dbt_distribution_destroy(dist_3d)
 
       CALL timestop(handle)
 
@@ -4083,5 +4143,4 @@ CONTAINS
 
       my_invsqrt = SQRT(1.0_dp/values)
    END FUNCTION
-
 END MODULE

--- a/src/hfx_ri_kp.F
+++ b/src/hfx_ri_kp.F
@@ -1,0 +1,4916 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2023 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief RI-methods for HFX and K-points.
+!> \auhtor Augustin Bussy (01.2023)
+! **************************************************************************************************
+
+MODULE hfx_ri_kp
+   USE admm_types,                      ONLY: get_admm_env
+   USE atomic_kind_types,               ONLY: atomic_kind_type,&
+                                              get_atomic_kind_set
+   USE basis_set_types,                 ONLY: get_gto_basis_set,&
+                                              gto_basis_set_p_type
+   USE cell_types,                      ONLY: cell_type,&
+                                              pbc,&
+                                              real_to_scaled,&
+                                              scaled_to_real
+   USE cp_array_utils,                  ONLY: cp_1d_logical_p_type,&
+                                              cp_2d_r_p_type,&
+                                              cp_3d_r_p_type
+   USE cp_blacs_env,                    ONLY: cp_blacs_env_create,&
+                                              cp_blacs_env_release,&
+                                              cp_blacs_env_type
+   USE cp_control_types,                ONLY: dft_control_type
+   USE cp_dbcsr_cholesky,               ONLY: cp_dbcsr_cholesky_decompose,&
+                                              cp_dbcsr_cholesky_invert
+   USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
+   USE cp_dbcsr_diag,                   ONLY: cp_dbcsr_power
+   USE cp_dbcsr_operations,             ONLY: cp_dbcsr_dist2d_to_dist
+   USE dbcsr_api,                       ONLY: &
+        dbcsr_add, dbcsr_clear, dbcsr_copy, dbcsr_create, dbcsr_distribution_get, &
+        dbcsr_distribution_new, dbcsr_distribution_release, dbcsr_distribution_type, dbcsr_dot, &
+        dbcsr_filter, dbcsr_finalize, dbcsr_get_block_p, dbcsr_get_info, &
+        dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, &
+        dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_p_type, dbcsr_put_block, dbcsr_release, &
+        dbcsr_type, dbcsr_type_no_symmetry, dbcsr_type_symmetric
+   USE dbt_api,                         ONLY: &
+        dbt_batched_contract_finalize, dbt_batched_contract_init, dbt_clear, dbt_contract, &
+        dbt_copy, dbt_copy_matrix_to_tensor, dbt_copy_tensor_to_matrix, dbt_create, dbt_destroy, &
+        dbt_distribution_destroy, dbt_distribution_new, dbt_distribution_type, dbt_filter, &
+        dbt_finalize, dbt_get_block, dbt_get_info, dbt_get_stored_coordinates, &
+        dbt_iterator_blocks_left, dbt_iterator_next_block, dbt_iterator_start, dbt_iterator_stop, &
+        dbt_iterator_type, dbt_mp_environ_pgrid, dbt_pgrid_create, dbt_pgrid_destroy, &
+        dbt_pgrid_type, dbt_put_block, dbt_type
+   USE distribution_2d_types,           ONLY: distribution_2d_release,&
+                                              distribution_2d_type
+   USE hfx_ri,                          ONLY: get_idx_to_atom,&
+                                              hfx_ri_pre_scf_calc_tensors
+   USE hfx_types,                       ONLY: hfx_ri_type
+   USE input_constants,                 ONLY: do_potential_short,&
+                                              hfx_ri_do_2c_cholesky,&
+                                              hfx_ri_do_2c_diag,&
+                                              hfx_ri_do_2c_iter
+   USE input_cp2k_hfx,                  ONLY: ri_pmat
+   USE input_section_types,             ONLY: section_vals_get_subs_vals,&
+                                              section_vals_type,&
+                                              section_vals_val_get,&
+                                              section_vals_val_set
+   USE iterate_matrix,                  ONLY: invert_hotelling
+   USE kinds,                           ONLY: dp,&
+                                              int_8
+   USE kpoint_types,                    ONLY: get_kpoint_info,&
+                                              kpoint_type
+   USE libint_2c_3c,                    ONLY: cutoff_screen_factor
+   USE machine,                         ONLY: m_flush,&
+                                              m_walltime
+   USE mathlib,                         ONLY: erfc_cutoff
+   USE message_passing,                 ONLY: mp_cart_type,&
+                                              mp_para_env_type,&
+                                              mp_request_type,&
+                                              mp_waitall
+   USE particle_methods,                ONLY: get_particle_set
+   USE particle_types,                  ONLY: particle_type
+   USE physcon,                         ONLY: angstrom
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_force_types,                  ONLY: qs_force_type
+   USE qs_integral_utils,               ONLY: basis_set_list_setup
+   USE qs_interactions,                 ONLY: init_interaction_radii_orb_basis
+   USE qs_kind_types,                   ONLY: qs_kind_type
+   USE qs_neighbor_list_types,          ONLY: get_iterator_info,&
+                                              neighbor_list_iterate,&
+                                              neighbor_list_iterator_create,&
+                                              neighbor_list_iterator_p_type,&
+                                              neighbor_list_iterator_release,&
+                                              neighbor_list_set_p_type,&
+                                              release_neighbor_list_sets
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
+   USE qs_tensors,                      ONLY: &
+        build_2c_derivatives, build_2c_neighbor_lists, build_3c_derivatives, &
+        build_3c_neighbor_lists, get_3c_iterator_info, get_tensor_occupancy, &
+        neighbor_list_3c_destroy, neighbor_list_3c_iterate, neighbor_list_3c_iterator_create, &
+        neighbor_list_3c_iterator_destroy
+   USE qs_tensors_types,                ONLY: create_2c_tensor,&
+                                              create_3c_tensor,&
+                                              create_tensor_batches,&
+                                              distribution_2d_create,&
+                                              distribution_3d_create,&
+                                              distribution_3d_type,&
+                                              neighbor_list_3c_iterator_type,&
+                                              neighbor_list_3c_type
+   USE virial_types,                    ONLY: virial_type
+#include "./base/base_uses.f90"
+
+!$ USE OMP_LIB, ONLY: omp_get_num_threads
+
+   IMPLICIT NONE
+   PRIVATE
+
+   PUBLIC :: hfx_ri_update_ks_kp, hfx_ri_update_forces_kp
+
+   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'hfx_ri_kp'
+CONTAINS
+
+! NOTES: for a start, we do not seek performance, but accuracy. So in this first implementation,
+!        we give little consideration to batching, load balance and such.
+!        We also put everything here, even if there is some code replication with the original RI_HFX
+!        We will only work in the RHO flavor
+!        For now, we will also always assume that there is a single para_env, and that there is no
+!        K-point subgroup. This might change in the future
+
+! **************************************************************************************************
+!> \brief I_1nitialize the ri_data for K-point. For now, we take the normal, usual existing ri_data
+!>        and we adapt it to our needs
+!> \param ri_data ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE adapt_ri_data_to_kp(ri_data, qs_env)
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      INTEGER                                            :: i_img, i_RI, iatom, natom, nblks_RI, &
+                                                            nimg, nkind
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes_RI_ext, dist1, dist2, dist3
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+
+      NULLIFY (dft_control, para_env)
+
+      !The main thing that we need to do is to allocate more space for the integrals, such that there
+      !is room for each periodic image. Note that we only go in 1D, i.e. we store (mu^0 sigma^a|P^0),
+      !and (P^0|Q^a) => the RI basis is always in the main cell.
+
+      !Get kpoint info
+      CALL get_qs_env(qs_env, dft_control=dft_control, natom=natom, para_env=para_env, nkind=nkind)
+      nimg = ri_data%nimg
+
+      !Along the RI direction we have basis elements spread accross ncell_RI images.
+      nblks_RI = SIZE(ri_data%bsizes_RI_split)
+      ALLOCATE (bsizes_RI_ext(nblks_RI*ri_data%ncell_RI))
+      DO i_RI = 1, ri_data%ncell_RI
+         bsizes_RI_ext((i_RI - 1)*nblks_RI + 1:i_RI*nblks_RI) = ri_data%bsizes_RI_split(:)
+      END DO
+
+      ALLOCATE (ri_data%t_3c_int_ctr_1(1, nimg))
+      CALL create_3c_tensor(ri_data%t_3c_int_ctr_1(1, 1), dist1, dist2, dist3, &
+                            ri_data%pgrid_1, ri_data%bsizes_AO_split, bsizes_RI_ext, &
+                            ri_data%bsizes_AO_split, [1, 2], [3], name="(AO RI | AO)")
+
+      DO i_img = 2, nimg
+         CALL dbt_create(ri_data%t_3c_int_ctr_1(1, 1), ri_data%t_3c_int_ctr_1(1, i_img))
+      END DO
+      DEALLOCATE (dist1, dist2, dist3)
+
+      ALLOCATE (ri_data%t_3c_int_ctr_2(1, 1))
+      CALL create_3c_tensor(ri_data%t_3c_int_ctr_2(1, 1), dist1, dist2, dist3, &
+                            ri_data%pgrid_1, ri_data%bsizes_AO_split, bsizes_RI_ext, &
+                            ri_data%bsizes_AO_split, [1], [2, 3], name="(AO RI | AO)")
+      DEALLOCATE (dist1, dist2, dist3)
+
+      !We use full block sizes for the 2c quantities
+      DEALLOCATE (bsizes_RI_ext)
+      nblks_RI = SIZE(ri_data%bsizes_RI)
+      ALLOCATE (bsizes_RI_ext(nblks_RI*ri_data%ncell_RI))
+      DO i_RI = 1, ri_data%ncell_RI
+         bsizes_RI_ext((i_RI - 1)*nblks_RI + 1:i_RI*nblks_RI) = ri_data%bsizes_RI(:)
+      END DO
+
+      ALLOCATE (ri_data%t_2c_inv(1, natom), ri_data%t_2c_int(1, natom))
+      CALL create_2c_tensor(ri_data%t_2c_inv(1, 1), dist1, dist2, ri_data%pgrid_2d, &
+                            bsizes_RI_ext, bsizes_RI_ext, &
+                            name="(RI | RI)")
+      DEALLOCATE (dist1, dist2)
+      CALL dbt_create(ri_data%t_2c_inv(1, 1), ri_data%t_2c_int(1, 1))
+      DO iatom = 2, natom
+         CALL dbt_create(ri_data%t_2c_inv(1, 1), ri_data%t_2c_inv(1, iatom))
+         CALL dbt_create(ri_data%t_2c_inv(1, 1), ri_data%t_2c_int(1, iatom))
+      END DO
+
+      ALLOCATE (ri_data%kp_cost(natom, natom, nimg))
+      ri_data%kp_cost = 0.0_dp
+
+   END SUBROUTINE adapt_ri_data_to_kp
+
+! **************************************************************************************************
+!> \brief The pre-scf steps for RI-HFX k-points calculation. Namely the calculation of the integrals
+!> \param ri_data ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE hfx_ri_pre_scf_kp(ri_data, qs_env)
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'hfx_ri_pre_scf_kp'
+
+      INTEGER                                            :: handle, i_img, iatom, natom, nimg, nkind
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: t_2c_op_pot, t_2c_op_RI
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_int
+      TYPE(dft_control_type), POINTER                    :: dft_control
+
+      NULLIFY (dft_control)
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, dft_control=dft_control, natom=natom, nkind=nkind)
+
+      CALL cleanup_kp(ri_data)
+
+      !We do all the checks on what we allow in this initial implementation
+      IF (ri_data%flavor .NE. ri_pmat) CPABORT("K-points RI-HFX only with RHO flavor")
+      IF (ri_data%same_op) ri_data%same_op = .FALSE. !force the full calculation with RI metric
+      IF (ABS(ri_data%eps_pgf_orb - dft_control%qs_control%eps_pgf_orb) > 1.0E-16_dp) &
+         CPABORT("RI%EPS_PGF_ORB and QS%EPS_PGF_ORB must be identical for RI-HFX k-points")
+
+      CALL get_kp_and_ri_images(ri_data, qs_env)
+      nimg = ri_data%nimg
+
+      !Calculate the integrals
+      ALLOCATE (t_2c_op_pot(nimg), t_2c_op_RI(nimg))
+      ALLOCATE (t_3c_int(1, nimg))
+      CALL hfx_ri_pre_scf_calc_tensors(qs_env, ri_data, t_2c_op_RI, t_2c_op_pot, t_3c_int, do_kpoints=.TRUE.)
+
+      !Make sure the internals have the k-point format
+      CALL adapt_ri_data_to_kp(ri_data, qs_env)
+
+      !We want the integral in the (mu^0 | P^i sigma^j) format
+      DO i_img = 1, nimg
+         CALL dbt_copy(t_3c_int(1, i_img), ri_data%t_3c_int_ctr_1(1, i_img), order=[2, 1, 3], move_data=.TRUE.)
+         CALL dbt_destroy(t_3c_int(1, i_img))
+      END DO
+
+      !reorder the 3c integrals such that empty images are bunched up together
+      CALL reorder_3c_ints(ri_data%t_3c_int_ctr_1(1, :), ri_data)
+
+      !For each atom i, we calculate the inverse RI metric (P^0 | Q^0)^-1 without external bumping yet
+      !Also store the off-diagonal integrals of the RI metric in case of forces, bumped from the left
+      DO iatom = 1, natom
+         CALL get_ext_2c_int(ri_data%t_2c_inv(1, iatom), t_2c_op_RI, iatom, iatom, 1, ri_data, qs_env, &
+                             do_inverse=.TRUE.)
+         !for the forces
+         CALL get_ext_2c_int(ri_data%t_2c_int(1, iatom), t_2c_op_RI, iatom, iatom, 1, ri_data, &
+                             qs_env, off_diagonal=.TRUE.)
+         CALL apply_bump(ri_data%t_2c_int(1, iatom), iatom, ri_data, qs_env, from_left=.TRUE., from_right=.FALSE.)
+      END DO
+
+      DO i_img = 1, nimg
+         CALL dbcsr_release(t_2c_op_RI(i_img))
+      END DO
+
+      ALLOCATE (ri_data%kp_mat_2c_pot(1, nimg))
+      DO i_img = 1, nimg
+         CALL dbcsr_create(ri_data%kp_mat_2c_pot(1, i_img), template=t_2c_op_pot(i_img))
+         CALL dbcsr_copy(ri_data%kp_mat_2c_pot(1, i_img), t_2c_op_pot(i_img))
+         CALL dbcsr_release(t_2c_op_pot(i_img))
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE hfx_ri_pre_scf_kp
+
+! **************************************************************************************************
+!> \brief clean-up the KP specific data from ri_data
+!> \param ri_data ...
+! **************************************************************************************************
+   SUBROUTINE cleanup_kp(ri_data)
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+
+      INTEGER                                            :: i, j
+
+      IF (ALLOCATED(ri_data%kp_cost)) DEALLOCATE (ri_data%kp_cost)
+      IF (ALLOCATED(ri_data%idx_to_img)) DEALLOCATE (ri_data%idx_to_img)
+      IF (ALLOCATED(ri_data%img_to_idx)) DEALLOCATE (ri_data%img_to_idx)
+      IF (ALLOCATED(ri_data%present_images)) DEALLOCATE (ri_data%present_images)
+      IF (ALLOCATED(ri_data%img_to_RI_cell)) DEALLOCATE (ri_data%img_to_RI_cell)
+      IF (ALLOCATED(ri_data%RI_cell_to_img)) DEALLOCATE (ri_data%RI_cell_to_img)
+
+      IF (ALLOCATED(ri_data%kp_mat_2c_pot)) THEN
+         DO j = 1, SIZE(ri_data%kp_mat_2c_pot, 2)
+            DO i = 1, SIZE(ri_data%kp_mat_2c_pot, 1)
+               CALL dbcsr_release(ri_data%kp_mat_2c_pot(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%kp_mat_2c_pot)
+      END IF
+
+      IF (ALLOCATED(ri_data%kp_t_3c_int)) THEN
+         DO i = 1, SIZE(ri_data%kp_t_3c_int)
+            CALL dbt_destroy(ri_data%kp_t_3c_int(i))
+         END DO
+         DEALLOCATE (ri_data%kp_t_3c_int)
+      END IF
+
+      IF (ALLOCATED(ri_data%kp_t_3c_apc)) THEN
+         DO j = 1, SIZE(ri_data%kp_t_3c_apc, 2)
+            DO i = 1, SIZE(ri_data%kp_t_3c_apc, 1)
+               CALL dbt_destroy(ri_data%kp_t_3c_apc(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%kp_t_3c_apc)
+      END IF
+
+      IF (ALLOCATED(ri_data%t_2c_inv)) THEN
+         DO j = 1, SIZE(ri_data%t_2c_inv, 2)
+            DO i = 1, SIZE(ri_data%t_2c_inv, 1)
+               CALL dbt_destroy(ri_data%t_2c_inv(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%t_2c_inv)
+      END IF
+
+      IF (ALLOCATED(ri_data%t_2c_int)) THEN
+         DO j = 1, SIZE(ri_data%t_2c_int, 2)
+            DO i = 1, SIZE(ri_data%t_2c_int, 1)
+               CALL dbt_destroy(ri_data%t_2c_int(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%t_2c_int)
+      END IF
+
+      IF (ALLOCATED(ri_data%t_3c_int_ctr_1)) THEN
+         DO j = 1, SIZE(ri_data%t_3c_int_ctr_1, 2)
+            DO i = 1, SIZE(ri_data%t_3c_int_ctr_1, 1)
+               CALL dbt_destroy(ri_data%t_3c_int_ctr_1(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%t_3c_int_ctr_1)
+      END IF
+
+      IF (ALLOCATED(ri_data%t_3c_int_ctr_2)) THEN
+         DO j = 1, SIZE(ri_data%t_3c_int_ctr_2, 2)
+            DO i = 1, SIZE(ri_data%t_3c_int_ctr_2, 1)
+               CALL dbt_destroy(ri_data%t_3c_int_ctr_2(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%t_3c_int_ctr_2)
+      END IF
+
+   END SUBROUTINE cleanup_kp
+
+! **************************************************************************************************
+!> \brief Update the KS matrices for each real-space image
+!> \param qs_env ...
+!> \param ri_data ...
+!> \param ks_matrix ...
+!> \param ehfx ...
+!> \param rho_ao ...
+!> \param geometry_did_change ...
+!> \param nspins ...
+!> \param hf_fraction ...
+!> \param calculate_forces If forces are to be calculated, some quantities are saved to avoid recomputation
+! **************************************************************************************************
+   SUBROUTINE hfx_ri_update_ks_kp(qs_env, ri_data, ks_matrix, ehfx, rho_ao, &
+                                  geometry_did_change, nspins, hf_fraction, &
+                                  calculate_forces)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: ks_matrix
+      REAL(KIND=dp), INTENT(OUT)                         :: ehfx
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_ao
+      LOGICAL, INTENT(IN)                                :: geometry_did_change
+      INTEGER, INTENT(IN)                                :: nspins
+      REAL(KIND=dp), INTENT(IN)                          :: hf_fraction
+      LOGICAL, INTENT(IN), OPTIONAL                      :: calculate_forces
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'hfx_ri_update_ks_kp'
+
+      INTEGER :: apc_img, b_img, batch_size, group_size, handle, handle2, i_batch, i_img, i_spin, &
+         iatom, iblk, igroup, j_batch, jatom, mb_img, n_batch_img, n_batch_nze, natom, ngroups, &
+         nimg, nimg_nze
+      INTEGER(int_8)                                     :: nflop, nze
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: batch_ranges_at, batch_ranges_img, &
+                                                            batch_ranges_nze, dist1, dist2, &
+                                                            idx_to_at_AO, int_indices
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: ac_pairs, iapc_pairs
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: sparsity_pattern
+      LOGICAL                                            :: calc_f
+      REAL(dp)                                           :: etmp, fac, occ, pref, t1, t2, t3, t4
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_sub
+      TYPE(dbcsr_type)                                   :: ks_desymm, rho_desymm, tmp
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: mat_2c_pot
+      TYPE(dbcsr_type), POINTER                          :: dbcsr_template
+      TYPE(dbt_type)                                     :: t_3c_tmp
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: ints_stack, ks_t_split, res_stack, &
+                                                            rho_stack, t_2c_ao_tmp, t_2c_inv, &
+                                                            t_2c_work, t_3c_int, t_3c_work_2, &
+                                                            t_3c_work_3
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: ks_t, ks_t_sub, rho_ao_t, t_3c_apc, &
+                                                            t_3c_apc_sub
+      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(section_vals_type), POINTER                   :: hfx_section
+
+      NULLIFY (para_env, para_env_sub, blacs_env_sub, hfx_section, dbcsr_template)
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, para_env=para_env, natom=natom)
+
+      calc_f = .FALSE.
+      IF (PRESENT(calculate_forces)) calc_f = calculate_forces
+
+      IF (nspins == 1) THEN
+         fac = 0.5_dp*hf_fraction
+      ELSE
+         fac = 1.0_dp*hf_fraction
+      END IF
+
+      IF (geometry_did_change) THEN
+         CALL hfx_ri_pre_scf_kp(ri_data, qs_env)
+      END IF
+      nimg = ri_data%nimg
+      nimg_nze = ri_data%nimg_nze
+
+      !We need to calculate the KS matrix for each periodic cell with index b: F_mu^0,nu^b
+      !F_mu^0,nu^b = -0.5 sum_a,c P_sigma^0,lambda^c (mu^0, sigma^a| P^0) V_P^0,Q^b (Q^b| nu^b lambda^a+c)
+
+      !We use a local RI basis set for each atom in the system, which inlcudes RI basis elements for
+      !each neighboring atom standing within the KIND radius (decay of Gaussian with smallest exponent)
+
+      !We also limit the number of periodic images we consider accorrding to the HFX potentail in the
+      !RI basis, because if V_P^0,Q^b is zero everywhere, then image b can be ignored (RI basis less diffuse)
+
+      !We manage to calculate each KS matrix doing a double loop on iamges, and a double loop on atoms
+      !First, we pre-contract and store P_sigma^0,lambda^c (mu^0, sigma^a| P^0) into T_mu^0,lambda^a+c,P^0
+      !Then, we loop over b_img, iatom, jatom to calculate V_P^0,Q^b
+      !Finally, we do an additional loop over a+c images where we do V_P^0,Q^b (Q^b| nu^b lambda^a+c)
+      !and the final contraction with T_mu^0,lambda^a+c,P^0
+
+      ALLOCATE (rho_ao_t(nspins, nimg), ks_t(nspins, nimg))
+      CALL create_2c_tensor(rho_ao_t(1, 1), dist1, dist2, ri_data%pgrid_2d, &
+                            ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
+                            name="(AO | AO)")
+      DEALLOCATE (dist1, dist2)
+      CALL dbt_create(ks_matrix(1, 1)%matrix, ks_t(1, 1))
+
+      IF (nspins == 2) THEN
+         CALL dbt_create(rho_ao_t(1, 1), rho_ao_t(2, 1))
+         CALL dbt_create(ks_t(1, 1), ks_t(2, 1))
+      END IF
+      DO i_img = 2, nimg
+         DO i_spin = 1, nspins
+            CALL dbt_create(rho_ao_t(1, 1), rho_ao_t(i_spin, i_img))
+            CALL dbt_create(ks_t(1, 1), ks_t(i_spin, i_img))
+         END DO
+      END DO
+      CALL get_pmat_images(rho_ao_t, rho_ao, ri_data, qs_env)
+
+      ALLOCATE (idx_to_at_AO(SIZE(ri_data%bsizes_AO_split)))
+      CALL get_idx_to_atom(idx_to_at_AO, ri_data%bsizes_AO_split, ri_data%bsizes_AO)
+
+      !First we calculate and store T^1_mu^0,lambda^a+c,P = P_mu^0,lambda^c * (mu_0 sigma^a | P)
+      !To avoid doing nimg**2 tiny contractions that do not scale well with a large number of CPUs,
+      !we instead do a single loop over the a+c image index. For each a+c, we get a list of allowed
+      !combination of a,c indices. Then we build TAS tensors P_mu^0,lambda^c with all concerned c's
+      !and (mu^0 sigma^a | P) with all a's. Then we perform a single contraction with larger tensors,
+      !were the sum over a,c is automatically taken care of
+      ALLOCATE (t_3c_apc(nspins, nimg))
+      DO i_img = 1, nimg
+         DO i_spin = 1, nspins
+            CALL dbt_create(ri_data%t_3c_int_ctr_2(1, 1), t_3c_apc(i_spin, i_img))
+         END DO
+      END DO
+      CALL dbt_create(ri_data%t_3c_int_ctr_1(1, 1), t_3c_tmp)
+      t1 = m_walltime()
+      CALL timeset(routineN//"_3c_1", handle2)
+
+      batch_size = nimg/ri_data%n_mem
+
+      !batching over all images
+      n_batch_img = nimg/batch_size
+      IF (MODULO(nimg, batch_size) .NE. 0) n_batch_img = n_batch_img + 1
+      ALLOCATE (batch_ranges_img(n_batch_img + 1))
+      DO i_batch = 1, n_batch_img
+         batch_ranges_img(i_batch) = (i_batch - 1)*batch_size + 1
+      END DO
+      batch_ranges_img(n_batch_img + 1) = nimg + 1
+
+      !batching over images with non-zero 3c integrals
+      n_batch_nze = nimg_nze/batch_size
+      IF (MODULO(nimg_nze, batch_size) .NE. 0) n_batch_nze = n_batch_nze + 1
+      ALLOCATE (batch_ranges_nze(n_batch_nze + 1))
+      DO i_batch = 1, n_batch_nze
+         batch_ranges_nze(i_batch) = (i_batch - 1)*batch_size + 1
+      END DO
+      batch_ranges_nze(n_batch_nze + 1) = nimg_nze + 1
+
+      !Create the stack tensors in the approriate distribution
+      ALLOCATE (rho_stack(2), ints_stack(2), res_stack(2))
+      CALL get_stack_tensors(res_stack, rho_stack, ints_stack, rho_ao_t(1, 1), &
+                             ri_data%t_3c_int_ctr_1(1, 1), batch_size, ri_data, qs_env)
+
+      ALLOCATE (ac_pairs(nimg, 2), int_indices(nimg_nze))
+      DO i_img = 1, nimg_nze
+         int_indices(i_img) = i_img
+      END DO
+
+      DO j_batch = 1, n_batch_nze
+         !First batch is over the integrals. They are always in the same order, consistent with get_ac_pairs
+         CALL fill_3c_stack(ints_stack(1), ri_data%t_3c_int_ctr_1(1, :), int_indices, 3, ri_data, &
+                            img_bounds=[batch_ranges_nze(j_batch), batch_ranges_nze(j_batch + 1)])
+         CALL dbt_copy(ints_stack(1), ints_stack(2), move_data=.TRUE.)
+
+         DO i_spin = 1, nspins
+            DO i_batch = 1, n_batch_img
+               !Second batch is over the P matrix. Here we fill the stacked rho tensors col by col
+               DO apc_img = batch_ranges_img(i_batch), batch_ranges_img(i_batch + 1) - 1
+                  CALL get_ac_pairs(ac_pairs, apc_img, ri_data, qs_env)
+                  CALL fill_2c_stack(rho_stack(1), rho_ao_t(i_spin, :), ac_pairs(:, 2), 1, ri_data, &
+                                     img_bounds=[batch_ranges_nze(j_batch), batch_ranges_nze(j_batch + 1)], &
+                                     shift=apc_img - batch_ranges_img(i_batch) + 1)
+
+               END DO !apc_img
+               CALL get_tensor_occupancy(rho_stack(1), nze, occ)
+               IF (nze == 0) CYCLE
+               CALL dbt_copy(rho_stack(1), rho_stack(2), move_data=.TRUE.)
+
+               !The actual contraction
+               CALL dbt_batched_contract_init(rho_stack(2))
+               CALL dbt_contract(1.0_dp, ints_stack(2), rho_stack(2), &
+                                 0.0_dp, res_stack(2), map_1=[1, 2], map_2=[3], &
+                                 contract_1=[3], notcontract_1=[1, 2], &
+                                 contract_2=[1], notcontract_2=[2], &
+                                 filter_eps=ri_data%filter_eps, flop=nflop)
+               ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+               CALL dbt_batched_contract_finalize(rho_stack(2))
+               CALL dbt_copy(res_stack(2), res_stack(1), move_data=.TRUE.)
+
+               DO apc_img = batch_ranges_img(i_batch), batch_ranges_img(i_batch + 1) - 1
+                  !Destack the resulting tensor and put it in t_3c_apc with correct apc_img
+                  CALL unstack_t_3c_apc(t_3c_tmp, res_stack(1), apc_img - batch_ranges_img(i_batch) + 1)
+                  CALL dbt_copy(t_3c_tmp, t_3c_apc(i_spin, apc_img), summation=.TRUE., move_data=.TRUE.)
+               END DO
+
+            END DO !i_batch
+         END DO !i_spin
+      END DO !j_batch
+      DEALLOCATE (batch_ranges_img)
+      DEALLOCATE (batch_ranges_nze)
+
+      CALL dbt_destroy(rho_stack(1))
+      CALL dbt_destroy(rho_stack(2))
+      CALL dbt_destroy(ints_stack(1))
+      CALL dbt_destroy(ints_stack(2))
+      CALL dbt_destroy(res_stack(1))
+      CALL dbt_destroy(res_stack(2))
+      CALL dbt_destroy(t_3c_tmp)
+      CALL timestop(handle2)
+
+      hfx_section => section_vals_get_subs_vals(qs_env%input, "DFT%XC%HF%RI")
+      CALL section_vals_val_get(hfx_section, "KP_NGROUPS", i_val=ngroups)
+      CALL section_vals_val_get(hfx_section, "KP_STACK_SIZE", i_val=batch_size)
+      ri_data%kp_stack_size = batch_size
+
+      IF (MOD(para_env%num_pe, ngroups) .NE. 0) THEN
+         CPWARN("KP_NGROUPS must be an integer divisor of the total number of MPI ranks. It was set to 1.")
+         ngroups = 1
+         CALL section_vals_val_set(hfx_section, "KP_NGROUPS", i_val=ngroups)
+      END IF
+      IF (MOD(ngroups, natom) .NE. 0) THEN
+         IF (ngroups > 1) &
+            CPWARN("Better load balancing is achieved when NGROUPS is a multiplie of the number of atoms")
+      END IF
+      group_size = para_env%num_pe/ngroups
+      igroup = para_env%mepos/group_size
+
+      ALLOCATE (para_env_sub)
+      CALL para_env_sub%from_split(para_env, igroup)
+      CALL cp_blacs_env_create(blacs_env_sub, para_env_sub)
+
+      ! The sparsity pattern of each iatom, jatom pair, on each b_img, and on which subgroup
+      ALLOCATE (sparsity_pattern(natom, natom, nimg))
+      CALL get_sparsity_pattern(sparsity_pattern, ri_data, qs_env)
+      CALL get_sub_dist(sparsity_pattern, ngroups, ri_data)
+
+      !Get all the required tensors in the subgroups
+      ALLOCATE (t_2c_inv(natom), mat_2c_pot(nimg), ks_t_sub(nspins, nimg), t_2c_ao_tmp(1), &
+                ks_t_split(2), t_2c_work(3))
+      CALL get_subgroup_2c_tensors(t_2c_inv, mat_2c_pot, t_2c_work, t_2c_ao_tmp, ks_t_split, ks_t_sub, &
+                                   group_size, ngroups, para_env, para_env_sub, ri_data)
+
+      ALLOCATE (t_3c_int(nimg), t_3c_apc_sub(nspins, nimg), t_3c_work_2(3), t_3c_work_3(3))
+      CALL get_subgroup_3c_tensors(t_3c_int, t_3c_work_2, t_3c_work_3, t_3c_apc, t_3c_apc_sub, &
+                                   group_size, ngroups, para_env, para_env_sub, ri_data)
+
+      !We go atom by atom, therefore there is an automatic batching along that direction
+      !Also, because we stack the 3c tensors nimg times, we naturally do some batching there too
+      ALLOCATE (batch_ranges_at(natom + 1))
+      batch_ranges_at(natom + 1) = SIZE(ri_data%bsizes_AO_split) + 1
+      iatom = 0
+      DO iblk = 1, SIZE(ri_data%bsizes_AO_split)
+         IF (idx_to_at_AO(iblk) == iatom + 1) THEN
+            iatom = iatom + 1
+            batch_ranges_at(iatom) = iblk
+         END IF
+      END DO
+
+      n_batch_nze = nimg_nze/batch_size
+      IF (MODULO(nimg_nze, batch_size) .NE. 0) n_batch_nze = n_batch_nze + 1
+      ALLOCATE (batch_ranges_nze(n_batch_nze + 1))
+      DO i_batch = 1, n_batch_nze
+         batch_ranges_nze(i_batch) = (i_batch - 1)*batch_size + 1
+      END DO
+      batch_ranges_nze(n_batch_nze + 1) = nimg_nze + 1
+
+      CALL dbt_batched_contract_init(t_3c_work_3(1), batch_range_2=batch_ranges_at)
+      CALL dbt_batched_contract_init(t_3c_work_3(2), batch_range_2=batch_ranges_at)
+      CALL dbt_batched_contract_init(t_3c_work_2(1), batch_range_1=batch_ranges_at)
+      CALL dbt_batched_contract_init(t_3c_work_2(2), batch_range_1=batch_ranges_at)
+
+      !Applying the external bump to ((P|Q)_D + B*(P|Q)_OD*B)^-1 from left and right
+      DO iatom = 1, natom
+         CALL apply_bump(t_2c_inv(iatom), iatom, ri_data, qs_env, from_left=.TRUE., from_right=.TRUE.)
+      END DO
+
+      ri_data%kp_cost(:, :, :) = 0.0_dp
+      ALLOCATE (iapc_pairs(nimg, 2))
+      DO b_img = 1, nimg
+         CALL dbt_batched_contract_init(ks_t_split(1))
+         CALL dbt_batched_contract_init(ks_t_split(2))
+         DO jatom = 1, natom
+            DO iatom = 1, natom
+               IF (.NOT. sparsity_pattern(iatom, jatom, b_img) == igroup) CYCLE
+               pref = 1.0_dp
+               IF (iatom == jatom .AND. b_img == 1) pref = 0.5_dp
+
+               !measure the cost of the given i, j, b configuration
+               t3 = m_walltime()
+
+               !Get the proper HFX potential 2c integrals (P_i^0|Q_j^b), and multply by RI metric
+               CALL timeset(routineN//"_2c", handle2)
+               CALL get_ext_2c_int(t_2c_work(1), mat_2c_pot, iatom, jatom, b_img, ri_data, qs_env, &
+                                   blacs_env_ext=blacs_env_sub, para_env_ext=para_env_sub, &
+                                   dbcsr_template=dbcsr_template)
+               CALL dbt_contract(1.0_dp, t_2c_work(1), t_2c_inv(jatom), &
+                                 0.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                 contract_1=[2], notcontract_1=[1], &
+                                 contract_2=[1], notcontract_2=[2], &
+                                 filter_eps=ri_data%filter_eps, flop=nflop)
+               ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+               CALL dbt_contract(1.0_dp, t_2c_inv(iatom), t_2c_work(2), &
+                                 0.0_dp, t_2c_work(1), map_1=[1], map_2=[2], &
+                                 contract_1=[2], notcontract_1=[1], &
+                                 contract_2=[1], notcontract_2=[2], &
+                                 filter_eps=ri_data%filter_eps, flop=nflop)
+               ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+               CALL dbt_copy(t_2c_work(1), t_2c_work(3), move_data=.TRUE.) !move to split blocks
+               CALL dbt_filter(t_2c_work(3), ri_data%filter_eps)
+               CALL timestop(handle2)
+
+               CALL dbt_batched_contract_init(t_2c_work(3))
+               CALL get_iapc_pairs(iapc_pairs, b_img, ri_data, qs_env)
+               CALL timeset(routineN//"_3c_2", handle2)
+
+               !Stack the (Q^b| nu^b lambda^a+c) integrals over a+c and multiply by V_PQ
+               DO i_batch = 1, n_batch_nze
+                  CALL fill_3c_stack(t_3c_work_3(3), t_3c_int, iapc_pairs(:, 1), 3, ri_data, &
+                                     filter_at=jatom, filter_dim=2, idx_to_at=idx_to_at_AO, &
+                                     img_bounds=[batch_ranges_nze(i_batch), batch_ranges_nze(i_batch + 1)])
+                  CALL dbt_copy(t_3c_work_3(3), t_3c_work_3(1), move_data=.TRUE.)
+
+                  CALL dbt_contract(1.0_dp, t_2c_work(3), t_3c_work_3(1), &
+                                    0.0_dp, t_3c_work_3(2), map_1=[1], map_2=[2, 3], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2, 3], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+                  CALL dbt_copy(t_3c_work_3(2), t_3c_work_2(2), order=[2, 1, 3], move_data=.TRUE.)
+                  CALL dbt_copy(t_3c_work_3(3), t_3c_work_3(1))
+
+                  !Stack the P_sigma^a,lambda^a+c * (mu^0 sigma^a | P) integrals over a+c and contract
+                  !to get the final block of the KS matrix
+                  DO i_spin = 1, nspins
+                     CALL fill_3c_stack(t_3c_work_2(3), t_3c_apc_sub(i_spin, :), iapc_pairs(:, 2), 3, &
+                                        ri_data, filter_at=iatom, filter_dim=1, idx_to_at=idx_to_at_AO, &
+                                        img_bounds=[batch_ranges_nze(i_batch), batch_ranges_nze(i_batch + 1)])
+                     CALL get_tensor_occupancy(t_3c_work_2(3), nze, occ)
+                     IF (nze == 0) CYCLE
+                     CALL dbt_copy(t_3c_work_2(3), t_3c_work_2(1), move_data=.TRUE.)
+                     CALL dbt_contract(-pref*fac, t_3c_work_2(1), t_3c_work_2(2), &
+                                       1.0_dp, ks_t_split(i_spin), map_1=[1], map_2=[2], &
+                                       contract_1=[2, 3], notcontract_1=[1], &
+                                       contract_2=[2, 3], notcontract_2=[1], &
+                                       filter_eps=ri_data%filter_eps, &
+                                       move_data=i_spin == nspins, flop=nflop)
+                     ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+                  END DO
+               END DO !i_batch
+               CALL timestop(handle2)
+               CALL dbt_batched_contract_finalize(t_2c_work(3))
+
+               t4 = m_walltime()
+               ri_data%kp_cost(iatom, jatom, b_img) = t4 - t3
+            END DO !iatom
+         END DO !jatom
+         CALL dbt_batched_contract_finalize(ks_t_split(1))
+         CALL dbt_batched_contract_finalize(ks_t_split(2))
+
+         DO i_spin = 1, nspins
+            CALL dbt_copy(ks_t_split(i_spin), t_2c_ao_tmp(1), move_data=.TRUE.)
+            CALL dbt_copy(t_2c_ao_tmp(1), ks_t_sub(i_spin, b_img), summation=.TRUE.)
+         END DO
+      END DO !b_img
+      CALL dbt_batched_contract_finalize(t_3c_work_3(1))
+      CALL dbt_batched_contract_finalize(t_3c_work_3(2))
+      CALL dbt_batched_contract_finalize(t_3c_work_2(1))
+      CALL dbt_batched_contract_finalize(t_3c_work_2(2))
+      CALL para_env%sync()
+      CALL para_env%sum(ri_data%dbcsr_nflop)
+      CALL para_env%sum(ri_data%kp_cost)
+      t2 = m_walltime()
+      ri_data%dbcsr_time = ri_data%dbcsr_time + t2 - t1
+
+      !transfer KS tensor from subgroup to main group
+      CALL gather_ks_matrix(ks_t, ks_t_sub, group_size, sparsity_pattern, para_env, ri_data)
+
+      !Keep the 3c integrals on the subgroups to avoid communication at next SCF step
+      DO i_img = 1, nimg
+         CALL dbt_copy(t_3c_int(i_img), ri_data%kp_t_3c_int(i_img), move_data=.TRUE.)
+      END DO
+      !If forces are to be calculated, then we keep t_3c_apc on the subgroups too
+      IF (calc_f) THEN
+         IF (.NOT. ALLOCATED(ri_data%kp_t_3c_apc)) THEN
+            ALLOCATE (ri_data%kp_t_3c_apc(nspins, nimg))
+            DO i_img = 1, nimg
+               DO i_spin = 1, nspins
+                  CALL dbt_create(t_3c_apc_sub(i_spin, i_img), ri_data%kp_t_3c_apc(i_spin, i_img))
+               END DO
+            END DO
+         END IF
+         DO i_img = 1, nimg
+            DO i_spin = 1, nspins
+               CALL dbt_copy(t_3c_apc_sub(i_spin, i_img), ri_data%kp_t_3c_apc(i_spin, i_img), move_data=.TRUE.)
+            END DO
+         END DO
+      END IF
+
+      !clean-up subgroup tensors
+      CALL dbt_destroy(t_2c_ao_tmp(1))
+      CALL dbt_destroy(ks_t_split(1))
+      CALL dbt_destroy(ks_t_split(2))
+      CALL dbt_destroy(t_2c_work(1))
+      CALL dbt_destroy(t_2c_work(2))
+      CALL dbt_destroy(t_2c_work(3))
+      CALL dbt_destroy(t_3c_work_2(1))
+      CALL dbt_destroy(t_3c_work_2(2))
+      CALL dbt_destroy(t_3c_work_2(3))
+      CALL dbt_destroy(t_3c_work_3(1))
+      CALL dbt_destroy(t_3c_work_3(2))
+      CALL dbt_destroy(t_3c_work_3(3))
+      DO i_img = 1, nimg
+         CALL dbt_destroy(t_3c_int(i_img))
+         CALL dbcsr_release(mat_2c_pot(i_img))
+         DO i_spin = 1, nspins
+            CALL dbt_destroy(t_3c_apc_sub(i_spin, i_img))
+            CALL dbt_destroy(ks_t_sub(i_spin, i_img))
+         END DO
+      END DO
+      DO iatom = 1, natom
+         CALL dbt_destroy(t_2c_inv(iatom))
+      END DO
+      DEALLOCATE (t_2c_ao_tmp)
+      IF (ASSOCIATED(dbcsr_template)) THEN
+         CALL dbcsr_release(dbcsr_template)
+         DEALLOCATE (dbcsr_template)
+      END IF
+
+      !End of subgroup parallelization
+      CALL cp_blacs_env_release(blacs_env_sub)
+      CALL para_env_sub%free()
+      DEALLOCATE (para_env_sub)
+
+      !symmetrize the KS matrices
+      ALLOCATE (t_2c_ao_tmp(nimg))
+      DO i_spin = 1, nspins
+         DO b_img = 1, nimg
+            CALL dbt_create(ks_t(1, 1), t_2c_ao_tmp(b_img))
+            CALL dbt_copy(ks_t(i_spin, b_img), t_2c_ao_tmp(b_img))
+         END DO
+         DO b_img = 1, nimg
+            mb_img = get_opp_index(b_img, qs_env)
+            IF (mb_img > 0 .AND. mb_img .LE. nimg) THEN
+               CALL dbt_copy(t_2c_ao_tmp(b_img), ks_t(i_spin, mb_img), order=[2, 1], summation=.TRUE.)
+            END IF
+            CALL dbt_destroy(t_2c_ao_tmp(b_img))
+         END DO
+      END DO
+
+      !calculate the energy
+      CALL dbt_create(ks_t(1, 1), t_2c_ao_tmp(1))
+      CALL dbcsr_create(tmp, template=ks_matrix(1, 1)%matrix, matrix_type=dbcsr_type_symmetric)
+      CALL dbcsr_create(ks_desymm, template=ks_matrix(1, 1)%matrix, matrix_type=dbcsr_type_no_symmetry)
+      CALL dbcsr_create(rho_desymm, template=ks_matrix(1, 1)%matrix, matrix_type=dbcsr_type_no_symmetry)
+      ehfx = 0.0_dp
+      DO i_img = 1, nimg
+         DO i_spin = 1, nspins
+            CALL dbt_filter(ks_t(i_spin, i_img), ri_data%filter_eps)
+            CALL dbt_copy(ks_t(i_spin, i_img), t_2c_ao_tmp(1))
+            CALL dbt_copy_tensor_to_matrix(t_2c_ao_tmp(1), ks_desymm)
+            CALL dbt_copy_tensor_to_matrix(t_2c_ao_tmp(1), tmp)
+            CALL dbcsr_add(ks_matrix(i_spin, i_img)%matrix, tmp, 1.0_dp, 1.0_dp)
+
+            CALL dbt_copy(rho_ao_t(i_spin, i_img), t_2c_ao_tmp(1))
+            CALL dbt_copy_tensor_to_matrix(t_2c_ao_tmp(1), rho_desymm)
+
+            CALL dbcsr_dot(ks_desymm, rho_desymm, etmp)
+            ehfx = ehfx + 0.5_dp*etmp
+         END DO
+      END DO
+      CALL dbcsr_release(rho_desymm)
+      CALL dbcsr_release(ks_desymm)
+      CALL dbcsr_release(tmp)
+
+      CALL dbt_destroy(t_2c_ao_tmp(1))
+      DO i_img = 1, nimg
+         DO i_spin = 1, nspins
+            CALL dbt_destroy(rho_ao_t(i_spin, i_img))
+            CALL dbt_destroy(ks_t(i_spin, i_img))
+         END DO
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE hfx_ri_update_ks_kp
+
+! **************************************************************************************************
+!> \brief Update the K-points RI-HFX forces
+!> \param qs_env ...
+!> \param ri_data ...
+!> \param nspins ...
+!> \param hf_fraction ...
+!> \param rho_ao ...
+!> \param use_virial ...
+!> \note Because this routine uses stored quantities calculated in the energy calculation, they should
+!>       always be called by pairs, and with the same input densities
+! **************************************************************************************************
+   SUBROUTINE hfx_ri_update_forces_kp(qs_env, ri_data, nspins, hf_fraction, rho_ao, use_virial)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      INTEGER, INTENT(IN)                                :: nspins
+      REAL(KIND=dp), INTENT(IN)                          :: hf_fraction
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_ao
+      LOGICAL, INTENT(IN), OPTIONAL                      :: use_virial
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'hfx_ri_update_forces_kp'
+
+      INTEGER :: b_img, batch_size, group_size, handle, handle2, i_batch, i_img, i_loop, i_spin, &
+         i_xyz, iatom, iblk, igroup, j_xyz, jatom, k_xyz, n_batch, natom, ngroups, nimg, nimg_nze
+      INTEGER(int_8)                                     :: nflop, nze
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, batch_ranges_at, &
+                                                            batch_ranges_nze, dist1, dist2, &
+                                                            i_images, idx_to_at_AO, idx_to_at_RI, &
+                                                            kind_of
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: iapc_pairs
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: force_pattern, sparsity_pattern
+      INTEGER, DIMENSION(2, 1)                           :: bounds_iat, bounds_jat
+      LOGICAL                                            :: use_virial_prv
+      REAL(dp)                                           :: fac, occ, pref, t1, t2
+      REAL(dp), DIMENSION(3, 3)                          :: work_virial
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env_sub
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: mat_2c_pot
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:, :)     :: mat_der_pot, mat_der_pot_sub
+      TYPE(dbcsr_type), POINTER                          :: dbcsr_template
+      TYPE(dbt_type)                                     :: t_2c_R, t_2c_R_split
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_2c_bint, t_2c_binv, t_2c_der_pot, &
+                                                            t_2c_inv, t_2c_work, t_3c_der_stack, &
+                                                            t_3c_work_2, t_3c_work_3
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :) :: rho_ao_t, rho_ao_t_sub, t_2c_der_metric, &
+         t_2c_der_metric_sub, t_3c_der_AO, t_3c_der_AO_sub, t_3c_der_RI, t_3c_der_RI_sub
+      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(section_vals_type), POINTER                   :: hfx_section
+      TYPE(virial_type), POINTER                         :: virial
+
+      NULLIFY (para_env, para_env_sub, hfx_section, blacs_env_sub, dbcsr_template, force, atomic_kind_set, &
+               virial, particle_set, cell)
+
+      CALL timeset(routineN, handle)
+
+      use_virial_prv = .FALSE.
+      IF (PRESENT(use_virial)) use_virial_prv = use_virial
+
+      IF (nspins == 1) THEN
+         fac = 0.5_dp*hf_fraction
+      ELSE
+         fac = 1.0_dp*hf_fraction
+      END IF
+
+      CALL get_qs_env(qs_env, natom=natom, para_env=para_env, force=force, cell=cell, virial=virial, &
+                      atomic_kind_set=atomic_kind_set, particle_set=particle_set)
+      CALL get_atomic_kind_set(atomic_kind_set, kind_of=kind_of, atom_of_kind=atom_of_kind)
+
+      ALLOCATE (idx_to_at_AO(SIZE(ri_data%bsizes_AO_split)))
+      CALL get_idx_to_atom(idx_to_at_AO, ri_data%bsizes_AO_split, ri_data%bsizes_AO)
+
+      ALLOCATE (idx_to_at_RI(SIZE(ri_data%bsizes_RI_split)))
+      CALL get_idx_to_atom(idx_to_at_RI, ri_data%bsizes_RI_split, ri_data%bsizes_RI)
+
+      nimg = ri_data%nimg
+      ALLOCATE (t_3c_der_RI(nimg, 3), t_3c_der_AO(nimg, 3), mat_der_pot(nimg, 3), t_2c_der_metric(natom, 3))
+
+      !We assume that the integrals are available from the SCF
+      !pre-calculate the derivs. 3c tensors as (P^0| sigma^a mu^0), with t_3c_der_AO holding deric wrt mu^0
+      CALL precalc_derivatives(t_3c_der_RI, t_3c_der_AO, mat_der_pot, t_2c_der_metric, ri_data, qs_env)
+
+      !Calculate the density matrix at each image
+      ALLOCATE (rho_ao_t(nspins, nimg))
+      CALL create_2c_tensor(rho_ao_t(1, 1), dist1, dist2, ri_data%pgrid_2d, &
+                            ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
+                            name="(AO | AO)")
+      DEALLOCATE (dist1, dist2)
+      IF (nspins == 2) CALL dbt_create(rho_ao_t(1, 1), rho_ao_t(2, 1))
+      DO i_img = 2, nimg
+         DO i_spin = 1, nspins
+            CALL dbt_create(rho_ao_t(1, 1), rho_ao_t(i_spin, i_img))
+         END DO
+      END DO
+      CALL get_pmat_images(rho_ao_t, rho_ao, ri_data, qs_env)
+
+      !Setup the subgroups
+      hfx_section => section_vals_get_subs_vals(qs_env%input, "DFT%XC%HF%RI")
+      CALL section_vals_val_get(hfx_section, "KP_NGROUPS", i_val=ngroups)
+      group_size = para_env%num_pe/ngroups
+      igroup = para_env%mepos/group_size
+
+      ALLOCATE (para_env_sub)
+      CALL para_env_sub%from_split(para_env, igroup)
+      CALL cp_blacs_env_create(blacs_env_sub, para_env_sub)
+
+      !Get the ususal sparsity pattern
+      ALLOCATE (sparsity_pattern(natom, natom, nimg))
+      CALL get_sparsity_pattern(sparsity_pattern, ri_data, qs_env)
+      CALL get_sub_dist(sparsity_pattern, ngroups, ri_data)
+
+      !Get the 2-center quantities in the subgroups (note: main group derivs are deleted wihtin)
+      ALLOCATE (t_2c_inv(natom), mat_2c_pot(nimg), rho_ao_t_sub(nspins, nimg), t_2c_work(5), &
+                t_2c_der_metric_sub(natom, 3), mat_der_pot_sub(nimg, 3), t_2c_bint(natom))
+      CALL get_subgroup_2c_derivs(t_2c_inv, t_2c_bint, mat_2c_pot, t_2c_work, rho_ao_t, rho_ao_t_sub, &
+                                  t_2c_der_metric, t_2c_der_metric_sub, mat_der_pot, mat_der_pot_sub, &
+                                  group_size, ngroups, para_env, para_env_sub, ri_data)
+      CALL dbt_create(t_2c_work(1), t_2c_R) !nRI x nRI
+      CALL dbt_create(t_2c_work(5), t_2c_R_split) !nRI x nRI with split blocks
+
+      ALLOCATE (t_2c_der_pot(3))
+      DO i_xyz = 1, 3
+         CALL dbt_create(t_2c_R, t_2c_der_pot(i_xyz))
+      END DO
+
+      !Get the 3-center quantities in the subgroups. The integrals and t_3c_apc already there
+      ALLOCATE (t_3c_work_2(3), t_3c_work_3(4), t_3c_der_stack(6), t_3c_der_AO_sub(nimg, 3), t_3c_der_RI_sub(nimg, 3))
+      CALL get_subgroup_3c_derivs(t_3c_work_2, t_3c_work_3, t_3c_der_AO, t_3c_der_AO_sub, &
+                                  t_3c_der_RI, t_3c_der_RI_sub, t_3c_der_stack, group_size, ngroups, &
+                                  para_env, para_env_sub, ri_data)
+
+      !Set up batched contraction (go atom by atom)
+      ALLOCATE (batch_ranges_at(natom + 1))
+      batch_ranges_at(natom + 1) = SIZE(ri_data%bsizes_AO_split) + 1
+      iatom = 0
+      DO iblk = 1, SIZE(ri_data%bsizes_AO_split)
+         IF (idx_to_at_AO(iblk) == iatom + 1) THEN
+            iatom = iatom + 1
+            batch_ranges_at(iatom) = iblk
+         END IF
+      END DO
+
+      CALL dbt_batched_contract_init(t_3c_work_3(1), batch_range_2=batch_ranges_at)
+      CALL dbt_batched_contract_init(t_3c_work_3(2), batch_range_2=batch_ranges_at)
+      CALL dbt_batched_contract_init(t_3c_work_3(3), batch_range_2=batch_ranges_at)
+      CALL dbt_batched_contract_init(t_3c_work_2(1), batch_range_1=batch_ranges_at)
+      CALL dbt_batched_contract_init(t_3c_work_2(2), batch_range_1=batch_ranges_at)
+
+      !Preparing for the stacking of 3c tensors
+      nimg_nze = ri_data%nimg_nze
+      batch_size = ri_data%kp_stack_size
+      n_batch = nimg_nze/batch_size
+      IF (MODULO(nimg_nze, batch_size) .NE. 0) n_batch = n_batch + 1
+      ALLOCATE (batch_ranges_nze(n_batch + 1))
+      DO i_batch = 1, n_batch
+         batch_ranges_nze(i_batch) = (i_batch - 1)*batch_size + 1
+      END DO
+      batch_ranges_nze(n_batch + 1) = nimg_nze + 1
+
+      !Applying the external bump to ((P|Q)_D + B*(P|Q)_OD*B)^-1 from left and right
+      !And keep the bump on LHS only version as well, with B*M^-1 = (M^-1*B)^T
+      ALLOCATE (t_2c_binv(natom))
+      DO iatom = 1, natom
+         CALL dbt_create(t_2c_inv(iatom), t_2c_binv(iatom))
+         CALL dbt_copy(t_2c_inv(iatom), t_2c_binv(iatom))
+         CALL apply_bump(t_2c_binv(iatom), iatom, ri_data, qs_env, from_left=.TRUE., from_right=.FALSE.)
+         CALL apply_bump(t_2c_inv(iatom), iatom, ri_data, qs_env, from_left=.TRUE., from_right=.TRUE.)
+      END DO
+
+      t1 = m_walltime()
+      work_virial = 0.0_dp
+      ALLOCATE (iapc_pairs(nimg, 2), i_images(nimg))
+      ALLOCATE (force_pattern(natom, natom, nimg))
+      force_pattern(:, :, :) = -1
+      !We proceed with 2 loops: one over the sparsity pattern from the SCF, one over the rest
+      !We use the SCF cost model for the first loop, while we calculate the cost of the upcoming loop
+      DO i_loop = 1, 2
+         DO b_img = 1, nimg
+            DO jatom = 1, natom
+               DO iatom = 1, natom
+
+                  pref = -0.5_dp*fac
+                  IF (i_loop == 1 .AND. (.NOT. sparsity_pattern(iatom, jatom, b_img) == igroup)) CYCLE
+                  IF (i_loop == 2 .AND. (.NOT. force_pattern(iatom, jatom, b_img) == igroup)) CYCLE
+
+                  !Get the proper HFX potential 2c integrals (P_i^0|Q_j^b), and multply by RI metric
+                  CALL timeset(routineN//"_2c_1", handle2)
+                  CALL get_ext_2c_int(t_2c_work(1), mat_2c_pot, iatom, jatom, b_img, ri_data, qs_env, &
+                                      blacs_env_ext=blacs_env_sub, para_env_ext=para_env_sub, &
+                                      dbcsr_template=dbcsr_template)
+                  CALL dbt_contract(1.0_dp, t_2c_work(1), t_2c_inv(jatom), &
+                                    0.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+                  CALL dbt_contract(1.0_dp, t_2c_inv(iatom), t_2c_work(2), &
+                                    0.0_dp, t_2c_work(1), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+                  CALL dbt_copy(t_2c_work(1), t_2c_work(5), move_data=.TRUE.) !move to split blocks
+                  CALL dbt_filter(t_2c_work(5), ri_data%filter_eps)
+                  CALL timestop(handle2)
+
+                  CALL timeset(routineN//"_3c", handle2)
+                  bounds_iat(:, 1) = [SUM(ri_data%bsizes_AO(1:iatom - 1)) + 1, SUM(ri_data%bsizes_AO(1:iatom))]
+                  bounds_jat(:, 1) = [SUM(ri_data%bsizes_AO(1:jatom - 1)) + 1, SUM(ri_data%bsizes_AO(1:jatom))]
+                  CALL dbt_clear(t_2c_R_split)
+                  CALL dbt_batched_contract_init(t_2c_work(5))
+                  CALL dbt_batched_contract_init(t_2c_R_split)
+                  DO i_spin = 1, nspins
+                     CALL dbt_batched_contract_init(rho_ao_t_sub(i_spin, b_img))
+                  END DO
+
+                  CALL get_iapc_pairs(iapc_pairs, b_img, ri_data, qs_env, i_images) !i = a+c-b
+                  DO i_batch = 1, n_batch
+
+                     !Stack the 3c derivatives to take the trace later on
+                     DO i_xyz = 1, 3
+                        CALL dbt_clear(t_3c_der_stack(i_xyz))
+                        CALL fill_3c_stack(t_3c_der_stack(i_xyz), t_3c_der_RI_sub(:, i_xyz), &
+                                           iapc_pairs(:, 1), 3, ri_data, filter_at=jatom, &
+                                           filter_dim=2, idx_to_at=idx_to_at_AO, &
+                                           img_bounds=[batch_ranges_nze(i_batch), batch_ranges_nze(i_batch + 1)])
+
+                        CALL dbt_clear(t_3c_der_stack(3 + i_xyz))
+                        CALL fill_3c_stack(t_3c_der_stack(3 + i_xyz), t_3c_der_AO_sub(:, i_xyz), &
+                                           iapc_pairs(:, 1), 3, ri_data, filter_at=jatom, &
+                                           filter_dim=2, idx_to_at=idx_to_at_AO, &
+                                           img_bounds=[batch_ranges_nze(i_batch), batch_ranges_nze(i_batch + 1)])
+                     END DO
+
+                     DO i_spin = 1, nspins
+                        !stack the t_3c_apc tensors
+                        CALL dbt_clear(t_3c_work_2(3))
+                        CALL fill_3c_stack(t_3c_work_2(3), ri_data%kp_t_3c_apc(i_spin, :), iapc_pairs(:, 2), 3, &
+                                           ri_data, filter_at=iatom, filter_dim=1, idx_to_at=idx_to_at_AO, &
+                                           img_bounds=[batch_ranges_nze(i_batch), batch_ranges_nze(i_batch + 1)])
+                        CALL get_tensor_occupancy(t_3c_work_2(3), nze, occ)
+                        IF (nze == 0) CYCLE
+                        CALL dbt_copy(t_3c_work_2(3), t_3c_work_2(1), move_data=.TRUE.)
+
+                        !Contract with the second density matrix: P_mu^0,nu^b * t_3c_apc,
+                        !where t_3c_apc = P_sigma^a,lambda^a+c (mu^0 P^0 sigma^a) (stacked along a+c)
+                        CALL dbt_contract(1.0_dp, rho_ao_t_sub(i_spin, b_img), t_3c_work_2(1), &
+                                          0.0_dp, t_3c_work_2(2), map_1=[1], map_2=[2, 3], &
+                                          contract_1=[1], notcontract_1=[2], &
+                                          contract_2=[1], notcontract_2=[2, 3], &
+                                          bounds_1=bounds_iat, bounds_2=bounds_jat, &
+                                          filter_eps=ri_data%filter_eps, flop=nflop)
+                        ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                        CALL get_tensor_occupancy(t_3c_work_2(2), nze, occ)
+                        IF (nze == 0) CYCLE
+
+                        !Contract with V_PQ so that we can take the trace with (Q^b|nu^b lmabda^a+c)^(x)
+                        CALL dbt_copy(t_3c_work_2(2), t_3c_work_3(1), order=[2, 1, 3], move_data=.TRUE.)
+                        CALL dbt_contract(1.0_dp, t_2c_work(5), t_3c_work_3(1), &
+                                          0.0_dp, t_3c_work_3(2), map_1=[1], map_2=[2, 3], &
+                                          contract_1=[1], notcontract_1=[2], &
+                                          contract_2=[1], notcontract_2=[2, 3], &
+                                          filter_eps=ri_data%filter_eps, flop=nflop)
+                        ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                        !Contract with the 3c derivatives to get the force/virial
+                        CALL dbt_copy(t_3c_work_3(2), t_3c_work_3(4), move_data=.TRUE.)
+                        IF (use_virial_prv) THEN
+                           CALL get_force_from_3c_trace(force, t_3c_work_3(4), t_3c_der_stack(1:3), &
+                                                        t_3c_der_stack(4:6), atom_of_kind, kind_of, &
+                                                        idx_to_at_RI, idx_to_at_AO, i_images, &
+                                                        batch_ranges_nze(i_batch), 2.0_dp*pref, &
+                                                        ri_data, qs_env, work_virial, cell, particle_set)
+                        ELSE
+                           CALL get_force_from_3c_trace(force, t_3c_work_3(4), t_3c_der_stack(1:3), &
+                                                        t_3c_der_stack(4:6), atom_of_kind, kind_of, &
+                                                        idx_to_at_RI, idx_to_at_AO, i_images, &
+                                                        batch_ranges_nze(i_batch), 2.0_dp*pref, &
+                                                        ri_data, qs_env)
+                        END IF
+                        CALL dbt_clear(t_3c_work_3(4))
+
+                        !Contract with the 3-center integrals in order to have a matrix R_PQ such that
+                        !we can take the trace sum_PQ R_PQ V_PQ^(x)
+                        IF (i_loop == 2) CYCLE
+
+                        !Stack the 3c integrals
+                        CALL fill_3c_stack(t_3c_work_3(4), ri_data%kp_t_3c_int, iapc_pairs(:, 1), 3, ri_data, &
+                                           filter_at=jatom, filter_dim=2, idx_to_at=idx_to_at_AO, &
+                                           img_bounds=[batch_ranges_nze(i_batch), batch_ranges_nze(i_batch + 1)])
+                        CALL dbt_copy(t_3c_work_3(4), t_3c_work_3(3), move_data=.TRUE.)
+
+                        CALL dbt_contract(1.0_dp, t_3c_work_3(1), t_3c_work_3(3), &
+                                          1.0_dp, t_2c_R_split, map_1=[1], map_2=[2], &
+                                          contract_1=[2, 3], notcontract_1=[1], &
+                                          contract_2=[2, 3], notcontract_2=[1], &
+                                          filter_eps=ri_data%filter_eps, flop=nflop)
+                        ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+                        CALL dbt_copy(t_3c_work_3(4), t_3c_work_3(1))
+                     END DO
+                  END DO
+                  CALL dbt_batched_contract_finalize(t_2c_work(5))
+                  CALL dbt_batched_contract_finalize(t_2c_R_split)
+                  DO i_spin = 1, nspins
+                     CALL dbt_batched_contract_finalize(rho_ao_t_sub(i_spin, b_img))
+                  END DO
+                  CALL timestop(handle2)
+
+                  IF (i_loop == 2) CYCLE
+                  pref = 2.0_dp*pref
+                  IF (iatom == jatom .AND. b_img == 1) pref = 0.5_dp*pref
+
+                  CALL timeset(routineN//"_2c_2", handle2)
+                  !Note that the derivatives are in atomic block format (not split)
+                  CALL dbt_copy(t_2c_R_split, t_2c_R, move_data=.TRUE.)
+                  CALL get_ext_2c_int(t_2c_work(1), mat_2c_pot, iatom, jatom, b_img, ri_data, qs_env, &
+                                      blacs_env_ext=blacs_env_sub, para_env_ext=para_env_sub, &
+                                      dbcsr_template=dbcsr_template)
+
+                  !We have to calculate: S^-1(iat) * R_PQ * S^-1(jat)    to trace with HFX pot der
+                  !                      + R_PQ * S^-1(jat) * pot^T      to trace with S^(x) (iat)
+                  !                      + pot^T * S^-1(iat) *R_PQ       to trace with S^(x) (jat)
+
+                  !S^-1(iat) * R_PQ * S^-1(jat)
+                  CALL dbt_contract(1.0_dp, t_2c_R, t_2c_inv(jatom), &
+                                    0.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL dbt_contract(1.0_dp, t_2c_inv(iatom), t_2c_work(2), &
+                                    0.0_dp, t_2c_work(3), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  !Trace with HFX pot deriv, that we need to build first
+                  DO i_xyz = 1, 3
+                     CALL get_ext_2c_int(t_2c_der_pot(i_xyz), mat_der_pot_sub(:, i_xyz), iatom, jatom, &
+                                         b_img, ri_data, qs_env, blacs_env_ext=blacs_env_sub, &
+                                         para_env_ext=para_env_sub, dbcsr_template=dbcsr_template)
+                  END DO
+
+                  IF (use_virial_prv) THEN
+                     CALL get_2c_der_force(force, t_2c_work(3), t_2c_der_pot, atom_of_kind, kind_of, &
+                                           b_img, pref, ri_data, qs_env, work_virial, cell, particle_set)
+                  ELSE
+                     CALL get_2c_der_force(force, t_2c_work(3), t_2c_der_pot, atom_of_kind, kind_of, &
+                                           b_img, pref, ri_data, qs_env)
+                  END IF
+
+                  DO i_xyz = 1, 3
+                     CALL dbt_clear(t_2c_der_pot(i_xyz))
+                  END DO
+
+                  !R_PQ * S^-1(jat) * pot^T  (=A)
+                  CALL dbt_contract(1.0_dp, t_2c_work(2), t_2c_work(1), &
+                                    0.0_dp, t_2c_work(3), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[2], notcontract_2=[1], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  !With the RI bump function, things get more complex. M = (S|P)_D + B*(S|P)_OD*B
+                  !Calculate M^-1*B*A + A*B*M^-1 to contract with B^x. A is in t_2c_work(3)
+                  CALL dbt_contract(1.0_dp, t_2c_work(3), t_2c_binv(iatom), &
+                                    0.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL dbt_contract(1.0_dp, t_2c_binv(iatom), t_2c_work(3), & !use transpose of B*M^-1 = M^-1*B
+                                    0.0_dp, t_2c_work(4), map_1=[1], map_2=[2], &
+                                    contract_1=[1], notcontract_1=[2], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL dbt_copy(t_2c_work(2), t_2c_work(4), summation=.TRUE.)
+                  CALL get_2c_bump_forces(force, t_2c_work(4), iatom, atom_of_kind, kind_of, pref, &
+                                          ri_data, qs_env, work_virial)
+
+                  !Calculate -M^-1*B*A*B*M^-1 to contracte with diagonal RI metric deriv. t_2c_work(2) holds A*B*M^-1
+                  CALL dbt_contract(1.0_dp, t_2c_binv(iatom), t_2c_work(2), &
+                                    0.0_dp, t_2c_work(4), map_1=[1], map_2=[2], &
+                                    contract_1=[1], notcontract_1=[2], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  IF (use_virial_prv) THEN
+                     CALL get_2c_der_force(force, t_2c_work(4), t_2c_der_metric_sub(iatom, :), atom_of_kind, &
+                                           kind_of, 1, -pref, ri_data, qs_env, work_virial, cell, particle_set, &
+                                           diag=.TRUE., offdiag=.FALSE.)
+                  ELSE
+                     CALL get_2c_der_force(force, t_2c_work(4), t_2c_der_metric_sub(iatom, :), atom_of_kind, &
+                                           kind_of, 1, -pref, ri_data, qs_env, diag=.TRUE., offdiag=.FALSE.)
+                  END IF
+
+                  !Calculate -B*M^-1*B*A*B*M^-1*B to contract with off-diagonal RI metric derivs
+                  CALL dbt_copy(t_2c_work(4), t_2c_work(2))
+                  CALL apply_bump(t_2c_work(2), iatom, ri_data, qs_env, from_left=.TRUE., from_right=.TRUE.)
+
+                  IF (use_virial_prv) THEN
+                     CALL get_2c_der_force(force, t_2c_work(2), t_2c_der_metric_sub(iatom, :), atom_of_kind, &
+                                           kind_of, 1, -pref, ri_data, qs_env, work_virial, cell, particle_set, &
+                                           diag=.FALSE., offdiag=.TRUE.)
+                  ELSE
+                     CALL get_2c_der_force(force, t_2c_work(2), t_2c_der_metric_sub(iatom, :), atom_of_kind, &
+                                           kind_of, 1, -pref, ri_data, qs_env, diag=.FALSE., offdiag=.TRUE.)
+                  END IF
+
+                  !Calculate -O*B*M^-1*B*A*B*M^-1 - M^-1*B*A*B*M^-1*B*O, where O is off-diagonal integrals
+                  !t_2c_work(4) holds M^-1*B*A*B*M^-1, and exploit transpose of B*O (stored in t_2c_bint)
+                  CALL dbt_contract(1.0_dp, t_2c_work(4), t_2c_bint(iatom), &
+                                    0.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL dbt_contract(1.0_dp, t_2c_bint(iatom), t_2c_work(4), &
+                                    1.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                    contract_1=[1], notcontract_1=[2], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL get_2c_bump_forces(force, t_2c_work(2), iatom, atom_of_kind, kind_of, -pref, &
+                                          ri_data, qs_env, work_virial)
+
+                  ! pot^T * S^-1(iat) * R_PQ (=A)
+                  CALL dbt_contract(1.0_dp, t_2c_work(1), t_2c_inv(iatom), &
+                                    0.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                    contract_1=[1], notcontract_1=[2], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL dbt_contract(1.0_dp, t_2c_work(2), t_2c_R, &
+                                    0.0_dp, t_2c_work(3), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  !Do the same shenanigans with the S^(x) (jatom)
+                  !Calculate M^-1*B*A + A*B*M^-1 to contract with B^x. A is in t_2c_work(3)
+                  CALL dbt_contract(1.0_dp, t_2c_work(3), t_2c_binv(jatom), &
+                                    0.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL dbt_contract(1.0_dp, t_2c_binv(jatom), t_2c_work(3), & !use transpose of B*M^-1 = M^-1*B
+                                    0.0_dp, t_2c_work(4), map_1=[1], map_2=[2], &
+                                    contract_1=[1], notcontract_1=[2], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL dbt_copy(t_2c_work(2), t_2c_work(4), summation=.TRUE.)
+                  CALL get_2c_bump_forces(force, t_2c_work(4), jatom, atom_of_kind, kind_of, pref, &
+                                          ri_data, qs_env, work_virial)
+
+                  !Calculate -M^-1*B*A*B*M^-1 to contracte with diagonal RI metric deriv. t_2c_work(2) holds A*B*M^-1
+                  CALL dbt_contract(1.0_dp, t_2c_binv(jatom), t_2c_work(2), &
+                                    0.0_dp, t_2c_work(4), map_1=[1], map_2=[2], &
+                                    contract_1=[1], notcontract_1=[2], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  IF (use_virial_prv) THEN
+                     CALL get_2c_der_force(force, t_2c_work(4), t_2c_der_metric_sub(jatom, :), atom_of_kind, &
+                                           kind_of, 1, -pref, ri_data, qs_env, work_virial, cell, particle_set, &
+                                           diag=.TRUE., offdiag=.FALSE.)
+                  ELSE
+                     CALL get_2c_der_force(force, t_2c_work(4), t_2c_der_metric_sub(jatom, :), atom_of_kind, &
+                                           kind_of, 1, -pref, ri_data, qs_env, diag=.TRUE., offdiag=.FALSE.)
+                  END IF
+
+                  !Calculate -B*M^-1*B*A*B*M^-1*B to contract with off-diagonal RI metric derivs
+                  CALL dbt_copy(t_2c_work(4), t_2c_work(2))
+                  CALL apply_bump(t_2c_work(2), jatom, ri_data, qs_env, from_left=.TRUE., from_right=.TRUE.)
+
+                  IF (use_virial_prv) THEN
+                     CALL get_2c_der_force(force, t_2c_work(2), t_2c_der_metric_sub(jatom, :), atom_of_kind, &
+                                           kind_of, 1, -pref, ri_data, qs_env, work_virial, cell, particle_set, &
+                                           diag=.FALSE., offdiag=.TRUE.)
+                  ELSE
+                     CALL get_2c_der_force(force, t_2c_work(2), t_2c_der_metric_sub(jatom, :), atom_of_kind, &
+                                           kind_of, 1, -pref, ri_data, qs_env, diag=.FALSE., offdiag=.TRUE.)
+                  END IF
+
+                  !Calculate -O*B*M^-1*B*A*B*M^-1 - M^-1*B*A*B*M^-1*B*O, where O is off-diagonal integrals
+                  !t_2c_work(4) holds M^-1*B*A*B*M^-1, and exploit transpose of B*O (stored in t_2c_bint)
+                  CALL dbt_contract(1.0_dp, t_2c_work(4), t_2c_bint(jatom), &
+                                    0.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                    contract_1=[2], notcontract_1=[1], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL dbt_contract(1.0_dp, t_2c_bint(jatom), t_2c_work(4), &
+                                    1.0_dp, t_2c_work(2), map_1=[1], map_2=[2], &
+                                    contract_1=[1], notcontract_1=[2], &
+                                    contract_2=[1], notcontract_2=[2], &
+                                    filter_eps=ri_data%filter_eps, flop=nflop)
+                  ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
+
+                  CALL get_2c_bump_forces(force, t_2c_work(2), jatom, atom_of_kind, kind_of, -pref, &
+                                          ri_data, qs_env, work_virial)
+
+                  CALL timestop(handle2)
+               END DO !iatom
+            END DO !jatom
+         END DO !b_img
+
+         IF (i_loop == 1) THEN
+            CALL update_pattern_to_forces(force_pattern, sparsity_pattern, ngroups, ri_data, qs_env)
+         END IF
+      END DO !i_loop
+
+      CALL dbt_batched_contract_finalize(t_3c_work_3(1))
+      CALL dbt_batched_contract_finalize(t_3c_work_3(2))
+      CALL dbt_batched_contract_finalize(t_3c_work_3(3))
+      CALL dbt_batched_contract_finalize(t_3c_work_2(1))
+      CALL dbt_batched_contract_finalize(t_3c_work_2(2))
+
+      IF (use_virial_prv) THEN
+         DO k_xyz = 1, 3
+            DO j_xyz = 1, 3
+               DO i_xyz = 1, 3
+                  virial%pv_fock_4c(i_xyz, j_xyz) = virial%pv_fock_4c(i_xyz, j_xyz) &
+                                                    + work_virial(i_xyz, k_xyz)*cell%hmat(j_xyz, k_xyz)
+               END DO
+            END DO
+         END DO
+      END IF
+
+      !End of subgroup parallelization
+      CALL cp_blacs_env_release(blacs_env_sub)
+      CALL para_env_sub%free()
+      DEALLOCATE (para_env_sub)
+
+      CALL para_env%sync()
+      t2 = m_walltime()
+      ri_data%dbcsr_time = ri_data%dbcsr_time + t2 - t1
+
+      !clean-up
+      IF (ASSOCIATED(dbcsr_template)) THEN
+         CALL dbcsr_release(dbcsr_template)
+         DEALLOCATE (dbcsr_template)
+      END IF
+      CALL dbt_destroy(t_2c_R)
+      CALL dbt_destroy(t_2c_R_split)
+      CALL dbt_destroy(t_2c_work(1))
+      CALL dbt_destroy(t_2c_work(2))
+      CALL dbt_destroy(t_2c_work(3))
+      CALL dbt_destroy(t_2c_work(4))
+      CALL dbt_destroy(t_2c_work(5))
+      CALL dbt_destroy(t_3c_work_2(1))
+      CALL dbt_destroy(t_3c_work_2(2))
+      CALL dbt_destroy(t_3c_work_2(3))
+      CALL dbt_destroy(t_3c_work_3(1))
+      CALL dbt_destroy(t_3c_work_3(2))
+      CALL dbt_destroy(t_3c_work_3(3))
+      CALL dbt_destroy(t_3c_work_3(4))
+      CALL dbt_destroy(t_3c_der_stack(1))
+      CALL dbt_destroy(t_3c_der_stack(2))
+      CALL dbt_destroy(t_3c_der_stack(3))
+      CALL dbt_destroy(t_3c_der_stack(4))
+      CALL dbt_destroy(t_3c_der_stack(5))
+      CALL dbt_destroy(t_3c_der_stack(6))
+      DO i_xyz = 1, 3
+         CALL dbt_destroy(t_2c_der_pot(i_xyz))
+      END DO
+      DO iatom = 1, natom
+         CALL dbt_destroy(t_2c_inv(iatom))
+         CALL dbt_destroy(t_2c_binv(iatom))
+         CALL dbt_destroy(t_2c_bint(iatom))
+         DO i_xyz = 1, 3
+            CALL dbt_destroy(t_2c_der_metric_sub(iatom, i_xyz))
+         END DO
+      END DO
+      DO i_img = 1, nimg
+         CALL dbcsr_release(mat_2c_pot(i_img))
+         DO i_spin = 1, nspins
+            CALL dbt_destroy(rho_ao_t_sub(i_spin, i_img))
+         END DO
+      END DO
+      DO i_xyz = 1, 3
+         DO i_img = 1, nimg
+            CALL dbt_destroy(t_3c_der_RI_sub(i_img, i_xyz))
+            CALL dbt_destroy(t_3c_der_AO_sub(i_img, i_xyz))
+            CALL dbcsr_release(mat_der_pot_sub(i_img, i_xyz))
+         END DO
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE hfx_ri_update_forces_kp
+
+! **************************************************************************************************
+!> \brief A routine the applies the RI bump matrix from the left and/or the right, given an input
+!>        matrix and the central RI atom. We assume atomic block sizes
+!> \param t_2c_inout ...
+!> \param atom_i ...
+!> \param ri_data ...
+!> \param qs_env ...
+!> \param from_left ...
+!> \param from_right ...
+! **************************************************************************************************
+   SUBROUTINE apply_bump(t_2c_inout, atom_i, ri_data, qs_env, from_left, from_right)
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_2c_inout
+      INTEGER, INTENT(IN)                                :: atom_i
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      LOGICAL, INTENT(IN), OPTIONAL                      :: from_left, from_right
+
+      INTEGER                                            :: i_img, i_RI, iatom, ind(2), j_img, j_RI, &
+                                                            jatom, natom, nblks(2), nimg, nkind
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: found, my_left, my_right
+      REAL(dp)                                           :: r0, r1, ri(3), rj(3), rref(3), scoord(3)
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: blk
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(dbt_iterator_type)                            :: iter
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      NULLIFY (qs_kind_set, particle_set, kpoints, index_to_cell, cell_to_index, cell)
+
+      CALL get_qs_env(qs_env, natom=natom, nkind=nkind, qs_kind_set=qs_kind_set, cell=cell, &
+                      kpoints=kpoints, particle_set=particle_set)
+      CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index, index_to_cell=index_to_cell)
+
+      my_left = .FALSE.
+      IF (PRESENT(from_left)) my_left = from_left
+
+      my_right = .FALSE.
+      IF (PRESENT(from_right)) my_right = from_right
+      CPASSERT(my_left .OR. my_right)
+
+      CALL dbt_get_info(t_2c_inout, nblks_total=nblks)
+      CPASSERT(nblks(1) == ri_data%ncell_RI*natom)
+      CPASSERT(nblks(2) == ri_data%ncell_RI*natom)
+
+      nimg = ri_data%nimg
+
+      !Loop over the RI cells and atoms, and apply bump accordingly
+      r1 = ri_data%kp_RI_range
+      r0 = ri_data%kp_bump_rad
+      rref = pbc(particle_set(atom_i)%r, cell)
+
+!$OMP PARALLEL DEFAULT(NONE) SHARED(t_2c_inout,natom,ri_data,cell,particle_set,index_to_cell,my_left, &
+!$OMP                               my_right,r0,r1,rref) &
+!$OMP PRIVATE(iter,ind,blk,found,i_RI,i_img,iatom,j_RI,j_img,jatom,scoord,ri,rj)
+      CALL dbt_iterator_start(iter, t_2c_inout)
+      DO WHILE (dbt_iterator_blocks_left(iter))
+         CALL dbt_iterator_next_block(iter, ind)
+         CALL dbt_get_block(t_2c_inout, ind, blk, found)
+         IF (.NOT. found) CYCLE
+
+         i_RI = (ind(1) - 1)/natom + 1
+         i_img = ri_data%RI_cell_to_img(i_RI)
+         iatom = ind(1) - (i_RI - 1)*natom
+
+         CALL real_to_scaled(scoord, pbc(particle_set(iatom)%r, cell), cell)
+         CALL scaled_to_real(ri, scoord(:) + index_to_cell(:, i_img), cell)
+
+         j_RI = (ind(2) - 1)/natom + 1
+         j_img = ri_data%RI_cell_to_img(j_RI)
+         jatom = ind(2) - (j_RI - 1)*natom
+
+         CALL real_to_scaled(scoord, pbc(particle_set(jatom)%r, cell), cell)
+         CALL scaled_to_real(rj, scoord(:) + index_to_cell(:, j_img), cell)
+
+         IF (my_left) blk(:, :) = blk(:, :)*bump(NORM2(ri - rref), r0, r1)
+         IF (my_right) blk(:, :) = blk(:, :)*bump(NORM2(rj - rref), r0, r1)
+
+         CALL dbt_put_block(t_2c_inout, ind, SHAPE(blk), blk)
+
+         DEALLOCATE (blk)
+      END DO
+      CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+      CALL dbt_filter(t_2c_inout, ri_data%filter_eps)
+
+   END SUBROUTINE apply_bump
+
+! **************************************************************************************************
+!> \brief A routine that calculates the forces due to the derivative of the bump function
+!> \param force ...
+!> \param t_2c_in ...
+!> \param atom_i ...
+!> \param atom_of_kind ...
+!> \param kind_of ...
+!> \param pref ...
+!> \param ri_data ...
+!> \param qs_env ...
+!> \param work_virial ...
+! **************************************************************************************************
+   SUBROUTINE get_2c_bump_forces(force, t_2c_in, atom_i, atom_of_kind, kind_of, pref, ri_data, &
+                                 qs_env, work_virial)
+      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_2c_in
+      INTEGER, INTENT(IN)                                :: atom_i
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: atom_of_kind, kind_of
+      REAL(dp), INTENT(IN)                               :: pref
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      REAL(dp), DIMENSION(3, 3), INTENT(INOUT)           :: work_virial
+
+      INTEGER :: i, i_img, i_RI, i_xyz, iat_of_kind, iatom, ikind, ind(2), j_img, j_RI, j_xyz, &
+         jat_of_kind, jatom, jkind, natom, nblks(2), nimg, nkind
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: found
+      REAL(dp)                                           :: new_force, r0, r1, ri(3), rj(3), &
+                                                            rref(3), scoord(3), x
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: blk
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(dbt_iterator_type)                            :: iter
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      NULLIFY (qs_kind_set, particle_set, kpoints, index_to_cell, cell_to_index, cell)
+
+      CALL get_qs_env(qs_env, natom=natom, nkind=nkind, qs_kind_set=qs_kind_set, cell=cell, &
+                      kpoints=kpoints, particle_set=particle_set)
+      CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index, index_to_cell=index_to_cell)
+
+      CALL dbt_get_info(t_2c_in, nblks_total=nblks)
+      CPASSERT(nblks(1) == ri_data%ncell_RI*natom)
+      CPASSERT(nblks(2) == ri_data%ncell_RI*natom)
+
+      nimg = ri_data%nimg
+
+      !Loop over the RI cells and atoms, and apply bump accordingly
+      r1 = ri_data%kp_RI_range
+      r0 = ri_data%kp_bump_rad
+      rref = pbc(particle_set(atom_i)%r, cell)
+
+      iat_of_kind = atom_of_kind(atom_i)
+      ikind = kind_of(atom_i)
+
+!$OMP PARALLEL DEFAULT(NONE) SHARED(t_2c_in,natom,ri_data,cell,particle_set,index_to_cell,pref, &
+!$OMP force,r0,r1,rref,atom_of_kind,kind_of,iat_of_kind,ikind,work_virial) &
+!$OMP PRIVATE(iter,ind,blk,found,i_RI,i_img,iatom,j_RI,j_img,jatom,scoord,ri,rj,jkind,jat_of_kind, &
+!$OMP         new_force,i_xyz,i,x,j_xyz)
+      CALL dbt_iterator_start(iter, t_2c_in)
+      DO WHILE (dbt_iterator_blocks_left(iter))
+         CALL dbt_iterator_next_block(iter, ind)
+         IF (ind(1) .NE. ind(2)) CYCLE !bump matrix is diagonal
+
+         CALL dbt_get_block(t_2c_in, ind, blk, found)
+         IF (.NOT. found) CYCLE
+
+         !bump is a function of x = SQRT((R - Rref)^2). We refer to R as jatom, and Rref as atom_i
+         j_RI = (ind(2) - 1)/natom + 1
+         j_img = ri_data%RI_cell_to_img(j_RI)
+         jatom = ind(2) - (j_RI - 1)*natom
+         jat_of_kind = atom_of_kind(jatom)
+         jkind = kind_of(jatom)
+
+         CALL real_to_scaled(scoord, pbc(particle_set(jatom)%r, cell), cell)
+         CALL scaled_to_real(rj, scoord(:) + index_to_cell(:, j_img), cell)
+         x = NORM2(rj - rref)
+         IF (x < r0 .OR. x > r1) CYCLE
+
+         new_force = 0.0_dp
+         DO i = 1, SIZE(blk, 1)
+            new_force = new_force + blk(i, i)
+         END DO
+         new_force = pref*new_force*dbump(x, r0, r1)
+
+         !x = SQRT((R - Rref)^2), so we multiply by dx/dR and dx/dRref
+         DO i_xyz = 1, 3
+            !Force acting on second atom
+!$OMP ATOMIC
+            force(jkind)%fock_4c(i_xyz, jat_of_kind) = force(jkind)%fock_4c(i_xyz, jat_of_kind) + &
+                                                       new_force*(rj(i_xyz) - rref(i_xyz))/x
+
+            !virial acting on second atom
+            CALL real_to_scaled(scoord, rj, cell)
+            DO j_xyz = 1, 3
+!$OMP ATOMIC
+               work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) &
+                                           + new_force*scoord(j_xyz)*(rj(i_xyz) - rref(i_xyz))/x
+            END DO
+
+            !Force acting on reference atom, defining the RI basis
+!$OMP ATOMIC
+            force(ikind)%fock_4c(i_xyz, iat_of_kind) = force(ikind)%fock_4c(i_xyz, iat_of_kind) - &
+                                                       new_force*(rj(i_xyz) - rref(i_xyz))/x
+
+            !virial of ref atom
+            CALL real_to_scaled(scoord, rref, cell)
+            DO j_xyz = 1, 3
+!$OMP ATOMIC
+               work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) &
+                                           - new_force*scoord(j_xyz)*(rj(i_xyz) - rref(i_xyz))/x
+            END DO
+         END DO !i_xyz
+
+         DEALLOCATE (blk)
+      END DO
+      CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+
+   END SUBROUTINE get_2c_bump_forces
+
+! **************************************************************************************************
+!> \brief The bumb function as defined by Juerg
+!> \param x ...
+!> \param r0 ...
+!> \param r1 ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION bump(x, r0, r1) RESULT(b)
+      REAL(dp), INTENT(IN)                               :: x, r0, r1
+      REAL(dp)                                           :: b
+
+      REAL(dp)                                           :: r
+
+      !Head-Gordon
+      !b = 1.0_dp/(1.0_dp+EXP((r1-r0)/(r1-x)-(r1-r0)/(x-r0)))
+      !Juerg
+      r = (x - r0)/(r1 - r0)
+      b = -6.0_dp*r**5 + 15.0_dp*r**4 - 10.0_dp*r**3 + 1.0_dp
+      IF (x .GE. r1) b = 0.0_dp
+      IF (x .LE. r0) b = 1.0_dp
+
+   END FUNCTION bump
+
+! **************************************************************************************************
+!> \brief The derivative of the bump function
+!> \param x ...
+!> \param r0 ...
+!> \param r1 ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION dbump(x, r0, r1) RESULT(b)
+      REAL(dp), INTENT(IN)                               :: x, r0, r1
+      REAL(dp)                                           :: b
+
+      REAL(dp)                                           :: r
+
+      r = (x - r0)/(r1 - r0)
+      b = (-30.0_dp*r**4 + 60.0_dp*r**3 - 30.0_dp*r**2)/(r1 - r0)
+      IF (x .GE. r1) b = 0.0_dp
+      IF (x .LE. r0) b = 0.0_dp
+
+   END FUNCTION dbump
+
+! **************************************************************************************************
+!> \brief return the cell index a+c corresponding to given cell index i and b, with i = a+c-b
+!> \param i_index ...
+!> \param b_index ...
+!> \param qs_env ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION get_apc_index_from_ib(i_index, b_index, qs_env) RESULT(apc_index)
+      INTEGER, INTENT(IN)                                :: i_index, b_index
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER                                            :: apc_index
+
+      INTEGER, DIMENSION(3)                              :: cell_apc
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      CALL get_qs_env(qs_env, kpoints=kpoints)
+      CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index, index_to_cell=index_to_cell)
+
+      !i = a+c-b => a+c = i+b
+      cell_apc(:) = index_to_cell(:, i_index) + index_to_cell(:, b_index)
+
+      IF (ANY([cell_apc(1), cell_apc(2), cell_apc(3)] < LBOUND(cell_to_index)) .OR. &
+          ANY([cell_apc(1), cell_apc(2), cell_apc(3)] > UBOUND(cell_to_index))) THEN
+
+         apc_index = 0
+      ELSE
+         apc_index = cell_to_index(cell_apc(1), cell_apc(2), cell_apc(3))
+      END IF
+
+   END FUNCTION get_apc_index_from_ib
+
+! **************************************************************************************************
+!> \brief return the cell index i corresponding to the summ of cell_a and cell_c
+!> \param a_index ...
+!> \param c_index ...
+!> \param qs_env ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION get_apc_index(a_index, c_index, qs_env) RESULT(i_index)
+      INTEGER, INTENT(IN)                                :: a_index, c_index
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER                                            :: i_index
+
+      INTEGER, DIMENSION(3)                              :: cell_i
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      CALL get_qs_env(qs_env, kpoints=kpoints)
+      CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index, index_to_cell=index_to_cell)
+
+      cell_i(:) = index_to_cell(:, a_index) + index_to_cell(:, c_index)
+
+      IF (ANY([cell_i(1), cell_i(2), cell_i(3)] < LBOUND(cell_to_index)) .OR. &
+          ANY([cell_i(1), cell_i(2), cell_i(3)] > UBOUND(cell_to_index))) THEN
+
+         i_index = 0
+      ELSE
+         i_index = cell_to_index(cell_i(1), cell_i(2), cell_i(3))
+      END IF
+
+   END FUNCTION get_apc_index
+
+! **************************************************************************************************
+!> \brief return the cell index i corresponding to the summ of cell_a + cell_c - cell_b
+!> \param apc_index ...
+!> \param b_index ...
+!> \param qs_env ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION get_i_index(apc_index, b_index, qs_env) RESULT(i_index)
+      INTEGER, INTENT(IN)                                :: apc_index, b_index
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER                                            :: i_index
+
+      INTEGER, DIMENSION(3)                              :: cell_i
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      CALL get_qs_env(qs_env, kpoints=kpoints)
+      CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index, index_to_cell=index_to_cell)
+
+      cell_i(:) = index_to_cell(:, apc_index) - index_to_cell(:, b_index)
+
+      IF (ANY([cell_i(1), cell_i(2), cell_i(3)] < LBOUND(cell_to_index)) .OR. &
+          ANY([cell_i(1), cell_i(2), cell_i(3)] > UBOUND(cell_to_index))) THEN
+
+         i_index = 0
+      ELSE
+         i_index = cell_to_index(cell_i(1), cell_i(2), cell_i(3))
+      END IF
+
+   END FUNCTION get_i_index
+
+! **************************************************************************************************
+!> \brief A routine that returns all allowed a,c pairs such that a+c images corresponds to the value
+!>        of the apc_index input. Takes into account that image a corresponds to 3c integrals, which
+!>        are ordered in their own way
+!> \param ac_pairs ...
+!> \param apc_index ...
+!> \param ri_data ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE get_ac_pairs(ac_pairs, apc_index, ri_data, qs_env)
+      INTEGER, DIMENSION(:, :), INTENT(INOUT)            :: ac_pairs
+      INTEGER, INTENT(IN)                                :: apc_index
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      INTEGER                                            :: a_index, actual_img, c_index, i_pair, &
+                                                            nimg
+
+      nimg = SIZE(ac_pairs, 1)
+
+      ac_pairs(:, :) = 0
+      i_pair = 0
+      DO a_index = 1, nimg
+         i_pair = i_pair + 1
+         actual_img = ri_data%idx_to_img(a_index)
+         DO c_index = 1, nimg
+            IF (get_apc_index(actual_img, c_index, qs_env) == apc_index) THEN
+               ac_pairs(i_pair, 1) = a_index
+               ac_pairs(i_pair, 2) = c_index
+            END IF
+         END DO
+      END DO
+
+   END SUBROUTINE get_ac_pairs
+
+! **************************************************************************************************
+!> \brief A routine that returns all allowed i,a+c pairs such that, for the given value of b, we have
+!>        i = a+c-b. Takes into account that image i corrsponds to the 3c ints, which are ordered in
+!>        their own way
+!> \param iapc_pairs ...
+!> \param b_index ...
+!> \param ri_data ...
+!> \param qs_env ...
+!> \param actual_i_img ...
+! **************************************************************************************************
+   SUBROUTINE get_iapc_pairs(iapc_pairs, b_index, ri_data, qs_env, actual_i_img)
+      INTEGER, DIMENSION(:, :), INTENT(INOUT)            :: iapc_pairs
+      INTEGER, INTENT(IN)                                :: b_index
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER, DIMENSION(:), INTENT(INOUT), OPTIONAL     :: actual_i_img
+
+      INTEGER                                            :: actual_img, apc_index, i_index, i_pair, &
+                                                            nimg
+
+      nimg = SIZE(iapc_pairs, 1)
+      IF (PRESENT(actual_i_img)) actual_i_img(:) = 0
+
+      iapc_pairs(:, :) = 0
+      i_pair = 0
+      DO i_index = 1, nimg
+         i_pair = i_pair + 1
+         actual_img = ri_data%idx_to_img(i_index)
+         apc_index = get_apc_index_from_ib(actual_img, b_index, qs_env)
+         IF (apc_index == 0) CYCLE
+         iapc_pairs(i_pair, 1) = i_index
+         iapc_pairs(i_pair, 2) = apc_index
+         IF (PRESENT(actual_i_img)) actual_i_img(i_pair) = actual_img
+      END DO
+
+   END SUBROUTINE get_iapc_pairs
+
+! **************************************************************************************************
+!> \brief A function that, given a cell index a, returun the index corresponding to -a, and zero if
+!>        if out of bounds
+!> \param a_index ...
+!> \param qs_env ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION get_opp_index(a_index, qs_env) RESULT(opp_index)
+      INTEGER, INTENT(IN)                                :: a_index
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER                                            :: opp_index
+
+      INTEGER, DIMENSION(3)                              :: opp_cell
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      NULLIFY (kpoints, cell_to_index, index_to_cell)
+
+      CALL get_qs_env(qs_env, kpoints=kpoints)
+      CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index, index_to_cell=index_to_cell)
+
+      opp_cell(:) = -index_to_cell(:, a_index)
+
+      IF (ANY([opp_cell(1), opp_cell(2), opp_cell(3)] < LBOUND(cell_to_index)) .OR. &
+          ANY([opp_cell(1), opp_cell(2), opp_cell(3)] > UBOUND(cell_to_index))) THEN
+
+         opp_index = 0
+      ELSE
+         opp_index = cell_to_index(opp_cell(1), opp_cell(2), opp_cell(3))
+      END IF
+
+   END FUNCTION get_opp_index
+
+! **************************************************************************************************
+!> \brief A routine that returns the actual non-symemtric density matrix for each image, by Fourier
+!>        transforming the kpoint density matrix
+!> \param rho_ao_t ...
+!> \param rho_ao ...
+!> \param ri_data ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE get_pmat_images(rho_ao_t, rho_ao, ri_data, qs_env)
+      TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: rho_ao_t
+      TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(INOUT) :: rho_ao
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      INTEGER                                            :: cell_j(3), i_img, i_spin, iatom, icol, &
+                                                            irow, j_img, jatom, mi_img, mj_img, &
+                                                            nimg, nspins
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: found
+      REAL(dp)                                           :: fac
+      REAL(dp), DIMENSION(:, :), POINTER                 :: pblock, pblock_desymm
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks, rho_desymm
+      TYPE(dbt_type)                                     :: tmp
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_nl, sab_nl_nosym
+      TYPE(qs_scf_env_type), POINTER                     :: scf_env
+
+      NULLIFY (rho_desymm, kpoints, sab_nl_nosym, scf_env, matrix_ks, dft_control, &
+               sab_nl, nl_iterator, cell_to_index, pblock, pblock_desymm)
+
+      CALL get_qs_env(qs_env, kpoints=kpoints, scf_env=scf_env, matrix_ks_kp=matrix_ks, dft_control=dft_control)
+      CALL get_kpoint_info(kpoints, sab_nl_nosym=sab_nl_nosym, cell_to_index=cell_to_index, sab_nl=sab_nl)
+
+      IF (dft_control%do_admm) THEN
+         CALL get_admm_env(qs_env%admm_env, matrix_ks_aux_fit_kp=matrix_ks)
+      END IF
+
+      nspins = SIZE(matrix_ks, 1)
+      nimg = ri_data%nimg
+
+      ALLOCATE (rho_desymm(nspins, nimg))
+      DO i_img = 1, nimg
+         DO i_spin = 1, nspins
+            ALLOCATE (rho_desymm(i_spin, i_img)%matrix)
+            CALL dbcsr_create(rho_desymm(i_spin, i_img)%matrix, template=matrix_ks(i_spin, i_img)%matrix, &
+                              matrix_type=dbcsr_type_no_symmetry)
+            CALL cp_dbcsr_alloc_block_from_nbl(rho_desymm(i_spin, i_img)%matrix, sab_nl_nosym)
+         END DO
+      END DO
+      CALL dbt_create(rho_desymm(1, 1)%matrix, tmp)
+
+      !We transfor the symmtric typed (but not actually symmetric: P_ab^i = P_ba^-i) real-spaced density
+      !matrix into proper non-symemtric ones (using the same nl for consistency)
+      CALL neighbor_list_iterator_create(nl_iterator, sab_nl)
+      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+         CALL get_iterator_info(nl_iterator, iatom=iatom, jatom=jatom, cell=cell_j)
+         j_img = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
+         IF (j_img > nimg .OR. j_img < 1) CYCLE
+
+         fac = 1.0_dp
+         IF (iatom == jatom) fac = 0.5_dp
+         mj_img = get_opp_index(j_img, qs_env)
+         !if no opposite image, then no sum of P^j + P^-j => need full diag
+         IF (mj_img == 0) fac = 1.0_dp
+
+         irow = iatom
+         icol = jatom
+         IF (iatom > jatom) THEN
+            !because symmetric nl. Value for atom pair i,j is actually stored in j,i if i > j
+            irow = jatom
+            icol = iatom
+         END IF
+
+         DO i_spin = 1, nspins
+            CALL dbcsr_get_block_p(rho_ao(i_spin, j_img)%matrix, irow, icol, pblock, found)
+            IF (.NOT. found) CYCLE
+
+            !distribution of symm and non-symm matrix match in that way
+            CALL dbcsr_get_block_p(rho_desymm(i_spin, j_img)%matrix, iatom, jatom, pblock_desymm, found)
+            IF (.NOT. found) CYCLE
+
+            IF (iatom > jatom) THEN
+               pblock_desymm(:, :) = fac*TRANSPOSE(pblock(:, :))
+            ELSE
+               pblock_desymm(:, :) = fac*pblock(:, :)
+            END IF
+         END DO
+      END DO
+      CALL neighbor_list_iterator_release(nl_iterator)
+
+      DO i_img = 1, nimg
+         DO i_spin = 1, nspins
+            CALL dbt_copy_matrix_to_tensor(rho_desymm(i_spin, i_img)%matrix, tmp)
+            CALL dbt_copy(tmp, rho_ao_t(i_spin, i_img), summation=.TRUE., move_data=.TRUE.)
+
+            !symmetrize by addin transpose of opp img
+            mi_img = get_opp_index(i_img, qs_env)
+            IF (mi_img > 0 .AND. mi_img .LE. nimg) THEN
+               CALL dbt_copy_matrix_to_tensor(rho_desymm(i_spin, mi_img)%matrix, tmp)
+               CALL dbt_copy(tmp, rho_ao_t(i_spin, i_img), order=[2, 1], summation=.TRUE., move_data=.TRUE.)
+            END IF
+            CALL dbt_filter(rho_ao_t(i_spin, i_img), ri_data%filter_eps)
+         END DO
+      END DO
+
+      DO i_img = 1, nimg
+         DO i_spin = 1, nspins
+            CALL dbcsr_release(rho_desymm(i_spin, i_img)%matrix)
+            DEALLOCATE (rho_desymm(i_spin, i_img)%matrix)
+         END DO
+      END DO
+
+      CALL dbt_destroy(tmp)
+      DEALLOCATE (rho_desymm)
+
+   END SUBROUTINE get_pmat_images
+
+! **************************************************************************************************
+!> \brief A routine that, given a cell index b and atom indices ij, returns a 2c tensor with the HFX
+!>        potential (P_i^0|Q_j^b), within the extended RI basis
+!> \param t_2c_pot ...
+!> \param mat_orig ...
+!> \param atom_i ...
+!> \param atom_j ...
+!> \param img_b ...
+!> \param ri_data ...
+!> \param qs_env ...
+!> \param do_inverse ...
+!> \param para_env_ext ...
+!> \param blacs_env_ext ...
+!> \param dbcsr_template ...
+!> \param off_diagonal ...
+! **************************************************************************************************
+   SUBROUTINE get_ext_2c_int(t_2c_pot, mat_orig, atom_i, atom_j, img_b, ri_data, qs_env, do_inverse, &
+                             para_env_ext, blacs_env_ext, dbcsr_template, off_diagonal)
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_2c_pot
+      TYPE(dbcsr_type), DIMENSION(:), INTENT(INOUT)      :: mat_orig
+      INTEGER, INTENT(IN)                                :: atom_i, atom_j, img_b
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_inverse
+      TYPE(mp_para_env_type), OPTIONAL, POINTER          :: para_env_ext
+      TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env_ext
+      TYPE(dbcsr_type), OPTIONAL, POINTER                :: dbcsr_template
+      LOGICAL, INTENT(IN), OPTIONAL                      :: off_diagonal
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'get_ext_2c_int'
+
+      INTEGER :: blk, group, handle, handle2, i_img, i_RI, iatom, iblk, ikind, img_tot, j_img, &
+         j_RI, jatom, jblk, jkind, n_dependent, natom, nblks_RI, nimg, nkind
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: present_atoms_i, present_atoms_j
+      INTEGER, DIMENSION(3)                              :: cell_b, cell_i, cell_j, cell_tot
+      INTEGER, DIMENSION(:), POINTER                     :: col_dist, col_dist_ext, ri_blk_size_ext, &
+                                                            row_dist, row_dist_ext
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell, pgrid
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: do_inverse_prv, found, my_offd, &
+                                                            use_template
+      REAL(dp)                                           :: bfac, dij, r0, r1, threshold
+      REAL(dp), DIMENSION(3)                             :: ri, rij, rj, rref, scoord
+      REAL(dp), DIMENSION(:, :), POINTER                 :: pblock
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(dbcsr_distribution_type)                      :: dbcsr_dist, dbcsr_dist_ext
+      TYPE(dbcsr_iterator_type)                          :: dbcsr_iter
+      TYPE(dbcsr_type)                                   :: work, work_tight, work_tight_inv
+      TYPE(dbt_type)                                     :: t_2c_tmp
+      TYPE(distribution_2d_type), POINTER                :: dist_2d
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:), TARGET                            :: basis_set_RI
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: nl_2c
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      NULLIFY (qs_kind_set, nl_2c, nl_iterator, cell, kpoints, cell_to_index, index_to_cell, dist_2d, &
+               para_env, pblock, blacs_env, particle_set, col_dist, row_dist, pgrid, &
+               col_dist_ext, row_dist_ext)
+
+      CALL timeset(routineN, handle)
+
+      !Idea: run over the neighbor list once for i and once for j, and record in which cell the MIC
+      !      atoms are. Then loop over the atoms and only take the pairs the we need
+
+      CALL get_qs_env(qs_env, natom=natom, nkind=nkind, qs_kind_set=qs_kind_set, cell=cell, &
+                      kpoints=kpoints, para_env=para_env, blacs_env=blacs_env, particle_set=particle_set)
+      CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index, index_to_cell=index_to_cell)
+
+      do_inverse_prv = .FALSE.
+      IF (PRESENT(do_inverse)) do_inverse_prv = do_inverse
+      IF (do_inverse_prv) THEN
+         CPASSERT(atom_i == atom_j)
+      END IF
+
+      my_offd = .FALSE.
+      IF (PRESENT(off_diagonal)) my_offd = off_diagonal
+
+      IF (PRESENT(para_env_ext)) para_env => para_env_ext
+      IF (PRESENT(blacs_env_ext)) blacs_env => blacs_env_ext
+
+      nimg = SIZE(mat_orig)
+
+      CALL timeset(routineN//"_nl_iter", handle2)
+
+      !create our own dist_2d in the subgroup
+      ALLOCATE (dist1(natom), dist2(natom))
+      DO iatom = 1, natom
+         dist1(iatom) = MOD(iatom, blacs_env%num_pe(1))
+         dist2(iatom) = MOD(iatom, blacs_env%num_pe(2))
+      END DO
+      CALL distribution_2d_create(dist_2d, dist1, dist2, nkind, particle_set, blacs_env_ext=blacs_env)
+
+      ALLOCATE (basis_set_RI(nkind))
+      CALL basis_set_list_setup(basis_set_RI, ri_data%ri_basis_type, qs_kind_set)
+
+      CALL build_2c_neighbor_lists(nl_2c, basis_set_RI, basis_set_RI, ri_data%ri_metric, &
+                                   "HFX_2c_nl_RI", qs_env, sym_ij=.FALSE., dist_2d=dist_2d)
+
+      ALLOCATE (present_atoms_i(natom, nimg), present_atoms_j(natom, nimg))
+      present_atoms_i = 0
+      present_atoms_j = 0
+
+      CALL neighbor_list_iterator_create(nl_iterator, nl_2c)
+      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+         CALL get_iterator_info(nl_iterator, iatom=iatom, jatom=jatom, r=rij, cell=cell_j, &
+                                ikind=ikind, jkind=jkind)
+
+         dij = NORM2(rij)
+
+         j_img = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
+         IF (j_img > nimg .OR. j_img < 1) CYCLE
+
+         IF (iatom == atom_i .AND. dij .LE. ri_data%kp_RI_range) present_atoms_i(jatom, j_img) = 1
+         IF (iatom == atom_j .AND. dij .LE. ri_data%kp_RI_range) present_atoms_j(jatom, j_img) = 1
+      END DO
+      CALL neighbor_list_iterator_release(nl_iterator)
+      CALL release_neighbor_list_sets(nl_2c)
+      CALL distribution_2d_release(dist_2d)
+      CALL timestop(handle2)
+
+      CALL para_env%sum(present_atoms_i)
+      CALL para_env%sum(present_atoms_j)
+
+      !Need to build a work matrix with matching distribution to mat_orig
+      !If template is provided, use it. If not, we create it.
+      use_template = .FALSE.
+      IF (PRESENT(dbcsr_template)) THEN
+         IF (ASSOCIATED(dbcsr_template)) use_template = .TRUE.
+      END IF
+
+      IF (use_template) THEN
+         CALL dbcsr_create(work, template=dbcsr_template)
+      ELSE
+         CALL dbcsr_get_info(mat_orig(1), distribution=dbcsr_dist)
+         CALL dbcsr_distribution_get(dbcsr_dist, row_dist=row_dist, col_dist=col_dist, group=group, pgrid=pgrid)
+         ALLOCATE (row_dist_ext(ri_data%ncell_RI*natom), col_dist_ext(ri_data%ncell_RI*natom))
+         ALLOCATE (ri_blk_size_ext(ri_data%ncell_RI*natom))
+         DO i_RI = 1, ri_data%ncell_RI
+            row_dist_ext((i_RI - 1)*natom + 1:i_RI*natom) = row_dist(:)
+            col_dist_ext((i_RI - 1)*natom + 1:i_RI*natom) = col_dist(:)
+            RI_blk_size_ext((i_RI - 1)*natom + 1:i_RI*natom) = ri_data%bsizes_RI(:)
+         END DO
+
+         CALL dbcsr_distribution_new(dbcsr_dist_ext, group=group, pgrid=pgrid, &
+                                     row_dist=row_dist_ext, col_dist=col_dist_ext)
+         CALL dbcsr_create(work, dist=dbcsr_dist_ext, name="RI_ext", matrix_type=dbcsr_type_no_symmetry, &
+                           row_blk_size=RI_blk_size_ext, col_blk_size=RI_blk_size_ext)
+         CALL dbcsr_distribution_release(dbcsr_dist_ext)
+         DEALLOCATE (col_dist_ext, row_dist_ext, RI_blk_size_ext)
+
+         IF (PRESENT(dbcsr_template)) THEN
+            ALLOCATE (dbcsr_template)
+            CALL dbcsr_create(dbcsr_template, template=work)
+         END IF
+      END IF !use_template
+
+      cell_b(:) = index_to_cell(:, img_b)
+      DO i_img = 1, nimg
+         i_RI = ri_data%img_to_RI_cell(i_img)
+         IF (i_RI == 0) CYCLE
+         cell_i(:) = index_to_cell(:, i_img)
+         DO j_img = 1, nimg
+            j_RI = ri_data%img_to_RI_cell(j_img)
+            IF (j_RI == 0) CYCLE
+            cell_j(:) = index_to_cell(:, j_img)
+            cell_tot = cell_j - cell_i + cell_b
+
+            IF (ANY([cell_tot(1), cell_tot(2), cell_tot(3)] < LBOUND(cell_to_index)) .OR. &
+                ANY([cell_tot(1), cell_tot(2), cell_tot(3)] > UBOUND(cell_to_index))) CYCLE
+            img_tot = cell_to_index(cell_tot(1), cell_tot(2), cell_tot(3))
+            IF (img_tot > nimg .OR. img_tot < 1) CYCLE
+
+            CALL dbcsr_iterator_start(dbcsr_iter, mat_orig(img_tot))
+            DO WHILE (dbcsr_iterator_blocks_left(dbcsr_iter))
+               CALL dbcsr_iterator_next_block(dbcsr_iter, row=iatom, column=jatom, blk=blk)
+               IF (present_atoms_i(iatom, i_img) == 0) CYCLE
+               IF (present_atoms_j(jatom, j_img) == 0) CYCLE
+               IF (my_offd .AND. (i_RI - 1)*natom + iatom == (j_RI - 1)*natom + jatom) CYCLE
+
+               CALL dbcsr_get_block_p(mat_orig(img_tot), iatom, jatom, pblock, found)
+               IF (.NOT. found) CYCLE
+
+               CALL dbcsr_put_block(work, (i_RI - 1)*natom + iatom, (j_RI - 1)*natom + jatom, pblock)
+
+            END DO
+            CALL dbcsr_iterator_stop(dbcsr_iter)
+
+         END DO !j_img
+      END DO !i_img
+      CALL dbcsr_finalize(work)
+
+      IF (do_inverse_prv) THEN
+
+         r1 = ri_data%kp_RI_range
+         r0 = ri_data%kp_bump_rad
+
+         !Because there are a lot of empty rows/cols in work, we need to get rid of them for inversion
+         nblks_RI = SUM(present_atoms_i)
+         ALLOCATE (col_dist_ext(nblks_RI), row_dist_ext(nblks_RI), RI_blk_size_ext(nblks_RI))
+         iblk = 0
+         DO i_img = 1, nimg
+            i_RI = ri_data%img_to_RI_cell(i_img)
+            IF (i_RI == 0) CYCLE
+            DO iatom = 1, natom
+               IF (present_atoms_i(iatom, i_img) == 0) CYCLE
+               iblk = iblk + 1
+               col_dist_ext(iblk) = col_dist(iatom)
+               row_dist_ext(iblk) = row_dist(iatom)
+               RI_blk_size_ext(iblk) = ri_data%bsizes_RI(iatom)
+            END DO
+         END DO
+
+         CALL dbcsr_distribution_new(dbcsr_dist_ext, group=group, pgrid=pgrid, &
+                                     row_dist=row_dist_ext, col_dist=col_dist_ext)
+         CALL dbcsr_create(work_tight, dist=dbcsr_dist_ext, name="RI_ext", matrix_type=dbcsr_type_no_symmetry, &
+                           row_blk_size=RI_blk_size_ext, col_blk_size=RI_blk_size_ext)
+         CALL dbcsr_create(work_tight_inv, dist=dbcsr_dist_ext, name="RI_ext", matrix_type=dbcsr_type_no_symmetry, &
+                           row_blk_size=RI_blk_size_ext, col_blk_size=RI_blk_size_ext)
+         CALL dbcsr_distribution_release(dbcsr_dist_ext)
+         DEALLOCATE (col_dist_ext, row_dist_ext, RI_blk_size_ext)
+
+         !We apply a bump function to the RI metric inverse for smooth RI basis extension:
+         ! S^-1 = B * ((P|Q)_D + B*(P|Q)_OD*B)^-1 * B, with D block-diagonal blocks and OD off-diagonal
+         rref = pbc(particle_set(atom_i)%r, cell)
+
+         iblk = 0
+         DO i_img = 1, nimg
+            i_RI = ri_data%img_to_RI_cell(i_img)
+            IF (i_RI == 0) CYCLE
+            DO iatom = 1, natom
+               IF (present_atoms_i(iatom, i_img) == 0) CYCLE
+               iblk = iblk + 1
+
+               CALL real_to_scaled(scoord, pbc(particle_set(iatom)%r, cell), cell)
+               CALL scaled_to_real(ri, scoord(:) + index_to_cell(:, i_img), cell)
+
+               jblk = 0
+               DO j_img = 1, nimg
+                  j_RI = ri_data%img_to_RI_cell(j_img)
+                  IF (j_RI == 0) CYCLE
+                  DO jatom = 1, natom
+                     IF (present_atoms_j(jatom, j_img) == 0) CYCLE
+                     jblk = jblk + 1
+
+                     CALL real_to_scaled(scoord, pbc(particle_set(jatom)%r, cell), cell)
+                     CALL scaled_to_real(rj, scoord(:) + index_to_cell(:, j_img), cell)
+
+                     CALL dbcsr_get_block_p(work, (i_RI - 1)*natom + iatom, (j_RI - 1)*natom + jatom, pblock, found)
+                     IF (.NOT. found) CYCLE
+
+                     bfac = 1.0_dp
+                     IF (iblk .NE. jblk) bfac = bump(NORM2(ri - rref), r0, r1)*bump(NORM2(rj - rref), r0, r1)
+                     CALL dbcsr_put_block(work_tight, iblk, jblk, bfac*pblock(:, :))
+                  END DO
+               END DO
+            END DO
+         END DO
+         CALL dbcsr_finalize(work_tight)
+         CALL dbcsr_clear(work)
+
+         SELECT CASE (ri_data%t2c_method)
+         CASE (hfx_ri_do_2c_iter)
+            threshold = MAX(ri_data%filter_eps, 1.0e-12_dp)
+            CALL invert_hotelling(work_tight_inv, work_tight, threshold=threshold, silent=.FALSE.)
+         CASE (hfx_ri_do_2c_cholesky)
+            CALL dbcsr_copy(work_tight_inv, work_tight)
+            CALL cp_dbcsr_cholesky_decompose(work_tight_inv, para_env=para_env, blacs_env=blacs_env)
+            CALL cp_dbcsr_cholesky_invert(work_tight_inv, para_env=para_env, blacs_env=blacs_env, &
+                                          upper_to_full=.TRUE.)
+         CASE (hfx_ri_do_2c_diag)
+            CALL dbcsr_copy(work_tight_inv, work_tight)
+            CALL cp_dbcsr_power(work_tight_inv, -1.0_dp, ri_data%eps_eigval, n_dependent, &
+                                para_env, blacs_env, verbose=ri_data%unit_nr_dbcsr > 0)
+         END SELECT
+
+         !move back data to standard extended RI pattern
+         !Note: we apply the external bump to ((P|Q)_D + B*(P|Q)_OD*B)^-1 later, because this matrix
+         !      is required for forces
+         iblk = 0
+         DO i_img = 1, nimg
+            i_RI = ri_data%img_to_RI_cell(i_img)
+            IF (i_RI == 0) CYCLE
+            DO iatom = 1, natom
+               IF (present_atoms_i(iatom, i_img) == 0) CYCLE
+               iblk = iblk + 1
+
+               jblk = 0
+               DO j_img = 1, nimg
+                  j_RI = ri_data%img_to_RI_cell(j_img)
+                  IF (j_RI == 0) CYCLE
+                  DO jatom = 1, natom
+                     IF (present_atoms_j(jatom, j_img) == 0) CYCLE
+                     jblk = jblk + 1
+
+                     CALL dbcsr_get_block_p(work_tight_inv, iblk, jblk, pblock, found)
+                     IF (.NOT. found) CYCLE
+
+                     CALL dbcsr_put_block(work, (i_RI - 1)*natom + iatom, (j_RI - 1)*natom + jatom, pblock)
+                  END DO
+               END DO
+            END DO
+         END DO
+         CALL dbcsr_finalize(work)
+
+         CALL dbcsr_release(work_tight)
+         CALL dbcsr_release(work_tight_inv)
+      END IF
+
+      CALL dbt_create(work, t_2c_tmp)
+      CALL dbt_copy_matrix_to_tensor(work, t_2c_tmp)
+      CALL dbt_copy(t_2c_tmp, t_2c_pot, move_data=.TRUE.)
+      CALL dbt_filter(t_2c_pot, ri_data%filter_eps)
+
+      CALL dbt_destroy(t_2c_tmp)
+      CALL dbcsr_release(work)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE get_ext_2c_int
+
+! **************************************************************************************************
+!> \brief Copy the data of a 2D tensor living in the main MPI group to a sub-group, given the proc
+!>        mapping from one to the other (e.g. for a proc idx in the subgroup, we get the idx in the main)
+!> \param t2c_sub ...
+!> \param t2c_main ...
+!> \param group_size ...
+!> \param ngroups ...
+!> \param para_env ...
+! **************************************************************************************************
+   SUBROUTINE copy_2c_to_subgroup(t2c_sub, t2c_main, group_size, ngroups, para_env)
+      TYPE(dbt_type), INTENT(INOUT)                      :: t2c_sub, t2c_main
+      INTEGER, INTENT(IN)                                :: group_size, ngroups
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+
+      INTEGER                                            :: batch_size, i, i_batch, i_msg, iblk, &
+                                                            igroup, iproc, ir, is, jblk, n_batch, &
+                                                            nocc, tag
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes1, bsizes2
+      INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: block_dest, block_source
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: current_dest
+      INTEGER, DIMENSION(2)                              :: ind, nblks
+      LOGICAL                                            :: found
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: blk
+      TYPE(cp_2d_r_p_type), ALLOCATABLE, DIMENSION(:)    :: recv_buff, send_buff
+      TYPE(dbt_iterator_type)                            :: iter
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_req, send_req
+
+      !Stategy: we loop over the main tensor, and send all the data. Then we loop over the sub tensor
+      !         and receive it. We do all of it with async MPI communication. The sub tensor needs
+      !         to have blocks pre-reserved though
+
+      CALL dbt_get_info(t2c_main, nblks_total=nblks)
+
+      !Loop over the main tensor, count how many blocks are there, which ones, and on which proc
+      ALLOCATE (block_source(nblks(1), nblks(2)))
+      block_source = -1
+      nocc = 0
+!$OMP PARALLEL DEFAULT(NONE) SHARED(t2c_main,para_env,nocc,block_source) PRIVATE(iter,ind,blk,found)
+      CALL dbt_iterator_start(iter, t2c_main)
+      DO WHILE (dbt_iterator_blocks_left(iter))
+         CALL dbt_iterator_next_block(iter, ind)
+         CALL dbt_get_block(t2c_main, ind, blk, found)
+         IF (.NOT. found) CYCLE
+
+         block_source(ind(1), ind(2)) = para_env%mepos
+!$OMP ATOMIC
+         nocc = nocc + 1
+         DEALLOCATE (blk)
+      END DO
+      CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+
+      CALL para_env%sum(nocc)
+      CALL para_env%sum(block_source)
+      block_source = block_source + para_env%num_pe - 1
+
+      !Loop over the sub tensor, get the block destination
+      igroup = para_env%mepos/group_size
+      ALLOCATE (block_dest(nblks(1), nblks(2)))
+      block_dest = -1
+      DO jblk = 1, nblks(2)
+         DO iblk = 1, nblks(1)
+            IF (block_source(iblk, jblk) == -1) CYCLE
+
+            CALL dbt_get_stored_coordinates(t2c_sub, [iblk, jblk], iproc)
+            block_dest(iblk, jblk) = igroup*group_size + iproc !mapping of iproc in subgroup to main group idx
+         END DO
+      END DO
+
+      ALLOCATE (bsizes1(nblks(1)), bsizes2(nblks(2)))
+      CALL dbt_get_info(t2c_main, blk_size_1=bsizes1, blk_size_2=bsizes2)
+
+      ALLOCATE (current_dest(nblks(1), nblks(2), 0:ngroups - 1))
+      DO igroup = 0, ngroups - 1
+         !for a given subgroup, need to make the destination available to everyone in the main group
+         current_dest(:, :, igroup) = block_dest(:, :)
+         CALL para_env%bcast(current_dest(:, :, igroup), source=igroup*group_size) !bcast from first proc in sub-group
+      END DO
+
+      !Typically, the maximum value for a MPI tag is ~32000, so we go by batches to be sure
+      batch_size = 32000
+      n_batch = (nocc*ngroups)/batch_size
+      IF (MODULO(nocc*ngroups, batch_size) .NE. 0) n_batch = n_batch + 1
+
+      DO i_batch = 1, n_batch
+         !Loop over groups, blocks and send/receive
+         ALLOCATE (send_buff(batch_size), recv_buff(batch_size))
+         ALLOCATE (send_req(batch_size), recv_req(batch_size))
+         ir = 0
+         is = 0
+         i_msg = 0
+         DO jblk = 1, nblks(2)
+            DO iblk = 1, nblks(1)
+               DO igroup = 0, ngroups - 1
+                  IF (block_source(iblk, jblk) == -1) CYCLE
+
+                  i_msg = i_msg + 1
+                  IF (i_msg < (i_batch - 1)*batch_size + 1 .OR. i_msg > i_batch*batch_size) CYCLE
+
+                  !a unique tag per block, within this batch
+                  tag = i_msg - (i_batch - 1)*batch_size
+
+                  found = .FALSE.
+                  IF (para_env%mepos == block_source(iblk, jblk)) THEN
+                     CALL dbt_get_block(t2c_main, [iblk, jblk], blk, found)
+                  END IF
+
+                  !If blocks live on same proc, simply copy. Else MPI send/recv
+                  IF (block_source(iblk, jblk) == current_dest(iblk, jblk, igroup)) THEN
+                     IF (found) CALL dbt_put_block(t2c_sub, [iblk, jblk], SHAPE(blk), blk)
+                  ELSE
+                     IF (para_env%mepos == block_source(iblk, jblk) .AND. found) THEN
+                        ALLOCATE (send_buff(tag)%array(bsizes1(iblk), bsizes2(jblk)))
+                        send_buff(tag)%array(:, :) = blk(:, :)
+                        is = is + 1
+                        CALL para_env%isend(msgin=send_buff(tag)%array, dest=current_dest(iblk, jblk, igroup), &
+                                            request=send_req(is), tag=tag)
+                     END IF
+
+                     IF (para_env%mepos == current_dest(iblk, jblk, igroup)) THEN
+                        ALLOCATE (recv_buff(tag)%array(bsizes1(iblk), bsizes2(jblk)))
+                        ir = ir + 1
+                        CALL para_env%irecv(msgout=recv_buff(tag)%array, source=block_source(iblk, jblk), &
+                                            request=recv_req(ir), tag=tag)
+                     END IF
+                  END IF
+
+                  IF (found) DEALLOCATE (blk)
+               END DO
+            END DO
+         END DO
+
+         CALL mp_waitall(send_req(1:is))
+         CALL mp_waitall(recv_req(1:ir))
+         !clean-up
+         DO i = 1, batch_size
+            IF (ASSOCIATED(send_buff(i)%array)) DEALLOCATE (send_buff(i)%array)
+         END DO
+
+         !Finally copy the data from the buffer to the sub-tensor
+         i_msg = 0
+         DO jblk = 1, nblks(2)
+            DO iblk = 1, nblks(1)
+               DO igroup = 0, ngroups - 1
+                  IF (block_source(iblk, jblk) == -1) CYCLE
+
+                  i_msg = i_msg + 1
+                  IF (i_msg < (i_batch - 1)*batch_size + 1 .OR. i_msg > i_batch*batch_size) CYCLE
+
+                  !a unique tag per block, within this batch
+                  tag = i_msg - (i_batch - 1)*batch_size
+
+                  IF (para_env%mepos == current_dest(iblk, jblk, igroup) .AND. &
+                      block_source(iblk, jblk) .NE. current_dest(iblk, jblk, igroup)) THEN
+
+                     ALLOCATE (blk(bsizes1(iblk), bsizes2(jblk)))
+                     blk(:, :) = recv_buff(tag)%array(:, :)
+                     CALL dbt_put_block(t2c_sub, [iblk, jblk], SHAPE(blk), blk)
+                     DEALLOCATE (blk)
+                  END IF
+               END DO
+            END DO
+         END DO
+
+         !clean-up
+         DO i = 1, batch_size
+            IF (ASSOCIATED(recv_buff(i)%array)) DEALLOCATE (recv_buff(i)%array)
+         END DO
+         DEALLOCATE (send_buff, recv_buff, send_req, recv_req)
+      END DO !i_batch
+      CALL dbt_finalize(t2c_sub)
+
+   END SUBROUTINE copy_2c_to_subgroup
+
+! **************************************************************************************************
+!> \brief Copy the data of a 3D tensor living in the main MPI group to a sub-group, given the proc
+!>        mapping from one to the other (e.g. for a proc idx in the subgroup, we get the idx in the main)
+!> \param t3c_sub ...
+!> \param t3c_main ...
+!> \param group_size ...
+!> \param ngroups ...
+!> \param para_env ...
+!> \param iatom_to_subgroup ...
+!> \param dim_at ...
+!> \param idx_to_at ...
+! **************************************************************************************************
+   SUBROUTINE copy_3c_to_subgroup(t3c_sub, t3c_main, group_size, ngroups, para_env, iatom_to_subgroup, &
+                                  dim_at, idx_to_at)
+      TYPE(dbt_type), INTENT(INOUT)                      :: t3c_sub, t3c_main
+      INTEGER, INTENT(IN)                                :: group_size, ngroups
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(cp_1d_logical_p_type), DIMENSION(:), &
+         INTENT(INOUT), OPTIONAL                         :: iatom_to_subgroup
+      INTEGER, INTENT(IN), OPTIONAL                      :: dim_at
+      INTEGER, DIMENSION(:), OPTIONAL                    :: idx_to_at
+
+      INTEGER                                            :: batch_size, i, i_batch, i_msg, iatom, &
+                                                            iblk, igroup, iproc, ir, is, jblk, &
+                                                            kblk, n_batch, nocc, tag
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes1, bsizes2, bsizes3
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: block_dest, block_source
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :, :)        :: current_dest
+      INTEGER, DIMENSION(3)                              :: ind, nblks
+      LOGICAL                                            :: filter_at, found
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: blk
+      TYPE(cp_3d_r_p_type), ALLOCATABLE, DIMENSION(:)    :: recv_buff, send_buff
+      TYPE(dbt_iterator_type)                            :: iter
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_req, send_req
+
+      !Stategy: we loop over the main tensor, and send all the data. Then we loop over the sub tensor
+      !         and receive it. We do all of it with async MPI communication. The sub tensor needs
+      !         to have blocks pre-reserved though
+
+      CALL dbt_get_info(t3c_main, nblks_total=nblks)
+
+      !in some cases, only copy a fraction of the 3c tensor to a given subgroup (corresponding to some atoms)
+      filter_at = .FALSE.
+      IF (PRESENT(iatom_to_subgroup) .AND. PRESENT(dim_at) .AND. PRESENT(idx_to_at)) THEN
+         filter_at = .TRUE.
+         CPASSERT(nblks(dim_at) == SIZE(idx_to_at))
+      END IF
+
+      !Loop over the main tensor, count how many blocks are there, which ones, and on which proc
+      ALLOCATE (block_source(nblks(1), nblks(2), nblks(3)))
+      block_source = -1
+      nocc = 0
+!$OMP PARALLEL DEFAULT(NONE) SHARED(t3c_main,para_env,nocc,block_source) PRIVATE(iter,ind,blk,found)
+      CALL dbt_iterator_start(iter, t3c_main)
+      DO WHILE (dbt_iterator_blocks_left(iter))
+         CALL dbt_iterator_next_block(iter, ind)
+         CALL dbt_get_block(t3c_main, ind, blk, found)
+         IF (.NOT. found) CYCLE
+
+         block_source(ind(1), ind(2), ind(3)) = para_env%mepos
+!$OMP ATOMIC
+         nocc = nocc + 1
+         DEALLOCATE (blk)
+      END DO
+      CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+
+      CALL para_env%sum(nocc)
+      CALL para_env%sum(block_source)
+      block_source = block_source + para_env%num_pe - 1
+
+      !Loop over the sub tensor, get the block destination
+      igroup = para_env%mepos/group_size
+      ALLOCATE (block_dest(nblks(1), nblks(2), nblks(3)))
+      block_dest = -1
+      DO kblk = 1, nblks(3)
+         DO jblk = 1, nblks(2)
+            DO iblk = 1, nblks(1)
+               IF (block_source(iblk, jblk, kblk) == -1) CYCLE
+
+               CALL dbt_get_stored_coordinates(t3c_sub, [iblk, jblk, kblk], iproc)
+               block_dest(iblk, jblk, kblk) = igroup*group_size + iproc !mapping of iproc in subgroup to main group idx
+            END DO
+         END DO
+      END DO
+
+      ALLOCATE (bsizes1(nblks(1)), bsizes2(nblks(2)), bsizes3(nblks(3)))
+      CALL dbt_get_info(t3c_main, blk_size_1=bsizes1, blk_size_2=bsizes2, blk_size_3=bsizes3)
+
+      ALLOCATE (current_dest(nblks(1), nblks(2), nblks(3), 0:ngroups - 1))
+      DO igroup = 0, ngroups - 1
+         !for a given subgroup, need to make the destination available to everyone in the main group
+         current_dest(:, :, :, igroup) = block_dest(:, :, :)
+         CALL para_env%bcast(current_dest(:, :, :, igroup), source=igroup*group_size) !bcast from first proc in subgroup
+      END DO
+
+      !Typically, the maximum value for a MPI tag is ~32000, so we go by batches to be sure
+      batch_size = 32000
+      n_batch = (nocc*ngroups)/batch_size
+      IF (MODULO(nocc*ngroups, batch_size) .NE. 0) n_batch = n_batch + 1
+
+      DO i_batch = 1, n_batch
+         !Loop over groups, blocks and send/receive
+         ALLOCATE (send_buff(batch_size), recv_buff(batch_size))
+         ALLOCATE (send_req(batch_size), recv_req(batch_size))
+         ir = 0
+         is = 0
+         i_msg = 0
+         DO kblk = 1, nblks(3)
+            DO jblk = 1, nblks(2)
+               DO iblk = 1, nblks(1)
+                  DO igroup = 0, ngroups - 1
+                     IF (block_source(iblk, jblk, kblk) == -1) CYCLE
+
+                     i_msg = i_msg + 1
+                     IF (i_msg < (i_batch - 1)*batch_size + 1 .OR. i_msg > i_batch*batch_size) CYCLE
+
+                     !a unique tag per block, within this batch
+                     tag = i_msg - (i_batch - 1)*batch_size
+
+                     IF (filter_at) THEN
+                        ind(:) = [iblk, jblk, kblk]
+                        iatom = idx_to_at(ind(dim_at))
+                        IF (.NOT. iatom_to_subgroup(iatom)%array(igroup + 1)) CYCLE
+                     END IF
+
+                     found = .FALSE.
+                     IF (para_env%mepos == block_source(iblk, jblk, kblk)) THEN
+                        CALL dbt_get_block(t3c_main, [iblk, jblk, kblk], blk, found)
+                     END IF
+
+                     !If blocks live on same proc, simply copy. Else MPI send/recv
+                     IF (block_source(iblk, jblk, kblk) == current_dest(iblk, jblk, kblk, igroup)) THEN
+                        IF (found) CALL dbt_put_block(t3c_sub, [iblk, jblk, kblk], SHAPE(blk), blk)
+                     ELSE
+                        IF (para_env%mepos == block_source(iblk, jblk, kblk) .AND. found) THEN
+                           ALLOCATE (send_buff(tag)%array(bsizes1(iblk), bsizes2(jblk), bsizes3(kblk)))
+                           send_buff(tag)%array(:, :, :) = blk(:, :, :)
+                           is = is + 1
+                           CALL para_env%isend(msgin=send_buff(tag)%array, &
+                                               dest=current_dest(iblk, jblk, kblk, igroup), &
+                                               request=send_req(is), tag=tag)
+                        END IF
+
+                        IF (para_env%mepos == current_dest(iblk, jblk, kblk, igroup)) THEN
+                           ALLOCATE (recv_buff(tag)%array(bsizes1(iblk), bsizes2(jblk), bsizes3(kblk)))
+                           ir = ir + 1
+                           CALL para_env%irecv(msgout=recv_buff(tag)%array, source=block_source(iblk, jblk, kblk), &
+                                               request=recv_req(ir), tag=tag)
+                        END IF
+                     END IF
+
+                     IF (found) DEALLOCATE (blk)
+                  END DO
+               END DO
+            END DO
+         END DO
+
+         CALL mp_waitall(send_req(1:is))
+         CALL mp_waitall(recv_req(1:ir))
+         !clean-up
+         DO i = 1, batch_size
+            IF (ASSOCIATED(send_buff(i)%array)) DEALLOCATE (send_buff(i)%array)
+         END DO
+
+         !Finally copy the data from the buffer to the sub-tensor
+         i_msg = 0
+         DO kblk = 1, nblks(3)
+            DO jblk = 1, nblks(2)
+               DO iblk = 1, nblks(1)
+                  DO igroup = 0, ngroups - 1
+                     IF (block_source(iblk, jblk, kblk) == -1) CYCLE
+
+                     i_msg = i_msg + 1
+                     IF (i_msg < (i_batch - 1)*batch_size + 1 .OR. i_msg > i_batch*batch_size) CYCLE
+
+                     !a unique tag per block, within this batch
+                     tag = i_msg - (i_batch - 1)*batch_size
+
+                     IF (filter_at) THEN
+                        ind(:) = [iblk, jblk, kblk]
+                        iatom = idx_to_at(ind(dim_at))
+                        IF (.NOT. iatom_to_subgroup(iatom)%array(igroup + 1)) CYCLE
+                     END IF
+
+                     IF (para_env%mepos == current_dest(iblk, jblk, kblk, igroup) .AND. &
+                         block_source(iblk, jblk, kblk) .NE. current_dest(iblk, jblk, kblk, igroup)) THEN
+
+                        ALLOCATE (blk(bsizes1(iblk), bsizes2(jblk), bsizes3(kblk)))
+                        blk(:, :, :) = recv_buff(tag)%array(:, :, :)
+                        CALL dbt_put_block(t3c_sub, [iblk, jblk, kblk], SHAPE(blk), blk)
+                        DEALLOCATE (blk)
+                     END IF
+                  END DO
+               END DO
+            END DO
+         END DO
+
+         !clean-up
+         DO i = 1, batch_size
+            IF (ASSOCIATED(recv_buff(i)%array)) DEALLOCATE (recv_buff(i)%array)
+         END DO
+         DEALLOCATE (send_buff, recv_buff, send_req, recv_req)
+      END DO !i_batch
+      CALL dbt_finalize(t3c_sub)
+
+   END SUBROUTINE copy_3c_to_subgroup
+
+! **************************************************************************************************
+!> \brief A routine that gather the pieces of the KS matrix accross the subgroup and puts it in the
+!>        main group. Each b_img, iatom, jatom tuple is one a single CPU
+!> \param ks_t ...
+!> \param ks_t_sub ...
+!> \param group_size ...
+!> \param sparsity_pattern ...
+!> \param para_env ...
+!> \param ri_data ...
+! **************************************************************************************************
+   SUBROUTINE gather_ks_matrix(ks_t, ks_t_sub, group_size, sparsity_pattern, para_env, ri_data)
+      TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: ks_t, ks_t_sub
+      INTEGER, INTENT(IN)                                :: group_size
+      INTEGER, DIMENSION(:, :, :), INTENT(IN)            :: sparsity_pattern
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'gather_ks_matrix'
+
+      INTEGER                                            :: b_img, dest, handle, i, i_spin, iatom, &
+                                                            igroup, ir, is, jatom, n_mess, natom, &
+                                                            nimg, nspins, source, tag
+      LOGICAL                                            :: found
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: blk
+      TYPE(cp_2d_r_p_type), ALLOCATABLE, DIMENSION(:)    :: recv_buff, send_buff
+      TYPE(mp_request_type), ALLOCATABLE, DIMENSION(:)   :: recv_req, send_req
+
+      CALL timeset(routineN, handle)
+
+      nimg = SIZE(sparsity_pattern, 3)
+      natom = SIZE(sparsity_pattern, 2)
+      nspins = SIZE(ks_t, 1)
+
+      DO b_img = 1, nimg
+         n_mess = 0
+         DO i_spin = 1, nspins
+            DO jatom = 1, natom
+               DO iatom = 1, natom
+                  IF (sparsity_pattern(iatom, jatom, b_img) > -1) n_mess = n_mess + 1
+               END DO
+            END DO
+         END DO
+
+         ALLOCATE (send_buff(n_mess), recv_buff(n_mess))
+         ALLOCATE (send_req(n_mess), recv_req(n_mess))
+         ir = 0
+         is = 0
+         n_mess = 0
+         tag = 0
+
+         DO i_spin = 1, nspins
+            DO jatom = 1, natom
+               DO iatom = 1, natom
+                  IF (sparsity_pattern(iatom, jatom, b_img) < 0) CYCLE
+                  n_mess = n_mess + 1
+                  tag = tag + 1
+
+                  !sending the message
+                  CALL dbt_get_stored_coordinates(ks_t(i_spin, b_img), [iatom, jatom], dest)
+                  CALL dbt_get_stored_coordinates(ks_t_sub(i_spin, b_img), [iatom, jatom], source) !source within sub
+                  igroup = sparsity_pattern(iatom, jatom, b_img)
+                  source = source + igroup*group_size
+                  IF (para_env%mepos == source) THEN
+                     CALL dbt_get_block(ks_t_sub(i_spin, b_img), [iatom, jatom], blk, found)
+                     IF (source == dest) THEN
+                        IF (found) CALL dbt_put_block(ks_t(i_spin, b_img), [iatom, jatom], SHAPE(blk), blk)
+                     ELSE
+                        ALLOCATE (send_buff(n_mess)%array(ri_data%bsizes_AO(iatom), ri_data%bsizes_AO(jatom)))
+                        send_buff(n_mess)%array(:, :) = 0.0_dp
+                        IF (found) THEN
+                           send_buff(n_mess)%array(:, :) = blk(:, :)
+                        END IF
+                        is = is + 1
+                        CALL para_env%isend(msgin=send_buff(n_mess)%array, dest=dest, &
+                                            request=send_req(is), tag=tag)
+                     END IF
+                     DEALLOCATE (blk)
+                  END IF
+
+                  !receiving the message
+                  IF (para_env%mepos == dest .AND. source .NE. dest) THEN
+                     ALLOCATE (recv_buff(n_mess)%array(ri_data%bsizes_AO(iatom), ri_data%bsizes_AO(jatom)))
+                     ir = ir + 1
+                     CALL para_env%irecv(msgout=recv_buff(n_mess)%array, source=source, &
+                                         request=recv_req(ir), tag=tag)
+                  END IF
+               END DO !iatom
+            END DO !jatom
+         END DO !ispin
+
+         CALL mp_waitall(send_req(1:is))
+         CALL mp_waitall(recv_req(1:ir))
+
+         !Copy the messages received into the KS matrix
+         n_mess = 0
+         DO i_spin = 1, nspins
+            DO jatom = 1, natom
+               DO iatom = 1, natom
+                  IF (sparsity_pattern(iatom, jatom, b_img) < 0) CYCLE
+                  n_mess = n_mess + 1
+
+                  CALL dbt_get_stored_coordinates(ks_t(i_spin, b_img), [iatom, jatom], dest)
+                  IF (para_env%mepos == dest) THEN
+                     IF (.NOT. ASSOCIATED(recv_buff(n_mess)%array)) CYCLE
+                     ALLOCATE (blk(ri_data%bsizes_AO(iatom), ri_data%bsizes_AO(jatom)))
+                     blk(:, :) = recv_buff(n_mess)%array(:, :)
+                     CALL dbt_put_block(ks_t(i_spin, b_img), [iatom, jatom], SHAPE(blk), blk)
+                     DEALLOCATE (blk)
+                  END IF
+               END DO
+            END DO
+         END DO
+
+         !clean-up
+         DO i = 1, n_mess
+            IF (ASSOCIATED(send_buff(i)%array)) DEALLOCATE (send_buff(i)%array)
+            IF (ASSOCIATED(recv_buff(i)%array)) DEALLOCATE (recv_buff(i)%array)
+         END DO
+         DEALLOCATE (send_buff, recv_buff, send_req, recv_req)
+      END DO !b_img
+
+      CALL timestop(handle)
+
+   END SUBROUTINE gather_ks_matrix
+
+! **************************************************************************************************
+!> \brief copy all required 2c tensors from the main MPI group to the subgroups
+!> \param t_2c_inv ...
+!> \param mat_2c_pot ...
+!> \param t_2c_work ...
+!> \param t_2c_ao_tmp ...
+!> \param ks_t_split ...
+!> \param ks_t_sub ...
+!> \param group_size ...
+!> \param ngroups ...
+!> \param para_env ...
+!> \param para_env_sub ...
+!> \param ri_data ...
+! **************************************************************************************************
+   SUBROUTINE get_subgroup_2c_tensors(t_2c_inv, mat_2c_pot, t_2c_work, t_2c_ao_tmp, ks_t_split, ks_t_sub, &
+                                      group_size, ngroups, para_env, para_env_sub, ri_data)
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_2c_inv
+      TYPE(dbcsr_type), DIMENSION(:), INTENT(INOUT)      :: mat_2c_pot
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_2c_work, t_2c_ao_tmp, ks_t_split
+      TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: ks_t_sub
+      INTEGER, INTENT(IN)                                :: group_size, ngroups
+      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'get_subgroup_2c_tensors'
+
+      INTEGER                                            :: handle, i, i_img, i_RI, i_spin, iatom, &
+                                                            iproc, j, natom, nblks, nimg, nspins
+      INTEGER(int_8)                                     :: nze
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes_RI_ext, bsizes_RI_ext_split, &
+                                                            dist1, dist2
+      INTEGER, DIMENSION(2)                              :: pdims_2d
+      INTEGER, DIMENSION(:), POINTER                     :: col_dist, RI_blk_size, row_dist
+      INTEGER, DIMENSION(:, :), POINTER                  :: dbcsr_pgrid
+      REAL(dp)                                           :: occ
+      TYPE(dbcsr_distribution_type)                      :: dbcsr_dist_sub
+      TYPE(dbt_pgrid_type)                               :: pgrid_2d
+      TYPE(dbt_type)                                     :: work, work_sub
+
+      CALL timeset(routineN, handle)
+
+      !Create the 2d pgrid
+      pdims_2d = 0
+      CALL dbt_pgrid_create(para_env_sub, pdims_2d, pgrid_2d)
+
+      natom = SIZE(ri_data%bsizes_RI)
+      nblks = SIZE(ri_data%bsizes_RI_split)
+      ALLOCATE (bsizes_RI_ext(ri_data%ncell_RI*natom))
+      ALLOCATE (bsizes_RI_ext_split(ri_data%ncell_RI*nblks))
+      DO i_RI = 1, ri_data%ncell_RI
+         bsizes_RI_ext((i_RI - 1)*natom + 1:i_RI*natom) = ri_data%bsizes_RI(:)
+         bsizes_RI_ext_split((i_RI - 1)*nblks + 1:i_RI*nblks) = ri_data%bsizes_RI_split(:)
+      END DO
+
+      !nRI x nRI 2c tensors
+      CALL create_2c_tensor(t_2c_inv(1), dist1, dist2, pgrid_2d, &
+                            bsizes_RI_ext, bsizes_RI_ext, &
+                            name="(RI | RI)")
+      DEALLOCATE (dist1, dist2)
+
+      DO iatom = 2, natom
+         CALL dbt_create(t_2c_inv(1), t_2c_inv(iatom))
+      END DO
+      CALL dbt_create(t_2c_inv(1), t_2c_work(1))
+      CALL dbt_create(t_2c_inv(1), t_2c_work(2))
+
+      CALL create_2c_tensor(t_2c_work(3), dist1, dist2, pgrid_2d, &
+                            bsizes_RI_ext_split, bsizes_RI_ext_split, &
+                            name="(RI | RI)")
+      DEALLOCATE (dist1, dist2)
+
+      !cpoy the data from the main group.
+      DO iatom = 1, natom
+         CALL copy_2c_to_subgroup(t_2c_inv(iatom), ri_data%t_2c_inv(1, iatom), group_size, ngroups, para_env)
+      END DO
+
+      !the AO based tensors
+      CALL create_2c_tensor(ks_t_split(1), dist1, dist2, pgrid_2d, &
+                            ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
+                            name="(AO | AO)")
+      DEALLOCATE (dist1, dist2)
+      CALL dbt_create(ks_t_split(1), ks_t_split(2))
+
+      CALL create_2c_tensor(t_2c_ao_tmp(1), dist1, dist2, pgrid_2d, &
+                            ri_data%bsizes_AO, ri_data%bsizes_AO, &
+                            name="(AO | AO)")
+      DEALLOCATE (dist1, dist2)
+
+      nspins = SIZE(ks_t_sub, 1)
+      nimg = SIZE(ks_t_sub, 2)
+      DO i_img = 1, nimg
+         DO i_spin = 1, nspins
+            CALL dbt_create(t_2c_ao_tmp(1), ks_t_sub(i_spin, i_img))
+         END DO
+      END DO
+
+      !Finally the HFX potential matrices
+      !For now, we do a convoluted things where we go to tensors first, then back to matrices.
+      CALL create_2c_tensor(work_sub, dist1, dist2, pgrid_2d, &
+                            ri_data%bsizes_RI, ri_data%bsizes_RI, &
+                            name="(RI | RI)")
+      CALL dbt_create(ri_data%kp_mat_2c_pot(1, 1), work)
+
+      ALLOCATE (dbcsr_pgrid(0:pdims_2d(1) - 1, 0:pdims_2d(2) - 1))
+      iproc = 0
+      DO i = 0, pdims_2d(1) - 1
+         DO j = 0, pdims_2d(2) - 1
+            dbcsr_pgrid(i, j) = iproc
+            iproc = iproc + 1
+         END DO
+      END DO
+
+      !We need to have the same exact 2d block dist as the tensors
+      ALLOCATE (col_dist(natom), row_dist(natom))
+      row_dist(:) = dist1(:)
+      col_dist(:) = dist2(:)
+
+      ALLOCATE (RI_blk_size(natom))
+      RI_blk_size(:) = ri_data%bsizes_RI(:)
+
+      CALL dbcsr_distribution_new(dbcsr_dist_sub, group=para_env_sub%get_handle(), pgrid=dbcsr_pgrid, &
+                                  row_dist=row_dist, col_dist=col_dist)
+      CALL dbcsr_create(mat_2c_pot(1), dist=dbcsr_dist_sub, name="sub", matrix_type=dbcsr_type_no_symmetry, &
+                        row_blk_size=RI_blk_size, col_blk_size=RI_blk_size)
+
+      DO i_img = 1, nimg
+         IF (i_img > 1) CALL dbcsr_create(mat_2c_pot(i_img), template=mat_2c_pot(1))
+         CALL dbt_copy_matrix_to_tensor(ri_data%kp_mat_2c_pot(1, i_img), work)
+         CALL get_tensor_occupancy(work, nze, occ)
+         IF (nze == 0) CYCLE
+
+         CALL copy_2c_to_subgroup(work_sub, work, group_size, ngroups, para_env)
+         CALL dbt_copy_tensor_to_matrix(work_sub, mat_2c_pot(i_img))
+         CALL dbcsr_filter(mat_2c_pot(i_img), ri_data%filter_eps)
+         CALL dbt_clear(work_sub)
+      END DO
+
+      CALL dbt_destroy(work)
+      CALL dbt_destroy(work_sub)
+      CALL dbt_pgrid_destroy(pgrid_2d)
+      CALL dbcsr_distribution_release(dbcsr_dist_sub)
+      DEALLOCATE (col_dist, row_dist, RI_blk_size, dbcsr_pgrid)
+      CALL timestop(handle)
+
+   END SUBROUTINE get_subgroup_2c_tensors
+
+! **************************************************************************************************
+!> \brief copy all required 3c tensors from the main MPI group to the subgroups
+!> \param t_3c_int ...
+!> \param t_3c_work_2 ...
+!> \param t_3c_work_3 ...
+!> \param t_3c_apc ...
+!> \param t_3c_apc_sub ...
+!> \param group_size ...
+!> \param ngroups ...
+!> \param para_env ...
+!> \param para_env_sub ...
+!> \param ri_data ...
+! **************************************************************************************************
+   SUBROUTINE get_subgroup_3c_tensors(t_3c_int, t_3c_work_2, t_3c_work_3, t_3c_apc, t_3c_apc_sub, &
+                                      group_size, ngroups, para_env, para_env_sub, ri_data)
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_3c_int, t_3c_work_2, t_3c_work_3
+      TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: t_3c_apc, t_3c_apc_sub
+      INTEGER, INTENT(IN)                                :: group_size, ngroups
+      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'get_subgroup_3c_tensors'
+
+      INTEGER                                            :: batch_size, handle, handle2, i_img, &
+                                                            i_RI, i_spin, ib, natom, nblks_AO, &
+                                                            nblks_RI, nimg, nspins
+      INTEGER(int_8)                                     :: nze
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes_RI_ext_split, bsizes_stack, &
+                                                            dist1, dist2, dist3, dist_stack, &
+                                                            idx_to_at
+      INTEGER, DIMENSION(3)                              :: pdims
+      REAL(dp)                                           :: occ
+      TYPE(dbt_distribution_type)                        :: t_dist
+      TYPE(dbt_pgrid_type)                               :: pgrid
+      TYPE(dbt_type)                                     :: tmp
+
+      CALL timeset(routineN, handle)
+
+      nblks_RI = SIZE(ri_data%bsizes_RI_split)
+      ALLOCATE (bsizes_RI_ext_split(ri_data%ncell_RI*nblks_RI))
+      DO i_RI = 1, ri_data%ncell_RI
+         bsizes_RI_ext_split((i_RI - 1)*nblks_RI + 1:i_RI*nblks_RI) = ri_data%bsizes_RI_split(:)
+      END DO
+
+      batch_size = ri_data%kp_stack_size
+      nblks_AO = SIZE(ri_data%bsizes_AO_split)
+      ALLOCATE (bsizes_stack(batch_size*nblks_AO))
+      DO ib = 1, batch_size
+         bsizes_stack((ib - 1)*nblks_AO + 1:ib*nblks_AO) = ri_data%bsizes_AO_split(:)
+      END DO
+
+      !Create the pgrid for the configuration correspoinding to ri_data%t_3c_int_ctr_3
+      natom = SIZE(ri_data%bsizes_RI)
+      pdims = 0
+      CALL dbt_pgrid_create(para_env_sub, pdims, pgrid, &
+                            tensor_dims=[SIZE(bsizes_RI_ext_split), natom, batch_size*SIZE(ri_data%bsizes_AO_split)])
+
+      !Create all required 3c tensors in that configuration
+      CALL create_3c_tensor(t_3c_int(1), dist1, dist2, dist3, &
+                            pgrid, bsizes_RI_ext_split, ri_data%bsizes_AO_split, &
+                            ri_data%bsizes_AO_split, [1], [2, 3], name="(RI | AO AO)")
+      nimg = SIZE(t_3c_int)
+      DO i_img = 2, nimg
+         CALL dbt_create(t_3c_int(1), t_3c_int(i_img))
+      END DO
+
+      !The stacked work tensors, in a distribution that matches that of t_3c_int
+      ALLOCATE (dist_stack(batch_size*nblks_AO))
+      DO ib = 1, batch_size
+         dist_stack((ib - 1)*nblks_AO + 1:ib*nblks_AO) = dist3(:)
+      END DO
+
+      CALL dbt_distribution_new(t_dist, pgrid, dist1, dist2, dist_stack)
+      CALL dbt_create(t_3c_work_3(1), "work_3_stack", t_dist, [1], [2, 3], &
+                      bsizes_RI_ext_split, ri_data%bsizes_AO_split, bsizes_stack)
+      CALL dbt_create(t_3c_work_3(1), t_3c_work_3(2))
+      CALL dbt_create(t_3c_work_3(1), t_3c_work_3(3))
+      CALL dbt_distribution_destroy(t_dist)
+      DEALLOCATE (dist1, dist2, dist3, dist_stack)
+
+      CALL create_3c_tensor(tmp, dist1, dist2, dist3, &
+                            ri_data%pgrid, bsizes_RI_ext_split, ri_data%bsizes_AO_split, &
+                            ri_data%bsizes_AO_split, [1], [2, 3], name="(RI | AO AO)")
+      DEALLOCATE (dist1, dist2, dist3)
+
+      !Finally copy the integrals into the subgroups (if not there already)
+      CALL timeset(routineN//"_ints", handle2)
+      IF (ALLOCATED(ri_data%kp_t_3c_int)) THEN
+         DO i_img = 1, nimg
+            CALL dbt_copy(ri_data%kp_t_3c_int(i_img), t_3c_int(i_img), move_data=.TRUE.)
+         END DO
+      ELSE
+         ALLOCATE (ri_data%kp_t_3c_int(nimg))
+         DO i_img = 1, nimg
+            CALL dbt_create(t_3c_int(i_img), ri_data%kp_t_3c_int(i_img))
+            CALL get_tensor_occupancy(ri_data%t_3c_int_ctr_1(1, i_img), nze, occ)
+            IF (nze == 0) CYCLE
+            CALL dbt_copy(ri_data%t_3c_int_ctr_1(1, i_img), tmp, order=[2, 1, 3])
+            CALL copy_3c_to_subgroup(t_3c_int(i_img), tmp, group_size, ngroups, para_env)
+         END DO
+      END IF
+      CALL timestop(handle2)
+      CALL dbt_pgrid_destroy(pgrid)
+      CALL dbt_destroy(tmp)
+
+      !Do the same for the t_3c_ctr_2 configuration
+      pdims = 0
+      CALL dbt_pgrid_create(para_env_sub, pdims, pgrid, &
+                            tensor_dims=[natom, SIZE(bsizes_RI_ext_split), batch_size*SIZE(ri_data%bsizes_AO_split)])
+
+      !template for t_3c_apc_sub
+      CALL create_3c_tensor(tmp, dist1, dist2, dist3, &
+                            pgrid, ri_data%bsizes_AO_split, bsizes_RI_ext_split, &
+                            ri_data%bsizes_AO_split, [1], [2, 3], name="(AO RI | AO)")
+
+      !create t_3c_work_2 tensors in a distribution that matches the above
+      ALLOCATE (dist_stack(batch_size*nblks_AO))
+      DO ib = 1, batch_size
+         dist_stack((ib - 1)*nblks_AO + 1:ib*nblks_AO) = dist3(:)
+      END DO
+
+      CALL dbt_distribution_new(t_dist, pgrid, dist1, dist2, dist_stack)
+      CALL dbt_create(t_3c_work_2(1), "work_2_stack", t_dist, [1], [2, 3], &
+                      ri_data%bsizes_AO_split, bsizes_RI_ext_split, bsizes_stack)
+      CALL dbt_create(t_3c_work_2(1), t_3c_work_2(2))
+      CALL dbt_create(t_3c_work_2(1), t_3c_work_2(3))
+      CALL dbt_distribution_destroy(t_dist)
+      DEALLOCATE (dist1, dist2, dist3, dist_stack)
+
+      !Finally copy data from t_3c_apc to the subgroups
+      ALLOCATE (idx_to_at(SIZE(ri_data%bsizes_AO_split)))
+      CALL get_idx_to_atom(idx_to_at, ri_data%bsizes_AO_split, ri_data%bsizes_AO)
+      nspins = SIZE(t_3c_apc, 1)
+      CALL timeset(routineN//"_apc", handle2)
+      DO i_img = 1, nimg
+         DO i_spin = 1, nspins
+            CALL dbt_create(tmp, t_3c_apc_sub(i_spin, i_img))
+            CALL get_tensor_occupancy(t_3c_apc(i_spin, i_img), nze, occ)
+            IF (nze == 0) CYCLE
+            CALL copy_3c_to_subgroup(t_3c_apc_sub(i_spin, i_img), t_3c_apc(i_spin, i_img), group_size, &
+                                     ngroups, para_env, ri_data%iatom_to_subgroup, 1, idx_to_at)
+         END DO
+         DO i_spin = 1, nspins
+            CALL dbt_destroy(t_3c_apc(i_spin, i_img))
+         END DO
+      END DO
+      CALL timestop(handle2)
+      CALL dbt_pgrid_destroy(pgrid)
+      CALL dbt_destroy(tmp)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE get_subgroup_3c_tensors
+
+! **************************************************************************************************
+!> \brief copy all required 2c force tensors from the main MPI group to the subgroups
+!> \param t_2c_inv ...
+!> \param t_2c_bint ...
+!> \param mat_2c_pot ...
+!> \param t_2c_work ...
+!> \param rho_ao_t ...
+!> \param rho_ao_t_sub ...
+!> \param t_2c_der_metric ...
+!> \param t_2c_der_metric_sub ...
+!> \param mat_der_pot ...
+!> \param mat_der_pot_sub ...
+!> \param group_size ...
+!> \param ngroups ...
+!> \param para_env ...
+!> \param para_env_sub ...
+!> \param ri_data ...
+!> \note Main MPI group tensors are deleted within this routine, for memory optimization
+! **************************************************************************************************
+   SUBROUTINE get_subgroup_2c_derivs(t_2c_inv, t_2c_bint, mat_2c_pot, t_2c_work, rho_ao_t, rho_ao_t_sub, &
+                                     t_2c_der_metric, t_2c_der_metric_sub, mat_der_pot, mat_der_pot_sub, &
+                                     group_size, ngroups, para_env, para_env_sub, ri_data)
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_2c_inv, t_2c_bint
+      TYPE(dbcsr_type), DIMENSION(:), INTENT(INOUT)      :: mat_2c_pot
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_2c_work
+      TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: rho_ao_t, rho_ao_t_sub, t_2c_der_metric, &
+                                                            t_2c_der_metric_sub
+      TYPE(dbcsr_type), DIMENSION(:, :), INTENT(INOUT)   :: mat_der_pot, mat_der_pot_sub
+      INTEGER, INTENT(IN)                                :: group_size, ngroups
+      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'get_subgroup_2c_derivs'
+
+      INTEGER                                            :: handle, i, i_img, i_RI, i_spin, i_xyz, &
+                                                            iatom, iproc, j, natom, nblks, nimg, &
+                                                            nspins
+      INTEGER(int_8)                                     :: nze
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes_RI_ext, bsizes_RI_ext_split, &
+                                                            dist1, dist2
+      INTEGER, DIMENSION(2)                              :: pdims_2d
+      INTEGER, DIMENSION(:), POINTER                     :: col_dist, RI_blk_size, row_dist
+      INTEGER, DIMENSION(:, :), POINTER                  :: dbcsr_pgrid
+      REAL(dp)                                           :: occ
+      TYPE(dbcsr_distribution_type)                      :: dbcsr_dist_sub
+      TYPE(dbt_pgrid_type)                               :: pgrid_2d
+      TYPE(dbt_type)                                     :: work, work_sub
+
+      CALL timeset(routineN, handle)
+
+      !Note: a fair portion of this routine is copied from the energy version of it
+      !Create the 2d pgrid
+      pdims_2d = 0
+      CALL dbt_pgrid_create(para_env_sub, pdims_2d, pgrid_2d)
+
+      natom = SIZE(ri_data%bsizes_RI)
+      nblks = SIZE(ri_data%bsizes_RI_split)
+      ALLOCATE (bsizes_RI_ext(ri_data%ncell_RI*natom))
+      ALLOCATE (bsizes_RI_ext_split(ri_data%ncell_RI*nblks))
+      DO i_RI = 1, ri_data%ncell_RI
+         bsizes_RI_ext((i_RI - 1)*natom + 1:i_RI*natom) = ri_data%bsizes_RI(:)
+         bsizes_RI_ext_split((i_RI - 1)*nblks + 1:i_RI*nblks) = ri_data%bsizes_RI_split(:)
+      END DO
+
+      !nRI x nRI 2c tensors
+      CALL create_2c_tensor(t_2c_inv(1), dist1, dist2, pgrid_2d, &
+                            bsizes_RI_ext, bsizes_RI_ext, &
+                            name="(RI | RI)")
+      DEALLOCATE (dist1, dist2)
+
+      CALL dbt_create(t_2c_inv(1), t_2c_bint(1))
+      DO iatom = 2, natom
+         CALL dbt_create(t_2c_inv(1), t_2c_inv(iatom))
+         CALL dbt_create(t_2c_inv(1), t_2c_bint(iatom))
+      END DO
+      CALL dbt_create(t_2c_inv(1), t_2c_work(1))
+      CALL dbt_create(t_2c_inv(1), t_2c_work(2))
+      CALL dbt_create(t_2c_inv(1), t_2c_work(3))
+      CALL dbt_create(t_2c_inv(1), t_2c_work(4))
+
+      CALL create_2c_tensor(t_2c_work(5), dist1, dist2, pgrid_2d, &
+                            bsizes_RI_ext_split, bsizes_RI_ext_split, &
+                            name="(RI | RI)")
+      DEALLOCATE (dist1, dist2)
+
+      !copy the data from the main group.
+      DO iatom = 1, natom
+         CALL copy_2c_to_subgroup(t_2c_inv(iatom), ri_data%t_2c_inv(1, iatom), group_size, ngroups, para_env)
+         CALL copy_2c_to_subgroup(t_2c_bint(iatom), ri_data%t_2c_int(1, iatom), group_size, ngroups, para_env)
+      END DO
+
+      !This includes the derivatives of the RI metric, for which there is one per atom
+      DO i_xyz = 1, 3
+         DO iatom = 1, natom
+            CALL dbt_create(t_2c_inv(1), t_2c_der_metric_sub(iatom, i_xyz))
+            CALL copy_2c_to_subgroup(t_2c_der_metric_sub(iatom, i_xyz), t_2c_der_metric(iatom, i_xyz), &
+                                     group_size, ngroups, para_env)
+            CALL dbt_destroy(t_2c_der_metric(iatom, i_xyz))
+         END DO
+      END DO
+
+      !AO x AO 2c tensors
+      CALL create_2c_tensor(rho_ao_t_sub(1, 1), dist1, dist2, pgrid_2d, &
+                            ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
+                            name="(AO | AO)")
+      DEALLOCATE (dist1, dist2)
+      nspins = SIZE(rho_ao_t, 1)
+      nimg = SIZE(rho_ao_t, 2)
+
+      DO i_img = 1, nimg
+         DO i_spin = 1, nspins
+            IF (.NOT. (i_img == 1 .AND. i_spin == 1)) &
+               CALL dbt_create(rho_ao_t_sub(1, 1), rho_ao_t_sub(i_spin, i_img))
+            CALL copy_2c_to_subgroup(rho_ao_t_sub(i_spin, i_img), rho_ao_t(i_spin, i_img), &
+                                     group_size, ngroups, para_env)
+            CALL dbt_destroy(rho_ao_t(i_spin, i_img))
+         END DO
+      END DO
+
+      !The RIxRI matrices, going through tensors
+      CALL create_2c_tensor(work_sub, dist1, dist2, pgrid_2d, &
+                            ri_data%bsizes_RI, ri_data%bsizes_RI, &
+                            name="(RI | RI)")
+      CALL dbt_create(ri_data%kp_mat_2c_pot(1, 1), work)
+
+      ALLOCATE (dbcsr_pgrid(0:pdims_2d(1) - 1, 0:pdims_2d(2) - 1))
+      iproc = 0
+      DO i = 0, pdims_2d(1) - 1
+         DO j = 0, pdims_2d(2) - 1
+            dbcsr_pgrid(i, j) = iproc
+            iproc = iproc + 1
+         END DO
+      END DO
+
+      !We need to have the same exact 2d block dist as the tensors
+      ALLOCATE (col_dist(natom), row_dist(natom))
+      row_dist(:) = dist1(:)
+      col_dist(:) = dist2(:)
+
+      ALLOCATE (RI_blk_size(natom))
+      RI_blk_size(:) = ri_data%bsizes_RI(:)
+
+      CALL dbcsr_distribution_new(dbcsr_dist_sub, group=para_env_sub%get_handle(), pgrid=dbcsr_pgrid, &
+                                  row_dist=row_dist, col_dist=col_dist)
+      CALL dbcsr_create(mat_2c_pot(1), dist=dbcsr_dist_sub, name="sub", matrix_type=dbcsr_type_no_symmetry, &
+                        row_blk_size=RI_blk_size, col_blk_size=RI_blk_size)
+
+      !The HFX potential
+      DO i_img = 1, nimg
+         IF (i_img > 1) CALL dbcsr_create(mat_2c_pot(i_img), template=mat_2c_pot(1))
+         CALL dbt_copy_matrix_to_tensor(ri_data%kp_mat_2c_pot(1, i_img), work)
+         CALL get_tensor_occupancy(work, nze, occ)
+         IF (nze == 0) CYCLE
+
+         CALL copy_2c_to_subgroup(work_sub, work, group_size, ngroups, para_env)
+         CALL dbt_copy_tensor_to_matrix(work_sub, mat_2c_pot(i_img))
+         CALL dbcsr_filter(mat_2c_pot(i_img), ri_data%filter_eps)
+         CALL dbt_clear(work_sub)
+      END DO
+
+      !The derivatives of the HFX potential
+      DO i_xyz = 1, 3
+         DO i_img = 1, nimg
+            CALL dbcsr_create(mat_der_pot_sub(i_img, i_xyz), template=mat_2c_pot(1))
+            CALL dbt_copy_matrix_to_tensor(mat_der_pot(i_img, i_xyz), work)
+            CALL dbcsr_release(mat_der_pot(i_img, i_xyz))
+            CALL get_tensor_occupancy(work, nze, occ)
+            IF (nze == 0) CYCLE
+
+            CALL copy_2c_to_subgroup(work_sub, work, group_size, ngroups, para_env)
+            CALL dbt_copy_tensor_to_matrix(work_sub, mat_der_pot_sub(i_img, i_xyz))
+            CALL dbcsr_filter(mat_der_pot_sub(i_img, i_xyz), ri_data%filter_eps)
+            CALL dbt_clear(work_sub)
+         END DO
+      END DO
+
+      CALL dbt_destroy(work)
+      CALL dbt_destroy(work_sub)
+      CALL dbt_pgrid_destroy(pgrid_2d)
+      CALL dbcsr_distribution_release(dbcsr_dist_sub)
+      DEALLOCATE (col_dist, row_dist, RI_blk_size, dbcsr_pgrid)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE get_subgroup_2c_derivs
+
+! **************************************************************************************************
+!> \brief copy all required 3c derivative tensors from the main MPI group to the subgroups
+!> \param t_3c_work_2 ...
+!> \param t_3c_work_3 ...
+!> \param t_3c_der_AO ...
+!> \param t_3c_der_AO_sub ...
+!> \param t_3c_der_RI ...
+!> \param t_3c_der_RI_sub ...
+!> \param t_3c_der_stack ...
+!> \param group_size ...
+!> \param ngroups ...
+!> \param para_env ...
+!> \param para_env_sub ...
+!> \param ri_data ...
+!> \note the tensor containing the derivatives in the main MPI group are deleted for memory
+! **************************************************************************************************
+   SUBROUTINE get_subgroup_3c_derivs(t_3c_work_2, t_3c_work_3, t_3c_der_AO, t_3c_der_AO_sub, &
+                                     t_3c_der_RI, t_3c_der_RI_sub, t_3c_der_stack, group_size, &
+                                     ngroups, para_env, para_env_sub, ri_data)
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_3c_work_2, t_3c_work_3
+      TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: t_3c_der_AO, t_3c_der_AO_sub, &
+                                                            t_3c_der_RI, t_3c_der_RI_sub
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_3c_der_stack
+      INTEGER, INTENT(IN)                                :: group_size, ngroups
+      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'get_subgroup_3c_derivs'
+
+      INTEGER                                            :: batch_size, handle, i_img, i_RI, i_xyz, &
+                                                            ib, nblks_AO, nblks_RI, nimg, pdims(3)
+      INTEGER(int_8)                                     :: nze
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes_RI_ext_split, bsizes_stack, &
+                                                            dist1, dist2, dist3, dist_stack
+      REAL(dp)                                           :: occ
+      TYPE(dbt_distribution_type)                        :: t_dist
+      TYPE(dbt_pgrid_type)                               :: pgrid
+
+      CALL timeset(routineN, handle)
+
+      !We use the 3c integrals on the subgroup as template for the derivatives
+      nimg = ri_data%nimg
+      DO i_xyz = 1, 3
+         DO i_img = 1, nimg
+            CALL dbt_create(ri_data%kp_t_3c_int(1), t_3c_der_AO_sub(i_img, i_xyz))
+            CALL get_tensor_occupancy(t_3c_der_AO(i_img, i_xyz), nze, occ)
+            IF (nze == 0) CYCLE
+
+            CALL copy_3c_to_subgroup(t_3c_der_AO_sub(i_img, i_xyz), t_3c_der_AO(i_img, i_xyz), &
+                                     group_size, ngroups, para_env)
+         END DO
+
+         DO i_img = 1, nimg
+            CALL dbt_create(ri_data%kp_t_3c_int(1), t_3c_der_RI_sub(i_img, i_xyz))
+            CALL get_tensor_occupancy(t_3c_der_RI(i_img, i_xyz), nze, occ)
+            IF (nze == 0) CYCLE
+
+            CALL copy_3c_to_subgroup(t_3c_der_RI_sub(i_img, i_xyz), t_3c_der_RI(i_img, i_xyz), &
+                                     group_size, ngroups, para_env)
+         END DO
+
+         DO i_img = 1, nimg
+            CALL dbt_destroy(t_3c_der_RI(i_img, i_xyz))
+            CALL dbt_destroy(t_3c_der_AO(i_img, i_xyz))
+         END DO
+      END DO
+
+      !The stacked work tensors in the subgroup
+      nblks_RI = SIZE(ri_data%bsizes_RI_split)
+      ALLOCATE (bsizes_RI_ext_split(ri_data%ncell_RI*nblks_RI))
+      DO i_RI = 1, ri_data%ncell_RI
+         bsizes_RI_ext_split((i_RI - 1)*nblks_RI + 1:i_RI*nblks_RI) = ri_data%bsizes_RI_split(:)
+      END DO
+
+      batch_size = ri_data%kp_stack_size
+      nblks_AO = SIZE(ri_data%bsizes_AO_split)
+      ALLOCATE (bsizes_stack(batch_size*nblks_AO))
+      DO ib = 1, batch_size
+         bsizes_stack((ib - 1)*nblks_AO + 1:ib*nblks_AO) = ri_data%bsizes_AO_split(:)
+      END DO
+
+      !t_3c_work_3 based on structure of 3c integrals/derivs
+      ALLOCATE (dist1(ri_data%ncell_RI*nblks_RI), dist2(nblks_AO), dist3(nblks_AO))
+      CALL dbt_get_info(ri_data%kp_t_3c_int(1), proc_dist_1=dist1, proc_dist_2=dist2, &
+                        proc_dist_3=dist3, pdims=pdims)
+
+      ALLOCATE (dist_stack(batch_size*nblks_AO))
+      DO ib = 1, batch_size
+         dist_stack((ib - 1)*nblks_AO + 1:ib*nblks_AO) = dist3(:)
+      END DO
+
+      CALL dbt_pgrid_create(para_env_sub, pdims, pgrid)
+      CALL dbt_distribution_new(t_dist, pgrid, dist1, dist2, dist_stack)
+      CALL dbt_create(t_3c_work_3(1), "work_3_stack", t_dist, [1], [2, 3], &
+                      bsizes_RI_ext_split, ri_data%bsizes_AO_split, bsizes_stack)
+      CALL dbt_create(t_3c_work_3(1), t_3c_work_3(2))
+      CALL dbt_create(t_3c_work_3(1), t_3c_work_3(3))
+      CALL dbt_create(t_3c_work_3(1), t_3c_work_3(4))
+      CALL dbt_distribution_destroy(t_dist)
+      CALL dbt_pgrid_destroy(pgrid)
+      DEALLOCATE (dist1, dist2, dist3, dist_stack)
+
+      !the derivatives are stacked in the same way
+      CALL dbt_create(t_3c_work_3(1), t_3c_der_stack(1))
+      CALL dbt_create(t_3c_work_3(1), t_3c_der_stack(2))
+      CALL dbt_create(t_3c_work_3(1), t_3c_der_stack(3))
+      CALL dbt_create(t_3c_work_3(1), t_3c_der_stack(4))
+      CALL dbt_create(t_3c_work_3(1), t_3c_der_stack(5))
+      CALL dbt_create(t_3c_work_3(1), t_3c_der_stack(6))
+
+      !t_3c_work_2 based on struvture of t_3c_apc
+      ALLOCATE (dist1(nblks_AO), dist2(ri_data%ncell_RI*nblks_RI), dist3(nblks_AO))
+      CALL dbt_get_info(ri_data%kp_t_3c_apc(1, 1), proc_dist_1=dist1, proc_dist_2=dist2, &
+                        proc_dist_3=dist3, pdims=pdims)
+
+      ALLOCATE (dist_stack(batch_size*nblks_AO))
+      DO ib = 1, batch_size
+         dist_stack((ib - 1)*nblks_AO + 1:ib*nblks_AO) = dist3(:)
+      END DO
+
+      CALL dbt_pgrid_create(para_env_sub, pdims, pgrid)
+      CALL dbt_distribution_new(t_dist, pgrid, dist1, dist2, dist_stack)
+      CALL dbt_create(t_3c_work_2(1), "work_3_stack", t_dist, [1], [2, 3], &
+                      ri_data%bsizes_AO_split, bsizes_RI_ext_split, bsizes_stack)
+      CALL dbt_create(t_3c_work_2(1), t_3c_work_2(2))
+      CALL dbt_create(t_3c_work_2(1), t_3c_work_2(3))
+      CALL dbt_distribution_destroy(t_dist)
+      CALL dbt_pgrid_destroy(pgrid)
+      DEALLOCATE (dist1, dist2, dist3, dist_stack)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE get_subgroup_3c_derivs
+
+! **************************************************************************************************
+!> \brief A routine that reorders the t_3c_int tensors such that all items which are fully empty
+!>        are bunched together. This way, we can get much more efficient screening based on NZE
+!> \param t_3c_ints ...
+!> \param ri_data ...
+! **************************************************************************************************
+   SUBROUTINE reorder_3c_ints(t_3c_ints, ri_data)
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_3c_ints
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'reorder_3c_ints'
+
+      INTEGER                                            :: handle, i_img, idx, idx_empty, idx_full, &
+                                                            nimg
+      INTEGER(int_8)                                     :: nze
+      REAL(dp)                                           :: occ
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_3c_tmp
+
+      CALL timeset(routineN, handle)
+
+      nimg = ri_data%nimg
+      ALLOCATE (t_3c_tmp(nimg))
+      DO i_img = 1, nimg
+         CALL dbt_create(t_3c_ints(i_img), t_3c_tmp(i_img))
+         CALL dbt_copy(t_3c_ints(i_img), t_3c_tmp(i_img), move_data=.TRUE.)
+      END DO
+
+      !Loop over the images, check if ints have NZE == 0, and put them at the start or end of the
+      !initial tensor array. Keep the mapping in an array
+      ALLOCATE (ri_data%idx_to_img(nimg))
+      idx_full = 0
+      idx_empty = nimg + 1
+
+      DO i_img = 1, nimg
+         CALL get_tensor_occupancy(t_3c_tmp(i_img), nze, occ)
+         IF (nze == 0) THEN
+            idx_empty = idx_empty - 1
+            CALL dbt_copy(t_3c_tmp(i_img), t_3c_ints(idx_empty), move_data=.TRUE.)
+            ri_data%idx_to_img(idx_empty) = i_img
+         ELSE
+            idx_full = idx_full + 1
+            CALL dbt_copy(t_3c_tmp(i_img), t_3c_ints(idx_full), move_data=.TRUE.)
+            ri_data%idx_to_img(idx_full) = i_img
+         END IF
+         CALL dbt_destroy(t_3c_tmp(i_img))
+      END DO
+
+      !store the highest image index with non-zero integrals
+      ri_data%nimg_nze = idx_full
+
+      ALLOCATE (ri_data%img_to_idx(nimg))
+      DO idx = 1, nimg
+         ri_data%img_to_idx(ri_data%idx_to_img(idx)) = idx
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE reorder_3c_ints
+
+! **************************************************************************************************
+!> \brief A routine that reorders the 3c derivatives, the same way that the integrals are, also to
+!>        increase efficiency of screening
+!> \param t_3c_derivs ...
+!> \param ri_data ...
+! **************************************************************************************************
+   SUBROUTINE reorder_3c_derivs(t_3c_derivs, ri_data)
+      TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: t_3c_derivs
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'reorder_3c_derivs'
+
+      INTEGER                                            :: handle, i_img, i_xyz, idx, nimg
+      INTEGER(int_8)                                     :: nze
+      REAL(dp)                                           :: occ
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:)          :: t_3c_tmp
+
+      CALL timeset(routineN, handle)
+
+      nimg = ri_data%nimg
+      ALLOCATE (t_3c_tmp(nimg))
+      DO i_img = 1, nimg
+         CALL dbt_create(t_3c_derivs(1, 1), t_3c_tmp(i_img))
+      END DO
+
+      DO i_xyz = 1, 3
+         DO i_img = 1, nimg
+            CALL dbt_copy(t_3c_derivs(i_img, i_xyz), t_3c_tmp(i_img), move_data=.TRUE.)
+         END DO
+         DO i_img = 1, nimg
+            idx = ri_data%img_to_idx(i_img)
+            CALL dbt_copy(t_3c_tmp(i_img), t_3c_derivs(idx, i_xyz), move_data=.TRUE.)
+            CALL get_tensor_occupancy(t_3c_derivs(idx, i_xyz), nze, occ)
+            IF (nze > 0) ri_data%nimg_nze = MAX(idx, ri_data%nimg_nze)
+         END DO
+      END DO
+
+      DO i_img = 1, nimg
+         CALL dbt_destroy(t_3c_tmp(i_img))
+      END DO
+
+      CALL timestop(handle)
+
+   END SUBROUTINE reorder_3c_derivs
+
+! **************************************************************************************************
+!> \brief Get the sparsity pattern related to the non-symmetric AO basis overlap neighbor list
+!> \param pattern ...
+!> \param ri_data ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE get_sparsity_pattern(pattern, ri_data, qs_env)
+      INTEGER, DIMENSION(:, :, :), INTENT(INOUT)         :: pattern
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      INTEGER                                            :: iatom, j_img, jatom, mj_img, natom, nimg
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bins
+      INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: tmp_pattern
+      INTEGER, DIMENSION(3)                              :: cell_j
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: nl_2c
+
+      NULLIFY (nl_2c, nl_iterator, kpoints, cell_to_index, dft_control, index_to_cell, para_env)
+
+      CALL get_qs_env(qs_env, kpoints=kpoints, dft_control=dft_control, para_env=para_env, natom=natom)
+      CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index, index_to_cell=index_to_cell, sab_nl=nl_2c)
+
+      nimg = ri_data%nimg
+      pattern(:, :, :) = 0
+
+      !We use the symmetric nl for all images that have an opposite cell
+      CALL neighbor_list_iterator_create(nl_iterator, nl_2c)
+      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+         CALL get_iterator_info(nl_iterator, iatom=iatom, jatom=jatom, cell=cell_j)
+
+         j_img = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
+         IF (j_img > nimg .OR. j_img < 1) CYCLE
+
+         mj_img = get_opp_index(j_img, qs_env)
+         IF (mj_img > nimg .OR. mj_img < 1) CYCLE
+
+         IF (ri_data%present_images(j_img) == 0) CYCLE
+
+         pattern(iatom, jatom, j_img) = 1
+      END DO
+      CALL neighbor_list_iterator_release(nl_iterator)
+
+      !If there is no opposite cell present, then we take into account the non-symmetric nl
+      CALL get_kpoint_info(kpoints, sab_nl_nosym=nl_2c)
+
+      CALL neighbor_list_iterator_create(nl_iterator, nl_2c)
+      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+         CALL get_iterator_info(nl_iterator, iatom=iatom, jatom=jatom, cell=cell_j)
+
+         j_img = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
+         IF (j_img > nimg .OR. j_img < 1) CYCLE
+
+         mj_img = get_opp_index(j_img, qs_env)
+         IF (mj_img .LE. nimg .AND. mj_img > 0) CYCLE
+
+         IF (ri_data%present_images(j_img) == 0) CYCLE
+
+         pattern(iatom, jatom, j_img) = 1
+      END DO
+      CALL neighbor_list_iterator_release(nl_iterator)
+
+      CALL para_env%sum(pattern)
+
+      !If the opposite image is considered, then there is no need to compute diagonal twice
+      DO j_img = 2, nimg
+         DO iatom = 1, natom
+            IF (pattern(iatom, iatom, j_img) .NE. 0) THEN
+               mj_img = get_opp_index(j_img, qs_env)
+               IF (mj_img > nimg .OR. mj_img < 1) CYCLE
+               pattern(iatom, iatom, mj_img) = 0
+            END IF
+         END DO
+      END DO
+
+      ! We want to equilibrate the sparsity pattern such that there are same amount of blocks
+      ! for each atom i of i,j pairs
+      ALLOCATE (bins(natom))
+      bins(:) = 0
+
+      ALLOCATE (tmp_pattern(natom, natom, nimg))
+      tmp_pattern(:, :, :) = 0
+      DO j_img = 1, nimg
+         DO jatom = 1, natom
+            DO iatom = 1, natom
+               IF (pattern(iatom, jatom, j_img) == 0) CYCLE
+               mj_img = get_opp_index(j_img, qs_env)
+
+               !Should we take the i,j,b or th j,i,-b atomic block?
+               IF (mj_img > nimg .OR. mj_img < 1) THEN
+                  !No opposite image, no choice
+                  bins(iatom) = bins(iatom) + 1
+                  tmp_pattern(iatom, jatom, j_img) = 1
+               ELSE
+
+                  IF (bins(iatom) > bins(jatom)) THEN
+                     bins(jatom) = bins(jatom) + 1
+                     tmp_pattern(jatom, iatom, mj_img) = 1
+                  ELSE
+                     bins(iatom) = bins(iatom) + 1
+                     tmp_pattern(iatom, jatom, j_img) = 1
+                  END IF
+               END IF
+            END DO
+         END DO
+      END DO
+
+      ! -1 => unoccupied, 0 => occupied
+      pattern(:, :, :) = tmp_pattern(:, :, :) - 1
+
+   END SUBROUTINE get_sparsity_pattern
+
+! **************************************************************************************************
+!> \brief Distribute the iatom, jatom, b_img triplet over the subgroupd to spread the load
+!>        the group id for each triplet is passed as the value of sparsity_pattern(i, j, b),
+!>        with -1 being an unoccupied block
+!> \param sparsity_pattern ...
+!> \param ngroups ...
+!> \param ri_data ...
+! **************************************************************************************************
+   SUBROUTINE get_sub_dist(sparsity_pattern, ngroups, ri_data)
+      INTEGER, DIMENSION(:, :, :), INTENT(INOUT)         :: sparsity_pattern
+      INTEGER, INTENT(IN)                                :: ngroups
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+
+      INTEGER                                            :: b_img, ctr, iat, iatom, igroup, jatom, &
+                                                            natom, nimg, ub
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: max_at_per_group
+      REAL(dp)                                           :: cost
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: bins
+
+      natom = SIZE(sparsity_pattern, 2)
+      nimg = SIZE(sparsity_pattern, 3)
+
+      !To avoid unnecessary data replication accross the subgroups, we want to have a limited number
+      !of subgroup with the data of a given iatom. At the minimum, all groups have 1 atom
+      !We assume that the cost associated to each iatom is roughly the same
+      IF (.NOT. ALLOCATED(ri_data%iatom_to_subgroup)) THEN
+         ALLOCATE (ri_data%iatom_to_subgroup(natom), max_at_per_group(ngroups))
+         DO iatom = 1, natom
+            NULLIFY (ri_data%iatom_to_subgroup(iatom)%array)
+            ALLOCATE (ri_data%iatom_to_subgroup(iatom)%array(ngroups))
+            ri_data%iatom_to_subgroup(iatom)%array(:) = .FALSE.
+         END DO
+
+         ub = natom/ngroups
+         IF (ub*ngroups < natom) ub = ub + 1
+         max_at_per_group(:) = MAX(1, ub)
+
+         !We want each atom to be present the same amount of times. Some groups might have more atoms
+         !than other to achieve this.
+         ctr = 0
+         DO WHILE (MODULO(SUM(max_at_per_group), natom) .NE. 0)
+            igroup = MODULO(ctr, ngroups) + 1
+            max_at_per_group(igroup) = max_at_per_group(igroup) + 1
+            ctr = ctr + 1
+         END DO
+
+         ctr = 0
+         DO igroup = 1, ngroups
+            DO iat = 1, max_at_per_group(igroup)
+               iatom = MODULO(ctr, natom) + 1
+               ri_data%iatom_to_subgroup(iatom)%array(igroup) = .TRUE.
+               ctr = ctr + 1
+            END DO
+         END DO
+      END IF
+
+      ALLOCATE (bins(ngroups))
+      bins = 0.0_dp
+      DO b_img = 1, nimg
+         DO jatom = 1, natom
+            DO iatom = 1, natom
+               IF (sparsity_pattern(iatom, jatom, b_img) == -1) CYCLE
+               igroup = MINLOC(bins, 1, MASK=ri_data%iatom_to_subgroup(iatom)%array) - 1
+
+               !Use cost information from previous SCF if available
+               IF (ANY(ri_data%kp_cost > EPSILON(0.0_dp))) THEN
+                  cost = ri_data%kp_cost(iatom, jatom, b_img)
+               ELSE
+                  cost = REAL(ri_data%bsizes_AO(iatom)*ri_data%bsizes_AO(jatom), dp)
+               END IF
+               bins(igroup + 1) = bins(igroup + 1) + cost
+               sparsity_pattern(iatom, jatom, b_img) = igroup
+            END DO
+         END DO
+      END DO
+
+   END SUBROUTINE get_sub_dist
+
+! **************************************************************************************************
+!> \brief A rouine that updates the sparsity pattern for force calculation, where all i,j,b combinations
+!>        are visited.
+!> \param force_pattern ...
+!> \param scf_pattern ...
+!> \param ngroups ...
+!> \param ri_data ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE update_pattern_to_forces(force_pattern, scf_pattern, ngroups, ri_data, qs_env)
+      INTEGER, DIMENSION(:, :, :), INTENT(INOUT)         :: force_pattern, scf_pattern
+      INTEGER, INTENT(IN)                                :: ngroups
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      INTEGER                                            :: b_img, iatom, igroup, jatom, mb_img, &
+                                                            natom, nimg
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: bins
+
+      natom = SIZE(scf_pattern, 2)
+      nimg = SIZE(scf_pattern, 3)
+
+      ALLOCATE (bins(ngroups))
+      bins = 0.0_dp
+
+      DO b_img = 1, nimg
+         mb_img = get_opp_index(b_img, qs_env)
+         DO jatom = 1, natom
+            DO iatom = 1, natom
+               !Important: same distribution as KS matrix, because reuse t_3c_apc
+               igroup = MINLOC(bins, 1, MASK=ri_data%iatom_to_subgroup(iatom)%array) - 1
+
+               !check that block not already treated
+               IF (scf_pattern(iatom, jatom, b_img) > -1) CYCLE
+
+               !If not, take the cost of block j, i, -b (same energy contribution)
+               IF (mb_img > 0 .AND. mb_img .LE. nimg) THEN
+                  IF (scf_pattern(jatom, iatom, mb_img) == -1) CYCLE
+                  bins(igroup + 1) = bins(igroup + 1) + ri_data%kp_cost(jatom, iatom, mb_img)
+                  force_pattern(iatom, jatom, b_img) = igroup
+               END IF
+            END DO
+         END DO
+      END DO
+
+   END SUBROUTINE update_pattern_to_forces
+
+! **************************************************************************************************
+!> \brief A routine that determines the extend of the KP RI-HFX periodic images, including for the
+!>        extension of the RI basis
+!> \param ri_data ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE get_kp_and_ri_images(ri_data, qs_env)
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_kp_and_ri_images'
+
+      INTEGER :: cell_j(3), cell_k(3), handle, i_img, iatom, ikind, j_img, jatom, jcell, katom, &
+         kcell, kp_index_lbounds(3), kp_index_ubounds(3), natom, ngroups, nimg, nkind, pcoord(3), &
+         pdims(3)
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist_AO_1, dist_AO_2, dist_RI, &
+                                                            nRI_per_atom, present_img, RI_cells
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      REAL(dp)                                           :: bump_fact, dij, dik, fact, image_range, &
+                                                            RI_range, rij(3), rik(3)
+      TYPE(dbt_type)                                     :: t_dummy
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(distribution_2d_type), POINTER                :: dist_2d
+      TYPE(distribution_3d_type)                         :: dist_3d
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:), TARGET                            :: basis_set_AO, basis_set_RI
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(mp_cart_type)                                 :: mp_comm_t3c
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_3c_iterator_type)               :: nl_3c_iter
+      TYPE(neighbor_list_3c_type)                        :: nl_3c
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: nl_2c
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(section_vals_type), POINTER                   :: hfx_section
+
+      NULLIFY (qs_kind_set, dist_2d, nl_2c, nl_iterator, dft_control, &
+               particle_set, kpoints, para_env, cell_to_index, hfx_section)
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, nkind=nkind, qs_kind_set=qs_kind_set, distribution_2d=dist_2d, &
+                      dft_control=dft_control, particle_set=particle_set, kpoints=kpoints, &
+                      para_env=para_env, natom=natom)
+      nimg = dft_control%nimages
+      CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
+      kp_index_lbounds = LBOUND(cell_to_index)
+      kp_index_ubounds = UBOUND(cell_to_index)
+
+      hfx_section => section_vals_get_subs_vals(qs_env%input, "DFT%XC%HF%RI")
+      CALL section_vals_val_get(hfx_section, "KP_RI_EXTENSION_FACTOR", r_val=fact)
+      CALL section_vals_val_get(hfx_section, "KP_NGROUPS", i_val=ngroups)
+
+      ALLOCATE (basis_set_RI(nkind), basis_set_AO(nkind))
+      CALL basis_set_list_setup(basis_set_RI, ri_data%ri_basis_type, qs_kind_set)
+      CALL basis_set_list_setup(basis_set_AO, ri_data%orb_basis_type, qs_kind_set)
+
+      !In case of shortrange HFX potential, it is imprtant to be consistent with the rest of the KP
+      !code, and use EPS_SCHWARZ to determine the range (rather than eps_filter_2c in normal RI-HFX)
+      IF (ri_data%hfx_pot%potential_type == do_potential_short) THEN
+         CALL erfc_cutoff(ri_data%eps_schwarz, ri_data%hfx_pot%omega, ri_data%hfx_pot%cutoff_radius)
+      END IF
+
+      !Determine the range for contributing periodic images, and for the RI basis extension
+      ri_data%kp_RI_range = 0.0_dp
+      ri_data%kp_image_range = 0.0_dp
+      DO ikind = 1, nkind
+
+         CALL init_interaction_radii_orb_basis(basis_set_AO(ikind)%gto_basis_set, fact*ri_data%eps_pgf_orb)
+         CALL get_gto_basis_set(basis_set_AO(ikind)%gto_basis_set, kind_radius=RI_range)
+         ri_data%kp_RI_range = MAX(RI_range, ri_data%kp_RI_range)
+
+         CALL init_interaction_radii_orb_basis(basis_set_AO(ikind)%gto_basis_set, ri_data%eps_pgf_orb)
+         CALL init_interaction_radii_orb_basis(basis_set_RI(ikind)%gto_basis_set, ri_data%eps_pgf_orb)
+         CALL get_gto_basis_set(basis_set_RI(ikind)%gto_basis_set, kind_radius=image_range)
+
+         image_range = 2.0_dp*image_range + cutoff_screen_factor*ri_data%hfx_pot%cutoff_radius
+         ri_data%kp_image_range = MAX(image_range, ri_data%kp_image_range)
+      END DO
+
+      CALL section_vals_val_get(hfx_section, "KP_RI_BUMP_FACTOR", r_val=bump_fact)
+      ri_data%kp_bump_rad = bump_fact*ri_data%kp_RI_range
+
+      !For the extent of the KP RI-HFX images, we are limited by the RI-HFX potential in
+      !(mu^0 sigma^a|P^0) (P^0|Q^b) (Q^b|nu^b lambda^a+c), if there is no contact between
+      !any P^0 and Q^b, then image b does not contribute
+      CALL build_2c_neighbor_lists(nl_2c, basis_set_RI, basis_set_RI, ri_data%hfx_pot, &
+                                   "HFX_2c_nl_RI", qs_env, sym_ij=.FALSE., dist_2d=dist_2d)
+
+      ALLOCATE (present_img(nimg))
+      present_img = 0
+      ri_data%nimg = 0
+      CALL neighbor_list_iterator_create(nl_iterator, nl_2c)
+      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+         CALL get_iterator_info(nl_iterator, r=rij, cell=cell_j)
+
+         dij = NORM2(rij)
+
+         j_img = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
+         IF (j_img > nimg .OR. j_img < 1) CYCLE
+
+         IF (dij > ri_data%kp_image_range) CYCLE
+
+         ri_data%nimg = MAX(j_img, ri_data%nimg)
+         present_img(j_img) = 1
+
+      END DO
+      CALL neighbor_list_iterator_release(nl_iterator)
+      CALL release_neighbor_list_sets(nl_2c)
+      CALL para_env%max(ri_data%nimg)
+      IF (ri_data%nimg > nimg) &
+         CPABORT("Make sure the smallest exponent of the RI-HFX basis is larger than that of the ORB basis.")
+
+      !Keep track of which images will not contribute, so that can be ignored before calculation
+      CALL para_env%sum(present_img)
+      ALLOCATE (ri_data%present_images(ri_data%nimg))
+      ri_data%present_images = 0
+      DO i_img = 1, ri_data%nimg
+         IF (present_img(i_img) > 0) ri_data%present_images(i_img) = 1
+      END DO
+
+      CALL create_3c_tensor(t_dummy, dist_AO_1, dist_AO_2, dist_RI, &
+                            ri_data%pgrid, ri_data%bsizes_AO, ri_data%bsizes_AO, ri_data%bsizes_RI, &
+                            map1=[1, 2], map2=[3], name="(AO AO | RI)")
+
+      CALL dbt_mp_environ_pgrid(ri_data%pgrid, pdims, pcoord)
+      CALL mp_comm_t3c%create(ri_data%pgrid%mp_comm_2d, 3, pdims)
+      CALL distribution_3d_create(dist_3d, dist_AO_1, dist_AO_2, dist_RI, &
+                                  nkind, particle_set, mp_comm_t3c, own_comm=.TRUE.)
+      DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
+      CALL dbt_destroy(t_dummy)
+
+      !For the extension of the RI basis P in (mu^0 sigma^a |P^i), we consider an atom if the distance,
+      !between mu^0 and P^i if smaller or equal to the kind radius of mu^0
+      CALL build_3c_neighbor_lists(nl_3c, basis_set_AO, basis_set_AO, basis_set_RI, dist_3d, &
+                                   ri_data%ri_metric, "HFX_3c_nl", qs_env, op_pos=2, sym_ij=.FALSE., &
+                                   own_dist=.TRUE.)
+
+      ALLOCATE (RI_cells(nimg))
+      RI_cells = 0
+
+      ALLOCATE (nRI_per_atom(natom))
+      nRI_per_atom = 0
+
+      CALL neighbor_list_3c_iterator_create(nl_3c_iter, nl_3c)
+      DO WHILE (neighbor_list_3c_iterate(nl_3c_iter) == 0)
+         CALL get_3c_iterator_info(nl_3c_iter, cell_k=cell_k, rik=rik, cell_j=cell_j, &
+                                   iatom=iatom, jatom=jatom, katom=katom)
+         dik = NORM2(rik)
+
+         IF (ANY([cell_j(1), cell_j(2), cell_j(3)] < kp_index_lbounds) .OR. &
+             ANY([cell_j(1), cell_j(2), cell_j(3)] > kp_index_ubounds)) CYCLE
+
+         jcell = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
+         IF (jcell > nimg .OR. jcell < 1) CYCLE
+
+         IF (ANY([cell_k(1), cell_k(2), cell_k(3)] < kp_index_lbounds) .OR. &
+             ANY([cell_k(1), cell_k(2), cell_k(3)] > kp_index_ubounds)) CYCLE
+
+         kcell = cell_to_index(cell_k(1), cell_k(2), cell_k(3))
+         IF (kcell > nimg .OR. kcell < 1) CYCLE
+
+         IF (dik > ri_data%kp_RI_range) CYCLE
+         RI_cells(kcell) = 1
+
+         IF (jcell == 1 .AND. iatom == jatom) nRI_per_atom(iatom) = nRI_per_atom(iatom) + ri_data%bsizes_RI(katom)
+      END DO
+      CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
+      CALL neighbor_list_3c_destroy(nl_3c)
+      CALL para_env%sum(RI_cells)
+      CALL para_env%sum(nRI_per_atom)
+
+      ALLOCATE (ri_data%img_to_RI_cell(nimg))
+      ri_data%ncell_RI = 0
+      ri_data%img_to_RI_cell = 0
+      DO i_img = 1, nimg
+         IF (RI_cells(i_img) > 0) THEN
+            ri_data%ncell_RI = ri_data%ncell_RI + 1
+            ri_data%img_to_RI_cell(i_img) = ri_data%ncell_RI
+         END IF
+      END DO
+
+      ALLOCATE (ri_data%RI_cell_to_img(ri_data%ncell_RI))
+      DO i_img = 1, nimg
+         IF (ri_data%img_to_RI_cell(i_img) > 0) ri_data%RI_cell_to_img(ri_data%img_to_RI_cell(i_img)) = i_img
+      END DO
+
+      !Print some info
+      IF (ri_data%unit_nr > 0) THEN
+         WRITE (ri_data%unit_nr, FMT="(/T3,A,I29)") &
+            "KP-HFX_RI_INFO| Number of RI-KP parallel groups:", ngroups
+         WRITE (ri_data%unit_nr, FMT="(T3,A,F35.3)") &
+            "KP-HFX_RI_INFO| RI basis extension factor:", fact
+         WRITE (ri_data%unit_nr, FMT="(T3,A,F31.3,A)") &
+            "KP-HFX_RI_INFO| RI basis extension radius:", ri_data%kp_RI_range*angstrom, " Ang"
+         WRITE (ri_data%unit_nr, FMT="(T3,A,F12.3,A, F6.3, A)") &
+            "KP-HFX_RI_INFO| RI basis bump factor and bump radius:", bump_fact, " /", &
+            ri_data%kp_bump_rad*angstrom, " Ang"
+         WRITE (ri_data%unit_nr, FMT="(T3,A,I16,A)") &
+            "KP-HFX_RI_INFO| The extended RI bases cover up to ", ri_data%ncell_RI, " unit cells"
+         WRITE (ri_data%unit_nr, FMT="(T3,A,I18)") &
+            "KP-HFX_RI_INFO| Average number of sgf in extended RI bases:", SUM(nRI_per_atom)/natom
+         WRITE (ri_data%unit_nr, FMT="(T3,A,F13.3,A)") &
+            "KP-HFX_RI_INFO| Consider all image cells within a radius of ", ri_data%kp_image_range*angstrom, " Ang"
+         WRITE (ri_data%unit_nr, FMT="(T3,A,I27/)") &
+            "KP-HFX_RI_INFO| Number of image cells considered: ", ri_data%nimg
+         CALL m_flush(ri_data%unit_nr)
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE get_kp_and_ri_images
+
+! **************************************************************************************************
+!> \brief A routine that creates tensors structure for rho_ao and 3c_ints in a stacked format for
+!>        the efficient contractions of rho_sigma^0,lambda^c * (mu^0 sigam^a | P) => TAS tensors
+!> \param res_stack ...
+!> \param rho_stack ...
+!> \param ints_stack ...
+!> \param rho_template ...
+!> \param ints_template ...
+!> \param stack_size ...
+!> \param ri_data ...
+!> \param qs_env ...
+!> \note The result tensor has the exact same shape and distribution as the integral tensor
+! **************************************************************************************************
+   SUBROUTINE get_stack_tensors(res_stack, rho_stack, ints_stack, rho_template, ints_template, &
+                                stack_size, ri_data, qs_env)
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: res_stack, rho_stack, ints_stack
+      TYPE(dbt_type), INTENT(INOUT)                      :: rho_template, ints_template
+      INTEGER, INTENT(IN)                                :: stack_size
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      INTEGER                                            :: is, nblks, nblks_3c(3), pdims_3d(3)
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes_RI_ext, bsizes_stack, dist1, &
+                                                            dist2, dist3, dist_stack1, &
+                                                            dist_stack2, dist_stack3
+      TYPE(dbt_distribution_type)                        :: t_dist
+      TYPE(dbt_pgrid_type)                               :: pgrid
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+
+      NULLIFY (para_env)
+
+      CALL get_qs_env(qs_env, para_env=para_env)
+
+      nblks = SIZE(ri_data%bsizes_AO_split)
+      ALLOCATE (bsizes_stack(stack_size*nblks))
+      DO is = 1, stack_size
+         bsizes_stack((is - 1)*nblks + 1:is*nblks) = ri_data%bsizes_AO_split(:)
+      END DO
+
+      ALLOCATE (dist1(nblks), dist2(nblks), dist_stack1(stack_size*nblks), dist_stack2(stack_size*nblks))
+      CALL dbt_get_info(rho_template, proc_dist_1=dist1, proc_dist_2=dist2)
+      DO is = 1, stack_size
+         dist_stack1((is - 1)*nblks + 1:is*nblks) = dist1(:)
+         dist_stack2((is - 1)*nblks + 1:is*nblks) = dist2(:)
+      END DO
+
+      !First 2c tensor matches the distribution of template
+      !It is stacked in both directions
+      CALL dbt_distribution_new(t_dist, ri_data%pgrid_2d, dist_stack1, dist_stack2)
+      CALL dbt_create(rho_stack(1), "RHO_stack", t_dist, [1], [2], bsizes_stack, bsizes_stack)
+      CALL dbt_distribution_destroy(t_dist)
+      DEALLOCATE (dist1, dist2, dist_stack1, dist_stack2)
+
+      !Second 2c tensor has optimal distribution on the 2d pgrid
+      CALL create_2c_tensor(rho_stack(2), dist1, dist2, ri_data%pgrid_2d, bsizes_stack, bsizes_stack, name="RHO_stack")
+      DEALLOCATE (dist1, dist2)
+
+      CALL dbt_get_info(ints_template, nblks_total=nblks_3c)
+      ALLOCATE (dist1(nblks_3c(1)), dist2(nblks_3c(2)), dist3(nblks_3c(3)))
+      ALLOCATE (dist_stack3(stack_size*nblks_3c(3)), bsizes_RI_ext(nblks_3c(2)))
+      CALL dbt_get_info(ints_template, proc_dist_1=dist1, proc_dist_2=dist2, &
+                        proc_dist_3=dist3, blk_size_2=bsizes_RI_ext)
+      DO is = 1, stack_size
+         dist_stack3((is - 1)*nblks_3c(3) + 1:is*nblks_3c(3)) = dist3(:)
+      END DO
+
+      !First 3c tensor matches the distribution of template
+      CALL dbt_distribution_new(t_dist, ri_data%pgrid_1, dist1, dist2, dist_stack3)
+      CALL dbt_create(ints_stack(1), "ints_stack", t_dist, [1, 2], [3], ri_data%bsizes_AO_split, &
+                      bsizes_RI_ext, bsizes_stack)
+      CALL dbt_distribution_destroy(t_dist)
+      DEALLOCATE (dist1, dist2, dist3, dist_stack3)
+
+      !Second 3c tensor has optimal pgrid
+      pdims_3d = 0
+      CALL dbt_pgrid_create(para_env, pdims_3d, pgrid, tensor_dims=[nblks_3c(1), nblks_3c(2), stack_size*nblks_3c(3)])
+      CALL create_3c_tensor(ints_stack(2), dist1, dist2, dist3, pgrid, ri_data%bsizes_AO_split, &
+                            bsizes_RI_ext, bsizes_stack, [1, 2], [3], name="ints_stack")
+      DEALLOCATE (dist1, dist2, dist3)
+      CALL dbt_pgrid_destroy(pgrid)
+
+      !The result tensor has the same shape and dist as the integral tensor
+      CALL dbt_create(ints_stack(1), res_stack(1))
+      CALL dbt_create(ints_stack(2), res_stack(2))
+
+   END SUBROUTINE get_stack_tensors
+
+! **************************************************************************************************
+!> \brief Fill the stack of 3c tensors accrding to the order in the images input
+!> \param t_3c_stack ...
+!> \param t_3c_in ...
+!> \param images ...
+!> \param stack_dim ...
+!> \param ri_data ...
+!> \param filter_at ...
+!> \param filter_dim ...
+!> \param idx_to_at ...
+!> \param img_bounds ...
+! **************************************************************************************************
+   SUBROUTINE fill_3c_stack(t_3c_stack, t_3c_in, images, stack_dim, ri_data, filter_at, filter_dim, &
+                            idx_to_at, img_bounds)
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_stack
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_3c_in
+      INTEGER, DIMENSION(:), INTENT(INOUT)               :: images
+      INTEGER, INTENT(IN)                                :: stack_dim
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      INTEGER, INTENT(IN), OPTIONAL                      :: filter_at, filter_dim
+      INTEGER, DIMENSION(:), INTENT(INOUT), OPTIONAL     :: idx_to_at
+      INTEGER, INTENT(IN), OPTIONAL                      :: img_bounds(2)
+
+      INTEGER                                            :: dest(3), i_img, idx, ind(3), lb, nblks, &
+                                                            nimg, offset, ub
+      LOGICAL                                            :: do_filter, found
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: blk
+      TYPE(dbt_iterator_type)                            :: iter
+
+      !We loop over the a images from the ac_pairs, then copy the 3c ints to the correct spot in
+      !in the stack tensor (corresponding to pair index). Distributions match by construction
+      nimg = ri_data%nimg
+      nblks = SIZE(ri_data%bsizes_AO_split)
+
+      do_filter = .FALSE.
+      IF (PRESENT(filter_at) .AND. PRESENT(filter_dim) .AND. PRESENT(idx_to_at)) do_filter = .TRUE.
+
+      lb = 1
+      ub = nimg
+      offset = 0
+      IF (PRESENT(img_bounds)) THEN
+         lb = img_bounds(1)
+         ub = img_bounds(2) - 1
+         offset = lb - 1
+      END IF
+
+      DO idx = lb, ub
+         i_img = images(idx)
+         IF (i_img == 0 .OR. i_img > nimg) CYCLE
+
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED(idx,i_img,t_3c_in,t_3c_stack,nblks,stack_dim,filter_at,filter_dim,idx_to_at,do_filter,offset) &
+!$OMP PRIVATE(iter,ind,blk,found,dest)
+         CALL dbt_iterator_start(iter, t_3c_in(i_img))
+         DO WHILE (dbt_iterator_blocks_left(iter))
+            CALL dbt_iterator_next_block(iter, ind)
+            CALL dbt_get_block(t_3c_in(i_img), ind, blk, found)
+            IF (.NOT. found) CYCLE
+
+            IF (do_filter) THEN
+               IF (.NOT. idx_to_at(ind(filter_dim)) == filter_at) CYCLE
+            END IF
+
+            IF (stack_dim == 1) THEN
+               dest = [(idx - offset - 1)*nblks + ind(1), ind(2), ind(3)]
+            ELSE IF (stack_dim == 2) THEN
+               dest = [ind(1), (idx - offset - 1)*nblks + ind(2), ind(3)]
+            ELSE
+               dest = [ind(1), ind(2), (idx - offset - 1)*nblks + ind(3)]
+            END IF
+
+            CALL dbt_put_block(t_3c_stack, dest, SHAPE(blk), blk)
+            DEALLOCATE (blk)
+         END DO
+         CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+      END DO !i_img
+      CALL dbt_finalize(t_3c_stack)
+
+   END SUBROUTINE fill_3c_stack
+
+! **************************************************************************************************
+!> \brief Fill the stack of 2c tensors based on the content of images input
+!> \param t_2c_stack ...
+!> \param t_2c_in ...
+!> \param images ...
+!> \param stack_dim ...
+!> \param ri_data ...
+!> \param img_bounds ...
+!> \param shift ...
+! **************************************************************************************************
+   SUBROUTINE fill_2c_stack(t_2c_stack, t_2c_in, images, stack_dim, ri_data, img_bounds, shift)
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_2c_stack
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_2c_in
+      INTEGER, DIMENSION(:), INTENT(INOUT)               :: images
+      INTEGER, INTENT(IN)                                :: stack_dim
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      INTEGER, INTENT(IN), OPTIONAL                      :: img_bounds(2), shift
+
+      INTEGER                                            :: dest(2), i_img, idx, ind(2), lb, &
+                                                            my_shift, nblks, nimg, offset, ub
+      LOGICAL                                            :: found
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: blk
+      TYPE(dbt_iterator_type)                            :: iter
+
+      !We loop over the a images from the ac_pairs, then copy the 3c ints to the correct spot in
+      !in the stack tensor (corresponding to pair index). Distributions match by construction
+      nimg = ri_data%nimg
+      nblks = SIZE(ri_data%bsizes_AO_split)
+
+      lb = 1
+      ub = nimg
+      offset = 0
+      IF (PRESENT(img_bounds)) THEN
+         lb = img_bounds(1)
+         ub = img_bounds(2) - 1
+         offset = lb - 1
+      END IF
+
+      my_shift = 1
+      IF (PRESENT(shift)) my_shift = shift
+
+      DO idx = lb, ub
+         i_img = images(idx)
+         IF (i_img == 0 .OR. i_img > nimg) CYCLE
+
+!$OMP PARALLEL DEFAULT(NONE) SHARED(idx,i_img,t_2c_in,t_2c_stack,nblks,stack_dim,offset,my_shift) &
+!$OMP PRIVATE(iter,ind,blk,found,dest)
+         CALL dbt_iterator_start(iter, t_2c_in(i_img))
+         DO WHILE (dbt_iterator_blocks_left(iter))
+            CALL dbt_iterator_next_block(iter, ind)
+            CALL dbt_get_block(t_2c_in(i_img), ind, blk, found)
+            IF (.NOT. found) CYCLE
+
+            IF (stack_dim == 1) THEN
+               dest = [(idx - offset - 1)*nblks + ind(1), (my_shift - 1)*nblks + ind(2)]
+            ELSE
+               dest = [(my_shift - 1)*nblks + ind(1), (idx - offset - 1)*nblks + ind(2)]
+            END IF
+
+            CALL dbt_put_block(t_2c_stack, dest, SHAPE(blk), blk)
+            DEALLOCATE (blk)
+         END DO
+         CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+      END DO !idx
+      CALL dbt_finalize(t_2c_stack)
+
+   END SUBROUTINE fill_2c_stack
+
+! **************************************************************************************************
+!> \brief Unstacks a stacked 3c tensor containing t_3c_apc
+!> \param t_3c_apc ...
+!> \param t_stacked ...
+!> \param idx ...
+! **************************************************************************************************
+   SUBROUTINE unstack_t_3c_apc(t_3c_apc, t_stacked, idx)
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_apc, t_stacked
+      INTEGER, INTENT(IN)                                :: idx
+
+      INTEGER                                            :: current_idx
+      INTEGER, DIMENSION(3)                              :: ind, nblks_3c
+      LOGICAL                                            :: found
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: blk
+      TYPE(dbt_iterator_type)                            :: iter
+
+      !Note: t_3c_apc and t_stacked must have the same ditribution
+      CALL dbt_get_info(t_3c_apc, nblks_total=nblks_3c)
+
+!$OMP PARALLEL DEFAULT(NONE) SHARED(t_3c_apc,t_stacked,idx,nblks_3c) PRIVATE(iter,ind,blk,found,current_idx)
+      CALL dbt_iterator_start(iter, t_stacked)
+      DO WHILE (dbt_iterator_blocks_left(iter))
+         CALL dbt_iterator_next_block(iter, ind)
+
+         !tensor is stacked along the 3rd dimension
+         current_idx = (ind(3) - 1)/nblks_3c(3) + 1
+         IF (.NOT. idx == current_idx) CYCLE
+
+         CALL dbt_get_block(t_stacked, ind, blk, found)
+         IF (.NOT. found) CYCLE
+
+         CALL dbt_put_block(t_3c_apc, [ind(1), ind(2), ind(3) - (idx - 1)*nblks_3c(3)], SHAPE(blk), blk)
+         DEALLOCATE (blk)
+      END DO
+      CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+
+   END SUBROUTINE unstack_t_3c_apc
+
+! **************************************************************************************************
+!> \brief copies the 3c integrals correspoinding to a single atom mu from the general (P^0| mu^0 sigam^a)
+!> \param t_3c_at ...
+!> \param t_3c_ints ...
+!> \param iatom ...
+!> \param dim_at ...
+!> \param idx_to_at ...
+! **************************************************************************************************
+   SUBROUTINE get_atom_3c_ints(t_3c_at, t_3c_ints, iatom, dim_at, idx_to_at)
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_at, t_3c_ints
+      INTEGER, INTENT(IN)                                :: iatom, dim_at
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: idx_to_at
+
+      INTEGER, DIMENSION(3)                              :: ind
+      LOGICAL                                            :: found
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: blk
+      TYPE(dbt_iterator_type)                            :: iter
+
+!$OMP PARALLEL DEFAULT(NONE) SHARED(t_3c_ints,t_3c_at,iatom,idx_to_at,dim_at) PRIVATE(iter,ind,blk,found)
+      CALL dbt_iterator_start(iter, t_3c_ints)
+      DO WHILE (dbt_iterator_blocks_left(iter))
+         CALL dbt_iterator_next_block(iter, ind)
+         IF (.NOT. idx_to_at(ind(dim_at)) == iatom) CYCLE
+
+         CALL dbt_get_block(t_3c_ints, ind, blk, found)
+         IF (.NOT. found) CYCLE
+
+         CALL dbt_put_block(t_3c_at, ind, SHAPE(blk), blk)
+         DEALLOCATE (blk)
+      END DO
+      CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+      CALL dbt_finalize(t_3c_at)
+
+   END SUBROUTINE get_atom_3c_ints
+
+! **************************************************************************************************
+!> \brief Precalculate the 3c and 2c derivatives tensors
+!> \param t_3c_der_RI ...
+!> \param t_3c_der_AO ...
+!> \param mat_der_pot ...
+!> \param t_2c_der_metric ...
+!> \param ri_data ...
+!> \param qs_env ...
+! **************************************************************************************************
+   SUBROUTINE precalc_derivatives(t_3c_der_RI, t_3c_der_AO, mat_der_pot, t_2c_der_metric, ri_data, qs_env)
+      TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: t_3c_der_RI, t_3c_der_AO
+      TYPE(dbcsr_type), DIMENSION(:, :), INTENT(INOUT)   :: mat_der_pot
+      TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: t_2c_der_metric
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'precalc_derivatives'
+
+      INTEGER                                            :: handle, handle2, i_img, i_mem, i_RI, &
+                                                            i_xyz, iatom, n_mem, natom, nblks_RI, &
+                                                            ncell_RI, nimg, nkind, nthreads
+      INTEGER(int_8)                                     :: nze
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: bsizes_RI_ext, bsizes_RI_ext_split, dist_AO_1, &
+         dist_AO_2, dist_RI, dist_RI_ext, dummy_end, dummy_start, end_blocks, start_blocks
+      INTEGER, DIMENSION(3)                              :: pcoord, pdims
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
+      REAL(dp)                                           :: occ
+      TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
+      TYPE(dbcsr_type)                                   :: dbcsr_template
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:, :)     :: mat_der_metric
+      TYPE(dbt_distribution_type)                        :: t_dist
+      TYPE(dbt_pgrid_type)                               :: pgrid
+      TYPE(dbt_type)                                     :: t_3c_template
+      TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :, :)    :: t_3c_der_AO_prv, t_3c_der_RI_prv
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(distribution_2d_type), POINTER                :: dist_2d
+      TYPE(distribution_3d_type)                         :: dist_3d
+      TYPE(gto_basis_set_p_type), ALLOCATABLE, &
+         DIMENSION(:), TARGET                            :: basis_set_AO, basis_set_RI
+      TYPE(mp_cart_type)                                 :: mp_comm_t3c
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(neighbor_list_3c_type)                        :: nl_3c
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: nl_2c
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      NULLIFY (qs_kind_set, dist_2d, nl_2c, particle_set, dft_control, para_env, row_bsize, col_bsize)
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, nkind=nkind, qs_kind_set=qs_kind_set, distribution_2d=dist_2d, natom=natom, &
+                      particle_set=particle_set, dft_control=dft_control, para_env=para_env)
+
+      nimg = ri_data%nimg
+      ncell_RI = ri_data%ncell_RI
+
+      ALLOCATE (basis_set_RI(nkind), basis_set_AO(nkind))
+      CALL basis_set_list_setup(basis_set_RI, ri_data%ri_basis_type, qs_kind_set)
+      CALL get_particle_set(particle_set, qs_kind_set, basis=basis_set_RI)
+      CALL basis_set_list_setup(basis_set_AO, ri_data%orb_basis_type, qs_kind_set)
+      CALL get_particle_set(particle_set, qs_kind_set, basis=basis_set_AO)
+
+      !Dealing with the 3c derivatives
+      nthreads = 1
+!$    nthreads = omp_get_num_threads()
+      pdims = 0
+      CALL dbt_pgrid_create(para_env, pdims, pgrid, tensor_dims=[MAX(1, natom/(ri_data%n_mem*nthreads)), natom, natom])
+
+      CALL create_3c_tensor(t_3c_template, dist_AO_1, dist_AO_2, dist_RI, pgrid, &
+                            ri_data%bsizes_AO, ri_data%bsizes_AO, ri_data%bsizes_RI, &
+                            map1=[1, 2], map2=[3], name="tmp")
+      CALL dbt_destroy(t_3c_template)
+
+      !We stack the RI basis images. Keep consistent distribution
+      nblks_RI = SIZE(ri_data%bsizes_RI_split)
+      ALLOCATE (dist_RI_ext(natom*ncell_RI))
+      ALLOCATE (bsizes_RI_ext(natom*ncell_RI))
+      ALLOCATE (bsizes_RI_ext_split(nblks_RI*ncell_RI))
+      DO i_RI = 1, ncell_RI
+         bsizes_RI_ext((i_RI - 1)*natom + 1:i_RI*natom) = ri_data%bsizes_RI(:)
+         dist_RI_ext((i_RI - 1)*natom + 1:i_RI*natom) = dist_RI(:)
+         bsizes_RI_ext_split((i_RI - 1)*nblks_RI + 1:i_RI*nblks_RI) = ri_data%bsizes_RI_split(:)
+      END DO
+
+      CALL dbt_distribution_new(t_dist, pgrid, dist_AO_1, dist_AO_2, dist_RI_ext)
+      CALL dbt_create(t_3c_template, "KP_3c_der", t_dist, [1, 2], [3], &
+                      ri_data%bsizes_AO, ri_data%bsizes_AO, bsizes_RI_ext)
+      CALL dbt_distribution_destroy(t_dist)
+
+      ALLOCATE (t_3c_der_RI_prv(nimg, 1, 3), t_3c_der_AO_prv(nimg, 1, 3))
+      DO i_xyz = 1, 3
+         DO i_img = 1, nimg
+            CALL dbt_create(t_3c_template, t_3c_der_RI_prv(i_img, 1, i_xyz))
+            CALL dbt_create(t_3c_template, t_3c_der_AO_prv(i_img, 1, i_xyz))
+         END DO
+      END DO
+      CALL dbt_destroy(t_3c_template)
+
+      CALL dbt_mp_environ_pgrid(pgrid, pdims, pcoord)
+      CALL mp_comm_t3c%create(pgrid%mp_comm_2d, 3, pdims)
+      CALL distribution_3d_create(dist_3d, dist_AO_1, dist_AO_2, dist_RI, &
+                                  nkind, particle_set, mp_comm_t3c, own_comm=.TRUE.)
+      DEALLOCATE (dist_RI, dist_AO_1, dist_AO_2)
+      CALL dbt_pgrid_destroy(pgrid)
+
+      CALL build_3c_neighbor_lists(nl_3c, basis_set_AO, basis_set_AO, basis_set_RI, dist_3d, ri_data%ri_metric, &
+                                   "HFX_3c_nl", qs_env, op_pos=2, sym_jk=.FALSE., own_dist=.TRUE.)
+
+      n_mem = ri_data%n_mem
+      CALL create_tensor_batches(ri_data%bsizes_RI, n_mem, dummy_start, dummy_end, &
+                                 start_blocks, end_blocks)
+      DEALLOCATE (dummy_start, dummy_end)
+
+      CALL create_3c_tensor(t_3c_template, dist_RI, dist_AO_1, dist_AO_2, ri_data%pgrid_2, &
+                            bsizes_RI_ext_split, ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
+                            map1=[1], map2=[2, 3], name="der (RI | AO AO)")
+      DO i_xyz = 1, 3
+         DO i_img = 1, nimg
+            CALL dbt_create(t_3c_template, t_3c_der_RI(i_img, i_xyz))
+            CALL dbt_create(t_3c_template, t_3c_der_AO(i_img, i_xyz))
+         END DO
+      END DO
+
+      DO i_mem = 1, n_mem
+         CALL build_3c_derivatives(t_3c_der_AO_prv, t_3c_der_RI_prv, ri_data%filter_eps, qs_env, &
+                                   nl_3c, basis_set_AO, basis_set_AO, basis_set_RI, &
+                                   ri_data%ri_metric, der_eps=ri_data%eps_schwarz_forces, op_pos=2, &
+                                   do_kpoints=.TRUE., do_hfx_kpoints=.TRUE., &
+                                   bounds_k=[start_blocks(i_mem), end_blocks(i_mem)], &
+                                   RI_range=ri_data%kp_RI_range, img_to_RI_cell=ri_data%img_to_RI_cell)
+
+         CALL timeset(routineN//"_cpy", handle2)
+         !We go from (mu^0 sigma^i | P^j) to (P^i| sigma^j mu^0) and finally to (P^i| mu^0 sigma^j)
+         DO i_img = 1, nimg
+            DO i_xyz = 1, 3
+               !derivative wrt to mu^0
+               CALL get_tensor_occupancy(t_3c_der_AO_prv(i_img, 1, i_xyz), nze, occ)
+               IF (nze > 0) THEN
+                  CALL dbt_copy(t_3c_der_AO_prv(i_img, 1, i_xyz), t_3c_template, &
+                                order=[3, 2, 1], move_data=.TRUE.)
+                  CALL dbt_filter(t_3c_template, ri_data%filter_eps)
+                  CALL dbt_copy(t_3c_template, t_3c_der_AO(i_img, i_xyz), &
+                                order=[1, 3, 2], move_data=.TRUE., summation=.TRUE.)
+               END IF
+
+               !derivative wrt to P^i
+               CALL get_tensor_occupancy(t_3c_der_RI_prv(i_img, 1, i_xyz), nze, occ)
+               IF (nze > 0) THEN
+                  CALL dbt_copy(t_3c_der_RI_prv(i_img, 1, i_xyz), t_3c_template, &
+                                order=[3, 2, 1], move_data=.TRUE.)
+                  CALL dbt_filter(t_3c_template, ri_data%filter_eps)
+                  CALL dbt_copy(t_3c_template, t_3c_der_RI(i_img, i_xyz), &
+                                order=[1, 3, 2], move_data=.TRUE., summation=.TRUE.)
+               END IF
+            END DO
+         END DO
+         CALL timestop(handle2)
+      END DO
+      CALL dbt_destroy(t_3c_template)
+
+      CALL neighbor_list_3c_destroy(nl_3c)
+      DO i_xyz = 1, 3
+         DO i_img = 1, nimg
+            CALL dbt_destroy(t_3c_der_RI_prv(i_img, 1, i_xyz))
+            CALL dbt_destroy(t_3c_der_AO_prv(i_img, 1, i_xyz))
+         END DO
+      END DO
+      DEALLOCATE (t_3c_der_RI_prv, t_3c_der_AO_prv)
+
+      !Reorder 3c derivatives to be consistant with ints
+      CALL reorder_3c_derivs(t_3c_der_RI, ri_data)
+      CALL reorder_3c_derivs(t_3c_der_AO, ri_data)
+
+      CALL timeset(routineN//"_2c", handle2)
+      !The 2-center derivatives
+      CALL cp_dbcsr_dist2d_to_dist(dist_2d, dbcsr_dist)
+      ALLOCATE (row_bsize(SIZE(ri_data%bsizes_RI)))
+      ALLOCATE (col_bsize(SIZE(ri_data%bsizes_RI)))
+      row_bsize(:) = ri_data%bsizes_RI
+      col_bsize(:) = ri_data%bsizes_RI
+
+      CALL dbcsr_create(dbcsr_template, "2c_der", dbcsr_dist, dbcsr_type_no_symmetry, &
+                        row_bsize, col_bsize)
+      CALL dbcsr_distribution_release(dbcsr_dist)
+      DEALLOCATE (col_bsize, row_bsize)
+
+      ALLOCATE (mat_der_metric(nimg, 3))
+      DO i_xyz = 1, 3
+         DO i_img = 1, nimg
+            CALL dbcsr_create(mat_der_pot(i_img, i_xyz), template=dbcsr_template)
+            CALL dbcsr_create(mat_der_metric(i_img, i_xyz), template=dbcsr_template)
+         END DO
+      END DO
+      CALL dbcsr_release(dbcsr_template)
+
+      !HFX potential derivatives
+      CALL build_2c_neighbor_lists(nl_2c, basis_set_RI, basis_set_RI, ri_data%hfx_pot, &
+                                   "HFX_2c_nl_pot", qs_env, sym_ij=.FALSE., dist_2d=dist_2d)
+      CALL build_2c_derivatives(mat_der_pot, ri_data%filter_eps_2c, qs_env, nl_2c, &
+                                basis_set_RI, basis_set_RI, ri_data%hfx_pot, do_kpoints=.TRUE.)
+      CALL release_neighbor_list_sets(nl_2c)
+
+      !RI metric derivatives
+      CALL build_2c_neighbor_lists(nl_2c, basis_set_RI, basis_set_RI, ri_data%ri_metric, &
+                                   "HFX_2c_nl_pot", qs_env, sym_ij=.FALSE., dist_2d=dist_2d)
+      CALL build_2c_derivatives(mat_der_metric, ri_data%filter_eps_2c, qs_env, nl_2c, &
+                                basis_set_RI, basis_set_RI, ri_data%ri_metric, do_kpoints=.TRUE.)
+      CALL release_neighbor_list_sets(nl_2c)
+
+      !Get into extended RI basis and tensor format
+      DO i_xyz = 1, 3
+         DO iatom = 1, natom
+            CALL dbt_create(ri_data%t_2c_inv(1, 1), t_2c_der_metric(iatom, i_xyz))
+            CALL get_ext_2c_int(t_2c_der_metric(iatom, i_xyz), mat_der_metric(:, i_xyz), &
+                                iatom, iatom, 1, ri_data, qs_env)
+         END DO
+         DO i_img = 1, nimg
+            CALL dbcsr_release(mat_der_metric(i_img, i_xyz))
+         END DO
+      END DO
+      CALL timestop(handle2)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE precalc_derivatives
+
+! **************************************************************************************************
+!> \brief Update the forces due to the derivative of the a 2-center product d/dR (Q|R)
+!> \param force ...
+!> \param t_2c_contr A precontracted tensor containing sum_abcdPS (ab|P)(P|Q)^-1 (R|S)^-1 (S|cd) P_ac P_bd
+!> \param t_2c_der the d/dR (Q|R) tensor, in all 3 cartesian directions
+!> \param atom_of_kind ...
+!> \param kind_of ...
+!> \param img in which periodic image the second center of the tensor is
+!> \param pref ...
+!> \param ri_data ...
+!> \param qs_env ...
+!> \param work_virial ...
+!> \param cell ...
+!> \param particle_set ...
+!> \param diag ...
+!> \param offdiag ...
+!> \note IMPORTANT: t_tc_contr and t_2c_der need to have the same distribution. Atomic block sizes are
+!>                  assumed
+! **************************************************************************************************
+   SUBROUTINE get_2c_der_force(force, t_2c_contr, t_2c_der, atom_of_kind, kind_of, img, pref, &
+                               ri_data, qs_env, work_virial, cell, particle_set, diag, offdiag)
+
+      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_2c_contr
+      TYPE(dbt_type), DIMENSION(:), INTENT(INOUT)        :: t_2c_der
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: atom_of_kind, kind_of
+      INTEGER, INTENT(IN)                                :: img
+      REAL(dp), INTENT(IN)                               :: pref
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      REAL(dp), DIMENSION(3, 3), INTENT(INOUT), OPTIONAL :: work_virial
+      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
+      TYPE(particle_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: particle_set
+      LOGICAL, INTENT(IN), OPTIONAL                      :: diag, offdiag
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'get_2c_der_force'
+
+      INTEGER                                            :: handle, i_img, i_RI, i_xyz, iat, &
+                                                            iat_of_kind, ikind, j_img, j_RI, &
+                                                            j_xyz, jat, jat_of_kind, jkind, natom
+      INTEGER, DIMENSION(2)                              :: ind
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      LOGICAL                                            :: found, my_diag, my_offdiag, use_virial
+      REAL(dp)                                           :: new_force
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :), TARGET     :: contr_blk, der_blk
+      REAL(dp), DIMENSION(3)                             :: scoord
+      TYPE(dbt_iterator_type)                            :: iter
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      NULLIFY (kpoints, index_to_cell)
+
+      !Loop over the blocks of d/dR (Q|R), contract with the corresponding block of t_2c_contr and
+      !update the relevant force
+
+      CALL timeset(routineN, handle)
+
+      use_virial = .FALSE.
+      IF (PRESENT(work_virial) .AND. PRESENT(cell) .AND. PRESENT(particle_set)) use_virial = .TRUE.
+
+      my_diag = .FALSE.
+      IF (PRESENT(diag)) my_diag = diag
+
+      my_offdiag = .FALSE.
+      IF (PRESENT(diag)) my_offdiag = offdiag
+
+      CALL get_qs_env(qs_env, kpoints=kpoints, natom=natom)
+      CALL get_kpoint_info(kpoints, index_to_cell=index_to_cell)
+
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED(t_2c_der,t_2c_contr,work_virial,force,use_virial,natom,index_to_cell,ri_data,img) &
+!$OMP SHARED(pref,atom_of_kind,kind_of,particle_set,cell,my_diag,my_offdiag) &
+!$OMP PRIVATE(i_xyz,j_xyz,iter,ind,der_blk,contr_blk,found,new_force,i_RI,i_img,j_RI,j_img) &
+!$OMP PRIVATE(iat,jat,iat_of_kind,jat_of_kind,ikind,jkind,scoord)
+      DO i_xyz = 1, 3
+         CALL dbt_iterator_start(iter, t_2c_der(i_xyz))
+         DO WHILE (dbt_iterator_blocks_left(iter))
+            CALL dbt_iterator_next_block(iter, ind)
+
+            !Only take forecs due to block diagonal or block off-diagonal, depending on arguments
+            IF ((my_diag .AND. .NOT. my_offdiag) .OR. (.NOT. my_diag .AND. my_offdiag)) THEN
+               IF (my_diag .AND. (ind(1) .NE. ind(2))) CYCLE
+               IF (my_offdiag .AND. (ind(1) == ind(2))) CYCLE
+            END IF
+
+            CALL dbt_get_block(t_2c_der(i_xyz), ind, der_blk, found)
+            CPASSERT(found)
+            CALL dbt_get_block(t_2c_contr, ind, contr_blk, found)
+
+            IF (found) THEN
+
+               !an element of d/dR (Q|R) corresponds to 2 things because of translational invariance
+               !(Q'| R) = - (Q| R'), once wrt the center on Q, and once on R
+               new_force = pref*SUM(der_blk(:, :)*contr_blk(:, :))
+
+               i_RI = (ind(1) - 1)/natom + 1
+               i_img = ri_data%RI_cell_to_img(i_RI)
+               iat = ind(1) - (i_RI - 1)*natom
+               iat_of_kind = atom_of_kind(iat)
+               ikind = kind_of(iat)
+
+               j_RI = (ind(2) - 1)/natom + 1
+               j_img = ri_data%RI_cell_to_img(j_RI)
+               jat = ind(2) - (j_RI - 1)*natom
+               jat_of_kind = atom_of_kind(jat)
+               jkind = kind_of(jat)
+
+               !Force on iatom (first center)
+!$OMP ATOMIC
+               force(ikind)%fock_4c(i_xyz, iat_of_kind) = force(ikind)%fock_4c(i_xyz, iat_of_kind) &
+                                                          + new_force
+
+               IF (use_virial) THEN
+
+                  CALL real_to_scaled(scoord, pbc(particle_set(iat)%r, cell), cell)
+                  scoord(:) = scoord(:) + REAL(index_to_cell(:, i_img), dp)
+
+                  DO j_xyz = 1, 3
+!$OMP ATOMIC
+                     work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + new_force*scoord(j_xyz)
+                  END DO
+               END IF
+
+               !Force on jatom (second center)
+!$OMP ATOMIC
+               force(jkind)%fock_4c(i_xyz, jat_of_kind) = force(jkind)%fock_4c(i_xyz, jat_of_kind) &
+                                                          - new_force
+
+               IF (use_virial) THEN
+
+                  CALL real_to_scaled(scoord, pbc(particle_set(jat)%r, cell), cell)
+                  scoord(:) = scoord(:) + REAL(index_to_cell(:, j_img) + index_to_cell(:, img), dp)
+
+                  DO j_xyz = 1, 3
+!$OMP ATOMIC
+                     work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) - new_force*scoord(j_xyz)
+                  END DO
+               END IF
+
+               DEALLOCATE (contr_blk)
+            END IF
+
+            DEALLOCATE (der_blk)
+         END DO !iter
+         CALL dbt_iterator_stop(iter)
+
+      END DO !i_xyz
+!$OMP END PARALLEL
+      CALL timestop(handle)
+
+   END SUBROUTINE get_2c_der_force
+
+! **************************************************************************************************
+!> \brief This routines calculates the force contribution from a trace over 3D tensors, i.e.
+!>        force = sum_ijk A_ijk B_ijk., the B tensor is (P^0| sigma^0 lambda^img), with P in the
+!>        extended RI basis. Note that all tensors are stacked along the 3rd dimension
+!> \param force ...
+!> \param t_3c_contr ...
+!> \param t_3c_der_1 ...
+!> \param t_3c_der_2 ...
+!> \param atom_of_kind ...
+!> \param kind_of ...
+!> \param idx_to_at_RI ...
+!> \param idx_to_at_AO ...
+!> \param i_images ...
+!> \param lb_img ...
+!> \param pref ...
+!> \param ri_data ...
+!> \param qs_env ...
+!> \param work_virial ...
+!> \param cell ...
+!> \param particle_set ...
+! **************************************************************************************************
+   SUBROUTINE get_force_from_3c_trace(force, t_3c_contr, t_3c_der_1, t_3c_der_2, atom_of_kind, kind_of, &
+                                      idx_to_at_RI, idx_to_at_AO, i_images, lb_img, pref, &
+                                      ri_data, qs_env, work_virial, cell, particle_set)
+
+      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_contr
+      TYPE(dbt_type), DIMENSION(3), INTENT(INOUT)        :: t_3c_der_1, t_3c_der_2
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: atom_of_kind, kind_of, idx_to_at_RI, &
+                                                            idx_to_at_AO, i_images
+      INTEGER, INTENT(IN)                                :: lb_img
+      REAL(dp), INTENT(IN)                               :: pref
+      TYPE(hfx_ri_type), INTENT(INOUT)                   :: ri_data
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      REAL(dp), DIMENSION(3, 3), INTENT(INOUT), OPTIONAL :: work_virial
+      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
+      TYPE(particle_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: particle_set
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'get_force_from_3c_trace'
+
+      INTEGER :: handle, i_RI, i_xyz, iat, iat_of_kind, idx, ikind, j_xyz, jat, jat_of_kind, &
+         jkind, kat, kat_of_kind, kkind, nblks_AO, nblks_RI, RI_img
+      INTEGER, DIMENSION(3)                              :: ind
+      INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
+      LOGICAL                                            :: found, found_1, found_2, use_virial
+      REAL(dp)                                           :: new_force
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :), TARGET  :: contr_blk, der_blk_1, der_blk_2, &
+                                                            der_blk_3
+      REAL(dp), DIMENSION(3)                             :: scoord
+      TYPE(dbt_iterator_type)                            :: iter
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      NULLIFY (kpoints, index_to_cell)
+
+      CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env, kpoints=kpoints)
+      CALL get_kpoint_info(kpoints, index_to_cell=index_to_cell)
+
+      nblks_RI = SIZE(ri_data%bsizes_RI_split)
+      nblks_AO = SIZE(ri_data%bsizes_AO_split)
+
+      use_virial = .FALSE.
+      IF (PRESENT(work_virial) .AND. PRESENT(cell) .AND. PRESENT(particle_set)) use_virial = .TRUE.
+
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP SHARED(t_3c_der_1, t_3c_der_2,t_3c_contr,work_virial,force,use_virial,index_to_cell,i_images,lb_img) &
+!$OMP SHARED(pref,idx_to_at_AO,atom_of_kind,kind_of,particle_set,cell,idx_to_at_RI,ri_data,nblks_RI,nblks_AO) &
+!$OMP PRIVATE(i_xyz,j_xyz,iter,ind,der_blk_1,contr_blk,found,new_force,iat,iat_of_kind,ikind,scoord) &
+!$OMP PRIVATE(jat,kat,jat_of_kind,kat_of_kind,jkind,kkind,i_RI,RI_img,der_blk_2,der_blk_3,found_1,found_2,idx)
+      CALL dbt_iterator_start(iter, t_3c_contr)
+      DO WHILE (dbt_iterator_blocks_left(iter))
+         CALL dbt_iterator_next_block(iter, ind)
+
+         CALL dbt_get_block(t_3c_contr, ind, contr_blk, found)
+         IF (found) THEN
+
+            DO i_xyz = 1, 3
+               CALL dbt_get_block(t_3c_der_1(i_xyz), ind, der_blk_1, found_1)
+               IF (.NOT. found_1) THEN
+                  DEALLOCATE (der_blk_1)
+                  ALLOCATE (der_blk_1(SIZE(contr_blk, 1), SIZE(contr_blk, 2), SIZE(contr_blk, 3)))
+                  der_blk_1(:, :, :) = 0.0_dp
+               END IF
+               CALL dbt_get_block(t_3c_der_2(i_xyz), ind, der_blk_2, found_2)
+               IF (.NOT. found_2) THEN
+                  DEALLOCATE (der_blk_2)
+                  ALLOCATE (der_blk_2(SIZE(contr_blk, 1), SIZE(contr_blk, 2), SIZE(contr_blk, 3)))
+                  der_blk_2(:, :, :) = 0.0_dp
+               END IF
+
+               ALLOCATE (der_blk_3(SIZE(contr_blk, 1), SIZE(contr_blk, 2), SIZE(contr_blk, 3)))
+               der_blk_3(:, :, :) = -(der_blk_1(:, :, :) + der_blk_2(:, :, :))
+
+               !We assume the tensors are in the format (P^0| sigma^0 mu^a+c-b), with P a member of the
+               !extended RI basis set
+
+               !Force for the first center (RI extended basis, zero cell)
+               new_force = pref*SUM(der_blk_1(:, :, :)*contr_blk(:, :, :))
+
+               i_RI = (ind(1) - 1)/nblks_RI + 1
+               RI_img = ri_data%RI_cell_to_img(i_RI)
+               iat = idx_to_at_RI(ind(1) - (i_RI - 1)*nblks_RI)
+               iat_of_kind = atom_of_kind(iat)
+               ikind = kind_of(iat)
+
+!$OMP ATOMIC
+               force(ikind)%fock_4c(i_xyz, iat_of_kind) = force(ikind)%fock_4c(i_xyz, iat_of_kind) &
+                                                          + new_force
+
+               IF (use_virial) THEN
+
+                  CALL real_to_scaled(scoord, pbc(particle_set(iat)%r, cell), cell)
+                  scoord(:) = scoord(:) + REAL(index_to_cell(:, RI_img), dp)
+
+                  DO j_xyz = 1, 3
+!$OMP ATOMIC
+                     work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + new_force*scoord(j_xyz)
+                  END DO
+               END IF
+
+               !Force with respect to the second center (AO basis, zero cell)
+               new_force = pref*SUM(der_blk_2(:, :, :)*contr_blk(:, :, :))
+               jat = idx_to_at_AO(ind(2))
+               jat_of_kind = atom_of_kind(jat)
+               jkind = kind_of(jat)
+
+!$OMP ATOMIC
+               force(jkind)%fock_4c(i_xyz, jat_of_kind) = force(jkind)%fock_4c(i_xyz, jat_of_kind) &
+                                                          + new_force
+
+               IF (use_virial) THEN
+
+                  CALL real_to_scaled(scoord, pbc(particle_set(jat)%r, cell), cell)
+
+                  DO j_xyz = 1, 3
+!$OMP ATOMIC
+                     work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + new_force*scoord(j_xyz)
+                  END DO
+               END IF
+
+               !Force with respect to the third center (AO basis, apc_img - b_img)
+               !Note: tensors are stacked along the 3rd direction
+               new_force = pref*SUM(der_blk_3(:, :, :)*contr_blk(:, :, :))
+               idx = (ind(3) - 1)/nblks_AO + 1
+               kat = idx_to_at_AO(ind(3) - (idx - 1)*nblks_AO)
+               kat_of_kind = atom_of_kind(kat)
+               kkind = kind_of(kat)
+
+!$OMP ATOMIC
+               force(kkind)%fock_4c(i_xyz, kat_of_kind) = force(kkind)%fock_4c(i_xyz, kat_of_kind) &
+                                                          + new_force
+
+               IF (use_virial) THEN
+                  CALL real_to_scaled(scoord, pbc(particle_set(kat)%r, cell), cell)
+                  scoord(:) = scoord(:) + REAL(index_to_cell(:, i_images(lb_img - 1 + idx)), dp)
+
+                  DO j_xyz = 1, 3
+!$OMP ATOMIC
+                     work_virial(i_xyz, j_xyz) = work_virial(i_xyz, j_xyz) + new_force*scoord(j_xyz)
+                  END DO
+               END IF
+
+               DEALLOCATE (der_blk_1, der_blk_2, der_blk_3)
+            END DO !i_xyz
+            DEALLOCATE (contr_blk)
+         END IF !found
+      END DO !iter
+      CALL dbt_iterator_stop(iter)
+!$OMP END PARALLEL
+      CALL timestop(handle)
+
+   END SUBROUTINE get_force_from_3c_trace
+
+END MODULE

--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -26,6 +26,7 @@ MODULE hfx_types
                                               get_cell,&
                                               plane_distance,&
                                               scaled_to_real
+   USE cp_array_utils,                  ONLY: cp_1d_logical_p_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_files,                        ONLY: close_file,&
                                               file_exists,&
@@ -35,6 +36,8 @@ MODULE hfx_types
    USE cp_output_handling,              ONLY: cp_print_key_finished_output,&
                                               cp_print_key_unit_nr
    USE cp_units,                        ONLY: cp_unit_from_cp2k
+   USE dbcsr_api,                       ONLY: dbcsr_release,&
+                                              dbcsr_type
    USE dbt_api,                         ONLY: &
         dbt_create, dbt_default_distvec, dbt_destroy, dbt_distribution_destroy, &
         dbt_distribution_new, dbt_distribution_type, dbt_mp_dims_create, dbt_pgrid_create, &
@@ -367,9 +370,11 @@ MODULE hfx_types
    TYPE hfx_ri_type
       ! input parameters (see input_cp2k_hfx)
       REAL(KIND=dp) :: filter_eps = 0.0_dp, filter_eps_2c = 0.0_dp, filter_eps_storage = 0.0_dp, filter_eps_mo = 0.0_dp, &
-                       eps_lanczos = 0.0_dp, eps_pgf_orb = 0.0_dp, eps_eigval = 0.0_dp
+                       eps_lanczos = 0.0_dp, eps_pgf_orb = 0.0_dp, eps_eigval = 0.0_dp, kp_RI_range = 0.0_dp, &
+                       kp_image_range = 0.0_dp, kp_bump_rad = 0.0_dp
       INTEGER :: t2c_sqrt_order = 0, max_iter_lanczos = 0, flavor = 0, unit_nr_dbcsr = -1, unit_nr = -1, &
-                 min_bsize = 0, max_bsize_MO = 0, t2c_method = 0, nelectron_total = 0, input_flavor = 0
+                 min_bsize = 0, max_bsize_MO = 0, t2c_method = 0, nelectron_total = 0, input_flavor = 0, &
+                 ncell_RI = 0, nimg = 0, kp_stack_size = 0, nimg_nze = 0
       LOGICAL :: check_2c_inv = .FALSE., calc_condnum = .FALSE.
 
       TYPE(libint_potential_type) :: ri_metric = libint_potential_type()
@@ -393,12 +398,29 @@ MODULE hfx_types
       INTEGER, DIMENSION(:), ALLOCATABLE :: bsizes_RI, bsizes_AO, bsizes_RI_split, bsizes_AO_split, &
                                             bsizes_RI_fit, bsizes_AO_fit
 
+      ! KP RI-HFX basis info
+      INTEGER, DIMENSION(:), ALLOCATABLE ::  img_to_RI_cell, present_images, idx_to_img, img_to_idx, &
+                                            RI_cell_to_img
+
+      ! KP RI-HFX cost information for a given atom pair i,j at a given cell b
+      REAL(dp), DIMENSION(:, :, :), ALLOCATABLE :: kp_cost
+
+      ! KP distribution of iatom (of i,j atom pairs) to subgroups
+      TYPE(cp_1d_logical_p_type), DIMENSION(:), ALLOCATABLE :: iatom_to_subgroup
+
+      ! KP 3c tensors replicated on the subgroups
+      TYPE(dbt_type), DIMENSION(:), ALLOCATABLE :: kp_t_3c_int
+      TYPE(dbt_type), DIMENSION(:, :), ALLOCATABLE :: kp_t_3c_apc
+
       ! Note: changed static DIMENSION(1,1) of dbt_type to allocatables as workaround for gfortran 8.3.0,
       ! with static dimension gfortran gets stuck during compilation
 
       ! 2c tensors in (RI | RI) format for forces
       TYPE(dbt_type), DIMENSION(:, :), ALLOCATABLE    :: t_2c_inv
       TYPE(dbt_type), DIMENSION(:, :), ALLOCATABLE    :: t_2c_pot
+
+      ! 2c tensor in matrix format for K-points RI-HFX
+      TYPE(dbcsr_type), DIMENSION(:, :), ALLOCATABLE  :: kp_mat_2c_pot
 
       ! 2c tensor in (RI | RI) format for contraction
       TYPE(dbt_type), DIMENSION(:, :), ALLOCATABLE    :: t_2c_int
@@ -551,6 +573,7 @@ CONTAINS
 !> \param cell ...
 !> \param do_exx ...
 !> \param nelectron_total ...
+!> \param nkp_grid ...
 !> \par History
 !>      09.2007 created [Manuel Guidon]
 !> \author Manuel Guidon
@@ -559,7 +582,7 @@ CONTAINS
 !>        unknown at invocation time
 ! **************************************************************************************************
    SUBROUTINE hfx_create(x_data, para_env, hfx_section, atomic_kind_set, qs_kind_set, &
-                         particle_set, dft_control, cell, do_exx, nelectron_total)
+                         particle_set, dft_control, cell, do_exx, nelectron_total, nkp_grid)
       TYPE(hfx_type), DIMENSION(:, :), POINTER           :: x_data
       TYPE(mp_para_env_type)                             :: para_env
       TYPE(section_vals_type), POINTER                   :: hfx_section
@@ -570,6 +593,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       LOGICAL, OPTIONAL                                  :: do_exx
       INTEGER, OPTIONAL                                  :: nelectron_total
+      INTEGER, DIMENSION(3), OPTIONAL                    :: nkp_grid
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'hfx_create'
 
@@ -679,6 +703,9 @@ CONTAINS
                CALL erfc_cutoff(actual_x_data%screening_parameter%eps_schwarz, &
                                 actual_x_data%potential_parameter%omega, &
                                 actual_x_data%potential_parameter%cutoff_radius)
+            END IF
+            IF (actual_x_data%potential_parameter%potential_type == do_potential_id) THEN
+               actual_x_data%potential_parameter%cutoff_radius = 0.0_dp
             END IF
 
             !! LOAD_BALANCE section
@@ -820,7 +847,7 @@ CONTAINS
                CALL section_vals_val_get(hf_pbc_section, "NUMBER_OF_SHELLS", i_val=pbc_shells)
                actual_x_data%periodic_parameter%number_of_shells_from_input = pbc_shells
                ALLOCATE (actual_x_data%neighbor_cells(1))
-               CALL hfx_create_neighbor_cells(actual_x_data, pbc_shells, cell, i_thread)
+               CALL hfx_create_neighbor_cells(actual_x_data, pbc_shells, cell, i_thread, nkp_grid=nkp_grid)
             ELSE
                ALLOCATE (actual_x_data%neighbor_cells(1))
                ! ** Initialize this guy to enable non periodic stress regtests
@@ -1111,6 +1138,10 @@ CONTAINS
          IF (.NOT. explicit) THEN
             ri_metric%cutoff_radius = hfx_pot%cutoff_radius
          END IF
+
+         IF (ri_metric%potential_type == do_potential_short) &
+            CALL erfc_cutoff(ri_data%eps_schwarz, ri_metric%omega, ri_metric%cutoff_radius)
+         IF (ri_metric%potential_type == do_potential_id) ri_metric%cutoff_radius = 0.0_dp
       END ASSOCIATE
 
       CALL section_vals_val_get(ri_section, "2C_MATRIX_FUNCTIONS", i_val=ri_data%t2c_method)
@@ -1391,11 +1422,11 @@ CONTAINS
                  dbcsr_time => ri_data%dbcsr_time, num_pe => ri_data%num_pe)
          my_flop_rate = REAL(dbcsr_nflop, dp)/(1.0E09_dp*ri_data%dbcsr_time)
          IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(/T2,A,T73,ES8.2)") &
-            "RI-HFX PERFORMANCE| DBCSR total number of flops:", REAL(dbcsr_nflop*num_pe, dp)
+            "RI-HFX PERFORMANCE| DBT total number of flops:", REAL(dbcsr_nflop*num_pe, dp)
          IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T2,A,T66,F15.2)") &
-            "RI-HFX PERFORMANCE| DBCSR total execution time:", dbcsr_time
+            "RI-HFX PERFORMANCE| DBT total execution time:", dbcsr_time
          IF (unit_nr > 0) WRITE (UNIT=unit_nr, FMT="(T2,A,T66,F15.2)") &
-            "RI-HFX PERFORMANCE| DBCSR flop rate (Gflops / MPI rank):", my_flop_rate
+            "RI-HFX PERFORMANCE| DBT flop rate (Gflops / MPI rank):", my_flop_rate
       END ASSOCIATE
    END SUBROUTINE
 
@@ -1410,7 +1441,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'hfx_ri_release'
 
-      INTEGER                                            :: handle, i_mem, ispin, j_mem, unused
+      INTEGER                                            :: handle, i, i_mem, ispin, j, j_mem, unused
       LOGICAL                                            :: my_write_stats
 
       CALL timeset(routineN, handle)
@@ -1455,14 +1486,35 @@ CONTAINS
             CALL dealloc_containers(ri_data%store_3c(i_mem, j_mem), unused)
          END DO
          END DO
-         CALL dbt_destroy(ri_data%t_3c_int_ctr_1(1, 1))
+
+         DO j = 1, SIZE(ri_data%t_3c_int_ctr_1, 2)
+            DO i = 1, SIZE(ri_data%t_3c_int_ctr_1, 1)
+               CALL dbt_destroy(ri_data%t_3c_int_ctr_1(i, j))
+            END DO
+         END DO
          DEALLOCATE (ri_data%t_3c_int_ctr_1)
-         CALL dbt_destroy(ri_data%t_3c_int_ctr_2(1, 1))
+
+         DO j = 1, SIZE(ri_data%t_3c_int_ctr_2, 2)
+            DO i = 1, SIZE(ri_data%t_3c_int_ctr_2, 1)
+               CALL dbt_destroy(ri_data%t_3c_int_ctr_2(i, j))
+            END DO
+         END DO
          DEALLOCATE (ri_data%t_3c_int_ctr_2)
-         CALL dbt_destroy(ri_data%t_3c_int_ctr_3(1, 1))
+
+         DO j = 1, SIZE(ri_data%t_3c_int_ctr_3, 2)
+            DO i = 1, SIZE(ri_data%t_3c_int_ctr_3, 1)
+               CALL dbt_destroy(ri_data%t_3c_int_ctr_3(i, j))
+            END DO
+         END DO
          DEALLOCATE (ri_data%t_3c_int_ctr_3)
-         CALL dbt_destroy(ri_data%t_2c_int(1, 1))
+
+         DO j = 1, SIZE(ri_data%t_2c_int, 2)
+            DO i = 1, SIZE(ri_data%t_2c_int, 1)
+               CALL dbt_destroy(ri_data%t_2c_int(i, j))
+            END DO
+         END DO
          DEALLOCATE (ri_data%t_2c_int)
+
          DEALLOCATE (ri_data%starts_array_mem_block, ri_data%ends_array_mem_block, &
                      ri_data%starts_array_mem, ri_data%ends_array_mem)
          DEALLOCATE (ri_data%starts_array_RI_mem_block, ri_data%ends_array_RI_mem_block, &
@@ -1492,10 +1544,51 @@ CONTAINS
          DEALLOCATE (ri_data%t_3c_ctr_KS_copy)
       END IF
 
-      CALL dbt_destroy(ri_data%t_2c_inv(1, 1))
+      DO j = 1, SIZE(ri_data%t_2c_inv, 2)
+         DO i = 1, SIZE(ri_data%t_2c_inv, 1)
+            CALL dbt_destroy(ri_data%t_2c_inv(i, j))
+         END DO
+      END DO
       DEALLOCATE (ri_data%t_2c_inv)
-      CALL dbt_destroy(ri_data%t_2c_pot(1, 1))
+
+      DO j = 1, SIZE(ri_data%t_2c_pot, 2)
+         DO i = 1, SIZE(ri_data%t_2c_pot, 1)
+            CALL dbt_destroy(ri_data%t_2c_pot(i, j))
+         END DO
+      END DO
       DEALLOCATE (ri_data%t_2c_pot)
+
+      IF (ALLOCATED(ri_data%kp_mat_2c_pot)) THEN
+         DO j = 1, SIZE(ri_data%kp_mat_2c_pot, 2)
+            DO i = 1, SIZE(ri_data%kp_mat_2c_pot, 1)
+               CALL dbcsr_release(ri_data%kp_mat_2c_pot(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%kp_mat_2c_pot)
+      END IF
+
+      IF (ALLOCATED(ri_data%kp_t_3c_int)) THEN
+         DO i = 1, SIZE(ri_data%kp_t_3c_int)
+            CALL dbt_destroy(ri_data%kp_t_3c_int(i))
+         END DO
+         DEALLOCATE (ri_data%kp_t_3c_int)
+      END IF
+
+      IF (ALLOCATED(ri_data%kp_t_3c_apc)) THEN
+         DO j = 1, SIZE(ri_data%kp_t_3c_apc, 2)
+            DO i = 1, SIZE(ri_data%kp_t_3c_apc, 1)
+               CALL dbt_destroy(ri_data%kp_t_3c_apc(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%kp_t_3c_apc)
+      END IF
+
+      IF (ALLOCATED(ri_data%iatom_to_subgroup)) THEN
+         DO i = 1, SIZE(ri_data%iatom_to_subgroup)
+            DEALLOCATE (ri_data%iatom_to_subgroup(i)%array)
+         END DO
+         DEALLOCATE (ri_data%iatom_to_subgroup)
+      END IF
 
       CALL timestop(handle)
    END SUBROUTINE
@@ -1907,28 +2000,35 @@ CONTAINS
 !> \param pbc_shells number of shells taken into account
 !> \param cell cell
 !> \param i_thread current thread ID
+!> \param nkp_grid ...
 !> \par History
 !>      09.2007 created [Manuel Guidon]
 !> \author Manuel Guidon
 ! **************************************************************************************************
-   SUBROUTINE hfx_create_neighbor_cells(x_data, pbc_shells, cell, i_thread)
+   SUBROUTINE hfx_create_neighbor_cells(x_data, pbc_shells, cell, i_thread, nkp_grid)
       TYPE(hfx_type), POINTER                            :: x_data
       INTEGER, INTENT(INOUT)                             :: pbc_shells
       TYPE(cell_type), POINTER                           :: cell
       INTEGER, INTENT(IN)                                :: i_thread
+      INTEGER, DIMENSION(3), OPTIONAL                    :: nkp_grid
 
       CHARACTER(LEN=512)                                 :: error_msg
       CHARACTER(LEN=64)                                  :: char_nshells
       INTEGER :: i, idx, ikind, ipgf, iset, ishell, j, jkind, jpgf, jset, jshell, k, kshell, l, &
-         m(3), max_shell, nseta, nsetb, perd(3), total_number_of_cells, ub, ub_max
+         m(3), max_shell, nkp(3), nseta, nsetb, perd(3), total_number_of_cells, ub, ub_max
       INTEGER, DIMENSION(:), POINTER                     :: la_max, lb_max, npgfa, npgfb
-      LOGICAL                                            :: image_cell_found, nothing_more_to_add
+      LOGICAL                                            :: do_kpoints, image_cell_found, &
+                                                            nothing_more_to_add
       REAL(dp) :: cross_product(3), dist_min, distance(14), l_min, normal(3, 6), P(3, 14), &
          plane_vector(3, 2), point_in_plane(3), r(3), R1, R_max, R_max_stress, s(3), x, y, z, Zeta1
       REAL(dp), DIMENSION(:, :), POINTER                 :: zeta, zetb
       TYPE(hfx_cell_type), ALLOCATABLE, DIMENSION(:)     :: tmp_neighbor_cells
 
       total_number_of_cells = 0
+
+      nkp = 1
+      IF (PRESENT(nkp_grid)) nkp = nkp_grid
+      do_kpoints = ANY(nkp > 1)
 
       ! ** Check some settings
       IF (i_thread == 1) THEN
@@ -1941,17 +2041,27 @@ CONTAINS
                          "of a truncated or shortrange potential. This may lead to unphysical total energies. "// &
                          "Use a truncated  potential to avoid possible problems.")
          ELSE IF (x_data%potential_parameter%potential_type /= do_potential_id) THEN
-            l_min = MIN(plane_distance(1, 0, 0, cell), &
-                        plane_distance(0, 1, 0, cell), &
-                        plane_distance(0, 0, 1, cell))
+            !If k-points, use the Born-von Karman super cell as reference
+            l_min = MIN(REAL(nkp(1), dp)*plane_distance(1, 0, 0, cell), &
+                        REAL(nkp(2), dp)*plane_distance(0, 1, 0, cell), &
+                        REAL(nkp(3), dp)*plane_distance(0, 0, 1, cell))
             l_min = 0.5_dp*l_min
             IF (x_data%potential_parameter%cutoff_radius >= l_min) THEN
-               CALL cp_warn(__LOCATION__, &
-                            "Periodic Hartree Fock calculation requested with use "// &
-                            "of a truncated or shortrange potential. The cutoff radius is larger than half "// &
-                            "the minimal cell dimension. This may lead to unphysical "// &
-                            "total energies. Reduce the cutoff radius in order to avoid "// &
-                            "possible problems.")
+               IF (.NOT. do_kpoints) THEN
+                  CALL cp_warn(__LOCATION__, &
+                               "Periodic Hartree Fock calculation requested with the use "// &
+                               "of a truncated or shortrange potential. The cutoff radius is larger than half "// &
+                               "the minimal cell dimension. This may lead to unphysical "// &
+                               "total energies. Reduce the cutoff radius in order to avoid "// &
+                               "possible problems.")
+               ELSE
+                  CALL cp_warn(__LOCATION__, &
+                               "K-point Hartree-Fock calculation requested with the use of a "// &
+                               "truncated or shortrange potential. The cutoff radius is larger than "// &
+                               "half the minimal Born-von Karman supercell dimension. This may lead "// &
+                               "to unphysical total energies. Reduce the cutoff radius or increase "// &
+                               "the number of K-points in order to avoid possible problems.")
+               END IF
             END IF
          END IF
       END IF

--- a/src/input_cp2k_hfx.F
+++ b/src/input_cp2k_hfx.F
@@ -537,6 +537,62 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create(keyword, __LOCATION__, name="KP_NGROUPS", &
+                          description="The number of MPI subgroup that work in parallel during the SCF. "// &
+                          "The default value is 1. Using N subgroups should speed up the "// &
+                          "calculation by a factor ~N, at the cost of N times more memory usage.", &
+                          variants=(/"NGROUPS"/), &
+                          usage="KP_NGROUPS {int}", &
+                          repeats=.FALSE., &
+                          default_i_val=1)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="KP_STACK_SIZE", &
+                          description="When doing contraction over periodic cells of the type: "// &
+                          "T_mu^a,nu^b,P^c = (mu^a nu^b | Q^d) * (Q^d | P^c), with "// &
+                          "a,b,c,d labeling cells, there are in principle Ncells "// &
+                          "contractions taking place. Because a smaller number of "// &
+                          "contractions involving larger tensors is more efficient, "// &
+                          "the tensors can be stacked along the d direction. STCK_SIZE "// &
+                          "controls the size of this stack. Larger stacks are more efficient, "// &
+                          "but required more memory.", &
+                          variants=(/"STACK_SIZE"/), &
+                          usage="KP_STACK_SIZE {int}", &
+                          repeats=.FALSE., &
+                          default_i_val=32)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="KP_RI_EXTENSION_FACTOR", &
+                          variants=s2a("RI_EXTENSION_FACTOR", "RI_EXT", "RI_EXT_FACT", "KP_RI_EXT", &
+                                       "KP_RI_EXT_FACT", "KP_RI_BASIS_EXT", "RI_BASIS_EXT"), &
+                          description="In KP-RI-HFX, each atom has its own local RI basis. The RI "// &
+                          "basis is defined by a sphere of radius R centered on the atom, "// &
+                          "whereby all neighboring atoms within that sphere contribute their "// &
+                          "RI basis elements. The radius of that sphere is calculated based "// &
+                          "on the systems' most diffuse orbital PGF (with exponant alpha), such "// &
+                          "that EPS_PGF_ORB * KP_RI_EXTENSION_FACTOR  = exp(-alpha*R^2). "// &
+                          "The default value of 1.0 is safe. More accurate results can be "// &
+                          "obtained with a value < 1.0, at greated computational cost.", &
+                          default_r_val=1.0_dp, &
+                          repeats=.FALSE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="KP_RI_BUMP_FACTOR", &
+                          variants=s2a("RI_BUMP", "BUMP", "BUMP_FACTOR"), &
+                          description="In KP-RI-HFX, the extended RI basis set has a bump radius. "// &
+                          "All basis elements within that radius contribute with full weight. "// &
+                          "All basis elements beyond that radius have decaying weight, from "// &
+                          "1 at the bump radius, to zero at the RI extension radius. The "// &
+                          "bump radius is calculated as a fraction of the RI extension radius: "// &
+                          "bump radius = KP_RI_NUMP_FACTOR * RI extension radius", &
+                          default_r_val=0.85_dp, &
+                          repeats=.FALSE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
       CALL keyword_create(keyword, __LOCATION__, name="RI_METRIC", &
                           description="The type of RI operator. "// &
                           "Default is POTENTIAL_TYPE from INTERACTION_POTENTIAL. "// &

--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -41,7 +41,8 @@ MODULE kpoint_methods
         dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_distribution_get, &
         dbcsr_distribution_type, dbcsr_get_block_p, dbcsr_get_info, dbcsr_iterator_blocks_left, &
         dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, &
-        dbcsr_p_type, dbcsr_set, dbcsr_type, dbcsr_type_antisymmetric, dbcsr_type_symmetric
+        dbcsr_p_type, dbcsr_set, dbcsr_type, dbcsr_type_antisymmetric, dbcsr_type_no_symmetry, &
+        dbcsr_type_symmetric
    USE fermi_utils,                     ONLY: fermikp,&
                                               fermikp2
    USE input_constants,                 ONLY: smear_fermi_dirac
@@ -259,24 +260,33 @@ CONTAINS
 !> \param kpoint       Kpoint environment
 !> \param para_env ...
 !> \param blacs_env ...
+!> \param with_aux_fit ...
 ! **************************************************************************************************
-   SUBROUTINE kpoint_env_initialize(kpoint, para_env, blacs_env)
+   SUBROUTINE kpoint_env_initialize(kpoint, para_env, blacs_env, with_aux_fit)
 
       TYPE(kpoint_type), INTENT(INOUT)                   :: kpoint
       TYPE(mp_para_env_type), INTENT(IN), TARGET         :: para_env
       TYPE(cp_blacs_env_type), INTENT(IN), TARGET        :: blacs_env
+      LOGICAL, INTENT(IN), OPTIONAL                      :: with_aux_fit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_env_initialize'
 
       INTEGER                                            :: handle, igr, ik, ikk, ngr, niogrp, nkp, &
                                                             nkp_grp, nkp_loc, npe, unit_nr
       INTEGER, DIMENSION(2)                              :: dims, pos
-      TYPE(kpoint_env_p_type), DIMENSION(:), POINTER     :: kp_env
+      LOGICAL                                            :: aux_fit
+      TYPE(kpoint_env_p_type), DIMENSION(:), POINTER     :: kp_aux_env, kp_env
       TYPE(kpoint_env_type), POINTER                     :: kp
       TYPE(mp_cart_type)                                 :: comm_cart
       TYPE(mp_para_env_type), POINTER                    :: para_env_inter_kp, para_env_kp
 
       CALL timeset(routineN, handle)
+
+      IF (PRESENT(with_aux_fit)) THEN
+         aux_fit = with_aux_fit
+      ELSE
+         aux_fit = .FALSE.
+      END IF
 
       kpoint%para_env => para_env
       CALL kpoint%para_env%retain()
@@ -284,8 +294,11 @@ CONTAINS
       CALL kpoint%blacs_env_all%retain()
 
       CPASSERT(.NOT. ASSOCIATED(kpoint%kp_env))
+      IF (aux_fit) THEN
+         CPASSERT(.NOT. ASSOCIATED(kpoint%kp_aux_env))
+      END IF
 
-      NULLIFY (kp_env)
+      NULLIFY (kp_env, kp_aux_env)
       nkp = kpoint%nkp
       npe = para_env%num_pe
       IF (npe == 1) THEN
@@ -300,12 +313,29 @@ CONTAINS
             kp%xkp(1:3) = kpoint%xkp(1:3, ik)
             kp%is_local = .TRUE.
          END DO
+         kpoint%kp_env => kp_env
+
+         IF (aux_fit) THEN
+            ALLOCATE (kp_aux_env(nkp))
+            DO ik = 1, nkp
+               NULLIFY (kp_aux_env(ik)%kpoint_env)
+               CALL kpoint_env_create(kp_aux_env(ik)%kpoint_env)
+               kp => kp_aux_env(ik)%kpoint_env
+               kp%nkpoint = ik
+               kp%wkp = kpoint%wkp(ik)
+               kp%xkp(1:3) = kpoint%xkp(1:3, ik)
+               kp%is_local = .TRUE.
+            END DO
+
+            kpoint%kp_aux_env => kp_aux_env
+         END IF
+
          ALLOCATE (kpoint%kp_dist(2, 1))
          kpoint%kp_dist(1, 1) = 1
          kpoint%kp_dist(2, 1) = nkp
          kpoint%kp_range(1) = 1
          kpoint%kp_range(2) = nkp
-         kpoint%kp_env => kp_env
+
          ! parallel environments
          kpoint%para_env_kp => para_env
          CALL kpoint%para_env_kp%retain()
@@ -368,6 +398,7 @@ CONTAINS
          END DO
          ! local kpoints
          kpoint%kp_range(1:2) = kpoint%kp_dist(1:2, para_env_inter_kp%mepos + 1)
+
          ALLOCATE (kp_env(nkp_loc))
          DO ik = 1, nkp_loc
             NULLIFY (kp_env(ik)%kpoint_env)
@@ -379,8 +410,22 @@ CONTAINS
             kp%xkp(1:3) = kpoint%xkp(1:3, ikk)
             kp%is_local = (ngr == 1)
          END DO
-
          kpoint%kp_env => kp_env
+
+         IF (aux_fit) THEN
+            ALLOCATE (kp_aux_env(nkp_loc))
+            DO ik = 1, nkp_loc
+               NULLIFY (kp_aux_env(ik)%kpoint_env)
+               ikk = kpoint%kp_range(1) + ik - 1
+               CALL kpoint_env_create(kp_aux_env(ik)%kpoint_env)
+               kp => kp_aux_env(ik)%kpoint_env
+               kp%nkpoint = ikk
+               kp%wkp = kpoint%wkp(ikk)
+               kp%xkp(1:3) = kpoint%xkp(1:3, ikk)
+               kp%is_local = (ngr == 1)
+            END DO
+            kpoint%kp_aux_env => kp_aux_env
+         END IF
 
          unit_nr = cp_logger_get_default_io_unit()
 
@@ -403,18 +448,21 @@ CONTAINS
 !> \param kpoint  Kpoint environment
 !> \param mos     Reference MOs (global)
 !> \param added_mos ...
+!> \param for_aux_fit ...
 ! **************************************************************************************************
-   SUBROUTINE kpoint_initialize_mos(kpoint, mos, added_mos)
+   SUBROUTINE kpoint_initialize_mos(kpoint, mos, added_mos, for_aux_fit)
 
       TYPE(kpoint_type), POINTER                         :: kpoint
       TYPE(mo_set_type), DIMENSION(:), INTENT(INOUT)     :: mos
       INTEGER, INTENT(IN), OPTIONAL                      :: added_mos
+      LOGICAL, OPTIONAL                                  :: for_aux_fit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_initialize_mos'
 
       INTEGER                                            :: handle, ic, ik, is, nadd, nao, nc, &
                                                             nelectron, nkp_loc, nmo, nmorig(2), &
                                                             nspin
+      LOGICAL                                            :: aux_fit
       REAL(KIND=dp)                                      :: flexible_electron_count, maxocc, n_el_f
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_ao_fm_pools
@@ -425,9 +473,18 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
+      IF (PRESENT(for_aux_fit)) THEN
+         aux_fit = for_aux_fit
+      ELSE
+         aux_fit = .FALSE.
+      END IF
+
       CPASSERT(ASSOCIATED(kpoint))
 
       IF (.TRUE. .OR. ASSOCIATED(mos(1)%mo_coeff)) THEN
+         IF (aux_fit) THEN
+            CPASSERT(ASSOCIATED(kpoint%kp_aux_env))
+         END IF
 
          IF (PRESENT(added_mos)) THEN
             nadd = added_mos
@@ -443,10 +500,18 @@ CONTAINS
          nspin = SIZE(mos, 1)
          nkp_loc = kpoint%kp_range(2) - kpoint%kp_range(1) + 1
          IF (nkp_loc > 0) THEN
-            CPASSERT(SIZE(kpoint%kp_env) == nkp_loc)
+            IF (aux_fit) THEN
+               CPASSERT(SIZE(kpoint%kp_aux_env) == nkp_loc)
+            ELSE
+               CPASSERT(SIZE(kpoint%kp_env) == nkp_loc)
+            END IF
             ! allocate the mo sets, correct number of kpoints (local), real/complex, spin
             DO ik = 1, nkp_loc
-               kp => kpoint%kp_env(ik)%kpoint_env
+               IF (aux_fit) THEN
+                  kp => kpoint%kp_aux_env(ik)%kpoint_env
+               ELSE
+                  kp => kpoint%kp_env(ik)%kpoint_env
+               END IF
                ALLOCATE (kp%mos(nc, nspin))
                DO is = 1, nspin
                   CALL get_mo_set(mos(is), nao=nao, nmo=nmo, nelectron=nelectron, &
@@ -464,8 +529,12 @@ CONTAINS
             ! we assume here that the group para_env_inter_kp will connect
             ! equivalent parts of fm matrices, i.e. no reshuffeling of processors
             NULLIFY (blacs_env)
-            CALL cp_blacs_env_create(blacs_env=blacs_env, para_env=kpoint%para_env_kp)
-            kpoint%blacs_env => blacs_env
+            IF (ASSOCIATED(kpoint%blacs_env)) THEN
+               blacs_env => kpoint%blacs_env
+            ELSE
+               CALL cp_blacs_env_create(blacs_env=blacs_env, para_env=kpoint%para_env_kp)
+               kpoint%blacs_env => blacs_env
+            END IF
 
             ! set possible new number of MOs
             DO is = 1, nspin
@@ -479,7 +548,13 @@ CONTAINS
             CALL mpools_create(mpools=mpools)
             CALL mpools_rebuild_fm_pools(mpools=mpools, mos=mos, &
                                          blacs_env=blacs_env, para_env=kpoint%para_env_kp)
-            kpoint%mpools => mpools
+
+            IF (aux_fit) THEN
+               kpoint%mpools_aux_fit => mpools
+            ELSE
+               kpoint%mpools => mpools
+            END IF
+
             ! reset old number of MOs
             DO is = 1, nspin
                CALL set_mo_set(mos(is), nmo=nmorig(is))
@@ -491,7 +566,11 @@ CONTAINS
             CALL fm_pool_create_fm(ao_ao_fm_pools(1)%pool, fmlocal)
             CALL cp_fm_get_info(fmlocal, matrix_struct=matrix_struct)
             DO ik = 1, nkp_loc
-               kp => kpoint%kp_env(ik)%kpoint_env
+               IF (aux_fit) THEN
+                  kp => kpoint%kp_aux_env(ik)%kpoint_env
+               ELSE
+                  kp => kpoint%kp_env(ik)%kpoint_env
+               END IF
                ! density matrix
                CALL cp_fm_release(kp%pmat)
                ALLOCATE (kp%pmat(nc, nspin))
@@ -578,10 +657,12 @@ CONTAINS
                                                             ncount
       INTEGER, DIMENSION(3)                              :: cell, itm
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell, list
-      INTEGER, DIMENSION(:, :, :), POINTER               :: cti
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index, cti
       LOGICAL                                            :: new
       TYPE(neighbor_list_iterator_p_type), &
          DIMENSION(:), POINTER                           :: nl_iterator
+
+      NULLIFY (cell_to_index, index_to_cell)
 
       CALL timeset(routineN, handle)
 
@@ -623,7 +704,8 @@ CONTAINS
          DEALLOCATE (kpoint%cell_to_index)
       END IF
       ALLOCATE (kpoint%cell_to_index(-itm(1):itm(1), -itm(2):itm(2), -itm(3):itm(3)))
-      cti => kpoint%cell_to_index
+      cell_to_index => kpoint%cell_to_index
+      cti => cell_to_index
       cti(:, :, :) = 0
       DO ic = 1, icount
          i1 = list(1, ic)
@@ -709,7 +791,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'rskp_transform'
 
-      INTEGER                                            :: handle, iatom, ic, icol, irow, jatom
+      INTEGER                                            :: handle, iatom, ic, icol, irow, jatom, &
+                                                            nimg
       INTEGER, DIMENSION(3)                              :: cell
       LOGICAL                                            :: do_symmetric, found, my_complex, &
                                                             wfn_real_only
@@ -729,12 +812,16 @@ CONTAINS
       wfn_real_only = .TRUE.
       IF (PRESENT(cmatrix)) wfn_real_only = .FALSE.
 
+      nimg = SIZE(rsmat, 2)
+
       CALL get_neighbor_list_set_p(neighbor_list_sets=sab_nl, symmetric=do_symmetric)
 
       CALL neighbor_list_iterator_create(nl_iterator, sab_nl)
       DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
          CALL get_iterator_info(nl_iterator, iatom=iatom, jatom=jatom, cell=cell)
 
+         ! fsym = =- 1 is due to real space matrices being non-symmetric (although in a symmtric type)
+         ! with the link S_mu^0,nu^b = S_nu^0,mu^-b, and the KP matrices beeing Hermitian
          fsym = 1.0_dp
          irow = iatom
          icol = jatom
@@ -743,6 +830,9 @@ CONTAINS
             icol = iatom
             fsym = -1.0_dp
          END IF
+
+         ic = cell_to_index(cell(1), cell(2), cell(3))
+         IF (ic < 1 .OR. ic > nimg) CYCLE
 
          arg = REAL(cell(1), dp)*xkp(1) + REAL(cell(2), dp)*xkp(2) + REAL(cell(3), dp)*xkp(3)
          IF (my_complex) THEN
@@ -753,18 +843,16 @@ CONTAINS
             sinkl = fsign*fsym*SIN(twopi*arg)
          END IF
 
-         ic = cell_to_index(cell(1), cell(2), cell(3))
-         IF (.NOT. do_symmetric .AND. ic < 1) ic = cell_to_index(-cell(1), -cell(2), -cell(3))
-         CPASSERT(ic > 0)
-
          CALL dbcsr_get_block_p(matrix=rsmat(ispin, ic)%matrix, row=irow, col=icol, &
                                 block=rsblock, found=found)
          CPASSERT(found)
+         IF (.NOT. found) CYCLE
 
          IF (wfn_real_only) THEN
             CALL dbcsr_get_block_p(matrix=rmatrix, row=irow, col=icol, &
                                    block=rblock, found=found)
             CPASSERT(found)
+            IF (.NOT. found) CYCLE
             rblock = rblock + coskl*rsblock
          ELSE
             CALL dbcsr_get_block_p(matrix=rmatrix, row=irow, col=icol, &
@@ -898,18 +986,19 @@ CONTAINS
 !> \brief Calculate kpoint density matrices (rho(k), owned by kpoint groups)
 !> \param kpoint    kpoint environment
 !> \param energy_weighted  calculate energy weighted density matrix
+!> \param for_aux_fit ...
 ! **************************************************************************************************
-   SUBROUTINE kpoint_density_matrices(kpoint, energy_weighted)
+   SUBROUTINE kpoint_density_matrices(kpoint, energy_weighted, for_aux_fit)
 
       TYPE(kpoint_type), POINTER                         :: kpoint
-      LOGICAL, OPTIONAL                                  :: energy_weighted
+      LOGICAL, OPTIONAL                                  :: energy_weighted, for_aux_fit
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_density_matrices'
 
       INTEGER                                            :: handle, ikpgr, ispin, kplocal, nao, nmo, &
                                                             nspin
       INTEGER, DIMENSION(2)                              :: kp_range
-      LOGICAL                                            :: wtype
+      LOGICAL                                            :: aux_fit, wtype
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
       TYPE(cp_fm_type)                                   :: fwork
@@ -926,8 +1015,22 @@ CONTAINS
          wtype = .FALSE.
       END IF
 
+      IF (PRESENT(for_aux_fit)) THEN
+         aux_fit = for_aux_fit
+      ELSE
+         aux_fit = .FALSE.
+      END IF
+
+      IF (aux_fit) THEN
+         CPASSERT(ASSOCIATED(kpoint%kp_aux_env))
+      END IF
+
       ! work matrix
-      mo_set => kpoint%kp_env(1)%kpoint_env%mos(1, 1)
+      IF (aux_fit) THEN
+         mo_set => kpoint%kp_aux_env(1)%kpoint_env%mos(1, 1)
+      ELSE
+         mo_set => kpoint%kp_env(1)%kpoint_env%mos(1, 1)
+      END IF
       CALL get_mo_set(mo_set, nao=nao, nmo=nmo)
       CALL cp_fm_get_info(mo_set%mo_coeff, matrix_struct=matrix_struct)
       CALL cp_fm_create(fwork, matrix_struct)
@@ -935,7 +1038,11 @@ CONTAINS
       CALL get_kpoint_info(kpoint, kp_range=kp_range)
       kplocal = kp_range(2) - kp_range(1) + 1
       DO ikpgr = 1, kplocal
-         kp => kpoint%kp_env(ikpgr)%kpoint_env
+         IF (aux_fit) THEN
+            kp => kpoint%kp_aux_env(ikpgr)%kpoint_env
+         ELSE
+            kp => kpoint%kp_env(ikpgr)%kpoint_env
+         END IF
          nspin = SIZE(kp%mos, 2)
          DO ispin = 1, nspin
             mo_set => kp%mos(1, ispin)
@@ -973,9 +1080,9 @@ CONTAINS
                CALL parallel_gemm("N", "T", nao, nao, nmo, 1.0_dp, mo_set%mo_coeff, fwork, 0.0_dp, rpmat)
                mo_set => kp%mos(2, ispin)
                ! Im(c)*Re(c)
-               CALL parallel_gemm("N", "T", nao, nao, nmo, -1.0_dp, mo_set%mo_coeff, fwork, 0.0_dp, cpmat)
+               CALL parallel_gemm("N", "T", nao, nao, nmo, 1.0_dp, mo_set%mo_coeff, fwork, 0.0_dp, cpmat)
                ! Re(c)*Im(c)
-               CALL parallel_gemm("N", "T", nao, nao, nmo, 1.0_dp, fwork, mo_set%mo_coeff, 1.0_dp, cpmat)
+               CALL parallel_gemm("N", "T", nao, nao, nmo, -1.0_dp, fwork, mo_set%mo_coeff, 1.0_dp, cpmat)
                CALL cp_fm_to_fm(mo_set%mo_coeff, fwork)
                CALL cp_fm_column_scale(fwork, occupation)
                IF (wtype) THEN
@@ -1002,23 +1109,29 @@ CONTAINS
 !> \param tempmat DBCSR matrix to be used as template
 !> \param sab_nl ...
 !> \param fmwork  FM work matrices (kpoint group)
+!> \param for_aux_fit ...
+!> \param pmat_ext ...
 ! **************************************************************************************************
-   SUBROUTINE kpoint_density_transform(kpoint, denmat, wtype, tempmat, sab_nl, fmwork)
+   SUBROUTINE kpoint_density_transform(kpoint, denmat, wtype, tempmat, sab_nl, fmwork, for_aux_fit, pmat_ext)
 
       TYPE(kpoint_type), POINTER                         :: kpoint
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: denmat
+      TYPE(dbcsr_p_type), DIMENSION(:, :)                :: denmat
       LOGICAL, INTENT(IN)                                :: wtype
       TYPE(dbcsr_type), POINTER                          :: tempmat
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_nl
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fmwork
+      LOGICAL, OPTIONAL                                  :: for_aux_fit
+      TYPE(cp_fm_type), DIMENSION(:, :, :), INTENT(IN), &
+         OPTIONAL                                        :: pmat_ext
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_density_transform'
 
       INTEGER                                            :: handle, ic, ik, ikk, indx, is, ispin, &
                                                             nc, nimg, nkp, nspin
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
-      LOGICAL                                            :: my_kpgrp, real_only
+      LOGICAL                                            :: aux_fit, do_ext, do_symmetric, my_kpgrp, &
+                                                            real_only
       REAL(KIND=dp)                                      :: wkpx
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
@@ -1027,16 +1140,33 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: cpmat, rpmat, scpmat, srpmat
       TYPE(kpoint_env_type), POINTER                     :: kp
       TYPE(kpoint_sym_type), POINTER                     :: kpsym
-      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_inter_kp
+      TYPE(mp_para_env_type), POINTER                    :: para_env
 
       CALL timeset(routineN, handle)
 
+      CALL get_neighbor_list_set_p(neighbor_list_sets=sab_nl, symmetric=do_symmetric)
+
+      IF (PRESENT(for_aux_fit)) THEN
+         aux_fit = for_aux_fit
+      ELSE
+         aux_fit = .FALSE.
+      END IF
+
+      do_ext = .FALSE.
+      IF (PRESENT(pmat_ext)) do_ext = .TRUE.
+
+      IF (aux_fit) THEN
+         CPASSERT(ASSOCIATED(kpoint%kp_aux_env))
+      END IF
+
       ! work storage
       ALLOCATE (rpmat)
-      CALL dbcsr_create(rpmat, template=tempmat, matrix_type=dbcsr_type_symmetric)
+      CALL dbcsr_create(rpmat, template=tempmat, &
+                        matrix_type=MERGE(dbcsr_type_symmetric, dbcsr_type_no_symmetry, do_symmetric))
       CALL cp_dbcsr_alloc_block_from_nbl(rpmat, sab_nl)
       ALLOCATE (cpmat)
-      CALL dbcsr_create(cpmat, template=tempmat, matrix_type=dbcsr_type_antisymmetric)
+      CALL dbcsr_create(cpmat, template=tempmat, &
+                        matrix_type=MERGE(dbcsr_type_antisymmetric, dbcsr_type_no_symmetry, do_symmetric))
       CALL cp_dbcsr_alloc_block_from_nbl(cpmat, sab_nl)
       IF (.NOT. kpoint%full_grid) THEN
          ALLOCATE (srpmat)
@@ -1048,10 +1178,13 @@ CONTAINS
       END IF
 
       CALL get_kpoint_info(kpoint, nkp=nkp, xkp=xkp, wkp=wkp, &
-                           para_env_inter_kp=para_env_inter_kp, &
-                           sab_nl=sab_nl, cell_to_index=cell_to_index)
+                           cell_to_index=cell_to_index)
       ! initialize real space density matrices
-      kp => kpoint%kp_env(1)%kpoint_env
+      IF (aux_fit) THEN
+         kp => kpoint%kp_aux_env(1)%kpoint_env
+      ELSE
+         kp => kpoint%kp_env(1)%kpoint_env
+      END IF
       nspin = SIZE(kp%mos, 2)
       nc = SIZE(kp%mos, 1)
       nimg = SIZE(denmat, 2)
@@ -1071,7 +1204,11 @@ CONTAINS
             my_kpgrp = (ik >= kpoint%kp_range(1) .AND. ik <= kpoint%kp_range(2))
             IF (my_kpgrp) THEN
                ikk = ik - kpoint%kp_range(1) + 1
-               kp => kpoint%kp_env(ikk)%kpoint_env
+               IF (aux_fit) THEN
+                  kp => kpoint%kp_aux_env(ikk)%kpoint_env
+               ELSE
+                  kp => kpoint%kp_env(ikk)%kpoint_env
+               END IF
             ELSE
                NULLIFY (kp)
             END IF
@@ -1081,10 +1218,14 @@ CONTAINS
             IF (my_kpgrp) THEN
                DO ic = 1, nc
                   indx = indx + 1
-                  IF (wtype) THEN
-                     CALL cp_fm_start_copy_general(kp%wmat(ic, ispin), fmwork(ic), para_env, info(indx))
+                  IF (do_ext) THEN
+                     CALL cp_fm_start_copy_general(pmat_ext(ikk, ic, ispin), fmwork(ic), para_env, info(indx))
                   ELSE
-                     CALL cp_fm_start_copy_general(kp%pmat(ic, ispin), fmwork(ic), para_env, info(indx))
+                     IF (wtype) THEN
+                        CALL cp_fm_start_copy_general(kp%wmat(ic, ispin), fmwork(ic), para_env, info(indx))
+                     ELSE
+                        CALL cp_fm_start_copy_general(kp%pmat(ic, ispin), fmwork(ic), para_env, info(indx))
+                     END IF
                   END IF
                END DO
             ELSE
@@ -1110,7 +1251,6 @@ CONTAINS
                CALL copy_fm_to_dbcsr(fmwork(1), rpmat, keep_sparsity=.TRUE.)
             ELSE
                CALL copy_fm_to_dbcsr(fmwork(1), rpmat, keep_sparsity=.TRUE.)
-               ! it seems this copy to a antisymmetric dbcsr matrix changes sign!
                CALL copy_fm_to_dbcsr(fmwork(2), cpmat, keep_sparsity=.TRUE.)
             END IF
 
@@ -1145,7 +1285,11 @@ CONTAINS
             my_kpgrp = (ik >= kpoint%kp_range(1) .AND. ik <= kpoint%kp_range(2))
             IF (my_kpgrp) THEN
                ikk = ik - kpoint%kp_range(1) + 1
-               kp => kpoint%kp_env(ikk)%kpoint_env
+               IF (aux_fit) THEN
+                  kp => kpoint%kp_aux_env(ikk)%kpoint_env
+               ELSE
+                  kp => kpoint%kp_env(ikk)%kpoint_env
+               END IF
 
                DO ic = 1, nc
                   indx = indx + 1
@@ -1187,7 +1331,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE transform_dmat(denmat, rpmat, cpmat, ispin, real_only, sab_nl, cell_to_index, xkp, wkp)
 
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: denmat
+      TYPE(dbcsr_p_type), DIMENSION(:, :)                :: denmat
       TYPE(dbcsr_type), POINTER                          :: rpmat, cpmat
       INTEGER, INTENT(IN)                                :: ispin
       LOGICAL, INTENT(IN)                                :: real_only
@@ -1199,7 +1343,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'transform_dmat'
 
-      INTEGER                                            :: handle, iatom, icell, icol, irow, jatom
+      INTEGER                                            :: handle, iatom, icell, icol, irow, jatom, &
+                                                            nimg
       INTEGER, DIMENSION(3)                              :: cell
       LOGICAL                                            :: do_symmetric, found
       REAL(KIND=dp)                                      :: arg, coskl, fc, sinkl
@@ -1209,23 +1354,31 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
+      nimg = SIZE(denmat, 2)
+
       ! transformation
       CALL get_neighbor_list_set_p(neighbor_list_sets=sab_nl, symmetric=do_symmetric)
       CALL neighbor_list_iterator_create(nl_iterator, sab_nl)
       DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
          CALL get_iterator_info(nl_iterator, iatom=iatom, jatom=jatom, cell=cell)
 
-         ! fc = +/-1 sign change from above, is used to get correct sign due to
-         !           a<->b ==> cell = -cell
+         !We have a FT from KP to real-space: S(R) = sum_k S(k)*exp(-i*k*R), with S(k) a complex number
+         !Therefore, we have: S(R) = sum_k Re(S(k))*cos(k*R) -i^2*Im(S(k))*sin(k*R)
+         !                         = sum_k Re(S(k))*cos(k*R) + Im(S(k))*sin(k*R)
+         !fc = +- 1 is due to the usual non-symmetric real-sapce matrices stored as symmetric ones
+
          irow = iatom
          icol = jatom
-         fc = -1.0_dp
+         fc = 1.0_dp
          IF (do_symmetric .AND. iatom > jatom) THEN
             irow = jatom
             icol = iatom
-            fc = 1.0_dp
+            fc = -1.0_dp
          END IF
+
          icell = cell_to_index(cell(1), cell(2), cell(3))
+         IF (icell < 1 .OR. icell > nimg) CYCLE
+
          arg = REAL(cell(1), dp)*xkp(1) + REAL(cell(2), dp)*xkp(2) + REAL(cell(3), dp)*xkp(3)
          coskl = wkp*COS(twopi*arg)
          sinkl = wkp*fc*SIN(twopi*arg)

--- a/src/kpoint_types.F
+++ b/src/kpoint_types.F
@@ -49,7 +49,7 @@ MODULE kpoint_types
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'kpoint_types'
 
    PUBLIC :: kpoint_type
-   PUBLIC :: kpoint_create, kpoint_release, get_kpoint_info
+   PUBLIC :: kpoint_create, kpoint_release, get_kpoint_info, set_kpoint_info
    PUBLIC :: read_kpoint_section, write_kpoint_info
    PUBLIC :: kpoint_env_type, kpoint_env_p_type
    PUBLIC :: kpoint_env_create, get_kpoint_env
@@ -65,6 +65,8 @@ MODULE kpoint_types
 !> \param mos       associated MOs (r/i,spin)
 !> \param pmat      associated density matrix (r/i,spin)
 !> \param wmat      associated energy weighted density matrix (r/i,spin)
+!> \param smat      associated overlap matrix (for ADMM) (r/i,spin)
+!> \param amat      associated ADMM basis projection matrix (r/i,spin)
 !> \author JGH
 ! **************************************************************************************************
    TYPE kpoint_env_type
@@ -75,6 +77,8 @@ MODULE kpoint_types
       TYPE(mo_set_type), DIMENSION(:, :), POINTER     :: mos
       TYPE(cp_fm_type), DIMENSION(:, :), POINTER      :: pmat
       TYPE(cp_fm_type), DIMENSION(:, :), POINTER      :: wmat
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER      :: smat
+      TYPE(cp_fm_type), DIMENSION(:, :), POINTER      :: amat
    END TYPE kpoint_env_type
 
    TYPE kpoint_env_p_type
@@ -157,14 +161,18 @@ MODULE kpoint_types
       INTEGER, DIMENSION(:, :, :), POINTER    :: cell_to_index => Null()
       INTEGER, DIMENSION(:, :), POINTER       :: index_to_cell => Null()
       TYPE(neighbor_list_set_p_type), &
-         DIMENSION(:), POINTER                :: sab_nl => Null()
+         DIMENSION(:), POINTER                :: sab_nl => Null(), &
+                                                 sab_nl_nosym => Null()
       ! environment
       TYPE(kpoint_env_p_type), DIMENSION(:), &
          POINTER                              :: kp_env => Null()
+      TYPE(kpoint_env_p_type), DIMENSION(:), &
+         POINTER                              :: kp_aux_env => Null()
       TYPE(kpoint_sym_p_type), DIMENSION(:), &
          POINTER                              :: kp_sym => Null()
       TYPE(qs_matrix_pools_type), POINTER     :: mpools => Null()
       TYPE(qs_diis_buffer_type_kp), POINTER   :: scf_diis_buffer => Null()
+      TYPE(qs_matrix_pools_type), POINTER     :: mpools_aux_fit => Null()
    END TYPE kpoint_type
 
 ! **************************************************************************************************
@@ -240,6 +248,8 @@ CONTAINS
          END IF
 
          CALL mpools_release(kpoint%mpools)
+         CALL mpools_release(kpoint%mpools_aux_fit)
+
          CALL cp_blacs_env_release(kpoint%blacs_env)
          CALL cp_blacs_env_release(kpoint%blacs_env_all)
 
@@ -255,6 +265,13 @@ CONTAINS
                CALL kpoint_env_release(kpoint%kp_env(ik)%kpoint_env)
             END DO
             DEALLOCATE (kpoint%kp_env)
+         END IF
+
+         IF (ASSOCIATED(kpoint%kp_aux_env)) THEN
+            DO ik = 1, SIZE(kpoint%kp_aux_env)
+               CALL kpoint_env_release(kpoint%kp_aux_env(ik)%kpoint_env)
+            END DO
+            DEALLOCATE (kpoint%kp_aux_env)
          END IF
 
          IF (ASSOCIATED(kpoint%kp_sym)) THEN
@@ -297,18 +314,22 @@ CONTAINS
 !> \param para_env_inter_kp   parallel environment between kpoints
 !> \param blacs_env     BLACS env for the kpoint group
 !> \param kp_env        Information for each kpoint
+!> \param kp_aux_env ...
 !> \param mpools        FM matrix pools for kpoint groups
 !> \param iogrp         this kpoint group has the IO processor
 !> \param nkp_groups    number of kpoint groups
 !> \param kp_dist       kpoints distribution on groups
 !> \param cell_to_index given a cell triple, returns the real space index
+!> \param index_to_cell ...
 !> \param sab_nl        neighbourlist that defines real space matrices
+!> \param sab_nl_nosym neighbourlist that defines real space matrices, non-symmetric
 !> \author JGH
 ! **************************************************************************************************
    SUBROUTINE get_kpoint_info(kpoint, kp_scheme, nkp_grid, kp_shift, symmetry, verbose, &
                               full_grid, use_real_wfn, eps_geo, parallel_group_size, kp_range, nkp, xkp, wkp, &
                               para_env, blacs_env_all, para_env_kp, para_env_inter_kp, blacs_env, &
-                              kp_env, mpools, iogrp, nkp_groups, kp_dist, cell_to_index, sab_nl)
+                              kp_env, kp_aux_env, mpools, iogrp, nkp_groups, kp_dist, cell_to_index, index_to_cell, &
+                              sab_nl, sab_nl_nosym)
       TYPE(kpoint_type), INTENT(IN)                      :: kpoint
       CHARACTER(LEN=*), OPTIONAL                         :: kp_scheme
       INTEGER, DIMENSION(3), OPTIONAL                    :: nkp_grid
@@ -326,14 +347,15 @@ CONTAINS
       TYPE(mp_para_env_type), OPTIONAL, POINTER          :: para_env_kp, para_env_inter_kp
       TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env
       TYPE(kpoint_env_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: kp_env
+         POINTER                                         :: kp_env, kp_aux_env
       TYPE(qs_matrix_pools_type), OPTIONAL, POINTER      :: mpools
       LOGICAL, OPTIONAL                                  :: iogrp
       INTEGER, OPTIONAL                                  :: nkp_groups
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: kp_dist
       INTEGER, DIMENSION(:, :, :), OPTIONAL, POINTER     :: cell_to_index
+      INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: index_to_cell
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         OPTIONAL, POINTER                               :: sab_nl
+         OPTIONAL, POINTER                               :: sab_nl, sab_nl_nosym
 
       IF (PRESENT(kp_scheme)) kp_scheme = kpoint%kp_scheme
       IF (PRESENT(nkp_grid)) nkp_grid = kpoint%nkp_grid
@@ -361,10 +383,13 @@ CONTAINS
       IF (PRESENT(kp_dist)) kp_dist => kpoint%kp_dist
 
       IF (PRESENT(kp_env)) kp_env => kpoint%kp_env
+      IF (PRESENT(kp_aux_env)) kp_aux_env => kpoint%kp_aux_env
       IF (PRESENT(mpools)) mpools => kpoint%mpools
 
       IF (PRESENT(cell_to_index)) cell_to_index => kpoint%cell_to_index
+      IF (PRESENT(index_to_cell)) index_to_cell => kpoint%index_to_cell
       IF (PRESENT(sab_nl)) sab_nl => kpoint%sab_nl
+      IF (PRESENT(sab_nl_nosym)) sab_nl_nosym => kpoint%sab_nl_nosym
 
    END SUBROUTINE get_kpoint_info
 
@@ -390,18 +415,22 @@ CONTAINS
 !> \param para_env_inter_kp   parallel environment between kpoints
 !> \param blacs_env     BLACS env for the kpoint group
 !> \param kp_env        Information for each kpoint
+!> \param kp_aux_env ...
 !> \param mpools        FM matrix pools for kpoint groups
 !> \param iogrp         this kpoint group has the IO processor
 !> \param nkp_groups    number of kpoint groups
 !> \param kp_dist       kpoints distribution on groups
 !> \param cell_to_index given a cell triple, returns the real space index
+!> \param index_to_cell ...
 !> \param sab_nl        neighbourlist that defines real space matrices
+!> \param sab_nl_nosym  neighbourlist that defines real space matrices
 !> \author JGH
 ! **************************************************************************************************
    SUBROUTINE set_kpoint_info(kpoint, kp_scheme, nkp_grid, kp_shift, symmetry, verbose, &
                               full_grid, use_real_wfn, eps_geo, parallel_group_size, kp_range, nkp, xkp, wkp, &
                               para_env, blacs_env_all, para_env_kp, para_env_inter_kp, blacs_env, &
-                              kp_env, mpools, iogrp, nkp_groups, kp_dist, cell_to_index, sab_nl)
+                              kp_env, kp_aux_env, mpools, iogrp, nkp_groups, kp_dist, cell_to_index, index_to_cell, &
+                              sab_nl, sab_nl_nosym)
       TYPE(kpoint_type), INTENT(INOUT)                   :: kpoint
       CHARACTER(LEN=*), OPTIONAL                         :: kp_scheme
       INTEGER, DIMENSION(3), OPTIONAL                    :: nkp_grid
@@ -419,14 +448,15 @@ CONTAINS
       TYPE(mp_para_env_type), OPTIONAL, POINTER          :: para_env_kp, para_env_inter_kp
       TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env
       TYPE(kpoint_env_p_type), DIMENSION(:), OPTIONAL, &
-         POINTER                                         :: kp_env
+         POINTER                                         :: kp_env, kp_aux_env
       TYPE(qs_matrix_pools_type), OPTIONAL, POINTER      :: mpools
       LOGICAL, OPTIONAL                                  :: iogrp
       INTEGER, OPTIONAL                                  :: nkp_groups
       INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: kp_dist
       INTEGER, DIMENSION(:, :, :), OPTIONAL, POINTER     :: cell_to_index
+      INTEGER, DIMENSION(:, :), OPTIONAL, POINTER        :: index_to_cell
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         OPTIONAL, POINTER                               :: sab_nl
+         OPTIONAL, POINTER                               :: sab_nl, sab_nl_nosym
 
       IF (PRESENT(kp_scheme)) kpoint%kp_scheme = kp_scheme
       IF (PRESENT(nkp_grid)) kpoint%nkp_grid = nkp_grid
@@ -454,12 +484,19 @@ CONTAINS
       IF (PRESENT(kp_dist)) kpoint%kp_dist => kp_dist
 
       IF (PRESENT(kp_env)) kpoint%kp_env => kp_env
+      IF (PRESENT(kp_env)) kpoint%kp_aux_env => kp_aux_env
       IF (PRESENT(mpools)) kpoint%mpools => mpools
       IF (PRESENT(sab_nl)) kpoint%sab_nl => sab_nl
+      IF (PRESENT(sab_nl_nosym)) kpoint%sab_nl_nosym => sab_nl_nosym
 
       IF (PRESENT(cell_to_index)) THEN
          IF (ASSOCIATED(kpoint%cell_to_index)) DEALLOCATE (kpoint%cell_to_index)
          kpoint%cell_to_index => cell_to_index
+      END IF
+
+      IF (PRESENT(index_to_cell)) THEN
+         IF (ASSOCIATED(kpoint%index_to_cell)) DEALLOCATE (kpoint%index_to_cell)
+         kpoint%index_to_cell => index_to_cell
       END IF
 
    END SUBROUTINE set_kpoint_info
@@ -659,6 +696,8 @@ CONTAINS
       NULLIFY (kp_env%mos)
       NULLIFY (kp_env%pmat)
       NULLIFY (kp_env%wmat)
+      NULLIFY (kp_env%smat)
+      NULLIFY (kp_env%amat)
 
    END SUBROUTINE kpoint_env_create
 
@@ -685,6 +724,8 @@ CONTAINS
 
          CALL cp_fm_release(kp_env%pmat)
          CALL cp_fm_release(kp_env%wmat)
+         CALL cp_fm_release(kp_env%smat)
+         CALL cp_fm_release(kp_env%amat)
 
          DEALLOCATE (kp_env)
 

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -645,7 +645,7 @@ CONTAINS
       END DO
 
       CALL build_2c_integrals(mat_2c, 0.0_dp, qs_env, sab_RI, basis_set_RI, basis_set_RI, &
-                              ri_metric, do_kpoints=do_kpoints, kpoints=kpoints, &
+                              ri_metric, do_kpoints=do_kpoints, ext_kpoints=kpoints, &
                               regularization_RI=my_regularization_RI)
 
       CALL dbcsr_distribution_release(dbcsr_dist)

--- a/src/qs_energy_init.F
+++ b/src/qs_energy_init.F
@@ -29,7 +29,8 @@ MODULE qs_energy_init
    USE kg_environment_types,            ONLY: kg_environment_type
    USE kinds,                           ONLY: dp
    USE kpoint_methods,                  ONLY: kpoint_init_cell_index
-   USE kpoint_types,                    ONLY: kpoint_type
+   USE kpoint_types,                    ONLY: kpoint_type,&
+                                              set_kpoint_info
    USE lri_environment_methods,         ONLY: build_lri_matrices,&
                                               calculate_lri_integrals
    USE lri_environment_types,           ONLY: lri_environment_type
@@ -255,7 +256,7 @@ CONTAINS
       TYPE(lri_environment_type), POINTER                :: lri_env
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_nl
+         POINTER                                         :: sab_nl, sab_nl_nosym
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_gcp_type), POINTER                         :: gcp_env
@@ -276,8 +277,9 @@ CONTAINS
 
       ! calculate cell index for k-point calculations
       IF (do_kpoints) THEN
-         CALL get_qs_env(qs_env, sab_kp=sab_nl)
+         CALL get_qs_env(qs_env, sab_kp=sab_nl, sab_kp_nosym=sab_nl_nosym)
          CALL kpoint_init_cell_index(kpoints, sab_nl, para_env, dft_control)
+         CALL set_kpoint_info(kpoints, sab_nl_nosym=sab_nl_nosym)
       END IF
       IF (dft_control%qs_control%cdft) THEN
          IF (.NOT. (dft_control%qs_control%cdft_control%external_control)) &

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -110,7 +110,8 @@ MODULE qs_environment
    USE kpoint_methods,                  ONLY: kpoint_env_initialize,&
                                               kpoint_initialize,&
                                               kpoint_initialize_mos
-   USE kpoint_types,                    ONLY: kpoint_create,&
+   USE kpoint_types,                    ONLY: get_kpoint_info,&
+                                              kpoint_create,&
                                               kpoint_type,&
                                               read_kpoint_section,&
                                               write_kpoint_info
@@ -250,7 +251,8 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: force_env_section, subsys_section
       LOGICAL, INTENT(IN)                                :: use_motion_section
 
-      INTEGER                                            :: ikind, method_id, nelectron_total, nkind
+      INTEGER                                            :: ikind, method_id, nelectron_total, &
+                                                            nkind, nkp_grid(3)
       LOGICAL :: do_admm_rpa, do_ec_hfx, do_et, do_exx, do_hfx, do_kpoints, is_identical, is_semi, &
          mp2_present, my_qmmm, qmmm_decoupl, same_except_frac, silent, use_ref_cell
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rtmat
@@ -387,7 +389,7 @@ CONTAINS
       ! more kpoint stuff
       CALL get_qs_env(qs_env=qs_env, do_kpoints=do_kpoints, blacs_env=blacs_env)
       IF (do_kpoints) THEN
-         CALL kpoint_env_initialize(kpoints, para_env, blacs_env)
+         CALL kpoint_env_initialize(kpoints, para_env, blacs_env, with_aux_fit=dft_control%do_admm)
          CALL kpoint_initialize_mos(kpoints, qs_env%mos)
          CALL get_qs_env(qs_env=qs_env, wf_history=wf_history)
          CALL wfi_create_for_kp(wf_history)
@@ -399,9 +401,11 @@ CONTAINS
       CALL get_qs_env(qs_env, dft_control=dft_control, scf_control=scf_control, nelectron_total=nelectron_total)
       IF (do_hfx) THEN
          ! Retrieve particle_set and atomic_kind_set (needed for both kinds of initialization)
+         nkp_grid = 1
+         IF (do_kpoints) CALL get_kpoint_info(kpoints, nkp_grid=nkp_grid)
          CALL hfx_create(qs_env%x_data, para_env, hfx_section, atomic_kind_set, &
                          qs_kind_set, particle_set, dft_control, my_cell, &
-                         nelectron_total=nelectron_total)
+                         nelectron_total=nelectron_total, nkp_grid=nkp_grid)
       END IF
 
       mp2_section => section_vals_get_subs_vals(qs_env%input, "DFT%XC%WF_CORRELATION")

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -344,6 +344,7 @@ CONTAINS
 !> \param sab_xtb_nonbond ...
 !> \param sab_almo ...
 !> \param sab_kp ...
+!> \param sab_kp_nosym ...
 !> \param particle_set ...
 !> \param energy ...
 !> \param force ...
@@ -475,7 +476,7 @@ CONTAINS
    SUBROUTINE get_qs_env(qs_env, atomic_kind_set, qs_kind_set, cell, super_cell, cell_ref, use_ref_cell, kpoints, &
                          dft_control, mos, sab_orb, sab_all, qmmm, qmmm_periodic, sac_ae, sac_ppl, sac_lri, &
                          sap_ppnl, sab_vdw, sab_scp, sap_oce, sab_lrc, sab_se, sab_xtbe, sab_tbe, sab_core, &
-                         sab_xb, sab_xtb_nonbond, sab_almo, sab_kp, particle_set, energy, force, &
+                         sab_xb, sab_xtb_nonbond, sab_almo, sab_kp, sab_kp_nosym, particle_set, energy, force, &
                          matrix_h, matrix_h_im, matrix_ks, matrix_ks_im, matrix_vxc, run_rtp, rtp, &
                          matrix_h_kp, matrix_h_im_kp, matrix_ks_kp, matrix_ks_im_kp, matrix_vxc_kp, kinetic_kp, matrix_s_kp, &
                          matrix_w_kp, matrix_s_RI_aux_kp, matrix_s, matrix_s_RI_aux, matrix_w, &
@@ -513,7 +514,7 @@ CONTAINS
       LOGICAL, OPTIONAL                                  :: qmmm, qmmm_periodic
       TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sac_ae, sac_ppl, sac_lri, &
          sap_ppnl, sab_vdw, sab_scp, sap_oce, sab_lrc, sab_se, sab_xtbe, sab_tbe, sab_core, &
-         sab_xb, sab_xtb_nonbond, sab_almo, sab_kp
+         sab_xb, sab_xtb_nonbond, sab_almo, sab_kp, sab_kp_nosym
       TYPE(particle_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: particle_set
       TYPE(qs_energy_type), OPTIONAL, POINTER            :: energy
@@ -780,6 +781,7 @@ CONTAINS
                       sab_xtb_nonbond=sab_xtb_nonbond, &
                       sab_almo=sab_almo, &
                       sab_kp=sab_kp, &
+                      sab_kp_nosym=sab_kp_nosym, &
                       task_list=task_list, &
                       task_list_soft=task_list_soft, &
                       kpoints=kpoints, &

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -23,10 +23,12 @@ MODULE qs_ks_methods
    USE admm_dm_methods,                 ONLY: admm_dm_calc_rho_aux,&
                                               admm_dm_merge_ks_matrix
    USE admm_methods,                    ONLY: admm_mo_calc_rho_aux,&
+                                              admm_mo_calc_rho_aux_kp,&
                                               admm_mo_merge_ks_matrix,&
                                               admm_update_ks_atom,&
                                               calc_admm_mo_derivatives,&
-                                              calc_admm_ovlp_forces
+                                              calc_admm_ovlp_forces,&
+                                              calc_admm_ovlp_forces_kp
    USE admm_types,                      ONLY: admm_type,&
                                               get_admm_env
    USE cell_types,                      ONLY: cell_type
@@ -49,7 +51,8 @@ MODULE qs_ks_methods
    USE hartree_local_methods,           ONLY: Vh_1c_gg_integrals
    USE hartree_local_types,             ONLY: ecoul_1center_type
    USE hfx_admm_utils,                  ONLY: hfx_admm_init,&
-                                              hfx_ks_matrix
+                                              hfx_ks_matrix,&
+                                              hfx_ks_matrix_kp
    USE input_constants,                 ONLY: do_ppl_grid,&
                                               outer_scf_becke_constraint,&
                                               outer_scf_hirshfeld_constraint
@@ -60,6 +63,8 @@ MODULE qs_ks_methods
    USE kg_correction,                   ONLY: kg_ekin_subset
    USE kinds,                           ONLY: default_string_length,&
                                               dp
+   USE kpoint_types,                    ONLY: get_kpoint_info,&
+                                              kpoint_type
    USE lri_environment_methods,         ONLY: v_int_ppl_energy
    USE lri_environment_types,           ONLY: lri_density_type,&
                                               lri_environment_type,&
@@ -182,7 +187,7 @@ CONTAINS
       CHARACTER(len=default_string_length)               :: name
       INTEGER                                            :: handle, iatom, img, ispin, nimages, ns, &
                                                             nspins
-      LOGICAL :: do_adiabatic_rescaling, do_ddapc, do_hfx, do_ppl, gapw, gapw_xc, &
+      LOGICAL :: do_adiabatic_rescaling, do_ddapc, do_hfx, do_ppl, dokp, gapw, gapw_xc, &
          hfx_treat_lsd_in_core, just_energy_xc, lrigpw, my_print, rigpw, use_virial
       REAL(KIND=dp)                                      :: ecore_ppl, edisp, ee_ener, ekin_mol, &
                                                             mulliken_order_p, vscale
@@ -288,6 +293,7 @@ CONTAINS
       CPASSERT(ASSOCIATED(rho))
       CPASSERT(ASSOCIATED(pw_env))
       CPASSERT(SIZE(ks_matrix, 1) > 0)
+      dokp = (nimages > 1)
 
       ! Setup the possible usage of DDAPC charges
       do_ddapc = dft_control%qs_control%ddapc_restraint .OR. &
@@ -497,13 +503,17 @@ CONTAINS
 
       ! calculate the density matrix for the fitted mo_coeffs
       IF (dft_control%do_admm) THEN
-         CALL hfx_admm_init(qs_env)
+         CALL hfx_admm_init(qs_env, calculate_forces)
 
          IF (dft_control%do_admm_mo) THEN
             IF (qs_env%run_rtp) THEN
                CALL rtp_admm_calc_rho_aux(qs_env)
             ELSE
-               CALL admm_mo_calc_rho_aux(qs_env)
+               IF (dokp) THEN
+                  CALL admm_mo_calc_rho_aux_kp(qs_env)
+               ELSE
+                  CALL admm_mo_calc_rho_aux(qs_env)
+               END IF
             END IF
          ELSEIF (dft_control%do_admm_dm) THEN
             CALL admm_dm_calc_rho_aux(qs_env)
@@ -600,8 +610,12 @@ CONTAINS
 
       ! *** Add Hartree-Fock contribution if required ***
       IF (do_hfx) THEN
-         CALL hfx_ks_matrix(qs_env, ks_matrix, rho, energy, calculate_forces, &
-                            just_energy, v_rspace_new, v_tau_rspace)
+         IF (dokp) THEN
+            CALL hfx_ks_matrix_kp(qs_env, ks_matrix, energy, calculate_forces)
+         ELSE
+            CALL hfx_ks_matrix(qs_env, ks_matrix, rho, energy, calculate_forces, &
+                               just_energy, v_rspace_new, v_tau_rspace)
+         END IF
 !!    Adiabatic rescaling  only if do_hfx; right?????
       END IF !do_hfx
 
@@ -835,7 +849,13 @@ CONTAINS
       END IF
 
       ! ADMM overlap forces
-      IF (calculate_forces .AND. dft_control%do_admm) CALL calc_admm_ovlp_forces(qs_env)
+      IF (calculate_forces .AND. dft_control%do_admm) THEN
+         IF (dokp) THEN
+            CALL calc_admm_ovlp_forces_kp(qs_env)
+         ELSE
+            CALL calc_admm_ovlp_forces(qs_env)
+         END IF
+      END IF
 
       ! deal with low spin roks
       CALL low_spin_roks(energy, qs_env, dft_control, do_hfx, just_energy, &
@@ -1223,22 +1243,31 @@ CONTAINS
 
       CHARACTER(LEN=default_string_length)               :: headline
       INTEGER                                            :: ic, ispin, nimages, nspins
+      LOGICAL                                            :: do_kpoints
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp, matrixkp_im_ks, matrixkp_ks
       TYPE(dbcsr_type), POINTER                          :: refmatrix
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
 
-      NULLIFY (dft_control, ks_env, matrix_s_kp, sab_orb, matrixkp_ks, refmatrix, matrixkp_im_ks)
+      NULLIFY (dft_control, ks_env, matrix_s_kp, sab_orb, matrixkp_ks, refmatrix, matrixkp_im_ks, kpoints)
 
       CALL get_qs_env(qs_env, &
                       dft_control=dft_control, &
                       matrix_s_kp=matrix_s_kp, &
                       ks_env=ks_env, &
-                      sab_orb=sab_orb, &
+                      kpoints=kpoints, &
+                      do_kpoints=do_kpoints, &
                       matrix_ks_kp=matrixkp_ks, &
                       matrix_ks_im_kp=matrixkp_im_ks)
+
+      IF (do_kpoints) THEN
+         CALL get_kpoint_info(kpoints, sab_nl=sab_orb)
+      ELSE
+         CALL get_qs_env(qs_env, sab_orb=sab_orb)
+      END IF
 
       nspins = dft_control%nspins
       nimages = dft_control%nimages

--- a/src/qs_ks_types.F
+++ b/src/qs_ks_types.F
@@ -116,6 +116,7 @@ MODULE qs_ks_types
 !> \param sab_scp: neighbor lists for the calculation of self-consistent polarization
 !> \param sab_almo: neighbor lists to create ALMO delocalization template
 !> \param sab_kp: neighbor lists to create kp image cell lists
+!> \param sab_kp_nosym: neighbor lists to create kp image cell lists, non-symmetric
 !>
 !> \param kpoints information on the kpoints used
 !> \param subsys the particles, molecules,... of this environment
@@ -185,7 +186,8 @@ MODULE qs_ks_types
                                                                sab_all => Null(), &
                                                                sab_lrc => Null(), &
                                                                sab_almo => Null(), &
-                                                               sab_kp => Null()
+                                                               sab_kp => Null(), &
+                                                               sab_kp_nosym => Null()
 
       TYPE(task_list_type), POINTER                         :: task_list => Null()
       TYPE(task_list_type), POINTER                         :: task_list_soft => Null()
@@ -271,6 +273,7 @@ CONTAINS
 !> \param sab_scp ...
 !> \param sab_almo ...
 !> \param sab_kp ...
+!> \param sab_kp_nosym ...
 !> \param task_list ...
 !> \param task_list_soft ...
 !> \param kpoints ...
@@ -315,7 +318,8 @@ CONTAINS
                          vppl, rho_core, rho_nlcc, rho_nlcc_g, vee, &
                          neighbor_list_id, &
                          sab_orb, sab_all, sac_ae, sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, &
-                         sab_se, sab_xtbe, sab_tbe, sab_core, sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp, &
+                         sab_se, sab_xtbe, sab_tbe, sab_core, sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, &
+                         sab_almo, sab_kp, sab_kp_nosym, &
                          task_list, task_list_soft, &
                          kpoints, do_kpoints, &
                          atomic_kind_set, qs_kind_set, cell, cell_ref, use_ref_cell, &
@@ -340,7 +344,7 @@ CONTAINS
       INTEGER, OPTIONAL                                  :: neighbor_list_id
       TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_all, sac_ae, &
          sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, sab_se, sab_xtbe, sab_tbe, sab_core, &
-         sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp
+         sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp, sab_kp_nosym
       TYPE(task_list_type), OPTIONAL, POINTER            :: task_list, task_list_soft
       TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints
       LOGICAL, OPTIONAL                                  :: do_kpoints
@@ -433,6 +437,7 @@ CONTAINS
       IF (PRESENT(sab_xtb_nonbond)) sab_xtb_nonbond => ks_env%sab_xtb_nonbond
       IF (PRESENT(sab_almo)) sab_almo => ks_env%sab_almo
       IF (PRESENT(sab_kp)) sab_kp => ks_env%sab_kp
+      IF (PRESENT(sab_kp_nosym)) sab_kp_nosym => ks_env%sab_kp_nosym
       IF (PRESENT(dft_control)) dft_control => ks_env%dft_control
       IF (PRESENT(dbcsr_dist)) dbcsr_dist => ks_env%dbcsr_dist
       IF (PRESENT(distribution_2d)) distribution_2d => ks_env%distribution_2d
@@ -527,6 +532,7 @@ CONTAINS
 !> \param sab_scp ...
 !> \param sab_almo ...
 !> \param sab_kp ...
+!> \param sab_kp_nosym ...
 !> \param task_list ...
 !> \param task_list_soft ...
 !> \param subsys ...
@@ -549,7 +555,8 @@ CONTAINS
                          neighbor_list_id, &
                          kpoints, &
                          sab_orb, sab_all, sac_ae, sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, &
-                         sab_se, sab_xtbe, sab_tbe, sab_core, sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp, &
+                         sab_se, sab_xtbe, sab_tbe, sab_core, sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, &
+                         sab_almo, sab_kp, sab_kp_nosym, &
                          task_list, task_list_soft, &
                          subsys, dft_control, dbcsr_dist, distribution_2d, pw_env, &
                          para_env, blacs_env)
@@ -570,7 +577,7 @@ CONTAINS
       TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints
       TYPE(neighbor_list_set_p_type), DIMENSION(:), OPTIONAL, POINTER :: sab_orb, sab_all, sac_ae, &
          sac_ppl, sac_lri, sap_ppnl, sap_oce, sab_lrc, sab_se, sab_xtbe, sab_tbe, sab_core, &
-         sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp
+         sab_xb, sab_xtb_nonbond, sab_vdw, sab_scp, sab_almo, sab_kp, sab_kp_nosym
       TYPE(task_list_type), OPTIONAL, POINTER            :: task_list, task_list_soft
       TYPE(qs_subsys_type), OPTIONAL, POINTER            :: subsys
       TYPE(dft_control_type), OPTIONAL, POINTER          :: dft_control
@@ -644,6 +651,7 @@ CONTAINS
       IF (PRESENT(sab_xtb_nonbond)) ks_env%sab_xtb_nonbond => sab_xtb_nonbond
       IF (PRESENT(sab_almo)) ks_env%sab_almo => sab_almo
       IF (PRESENT(sab_kp)) ks_env%sab_kp => sab_kp
+      IF (PRESENT(sab_kp_nosym)) ks_env%sab_kp_nosym => sab_kp_nosym
 
       IF (PRESENT(task_list)) ks_env%task_list => task_list
       IF (PRESENT(task_list_soft)) ks_env%task_list_soft => task_list_soft
@@ -784,6 +792,7 @@ CONTAINS
       CALL release_neighbor_list_sets(ks_env%sab_lrc)
       CALL release_neighbor_list_sets(ks_env%sab_almo)
       CALL release_neighbor_list_sets(ks_env%sab_kp)
+      CALL release_neighbor_list_sets(ks_env%sab_kp_nosym)
       IF (ASSOCIATED(ks_env%dft_control)) THEN
          CALL dft_control_release(ks_env%dft_control)
          DEALLOCATE (ks_env%dft_control)
@@ -876,6 +885,7 @@ CONTAINS
       CALL release_neighbor_list_sets(ks_env%sab_lrc)
       CALL release_neighbor_list_sets(ks_env%sab_almo)
       CALL release_neighbor_list_sets(ks_env%sab_kp)
+      CALL release_neighbor_list_sets(ks_env%sab_kp_nosym)
       CALL kpoint_release(ks_env%kpoints)
       CALL pw_env_release(ks_env%pw_env, ks_env%para_env)
    END SUBROUTINE qs_ks_part_release

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -1286,17 +1286,17 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'sum_up_and_integrate'
 
       CHARACTER(LEN=default_string_length)               :: basis_type
-      INTEGER                                            :: handle, igroup, ikind, ispin, nkind, &
-                                                            nspins
+      INTEGER                                            :: handle, igroup, ikind, img, ispin, &
+                                                            nkind, nspins
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: do_ppl, gapw, gapw_xc, lrigpw, rigpw
       REAL(KIND=dp)                                      :: csign, dvol, fadm
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ksmat, matrix_ks_aux_fit, &
-                                                            matrix_ks_aux_fit_dft, rho_ao, &
-                                                            rho_ao_aux, rho_ao_nokp, smat
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_ao_kp
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ksmat, rho_ao, rho_ao_nokp, smat
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_aux_fit, &
+                                                            matrix_ks_aux_fit_dft, rho_ao_aux, &
+                                                            rho_ao_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(lri_density_type), POINTER                    :: lri_density
@@ -1604,17 +1604,19 @@ CONTAINS
       ! Add contributions from ADMM if requested
       IF (dft_control%do_admm) THEN
          CALL get_qs_env(qs_env, admm_env=admm_env)
-         CALL get_admm_env(admm_env, matrix_ks_aux_fit=matrix_ks_aux_fit, rho_aux_fit=rho_aux_fit, &
-                           matrix_ks_aux_fit_dft=matrix_ks_aux_fit_dft)
-         CALL qs_rho_get(rho_aux_fit, rho_ao=rho_ao_aux)
+         CALL get_admm_env(admm_env, matrix_ks_aux_fit_kp=matrix_ks_aux_fit, rho_aux_fit=rho_aux_fit, &
+                           matrix_ks_aux_fit_dft_kp=matrix_ks_aux_fit_dft)
+         CALL qs_rho_get(rho_aux_fit, rho_ao_kp=rho_ao_aux)
          IF (ASSOCIATED(v_rspace_new_aux_fit)) THEN
             DO ispin = 1, nspins
                ! Calculate the xc potential
                CALL pw_scale(v_rspace_new_aux_fit(ispin), v_rspace_new_aux_fit(ispin)%pw_grid%dvol)
 
                ! set matrix_ks_aux_fit_dft = matrix_ks_aux_fit(k_HF)
-               CALL dbcsr_copy(matrix_ks_aux_fit_dft(ispin)%matrix, matrix_ks_aux_fit(ispin)%matrix, &
-                               name="DFT exch. part of matrix_ks_aux_fit")
+               DO img = 1, dft_control%nimages
+                  CALL dbcsr_copy(matrix_ks_aux_fit_dft(ispin, img)%matrix, matrix_ks_aux_fit(ispin, img)%matrix, &
+                                  name="DFT exch. part of matrix_ks_aux_fit")
+               END DO
 
                ! Add potential to ks_matrix aux_fit, skip integration if no DFT correction
 
@@ -1635,9 +1637,12 @@ CONTAINS
                      fadm = (admm_env%gsi(ispin))**(2.0_dp/3.0_dp)
                   END IF
 
+                  rho_ao => rho_ao_aux(ispin, :)
+                  ksmat => matrix_ks_aux_fit(ispin, :)
+
                   CALL integrate_v_rspace(v_rspace=v_rspace_new_aux_fit(ispin), &
-                                          pmat=rho_ao_aux(ispin), &
-                                          hmat=matrix_ks_aux_fit(ispin), &
+                                          pmat_kp=rho_ao, &
+                                          hmat_kp=ksmat, &
                                           qs_env=qs_env, &
                                           calculate_forces=calculate_forces, &
                                           force_adm=fadm, &
@@ -1647,8 +1652,10 @@ CONTAINS
                END IF
 
                ! matrix_ks_aux_fit_dft(x_DFT)=matrix_ks_aux_fit_dft(old,k_HF)-matrix_ks_aux_fit(k_HF-x_DFT)
-               CALL dbcsr_add(matrix_ks_aux_fit_dft(ispin)%matrix, &
-                              matrix_ks_aux_fit(ispin)%matrix, 1.0_dp, -1.0_dp)
+               DO img = 1, dft_control%nimages
+                  CALL dbcsr_add(matrix_ks_aux_fit_dft(ispin, img)%matrix, &
+                                 matrix_ks_aux_fit(ispin, img)%matrix, 1.0_dp, -1.0_dp)
+               END DO
 
                CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new_aux_fit(ispin))
             END DO

--- a/src/qs_neighbor_lists.F
+++ b/src/qs_neighbor_lists.F
@@ -46,13 +46,10 @@ MODULE qs_neighbor_lists
                                               get_potential,&
                                               gth_potential_type,&
                                               sgp_potential_type
-   USE input_constants,                 ONLY: dispersion_uff,&
-                                              do_method_lrigpw,&
-                                              do_method_rigpw,&
-                                              do_se_IS_slater,&
-                                              vdw_pairpot_dftd3,&
-                                              vdw_pairpot_dftd3bj,&
-                                              xc_vdw_fun_pairpot
+   USE input_constants,                 ONLY: &
+        dispersion_uff, do_method_lrigpw, do_method_rigpw, do_potential_id, do_potential_short, &
+        do_potential_truncated, do_se_IS_slater, vdw_pairpot_dftd3, vdw_pairpot_dftd3bj, &
+        xc_vdw_fun_pairpot
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
@@ -61,6 +58,8 @@ MODULE qs_neighbor_lists
                                               dp,&
                                               int_8
    USE kpoint_types,                    ONLY: kpoint_type
+   USE libint_2c_3c,                    ONLY: cutoff_screen_factor
+   USE mathlib,                         ONLY: erfc_cutoff
    USE message_passing,                 ONLY: mp_para_env_type
    USE molecule_types,                  ONLY: molecule_type
    USE particle_types,                  ONLY: particle_type
@@ -294,19 +293,19 @@ CONTAINS
 
       CHARACTER(LEN=2)                                   :: element_symbol, element_symbol2
       CHARACTER(LEN=default_string_length)               :: print_key_path
-      INTEGER                                            :: handle, ikind, ingp, iw, jkind, maxatom, &
-                                                            ngp, nkind, numshells, zat
-      LOGICAL :: all_potential_present, almo, dftb, do_hfx, dokp, explicit, gth_potential_present, &
+      INTEGER                                            :: handle, hfx_pot, ikind, ingp, iw, jkind, &
+                                                            maxatom, ngp, nkind, zat
+      LOGICAL :: all_potential_present, almo, dftb, do_hfx, dokp, gth_potential_present, &
          lri_optbas, lrigpw, mic, molecule_only, nddo, paw_atom, paw_atom_present, rigpw, &
          sgp_potential_present, xtb
       LOGICAL, ALLOCATABLE, DIMENSION(:) :: all_present, aux_fit_present, aux_present, &
          core_present, default_present, nonbond1_atom, nonbond2_atom, oce_present, orb_present, &
          ppl_present, ppnl_present, ri_present, xb1_atom, xb2_atom
-      REAL(dp)                                           :: almo_rcov, almo_rvdw, pdist, rcut, &
-                                                            roperator, subcells
+      REAL(dp)                                           :: almo_rcov, almo_rvdw, eps_schwarz, &
+                                                            omega, pdist, rcut, roperator, subcells
       REAL(dp), ALLOCATABLE, DIMENSION(:) :: all_pot_rad, aux_fit_radius, c_radius, calpha, &
          core_radius, oce_radius, orb_radius, ppl_radius, ppnl_radius, ri_radius, zeff
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: pair_radius
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: pair_radius, pair_radius_lb
       TYPE(all_potential_type), POINTER                  :: all_potential
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
@@ -322,9 +321,9 @@ CONTAINS
       TYPE(local_atoms_type), ALLOCATABLE, DIMENSION(:)  :: atom2d
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
       TYPE(neighbor_list_set_p_type), DIMENSION(:), POINTER :: saa_list, sab_all, sab_almo, &
-         sab_cn, sab_core, sab_gcp, sab_kp, sab_lrc, sab_orb, sab_scp, sab_se, sab_tbe, sab_vdw, &
-         sab_xb, sab_xtb_nonbond, sab_xtbe, sac_ae, sac_lri, sac_ppl, sap_oce, sap_ppnl, soa_list, &
-         soo_list
+         sab_cn, sab_core, sab_gcp, sab_kp, sab_kp_nosym, sab_lrc, sab_orb, sab_scp, sab_se, &
+         sab_tbe, sab_vdw, sab_xb, sab_xtb_nonbond, sab_xtbe, sac_ae, sac_lri, sac_ppl, sap_oce, &
+         sap_ppnl, soa_list, soo_list
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(paw_proj_set_type), POINTER                   :: paw_proj
       TYPE(qs_dftb_atom_type), POINTER                   :: dftb_atom
@@ -364,6 +363,7 @@ CONTAINS
       NULLIFY (sab_scp)
       NULLIFY (sab_almo)
       NULLIFY (sab_kp)
+      NULLIFY (sab_kp_nosym)
 
       CALL get_qs_env(qs_env, &
                       ks_env=ks_env, &
@@ -402,7 +402,8 @@ CONTAINS
                       sab_scp=sab_scp, &
                       sab_all=sab_all, &
                       sab_almo=sab_almo, &
-                      sab_kp=sab_kp)
+                      sab_kp=sab_kp, &
+                      sab_kp_nosym=sab_kp_nosym)
 
       dokp = (kpoints%nkp > 0)
       nddo = dft_control%qs_control%semi_empirical
@@ -610,35 +611,54 @@ CONTAINS
          ! We try to guess an integration radius for K-points
          ! For non-HFX calculations we use the overlap list
          ! For HFX we use the interaction radius of kinds (ORB or ADMM basis)
-         ! plus a range for the operator (some arbitrary guess, should be revisited!)
+         ! plus a range for the operator
          IF (do_hfx) THEN
-            roperator = 0.0_dp
-            CALL section_vals_val_get(hfx_sections, "INTERACTION_POTENTIAL%CUTOFF_RADIUS", &
-                                      explicit=explicit)
-            IF (explicit) THEN
-               CALL section_vals_val_get(hfx_sections, "INTERACTION_POTENTIAL%CUTOFF_RADIUS", &
-                                         r_val=roperator)
-            ELSE
-               CALL section_vals_val_get(hfx_sections, "PERIODIC%NUMBER_OF_SHELLS", &
-                                         i_val=numshells)
-               numshells = MAX(1, numshells)
-               roperator = MAX(plane_distance(1, 0, 0, cell), &
-                               plane_distance(0, 1, 0, cell), &
-                               plane_distance(0, 0, 1, cell))*numshells
-            END IF
+
+            !case study on the HFX potential: TC, SR or Overlap?
+            CALL section_vals_val_get(hfx_sections, "INTERACTION_POTENTIAL%POTENTIAL_TYPE", i_val=hfx_pot)
+
+            SELECT CASE (hfx_pot)
+            CASE (do_potential_id)
+               roperator = 0.0_dp
+            CASE (do_potential_truncated)
+               CALL section_vals_val_get(hfx_sections, "INTERACTION_POTENTIAL%CUTOFF_RADIUS", r_val=roperator)
+            CASE (do_potential_short)
+               CALL section_vals_val_get(hfx_sections, "INTERACTION_POTENTIAL%OMEGA", r_val=omega)
+               CALL section_vals_val_get(hfx_sections, "SCREENING%EPS_SCHWARZ", r_val=eps_schwarz)
+               CALL erfc_cutoff(eps_schwarz, omega, roperator)
+            CASE DEFAULT
+               CPABORT("HFX potential not available for K-points (NYI)")
+            END SELECT
+
             IF (dft_control%do_admm) THEN
                CALL pair_radius_setup(aux_fit_present, aux_fit_present, aux_fit_radius, aux_fit_radius, &
                                       pair_radius)
+
+               !We cannot accept a pair radius smaller than the ORB overlap, for sanity reasons
+               ALLOCATE (pair_radius_lb(nkind, nkind))
+               CALL pair_radius_setup(orb_present, orb_present, orb_radius, orb_radius, pair_radius_lb)
+               DO jkind = 1, nkind
+                  DO ikind = 1, nkind
+                     IF (pair_radius(ikind, jkind) + cutoff_screen_factor*roperator .LE. pair_radius_lb(ikind, jkind)) &
+                        pair_radius(ikind, jkind) = pair_radius_lb(ikind, jkind) - roperator
+                  END DO
+               END DO
             ELSE
                CALL pair_radius_setup(orb_present, orb_present, orb_radius, orb_radius, pair_radius)
             END IF
-            pair_radius = pair_radius + roperator
+            pair_radius = pair_radius + cutoff_screen_factor*roperator
          ELSE
             CALL pair_radius_setup(orb_present, orb_present, orb_radius, orb_radius, pair_radius)
          END IF
          CALL build_neighbor_lists(sab_kp, particle_set, atom2d, cell, pair_radius, &
                                    subcells=subcells, nlname="sab_kp")
          CALL set_ks_env(ks_env=ks_env, sab_kp=sab_kp)
+
+         IF (do_hfx) THEN
+            CALL build_neighbor_lists(sab_kp_nosym, particle_set, atom2d, cell, pair_radius, &
+                                      subcells=subcells, nlname="sab_kp_nosym", symmetric=.FALSE.)
+            CALL set_ks_env(ks_env=ks_env, sab_kp_nosym=sab_kp_nosym)
+         END IF
       END IF
 
       ! Build orbital GTH-PPL operator overlap list

--- a/src/qs_overlap.F
+++ b/src/qs_overlap.F
@@ -301,7 +301,7 @@ CONTAINS
 
 !$OMP PARALLEL DEFAULT(NONE) &
 !$OMP SHARED (do_forces, ldsab, maxder, use_cell_mapping, do_symmetric, maxs, dokp, &
-!$OMP         ncoset, nder, use_virial, ndod, sab_nl, &
+!$OMP         ncoset, nder, use_virial, ndod, sab_nl, nimg,&
 !$OMP         matrix_s, matrix_p,basis_set_list_a, basis_set_list_b, cell_to_index, &
 !$OMP         matrixkp_s, matrixkp_p, locks, natom)  &
 !$OMP PRIVATE (oint, owork, pmat, sint, ikind, jkind, iatom, jatom, rab, cell, &
@@ -373,7 +373,7 @@ CONTAINS
 
          IF (use_cell_mapping) THEN
             ic = cell_to_index(cell(1), cell(2), cell(3))
-            CPASSERT(ic > 0)
+            IF (ic < 1 .OR. ic > nimg) CYCLE
          ELSE
             ic = 1
          END IF
@@ -766,6 +766,7 @@ CONTAINS
 !> \param   basis_type_b basis set to be used for ket in <a|b>
 !> \param   sab_nl pair list (must be consistent with basis sets!)
 !> \param   matrix_p density matrix for force calculation
+!> \param matrixkp_p ...
 !> \date    11.03.2002
 !> \par     History
 !>          Enlarged functionality of this routine. Now overlap matrices based
@@ -779,25 +780,27 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE build_overlap_force(ks_env, force, basis_type_a, basis_type_b, &
-                                  sab_nl, matrix_p)
+                                  sab_nl, matrix_p, matrixkp_p)
 
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: force
       CHARACTER(LEN=*), INTENT(IN)                       :: basis_type_a, basis_type_b
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_nl
-      TYPE(dbcsr_type), POINTER                          :: matrix_p
+      TYPE(dbcsr_type), OPTIONAL                         :: matrix_p
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL         :: matrixkp_p
 
       CHARACTER(len=*), PARAMETER :: routineN = 'build_overlap_force'
 
-      INTEGER                                            :: handle, iatom, icol, ikind, irow, iset, &
-                                                            jatom, jkind, jset, ldsab, n1, n2, &
-                                                            natom, ncoa, ncob, nder, nkind, nseta, &
-                                                            nsetb, sgfa, sgfb, slot
+      INTEGER :: handle, iatom, ic, icol, ikind, irow, iset, jatom, jkind, jset, ldsab, n1, n2, &
+         natom, ncoa, ncob, nder, nimg, nkind, nseta, nsetb, sgfa, sgfb, slot
+      INTEGER, DIMENSION(3)                              :: cell
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, lb_max, lb_min, npgfa, &
                                                             npgfb, nsgfa, nsgfb
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb
-      LOGICAL                                            :: do_symmetric, found, trans, use_virial
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      LOGICAL                                            :: do_symmetric, dokp, found, trans, &
+                                                            use_cell_mapping, use_virial
       REAL(KIND=dp)                                      :: dab, f0, ff, rab2
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: pab, sab
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: drab
@@ -807,15 +810,31 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, SIZE(force, 2))        :: force_thread
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: p_block, rpgfa, rpgfb, scon_a, scon_b, &
                                                             zeta, zetb
+      TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set_list_a, basis_set_list_b
       TYPE(gto_basis_set_type), POINTER                  :: basis_set_a, basis_set_b
+      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(virial_type), POINTER                         :: virial
 
       CALL timeset(routineN, handle)
 
       NULLIFY (qs_kind_set)
-      CALL get_ks_env(ks_env=ks_env, qs_kind_set=qs_kind_set)
+      CALL get_ks_env(ks_env=ks_env, qs_kind_set=qs_kind_set, dft_control=dft_control)
+      nimg = dft_control%nimages
+
+      ! test for matrices (kpoints or standard gamma point)
+      IF (PRESENT(matrix_p)) THEN
+         dokp = .FALSE.
+         use_cell_mapping = .FALSE.
+      ELSEIF (PRESENT(matrixkp_p)) THEN
+         dokp = .TRUE.
+         CALL get_ks_env(ks_env=ks_env, kpoints=kpoints)
+         CALL get_kpoint_info(kpoint=kpoints, cell_to_index=cell_to_index)
+         use_cell_mapping = (SIZE(cell_to_index) > 1)
+      ELSE
+         CPABORT("")
+      END IF
 
       nkind = SIZE(qs_kind_set)
       nder = 1
@@ -838,14 +857,14 @@ CONTAINS
       force_thread = 0.0_dp
 
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP SHARED (ldsab, do_symmetric, ncoset, nder, use_virial, force, virial, ndod, sab_nl, &
-!$OMP         matrix_p, basis_set_list_a, basis_set_list_b)  &
-!$OMP PRIVATE (ikind, jkind, iatom, jatom, rab, &
+!$OMP SHARED (ldsab, do_symmetric, ncoset, nder, use_virial, force, virial, ndod, sab_nl, cell_to_index, &
+!$OMP         matrix_p, basis_set_list_a, basis_set_list_b, dokp, use_cell_mapping, nimg, matrixkp_p)  &
+!$OMP PRIVATE (ikind, jkind, iatom, jatom, rab, ic, &
 !$OMP          basis_set_a, basis_set_b, sab, pab, drab, &
 !$OMP          first_sgfa, la_max, la_min, npgfa, nsgfa, nseta, rpgfa, set_radius_a, ncoa, ncob, force_a, &
 !$OMP          zeta, first_sgfb, lb_max, lb_min, npgfb, nsetb, rpgfb, set_radius_b, nsgfb, p_block, dab, &
 !$OMP          zetb, scon_a, scon_b, irow, icol, f0, ff, found, trans, rab2, n1, n2, sgfa, sgfb, iset, jset, &
-!$OMP          slot) &
+!$OMP          slot, cell) &
 !$OMP REDUCTION (+ : virial_thread, force_thread )
 
       ! *** Allocate work storage ***
@@ -859,6 +878,7 @@ CONTAINS
          jkind = sab_nl(1)%nlist_task(slot)%jkind
          iatom = sab_nl(1)%nlist_task(slot)%iatom
          jatom = sab_nl(1)%nlist_task(slot)%jatom
+         cell(:) = sab_nl(1)%nlist_task(slot)%cell(:)
          rab(1:3) = sab_nl(1)%nlist_task(slot)%r(1:3)
 
          basis_set_a => basis_set_list_a(ikind)%gto_basis_set
@@ -888,6 +908,13 @@ CONTAINS
          scon_b => basis_set_b%scon
          zetb => basis_set_b%zet
 
+         IF (use_cell_mapping) THEN
+            ic = cell_to_index(cell(1), cell(2), cell(3))
+            IF (ic < 1 .OR. ic > nimg) CYCLE
+         ELSE
+            ic = 1
+         END IF
+
          IF (do_symmetric) THEN
             IF (iatom <= jatom) THEN
                irow = iatom
@@ -906,8 +933,13 @@ CONTAINS
             ff = 1.0_dp
          END IF
          NULLIFY (p_block)
-         CALL dbcsr_get_block_p(matrix=matrix_p, row=irow, col=icol, &
-                                block=p_block, found=found)
+         IF (dokp) THEN
+            CALL dbcsr_get_block_p(matrix=matrixkp_p(ic)%matrix, row=irow, col=icol, &
+                                   block=p_block, found=found)
+         ELSE
+            CALL dbcsr_get_block_p(matrix=matrix_p, row=irow, col=icol, &
+                                   block=p_block, found=found)
+         END IF
 
          trans = do_symmetric .AND. (iatom > jatom)
 
@@ -1153,4 +1185,3 @@ CONTAINS
    END SUBROUTINE create_sab_matrix_2d
 
 END MODULE qs_overlap
-

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -110,7 +110,6 @@ CONTAINS
       LOGICAL                                            :: do_kpoints, my_admm, my_rebuild_ao, &
                                                             my_rebuild_grids, rho_ao_is_complex
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_r
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp, rho_ao_im_kp, rho_ao_kp
       TYPE(dbcsr_type), POINTER                          :: refmatrix, tmatrix
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -125,7 +124,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (pw_env, auxbas_pw_pool, matrix_s, matrix_s_kp, dft_control)
+      NULLIFY (pw_env, auxbas_pw_pool, matrix_s_kp, dft_control)
       NULLIFY (tot_rho_r, rho_ao_kp, rho_r, rho_g, drho_r, drho_g, tau_r, tau_g, rho_ao_im_kp)
       NULLIFY (rho_r_sccs)
       NULLIFY (sab_orb)
@@ -147,13 +146,17 @@ CONTAINS
       nimg = dft_control%nimages
 
       IF (my_admm) THEN
-         CPASSERT(.NOT. do_kpoints)
-         CALL get_admm_env(qs_env%admm_env, sab_aux_fit=sab_orb, matrix_s_aux_fit=matrix_s)
-         refmatrix => matrix_s(1)%matrix
+         CALL get_admm_env(qs_env%admm_env, sab_aux_fit=sab_orb, matrix_s_aux_fit_kp=matrix_s_kp)
       ELSE
-         CALL get_qs_env(qs_env, matrix_s_kp=matrix_s_kp, sab_orb=sab_orb)
-         refmatrix => matrix_s_kp(1, 1)%matrix
+         CALL get_qs_env(qs_env, matrix_s_kp=matrix_s_kp)
+
+         IF (do_kpoints) THEN
+            CALL get_kpoint_info(kpoints, sab_nl=sab_orb)
+         ELSE
+            CALL get_qs_env(qs_env, sab_orb=sab_orb)
+         END IF
       END IF
+      refmatrix => matrix_s_kp(1, 1)%matrix
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
       nspins = dft_control%nspins

--- a/src/qs_scf_initialization.F
+++ b/src/qs_scf_initialization.F
@@ -630,8 +630,6 @@ CONTAINS
             ! possible for OT gamma point calculations
             qs_env%requires_mo_derivs = .FALSE.
          END IF
-         IF (dft_control%do_admm) &
-            CPABORT("No ADMM implemented with kpoints")
          IF (dft_control%do_xas_calculation) &
             CPABORT("No XAS implemented with kpoints")
          DO ik = 1, SIZE(kpoints%kp_env)

--- a/src/qs_tensors.F
+++ b/src/qs_tensors.F
@@ -277,7 +277,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE build_3c_neighbor_lists(ijk_list, basis_i, basis_j, basis_k, &
                                       dist_3d, potential_parameter, name, qs_env, &
-                                      sym_ij, sym_jk, sym_ik, molecular, op_pos, own_dist)
+                                      sym_ij, sym_jk, sym_ik, molecular, op_pos, &
+                                      own_dist)
       TYPE(neighbor_list_3c_type), INTENT(OUT)           :: ijk_list
       TYPE(gto_basis_set_p_type), DIMENSION(:)           :: basis_i, basis_j, basis_k
       TYPE(distribution_3d_type), INTENT(IN)             :: dist_3d
@@ -612,52 +613,76 @@ CONTAINS
 !> \param potential_parameter ...
 !> \param op_pos ...
 !> \param do_kpoints ...
+!> \param do_hfx_kpoints ...
 !> \param bounds_i ...
 !> \param bounds_j ...
 !> \param bounds_k ...
+!> \param RI_range ...
+!> \param img_to_RI_cell ...
 ! **************************************************************************************************
    SUBROUTINE alloc_block_3c(t3c, nl_3c, basis_i, basis_j, basis_k, qs_env, potential_parameter, op_pos, &
-                             do_kpoints, bounds_i, bounds_j, bounds_k)
+                             do_kpoints, do_hfx_kpoints, bounds_i, bounds_j, bounds_k, RI_range, &
+                             img_to_RI_cell)
       TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: t3c
       TYPE(neighbor_list_3c_type), INTENT(INOUT)         :: nl_3c
       TYPE(gto_basis_set_p_type), DIMENSION(:)           :: basis_i, basis_j, basis_k
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
       INTEGER, INTENT(IN), OPTIONAL                      :: op_pos
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_kpoints
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_kpoints, do_hfx_kpoints
       INTEGER, DIMENSION(2), INTENT(IN), OPTIONAL        :: bounds_i, bounds_j, bounds_k
+      REAL(dp), INTENT(IN), OPTIONAL                     :: RI_range
+      INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: img_to_RI_cell
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'alloc_block_3c'
 
-      INTEGER                                            :: handle, i_img, iatom, ikind, j_img, &
-                                                            jatom, jcell, jkind, katom, kcell, &
-                                                            kkind, natom, nimg, op_ij, op_jk, &
-                                                            op_pos_prv
+      INTEGER                                            :: handle, iatom, ikind, j_img, jatom, &
+                                                            jcell, jkind, k_img, katom, kcell, &
+                                                            kkind, natom, ncell_RI, nimg, op_ij, &
+                                                            op_jk, op_pos_prv
       INTEGER(int_8)                                     :: a, b, nblk_per_thread
       INTEGER(int_8), ALLOCATABLE, DIMENSION(:, :)       :: nblk
-      INTEGER, DIMENSION(3)                              :: cell_j, cell_k, kp_index_lbounds, &
-                                                            kp_index_ubounds
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: img_to_RI_cell_prv
+      INTEGER, DIMENSION(3)                              :: blk_idx, cell_j, cell_k, &
+                                                            kp_index_lbounds, kp_index_ubounds
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
-      LOGICAL                                            :: do_kpoints_prv
+      LOGICAL                                            :: do_hfx_kpoints_prv, do_kpoints_prv
       REAL(KIND=dp)                                      :: dij, dik, djk, dr_ij, dr_ik, dr_jk, &
                                                             kind_radius_i, kind_radius_j, &
                                                             kind_radius_k
       REAL(KIND=dp), DIMENSION(3)                        :: rij, rik, rjk
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: cell
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(neighbor_list_3c_iterator_type)               :: nl_3c_iter
       TYPE(one_dim_int_array), ALLOCATABLE, &
          DIMENSION(:, :)                                 :: alloc_i, alloc_j, alloc_k
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
 
       CALL timeset(routineN, handle)
-      NULLIFY (qs_kind_set, atomic_kind_set)
+      NULLIFY (qs_kind_set, atomic_kind_set, cell)
 
       IF (PRESENT(do_kpoints)) THEN
          do_kpoints_prv = do_kpoints
       ELSE
          do_kpoints_prv = .FALSE.
+      END IF
+      IF (PRESENT(do_hfx_kpoints)) THEN
+         do_hfx_kpoints_prv = do_hfx_kpoints
+      ELSE
+         do_hfx_kpoints_prv = .FALSE.
+      END IF
+      IF (do_hfx_kpoints_prv) THEN
+         CPASSERT(do_kpoints_prv)
+         CPASSERT(PRESENT(RI_range))
+         CPASSERT(PRESENT(img_to_RI_cell))
+      END IF
+
+      IF (PRESENT(img_to_RI_cell)) THEN
+         ALLOCATE (img_to_RI_cell_prv(SIZE(img_to_RI_cell)))
+         img_to_RI_cell_prv(:) = img_to_RI_cell
       END IF
 
       dr_ij = 0.0_dp; dr_jk = 0.0_dp; dr_ik = 0.0_dp
@@ -694,13 +719,19 @@ CONTAINS
       END IF
 
       CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, natom=natom, &
-                      dft_control=dft_control, kpoints=kpoints)
+                      dft_control=dft_control, kpoints=kpoints, para_env=para_env, cell=cell)
 
       IF (do_kpoints_prv) THEN
          nimg = dft_control%nimages
+         ncell_RI = nimg
+         IF (do_hfx_kpoints_prv) THEN
+            nimg = SIZE(t3c, 1)
+            ncell_RI = SIZE(t3c, 2)
+         END IF
          CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
       ELSE
          nimg = 1
+         ncell_RI = 1
       END IF
 
       IF (do_kpoints_prv) THEN
@@ -709,7 +740,7 @@ CONTAINS
       END IF
 
       !Do a first loop over the nl and count the blocks present
-      ALLOCATE (nblk(nimg, nimg))
+      ALLOCATE (nblk(nimg, ncell_RI))
       nblk(:, :) = 0
 
       CALL neighbor_list_3c_iterator_create(nl_3c_iter, nl_3c)
@@ -717,8 +748,12 @@ CONTAINS
       CALL nl_3c_iter_set_bounds(nl_3c_iter, bounds_i, bounds_j, bounds_k)
 
       DO WHILE (neighbor_list_3c_iterate(nl_3c_iter) == 0)
-         CALL get_3c_iterator_info(nl_3c_iter, ikind=ikind, jkind=jkind, kkind=kkind, &
+         CALL get_3c_iterator_info(nl_3c_iter, iatom=iatom, ikind=ikind, jkind=jkind, kkind=kkind, &
                                    rij=rij, rjk=rjk, rik=rik, cell_j=cell_j, cell_k=cell_k)
+
+         djk = NORM2(rjk)
+         dij = NORM2(rij)
+         dik = NORM2(rik)
 
          IF (do_kpoints_prv) THEN
 
@@ -726,20 +761,20 @@ CONTAINS
                 ANY([cell_j(1), cell_j(2), cell_j(3)] > kp_index_ubounds)) CYCLE
 
             jcell = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
-            IF (jcell > nimg) CYCLE
+            IF (jcell > nimg .OR. jcell < 1) CYCLE
 
             IF (ANY([cell_k(1), cell_k(2), cell_k(3)] < kp_index_lbounds) .OR. &
                 ANY([cell_k(1), cell_k(2), cell_k(3)] > kp_index_ubounds)) CYCLE
 
             kcell = cell_to_index(cell_k(1), cell_k(2), cell_k(3))
-            IF (kcell > nimg) CYCLE
+            IF (kcell > nimg .OR. kcell < 1) CYCLE
+            IF (do_hfx_kpoints_prv) THEN
+               IF (dik > RI_range) CYCLE
+               kcell = 1
+            END IF
          ELSE
             jcell = 1; kcell = 1
          END IF
-
-         djk = NORM2(rjk)
-         dij = NORM2(rij)
-         dik = NORM2(rik)
 
          CALL get_gto_basis_set(basis_i(ikind)%gto_basis_set, kind_radius=kind_radius_i)
          CALL get_gto_basis_set(basis_j(jkind)%gto_basis_set, kind_radius=kind_radius_j)
@@ -754,14 +789,14 @@ CONTAINS
       CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
 
       !Do a second loop over the nl to give block indices
-      ALLOCATE (alloc_i(nimg, nimg))
-      ALLOCATE (alloc_j(nimg, nimg))
-      ALLOCATE (alloc_k(nimg, nimg))
-      DO j_img = 1, nimg
-         DO i_img = 1, nimg
-            ALLOCATE (alloc_i(i_img, j_img)%array(nblk(i_img, j_img)))
-            ALLOCATE (alloc_j(i_img, j_img)%array(nblk(i_img, j_img)))
-            ALLOCATE (alloc_k(i_img, j_img)%array(nblk(i_img, j_img)))
+      ALLOCATE (alloc_i(nimg, ncell_RI))
+      ALLOCATE (alloc_j(nimg, ncell_RI))
+      ALLOCATE (alloc_k(nimg, ncell_RI))
+      DO k_img = 1, ncell_RI
+         DO j_img = 1, nimg
+            ALLOCATE (alloc_i(j_img, k_img)%array(nblk(j_img, k_img)))
+            ALLOCATE (alloc_j(j_img, k_img)%array(nblk(j_img, k_img)))
+            ALLOCATE (alloc_k(j_img, k_img)%array(nblk(j_img, k_img)))
          END DO
       END DO
       nblk(:, :) = 0
@@ -775,26 +810,36 @@ CONTAINS
                                    iatom=iatom, jatom=jatom, katom=katom, &
                                    rij=rij, rjk=rjk, rik=rik, cell_j=cell_j, cell_k=cell_k)
 
+         djk = NORM2(rjk)
+         dij = NORM2(rij)
+         dik = NORM2(rik)
+
          IF (do_kpoints_prv) THEN
 
             IF (ANY([cell_j(1), cell_j(2), cell_j(3)] < kp_index_lbounds) .OR. &
                 ANY([cell_j(1), cell_j(2), cell_j(3)] > kp_index_ubounds)) CYCLE
 
             jcell = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
-            IF (jcell > nimg) CYCLE
+            IF (jcell > nimg .OR. jcell < 1) CYCLE
 
             IF (ANY([cell_k(1), cell_k(2), cell_k(3)] < kp_index_lbounds) .OR. &
                 ANY([cell_k(1), cell_k(2), cell_k(3)] > kp_index_ubounds)) CYCLE
 
             kcell = cell_to_index(cell_k(1), cell_k(2), cell_k(3))
-            IF (kcell > nimg) CYCLE
+            IF (kcell > nimg .OR. kcell < 1) CYCLE
+            IF (do_hfx_kpoints_prv) THEN
+               IF (dik > RI_range) CYCLE
+               kcell = img_to_RI_cell_prv(kcell)
+            END IF
          ELSE
             jcell = 1; kcell = 1
          END IF
 
-         djk = NORM2(rjk)
-         dij = NORM2(rij)
-         dik = NORM2(rik)
+         blk_idx = [iatom, jatom, katom]
+         IF (do_hfx_kpoints_prv) THEN
+            blk_idx(3) = (kcell - 1)*natom + katom
+            kcell = 1
+         END IF
 
          CALL get_gto_basis_set(basis_i(ikind)%gto_basis_set, kind_radius=kind_radius_i)
          CALL get_gto_basis_set(basis_j(jkind)%gto_basis_set, kind_radius=kind_radius_j)
@@ -807,26 +852,26 @@ CONTAINS
          nblk(jcell, kcell) = nblk(jcell, kcell) + 1
 
          !Note: there may be repeated indices due to periodic images => dbt_reserve_blocks takes care of it
-         alloc_i(jcell, kcell)%array(nblk(jcell, kcell)) = iatom
-         alloc_j(jcell, kcell)%array(nblk(jcell, kcell)) = jatom
-         alloc_k(jcell, kcell)%array(nblk(jcell, kcell)) = katom
+         alloc_i(jcell, kcell)%array(nblk(jcell, kcell)) = blk_idx(1)
+         alloc_j(jcell, kcell)%array(nblk(jcell, kcell)) = blk_idx(2)
+         alloc_k(jcell, kcell)%array(nblk(jcell, kcell)) = blk_idx(3)
 
       END DO
       CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
 
 !TODO: Parallelize creation of block list.
-!$OMP PARALLEL DEFAULT(NONE) SHARED(t3c,nimg,nblk,alloc_i,alloc_j,alloc_k) &
-!$OMP PRIVATE(i_img,j_img,nblk_per_thread,A,b)
-      DO j_img = 1, nimg
-         DO i_img = 1, nimg
-            IF (ALLOCATED(alloc_i(i_img, j_img)%array)) THEN
-               nblk_per_thread = nblk(i_img, j_img)/omp_get_num_threads() + 1
+!$OMP PARALLEL DEFAULT(NONE) SHARED(t3c,nimg,nblk,alloc_i,alloc_j,alloc_k,ncell_RI) &
+!$OMP PRIVATE(k_img,j_img,nblk_per_thread,A,b)
+      DO k_img = 1, ncell_RI
+         DO j_img = 1, nimg
+            IF (ALLOCATED(alloc_i(j_img, k_img)%array)) THEN
+               nblk_per_thread = nblk(j_img, k_img)/omp_get_num_threads() + 1
                a = omp_get_thread_num()*nblk_per_thread + 1
-               b = MIN(a + nblk_per_thread, nblk(i_img, j_img))
-               CALL dbt_reserve_blocks(t3c(i_img, j_img), &
-                                       alloc_i(i_img, j_img)%array(a:b), &
-                                       alloc_j(i_img, j_img)%array(a:b), &
-                                       alloc_k(i_img, j_img)%array(a:b))
+               b = MIN(a + nblk_per_thread, nblk(j_img, k_img))
+               CALL dbt_reserve_blocks(t3c(j_img, k_img), &
+                                       alloc_i(j_img, k_img)%array(a:b), &
+                                       alloc_j(j_img, k_img)%array(a:b), &
+                                       alloc_k(j_img, k_img)%array(a:b))
             END IF
          END DO
       END DO
@@ -958,13 +1003,13 @@ CONTAINS
                 ANY([cell_j(1), cell_j(2), cell_j(3)] > kp_index_ubounds)) CYCLE
 
             jcell = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
-            IF (jcell > nimg) CYCLE
+            IF (jcell > nimg .OR. jcell < 1) CYCLE
 
             IF (ANY([cell_k(1), cell_k(2), cell_k(3)] < kp_index_lbounds) .OR. &
                 ANY([cell_k(1), cell_k(2), cell_k(3)] > kp_index_ubounds)) CYCLE
 
             kcell = cell_to_index(cell_k(1), cell_k(2), cell_k(3))
-            IF (kcell > nimg) CYCLE
+            IF (kcell > nimg .OR. kcell < 1) CYCLE
          ELSE
             jcell = 1; kcell = 1
          END IF
@@ -1086,16 +1131,19 @@ CONTAINS
 !>        2: calculate (ij|k) integrals
 !> \param do_kpoints ...
 !> this routine requires that libint has been static initialised somewhere else
+!> \param do_hfx_kpoints ...
 !> \param bounds_i ...
 !> \param bounds_j ...
 !> \param bounds_k ...
+!> \param RI_range ...
+!> \param img_to_RI_cell ...
 ! **************************************************************************************************
    SUBROUTINE build_3c_derivatives(t3c_der_i, t3c_der_k, filter_eps, qs_env, &
                                    nl_3c, basis_i, basis_j, basis_k, &
-                                   potential_parameter, &
-                                   der_eps, &
-                                   op_pos, do_kpoints, &
-                                   bounds_i, bounds_j, bounds_k)
+                                   potential_parameter, der_eps, &
+                                   op_pos, do_kpoints, do_hfx_kpoints, &
+                                   bounds_i, bounds_j, bounds_k, &
+                                   RI_range, img_to_RI_cell)
 
       TYPE(dbt_type), DIMENSION(:, :, :), INTENT(INOUT)  :: t3c_der_i, t3c_der_k
       REAL(KIND=dp), INTENT(IN)                          :: filter_eps
@@ -1105,8 +1153,10 @@ CONTAINS
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: der_eps
       INTEGER, INTENT(IN), OPTIONAL                      :: op_pos
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_kpoints
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_kpoints, do_hfx_kpoints
       INTEGER, DIMENSION(2), INTENT(IN), OPTIONAL        :: bounds_i, bounds_j, bounds_k
+      REAL(dp), INTENT(IN), OPTIONAL                     :: RI_range
+      INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: img_to_RI_cell
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_3c_derivatives'
 
@@ -1114,17 +1164,19 @@ CONTAINS
          block_start_k, egfi, handle, handle2, i, i_img, i_xyz, iatom, ibasis, ikind, ilist, imax, &
          iset, j_img, jatom, jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoi, &
          max_ncoj, max_ncok, max_nset, max_nsgfi, max_nsgfj, max_nsgfk, maxli, maxlj, maxlk, &
-         mepos, natom, nbasis, ncoi, ncoj, ncok, nimg, nseti, nsetj, nsetk, nthread, op_ij, op_jk, &
-         op_pos_prv, sgfi, sgfj, sgfk, unit_id
+         mepos, natom, nbasis, ncell_RI, ncoi, ncoj, ncok, nimg, nseti, nsetj, nsetk, nthread, &
+         op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: img_to_RI_cell_prv
       INTEGER, DIMENSION(2)                              :: bo
-      INTEGER, DIMENSION(3)                              :: blk_size, cell_j, cell_k, &
+      INTEGER, DIMENSION(3)                              :: blk_idx, blk_size, cell_j, cell_k, &
                                                             kp_index_lbounds, kp_index_ubounds, sp
       INTEGER, DIMENSION(:), POINTER                     :: lmax_i, lmax_j, lmax_k, lmin_i, lmin_j, &
                                                             lmin_k, npgfi, npgfj, npgfk, nsgfi, &
                                                             nsgfj, nsgfk
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf_i, first_sgf_j, first_sgf_k
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
-      LOGICAL                                            :: do_kpoints_prv, found, skip
+      LOGICAL                                            :: do_hfx_kpoints_prv, do_kpoints_prv, &
+                                                            found, skip
       LOGICAL, DIMENSION(3)                              :: block_j_not_zero, block_k_not_zero, &
                                                             der_j_zero, der_k_zero
       REAL(dp), DIMENSION(3)                             :: der_ext_i, der_ext_j, der_ext_k
@@ -1136,7 +1188,7 @@ CONTAINS
                                                             max_contraction_k
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: dijk_contr, dummy_block_t
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: block_t_i, block_t_j, block_t_k, dijk_j, &
-                                                            dijk_k
+                                                            dijk_k, tmp_ijk_i, tmp_ijk_j
       REAL(KIND=dp), DIMENSION(3)                        :: ri, rij, rik, rj, rjk, rk
       REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_i, set_radius_j, set_radius_k
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgf_i, rpgf_j, rpgf_k, sphi_i, sphi_j, &
@@ -1160,6 +1212,22 @@ CONTAINS
          do_kpoints_prv = do_kpoints
       ELSE
          do_kpoints_prv = .FALSE.
+      END IF
+
+      IF (PRESENT(do_hfx_kpoints)) THEN
+         do_hfx_kpoints_prv = do_hfx_kpoints
+      ELSE
+         do_hfx_kpoints_prv = .FALSE.
+      END IF
+      IF (do_hfx_kpoints_prv) THEN
+         CPASSERT(do_kpoints_prv)
+         CPASSERT(PRESENT(RI_range))
+         CPASSERT(PRESENT(img_to_RI_cell))
+      END IF
+
+      IF (PRESENT(img_to_RI_cell)) THEN
+         ALLOCATE (img_to_RI_cell_prv(SIZE(img_to_RI_cell)))
+         img_to_RI_cell_prv(:) = img_to_RI_cell
       END IF
 
       op_ij = do_potential_id; op_jk = do_potential_id
@@ -1203,26 +1271,36 @@ CONTAINS
 
       IF (do_kpoints_prv) THEN
          nimg = dft_control%nimages
+         ncell_RI = nimg
+         IF (do_hfx_kpoints_prv) THEN
+            nimg = SIZE(t3c_der_k, 1)
+            ncell_RI = SIZE(t3c_der_k, 2)
+         END IF
          CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
       ELSE
          nimg = 1
+         ncell_RI = 1
       END IF
 
-      CPASSERT(ALL(SHAPE(t3c_der_i) == [nimg, nimg, 3]))
-      CPASSERT(ALL(SHAPE(t3c_der_k) == [nimg, nimg, 3]))
+      IF (do_hfx_kpoints_prv) THEN
+         CPASSERT(op_pos_prv == 2)
+      ELSE
+         CPASSERT(ALL(SHAPE(t3c_der_k) == [nimg, ncell_RI, 3]))
+      END IF
 
-      ALLOCATE (t3c_template(nimg, nimg))
-      DO j_img = 1, nimg
+      ALLOCATE (t3c_template(nimg, ncell_RI))
+      DO j_img = 1, ncell_RI
          DO i_img = 1, nimg
             CALL dbt_create(t3c_der_i(i_img, j_img, 1), t3c_template(i_img, j_img))
          END DO
       END DO
 
-      CALL alloc_block_3c(t3c_template, nl_3c, basis_i, basis_j, basis_k, qs_env, &
-                          potential_parameter, op_pos=op_pos_prv, do_kpoints=do_kpoints, &
-                          bounds_i=bounds_i, bounds_j=bounds_j, bounds_k=bounds_k)
+      CALL alloc_block_3c(t3c_template, nl_3c, basis_i, basis_j, basis_k, qs_env, potential_parameter, &
+                          op_pos=op_pos_prv, do_kpoints=do_kpoints, do_hfx_kpoints=do_hfx_kpoints, &
+                          bounds_i=bounds_i, bounds_j=bounds_j, bounds_k=bounds_k, &
+                          RI_range=RI_range, img_to_RI_cell=img_to_RI_cell)
       DO i_xyz = 1, 3
-         DO j_img = 1, nimg
+         DO j_img = 1, ncell_RI
             DO i_img = 1, nimg
                CALL dbt_copy(t3c_template(i_img, j_img), t3c_der_i(i_img, j_img, i_xyz))
                CALL dbt_copy(t3c_template(i_img, j_img), t3c_der_k(i_img, j_img, i_xyz))
@@ -1230,7 +1308,7 @@ CONTAINS
          END DO
       END DO
 
-      DO j_img = 1, nimg
+      DO j_img = 1, ncell_RI
          DO i_img = 1, nimg
             CALL dbt_destroy(t3c_template(i_img, j_img))
          END DO
@@ -1238,9 +1316,9 @@ CONTAINS
       DEALLOCATE (t3c_template)
 
       IF (nl_3c%sym == symmetric_jk) THEN
-         ALLOCATE (t3c_der_j(nimg, nimg, 3))
+         ALLOCATE (t3c_der_j(nimg, ncell_RI, 3))
          DO i_xyz = 1, 3
-            DO j_img = 1, nimg
+            DO j_img = 1, ncell_RI
                DO i_img = 1, nimg
                   CALL dbt_create(t3c_der_k(i_img, j_img, i_xyz), t3c_der_j(i_img, j_img, i_xyz))
                   CALL dbt_copy(t3c_der_k(i_img, j_img, i_xyz), t3c_der_j(i_img, j_img, i_xyz))
@@ -1357,19 +1435,20 @@ CONTAINS
 
 !$OMP PARALLEL DEFAULT(NONE) &
 !$OMP SHARED (nthread,do_kpoints_prv,kp_index_lbounds,kp_index_ubounds,maxli,maxlk,maxlj,bounds_i,&
-!$OMP         bounds_j,bounds_k,nimg,basis_i,basis_j,basis_k,dr_ij,dr_jk,dr_ik,ncoset,&
-!$OMP         potential_parameter,der_eps,tspj,spi,spk,cell_to_index,max_ncoi,max_nsgfk,&
-!$OMP         max_nsgfj,max_ncok,natom,nl_3c,t3c_der_i,t3c_der_k,t3c_der_j) &
+!$OMP         bounds_j,bounds_k,nimg,basis_i,basis_j,basis_k,dr_ij,dr_jk,dr_ik,ncoset,op_pos_prv,&
+!$OMP         potential_parameter,der_eps,tspj,spi,spk,cell_to_index,max_ncoi,max_nsgfk,RI_range,&
+!$OMP         max_nsgfj,max_ncok,natom,nl_3c,t3c_der_i,t3c_der_k,t3c_der_j,ncell_RI,&
+!$OMP         img_to_RI_cell_prv,do_hfx_kpoints_prv) &
 !$OMP PRIVATE (lib,nl_3c_iter,ikind,jkind,kkind,iatom,jatom,katom,rij,rjk,rik,cell_j,cell_k,&
 !$OMP          prefac,jcell,kcell,first_sgf_i,lmax_i,lmin_i,npgfi,nseti,nsgfi,rpgf_i,set_radius_i,&
 !$OMP          sphi_i,zeti,kind_radius_i,first_sgf_j,lmax_j,lmin_j,npgfj,nsetj,nsgfj,rpgf_j,&
 !$OMP          set_radius_j,sphi_j,zetj,kind_radius_j,first_sgf_k,lmax_k,lmin_k,npgfk,nsetk,nsgfk,&
 !$OMP          rpgf_k,set_radius_k,sphi_k,zetk,kind_radius_k,djk,dij,dik,ncoi,ncoj,ncok,sgfi,sgfj,&
-!$OMP          sgfk,dijk_j,dijk_k,ri,rj,rk,max_contraction_i,max_contraction_j,&
+!$OMP          sgfk,dijk_j,dijk_k,ri,rj,rk,max_contraction_i,max_contraction_j,blk_idx,&
 !$OMP          max_contraction_k,iset,jset,kset,block_t_i,blk_size,dijk_contr,cpp_buffer,ccp_buffer,&
 !$OMP          block_start_j,block_end_j,block_start_k,block_end_k,block_start_i,block_end_i,found,&
-!$OMP          dummy_block_t,sp,handle2,mepos,bo,block_t_k,der_ext_i,der_ext_j,der_ext_k,&
-!$OMP          block_k_not_zero,der_k_zero,skip,der_j_zero,block_t_j,block_j_not_zero)
+!$OMP          dummy_block_t,sp,handle2,mepos,bo,block_t_k,der_ext_i,der_ext_j,der_ext_k,tmp_ijk_i,&
+!$OMP          block_k_not_zero,der_k_zero,skip,der_j_zero,block_t_j,block_j_not_zero,tmp_ijk_j,i)
 
       mepos = 0
 !$    mepos = omp_get_thread_num()
@@ -1409,6 +1488,10 @@ CONTAINS
                                    rij=rij, rjk=rjk, rik=rik, cell_j=cell_j, cell_k=cell_k)
          IF (skip) EXIT
 
+         djk = NORM2(rjk)
+         dij = NORM2(rij)
+         dik = NORM2(rik)
+
          IF (do_kpoints_prv) THEN
             prefac = 0.5_dp
          ELSEIF (nl_3c%sym == symmetric_jk) THEN
@@ -1420,6 +1503,7 @@ CONTAINS
          ELSE
             prefac = 1.0_dp
          END IF
+         IF (do_hfx_kpoints_prv) prefac = 1.0_dp
 
          IF (do_kpoints_prv) THEN
 
@@ -1427,16 +1511,26 @@ CONTAINS
                 ANY([cell_j(1), cell_j(2), cell_j(3)] > kp_index_ubounds)) CYCLE
 
             jcell = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
-            IF (jcell > nimg) CYCLE
+            IF (jcell > nimg .OR. jcell < 1) CYCLE
 
             IF (ANY([cell_k(1), cell_k(2), cell_k(3)] < kp_index_lbounds) .OR. &
                 ANY([cell_k(1), cell_k(2), cell_k(3)] > kp_index_ubounds)) CYCLE
 
             kcell = cell_to_index(cell_k(1), cell_k(2), cell_k(3))
-            IF (kcell > nimg) CYCLE
-
+            IF (kcell > nimg .OR. kcell < 1) CYCLE
+            !In case of HFX k-points, we only consider P^k if d_ik <= RI_range
+            IF (do_hfx_kpoints_prv) THEN
+               IF (dik > RI_range) CYCLE
+               kcell = img_to_RI_cell_prv(kcell)
+            END IF
          ELSE
             jcell = 1; kcell = 1
+         END IF
+
+         blk_idx = [iatom, jatom, katom]
+         IF (do_hfx_kpoints_prv) THEN
+            blk_idx(3) = (kcell - 1)*natom + katom
+            kcell = 1
          END IF
 
          CALL get_gto_basis_set(basis_i(ikind)%gto_basis_set, first_sgf=first_sgf_i, lmax=lmax_i, lmin=lmin_i, &
@@ -1450,10 +1544,6 @@ CONTAINS
          CALL get_gto_basis_set(basis_k(kkind)%gto_basis_set, first_sgf=first_sgf_k, lmax=lmax_k, lmin=lmin_k, &
                                 npgf=npgfk, nset=nsetk, nsgf_set=nsgfk, pgf_radius=rpgf_k, set_radius=set_radius_k, &
                                 sphi=sphi_k, zet=zetk, kind_radius=kind_radius_k)
-
-         djk = NORM2(rjk)
-         dij = NORM2(rij)
-         dik = NORM2(rik)
 
          IF (kind_radius_j + kind_radius_i + dr_ij < dij) CYCLE
          IF (kind_radius_j + kind_radius_k + dr_jk < djk) CYCLE
@@ -1480,7 +1570,7 @@ CONTAINS
             max_contraction_k(kset) = MAXVAL((/(SUM(ABS(sphi_k(:, i))), i=sgfk, sgfk + nsgfk(kset) - 1)/))
          END DO
 
-         CALL dbt_blk_sizes(t3c_der_i(jcell, kcell, 1), [iatom, jatom, katom], blk_size)
+         CALL dbt_blk_sizes(t3c_der_i(jcell, kcell, 1), blk_idx, blk_size)
 
          ALLOCATE (block_t_i(blk_size(2), blk_size(3), blk_size(1), 3))
          ALLOCATE (block_t_j(blk_size(2), blk_size(3), blk_size(1), 3))
@@ -1525,12 +1615,38 @@ CONTAINS
                      rj = rij ! ri + rij
                      rk = rik ! ri + rik
 
-                     CALL eri_3center_derivs(dijk_j, dijk_k, &
-                                             lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), rj, &
-                                             lmin_k(kset), lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), rk, &
-                                             lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
-                                             djk, dij, dik, lib, potential_parameter, &
-                                             der_abc_1_ext=der_ext_j, der_abc_2_ext=der_ext_k)
+                     IF (op_pos_prv == 1) THEN
+                        CALL eri_3center_derivs(dijk_j, dijk_k, &
+                                                lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), rj, &
+                                                lmin_k(kset), lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), rk, &
+                                                lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
+                                                djk, dij, dik, lib, potential_parameter, &
+                                                der_abc_1_ext=der_ext_j, der_abc_2_ext=der_ext_k)
+                     ELSE
+                        ALLOCATE (tmp_ijk_i(ncoi, ncoj, ncok, 3))
+                        ALLOCATE (tmp_ijk_j(ncoi, ncoj, ncok, 3))
+                        tmp_ijk_i(:, :, :, :) = 0.0_dp
+                        tmp_ijk_j(:, :, :, :) = 0.0_dp
+
+                        CALL eri_3center_derivs(tmp_ijk_i, tmp_ijk_j, &
+                                                lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
+                                                lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), rj, &
+                                                lmin_k(kset), lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), rk, &
+                                                dij, dik, djk, lib, potential_parameter, &
+                                                der_abc_1_ext=der_ext_i, der_abc_2_ext=der_ext_j)
+
+                        !TODO: is that inefficient?
+                        der_ext_k = 0
+                        DO i_xyz = 1, 3
+                           DO i = 1, ncoi
+                              dijk_j(:, :, i, i_xyz) = tmp_ijk_j(i, :, :, i_xyz)
+                              dijk_k(:, :, i, i_xyz) = -(dijk_j(:, :, i, i_xyz) + tmp_ijk_i(i, :, :, i_xyz))
+                              der_ext_k(i_xyz) = MAX(der_ext_k(i_xyz), MAXVAL(ABS(dijk_k(:, :, i, i_xyz))))
+                           END DO
+                        END DO
+                        DEALLOCATE (tmp_ijk_i, tmp_ijk_j)
+
+                     END IF
 
                      IF (PRESENT(der_eps)) THEN
                         DO i_xyz = 1, 3
@@ -1617,7 +1733,7 @@ CONTAINS
             IF ((.NOT. block_j_not_zero(i_xyz)) .AND. (.NOT. block_k_not_zero(i_xyz))) CYCLE
             block_t_i(:, :, :, i_xyz) = -(block_t_j(:, :, :, i_xyz) + block_t_k(:, :, :, i_xyz))
 
-            CALL dbt_put_block(t3c_der_i(jcell, kcell, i_xyz), [iatom, jatom, katom], sp, &
+            CALL dbt_put_block(t3c_der_i(jcell, kcell, i_xyz), blk_idx, sp, &
                                RESHAPE(block_t_i(:, :, :, i_xyz), SHAPE=sp, ORDER=[2, 3, 1]), &
                                summation=.TRUE.)
          END DO
@@ -1630,7 +1746,7 @@ CONTAINS
 
             DO i_xyz = 1, 3
                IF (.NOT. block_j_not_zero(i_xyz)) CYCLE
-               CALL dbt_put_block(t3c_der_j(jcell, kcell, i_xyz), [iatom, jatom, katom], sp, &
+               CALL dbt_put_block(t3c_der_j(jcell, kcell, i_xyz), blk_idx, sp, &
                                   RESHAPE(block_t_j(:, :, :, i_xyz), SHAPE=sp, ORDER=[2, 3, 1]), &
                                   summation=.TRUE.)
             END DO
@@ -1642,7 +1758,7 @@ CONTAINS
 
          DO i_xyz = 1, 3
             IF (.NOT. block_k_not_zero(i_xyz)) CYCLE
-            CALL dbt_put_block(t3c_der_k(jcell, kcell, i_xyz), [iatom, jatom, katom], sp, &
+            CALL dbt_put_block(t3c_der_k(jcell, kcell, i_xyz), blk_idx, sp, &
                                RESHAPE(block_t_k(:, :, :, i_xyz), SHAPE=sp, ORDER=[2, 3, 1]), &
                                summation=.TRUE.)
          END DO
@@ -1662,7 +1778,7 @@ CONTAINS
       CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
 !$OMP END PARALLEL
 
-      IF (do_kpoints_prv) THEN
+      IF (do_kpoints_prv .AND. .NOT. do_hfx_kpoints_prv) THEN
          DO i_xyz = 1, 3
             DO kcell = 1, nimg
                DO jcell = 1, nimg
@@ -1694,7 +1810,7 @@ CONTAINS
 
       ELSEIF (nl_3c%sym == symmetric_none) THEN
          DO i_xyz = 1, 3
-            DO kcell = 1, nimg
+            DO kcell = 1, ncell_RI
                DO jcell = 1, nimg
                   CALL dbt_filter(t3c_der_i(jcell, kcell, i_xyz), filter_eps)
                   CALL dbt_filter(t3c_der_k(jcell, kcell, i_xyz), filter_eps)
@@ -2243,16 +2359,20 @@ CONTAINS
 !>        2: calculate (ij|k) integrals
 !> \param do_kpoints ...
 !> this routine requires that libint has been static initialised somewhere else
+!> \param do_hfx_kpoints ...
 !> \param desymmetrize ...
 !> \param bounds_i ...
 !> \param bounds_j ...
 !> \param bounds_k ...
+!> \param RI_range ...
+!> \param img_to_RI_cell ...
 ! **************************************************************************************************
    SUBROUTINE build_3c_integrals(t3c, filter_eps, qs_env, &
                                  nl_3c, basis_i, basis_j, basis_k, &
                                  potential_parameter, int_eps, &
-                                 op_pos, do_kpoints, desymmetrize, &
-                                 bounds_i, bounds_j, bounds_k)
+                                 op_pos, do_kpoints, do_hfx_kpoints, desymmetrize, &
+                                 bounds_i, bounds_j, bounds_k, &
+                                 RI_range, img_to_RI_cell)
 
       TYPE(dbt_type), DIMENSION(:, :), INTENT(INOUT)     :: t3c
       REAL(KIND=dp), INTENT(IN)                          :: filter_eps
@@ -2262,8 +2382,10 @@ CONTAINS
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: int_eps
       INTEGER, INTENT(IN), OPTIONAL                      :: op_pos
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_kpoints, desymmetrize
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_kpoints, do_hfx_kpoints, desymmetrize
       INTEGER, DIMENSION(2), INTENT(IN), OPTIONAL        :: bounds_i, bounds_j, bounds_k
+      REAL(dp), INTENT(IN), OPTIONAL                     :: RI_range
+      INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: img_to_RI_cell
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_3c_integrals'
 
@@ -2271,10 +2393,11 @@ CONTAINS
          block_start_k, egfi, handle, handle2, i, iatom, ibasis, ikind, ilist, imax, iset, jatom, &
          jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoi, max_ncoj, max_ncok, &
          max_nset, max_nsgfi, max_nsgfj, max_nsgfk, maxli, maxlj, maxlk, mepos, natom, nbasis, &
-         ncoi, ncoj, ncok, nimg, nseti, nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, sgfi, &
-         sgfj, sgfk, unit_id
+         ncell_RI, ncoi, ncoj, ncok, nimg, nseti, nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, &
+         sgfi, sgfj, sgfk, unit_id
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: img_to_RI_cell_prv
       INTEGER, DIMENSION(2)                              :: bo
-      INTEGER, DIMENSION(3)                              :: blk_size, cell_j, cell_k, &
+      INTEGER, DIMENSION(3)                              :: blk_idx, blk_size, cell_j, cell_k, &
                                                             kp_index_lbounds, kp_index_ubounds, sp
       INTEGER, DIMENSION(:), POINTER                     :: lmax_i, lmax_j, lmax_k, lmin_i, lmin_j, &
                                                             lmin_k, npgfi, npgfj, npgfk, nsgfi, &
@@ -2282,19 +2405,23 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf_i, first_sgf_j, first_sgf_k
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: block_not_zero, debug, desymmetrize_prv, &
-                                                            do_kpoints_prv, found, skip
+                                                            do_hfx_kpoints_prv, do_kpoints_prv, &
+                                                            found, skip
       REAL(KIND=dp)                                      :: dij, dik, djk, dr_ij, dr_ik, dr_jk, &
                                                             kind_radius_i, kind_radius_j, &
                                                             kind_radius_k, prefac, sijk_ext
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: ccp_buffer, cpp_buffer, &
                                                             max_contraction_i, max_contraction_j, &
                                                             max_contraction_k
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: block_t, dummy_block_t, sijk, sijk_contr
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: block_t, dummy_block_t, sijk, &
+                                                            sijk_contr, tmp_ijk
+      REAL(KIND=dp), DIMENSION(1, 1, 1)                  :: counter
       REAL(KIND=dp), DIMENSION(3)                        :: ri, rij, rik, rj, rjk, rk
       REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_i, set_radius_j, set_radius_k
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rpgf_i, rpgf_j, rpgf_k, sphi_i, sphi_j, &
                                                             sphi_k, zeti, zetj, zetk
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_2d_r_p_type), DIMENSION(:, :), POINTER     :: spi, spk, tspj
       TYPE(cp_libint_t)                                  :: lib
       TYPE(dbt_type)                                     :: t_3c_tmp
@@ -2313,6 +2440,22 @@ CONTAINS
          do_kpoints_prv = do_kpoints
       ELSE
          do_kpoints_prv = .FALSE.
+      END IF
+
+      IF (PRESENT(do_hfx_kpoints)) THEN
+         do_hfx_kpoints_prv = do_hfx_kpoints
+      ELSE
+         do_hfx_kpoints_prv = .FALSE.
+      END IF
+      IF (do_hfx_kpoints_prv) THEN
+         CPASSERT(do_kpoints_prv)
+         CPASSERT(PRESENT(RI_range))
+         CPASSERT(PRESENT(img_to_RI_cell))
+      END IF
+
+      IF (PRESENT(img_to_RI_cell)) THEN
+         ALLOCATE (img_to_RI_cell_prv(SIZE(img_to_RI_cell)))
+         img_to_RI_cell_prv(:) = img_to_RI_cell
       END IF
 
       IF (PRESENT(desymmetrize)) THEN
@@ -2356,25 +2499,34 @@ CONTAINS
 
       NULLIFY (qs_kind_set, atomic_kind_set)
 
-      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
-                      natom=natom, kpoints=kpoints, dft_control=dft_control, para_env=para_env)
-
-      CALL alloc_block_3c(t3c, nl_3c, basis_i, basis_j, basis_k, qs_env, &
-                          potential_parameter, op_pos=op_pos_prv, do_kpoints=do_kpoints, &
-                          bounds_i=bounds_i, bounds_j=bounds_j, bounds_k=bounds_k)
-
       ! get stuff
-      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
+      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, cell=cell, &
                       natom=natom, kpoints=kpoints, dft_control=dft_control, para_env=para_env)
+
+      CALL alloc_block_3c(t3c, nl_3c, basis_i, basis_j, basis_k, qs_env, potential_parameter, &
+                          op_pos=op_pos_prv, do_kpoints=do_kpoints, do_hfx_kpoints=do_hfx_kpoints, &
+                          bounds_i=bounds_i, bounds_j=bounds_j, bounds_k=bounds_k, &
+                          RI_range=RI_range, img_to_RI_cell=img_to_RI_cell)
 
       IF (do_kpoints_prv) THEN
          nimg = dft_control%nimages
+         ncell_RI = nimg
+         IF (do_hfx_kpoints_prv) THEN
+            nimg = SIZE(t3c, 1)
+            ncell_RI = SIZE(t3c, 2)
+         END IF
          CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
       ELSE
          nimg = 1
+         ncell_RI = 1
       END IF
 
-      CPASSERT(ALL(SHAPE(t3c) == [nimg, nimg]))
+      IF (do_hfx_kpoints_prv) THEN
+         CPASSERT(op_pos_prv == 2)
+         CPASSERT(.NOT. desymmetrize_prv)
+      ELSE IF (do_kpoints_prv) THEN
+         CPASSERT(ALL(SHAPE(t3c) == [nimg, ncell_RI]))
+      END IF
 
       !Need the max l for each basis for libint and max nset, nco and nsgf for LIBXSMM contraction
       nbasis = SIZE(basis_i)
@@ -2479,6 +2631,8 @@ CONTAINS
          kp_index_ubounds = UBOUND(cell_to_index)
       END IF
 
+      counter = 1.0_dp
+
       nthread = 1
 !$    nthread = omp_get_max_threads()
 
@@ -2486,7 +2640,8 @@ CONTAINS
 !$OMP SHARED (nthread,do_kpoints_prv,kp_index_lbounds,kp_index_ubounds,maxli,maxlk,maxlj,bounds_i,&
 !$OMP         bounds_j,bounds_k,nimg,basis_i,basis_j,basis_k,dr_ij,dr_jk,dr_ik,ncoset,&
 !$OMP         potential_parameter,int_eps,t3c,tspj,spi,spk,debug,cell_to_index,max_ncoi,max_nsgfk,&
-!$OMP         max_nsgfj,max_ncok,natom,nl_3c) &
+!$OMP         max_nsgfj,max_ncok,natom,nl_3c,cell,op_pos_prv,do_hfx_kpoints_prv,RI_range,ncell_RI, &
+!$OMP         img_to_RI_cell_prv) &
 !$OMP PRIVATE (lib,nl_3c_iter,ikind,jkind,kkind,iatom,jatom,katom,rij,rjk,rik,cell_j,cell_k,&
 !$OMP          prefac,jcell,kcell,first_sgf_i,lmax_i,lmin_i,npgfi,nseti,nsgfi,rpgf_i,set_radius_i,&
 !$OMP          sphi_i,zeti,kind_radius_i,first_sgf_j,lmax_j,lmin_j,npgfj,nsetj,nsgfj,rpgf_j,&
@@ -2495,7 +2650,7 @@ CONTAINS
 !$OMP          sgfk,sijk,ri,rj,rk,sijk_ext,block_not_zero,max_contraction_i,max_contraction_j,&
 !$OMP          max_contraction_k,iset,jset,kset,block_t,blk_size,sijk_contr,cpp_buffer,ccp_buffer,&
 !$OMP          block_start_j,block_end_j,block_start_k,block_end_k,block_start_i,block_end_i,found,&
-!$OMP          dummy_block_t,sp,handle2,mepos,bo,skip)
+!$OMP          dummy_block_t,sp,handle2,mepos,bo,skip,tmp_ijk,i,blk_idx)
 
       mepos = 0
 !$    mepos = omp_get_thread_num()
@@ -2536,6 +2691,10 @@ CONTAINS
                                    rij=rij, rjk=rjk, rik=rik, cell_j=cell_j, cell_k=cell_k)
          IF (skip) EXIT
 
+         djk = NORM2(rjk)
+         dij = NORM2(rij)
+         dik = NORM2(rik)
+
          IF (do_kpoints_prv) THEN
             prefac = 0.5_dp
          ELSEIF (nl_3c%sym == symmetric_jk) THEN
@@ -2546,9 +2705,18 @@ CONTAINS
             ELSE
                prefac = 1.0_dp
             END IF
+         ELSEIF (nl_3c%sym == symmetric_ij) THEN
+            IF (iatom == jatom) THEN
+               ! factor 0.5 due to double-counting of diagonal blocks
+               ! (we desymmetrize by adding transpose)
+               prefac = 0.5_dp
+            ELSE
+               prefac = 1.0_dp
+            END IF
          ELSE
             prefac = 1.0_dp
          END IF
+         IF (do_hfx_kpoints_prv) prefac = 1.0_dp
 
          IF (do_kpoints_prv) THEN
 
@@ -2556,17 +2724,28 @@ CONTAINS
                 ANY([cell_j(1), cell_j(2), cell_j(3)] > kp_index_ubounds)) CYCLE
 
             jcell = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
-            IF (jcell > nimg) CYCLE
+            IF (jcell > nimg .OR. jcell < 1) CYCLE
 
             IF (ANY([cell_k(1), cell_k(2), cell_k(3)] < kp_index_lbounds) .OR. &
                 ANY([cell_k(1), cell_k(2), cell_k(3)] > kp_index_ubounds)) CYCLE
 
             kcell = cell_to_index(cell_k(1), cell_k(2), cell_k(3))
-            IF (kcell > nimg) CYCLE
-
+            IF (kcell > nimg .OR. kcell < 1) CYCLE
+            !In case of HFX k-points, we only consider P^k if d_ik <= RI_range
+            IF (do_hfx_kpoints_prv) THEN
+               IF (dik > RI_range) CYCLE
+               kcell = img_to_RI_cell_prv(kcell)
+            END IF
          ELSE
             jcell = 1; kcell = 1
          END IF
+
+         blk_idx = [iatom, jatom, katom]
+         IF (do_hfx_kpoints_prv) THEN
+            blk_idx(3) = (kcell - 1)*natom + katom
+            kcell = 1
+         END IF
+
          CALL get_gto_basis_set(basis_i(ikind)%gto_basis_set, first_sgf=first_sgf_i, lmax=lmax_i, lmin=lmin_i, &
                                 npgf=npgfi, nset=nseti, nsgf_set=nsgfi, pgf_radius=rpgf_i, set_radius=set_radius_i, &
                                 sphi=sphi_i, zet=zeti, kind_radius=kind_radius_i)
@@ -2578,9 +2757,6 @@ CONTAINS
          CALL get_gto_basis_set(basis_k(kkind)%gto_basis_set, first_sgf=first_sgf_k, lmax=lmax_k, lmin=lmin_k, &
                                 npgf=npgfk, nset=nsetk, nsgf_set=nsgfk, pgf_radius=rpgf_k, set_radius=set_radius_k, &
                                 sphi=sphi_k, zet=zetk, kind_radius=kind_radius_k)
-         djk = NORM2(rjk)
-         dij = NORM2(rij)
-         dik = NORM2(rik)
 
          IF (kind_radius_j + kind_radius_i + dr_ij < dij) CYCLE
          IF (kind_radius_j + kind_radius_k + dr_jk < djk) CYCLE
@@ -2607,7 +2783,7 @@ CONTAINS
             max_contraction_k(kset) = MAXVAL((/(SUM(ABS(sphi_k(:, i))), i=sgfk, sgfk + nsgfk(kset) - 1)/))
          END DO
 
-         CALL dbt_blk_sizes(t3c(jcell, kcell), [iatom, jatom, katom], blk_size)
+         CALL dbt_blk_sizes(t3c(jcell, kcell), blk_idx, blk_size)
 
          ALLOCATE (block_t(blk_size(2), blk_size(3), blk_size(1)))
 
@@ -2641,11 +2817,26 @@ CONTAINS
                      rj = rij ! ri + rij
                      rk = rik ! ri + rik
 
-                     CALL eri_3center(sijk, &
-                                      lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), rj, &
-                                      lmin_k(kset), lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), rk, &
-                                      lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
-                                      djk, dij, dik, lib, potential_parameter, int_abc_ext=sijk_ext)
+                     IF (op_pos_prv == 1) THEN
+                        CALL eri_3center(sijk, &
+                                         lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), rj, &
+                                         lmin_k(kset), lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), rk, &
+                                         lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
+                                         djk, dij, dik, lib, potential_parameter, int_abc_ext=sijk_ext)
+                     ELSE
+                        ALLOCATE (tmp_ijk(ncoi, ncoj, ncok))
+                        tmp_ijk = 0.0_Dp
+                        CALL eri_3center(tmp_ijk, &
+                                         lmin_i(iset), lmax_i(iset), npgfi(iset), zeti(:, iset), rpgf_i(:, iset), ri, &
+                                         lmin_j(jset), lmax_j(jset), npgfj(jset), zetj(:, jset), rpgf_j(:, jset), rj, &
+                                         lmin_k(kset), lmax_k(kset), npgfk(kset), zetk(:, kset), rpgf_k(:, kset), rk, &
+                                         dij, dik, djk, lib, potential_parameter, int_abc_ext=sijk_ext)
+                        DO i = 1, ncoi
+                           !TODO: this cannot stay for efficiency (probably)
+                           sijk(:, :, i) = tmp_ijk(i, :, :)
+                        END DO
+                        DEALLOCATE (tmp_ijk)
+                     END IF
 
                      IF (PRESENT(int_eps)) THEN
                         IF (int_eps > sijk_ext*(max_contraction_i(iset)* &
@@ -2691,16 +2882,15 @@ CONTAINS
 !$OMP CRITICAL
             CALL timeset(routineN//"_put_dbcsr", handle2)
             IF (debug) THEN
-               CALL dbt_get_block(t3c(jcell, kcell), &
-                                  [iatom, jatom, katom], dummy_block_t, found=found)
+               CALL dbt_get_block(t3c(jcell, kcell), blk_idx, dummy_block_t, found=found)
                CPASSERT(found)
             END IF
             sp = SHAPE(block_t)
 
             sp([2, 3, 1]) = sp
 
-            CALL dbt_put_block(t3c(jcell, kcell), &
-                               [iatom, jatom, katom], sp, RESHAPE(block_t, SHAPE=sp, ORDER=[2, 3, 1]), summation=.TRUE.)
+            CALL dbt_put_block(t3c(jcell, kcell), blk_idx, sp, &
+                               RESHAPE(block_t, SHAPE=sp, ORDER=[2, 3, 1]), summation=.TRUE.)
 
             CALL timestop(handle2)
 !$OMP END CRITICAL
@@ -2715,13 +2905,23 @@ CONTAINS
       CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
 !$OMP END PARALLEL
 
+      !TODO: deal with hfx_kpoints, because should not filter by 1/2
       IF (nl_3c%sym == symmetric_jk .OR. do_kpoints_prv) THEN
-         DO kcell = 1, nimg
-            DO jcell = 1, nimg
-               ! need half of filter eps because afterwards we add transposed tensor
-               CALL dbt_filter(t3c(jcell, kcell), filter_eps/2)
+
+         IF (.NOT. do_hfx_kpoints_prv) THEN
+            DO kcell = 1, nimg
+               DO jcell = 1, nimg
+                  ! need half of filter eps because afterwards we add transposed tensor
+                  CALL dbt_filter(t3c(jcell, kcell), filter_eps/2)
+               END DO
             END DO
-         END DO
+         ELSE
+            DO kcell = 1, ncell_RI
+               DO jcell = 1, nimg
+                  CALL dbt_filter(t3c(jcell, kcell), filter_eps)
+               END DO
+            END DO
+         END IF
 
          IF (desymmetrize_prv) THEN
             ! add transposed of overlap integrals
@@ -2742,6 +2942,12 @@ CONTAINS
             END DO
             CALL dbt_destroy(t_3c_tmp)
          END IF
+      ELSEIF (nl_3c%sym == symmetric_ij) THEN
+         DO kcell = 1, nimg
+            DO jcell = 1, nimg
+               CALL dbt_filter(t3c(jcell, kcell), filter_eps/2)
+            END DO
+         END DO
       ELSEIF (nl_3c%sym == symmetric_none) THEN
          DO kcell = 1, nimg
             DO jcell = 1, nimg
@@ -2795,7 +3001,8 @@ CONTAINS
       INTEGER :: handle, i_xyz, iatom, ibasis, icol, ikind, imax, img, irow, iset, jatom, jkind, &
          jset, m_max, maxli, maxlj, natom, ncoi, ncoj, nimg, nseti, nsetj, op_prv, sgfi, sgfj, &
          unit_id
-      INTEGER, DIMENSION(3)                              :: cell
+      INTEGER, DIMENSION(3)                              :: cell_j, kp_index_lbounds, &
+                                                            kp_index_ubounds
       INTEGER, DIMENSION(:), POINTER                     :: lmax_i, lmax_j, lmin_i, lmin_j, npgfi, &
                                                             npgfj, nsgfi, nsgfj
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf_i, first_sgf_j
@@ -2836,13 +3043,13 @@ CONTAINS
                       natom=natom, kpoints=kpoints, dft_control=dft_control, para_env=para_env)
 
       IF (do_kpoints_prv) THEN
-         nimg = dft_control%nimages
+         nimg = SIZE(t2c_der, 1)
          CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
+         kp_index_lbounds = LBOUND(cell_to_index)
+         kp_index_ubounds = UBOUND(cell_to_index)
       ELSE
          nimg = 1
       END IF
-
-      CPASSERT(ALL(SHAPE(t2c_der) == [nimg, 3]))
 
       ! check for symmetry
       CPASSERT(SIZE(nl_2c) > 0)
@@ -2905,10 +3112,12 @@ CONTAINS
       DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
 
          CALL get_iterator_info(nl_iterator, ikind=ikind, jkind=jkind, &
-                                iatom=iatom, jatom=jatom, r=rij, cell=cell)
+                                iatom=iatom, jatom=jatom, r=rij, cell=cell_j)
          IF (do_kpoints_prv) THEN
-            img = cell_to_index(cell(1), cell(2), cell(3))
-            IF (img > nimg) CYCLE
+            IF (ANY([cell_j(1), cell_j(2), cell_j(3)] < kp_index_lbounds) .OR. &
+                ANY([cell_j(1), cell_j(2), cell_j(3)] > kp_index_ubounds)) CYCLE
+            img = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
+            IF (img > nimg .OR. img < 1) CYCLE
          ELSE
             img = 1
          END IF
@@ -3191,13 +3400,16 @@ CONTAINS
 !> \param basis_j ...
 !> \param potential_parameter ...
 !> \param do_kpoints ...
+!> \param do_hfx_kpoints ...
 !> this routine requires that libint has been static initialised somewhere else
-!> \param kpoints ...
+!> \param ext_kpoints ...
 !> \param regularization_RI ...
 ! **************************************************************************************************
    SUBROUTINE build_2c_integrals(t2c, filter_eps, qs_env, &
                                  nl_2c, basis_i, basis_j, &
-                                 potential_parameter, do_kpoints, kpoints, regularization_RI)
+                                 potential_parameter, do_kpoints, &
+                                 do_hfx_kpoints, ext_kpoints, regularization_RI)
+
       TYPE(dbcsr_type), DIMENSION(:), INTENT(INOUT)      :: t2c
       REAL(KIND=dp), INTENT(IN)                          :: filter_eps
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -3205,8 +3417,8 @@ CONTAINS
          POINTER                                         :: nl_2c
       TYPE(gto_basis_set_p_type), DIMENSION(:)           :: basis_i, basis_j
       TYPE(libint_potential_type), INTENT(IN)            :: potential_parameter
-      LOGICAL, INTENT(IN), OPTIONAL                      :: do_kpoints
-      TYPE(kpoint_type), OPTIONAL, POINTER               :: kpoints
+      LOGICAL, INTENT(IN), OPTIONAL                      :: do_kpoints, do_hfx_kpoints
+      TYPE(kpoint_type), OPTIONAL, POINTER               :: ext_kpoints
       REAL(KIND=dp), OPTIONAL                            :: regularization_RI
 
       CHARACTER(len=*), PARAMETER :: routineN = 'build_2c_integrals'
@@ -3214,13 +3426,14 @@ CONTAINS
       INTEGER :: handle, i_diag, iatom, ibasis, icol, ikind, imax, img, irow, iset, jatom, jkind, &
          jset, m_max, maxli, maxlj, natom, ncoi, ncoj, nimg, nseti, nsetj, op_prv, sgfi, sgfj, &
          unit_id
-      INTEGER, DIMENSION(3)                              :: cell
+      INTEGER, DIMENSION(3)                              :: cell_j, kp_index_lbounds, &
+                                                            kp_index_ubounds
       INTEGER, DIMENSION(:), POINTER                     :: lmax_i, lmax_j, lmin_i, lmin_j, npgfi, &
                                                             npgfj, nsgfi, nsgfj
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf_i, first_sgf_j
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
-      LOGICAL                                            :: do_kpoints_prv, do_symmetric, found, &
-                                                            trans
+      LOGICAL                                            :: do_hfx_kpoints_prv, do_kpoints_prv, &
+                                                            do_symmetric, found, trans
       REAL(KIND=dp)                                      :: dab, my_regularization_RI
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: sij, sij_contr, sij_rs
       REAL(KIND=dp), DIMENSION(3)                        :: ri, rij, rj
@@ -3229,8 +3442,10 @@ CONTAINS
                                                             zetj
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(block_p_type)                                 :: block_t
+      TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_libint_t)                                  :: lib
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(neighbor_list_iterator_p_type), &
          DIMENSION(:), POINTER                           :: nl_iterator
@@ -3244,26 +3459,36 @@ CONTAINS
          do_kpoints_prv = .FALSE.
       END IF
 
-      op_prv = potential_parameter%potential_type
-
-      NULLIFY (qs_kind_set, atomic_kind_set, block_t%block, cell_to_index)
-
-      ! get stuff
-      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
-                      natom=natom, dft_control=dft_control, para_env=para_env)
-
-      IF (do_kpoints_prv) THEN
-         CPASSERT(PRESENT(kpoints))
-         nimg = dft_control%nimages
-         CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
+      IF (PRESENT(do_hfx_kpoints)) THEN
+         do_hfx_kpoints_prv = do_hfx_kpoints
       ELSE
-         nimg = 1
+         do_hfx_kpoints_prv = .FALSE.
+      END IF
+      IF (do_hfx_kpoints_prv) THEN
+         CPASSERT(do_kpoints_prv)
       END IF
 
       my_regularization_RI = 0.0_dp
       IF (PRESENT(regularization_RI)) my_regularization_RI = regularization_RI
 
-      CPASSERT(ALL(SHAPE(t2c) == [nimg]))
+      op_prv = potential_parameter%potential_type
+
+      NULLIFY (qs_kind_set, atomic_kind_set, block_t%block, cell_to_index)
+
+      ! get stuff
+      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, cell=cell, &
+                      natom=natom, dft_control=dft_control, para_env=para_env, kpoints=kpoints)
+
+      IF (PRESENT(ext_kpoints)) kpoints => ext_kpoints
+
+      IF (do_kpoints_prv) THEN
+         nimg = SIZE(t2c)
+         CALL get_kpoint_info(kpoints, cell_to_index=cell_to_index)
+         kp_index_lbounds = LBOUND(cell_to_index)
+         kp_index_ubounds = UBOUND(cell_to_index)
+      ELSE
+         nimg = 1
+      END IF
 
       ! check for symmetry
       CPASSERT(SIZE(nl_2c) > 0)
@@ -3319,10 +3544,12 @@ CONTAINS
       DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
 
          CALL get_iterator_info(nl_iterator, ikind=ikind, jkind=jkind, &
-                                iatom=iatom, jatom=jatom, r=rij, cell=cell)
+                                iatom=iatom, jatom=jatom, r=rij, cell=cell_j)
          IF (do_kpoints_prv) THEN
-            img = cell_to_index(cell(1), cell(2), cell(3))
-            IF (img > nimg) CYCLE
+            IF (ANY([cell_j(1), cell_j(2), cell_j(3)] < kp_index_lbounds) .OR. &
+                ANY([cell_j(1), cell_j(2), cell_j(3)] > kp_index_ubounds)) CYCLE
+            img = cell_to_index(cell_j(1), cell_j(2), cell_j(3))
+            IF (img > nimg .OR. img < 1) CYCLE
          ELSE
             img = 1
          END IF
@@ -3395,12 +3622,14 @@ CONTAINS
                   DEALLOCATE (sij_contr)
 
                   ! RI regularization
-                  IF (do_kpoints_prv .AND. cell(1) == 0 .AND. cell(2) == 0 .AND. cell(3) == 0 .AND. &
-                      iatom == jatom .AND. iset == jset) THEN
-                     DO i_diag = 1, nsgfi(iset)
-                        sij_rs(i_diag, i_diag) = sij_rs(i_diag, i_diag) + &
-                                                 regularization_RI*MAX(1.0_dp, 1.0_dp/MINVAL(zeti(:, iset)))
-                     END DO
+                  IF (.NOT. do_hfx_kpoints_prv) THEN
+                     IF (do_kpoints_prv .AND. cell_j(1) == 0 .AND. cell_j(2) == 0 .AND. cell_j(3) == 0 .AND. &
+                         iatom == jatom .AND. iset == jset) THEN
+                        DO i_diag = 1, nsgfi(iset)
+                           sij_rs(i_diag, i_diag) = sij_rs(i_diag, i_diag) + &
+                                                    regularization_RI*MAX(1.0_dp, 1.0_dp/MINVAL(zeti(:, iset)))
+                        END DO
+                     END IF
                   END IF
 
                   CALL block_add("IN", sij_rs, &

--- a/src/qs_tensors_types.F
+++ b/src/qs_tensors_types.F
@@ -159,13 +159,15 @@ CONTAINS
 !> \param nkind ...
 !> \param particle_set ...
 !> \param mp_comm_2d MPI communicator with a 3d cartesian topology
+!> \param blacs_env_ext ...
 ! **************************************************************************************************
-   SUBROUTINE distribution_2d_create(dist_2d, dist1, dist2, nkind, particle_set, mp_comm_2d)
+   SUBROUTINE distribution_2d_create(dist_2d, dist1, dist2, nkind, particle_set, mp_comm_2d, blacs_env_ext)
       TYPE(distribution_2d_type), POINTER                :: dist_2d
       INTEGER, DIMENSION(:), INTENT(IN)                  :: dist1, dist2
       INTEGER, INTENT(IN)                                :: nkind
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      TYPE(mp_cart_type), INTENT(IN)                     :: mp_comm_2d
+      TYPE(mp_cart_type), INTENT(IN), OPTIONAL           :: mp_comm_2d
+      TYPE(cp_blacs_env_type), OPTIONAL, POINTER         :: blacs_env_ext
 
       CHARACTER(len=*), PARAMETER :: routineN = 'distribution_2d_create'
 
@@ -181,17 +183,26 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      mp_dims = mp_comm_2d%num_pe_cart
-      mp_coor = mp_comm_2d%mepos_cart
-      ALLOCATE (para_env)
-      para_env = mp_comm_2d
-      CALL cp_blacs_env_create(blacs_env, para_env, &
-                               grid_2d=mp_dims)
+      CPASSERT(PRESENT(mp_comm_2d) .OR. PRESENT(blacs_env_ext))
 
-      CPASSERT(blacs_env%mepos(1) == mp_coor(1))
-      CPASSERT(blacs_env%mepos(2) == mp_coor(2))
+      IF (PRESENT(mp_comm_2d)) THEN
+         mp_dims = mp_comm_2d%num_pe_cart
+         mp_coor = mp_comm_2d%mepos_cart
+         ALLOCATE (para_env)
+         para_env = mp_comm_2d
+         CALL cp_blacs_env_create(blacs_env, para_env, &
+                                  grid_2d=mp_dims)
 
-      CALL mp_para_env_release(para_env)
+         CPASSERT(blacs_env%mepos(1) == mp_coor(1))
+         CPASSERT(blacs_env%mepos(2) == mp_coor(2))
+         CALL mp_para_env_release(para_env)
+      END IF
+
+      IF (PRESENT(blacs_env_ext)) THEN
+         blacs_env => blacs_env_ext
+         mp_coor(1) = blacs_env%mepos(1)
+         mp_coor(2) = blacs_env%mepos(2)
+      END IF
 
       natom = SIZE(particle_set)
       ALLOCATE (dist1_prv(natom, 2), dist2_prv(natom, 2))
@@ -235,7 +246,9 @@ CONTAINS
                                       col_distribution_ptr=dist2_prv, local_rows_ptr=local_particle_row, &
                                       local_cols_ptr=local_particle_col, blacs_env=blacs_env)
 
-      CALL cp_blacs_env_release(blacs_env)
+      IF (.NOT. PRESENT(blacs_env_ext)) THEN
+         CALL cp_blacs_env_release(blacs_env)
+      END IF
 
       CALL timestop(handle)
    END SUBROUTINE

--- a/tests/QS/regtest-kp-hfx-ri-2/He_debug.inp
+++ b/tests/QS/regtest-kp-hfx-ri-2/He_debug.inp
@@ -1,0 +1,65 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME EMSL_BASIS_SETS
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        LSD
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 300
+            REL_CUTOFF 40
+        &END MGRID
+        &SCF
+            SCF_GUESS RESTART
+            MAX_SCF 30
+            EPS_SCF 1.0E-6
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   EPS_FILTER 1.0E-10
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    CUTOFF_RADIUS 1.0
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  12 4 4
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            ABC 4.0 3.0 3.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+            He 0.0 0.0 0.0
+            He 2.4 0.0 0.0
+        &END COORD
+        &KIND He
+            BASIS_SET 3-21Gx
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT He_debug
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE DEBUG
+&END GLOBAL
+&DEBUG
+   CHECK_ATOM_FORCE 1 X
+&END

--- a/tests/QS/regtest-kp-hfx-ri-2/LiH_gapw_stress.inp
+++ b/tests/QS/regtest-kp-hfx-ri-2/LiH_gapw_stress.inp
@@ -1,0 +1,85 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    STRESS_TENSOR ANALYTICAL
+    &PRINT
+      &STRESS_TENSOR
+         COMPONENTS
+      &END
+    &END
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+           EPS_PGF_ORB 1.0E-6
+        &END
+        &MGRID
+            CUTOFF 300
+            REL_CUTOFF 50
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 1.0
+                &RI
+                   RI_METRIC IDENTITY
+                   MEMORY_CUT 2
+                   NGROUPS 2
+                   EPS_FILTER 1.0E-12
+                   EPS_PGF_ORB 1.0E-6
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 1.5
+                &END
+                &SCREENING
+                  EPS_SCHWARZ 1.0E-10
+                  EPS_SCHWARZ_FORCES 1.0E-10
+                &END
+            &END
+        &END XC 
+        &KPOINTS
+           SCHEME  MONKHORST-PACK  2 2 2
+        &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 6.0 6.0 6.0
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END CELL
+        &TOPOLOGY
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END
+        &COORD
+           SCALED
+             Li  0.00000000  0.00000000  0.00000000
+             H   0.50000000  0.50000000  0.50000000
+        &END COORD
+        &KIND Li
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+        &KIND H
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT LiH
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY_FORCE
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-2/TEST_FILES
+++ b/tests/QS/regtest-kp-hfx-ri-2/TEST_FILES
@@ -1,0 +1,6 @@
+diamond_gapw_tc.inp                                      11   1.0E-10             -75.016281067533328
+diamond_gpw_stress.inp                                   31   1.0E-8               -4.12844740283E-01
+hBN_gapw_ovlp.inp                                        11   1.0E-10             -86.260185626957053
+hBN_gpw_pbe0.inp                                         11   1.0E-10              -8.628406066722894
+LiH_gapw_stress.inp                                      31   1.0E-8               -2.20168679931E+00
+He_debug.inp                                              0 

--- a/tests/QS/regtest-kp-hfx-ri-2/diamond_gapw_tc.inp
+++ b/tests/QS/regtest-kp-hfx-ri-2/diamond_gapw_tc.inp
@@ -1,0 +1,75 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        AUTO_BASIS RI_HFX SMALL
+        SORT_BASIS EXP
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 120
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &HYB_GGA_XC_B3LYP
+               &END HYB_GGA_XC_B3LYP
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.2
+                &RI
+                   RI_METRIC TRUNCATED
+                   CUTOFF_RADIUS 1.5
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                   EPS_FILTER 1.0E-10
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE TRUNCATED
+                    CUTOFF_RADIUS 1.5
+                &END
+            &END
+        &END XC 
+        &KPOINTS
+           SCHEME  MONKHORST-PACK  2 2 2
+        &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 7.5 7.5 7.5
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.00000000  0.00000000  0.00000000  
+           C   0.25000000  0.25000000  0.25000000  
+        &END COORD
+        &KIND C
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond_gapw_tc
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE GEO_OPT
+&END GLOBAL
+&MOTION
+   &GEO_OPT
+      MAX_ITER 1
+   &END GEO_OPT
+&END MOTION

--- a/tests/QS/regtest-kp-hfx-ri-2/diamond_gpw_stress.inp
+++ b/tests/QS/regtest-kp-hfx-ri-2/diamond_gpw_stress.inp
@@ -1,0 +1,77 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    STRESS_TENSOR ANALYTICAL
+    &PRINT
+      &STRESS_TENSOR
+         COMPONENTS
+      &END
+    &END
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_RI_cc-TZ
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        LSD
+        &QS
+           METHOD GPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 150
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &PBE
+                  SCALE_X 0.75
+               &END
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.25
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                   EPS_FILTER 1.0E-10
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE TRUNCATED
+                    CUTOFF_RADIUS 0.5
+                &END
+            &END
+        &END XC 
+        &KPOINTS
+           SCHEME  MONKHORST-PACK  2 2 2
+        &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 8.0 8.0 8.0
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.00000000  0.00000000  0.00000000  
+           C   0.25000000  0.25000000  0.25000000  
+        &END COORD
+        &KIND C
+            BASIS_SET cc-DZ
+            BASIS_SET RI_HFX RI_DZ
+            POTENTIAL GTH-HF
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond_gpw_stress
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY_FORCE
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-2/hBN_gapw_ovlp.inp
+++ b/tests/QS/regtest-kp-hfx-ri-2/hBN_gapw_ovlp.inp
@@ -1,0 +1,75 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        LSD
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 120
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   EPS_FILTER 1.0E-10
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE IDENTITY
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  2 2 1
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !note: this is not a realistic cell, but denser cells would be too expensive for a test
+            ABC 5.5 5.5 15.0
+            ALPHA_BETA_GAMMA 90.0 90.0 120.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           B 0.3333333 0.6666667 0.0
+           N 0.6666667 0.3333333 0.0
+        &END COORD
+        &KIND B
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+        &KIND N
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT hBN_gapw_ovlp
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE GEO_OPT
+&END GLOBAL
+&MOTION                                                                                              
+   &GEO_OPT                                                                                          
+      MAX_ITER 1                                                                                     
+   &END GEO_OPT                                                                                      
+&END MOTION

--- a/tests/QS/regtest-kp-hfx-ri-2/hBN_gpw_pbe0.inp
+++ b/tests/QS/regtest-kp-hfx-ri-2/hBN_gpw_pbe0.inp
@@ -1,0 +1,78 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        POTENTIAL_FILE_NAME POTENTIAL_UZH
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 120
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &PBE
+                  SCALE_X 0.75
+               &END
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.25
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   EPS_FILTER 1.0E-10
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE IDENTITY
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  2 2 1
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !note: this is not a realistic cell, but denser cells would be too expensive for a test
+            ABC 7.0 7.0 15.0
+            ALPHA_BETA_GAMMA 90.0 90.0 120.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           B 0.3333333 0.6666667 0.0
+           N 0.6666667 0.3333333 0.0
+        &END COORD
+        &KIND B
+            BASIS_SET ccGRB-D-q3
+            POTENTIAL GTH-PBE0-q3
+        &END KIND
+        &KIND N
+            BASIS_SET ccGRB-D-q5
+            POTENTIAL GTH-PBE0-q5
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT hBN_gpw_pbe0
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE GEO_OPT
+&END GLOBAL
+&MOTION
+   &GEO_OPT
+      MAX_ITER 1
+   &END GEO_OPT
+&END MOTION

--- a/tests/QS/regtest-kp-hfx-ri-admm-2/He_debug.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm-2/He_debug.inp
@@ -1,0 +1,71 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME EMSL_BASIS_SETS
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+          ADMM_PURIFICATION_METHOD NONE
+          EXCH_CORRECTION_FUNC PBEX
+          METHOD CHARGE_CONSTRAINED_PROJECTION
+          EXCH_SCALING_MODEL MERLOT
+        &END        
+        &MGRID
+            CUTOFF 300
+            REL_CUTOFF 40
+        &END MGRID
+        &SCF
+            SCF_GUESS RESTART !ATOMIC
+            MAX_SCF 30
+            EPS_SCF 1.0E-6
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   EPS_FILTER 1.0E-10
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED 
+                    CUTOFF_RADIUS 1.0
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  12 4 4
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            ABC 4.0 3.0 3.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+            He 0.0 0.0 0.0
+            He 2.4 0.0 0.0
+        &END COORD
+        &KIND He
+            BASIS_SET 6-31Gx
+            BASIS_SET AUX_FIT 3-21Gx
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT He_debug
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE DEBUG
+&END GLOBAL
+&DEBUG
+   CHECK_ATOM_FORCE 1 X
+&END

--- a/tests/QS/regtest-kp-hfx-ri-admm-2/LiH_gapw_pbex.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm-2/LiH_gapw_pbex.inp
@@ -1,0 +1,85 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+           EPS_PGF_ORB 1.0E-5
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+           ADMM_PURIFICATION_METHOD NONE
+           EXCH_CORRECTION_FUNC PBEX
+        &END
+        &MGRID
+            CUTOFF 150
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 1.0
+                &RI
+                   RI_METRIC IDENTITY
+                   MEMORY_CUT 2
+                   NGROUPS 2
+                   EPS_PGF_ORB 1.0E-5
+                &END
+                &INTERACTION_POTENTIAL
+                   POTENTIAL_TYPE TRUNCATED
+                   !this is too small for a real calculation. The only requirement is that it is
+                   !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                   !on efficiency, as it greatly increses the number of periodic images to consider
+                   CUTOFF_RADIUS 1.0
+                &END
+            &END
+        &END XC 
+        &KPOINTS
+           SCHEME  MONKHORST-PACK  2 2 2
+        &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 6.0 6.0 6.0
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END CELL
+        &TOPOLOGY
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END
+        &COORD
+           SCALED
+             Li  0.00000000  0.00000000  0.10000000
+             H   0.49000000  0.52000000  0.50000000
+        &END COORD
+        &KIND Li
+            BASIS_SET pob-TZVP-rev2
+            BASIS_SET AUX_FIT pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+        &KIND H
+            BASIS_SET pob-TZVP-rev2
+            BASIS_SET AUX_FIT pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT LiH
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE GEO_OPT
+&END GLOBAL
+&MOTION
+   &GEO_OPT
+      MAX_ITER 1
+   &END GEO_OPT
+&END MOTION

--- a/tests/QS/regtest-kp-hfx-ri-admm-2/LiH_gpw_none.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm-2/LiH_gpw_none.inp
@@ -1,0 +1,85 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+        POTENTIAL_FILE_NAME POTENTIAL_UZH
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GPW
+           PW_GRID_BLOCKED FALSE
+           EPS_PGF_ORB 1.0E-5
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+           ADMM_PURIFICATION_METHOD NONE
+           EXCH_CORRECTION_FUNC NONE
+        &END
+        &MGRID
+            CUTOFF 150
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 1.0
+                &RI
+                   RI_METRIC IDENTITY
+                   MEMORY_CUT 2
+                   NGROUPS 2
+                   EPS_PGF_ORB 1.0E-5
+                &END
+                &INTERACTION_POTENTIAL
+                   !this is too small for a real calculation. The only requirement is that it is
+                   !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                   !on efficiency, as it greatly increses the number of periodic images to consider 
+                   POTENTIAL_TYPE IDENTITY
+                &END
+            &END
+        &END XC 
+        &KPOINTS
+           SCHEME  MONKHORST-PACK  2 2 2
+        &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 6.5 6.5 6.5
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END CELL
+        &TOPOLOGY
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END
+        &COORD
+           SCALED
+             Li  0.00000000  0.10000000  0.10000000
+             H   0.49000000  0.52000000  0.50000000
+        &END COORD
+        &KIND Li
+            BASIS_SET ccGRB-D-q3
+            BASIS_SET AUX_FIT admm-dz-q3
+            POTENTIAL GTH-HYB-q3
+        &END KIND
+        &KIND H
+            BASIS_SET ccGRB-D-q1
+            BASIS_SET AUX_FIT admm-dz-q1
+            POTENTIAL GTH-HYB-q1
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT LiH
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE GEO_OPT
+&END GLOBAL
+&MOTION
+   &GEO_OPT
+      MAX_ITER 1
+   &END GEO_OPT
+&END MOTION

--- a/tests/QS/regtest-kp-hfx-ri-admm-2/TEST_FILES
+++ b/tests/QS/regtest-kp-hfx-ri-admm-2/TEST_FILES
@@ -1,0 +1,7 @@
+hBN_gpw_pbe0.inp                                         11   1.0E-10              -8.118837307488315
+LiH_gapw_pbex.inp                                        11   1.0E-10              -7.614795641607921
+LiH_gpw_none.inp                                         11   1.0E-10              -5.388882599979748
+hBN_gapw_lsd_stress.inp                                  31   1.0E-8               -1.16617186901E+00
+diamond_admmp.inp                                        11   1.0E-10              -7.517321426222286
+diamond_admms.inp                                        11   1.0E-10             -75.916448645919573
+diamond_admmq.inp                                        31   1.0E-8               -8.80537706373E+00

--- a/tests/QS/regtest-kp-hfx-ri-admm-2/diamond_admmp.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm-2/diamond_admmp.inp
@@ -1,0 +1,84 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &PRINT
+          &DERIVATIVES
+          &END
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+          ADMM_PURIFICATION_METHOD NONE
+          EXCH_CORRECTION_FUNC PBEX
+          METHOD BASIS_PROJECTION
+          EXCH_SCALING_MODEL MERLOT
+        &END
+        &QS
+           PW_GRID_BLOCKED FALSE
+           METHOD GPW
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 1.0
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 0.5
+                &END
+            &END
+        &END XC
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 3
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+      &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 6.5 6.5 6.5
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            SYMMETRY RHOMBOHEDRAL
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.05000000  0.10000000  0.00000000
+           C   0.23000000  0.28000000  0.24000000
+        &END COORD
+        &KIND C
+            BASIS_SET ccGRB-D-q4
+            BASIS_SET AUX_FIT admm-dz-q4
+            POTENTIAL GTH-PBE
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE GEO_OPT
+&END GLOBAL
+&MOTION
+   &GEO_OPT
+      MAX_ITER 1
+   &END GEO_OPT
+&END MOTION

--- a/tests/QS/regtest-kp-hfx-ri-admm-2/diamond_admmq.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm-2/diamond_admmq.inp
@@ -1,0 +1,88 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    STRESS_TENSOR ANALYTICAL
+    &PRINT
+      &STRESS_TENSOR
+         COMPONENTS
+      &END
+    &END
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &PRINT
+          &DERIVATIVES
+          &END
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+          ADMM_PURIFICATION_METHOD NONE
+          EXCH_CORRECTION_FUNC PBEX
+          METHOD CHARGE_CONSTRAINED_PROJECTION
+          EXCH_SCALING_MODEL NONE
+        &END
+        &QS
+           PW_GRID_BLOCKED FALSE
+           METHOD GPW
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &PBE
+                  SCALE_X 0.25
+               &END
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.75
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 1.0
+                &END
+            &END
+        &END XC
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 3
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+      &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 6.0 6.0 6.0
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            SYMMETRY RHOMBOHEDRAL
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.00000000  0.00000000  0.00000000
+           C   0.25000000  0.25000000  0.25000000
+        &END COORD
+        &KIND C
+            BASIS_SET ccGRB-D-q4
+            BASIS_SET AUX_FIT admm-dz-q4
+            POTENTIAL GTH-PBE
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY_FORCE
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-admm-2/diamond_admms.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm-2/diamond_admms.inp
@@ -1,0 +1,79 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+          ADMM_PURIFICATION_METHOD NONE
+          EXCH_CORRECTION_FUNC PBEX
+          METHOD CHARGE_CONSTRAINED_PROJECTION
+          EXCH_SCALING_MODEL MERLOT
+        &END
+        LSD
+        &QS
+           PW_GRID_BLOCKED FALSE
+           METHOD GAPW
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 1.0
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE IDENTITY
+                &END
+            &END
+        &END XC
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 3
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+      &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 6.5 6.5 6.5
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            SYMMETRY RHOMBOHEDRAL
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.10000000  0.00000000  0.20000000
+           C   0.24000000  0.26000000  0.25000000
+        &END COORD
+        &KIND C
+            BASIS_SET pob-TZVP
+            BASIS_SET AUX_FIT pob-DZVP
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE GEO_OPT
+&END GLOBAL
+&MOTION
+   &GEO_OPT
+      MAX_ITER 1
+   &END GEO_OPT
+&END MOTION

--- a/tests/QS/regtest-kp-hfx-ri-admm-2/hBN_gapw_lsd_stress.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm-2/hBN_gapw_lsd_stress.inp
@@ -1,0 +1,85 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    STRESS_TENSOR ANALYTICAL
+    &PRINT
+      &STRESS_TENSOR
+         COMPONENTS
+      &END
+    &END
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL_UZH
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        LSD
+        &QS
+           METHOD GPW
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+            ADMM_PURIFICATION_METHOD NONE
+            EXCH_CORRECTION_FUNC PBEX
+        &END
+        &MGRID
+            CUTOFF 300
+            REL_CUTOFF 50
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &PBE
+                  SCALE_X 0.55
+               &END
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.45
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 1.0
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 1
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !note: this is not a realistic cell, but denser cells would be too expensive for a test
+            ABC 5.5 5.5 15.0
+            ALPHA_BETA_GAMMA 90.0 90.0 120.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           B 0.3233333 0.6766667 0.0
+           N 0.6466667 0.3433333 0.0
+        &END COORD
+        &KIND B
+            BASIS_SET pob-TZVP
+            BASIS_SET AUX_FIT pob-DZVP
+            POTENTIAL GTH-PBE0-q3
+        &END KIND
+        &KIND N
+            BASIS_SET pob-TZVP
+            BASIS_SET AUX_FIT pob-DZVP
+            POTENTIAL GTH-PBE0-q5
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT hBN_gpw_pbe0
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY_FORCE
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-admm-2/hBN_gpw_pbe0.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm-2/hBN_gpw_pbe0.inp
@@ -1,0 +1,84 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+        POTENTIAL_FILE_NAME POTENTIAL_UZH
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GPW
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+            ADMM_PURIFICATION_METHOD NONE
+            EXCH_CORRECTION_FUNC PBEX
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 40
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &PBE
+                  SCALE_X 0.75
+               &END
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.25
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 0.5
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 1
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !note: this is not a realistic cell, but denser cells would be too expensive for a test
+            ABC 6.5 6.5 15.0
+            ALPHA_BETA_GAMMA 90.0 90.0 120.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           B 0.3233333 0.6866667 0.0
+           N 0.6466667 0.3433333 0.0
+        &END COORD
+        &KIND B
+            BASIS_SET ccGRB-D-q3
+            BASIS_SET AUX_FIT admm-dz-q3
+            POTENTIAL GTH-PBE0-q3
+        &END KIND
+        &KIND N
+            BASIS_SET ccGRB-D-q5
+            BASIS_SET AUX_FIT admm-dz-q5
+            POTENTIAL GTH-PBE0-q5
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT hBN_gpw_pbe0
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE GEO_OPT
+&END GLOBAL
+&MOTION
+   &GEO_OPT
+      MAX_ITER 1
+   &END GEO_OPT
+&END MOTION

--- a/tests/QS/regtest-kp-hfx-ri-admm/LiH_gapw_pbex.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm/LiH_gapw_pbex.inp
@@ -1,0 +1,80 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+           EPS_PGF_ORB 1.0E-5
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+           ADMM_PURIFICATION_METHOD NONE
+           EXCH_CORRECTION_FUNC PBEX
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 40
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 3
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 1.0
+                &RI
+                   RI_METRIC IDENTITY
+                   MEMORY_CUT 2
+                   NGROUPS 2
+                   EPS_PGF_ORB 1.0E-5
+                &END
+                &INTERACTION_POTENTIAL
+                   POTENTIAL_TYPE TRUNCATED
+                   !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                   CUTOFF_RADIUS 1.5
+                &END
+            &END
+        &END XC 
+        &KPOINTS
+           SCHEME  MONKHORST-PACK  3 3 3
+        &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 5.0 5.0 5.0
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END CELL
+        &TOPOLOGY
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END
+        &COORD
+           SCALED
+             Li  0.00000000  0.00000000  0.00000000
+             H   0.50000000  0.50000000  0.50000000
+        &END COORD
+        &KIND Li
+            BASIS_SET pob-TZVP-rev2
+            BASIS_SET AUX_FIT pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+        &KIND H
+            BASIS_SET pob-TZVP-rev2
+            BASIS_SET AUX_FIT pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT LiH
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-admm/LiH_gpw_none.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm/LiH_gpw_none.inp
@@ -1,0 +1,80 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+        POTENTIAL_FILE_NAME POTENTIAL_UZH
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GPW
+           PW_GRID_BLOCKED FALSE
+           EPS_PGF_ORB 1.0E-5
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+           ADMM_PURIFICATION_METHOD NONE
+           EXCH_CORRECTION_FUNC NONE
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 40
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 3
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 1.0
+                &RI
+                   RI_METRIC IDENTITY
+                   MEMORY_CUT 2
+                   NGROUPS 2
+                   EPS_PGF_ORB 1.0E-5
+                &END
+                &INTERACTION_POTENTIAL
+                   !this is too small for a real calculation. The only requirement is that it is
+                   !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                   !on efficiency, as it greatly increses the number of periodic images to consider
+                   POTENTIAL_TYPE IDENTITY
+                &END
+            &END
+        &END XC 
+        &KPOINTS
+           SCHEME  MONKHORST-PACK  3 3 3
+        &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 6.0 6.0 6.0
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END CELL
+        &TOPOLOGY
+            MULTIPLE_UNIT_CELL 1 1 1
+        &END
+        &COORD
+           SCALED
+             Li  0.00000000  0.00000000  0.00000000
+             H   0.50000000  0.50000000  0.50000000
+        &END COORD
+        &KIND Li
+            BASIS_SET ccGRB-D-q3
+            BASIS_SET AUX_FIT admm-dz-q3
+            POTENTIAL GTH-HYB-q3
+        &END KIND
+        &KIND H
+            BASIS_SET ccGRB-D-q1
+            BASIS_SET AUX_FIT admm-dz-q1
+            POTENTIAL GTH-HYB-q1
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT LiH
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-admm/TEST_FILES
+++ b/tests/QS/regtest-kp-hfx-ri-admm/TEST_FILES
@@ -1,0 +1,7 @@
+hBN_gapw_lsd.inp                                         11   1.0E-10              -12.026095275245570
+hBN_gpw_pbe0.inp                                         11   1.0E-10              -11.419680658874068
+LiH_gapw_pbex.inp                                        11   1.0E-10               -7.646121340276992
+LiH_gpw_none.inp                                         11   1.0E-10               -6.192180464806834
+diamond_admmp.inp                                        11   1.0E-10               -9.597066991103514
+diamond_admmq.inp                                        11   1.0E-10              -10.061483263107078
+diamond_admms.inp                                        11   1.0E-10              -79.262739163622967

--- a/tests/QS/regtest-kp-hfx-ri-admm/diamond_admmp.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm/diamond_admmp.inp
@@ -1,0 +1,79 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &PRINT
+          &DERIVATIVES
+          &END
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+          ADMM_PURIFICATION_METHOD NONE
+          EXCH_CORRECTION_FUNC PBEX
+          METHOD BASIS_PROJECTION
+          EXCH_SCALING_MODEL MERLOT
+        &END
+        &QS
+           PW_GRID_BLOCKED FALSE
+           METHOD GPW
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 3
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 1.0
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 1.0
+                &END
+            &END
+        &END XC
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 3
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+      &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 5.0 5.0 5.0
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            SYMMETRY RHOMBOHEDRAL
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.00000000  0.00000000  0.00000000
+           C   0.25000000  0.25000000  0.25000000
+        &END COORD
+        &KIND C
+            BASIS_SET ccGRB-D-q4
+            BASIS_SET AUX_FIT admm-dz-q4
+            POTENTIAL GTH-PBE
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-admm/diamond_admmq.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm/diamond_admmq.inp
@@ -1,0 +1,82 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &PRINT
+          &DERIVATIVES
+          &END
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+          ADMM_PURIFICATION_METHOD NONE
+          EXCH_CORRECTION_FUNC PBEX
+          METHOD CHARGE_CONSTRAINED_PROJECTION
+          EXCH_SCALING_MODEL NONE
+        &END
+        &QS
+           PW_GRID_BLOCKED FALSE
+           METHOD GPW
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 3
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &PBE
+                  SCALE_X 0.25
+               &END
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.75
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 1.0
+                &END
+            &END
+        &END XC
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 3
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+      &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 5.0 5.0 5.0
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            SYMMETRY RHOMBOHEDRAL
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.00000000  0.00000000  0.00000000
+           C   0.25000000  0.25000000  0.25000000
+        &END COORD
+        &KIND C
+            BASIS_SET ccGRB-D-q4
+            BASIS_SET AUX_FIT admm-dz-q4
+            POTENTIAL GTH-PBE
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-admm/diamond_admms.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm/diamond_admms.inp
@@ -1,0 +1,74 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+          ADMM_PURIFICATION_METHOD NONE
+          EXCH_CORRECTION_FUNC PBEX
+          METHOD CHARGE_CONSTRAINED_PROJECTION
+          EXCH_SCALING_MODEL MERLOT
+        &END
+        LSD
+        &QS
+           PW_GRID_BLOCKED FALSE
+           METHOD GAPW
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 3
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 1.0
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE IDENTITY
+                &END
+            &END
+        &END XC
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 3
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+      &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 6.0 6.0 6.0
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+            SYMMETRY RHOMBOHEDRAL
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.00000000  0.00000000  0.00000000
+           C   0.25000000  0.25000000  0.25000000
+        &END COORD
+        &KIND C
+            BASIS_SET pob-TZVP
+            BASIS_SET AUX_FIT pob-DZVP
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-admm/hBN_gapw_lsd.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm/hBN_gapw_lsd.inp
@@ -1,0 +1,80 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL_UZH
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        LSD
+        &QS
+           METHOD GPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+            ADMM_PURIFICATION_METHOD NONE
+            EXCH_CORRECTION_FUNC PBEX
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 40
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 3
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &PBE
+                  SCALE_X 0.55
+               &END
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.45
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 1.5
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 1
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !note: this is not a realistic cell, but denser cells would be too expensive for a test
+            ABC 5.5 5.5 15.0
+            ALPHA_BETA_GAMMA 90.0 90.0 120.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           B 0.3333333 0.6666667 0.0
+           N 0.6666667 0.3333333 0.0
+        &END COORD
+        &KIND B
+            BASIS_SET pob-TZVP
+            BASIS_SET AUX_FIT pob-DZVP
+            POTENTIAL GTH-PBE0-q3
+        &END KIND
+        &KIND N
+            BASIS_SET pob-TZVP
+            BASIS_SET AUX_FIT pob-DZVP
+            POTENTIAL GTH-PBE0-q5
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT hBN_gpw_pbe0
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri-admm/hBN_gpw_pbe0.inp
+++ b/tests/QS/regtest-kp-hfx-ri-admm/hBN_gpw_pbe0.inp
@@ -1,0 +1,80 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+        POTENTIAL_FILE_NAME POTENTIAL_UZH
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &AUXILIARY_DENSITY_MATRIX_METHOD
+            ADMM_PURIFICATION_METHOD NONE
+            EXCH_CORRECTION_FUNC PBEX
+        &END
+        &MGRID
+            CUTOFF 200
+            REL_CUTOFF 40
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 3
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &PBE
+                  SCALE_X 0.75
+               &END
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.25
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 0.5
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  3 3 1
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !note: this is not a realistic cell, but denser cells would be too expensive for a test
+            ABC 6.5 6.5 15.0
+            ALPHA_BETA_GAMMA 90.0 90.0 120.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           B 0.3333333 0.6666667 0.0
+           N 0.6666667 0.3333333 0.0
+        &END COORD
+        &KIND B
+            BASIS_SET ccGRB-D-q3
+            BASIS_SET AUX_FIT admm-dz-q3
+            POTENTIAL GTH-PBE0-q3
+        &END KIND
+        &KIND N
+            BASIS_SET ccGRB-D-q5
+            BASIS_SET AUX_FIT admm-dz-q5
+            POTENTIAL GTH-PBE0-q5
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT hBN_gpw_pbe0
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri/TEST_FILES
+++ b/tests/QS/regtest-kp-hfx-ri/TEST_FILES
@@ -1,0 +1,5 @@
+diamond_gapw_tc.inp                                      11   1.0E-10              -75.317785150617567
+diamond_gpw_extRI.inp                                    11   1.0E-10               -8.128239211260716
+hBN_gapw_ovlp.inp                                        11   1.0E-10              -86.213599739489808
+hBN_gapw_tc.inp                                          11   1.0E-10              -77.588144157636464
+hBN_gpw_pbe0.inp                                         11   1.0E-10              -11.615352808149828

--- a/tests/QS/regtest-kp-hfx-ri/diamond_gapw_tc.inp
+++ b/tests/QS/regtest-kp-hfx-ri/diamond_gapw_tc.inp
@@ -1,0 +1,70 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        AUTO_BASIS RI_HFX SMALL
+        SORT_BASIS EXP
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 120
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &HYB_GGA_XC_B3LYP
+               &END HYB_GGA_XC_B3LYP
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.2
+                &RI
+                   RI_METRIC TRUNCATED
+                   CUTOFF_RADIUS 1.5
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                   EPS_FILTER 1.0E-10
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE TRUNCATED
+                    CUTOFF_RADIUS 1.5
+                &END
+            &END
+        &END XC 
+        &KPOINTS
+           SCHEME  MONKHORST-PACK  2 2 2
+        &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 7.5 7.5 7.5
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.00000000  0.00000000  0.00000000  
+           C   0.25000000  0.25000000  0.25000000  
+        &END COORD
+        &KIND C
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond_gapw_tc
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri/diamond_gpw_extRI.inp
+++ b/tests/QS/regtest-kp-hfx-ri/diamond_gpw_extRI.inp
@@ -1,0 +1,65 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_RI_cc-TZ
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        &QS
+           METHOD GPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 120
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   MEMORY_CUT 2
+                   EPS_FILTER 1.0E-10
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE IDENTITY
+                &END
+            &END
+        &END XC 
+        &KPOINTS
+           SCHEME  MONKHORST-PACK  2 2 2
+        &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !this is not a realistic cell, but denser systems would be too expensive for a test
+            ABC 7.5 7.5 7.5
+            ALPHA_BETA_GAMMA 60.0 60.0 60.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           C   0.00000000  0.00000000  0.00000000  
+           C   0.25000000  0.25000000  0.25000000  
+        &END COORD
+        &KIND C
+            BASIS_SET cc-DZ
+            BASIS_SET RI_HFX RI_DZ
+            POTENTIAL GTH-HF
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT diamond_gpw_extRI
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri/hBN_gapw_ovlp.inp
+++ b/tests/QS/regtest-kp-hfx-ri/hBN_gapw_ovlp.inp
@@ -1,0 +1,70 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        LSD
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 120
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   EPS_FILTER 1.0E-10
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE IDENTITY
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  2 2 1
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !note: this is not a realistic cell, but denser cells would be too expensive for a test
+            ABC 5.0 5.0 15.0
+            ALPHA_BETA_GAMMA 90.0 90.0 120.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           B 0.3333333 0.6666667 0.0
+           N 0.6666667 0.3333333 0.0
+        &END COORD
+        &KIND B
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+        &KIND N
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT hBN_gapw_ovlp
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri/hBN_gapw_tc.inp
+++ b/tests/QS/regtest-kp-hfx-ri/hBN_gapw_tc.inp
@@ -1,0 +1,70 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_pob
+        POTENTIAL_FILE_NAME POTENTIAL
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GAPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 120
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL NONE
+            &END XC_FUNCTIONAL
+            &HF
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   EPS_FILTER 1.0E-10
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    POTENTIAL_TYPE TRUNCATED
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    CUTOFF_RADIUS 1.0
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  2 2 1
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !note: this is not a realistic cell, but denser cells would be too expensive for a test
+            ABC 5.0 5.0 15.0
+            ALPHA_BETA_GAMMA 90.0 90.0 120.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           B 0.3333333 0.6666667 0.0
+           N 0.6666667 0.3333333 0.0
+        &END COORD
+        &KIND B
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+        &KIND N
+            BASIS_SET pob-DZVP-rev2
+            POTENTIAL ALL
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT hBN_gapw_tc
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/QS/regtest-kp-hfx-ri/hBN_gpw_pbe0.inp
+++ b/tests/QS/regtest-kp-hfx-ri/hBN_gpw_pbe0.inp
@@ -1,0 +1,73 @@
+&FORCE_EVAL
+    METHOD Quickstep
+    &DFT
+        BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+        POTENTIAL_FILE_NAME POTENTIAL_UZH
+        SORT_BASIS EXP
+        AUTO_BASIS RI_HFX SMALL
+        &QS
+           METHOD GPW
+           PW_GRID_BLOCKED FALSE
+        &END
+        &MGRID
+            CUTOFF 120
+            REL_CUTOFF 30
+        &END MGRID
+        &SCF
+            SCF_GUESS ATOMIC
+            MAX_SCF 2
+        &END SCF
+        &XC
+            &XC_FUNCTIONAL
+               &PBE
+                  SCALE_X 0.75
+               &END
+            &END XC_FUNCTIONAL
+            &HF
+                FRACTION 0.25
+                &RI
+                   RI_METRIC IDENTITY
+                   NGROUPS 2
+                   EPS_FILTER 1.0E-10
+                   MEMORY_CUT 2
+                &END
+                &INTERACTION_POTENTIAL
+                    !this is too small for a real calculation. The only requirement is that it is
+                    !smaller than N_kp * L/2 in each direction. Potential range has a drastic effect
+                    !on efficiency, as it greatly increses the number of periodic images to consider
+                    POTENTIAL_TYPE IDENTITY
+                &END
+            &END
+        &END XC 
+       &KPOINTS
+          SCHEME  MONKHORST-PACK  2 2 1
+       &END KPOINTS
+    &END DFT
+    &SUBSYS
+        &CELL
+            !note: this is not a realistic cell, but denser cells would be too expensive for a test
+            ABC 6.5 6.5 15.0
+            ALPHA_BETA_GAMMA 90.0 90.0 120.0
+        &END CELL
+        &TOPOLOGY
+        &END
+        &COORD
+           SCALED
+           B 0.3333333 0.6666667 0.0
+           N 0.6666667 0.3333333 0.0
+        &END COORD
+        &KIND B
+            BASIS_SET ccGRB-D-q3
+            POTENTIAL GTH-PBE0-q3
+        &END KIND
+        &KIND N
+            BASIS_SET ccGRB-D-q5
+            POTENTIAL GTH-PBE0-q5
+        &END KIND
+    &END SUBSYS
+&END FORCE_EVAL
+&GLOBAL
+    PROJECT hBN_gpw_pbe0
+    PRINT_LEVEL MEDIUM
+    RUN_TYPE ENERGY
+&END GLOBAL

--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -163,6 +163,10 @@ QS/regtest-dft-vdw-corr-3                                   libxc
 QS/regtest-admm-4                                           libint
 Fist/regtest-1-4
 QS/regtest-hfx-ri                                           libint
+QS/regtest-kp-hfx-ri                                        libint
+QS/regtest-kp-hfx-ri-2                                      libint
+QS/regtest-kp-hfx-ri-admm                                   libint
+QS/regtest-kp-hfx-ri-admm-2                                 libint
 QS/regtest-almo-md
 SE/regtest-2-1
 QS/regtest-lrigpw-2


### PR DESCRIPTION
This PR introduces a new method for RI-HFX with K-point sampling. The exact exchange matrix is calculated in real-space for all interacting periodic images, before it is Fourier transformed to reciprocal space. Then, the complex Hermitian KS matrix is built, and the eigenvalue problem solved for each K-point. Details of the method will be published in a paper in the near future.

The method relies on the DBT library for sparse-tensor algebra, and on the libint library for analytical 3- and 2-center ERI evaluation. Forces and stress tensor calculations are also implemented. The method can be sped-up with the ADMM approximation (ADMM2, ADMMP, ADMMQ and ADMMS).

Careful testing was conducted. Equivalence to Gamma-point supercell calculations was verified, as well as convergence with the number of k-points. DEBUG runs were systematically ran for forces and stress tensors. Four new regtest directories were added, covering KP-RI-HFX energy and forces, with and without ADMM.

@dev-zero was instrumental in helping develop the ADMM approximation with k-point sampling. 