### PR TITLE
HOTFIX: EMD + Time Dependent Electric Field

### DIFF
--- a/src/qs_force.F
+++ b/src/qs_force.F
@@ -28,7 +28,8 @@ MODULE qs_force
                                               dbcsr_set
    USE dft_plus_u,                      ONLY: plus_u
    USE ec_env_types,                    ONLY: energy_correction_type
-   USE efield_utils,                    ONLY: calculate_ecore_efield
+   USE efield_utils,                    ONLY: calculate_ecore_efield,&
+                                              efield_potential_lengh_gauge
    USE energy_corrections,              ONLY: energy_correction
    USE excited_states,                  ONLY: excited_state_energy
    USE hfx_exx,                         ONLY: calculate_exx
@@ -290,6 +291,11 @@ CONTAINS
       ELSE
          ! Dispersion energy and forces are calculated in qs_energy?
          CALL build_core_hamiltonian_matrix(qs_env=qs_env, calculate_forces=.TRUE.)
+         ! The above line reset the core H, which should be re-updated in case a TD field is applied:
+         IF (qs_env%run_rtp) THEN
+            IF (dft_control%apply_efield_field) &
+               CALL efield_potential_lengh_gauge(qs_env)
+         END IF
          CALL calculate_ecore_self(qs_env)
          CALL calculate_ecore_overlap(qs_env, para_env, calculate_forces=.TRUE.)
          CALL calculate_ecore_efield(qs_env, calculate_forces=.TRUE.)
@@ -587,6 +593,7 @@ CONTAINS
                   iatom, ikind, "    dispersion", qs_force(ikind)%dispersion(1:3, i), &
                   iatom, ikind, "           gCP", qs_force(ikind)%gcp(1:3, i), &
                   iatom, ikind, "       fock_4c", qs_force(ikind)%fock_4c(1:3, i), &
+                  iatom, ikind, "     ehrenfest", qs_force(ikind)%ehrenfest(1:3, i), &
                   iatom, ikind, "        efield", qs_force(ikind)%efield(1:3, i), &
                   iatom, ikind, "           eev", qs_force(ikind)%eev(1:3, i), &
                   iatom, ikind, "   mp2_non_sep", qs_force(ikind)%mp2_non_sep(1:3, i), &

--- a/tests/QS/regtest-rtp-2/TEST_FILES
+++ b/tests/QS/regtest-rtp-2/TEST_FILES
@@ -10,9 +10,9 @@ H2-rtp_restart-1.inp                                   1      3e-13             
 H2-rtp-efield.inp                                      1      2e-10              -0.82613324527108
 H2-rtp-efield-vg.inp                                   1      2e-10              -0.83550227784861
 H2-rtp-efield-vg-restart.inp                           1      2e-10              -0.79589429986106
-H2-emd-efield.inp                                      2      4e-11                -0.902242711172
-H2-emd-efield-ramp.inp                                 2      5e-12                -0.902242710949
-H2-emd-efield-custom.inp                               2      1e-14                -0.902242709393
+H2-emd-efield.inp                                      2      4e-11                -0.894818188949
+H2-emd-efield-ramp.inp                                 2      5e-12                -0.885822019185
+H2-emd-efield-custom.inp                               2      1e-14                -0.902238043295
 H2-rtp_ETRS_ARNOLDI.inp                                1      3e-13              -0.90223968349550
-H2-emd_ETRS_ARNOLDI.inp                                1      1e-10             -17.08557183219799
+H2-emd_ETRS_ARNOLDI.inp                                1      1e-10             -17.08556436304139
 #EOF


### PR DESCRIPTION
In the current version of the code, the electric field is applied to the electrons only at the first iteration of each EMD step. 

For RTP: 
The core Hamiltonian is built at each RTP step at the first iteration, see line 133 and following of emd/rt_propagation_methods%propagation_step. In particular, once qs_energies_init is called, the core Hamiltonian is updated with the dipole operator for time-dependent fields (or velocity one for VG).  qs_energies_init is then never called before the end of the RTP step: we loop over the ''good'' core Hamiltonian through one RTP step. 

For EMD: 
It follows the same procedure, but the forces are also computed in qs_force. There, qs_energies_init is called to compute the forces. Which also reset the core Hamiltonian: it should thus be updated with the dipole operator. If not, the electronic Hamiltonian applied for the next iteration of the EMD step is field-free. Yet, the electric field is still applied to the nuclei. This produces a dynamics where the field interacts explicitly with the nuclei but not with the electrons. 

I have performed some tests to confirm that. For instance: run EMD with field and show the total energy for an isolated neutral molecule. This total energy should be independent with respect to the position of the nuclei since the nuclei-field and electron-field energy add up. In today's implementation it is not the case: moving the nuclei position changes the total energy value. With this fix the total energy is indeed position independent. 

This is a problem I have induced in the commit 78ff48d from 24 Feb: RTP: Add velocity gauge. There I have moved the electric field - electron interaction from a grid-based implementation to a matrix one in the core Hamiltonian (in order to have a similar implementation as the velocity gauge case). Therefore, this issue has been a problem since 24 Feb for EMD + field. 

Hence, I have also modified the regtests relative to the EMD + field since they were no longer correct. The obtained values with this fix are almost the same as the ones before the 24 Feb: the error may be explained by the new way of computing the electron-field interaction using matrices instead of the grid.  
 

As this is a potentially important fix, I allow myself to call this PR HOTFIX.  Should we communicate about this issue concerning the previous version of the code? 

Ps: I will soon push EMD for the velocity gauge