### PR TITLE
Create .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# prettify TEST_FILES files (@oschuett)
+bb17fff6cb5d3268353275b6fea7c5f276b83cc2


### PR DESCRIPTION
I was trying to look for which commit/PR changed some reference values in the test suite, and I hit this roadblock: https://github.com/cp2k/cp2k/commit/bb17fff6cb5d3268353275b6fea7c5f276b83cc2.

This PR adds a `.git-blame-ignore-revs` file, which allows to [ignore commits in blame view](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view). The goal is to ignore commits that mess up with the actually interesting commit history. 

I only added https://github.com/cp2k/cp2k/commit/bb17fff6cb5d3268353275b6fea7c5f276b83cc2 for the time being, but this file can be populated as needed.