### PR TITLE
RI-HFX| Some optimization

### DIFF
--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -54,7 +54,7 @@ MODULE hfx_ri
         dbt_distribution_type, dbt_filter, dbt_get_block, dbt_get_info, dbt_get_num_blocks_total, &
         dbt_iterator_blocks_left, dbt_iterator_next_block, dbt_iterator_start, dbt_iterator_stop, &
         dbt_iterator_type, dbt_mp_environ_pgrid, dbt_nd_mp_comm, dbt_pgrid_create, &
-        dbt_pgrid_destroy, dbt_pgrid_type, dbt_put_block, dbt_reserve_blocks, dbt_type
+        dbt_pgrid_destroy, dbt_pgrid_type, dbt_put_block, dbt_reserve_blocks, dbt_scale, dbt_type
    USE distribution_2d_types,           ONLY: distribution_2d_type
    USE hfx_types,                       ONLY: alloc_containers,&
                                               block_ind_type,&
@@ -1555,8 +1555,8 @@ CONTAINS
       REAL(dp)                                           :: memory_3c, occ, occ_3c, occ_3c_1, &
                                                             occ_3c_2, occ_ks, occ_rho, t1, t2, &
                                                             unused
-      TYPE(dbt_type)                                     :: ks_t, ks_tmp, rho_ao_t, rho_ao_tmp, &
-                                                            t_3c_1, t_3c_3, tensor_old
+      TYPE(dbt_type)                                     :: ks_t, ks_tmp, rho_ao_tmp, t_3c_1, &
+                                                            t_3c_3, tensor_old
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
       IF (.NOT. fac > EPSILON(0.0_dp)) RETURN
@@ -1575,6 +1575,10 @@ CONTAINS
 
       IF (geometry_did_change) THEN
          CALL hfx_ri_pre_scf_Pmat(qs_env, ri_data)
+         DO ispin = 1, nspins
+            CALL dbt_scale(ri_data%rho_ao_t(ispin, 1), 0.0_dp)
+            CALL dbt_scale(ri_data%ks_t(ispin, 1), 0.0_dp)
+         END DO
       END IF
 
       nblks = dbt_get_num_blocks_total(ri_data%t_3c_int_ctr_2(1, 1))
@@ -1587,11 +1591,6 @@ CONTAINS
 
       CALL dbt_create(ks_matrix(1, 1)%matrix, ks_tmp)
       CALL dbt_create(rho_ao(1, 1)%matrix, rho_ao_tmp)
-
-      CALL create_2c_tensor(rho_ao_t, dist1, dist2, ri_data%pgrid_2d, &
-                            ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
-                            name="(AO | AO)")
-      DEALLOCATE (dist1, dist2)
 
       CALL create_2c_tensor(ks_t, dist1, dist2, ri_data%pgrid_2d, &
                             ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
@@ -1626,9 +1625,12 @@ CONTAINS
          occ_3c_2 = 0.0_dp
 
          CALL dbt_copy_matrix_to_tensor(rho_ao(ispin, 1)%matrix, rho_ao_tmp)
-         CALL dbt_copy(rho_ao_tmp, rho_ao_t, move_data=.TRUE.)
 
-         CALL get_tensor_occupancy(rho_ao_t, nze_rho, occ_rho)
+         !We work with Delta P: the diff between previous SCF step and this one, for increased sparsity
+         CALL dbt_scale(ri_data%rho_ao_t(ispin, 1), -1.0_dp)
+         CALL dbt_copy(rho_ao_tmp, ri_data%rho_ao_t(ispin, 1), summation=.TRUE., move_data=.TRUE.)
+
+         CALL get_tensor_occupancy(ri_data%rho_ao_t(ispin, 1), nze_rho, occ_rho)
 
          CALL dbt_batched_contract_init(ri_data%t_3c_int_ctr_1(1, 1), batch_range_1=batch_ranges_AO, &
                                         batch_range_2=batch_ranges_RI)
@@ -1638,7 +1640,7 @@ CONTAINS
 
          DO i_mem = 1, n_mem
 
-            CALL dbt_batched_contract_init(rho_ao_t)
+            CALL dbt_batched_contract_init(ri_data%rho_ao_t(ispin, 1))
             CALL dbt_batched_contract_init(ri_data%t_3c_int_ctr_2(1, 1), batch_range_2=batch_ranges_RI, &
                                            batch_range_3=batch_ranges_AO)
             CALL dbt_batched_contract_init(t_3c_1, batch_range_2=batch_ranges_RI, batch_range_3=batch_ranges_AO)
@@ -1651,7 +1653,7 @@ CONTAINS
                bounds_j(:, 1) = [1, dims_3c(1)]
                bounds_j(:, 2) = [ri_data%starts_array_RI_mem(j_mem), ri_data%ends_array_RI_mem(j_mem)]
 
-               CALL dbt_contract(1.0_dp, rho_ao_t, ri_data%t_3c_int_ctr_2(1, 1), &
+               CALL dbt_contract(1.0_dp, ri_data%rho_ao_t(ispin, 1), ri_data%t_3c_int_ctr_2(1, 1), &
                                  0.0_dp, t_3c_1, &
                                  contract_1=[2], notcontract_1=[1], &
                                  contract_2=[3], notcontract_2=[1, 2], &
@@ -1701,7 +1703,7 @@ CONTAINS
                ri_data%dbcsr_nflop = ri_data%dbcsr_nflop + nflop
 
             END DO
-            CALL dbt_batched_contract_finalize(rho_ao_t, unit_nr=unit_nr_dbcsr)
+            CALL dbt_batched_contract_finalize(ri_data%rho_ao_t(ispin, 1), unit_nr=unit_nr_dbcsr)
             CALL dbt_batched_contract_finalize(ri_data%t_3c_int_ctr_2(1, 1))
             CALL dbt_batched_contract_finalize(t_3c_1)
          END DO
@@ -1724,11 +1726,14 @@ CONTAINS
 
          CALL dbt_destroy(tensor_old)
 
-         CALL dbt_clear(rho_ao_t)
          CALL get_tensor_occupancy(ks_t, nze_ks, occ_ks)
 
-         CALL dbt_copy(ks_t, ks_tmp)
-         CALL dbt_clear(ks_t)
+         !rho_ao_t holds the density difference, and ks_t is built upon it => need the full picture
+         CALL dbt_copy_matrix_to_tensor(rho_ao(ispin, 1)%matrix, rho_ao_tmp)
+         CALL dbt_copy(rho_ao_tmp, ri_data%rho_ao_t(ispin, 1), move_data=.TRUE.)
+         CALL dbt_copy(ks_t, ri_data%ks_t(ispin, 1), summation=.TRUE., move_data=.TRUE.)
+
+         CALL dbt_copy(ri_data%ks_t(ispin, 1), ks_tmp)
          CALL dbt_copy_tensor_to_matrix(ks_tmp, ks_matrix(ispin, 1)%matrix, summation=.TRUE.)
          CALL dbt_clear(ks_tmp)
 
@@ -1755,7 +1760,6 @@ CONTAINS
       CALL dbt_destroy(t_3c_1)
       CALL dbt_destroy(t_3c_3)
 
-      CALL dbt_destroy(rho_ao_t)
       CALL dbt_destroy(rho_ao_tmp)
       CALL dbt_destroy(ks_t)
       CALL dbt_destroy(ks_tmp)

--- a/src/hfx_ri_kp.F
+++ b/src/hfx_ri_kp.F
@@ -201,22 +201,22 @@ CONTAINS
 
       !We store the density and KS matrix in tensor format
       nspins = dft_control%nspins
-      ALLOCATE (ri_data%kp_rho_ao_t(nspins, nimg), ri_data%kp_ks_t(nspins, nimg))
-      CALL create_2c_tensor(ri_data%kp_rho_ao_t(1, 1), dist1, dist2, ri_data%pgrid_2d, &
+      ALLOCATE (ri_data%rho_ao_t(nspins, nimg), ri_data%ks_t(nspins, nimg))
+      CALL create_2c_tensor(ri_data%rho_ao_t(1, 1), dist1, dist2, ri_data%pgrid_2d, &
                             ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
                             name="(AO | AO)")
       DEALLOCATE (dist1, dist2)
 
-      CALL dbt_create(dbcsr_template, ri_data%kp_ks_t(1, 1))
+      CALL dbt_create(dbcsr_template, ri_data%ks_t(1, 1))
 
       IF (nspins == 2) THEN
-         CALL dbt_create(ri_data%kp_rho_ao_t(1, 1), ri_data%kp_rho_ao_t(2, 1))
-         CALL dbt_create(ri_data%kp_ks_t(1, 1), ri_data%kp_ks_t(2, 1))
+         CALL dbt_create(ri_data%rho_ao_t(1, 1), ri_data%rho_ao_t(2, 1))
+         CALL dbt_create(ri_data%ks_t(1, 1), ri_data%ks_t(2, 1))
       END IF
       DO i_img = 2, nimg
          DO i_spin = 1, nspins
-            CALL dbt_create(ri_data%kp_rho_ao_t(1, 1), ri_data%kp_rho_ao_t(i_spin, i_img))
-            CALL dbt_create(ri_data%kp_ks_t(1, 1), ri_data%kp_ks_t(i_spin, i_img))
+            CALL dbt_create(ri_data%rho_ao_t(1, 1), ri_data%rho_ao_t(i_spin, i_img))
+            CALL dbt_create(ri_data%ks_t(1, 1), ri_data%ks_t(i_spin, i_img))
          END DO
       END DO
 
@@ -383,22 +383,22 @@ CONTAINS
          DEALLOCATE (ri_data%t_3c_int_ctr_2)
       END IF
 
-      IF (ALLOCATED(ri_data%kp_rho_ao_t)) THEN
-         DO j = 1, SIZE(ri_data%kp_rho_ao_t, 2)
-            DO i = 1, SIZE(ri_data%kp_rho_ao_t, 1)
-               CALL dbt_destroy(ri_data%kp_rho_ao_t(i, j))
+      IF (ALLOCATED(ri_data%rho_ao_t)) THEN
+         DO j = 1, SIZE(ri_data%rho_ao_t, 2)
+            DO i = 1, SIZE(ri_data%rho_ao_t, 1)
+               CALL dbt_destroy(ri_data%rho_ao_t(i, j))
             END DO
          END DO
-         DEALLOCATE (ri_data%kp_rho_ao_t)
+         DEALLOCATE (ri_data%rho_ao_t)
       END IF
 
-      IF (ALLOCATED(ri_data%kp_ks_t)) THEN
-         DO j = 1, SIZE(ri_data%kp_ks_t, 2)
-            DO i = 1, SIZE(ri_data%kp_ks_t, 1)
-               CALL dbt_destroy(ri_data%kp_ks_t(i, j))
+      IF (ALLOCATED(ri_data%ks_t)) THEN
+         DO j = 1, SIZE(ri_data%ks_t, 2)
+            DO i = 1, SIZE(ri_data%ks_t, 1)
+               CALL dbt_destroy(ri_data%ks_t(i, j))
             END DO
          END DO
-         DEALLOCATE (ri_data%kp_ks_t)
+         DEALLOCATE (ri_data%ks_t)
       END IF
 
    END SUBROUTINE cleanup_kp
@@ -484,12 +484,12 @@ CONTAINS
       !(mu^0, sigma^a| P^0) (P^0|R^0)  <===> (S^b|Q^b)^-1 (Q^b| nu^b lambda^a+c) by relabelling the images
 
       !Build the density tensor based on the difference of this SCF P and that of the prev. SCF
-      CALL get_pmat_images(ri_data%kp_rho_ao_t, rho_ao, -1.0_dp, ri_data, qs_env)
+      CALL get_pmat_images(ri_data%rho_ao_t, rho_ao, -1.0_dp, ri_data, qs_env)
 
       ALLOCATE (ks_t(nspins, nimg))
       DO i_img = 1, nimg
          DO i_spin = 1, nspins
-            CALL dbt_create(ri_data%kp_ks_t(1, 1), ks_t(i_spin, i_img))
+            CALL dbt_create(ri_data%ks_t(1, 1), ks_t(i_spin, i_img))
          END DO
       END DO
 
@@ -508,7 +508,7 @@ CONTAINS
             CALL dbt_create(ri_data%t_3c_int_ctr_2(1, 1), t_3c_apc(i_spin, i_img))
          END DO
       END DO
-      CALL contract_pmat_3c(t_3c_apc, ri_data%kp_rho_ao_t, ri_data, qs_env)
+      CALL contract_pmat_3c(t_3c_apc, ri_data%rho_ao_t, ri_data, qs_env)
 
       hfx_section => section_vals_get_subs_vals(qs_env%input, "DFT%XC%HF%RI")
       CALL section_vals_val_get(hfx_section, "KP_NGROUPS", i_val=ngroups)
@@ -698,15 +698,15 @@ CONTAINS
       !Currently, rho_ao_t holds the density difference (wrt to pref SCF step).
       !ks_t also hold that diff, while only having half the blocks => need to add to prev ks_t and symmetrize
       !We need the full thing for the energy, on the next SCF step
-      CALL get_pmat_images(ri_data%kp_rho_ao_t, rho_ao, 0.0_dp, ri_data, qs_env)
+      CALL get_pmat_images(ri_data%rho_ao_t, rho_ao, 0.0_dp, ri_data, qs_env)
       DO i_spin = 1, nspins
          DO b_img = 1, nimg
-            CALL dbt_copy(ks_t(i_spin, b_img), ri_data%kp_ks_t(i_spin, b_img), summation=.TRUE.)
+            CALL dbt_copy(ks_t(i_spin, b_img), ri_data%ks_t(i_spin, b_img), summation=.TRUE.)
 
             !desymmetrize
             mb_img = get_opp_index(b_img, qs_env)
             IF (mb_img > 0 .AND. mb_img .LE. nimg) THEN
-               CALL dbt_copy(ks_t(i_spin, mb_img), ri_data%kp_ks_t(i_spin, b_img), order=[2, 1], summation=.TRUE.)
+               CALL dbt_copy(ks_t(i_spin, mb_img), ri_data%ks_t(i_spin, b_img), order=[2, 1], summation=.TRUE.)
             END IF
          END DO
       END DO
@@ -717,20 +717,20 @@ CONTAINS
       END DO
 
       !calculate the energy
-      CALL dbt_create(ri_data%kp_ks_t(1, 1), t_2c_ao_tmp(1))
+      CALL dbt_create(ri_data%ks_t(1, 1), t_2c_ao_tmp(1))
       CALL dbcsr_create(tmp, template=ks_matrix(1, 1)%matrix, matrix_type=dbcsr_type_symmetric)
       CALL dbcsr_create(ks_desymm, template=ks_matrix(1, 1)%matrix, matrix_type=dbcsr_type_no_symmetry)
       CALL dbcsr_create(rho_desymm, template=ks_matrix(1, 1)%matrix, matrix_type=dbcsr_type_no_symmetry)
       ehfx = 0.0_dp
       DO i_img = 1, nimg
          DO i_spin = 1, nspins
-            CALL dbt_filter(ri_data%kp_ks_t(i_spin, i_img), ri_data%filter_eps)
-            CALL dbt_copy(ri_data%kp_ks_t(i_spin, i_img), t_2c_ao_tmp(1))
+            CALL dbt_filter(ri_data%ks_t(i_spin, i_img), ri_data%filter_eps)
+            CALL dbt_copy(ri_data%ks_t(i_spin, i_img), t_2c_ao_tmp(1))
             CALL dbt_copy_tensor_to_matrix(t_2c_ao_tmp(1), ks_desymm)
             CALL dbt_copy_tensor_to_matrix(t_2c_ao_tmp(1), tmp)
             CALL dbcsr_add(ks_matrix(i_spin, i_img)%matrix, tmp, 1.0_dp, 1.0_dp)
 
-            CALL dbt_copy(ri_data%kp_rho_ao_t(i_spin, i_img), t_2c_ao_tmp(1))
+            CALL dbt_copy(ri_data%rho_ao_t(i_spin, i_img), t_2c_ao_tmp(1))
             CALL dbt_copy_tensor_to_matrix(t_2c_ao_tmp(1), rho_desymm)
 
             CALL dbcsr_dot(ks_desymm, rho_desymm, etmp)

--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -410,10 +410,12 @@ MODULE hfx_types
 
       ! KP 3c tensors replicated on the subgroups
       TYPE(dbt_type), DIMENSION(:), ALLOCATABLE :: kp_t_3c_int
-      TYPE(dbt_type), DIMENSION(:, :), ALLOCATABLE :: kp_rho_ao_t, kp_ks_t
 
       ! Note: changed static DIMENSION(1,1) of dbt_type to allocatables as workaround for gfortran 8.3.0,
       ! with static dimension gfortran gets stuck during compilation
+
+      ! 2c tensors in (AO | AO) format
+      TYPE(dbt_type), DIMENSION(:, :), ALLOCATABLE :: rho_ao_t, ks_t
 
       ! 2c tensors in (RI | RI) format for forces
       TYPE(dbt_type), DIMENSION(:, :), ALLOCATABLE    :: t_2c_inv
@@ -1346,6 +1348,21 @@ CONTAINS
                                name="(RI | RI)")
          DEALLOCATE (dist1, dist2)
 
+         !We store previous Pmat and KS mat, so that we can work with Delta P and gain sprasity as we go
+         ALLOCATE (ri_data%rho_ao_t(2, 1))
+         CALL create_2c_tensor(ri_data%rho_ao_t(1, 1), dist1, dist2, ri_data%pgrid_2d, &
+                               ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
+                               name="(AO | AO)")
+         DEALLOCATE (dist1, dist2)
+         CALL dbt_create(ri_data%rho_ao_t(1, 1), ri_data%rho_ao_t(2, 1))
+
+         ALLOCATE (ri_data%ks_t(2, 1))
+         CALL create_2c_tensor(ri_data%ks_t(1, 1), dist1, dist2, ri_data%pgrid_2d, &
+                               ri_data%bsizes_AO_split, ri_data%bsizes_AO_split, &
+                               name="(AO | AO)")
+         DEALLOCATE (dist1, dist2)
+         CALL dbt_create(ri_data%ks_t(1, 1), ri_data%ks_t(2, 1))
+
       ELSEIF (ri_data%flavor == ri_mo) THEN
          ALLOCATE (ri_data%t_2c_int(2, 1))
 
@@ -1515,6 +1532,20 @@ CONTAINS
          END DO
          DEALLOCATE (ri_data%t_2c_int)
 
+         DO j = 1, SIZE(ri_data%rho_ao_t, 2)
+            DO i = 1, SIZE(ri_data%rho_ao_t, 1)
+               CALL dbt_destroy(ri_data%rho_ao_t(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%rho_ao_t,)
+
+         DO j = 1, SIZE(ri_data%ks_t, 2)
+            DO i = 1, SIZE(ri_data%ks_t, 1)
+               CALL dbt_destroy(ri_data%ks_t(i, j))
+            END DO
+         END DO
+         DEALLOCATE (ri_data%ks_t,)
+
          DEALLOCATE (ri_data%starts_array_mem_block, ri_data%ends_array_mem_block, &
                      ri_data%starts_array_mem, ri_data%ends_array_mem)
          DEALLOCATE (ri_data%starts_array_RI_mem_block, ri_data%ends_array_RI_mem_block, &
@@ -1574,22 +1605,22 @@ CONTAINS
          DEALLOCATE (ri_data%kp_t_3c_int)
       END IF
 
-      IF (ALLOCATED(ri_data%kp_rho_ao_t)) THEN
-         DO j = 1, SIZE(ri_data%kp_rho_ao_t, 2)
-            DO i = 1, SIZE(ri_data%kp_rho_ao_t, 1)
-               CALL dbt_destroy(ri_data%kp_rho_ao_t(i, j))
+      IF (ALLOCATED(ri_data%rho_ao_t)) THEN
+         DO j = 1, SIZE(ri_data%rho_ao_t, 2)
+            DO i = 1, SIZE(ri_data%rho_ao_t, 1)
+               CALL dbt_destroy(ri_data%rho_ao_t(i, j))
             END DO
          END DO
-         DEALLOCATE (ri_data%kp_rho_ao_t)
+         DEALLOCATE (ri_data%rho_ao_t)
       END IF
 
-      IF (ALLOCATED(ri_data%kp_ks_t)) THEN
-         DO j = 1, SIZE(ri_data%kp_ks_t, 2)
-            DO i = 1, SIZE(ri_data%kp_ks_t, 1)
-               CALL dbt_destroy(ri_data%kp_ks_t(i, j))
+      IF (ALLOCATED(ri_data%ks_t)) THEN
+         DO j = 1, SIZE(ri_data%ks_t, 2)
+            DO i = 1, SIZE(ri_data%ks_t, 1)
+               CALL dbt_destroy(ri_data%ks_t(i, j))
             END DO
          END DO
-         DEALLOCATE (ri_data%kp_ks_t)
+         DEALLOCATE (ri_data%ks_t)
       END IF
 
       IF (ALLOCATED(ri_data%iatom_to_subgroup)) THEN


### PR DESCRIPTION
Some minor optimization to the RI-HFX code, based on the lessons learned doing KP-RI-HFX. Namely, greater sparsity can be achieved overall by considering the density matrix difference (wrt to previous step) to additively update the KS matrix. As the SCF progresses, the cost of each cycle goes down because the variation in the density is smaller.