### PR TITLE
Actually fix MPI_F08 in CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1569,7 +1569,7 @@ target_compile_definitions(
   cp2k
   PUBLIC $<$<BOOL:${CP2K_USE_MPI}>:__parallel>
          $<$<BOOL:${CP2K_USE_MPI}>:__SCALAPACK>
-         $<$<BOOL:${CP2K_USE_F08_MPI}>:__MPI_F08>
+         $<$<BOOL:${CP2K_USE_MPI_F08}>:__MPI_F08>
          __COMPILE_DATE=\"${CP2K_TIMESTAMP}\"
          __COMPILE_HOST=\"${CP2K_HOST_NAME}\"
          __COMPILE_REVISION=\"${CP2K_GIT_HASH}\"


### PR DESCRIPTION
https://github.com/cp2k/cp2k/pull/3063 did not contain the full fix, my bad. I opened it directly from GitHub because the actual changes I had locally were on a messy branch. This PR has been tested locally.

I don't think it would have helped here, but is it possible to automatically trigger the CMake CI action, when CMake files are changed?