### PR TITLE
Fix documentation for ELPA_FORCE_REDISTRIBUTE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1569,7 +1569,7 @@ target_compile_definitions(
   cp2k
   PUBLIC $<$<BOOL:${CP2K_USE_MPI}>:__parallel>
          $<$<BOOL:${CP2K_USE_MPI}>:__SCALAPACK>
-         $<$<BOOL:${CP2K_USE_MPI_F08}>:__MPI_F08>
+         $<$<BOOL:${CP2K_USE_F08_MPI}>:__MPI_F08>
          __COMPILE_DATE=\"${CP2K_TIMESTAMP}\"
          __COMPILE_HOST=\"${CP2K_HOST_NAME}\"
          __COMPILE_REVISION=\"${CP2K_GIT_HASH}\"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1569,7 +1569,7 @@ target_compile_definitions(
   cp2k
   PUBLIC $<$<BOOL:${CP2K_USE_MPI}>:__parallel>
          $<$<BOOL:${CP2K_USE_MPI}>:__SCALAPACK>
-         $<$<BOOL:${CP2K_USE_F08_MPI}>:__MPI_F08>
+         $<$<BOOL:${CP2K_USE_MPI_F08}>:__MPI_F08>
          __COMPILE_DATE=\"${CP2K_TIMESTAMP}\"
          __COMPILE_HOST=\"${CP2K_HOST_NAME}\"
          __COMPILE_REVISION=\"${CP2K_GIT_HASH}\"

--- a/src/input_cp2k_global.F
+++ b/src/input_cp2k_global.F
@@ -723,9 +723,9 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="ELPA_FORCE_REDISTRIBUTE", &
                           description="Controls how to perform redistribution when ELPA is used for diagonalization. "// &
-                          "By default, matrices are redistributed only to prevent crashes in the ELPA library "// &
-                          "which happens when the original matrix is distributed over too many processors. "// &
-                          "By turning on this keyword, redistribution is always performed using the defined rules. ", &
+                          "By default, redistribution is always performed using the defined rules. ", &
+                          "By turning off this keyword, matrices are redistributed only to prevent crashes in the ELPA"// &
+                          "library which happens when the original matrix is distributed over too many processors. "// &
                           usage="ELPA_FORCE_REDISTRIBUTE", type_of_var=logical_t, &
                           default_l_val=.TRUE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)

--- a/src/input_cp2k_global.F
+++ b/src/input_cp2k_global.F
@@ -723,9 +723,9 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="ELPA_FORCE_REDISTRIBUTE", &
                           description="Controls how to perform redistribution when ELPA is used for diagonalization. "// &
-                          "By default, redistribution is always performed using the defined rules. ", &
+                          "By default, redistribution is alway performed using the defined rules. "// &
                           "By turning off this keyword, matrices are redistributed only to prevent crashes in the ELPA"// &
-                          "library which happens when the original matrix is distributed over too many processors. "// &
+                          "library which happens when the original matrix is distributed over too many processors. ", &
                           usage="ELPA_FORCE_REDISTRIBUTE", type_of_var=logical_t, &
                           default_l_val=.TRUE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)

--- a/src/input_cp2k_global.F
+++ b/src/input_cp2k_global.F
@@ -723,8 +723,8 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="ELPA_FORCE_REDISTRIBUTE", &
                           description="Controls how to perform redistribution when ELPA is used for diagonalization. "// &
-                          "By default, redistribution is alway performed using the defined rules. "// &
-                          "By turning off this keyword, matrices are redistributed only to prevent crashes in the ELPA"// &
+                          "By default, redistribution is always performed using the defined rules. "// &
+                          "By turning off this keyword, matrices are redistributed only to prevent crashes in the ELPA "// &
                           "library which happens when the original matrix is distributed over too many processors. ", &
                           usage="ELPA_FORCE_REDISTRIBUTE", type_of_var=logical_t, &
                           default_l_val=.TRUE., lone_keyword_l_val=.TRUE.)


### PR DESCRIPTION
PR https://github.com/cp2k/cp2k/pull/1515 changed the default value of `ELPA_FORCE_REDISTRIBUTE` from `.FALSE.` to `.TRUE.`, but the corresponding documentation has not been updated.