### PR TITLE
Allow usage of wrapper script when running regression tests with MPI

### DIFF
--- a/tests/do_regtest.py
+++ b/tests/do_regtest.py
@@ -298,7 +298,7 @@ class Config:
         if self.valgrind:
             cmd = ["valgrind", "--error-exitcode=42", "--exit-on-first-error=yes"] + cmd
         if self.use_mpi:
-            cmd = self.mpiexec + ["-n", str(self.mpiranks)] + cmd
+            cmd = self.mpiexec[0:1] + ["-n", str(self.mpiranks)] + self.mpiexec[1:] + cmd
         if self.debug:
             print(f"Creating subprocess: {cmd} {args}")
         return asyncio.create_subprocess_exec(

--- a/tests/do_regtest.py
+++ b/tests/do_regtest.py
@@ -298,7 +298,7 @@ class Config:
         if self.valgrind:
             cmd = ["valgrind", "--error-exitcode=42", "--exit-on-first-error=yes"] + cmd
         if self.use_mpi:
-            cmd = self.mpiexec[0:1] + ["-n", str(self.mpiranks)] + self.mpiexec[1:] + cmd
+            cmd = [self.mpiexec[0], "-n", str(self.mpiranks)] + self.mpiexec[1:] + cmd
         if self.debug:
             print(f"Creating subprocess: {cmd} {args}")
         return asyncio.create_subprocess_exec(


### PR DESCRIPTION
Currently, the `--mpiranks` option is simply appended after the `--mpiexec` option.

https://github.com/cp2k/cp2k/blob/b1e573e5365af53cd5b64772cda048b47a415cd7/tests/do_regtest.py#L300-L301

This prevents the use of a wrapper scripts while spawning tests.

This PR moves the `-n RANKS` argument just after the first string in `--mpiexec`, so that a wrapper script can be used.

Example:
```bash
./tests/do_regtest.py local psmp \
    --mpiranks 2 --ompthreads 6 --num_gpus 0 \
    --mpiexec "mpiexec --bind-to core:6 wrapper.sh"
```