### PR TITLE
Fix SIRIUS scripts for different sed on Darwin

### DIFF
--- a/tools/toolchain/scripts/stage8/install_sirius.sh
+++ b/tools/toolchain/scripts/stage8/install_sirius.sh
@@ -116,7 +116,7 @@ case "$with_sirius" in
 
       # GCC 13 stopped including some common headers.
       # https://github.com/electronic-structure/SIRIUS/issues/854
-      sed -i '1 i\#include <cstdint>' src/*.hpp
+      sed -i'' -e '1s/.*/#include <cstdint>\n&/' src/*.hpp
 
       rm -Rf build
       mkdir build


### PR DESCRIPTION
This pull request fixes an issue with SIRIUS scripts on Darwin where sed behaves differently.