### PR TITLE
Allow setting CP2K_DATA_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,10 @@ set(CP2K_BUILD_OPTIONS
 set_property(CACHE CP2K_BUILD_OPTIONS PROPERTY STRINGS
                                                ${CP2K_BUILD_OPTIONS_LIST})
 
+set(CP2K_DATA_DIR
+    "default"
+    CACHE STRING "Set the location for cp2k data")
+
 string(TOUPPER ${CP2K_BUILD_OPTIONS} cp2k_build_options_up)
 
 if(NOT ${cp2k_build_options_up} IN_LIST CP2K_BUILD_OPTIONS_LIST)
@@ -759,10 +763,10 @@ if(CP2K_BUILD_DBCSR)
   add_library(DBCSR::dbcsr ALIAS dbcsr)
 endif()
 
+include(GNUInstallDirs)
+
 # subdirectories
 add_subdirectory(src)
-
-include(GNUInstallDirs)
 
 get_target_property(CP2K_LIBS cp2k_link_libs INTERFACE_LINK_LIBRARIES)
 configure_file(cmake/libcp2k.pc.in libcp2k.pc @ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1573,6 +1573,10 @@ target_link_libraries(
 
 string(TIMESTAMP CP2K_TIMESTAMP "%Y-%m-%d %H:%M:%S")
 
+if(CP2K_DATA_DIR STREQUAL "default")
+  set(CP2K_DATA_DIR "${CMAKE_INSTALL_FULL_DATAROOTDIR}/${PROJECT_NAME}/data")
+endif()
+
 target_link_libraries(cp2k PUBLIC cp2k_link_libs)
 target_compile_definitions(
   cp2k
@@ -1583,7 +1587,7 @@ target_compile_definitions(
     __COMPILE_DATE=\"${CP2K_TIMESTAMP}\"
     __COMPILE_HOST=\"${CP2K_HOST_NAME}\"
     __COMPILE_REVISION=\"${CP2K_GIT_HASH}\"
-    __DATA_DIR=\"${CMAKE_INSTALL_FULL_DATAROOTDIR}/cp2k/data\"
+    __DATA_DIR=\"${CP2K_DATA_DIR}\"
     __COMPILE_ARCH=\"${CMAKE_SYSTEM_PROCESSOR}\"
     $<$<CONFIG:COVERAGE>:__NO_ABORT>
     $<$<CONFIG:DEBUG>:__HAS_IEEE_EXCEPTIONS>
@@ -1777,8 +1781,7 @@ install(
   INCLUDES
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
 
-install(DIRECTORY "${CMAKE_SOURCE_DIR}/data"
-        DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/${PROJECT_NAME}")
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/data/" DESTINATION "${CP2K_DATA_DIR}")
 
 # ##############################################################################
 # cp2kConfig.cmake, etc...


### PR DESCRIPTION
The Fedora package keeps a single copy of the data for all builds (serial, openmpi, mpich) in /usr/share/cp2k/data.