### PR TITLE
Update WFN_MIX and RTP

### DIFF
--- a/src/cp_control_types.F
+++ b/src/cp_control_types.F
@@ -72,6 +72,7 @@ MODULE cp_control_types
       LOGICAL                              :: hfx_redistribute = .FALSE.
       INTEGER                              :: aspc_order = 0
       INTEGER                              :: sc_check_start = 0
+      LOGICAL                              :: apply_wfn_mix_init_restart = .FALSE.
       LOGICAL                              :: apply_delta_pulse = .FALSE.
       LOGICAL                              :: apply_delta_pulse_mag = .FALSE.
       LOGICAL                              :: periodic = .FALSE.

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -2262,6 +2262,8 @@ CONTAINS
                                 i_val=dft_control%rtp_control%initial_wfn)
       CALL section_vals_val_get(rtp_section, "HFX_BALANCE_IN_CORE", &
                                 l_val=dft_control%rtp_control%hfx_redistribute)
+      CALL section_vals_val_get(rtp_section, "APPLY_WFN_MIX_INIT_RESTART", &
+                                l_val=dft_control%rtp_control%apply_wfn_mix_init_restart)
       CALL section_vals_val_get(rtp_section, "APPLY_DELTA_PULSE", &
                                 l_val=dft_control%rtp_control%apply_delta_pulse)
       CALL section_vals_val_get(rtp_section, "APPLY_DELTA_PULSE_MAG", &

--- a/src/emd/rt_propagation_utils.F
+++ b/src/emd/rt_propagation_utils.F
@@ -26,6 +26,7 @@ MODULE rt_propagation_utils
                                               cp_fm_to_fm,&
                                               cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
+                                              cp_logger_get_default_io_unit,&
                                               cp_logger_get_default_unit_nr,&
                                               cp_logger_type
    USE cp_output_handling,              ONLY: cp_p_file,&
@@ -91,6 +92,7 @@ MODULE rt_propagation_utils
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_set,&
                                               qs_rho_type
+   USE qs_scf_wfn_mix,                  ONLY: wfn_mix
    USE qs_subsys_types,                 ONLY: qs_subsys_get,&
                                               qs_subsys_type
    USE rt_propagation_types,            ONLY: get_rtp,&
@@ -261,8 +263,8 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(LEN=default_path_length)                 :: file_name, project_name
-      INTEGER                                            :: i, id_nr, im, ispin, ncol, nspin, re, &
-                                                            unit_nr
+      INTEGER                                            :: i, id_nr, im, ispin, ncol, nspin, &
+                                                            output_unit, re, unit_nr
       REAL(KIND=dp)                                      :: alpha, cs_pos
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_fm_type)                                   :: mos_occ
@@ -292,6 +294,8 @@ CONTAINS
                       rho=rho_struct, &
                       para_env=para_env)
       logger => cp_get_default_logger()
+      output_unit = cp_logger_get_default_io_unit(logger)
+
       IF (logger%para_env%is_source()) THEN
          unit_nr = cp_logger_get_default_unit_nr(logger, local=.TRUE.)
       ELSE
@@ -307,6 +311,10 @@ CONTAINS
          CALL read_mo_set_from_restart(mo_array, atomic_kind_set, qs_kind_set, particle_set, para_env, &
                                        id_nr=id_nr, multiplicity=dft_control%multiplicity, dft_section=dft_section)
          CALL set_uniform_occupation_mo_array(mo_array, nspin)
+
+         IF (dft_control%rtp_control%apply_wfn_mix_init_restart) &
+            CALL wfn_mix(mo_array, particle_set, dft_section, qs_kind_set, para_env, output_unit, &
+                         for_rtp=.TRUE.)
 
          DO ispin = 1, nspin
             CALL calculate_density_matrix(mo_array(ispin), p_rmpv(ispin)%matrix)

--- a/src/input_constants.F
+++ b/src/input_constants.F
@@ -926,6 +926,7 @@ MODULE input_constants
                                                ramp_env = 3, &
                                                custom_env = 4
 
+   ! type of reference for RTP%PRINT%PROJECTION_MO
    INTEGER, PARAMETER, PUBLIC               :: proj_mo_ref_scf = 1, &
                                                proj_mo_ref_xas_tdp = 2
 
@@ -1256,5 +1257,10 @@ MODULE input_constants
                                                scan_xz = 13, &
                                                scan_yz = 23, &
                                                scan_xyz = 123
+
+   ! DFT%PRINT%WFN_MIX orgine type
+   INTEGER, PARAMETER, PUBLIC               :: wfn_mix_orig_occ = 1, &
+                                               wfn_mix_orig_virtual = 2, &
+                                               wfn_mix_orig_external = 3
 
 END MODULE input_constants

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -101,10 +101,11 @@ MODULE input_cp2k_dft
         weight_type_unit, wfi_aspc_nr, wfi_frozen_method_nr, wfi_linear_p_method_nr, &
         wfi_linear_ps_method_nr, wfi_linear_wf_method_nr, wfi_ps_method_nr, &
         wfi_use_guess_method_nr, wfi_use_prev_p_method_nr, wfi_use_prev_rho_r_method_nr, &
-        wfi_use_prev_wf_method_nr, xas_1s_type, xas_2p_type, xas_2s_type, xas_3d_type, &
-        xas_3p_type, xas_3s_type, xas_4d_type, xas_4f_type, xas_4p_type, xas_4s_type, xas_dip_len, &
-        xas_dip_vel, xas_dscf, xas_none, xas_not_excited, xas_tdp_by_index, xas_tdp_by_kind, &
-        xas_tp_fh, xas_tp_flex, xas_tp_hh, xas_tp_xfh, xas_tp_xhh, xes_tp_val
+        wfi_use_prev_wf_method_nr, wfn_mix_orig_external, wfn_mix_orig_occ, wfn_mix_orig_virtual, &
+        xas_1s_type, xas_2p_type, xas_2s_type, xas_3d_type, xas_3p_type, xas_3s_type, xas_4d_type, &
+        xas_4f_type, xas_4p_type, xas_4s_type, xas_dip_len, xas_dip_vel, xas_dscf, xas_none, &
+        xas_not_excited, xas_tdp_by_index, xas_tdp_by_kind, xas_tp_fh, xas_tp_flex, xas_tp_hh, &
+        xas_tp_xfh, xas_tp_xhh, xes_tp_val
    USE input_cp2k_almo,                 ONLY: create_almo_scf_section
    USE input_cp2k_distribution,         ONLY: create_distribution_section
    USE input_cp2k_ec,                   ONLY: create_ec_section
@@ -2849,12 +2850,19 @@ CONTAINS
                           description="A section that allows manipulation of the MO coeffs,"// &
                           " e.g. for changing a ground state into an excited state."// &
                           "Starting from a copy of the original MOs, changes can be made"// &
-                          "by adding linear combinations of HOMO/LUMO of the original MOs to the result MOs", &
+                          "by adding linear combinations of HOMO/LUMO of the original MOs to the result MOs."// &
+                          "This method is called after an SCF optimization or before an RTP run if "// &
+                          "INITIAL_WFN=RESTART_WFN. Note that if called after an SCF optimization, a restart file "// &
+                          "with the mixed MOs is saved. This is not the case for an RTP with "// &
+                          "INITIAL_WFN=RESTART_WFN.", &
                           n_keywords=1, n_subsections=0, repeats=.FALSE.)
 
       CALL keyword_create(keyword, __LOCATION__, name="OVERWRITE_MOS", &
-                          description="If the keyword is active molecular orbitals in memory will be replaced by the mixed wfn."// &
-                          " In combination with RTP or EMD no restart will be required to use the mixed wfn.", &
+                        description="If set to True, the active molecular orbitals in memory will be replaced by the mixed wfn "// &
+                        "at the end of the wfn mixing procedure. For instance, you can then use this new set of MOs to perform "// &
+                          "RTP or EMD directly. Not that in the case of an RTP run with INITIAL_WFN=RESTART_WFN, this keyword "// &
+                          "is not used: the mixed wfn is used to start the time-dependent run. "// &
+                          "Default value is False.", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -2865,7 +2873,8 @@ CONTAINS
                           n_keywords=1, n_subsections=0, repeats=.TRUE.)
 
       CALL keyword_create(keyword, __LOCATION__, name="RESULT_MO_INDEX", &
-                          description="Index of the MO (y) to be modified. Counting down in energy with HOMO=1", &
+                          description="Index of the MO (y) to be modified. Counting down in energy: "// &
+                          "set to 1 for the HOMO, to 3 for the HOMO-3.", &
                           usage="RESULT_MO_INDEX 1", type_of_var=integer_t, default_i_val=0)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
@@ -2895,7 +2904,13 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="ORIG_MO_INDEX", &
                           description="Index of the original MO (x). "// &
-                          "Counting down in energy with HOMO=1 or up from LUMO=1, depending on ORIG_IS_VIRTUAL.", &
+                          "If ORIG_TYPE is OCCUPIED, it counts down in energy: set to 1 to point to "// &
+                          "the HOMO and to 3 for the HOMO-3. "// &
+                          "If ORIG_TYPE is VIRTUAL, it counts up in energy: set to 1 to point to "// &
+                          "the LUMO and to 3 for the LUMO+3. "// &
+                          "If ORIG_TYPE is EXTERNAL, it counts down in energy for the external "// &
+                          "set of MOs: set to 1 to point to the HOMO and to 3 for the HOMO-3."// &
+                          "Do not set to zero or negative values.", &
                           usage="ORIG_MO_INDEX 1", type_of_var=integer_t, default_i_val=0)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
@@ -2923,9 +2938,31 @@ CONTAINS
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
 
-      CALL keyword_create(keyword, __LOCATION__, name="ORIG_IS_VIRTUAL", &
-                          description="The original MO (x) is a LUMO.", &
-                          usage="ORIG_IS_VIRTUAL", type_of_var=logical_t)
+      CALL keyword_create(keyword, __LOCATION__, name="ORIG_TYPE", &
+                          description="Type of the orgine MO. Note that using VIRTUAL along with an RTP run with "// &
+                          "INITIAL_WFN=RESTART_WFN will probably crash since no virtual state "// &
+                          "will be available.", &
+                          enum_c_vals=s2a("OCCUPIED", "VIRTUAL", 'EXTERNAL'), &
+                          usage="ORIG_TYPE OCCUPIED", &
+                          default_i_val=wfn_mix_orig_occ, &
+                          enum_desc=s2a("The original MO is in the MOs matrix itself.", &
+                                        "The original MO is not in the MOs matrix but in the 'unoccupied' one. "// &
+                                        "The SCF cycle shall provide it.", &
+                                        "The orginal MO is from an external .wfn file. Use the keyword "// &
+                                        "ORIG_EXT_FILE_NAME to define its name."), &
+                          enum_i_vals=(/wfn_mix_orig_occ, wfn_mix_orig_virtual, wfn_mix_orig_external/))
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="ORIG_EXT_FILE_NAME", &
+                          description="Name of the wavefunction file to read the original MO from. "// &
+                          "For instance, a restart wfn file from SCF calculation or an excited state from XAS_TDP calculation. "// &
+                          "If no file is specified, the run will crash."// &
+                          "Currently, a RTP restart file (.rtpwfn) cannot be used as reference."// &
+                          "Currently, this file SHALL have the basis set, number of MO and the same number of spin as the one "// &
+                          "from the SCF cycle.", &
+                          usage="ORIG_EXT_FILE_NAME <FILENAME>", &
+                          default_lc_val="EMPTY")
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
 
@@ -8528,6 +8565,18 @@ CONTAINS
                                         " if electronic constraints or restraints are used in the previous calculation, "// &
                                         "since these do not work in the rtp scheme.", &
                                         "use the wavefunction of a real time propagation/ehrenfest run"))
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="APPLY_WFN_MIX_INIT_RESTART", &
+                          description="If set to True and in the case of INITIAL_WFN=RESTART_WFN, call the "// &
+                          "DFT%PRINT%WFN_MIX section to mix the read initial wfn. The starting wave-function of the "// &
+                          "RTP will be the mixed one. Setting this to True without a defined WFN_MIX section will "// &
+                          "not do anything as defining a WFN_MIX section without this keyword for RTP run with "// &
+                          "INITIAL_WFN=RESTART_WFN. Note that if INITIAL_WFN=SCF_WFN, this keyword is not needed to "// &
+                          "apply the mixing defined in the WFN_MIX section. Default is False.", &
+                          usage="APPLY_WFN_MIX_INIT_RESTART", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_projection_rtp.F
+++ b/src/input_cp2k_projection_rtp.F
@@ -47,10 +47,12 @@ CONTAINS
 
       CPASSERT(.NOT. ASSOCIATED(section))
       CALL section_create(section, __LOCATION__, name="PROJECTION_MO", &
-                          description="Projects the time dependent MO "// &
-                          "coefficients on reference ones. You can define "// &
+                          description="Projects the Time Dependent (TD) MO "// &
+                          "coefficients to reference ones. You can define "// &
                           "several sections like this to project the TD-MOs "// &
-                          "on different reference MOs.", &
+                          "on different reference MOs. Note that each section "// &
+                          "projects from one spin of the TD MOs (TD_MO_INDEX) to "// &
+                          "one spin of the reference MOs (REF_MO_INDEX).", &
                           n_keywords=7, n_subsections=1, &
                           repeats=.TRUE.)
 
@@ -67,10 +69,12 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="REF_MO_FILE_NAME", &
-                          description="Name of the wavefunction file to read the reference MO form. "// &
-                          "For instance a restart wfn file from SCF calculation or an excited state from XAS_TDP calculation. "// &
+                          description="Name of the wavefunction file to read the reference MO from. "// &
+                          "For instance, a restart wfn file from SCF calculation or an excited state from XAS_TDP calculation. "// &
                           "If no file is specified, the default is to use DFT%WFN_RESTART_FILE_NAME."// &
-                          "Currently, a RTP restart file (.rtpwfn) cannot be used as reference.", &
+                          "Currently, a RTP restart file (.rtpwfn) cannot be used as reference."// &
+                          "Currently, this file SHALL have the same number of spin as the propagated one "// &
+                          "(eventhough you use only the first spin from this reference).", &
                           usage="REF_MO_FILE_NAME <FILENAME>", &
                           default_lc_val="DEFAULT")
       CALL section_add_keyword(section, keyword)
@@ -91,7 +95,7 @@ CONTAINS
                           description="Spin of the reference MOs to consider. "// &
                           "1 for ALPHA and 2 for BETA spin respectively. "// &
                           "If the reference MO is spin independent this key is not used.", &
-                          usage="MO_TD_SPIN 1", &
+                          usage="REF_MO_SPIN 1", &
                           default_i_val=1, &
                           n_var=1, type_of_var=integer_t, repeats=.FALSE.)
 
@@ -119,7 +123,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="TD_MO_SPIN", &
                           description="Spin of the TD MOs to consider. 1 for ALPHA spin, 2 for BETA spin. "// &
                           "If the TD calculation is spin independent this key is not used.", &
-                          usage="MO_TD_SPIN 1 2", &
+                          usage="MO_TD_SPIN 1", &
                           default_i_val=1, &
                           n_var=1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -272,6 +272,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
+      TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(pw_env_type), POINTER                         :: pw_env
@@ -749,9 +750,11 @@ CONTAINS
       IF (do_kpoints) THEN
          ! nothing at the moment, not implemented
       ELSE
-         CALL get_qs_env(qs_env, matrix_s=matrix_s)
-         CALL wfn_mix(mos, particle_set, dft_section, qs_kind_set, &
-                      lumo_ptr, scf_env, matrix_s, output_unit, marked_states)
+         CALL get_qs_env(qs_env, matrix_s=matrix_s, para_env=para_env)
+         CALL wfn_mix(mos, particle_set, dft_section, qs_kind_set, para_env, &
+                      output_unit, unoccupied_orbs=lumo_ptr, scf_env=scf_env, &
+                      matrix_s=matrix_s, marked_states=marked_states)
+
          IF (p_loc_lumo) CALL cp_fm_release(lumo_localized)
       END IF
       IF (ASSOCIATED(marked_states)) THEN

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -805,7 +805,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: dft_section
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
 
-      INTEGER                                            :: iounit, ispin, nao, nmo
+      INTEGER                                            :: ispin, nao, nmo, output_unit
       REAL(dp), DIMENSION(:), POINTER                    :: mo_eigenvalues
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_fm_struct_type), POINTER                   :: ao_ao_fmstruct, ao_lumo_struct
@@ -815,6 +815,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
+      TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(section_vals_type), POINTER                   :: wfn_mix_section
@@ -822,7 +823,7 @@ CONTAINS
       logger => cp_get_default_logger()
       CALL get_qs_env(qs_env=qs_env, matrix_s=matrix_s, matrix_ks=matrix_ks, &
                       particle_set=particle_set, atomic_kind_set=atomic_kind_set, &
-                      qs_kind_set=qs_kind_set, mos=mos)
+                      qs_kind_set=qs_kind_set, mos=mos, para_env=para_env)
 
       wfn_mix_section => section_vals_get_subs_vals(dft_section, "PRINT%WFN_MIX")
 
@@ -855,9 +856,9 @@ CONTAINS
          CALL cp_fm_struct_release(ao_lumo_struct)
       END DO
 
-      iounit = cp_logger_get_default_io_unit(logger)
-      CALL wfn_mix(mos, particle_set, dft_section, qs_kind_set, &
-                   lumos, scf_env, matrix_s, iounit)
+      output_unit = cp_logger_get_default_io_unit(logger)
+      CALL wfn_mix(mos, particle_set, dft_section, qs_kind_set, para_env, output_unit, &
+                   unoccupied_orbs=lumos, scf_env=scf_env, matrix_s=matrix_s)
 
       CALL cp_fm_release(lumos)
       CALL cp_fm_release(S_tmp)

--- a/src/qs_scf_wfn_mix.F
+++ b/src/qs_scf_wfn_mix.F
@@ -13,6 +13,8 @@
 ! **************************************************************************************************
 MODULE qs_scf_wfn_mix
    USE cp_dbcsr_operations,             ONLY: copy_fm_to_dbcsr
+   USE cp_files,                        ONLY: close_file,&
+                                              open_file
    USE cp_fm_basic_linalg,              ONLY: cp_fm_scale_and_add
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
@@ -22,14 +24,20 @@ MODULE qs_scf_wfn_mix
                                               cp_fm_to_fm,&
                                               cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_p_type
+   USE input_constants,                 ONLY: wfn_mix_orig_external,&
+                                              wfn_mix_orig_occ,&
+                                              wfn_mix_orig_virtual
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
                                               section_vals_val_get
-   USE kinds,                           ONLY: dp
+   USE kinds,                           ONLY: default_path_length,&
+                                              dp
+   USE message_passing,                 ONLY: mp_para_env_type
    USE particle_types,                  ONLY: particle_type
    USE qs_kind_types,                   ONLY: qs_kind_type
-   USE qs_mo_io,                        ONLY: write_mo_set_to_restart
+   USE qs_mo_io,                        ONLY: read_mos_restart_low,&
+                                              write_mo_set_to_restart
    USE qs_mo_methods,                   ONLY: calculate_orthonormality
    USE qs_mo_types,                     ONLY: deallocate_mo_set,&
                                               duplicate_mo_set,&
@@ -53,35 +61,42 @@ CONTAINS
 !> \param particle_set ...
 !> \param dft_section ...
 !> \param qs_kind_set ...
+!> \param para_env ...
+!> \param output_unit ...
 !> \param unoccupied_orbs ...
 !> \param scf_env ...
 !> \param matrix_s ...
-!> \param output_unit ...
 !> \param marked_states ...
+!> \param for_rtp ...
 ! **************************************************************************************************
-   SUBROUTINE wfn_mix(mos, particle_set, dft_section, qs_kind_set, &
-                      unoccupied_orbs, scf_env, matrix_s, output_unit, marked_states)
+   SUBROUTINE wfn_mix(mos, particle_set, dft_section, qs_kind_set, para_env, output_unit, &
+                      unoccupied_orbs, scf_env, matrix_s, marked_states, for_rtp)
 
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(section_vals_type), POINTER                   :: dft_section
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN), &
-         POINTER                                         :: unoccupied_orbs
-      TYPE(qs_scf_env_type), POINTER                     :: scf_env
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+      TYPE(mp_para_env_type), POINTER                    :: para_env
       INTEGER                                            :: output_unit
+      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN), &
+         OPTIONAL, POINTER                               :: unoccupied_orbs
+      TYPE(qs_scf_env_type), OPTIONAL, POINTER           :: scf_env
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_s
       INTEGER, DIMENSION(:, :, :), OPTIONAL, POINTER     :: marked_states
+      LOGICAL, OPTIONAL                                  :: for_rtp
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'wfn_mix'
 
+      CHARACTER(LEN=default_path_length)                 :: read_file_name
       INTEGER :: handle, i_rep, ispin, mark_ind, mark_number, n_rep, orig_mo_index, &
-         orig_spin_index, result_mo_index, result_spin_index
-      LOGICAL                                            :: explicit, orig_is_virtual, overwrite_mos
+         orig_spin_index, orig_type, restart_unit, result_mo_index, result_spin_index
+      LOGICAL                                            :: explicit, is_file, my_for_rtp, &
+                                                            overwrite_mos
       REAL(KIND=dp)                                      :: orig_scale, orthonormality, result_scale
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_vector
       TYPE(cp_fm_type)                                   :: matrix_x, matrix_y
-      TYPE(mo_set_type), ALLOCATABLE, DIMENSION(:)       :: mos_new
+      TYPE(mo_set_type), ALLOCATABLE, DIMENSION(:)       :: mos_new, mos_orig_ext
       TYPE(section_vals_type), POINTER                   :: update_section, wfn_mix_section
 
       CALL timeset(routineN, handle)
@@ -90,6 +105,12 @@ CONTAINS
 
       ! only perform action if explicitly required
       IF (explicit) THEN
+
+         IF (PRESENT(for_rtp)) THEN
+            my_for_rtp = for_rtp
+         ELSE
+            my_for_rtp = .FALSE.
+         END IF
 
          IF (output_unit > 0) THEN
             WRITE (output_unit, '()')
@@ -115,78 +136,135 @@ CONTAINS
          CALL section_vals_get(update_section, explicit=explicit)
          IF (.NOT. explicit) n_rep = 0
 
+         ! Mix the MOs as : y = ay + bx
          DO i_rep = 1, n_rep
-
+            ! The occupied MO that will be modified or saved, 'y'
             CALL section_vals_val_get(update_section, "RESULT_MO_INDEX", i_rep_section=i_rep, i_val=result_mo_index)
             CALL section_vals_val_get(update_section, "RESULT_MARKED_STATE", i_rep_section=i_rep, i_val=mark_number)
             CALL section_vals_val_get(update_section, "RESULT_SPIN_INDEX", i_rep_section=i_rep, i_val=result_spin_index)
+            ! result_scale is the 'b' coefficient
             CALL section_vals_val_get(update_section, "RESULT_SCALE", i_rep_section=i_rep, r_val=result_scale)
 
             mark_ind = 1
             IF (mark_number .GT. 0) result_mo_index = marked_states(mark_number, result_spin_index, mark_ind)
 
+            ! The MO that will be added to the previous one, 'x'
+            CALL section_vals_val_get(update_section, "ORIG_TYPE", i_rep_section=i_rep, &
+                                      i_val=orig_type)
             CALL section_vals_val_get(update_section, "ORIG_MO_INDEX", i_rep_section=i_rep, i_val=orig_mo_index)
             CALL section_vals_val_get(update_section, "ORIG_MARKED_STATE", i_rep_section=i_rep, i_val=mark_number)
             CALL section_vals_val_get(update_section, "ORIG_SPIN_INDEX", i_rep_section=i_rep, i_val=orig_spin_index)
+            ! orig_scal is the 'a' coefficient
             CALL section_vals_val_get(update_section, "ORIG_SCALE", i_rep_section=i_rep, r_val=orig_scale)
-            CALL section_vals_val_get(update_section, "ORIG_IS_VIRTUAL", i_rep_section=i_rep, l_val=orig_is_virtual)
 
-            IF (orig_is_virtual) mark_ind = 2
+            IF (orig_type == wfn_mix_orig_virtual) mark_ind = 2
             IF (mark_number .GT. 0) orig_mo_index = marked_states(mark_number, orig_spin_index, mark_ind)
 
             CALL section_vals_val_get(wfn_mix_section, "OVERWRITE_MOS", l_val=overwrite_mos)
 
-            ! first get a copy of the proper orig
-            IF (.NOT. ORIG_IS_VIRTUAL) THEN
+            ! First get a copy of the proper orig
+            ! Origin is in the MO matrix
+            IF (orig_type == wfn_mix_orig_occ) THEN
                CALL cp_fm_to_fm(mos(orig_spin_index)%mo_coeff, matrix_x, 1, &
                                 mos(orig_spin_index)%nmo - orig_mo_index + 1, 1)
-            ELSE
+
+               ! Orgin is in the virtual matrix
+            ELSE IF (orig_type == wfn_mix_orig_virtual) THEN
                IF (.NOT. ASSOCIATED(unoccupied_orbs)) &
-                  CPABORT("If ORIG_IS_VIRTUAL is set, the array unoccupied_orbs must be associated!")
+                  CALL cp_abort(__LOCATION__, &
+                                "If ORIG_TYPE is set to VIRTUAL, the array unoccupied_orbs must be associated!"// &
+                                "For instance, ask in the SCF section to compute virtual orbitals after the GS optimization.")
                CALL cp_fm_to_fm(unoccupied_orbs(orig_spin_index), matrix_x, 1, orig_mo_index, 1)
+
+               ! Orgin is to be read from an external .wfn file
+            ELSE IF (orig_type == wfn_mix_orig_external) THEN
+               CALL section_vals_val_get(update_section, "ORIG_EXT_FILE_NAME", i_rep_section=i_rep, &
+                                         c_val=read_file_name)
+               IF (read_file_name == "EMPTY") &
+                  CALL cp_abort(__LOCATION__, &
+                                "If ORIG_TYPE is set to EXTERNAL, a file name should be set in ORIG_EXT_FILE_NAME "// &
+                                "so that it can be used as the orginal MO.")
+
+               ALLOCATE (mos_orig_ext(SIZE(mos)))
+               DO ispin = 1, SIZE(mos)
+                  CALL duplicate_mo_set(mos_orig_ext(ispin), mos(ispin))
+               END DO
+
+               IF (para_env%is_source()) THEN
+                  INQUIRE (FILE=TRIM(read_file_name), exist=is_file)
+                  IF (.NOT. is_file) &
+                     CALL cp_abort(__LOCATION__, &
+                                   "Reference file not found! Name of the file CP2K looked for: "//TRIM(read_file_name))
+
+                  CALL open_file(file_name=read_file_name, &
+                                 file_action="READ", &
+                                 file_form="UNFORMATTED", &
+                                 file_status="OLD", &
+                                 unit_number=restart_unit)
+               END IF
+               CALL read_mos_restart_low(mos_orig_ext, para_env=para_env, qs_kind_set=qs_kind_set, &
+                                         particle_set=particle_set, natom=SIZE(particle_set, 1), &
+                                         rst_unit=restart_unit)
+               IF (para_env%is_source()) CALL close_file(unit_number=restart_unit)
+
+               CALL cp_fm_to_fm(mos_orig_ext(orig_spin_index)%mo_coeff, matrix_x, 1, &
+                                mos_orig_ext(orig_spin_index)%nmo - orig_mo_index + 1, 1)
+
+               DO ispin = 1, SIZE(mos_orig_ext)
+                  CALL deallocate_mo_set(mos_orig_ext(ispin))
+               END DO
+               DEALLOCATE (mos_orig_ext)
             END IF
 
-            ! now get a copy of the target
+            ! Second, get a copy of the target
             CALL cp_fm_to_fm(mos_new(result_spin_index)%mo_coeff, matrix_y, &
                              1, mos_new(result_spin_index)%nmo - result_mo_index + 1, 1)
 
-            ! properly mix
+            ! Third, perform the mix
             CALL cp_fm_scale_and_add(result_scale, matrix_y, orig_scale, matrix_x)
-
             ! and copy back in the result mos
             CALL cp_fm_to_fm(matrix_y, mos_new(result_spin_index)%mo_coeff, &
                              1, 1, mos_new(result_spin_index)%nmo - result_mo_index + 1)
-
          END DO
 
          CALL cp_fm_release(matrix_x)
          CALL cp_fm_release(matrix_y)
 
-         IF (scf_env%method == special_diag_method_nr) THEN
-            CALL calculate_orthonormality(orthonormality, mos)
-         ELSE
-            CALL calculate_orthonormality(orthonormality, mos, matrix_s(1)%matrix)
-         END IF
-
-         IF (output_unit > 0) THEN
-            WRITE (output_unit, '()')
-            WRITE (output_unit, '(T2,A,T61,E20.4)') &
-               "Maximum deviation from MO S-orthonormality", orthonormality
-            WRITE (output_unit, '(T2,A)') "Writing new MOs to file"
-         END IF
-
-         ! *** Write WaveFunction restart file ***
-
-         DO ispin = 1, SIZE(mos_new)
-            IF (overwrite_mos) THEN
+         IF (my_for_rtp) THEN
+            DO ispin = 1, SIZE(mos_new)
                CALL cp_fm_to_fm(mos_new(ispin)%mo_coeff, mos(ispin)%mo_coeff)
                IF (mos_new(1)%use_mo_coeff_b) &
                   CALL copy_fm_to_dbcsr(mos_new(ispin)%mo_coeff, mos_new(ispin)%mo_coeff_b)
+               IF (mos(1)%use_mo_coeff_b) &
+                  CALL copy_fm_to_dbcsr(mos_new(ispin)%mo_coeff, mos(ispin)%mo_coeff_b)
+            END DO
+         ELSE
+            IF (scf_env%method == special_diag_method_nr) THEN
+               CALL calculate_orthonormality(orthonormality, mos)
+            ELSE
+               CALL calculate_orthonormality(orthonormality, mos, matrix_s(1)%matrix)
             END IF
-            IF (mos(1)%use_mo_coeff_b) &
-               CALL copy_fm_to_dbcsr(mos_new(ispin)%mo_coeff, mos(ispin)%mo_coeff_b)
-         END DO
-         CALL write_mo_set_to_restart(mos_new, particle_set, dft_section=dft_section, qs_kind_set=qs_kind_set)
+
+            IF (output_unit > 0) THEN
+               WRITE (output_unit, '()')
+               WRITE (output_unit, '(T2,A,T61,E20.4)') &
+                  "Maximum deviation from MO S-orthonormality", orthonormality
+               WRITE (output_unit, '(T2,A)') "Writing new MOs to file"
+            END IF
+
+            ! *** Write WaveFunction restart file ***
+
+            DO ispin = 1, SIZE(mos_new)
+               IF (overwrite_mos) THEN
+                  CALL cp_fm_to_fm(mos_new(ispin)%mo_coeff, mos(ispin)%mo_coeff)
+                  IF (mos_new(1)%use_mo_coeff_b) &
+                     CALL copy_fm_to_dbcsr(mos_new(ispin)%mo_coeff, mos_new(ispin)%mo_coeff_b)
+               END IF
+               IF (mos(1)%use_mo_coeff_b) &
+                  CALL copy_fm_to_dbcsr(mos_new(ispin)%mo_coeff, mos(ispin)%mo_coeff_b)
+            END DO
+            CALL write_mo_set_to_restart(mos_new, particle_set, dft_section=dft_section, qs_kind_set=qs_kind_set)
+         END IF
 
          DO ispin = 1, SIZE(mos_new)
             CALL deallocate_mo_set(mos_new(ispin))

--- a/tests/DFTB/regtest-scc/c2h2_emd_mix.inp
+++ b/tests/DFTB/regtest-scc/c2h2_emd_mix.inp
@@ -50,7 +50,7 @@
            ORIG_SPIN_INDEX ALPHA
            ORIG_SCALE 1.00000000000
 
-           ORIG_IS_VIRTUAL .TRUE.
+           ORIG_TYPE VIRTUAL
        &END
       &END
 

--- a/tests/QS/regtest-rtp-3/H2O_excit_emd.inp
+++ b/tests/QS/regtest-rtp-3/H2O_excit_emd.inp
@@ -67,7 +67,7 @@
            ORIG_MARKED_STATE 1
            ORIG_SPIN_INDEX ALPHA
            ORIG_SCALE 1.000000000000000000000
-           ORIG_IS_VIRTUAL .TRUE.
+           ORIG_TYPE VIRTUAL
        &END
       &END
     &END

--- a/tests/QS/regtest-rtp-3/TEST_FILES
+++ b/tests/QS/regtest-rtp-3/TEST_FILES
@@ -1,8 +1,12 @@
 wfn_mix_0.inp                                          1      8e-14             -17.19408422718460
 wfn_mix_1.inp                                          1    3.0E-07            -16.047276791784139
 wfn_mix_2.inp                                          1      4e-14            -17.194084227184611
+wfn_mix_3.inp                                          1      8e-14             -17.19408422718460
+wfn_mix_4.inp                                          1      8e-14             -17.19408422718460
 wfn_mix_loc-0.inp                                      1    1.0E-14             -17.18852591875700
 wfn_mix_loc-1.inp                                      1      6e-13             -16.86459883779028
+wfn_mix_loc-2.inp                                      0
+wfn_mix_loc-3.inp                                      0
 wfn_mix_loc_mark-0.inp                                 1    1.0E-14             -17.18852591875700
 wfn_mix_loc_mark-1.inp                                 1      2e-13             -16.75084004876575
 H2O_excit_emd.inp                                      2    1.0E-14            -0.166780672968E+02

--- a/tests/QS/regtest-rtp-3/wfn_mix_1.inp
+++ b/tests/QS/regtest-rtp-3/wfn_mix_1.inp
@@ -38,8 +38,8 @@
            ORIG_MO_INDEX 1
            ORIG_SPIN_INDEX ALPHA
            ORIG_SCALE .70710678118654752440
-
-           ORIG_IS_VIRTUAL .TRUE.
+           
+           ORIG_TYPE VIRTUAL
        &END
        &UPDATE
            RESULT_MO_INDEX 1
@@ -50,7 +50,7 @@
            ORIG_SPIN_INDEX ALPHA
            ORIG_SCALE .70710678118654752440
 
-           ORIG_IS_VIRTUAL .TRUE.
+           ORIG_TYPE VIRTUAL
        &END
       &END
     &END

--- a/tests/QS/regtest-rtp-3/wfn_mix_2.inp
+++ b/tests/QS/regtest-rtp-3/wfn_mix_2.inp
@@ -37,7 +37,7 @@
            ORIG_MO_INDEX 1
            ORIG_SPIN_INDEX BETA
            ORIG_SCALE .70710678118654752440
-           ORIG_IS_VIRTUAL .TRUE.
+           ORIG_TYPE VIRTUAL
        &END
        &UPDATE
            RESULT_MO_INDEX 1
@@ -46,7 +46,7 @@
            ORIG_MO_INDEX 2
            ORIG_SPIN_INDEX BETA
            ORIG_SCALE .70710678118654752440
-           ORIG_IS_VIRTUAL .TRUE.
+           ORIG_TYPE VIRTUAL
        &END
       &END
     &END

--- a/tests/QS/regtest-rtp-3/wfn_mix_3.inp
+++ b/tests/QS/regtest-rtp-3/wfn_mix_3.inp
@@ -28,28 +28,17 @@
           WRITE_CUBE .FALSE.
       &END
       &WFN_MIX
-       ! replace HOMO with an orthonormal linear combination of lumo and lumo+1
+       ! replace HOMO with an orthonormal linear combination of homo and homo-1
        &UPDATE
            RESULT_MO_INDEX 1
            RESULT_SPIN_INDEX ALPHA
            RESULT_SCALE 0.0
 
-           ORIG_MO_INDEX 1
-           ORIG_SPIN_INDEX ALPHA
-           ORIG_SCALE .70710678118654752440
-           
-           ORIG_TYPE VIRTUAL
-       &END
-       &UPDATE
-           RESULT_MO_INDEX 1
-           RESULT_SPIN_INDEX ALPHA
-           RESULT_SCALE 1.0
-
            ORIG_MO_INDEX 2
            ORIG_SPIN_INDEX ALPHA
            ORIG_SCALE .70710678118654752440
            
-           ORIG_TYPE VIRTUAL
+           ORIG_TYPE OCCUPIED
        &END
       &END
     &END
@@ -74,7 +63,7 @@
   &END SUBSYS
 &END FORCE_EVAL
 &GLOBAL
-  PROJECT H2O_wfn_mix0
+  PROJECT H2O_wfn_mix3
   RUN_TYPE ENERGY_FORCE
   PRINT_LEVEL MEDIUM
 &END GLOBAL

--- a/tests/QS/regtest-rtp-3/wfn_mix_4.inp
+++ b/tests/QS/regtest-rtp-3/wfn_mix_4.inp
@@ -28,28 +28,18 @@
           WRITE_CUBE .FALSE.
       &END
       &WFN_MIX
-       ! replace HOMO with an orthonormal linear combination of lumo and lumo+1
+       ! replace HOMO with an orthonormal linear combination of homo and homo-1
        &UPDATE
            RESULT_MO_INDEX 1
            RESULT_SPIN_INDEX ALPHA
            RESULT_SCALE 0.0
 
-           ORIG_MO_INDEX 1
-           ORIG_SPIN_INDEX ALPHA
-           ORIG_SCALE .70710678118654752440
-           
-           ORIG_TYPE VIRTUAL
-       &END
-       &UPDATE
-           RESULT_MO_INDEX 1
-           RESULT_SPIN_INDEX ALPHA
-           RESULT_SCALE 1.0
-
            ORIG_MO_INDEX 2
            ORIG_SPIN_INDEX ALPHA
            ORIG_SCALE .70710678118654752440
            
-           ORIG_TYPE VIRTUAL
+           ORIG_TYPE EXTERNAL
+           ORIG_EXT_FILE_NAME H2O_wfn_mix3-RESTART.wfn 
        &END
       &END
     &END
@@ -74,7 +64,7 @@
   &END SUBSYS
 &END FORCE_EVAL
 &GLOBAL
-  PROJECT H2O_wfn_mix0
+  PROJECT H2O_wfn_mix3
   RUN_TYPE ENERGY_FORCE
   PRINT_LEVEL MEDIUM
 &END GLOBAL

--- a/tests/QS/regtest-rtp-3/wfn_mix_loc-0.inp
+++ b/tests/QS/regtest-rtp-3/wfn_mix_loc-0.inp
@@ -51,7 +51,7 @@
            ORIG_SPIN_INDEX ALPHA
            ORIG_SCALE 1.000000000000000000000
 
-           ORIG_IS_VIRTUAL .TRUE.
+           ORIG_TYPE VIRTUAL
        &END
       &END
     &END

--- a/tests/QS/regtest-rtp-3/wfn_mix_loc-1.inp
+++ b/tests/QS/regtest-rtp-3/wfn_mix_loc-1.inp
@@ -52,20 +52,6 @@
           NLUMO 4
           WRITE_CUBE .FALSE.
       &END
-      &WFN_MIX
-       ! replace HOMO with an orthonormal linear combination of lumo and lumo+1
-       &UPDATE
-           RESULT_MO_INDEX 1
-           RESULT_SPIN_INDEX ALPHA
-           RESULT_SCALE 0.0
-
-           ORIG_MO_INDEX 1
-           ORIG_SPIN_INDEX ALPHA
-           ORIG_SCALE 1.000000000000000000000
-
-           ORIG_IS_VIRTUAL .TRUE.
-       &END
-      &END
     &END
   &END DFT
   &SUBSYS

--- a/tests/QS/regtest-rtp-3/wfn_mix_loc-2.inp
+++ b/tests/QS/regtest-rtp-3/wfn_mix_loc-2.inp
@@ -1,10 +1,22 @@
+#CPQA DEPENDS wfn_mix_loc-0.inp
 &FORCE_EVAL
   METHOD Quickstep
   &DFT
+    LSD
     BASIS_SET_FILE_NAME BASIS_SET
     POTENTIAL_FILE_NAME POTENTIAL
+    RESTART_FILE_NAME mix_loc-RESTART.wfn
+    &REAL_TIME_PROPAGATION
+       MAX_ITER 6
+       MAT_EXP ARNOLDI
+       EXP_ACCURACY 1.0E-9
+       EPS_ITER 1.0E-9
+       PROPAGATOR ETRS
+       INITIAL_WFN RESTART_WFN
+       APPLY_WFN_MIX_INIT_RESTART .TRUE. 
+    &END
     &MGRID
-      CUTOFF 280
+      CUTOFF 150
     &END MGRID
     &QS
       EPS_DEFAULT 1.0E-12
@@ -21,35 +33,38 @@
       &XC_FUNCTIONAL BLYP
       &END XC_FUNCTIONAL
     &END XC
+    &LOCALIZE
+      METHOD CRAZY
+      EPS_LOCALIZATION 1.0E-10
+      STATES UNOCCUPIED
+      LIST_UNOCCUPIED 1..4
+      &PRINT
+        &WANNIER_CENTERS
+        &END
+        &MOLECULAR_STATES
+        &END
+      &END
+    &END
     &PRINT
+      &E_DENSITY_CUBE
+      &END
       &MO_CUBES
           NHOMO 4
           NLUMO 4
           WRITE_CUBE .FALSE.
       &END
       &WFN_MIX
-       ! replace HOMO with an orthonormal linear combination of lumo and lumo+1
+       ! replace HOMO with an orthonormal linear combination of homo and homo-1
        &UPDATE
            RESULT_MO_INDEX 1
            RESULT_SPIN_INDEX ALPHA
-           RESULT_SCALE 0.0
-
-           ORIG_MO_INDEX 1
-           ORIG_SPIN_INDEX ALPHA
-           ORIG_SCALE .70710678118654752440
-           
-           ORIG_TYPE VIRTUAL
-       &END
-       &UPDATE
-           RESULT_MO_INDEX 1
-           RESULT_SPIN_INDEX ALPHA
-           RESULT_SCALE 1.0
+           RESULT_SCALE 0.7071067
 
            ORIG_MO_INDEX 2
            ORIG_SPIN_INDEX ALPHA
-           ORIG_SCALE .70710678118654752440
-           
-           ORIG_TYPE VIRTUAL
+           ORIG_SCALE 0.7071067
+
+           ORIG_TYPE OCCUPIED
        &END
       &END
     &END
@@ -59,9 +74,9 @@
       ABC 5.0 5.0 5.0
     &END CELL
     &COORD
-    O   0.000000    0.000000   -0.065587
-    H   0.000000   -0.757136    0.520545
-    H   0.000000    0.757136    0.520545
+    O   0.000000    0.000000   -0.065587 H2O
+    H   0.000000   -0.757136    0.520545 H2O
+    H   0.000000    0.757136    0.520545 H2O
     &END COORD
     &KIND H
       BASIS_SET DZVP-GTH-BLYP
@@ -74,7 +89,13 @@
   &END SUBSYS
 &END FORCE_EVAL
 &GLOBAL
-  PROJECT H2O_wfn_mix0
-  RUN_TYPE ENERGY_FORCE
+  PROJECT mix_loc_rtp
+  RUN_TYPE RT_PROPAGATION
   PRINT_LEVEL MEDIUM
 &END GLOBAL
+&MOTION
+   &MD
+     STEPS 3
+     TIMESTEP [au_t] 0.2
+   &END
+&END

--- a/tests/QS/regtest-rtp-3/wfn_mix_loc-3.inp
+++ b/tests/QS/regtest-rtp-3/wfn_mix_loc-3.inp
@@ -1,9 +1,20 @@
+#CPQA DEPENDS wfn_mix_loc-0.inp
 &FORCE_EVAL
   METHOD Quickstep
   &DFT
     LSD
     BASIS_SET_FILE_NAME BASIS_SET
     POTENTIAL_FILE_NAME POTENTIAL
+    RESTART_FILE_NAME mix_loc-RESTART.wfn
+    &REAL_TIME_PROPAGATION
+       MAX_ITER 6
+       MAT_EXP ARNOLDI
+       EXP_ACCURACY 1.0E-9
+       EPS_ITER 1.0E-9
+       PROPAGATOR ETRS
+       INITIAL_WFN RESTART_WFN
+       APPLY_WFN_MIX_INIT_RESTART .TRUE. 
+    &END
     &MGRID
       CUTOFF 150
     &END MGRID
@@ -25,36 +36,36 @@
     &LOCALIZE
       METHOD CRAZY
       EPS_LOCALIZATION 1.0E-10
-      STATES ALL
-      LIST 1..4
+      STATES UNOCCUPIED
       LIST_UNOCCUPIED 1..4
       &PRINT
         &WANNIER_CENTERS
         &END
         &MOLECULAR_STATES
-           MARK_STATES 1 2
-           MARK_STATES 1 1
         &END
       &END
     &END
     &PRINT
+      &E_DENSITY_CUBE
+      &END
       &MO_CUBES
           NHOMO 4
           NLUMO 4
           WRITE_CUBE .FALSE.
       &END
       &WFN_MIX
-       ! replace HOMO with an orthonormal linear combination of lumo and lumo+1
+       ! replace HOMO with an orthonormal linear combination of homo and homo-1
        &UPDATE
-           RESULT_MARKED_STATE 2
+           RESULT_MO_INDEX 1
            RESULT_SPIN_INDEX ALPHA
-           RESULT_SCALE 0.0
+           RESULT_SCALE 0.7071067
 
-           ORIG_MARKED_STATE 1
+           ORIG_MO_INDEX 2
            ORIG_SPIN_INDEX ALPHA
-           ORIG_SCALE 1.000000000000000000000
-            
-           ORIG_TYPE VIRTUAL
+           ORIG_SCALE 0.7071067
+           
+           ORIG_TYPE EXTERNAL
+           ORIG_EXT_FILE_NAME mix_loc-RESTART.wfn
        &END
       &END
     &END
@@ -79,7 +90,13 @@
   &END SUBSYS
 &END FORCE_EVAL
 &GLOBAL
-  PROJECT mix_loc_mark
-  RUN_TYPE ENERGY_FORCE
+  PROJECT mix_loc_rtp
+  RUN_TYPE RT_PROPAGATION
   PRINT_LEVEL MEDIUM
 &END GLOBAL
+&MOTION
+   &MD
+     STEPS 3
+     TIMESTEP [au_t] 0.2
+   &END
+&END

--- a/tests/QS/regtest-rtp-5/H2O-wfn-mix-dens-pulse-1.inp
+++ b/tests/QS/regtest-rtp-5/H2O-wfn-mix-dens-pulse-1.inp
@@ -44,7 +44,7 @@
       &WFN_MIX
         OVERWRITE_MOS .TRUE.
         &UPDATE
-          ORIG_IS_VIRTUAL .TRUE.
+          ORIG_TYPE VIRTUAL
           ORIG_MO_INDEX 1
           ORIG_SPIN_INDEX ALPHA
           ORIG_SCALE 0.999999
@@ -53,11 +53,6 @@
           RESULT_SCALE 0.0000001
         &END UPDATE
       &END WFN_MIX
-      !&MO
-      !  COEFFICIENTS .TRUE.
-      !  OCCUPATION_NUMBERS .TRUE.
-      !  MO_INDEX_RANGE 1 5
-      !&END MO
       &MO_CUBES 
          NLUMO 1
       &END MO_CUBES
@@ -89,7 +84,4 @@
     TIMESTEP [au_t] 0.1
   &END
 &END MOTION
-!&EXT_RESTART
-!  RESTART_FILE_NAME H2O_rtp-1.restart
-!&END
 


### PR DESCRIPTION
Some work on wfn_mix: 

 - Update the documentation 
 - Add a new way for mixing the MOs using an external .wfn file
 - Add the possibility to use WFN_MIX before an RTP run in the RESTART_WFN case 

Add some tests and update the one with the modified keyword 