### PR TITLE
set(CMAKE_C_STANDARD 11)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ endif()
 
 # set language and standard
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 11)
 
 find_package(PkgConfig)
 


### PR DESCRIPTION
Since 77977db053aa4dd91906f197b16b60c454c6ff3f (or maybe earlier?) CP2K requires C11