### PR TITLE
HFX warning for KS sparsity

### DIFF
--- a/src/hfx_energy_potential.F
+++ b/src/hfx_energy_potential.F
@@ -586,8 +586,8 @@ CONTAINS
          IF (.NOT. ks_fully_occ) THEN
             CALL cp_warn(__LOCATION__, &
                          "The Kohn Sham matrix is not 100% occupied. This "// &
-                         "may result in incorrect Hartree-Fock results. Try to decrease EPS_PGF_ORB "// &
-                         "and EPS_FILTER_MATRIX in the QS section. For more information "// &
+                         "may result in incorrect Hartree-Fock results. Try setting "// &
+                         "MIN_PAIR_LIST_RADIUS to -1 in the QS section. For more information "// &
                          "see FAQ: https://www.cp2k.org/faq:hfx_eps_warning")
          END IF
       END IF

--- a/src/hfx_energy_potential.F
+++ b/src/hfx_energy_potential.F
@@ -586,8 +586,9 @@ CONTAINS
          IF (.NOT. ks_fully_occ) THEN
             CALL cp_warn(__LOCATION__, &
                          "The Kohn Sham matrix is not 100% occupied. This "// &
-                         "may result in incorrect Hartree-Fock results. Try setting "// &
-                         "MIN_PAIR_LIST_RADIUS to -1 in the QS section. For more information "// &
+                         "may result in incorrect Hartree-Fock results. Setting "// &
+                         "MIN_PAIR_LIST_RADIUS to -1 in the QS section ensures a "// &
+                         "fully occupied KS matrix. For more information "// &
                          "see FAQ: https://www.cp2k.org/faq:hfx_eps_warning")
          END IF
       END IF


### PR DESCRIPTION
modify KS sparsity warning for HFX calculations to recommend the more efficient MIN_PAIR_LIST_RADIUS keyword.