### PR TITLE
Fix CMake test command message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -933,7 +933,8 @@ endif()
 if(CP2K_ENABLE_REGTESTS OR cp2k_TESTS)
   message("\n\n" "To run the regtests you need to run the following commands\n"
           "\n\n cd ..\n"
-          "./tests/do_regtest.py ${__cp2k_cmake_name} ${__cp2k_cmake_exts}\n\n")
+          " export CP2K_DATA_DIR=${CMAKE_SOURCE_DIR}/data/\n"
+          " ./tests/do_regtest.py ${__cp2k_cmake_name} ${__cp2k_ext}\n\n")
 endif()
 
 # files needed for cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -932,8 +932,7 @@ endif()
 
 if(CP2K_ENABLE_REGTESTS OR cp2k_TESTS)
   message("\n\n" "To run the regtests you need to run the following commands\n"
-          "\n\n cd ..\n"
-          " export CP2K_DATA_DIR=${CMAKE_SOURCE_DIR}/data/\n"
+          "\n\n cd ..\n" " export CP2K_DATA_DIR=${CMAKE_SOURCE_DIR}/data/\n"
           " ./tests/do_regtest.py ${__cp2k_cmake_name} ${__cp2k_ext}\n\n")
 endif()
 


### PR DESCRIPTION
Use `${__cp2k_ext}` instead of `${__cp2k_cmake_exts}` and add `export CP2K_DATA_DIR` suggestion.