### PR TITLE
Linres solver convergence warning

### DIFF
--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -431,8 +431,9 @@ CONTAINS
          ! Max number of iteration reached
          IF (iter == linres_control%max_iter) THEN
             IF (iounit > 0) THEN
-               WRITE (iounit, "(T3,A)") &
-                  "The linear solver didn't converge! Maximum number of iterations reached."
+!               WRITE (iounit, "(T3,A)") &
+               CALL cp_warn(__LOCATION__, &
+                            "The linear solver didn't converge! Maximum number of iterations reached.")
                CALL m_flush(iounit)
             END IF
             linres_control%converged = .FALSE.

--- a/src/qs_linres_methods.F
+++ b/src/qs_linres_methods.F
@@ -431,7 +431,6 @@ CONTAINS
          ! Max number of iteration reached
          IF (iter == linres_control%max_iter) THEN
             IF (iounit > 0) THEN
-!               WRITE (iounit, "(T3,A)") &
                CALL cp_warn(__LOCATION__, &
                             "The linear solver didn't converge! Maximum number of iterations reached.")
                CALL m_flush(iounit)


### PR DESCRIPTION
Previously, only a message was printed in the output when linear response solver did not converge. Now it prints a warning.