### PR TITLE
PW: Bind functions to objects, remove reference counting from pw_poisson_type

### DIFF
--- a/src/cp_ddapc.F
+++ b/src/cp_ddapc.F
@@ -41,9 +41,7 @@ MODULE cp_ddapc
                                               pw_scale,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -139,13 +137,13 @@ CONTAINS
       dft_control%qs_control%ddapc_explicit_potential = explicit_potential
       dft_control%qs_control%ddapc_restraint_is_spin = ddapc_restraint_is_spin
       IF (explicit_potential) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, v_spin_ddapc_rest_g, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(v_spin_ddapc_rest_g, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_zero(v_spin_ddapc_rest_g)
          NULLIFY (v_spin_ddapc_rest_r)
          ALLOCATE (v_spin_ddapc_rest_r)
-         CALL pw_pool_create_pw(auxbas_pw_pool, v_spin_ddapc_rest_r, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(v_spin_ddapc_rest_r, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
       END IF
 
       IF (calculate_forces) CALL reset_ch_pulay(qs_env)
@@ -204,7 +202,7 @@ CONTAINS
       END IF
 
       IF (explicit_potential) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_spin_ddapc_rest_g)
+         CALL auxbas_pw_pool%give_back_pw(v_spin_ddapc_rest_g)
       END IF
       CALL timestop(handle)
 

--- a/src/cp_ddapc_types.F
+++ b/src/cp_ddapc_types.F
@@ -33,8 +33,7 @@ MODULE cp_ddapc_types
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_release
    USE pw_poisson_types,                ONLY: pw_poisson_multipole
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_release,&
+   USE pw_pool_types,                   ONLY: pw_pool_release,&
                                               pw_pool_type
    USE pw_types,                        ONLY: pw_type
 #include "./base/base_uses.f90"
@@ -407,11 +406,11 @@ CONTAINS
 
       IF (ASSOCIATED(cp_ddapc_ewald)) THEN
          IF (ASSOCIATED(cp_ddapc_ewald%coeff_qm)) THEN
-            CALL pw_pool_give_back_pw(cp_ddapc_ewald%pw_pool_qm, cp_ddapc_ewald%coeff_qm)
+            CALL cp_ddapc_ewald%pw_pool_qm%give_back_pw(cp_ddapc_ewald%coeff_qm)
             DEALLOCATE (cp_ddapc_ewald%coeff_qm)
          END IF
          IF (ASSOCIATED(cp_ddapc_ewald%coeff_mm)) THEN
-            CALL pw_pool_give_back_pw(cp_ddapc_ewald%pw_pool_mm, cp_ddapc_ewald%coeff_mm)
+            CALL cp_ddapc_ewald%pw_pool_mm%give_back_pw(cp_ddapc_ewald%coeff_mm)
             DEALLOCATE (cp_ddapc_ewald%coeff_mm)
          END IF
          IF (ASSOCIATED(cp_ddapc_ewald%pw_pool_qm)) THEN

--- a/src/cp_ddapc_util.F
+++ b/src/cp_ddapc_util.F
@@ -46,9 +46,7 @@ MODULE cp_ddapc_util
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_copy,&
                                               pw_transfer
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
                                               pw_type
@@ -136,8 +134,8 @@ CONTAINS
             WRITE (iw, '(/,A)') " Initializing the DDAPC Environment"
          END IF
          CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pool)
-         CALL pw_pool_create_pw(auxbas_pool, rho_tot_g, in_space=RECIPROCALSPACE, &
-                                use_data=COMPLEXDATA1D)
+         CALL auxbas_pool%create_pw(rho_tot_g, in_space=RECIPROCALSPACE, &
+                                    use_data=COMPLEXDATA1D)
          Vol = rho_tot_g%pw_grid%vol
          !
          ! Get Input Parameters
@@ -179,7 +177,7 @@ CONTAINS
          CALL cp_print_key_finished_output(iw2, logger, density_fit_section, &
                                            "PROGRAM_RUN_INFO/CONDITION_NUMBER")
          DEALLOCATE (radii)
-         CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g)
+         CALL auxbas_pool%give_back_pw(rho_tot_g)
       END IF
       CALL timestop(handle)
    END SUBROUTINE cp_ddapc_init
@@ -277,8 +275,8 @@ CONTAINS
       END IF
       CALL pw_env_get(pw_env=pw_env, &
                       auxbas_pw_pool=auxbas_pool)
-      CALL pw_pool_create_pw(auxbas_pool, rho_tot_g, in_space=RECIPROCALSPACE, &
-                             use_data=COMPLEXDATA1D)
+      CALL auxbas_pool%create_pw(rho_tot_g, in_space=RECIPROCALSPACE, &
+                                 use_data=COMPLEXDATA1D)
       IF (PRESENT(ext_rho_tot_g)) THEN
          ! If provided use the input density in g-space
          CALL pw_transfer(ext_rho_tot_g, rho_tot_g)
@@ -516,7 +514,7 @@ CONTAINS
          CALL cp_print_key_finished_output(iw, logger, density_fit_section, &
                                            "PROGRAM_RUN_INFO")
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_g)
+      CALL auxbas_pool%give_back_pw(rho_tot_g)
       CALL timestop(handle)
    END SUBROUTINE get_ddapc
 

--- a/src/dm_ls_scf_qs.F
+++ b/src/dm_ls_scf_qs.F
@@ -41,9 +41,7 @@ MODULE dm_ls_scf_qs
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -668,15 +666,13 @@ CONTAINS
       CALL pw_env_get(pw_env=pw_env, &
                       auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=wf_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=wf_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
       CALL pw_zero(wf_r)
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=wf_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=wf_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
       CALL pw_zero(wf_g)
       CALL calculate_rho_elec(matrix_p=matrix_p_qs, &
                               rho=wf_r, &
@@ -688,8 +684,8 @@ CONTAINS
                          particles=particles, stride=stride)
 
       !free memory
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
       CALL dbcsr_release(matrix_p_qs)
 
       CALL timestop(handle)

--- a/src/ec_env_types.F
+++ b/src/ec_env_types.F
@@ -21,8 +21,7 @@ MODULE ec_env_types
    USE input_section_types,             ONLY: section_vals_release,&
                                               section_vals_type
    USE kinds,                           ONLY: dp
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_dispersion_types,             ONLY: qs_dispersion_release,&
                                               qs_dispersion_type
    USE qs_force_types,                  ONLY: deallocate_qs_force,&
@@ -174,23 +173,23 @@ CONTAINS
          END IF
          ! potential
          IF (ASSOCIATED(ec_env%vh_rspace%pw_grid)) THEN
-            CALL pw_release(ec_env%vh_rspace)
+            CALL ec_env%vh_rspace%release()
          END IF
          IF (ASSOCIATED(ec_env%vxc_rspace)) THEN
             DO iab = 1, SIZE(ec_env%vxc_rspace)
-               CALL pw_release(ec_env%vxc_rspace(iab))
+               CALL ec_env%vxc_rspace(iab)%release()
             END DO
             DEALLOCATE (ec_env%vxc_rspace)
          END IF
          IF (ASSOCIATED(ec_env%vtau_rspace)) THEN
             DO iab = 1, SIZE(ec_env%vtau_rspace)
-               CALL pw_release(ec_env%vtau_rspace(iab))
+               CALL ec_env%vtau_rspace(iab)%release()
             END DO
             DEALLOCATE (ec_env%vtau_rspace)
          END IF
          IF (ASSOCIATED(ec_env%vadmm_rspace)) THEN
             DO iab = 1, SIZE(ec_env%vadmm_rspace)
-               CALL pw_release(ec_env%vadmm_rspace(iab))
+               CALL ec_env%vadmm_rspace(iab)%release()
             END DO
             DEALLOCATE (ec_env%vadmm_rspace)
          END IF

--- a/src/ec_orth_solver.F
+++ b/src/ec_orth_solver.F
@@ -50,9 +50,7 @@ MODULE ec_orth_solver
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -1182,18 +1180,15 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the NSC Hartree potential
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=rho_tot_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=v_hartree_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=rho_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=v_hartree_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       ! XC-Kernel
       NULLIFY (v_xc, v_xc_tau, xc_section)
@@ -1322,16 +1317,16 @@ CONTAINS
       CALL commutator(matrix_G, matrix_p, matrix_Ax, eps_filter, .FALSE., 1.0_dp, 1.0_dp)
 
       ! release pw grids
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
       END DO
       DEALLOCATE (v_xc)
       IF (ASSOCIATED(v_xc_tau)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
          END DO
          DEALLOCATE (v_xc_tau)
       END IF

--- a/src/ed_analysis.F
+++ b/src/ed_analysis.F
@@ -58,9 +58,7 @@ MODULE ed_analysis
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_scale
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -693,18 +691,18 @@ CONTAINS
       needs = xc_functionals_get_needs(xc_fun_section, (nspins == 2), .TRUE.)
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, xc_den, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(xc_den, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
       ALLOCATE (vxc(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, vxc(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(vxc(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
       END DO
       IF (needs%tau .OR. needs%tau_spin) THEN
          ALLOCATE (vtau(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, vtau(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(vtau(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
          END DO
       END IF
 
@@ -777,13 +775,13 @@ CONTAINS
          END IF
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, xc_den)
+      CALL auxbas_pw_pool%give_back_pw(xc_den)
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc(ispin))
+         CALL auxbas_pw_pool%give_back_pw(vxc(ispin))
       END DO
       IF (needs%tau .OR. needs%tau_spin) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vtau(ispin))
          END DO
       END IF
 

--- a/src/emd/rt_propagation_output.F
+++ b/src/emd/rt_propagation_output.F
@@ -59,9 +59,7 @@ MODULE rt_propagation_output
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -724,8 +722,8 @@ CONTAINS
       END IF
       current_env%gauge = -1
       current_env%gauge_init = .FALSE.
-      CALL pw_pool_create_pw(auxbas_pw_pool, rs, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rs, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       NULLIFY (stride)
       ALLOCATE (stride(3))
@@ -762,8 +760,8 @@ CONTAINS
 
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rs)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, gs)
+      CALL auxbas_pw_pool%give_back_pw(rs)
+      CALL auxbas_pw_pool%give_back_pw(gs)
 
       CALL dbcsr_deallocate_matrix(zero)
       CALL dbcsr_deallocate_matrix(tmp)

--- a/src/emd/rt_propagation_utils.F
+++ b/src/emd/rt_propagation_utils.F
@@ -61,9 +61,7 @@ MODULE rt_propagation_utils
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_multiply,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -793,15 +791,15 @@ CONTAINS
       ! Setup the grids needed to compute a wavefunction given a vector
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, density_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(density_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
       CALL get_rtp(rtp=rtp, mos_new=mos_new)
 
       DO ispin = 1, nspins
@@ -874,9 +872,9 @@ CONTAINS
       END DO
 
       ! Deallocate grids needed to compute wavefunctions
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, density_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
+      CALL auxbas_pw_pool%give_back_pw(density_r)
 
       CALL timestop(handle)
 

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -132,7 +132,6 @@ MODULE energy_corrections
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_create,&
                                               pw_type
    USE qs_atomic_block,                 ONLY: calculate_atomic_block_dm
    USE qs_collocate_density,            ONLY: calculate_rho_elec
@@ -792,8 +791,8 @@ CONTAINS
       pw_grid => v_hartree_rspace%pw_grid
       ALLOCATE (v_rspace_in(nspins))
       DO ispin = 1, nspins
-         CALL pw_create(v_rspace_in(ispin), pw_grid, &
-                        use_data=REALDATA3D, in_space=REALSPACE)
+         CALL v_rspace_in(ispin)%create(pw_grid, &
+                                        use_data=REALDATA3D, in_space=REALSPACE)
       END DO
 
       ! v_rspace_in = v_H[n_in] + v_xc[n_in] calculated in ks_ref_potential

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -124,9 +124,7 @@ MODULE energy_corrections
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -427,8 +425,8 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          ALLOCATE (ec_env%rhoz_r(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, ec_env%rhoz_r(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(ec_env%rhoz_r(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
          END DO
 
          CALL response_force(qs_env, &
@@ -451,8 +449,8 @@ CONTAINS
 
          ! Deallocate Harris density and response density on grid
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, ec_env%rhoout_r(ispin))
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, ec_env%rhoz_r(ispin))
+            CALL auxbas_pw_pool%give_back_pw(ec_env%rhoout_r(ispin))
+            CALL auxbas_pw_pool%give_back_pw(ec_env%rhoz_r(ispin))
          END DO
          DEALLOCATE (ec_env%rhoout_r, ec_env%rhoz_r)
 
@@ -687,12 +685,12 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the Hartree potential
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       ! Get the total input density in g-space [ions + electrons]
       CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
@@ -730,8 +728,8 @@ CONTAINS
       CALL qs_rho_get(rho, rho_r=rho_r)
       ALLOCATE (ec_env%rhoout_r(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, ec_env%rhoout_r(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(ec_env%rhoout_r(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_copy(rho_r(ispin), ec_env%rhoout_r(ispin))
       END DO
 
@@ -766,8 +764,8 @@ CONTAINS
       IF (.NOT. ASSOCIATED(v_rspace)) THEN
          ALLOCATE (v_rspace(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_rspace(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_rspace(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(v_rspace(ispin))
          END DO
       END IF
@@ -967,8 +965,8 @@ CONTAINS
          IF (.NOT. ASSOCIATED(v_tau_rspace)) THEN
             ALLOCATE (v_tau_rspace(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, v_tau_rspace(ispin), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(v_tau_rspace(ispin), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_zero(v_tau_rspace(ispin))
             END DO
          END IF
@@ -1029,19 +1027,19 @@ CONTAINS
 
       ! return pw grids
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_in(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_rspace(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_rspace_in(ispin))
          IF (ASSOCIATED(v_tau_rspace)) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_tau_rspace(ispin))
          END IF
       END DO
 
       DEALLOCATE (v_rspace, v_rspace_in)
       IF (ASSOCIATED(v_tau_rspace)) DEALLOCATE (v_tau_rspace)
       !
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
 
       ! Stress tensor - volume terms need to be stored,
       ! for a sign correction in QS at the end of qs_force
@@ -1388,8 +1386,8 @@ CONTAINS
       IF (.NOT. ASSOCIATED(v_rspace)) THEN
          ALLOCATE (v_rspace(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_rspace(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_rspace(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(v_rspace(ispin))
          END DO
       END IF
@@ -1435,9 +1433,9 @@ CONTAINS
 
       ! return pw grids
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_rspace(ispin))
          IF (ASSOCIATED(v_tau_rspace)) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_tau_rspace(ispin))
          END IF
       END DO
       DEALLOCATE (v_rspace)
@@ -1768,12 +1766,12 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the Hartree potential
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhodn_tot_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhodn_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL pw_transfer(ec_env%vh_rspace, v_hartree_rspace)
 
@@ -1784,15 +1782,15 @@ CONTAINS
       NULLIFY (rhoout_r, rhoout_g)
       ALLOCATE (rhoout_r(nspins), rhoout_g(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhoout_r(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhoout_g(ispin), &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rhoout_r(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rhoout_g(ispin), &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      CALL pw_pool_create_pw(auxbas_pw_pool, dv_hartree_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, vtot_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(dv_hartree_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(vtot_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL pw_zero(rhodn_tot_gspace)
       DO ispin = 1, nspins
@@ -1806,8 +1804,8 @@ CONTAINS
       ! Save Harris on real space grid for use in properties
       ALLOCATE (ec_env%rhoout_r(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, ec_env%rhoout_r(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(ec_env%rhoout_r(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_copy(rhoout_r(ispin), ec_env%rhoout_r(ispin))
       END DO
 
@@ -1817,11 +1815,11 @@ CONTAINS
             TYPE(pw_type) :: tauout_g
             ALLOCATE (tauout_r(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, tauout_r(ispin), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(tauout_r(ispin), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
             END DO
-            CALL pw_pool_create_pw(auxbas_pw_pool, tauout_g, &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(tauout_g, &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
             DO ispin = 1, nspins
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=ec_env%matrix_p(ispin, 1)%matrix, &
@@ -1832,15 +1830,15 @@ CONTAINS
                                        task_list_external=ec_env%task_list)
             END DO
 
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, tauout_g)
+            CALL auxbas_pw_pool%give_back_pw(tauout_g)
          END BLOCK
       END IF
 
       IF (use_virial) THEN
 
          ! Calculate the Hartree potential
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
          ! Get the total input density in g-space [ions + electrons]
          CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
@@ -1891,13 +1889,13 @@ CONTAINS
 
          IF (ASSOCIATED(v_rspace)) THEN
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_rspace(ispin))
             END DO
             DEALLOCATE (v_rspace)
          END IF
          IF (ASSOCIATED(v_tau_rspace)) THEN
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_tau_rspace(ispin))
             END DO
             DEALLOCATE (v_tau_rspace)
          END IF
@@ -1925,7 +1923,7 @@ CONTAINS
                                h_stress=h_stress, &
                                aux_density=rho_tot_gspace)  ! n_in
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+         CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
 
          virial%pv_ehartree = virial%pv_ehartree + h_stress/REAL(para_env%num_pe, dp)
          virial%pv_virial = virial%pv_virial + h_stress/REAL(para_env%num_pe, dp)
@@ -2101,8 +2099,8 @@ CONTAINS
       IF (.NOT. ASSOCIATED(v_rspace)) THEN
          ALLOCATE (v_rspace(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_rspace(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_rspace(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(v_rspace(ispin))
          END DO
       END IF
@@ -2218,11 +2216,11 @@ CONTAINS
       CALL dbcsr_deallocate_matrix_set(scrm)
 
       ! return pw grids
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_rspace(ispin))
          IF (ASSOCIATED(v_tau_rspace)) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_tau_rspace(ispin))
          END IF
       END DO
       IF (ASSOCIATED(v_tau_rspace)) DEALLOCATE (v_tau_rspace)
@@ -2255,28 +2253,28 @@ CONTAINS
 
       DEALLOCATE (v_rspace)
       !
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, dv_hartree_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vtot_rspace)
+      CALL auxbas_pw_pool%give_back_pw(dv_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(vtot_rspace)
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoout_r(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoout_g(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rhoout_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rhoout_g(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
       END DO
       DEALLOCATE (rhoout_r, rhoout_g, v_xc)
       IF (ASSOCIATED(tauout_r)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, tauout_r(ispin))
+            CALL auxbas_pw_pool%give_back_pw(tauout_r(ispin))
          END DO
          DEALLOCATE (tauout_r)
       END IF
       IF (ASSOCIATED(v_xc_tau)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
          END DO
          DEALLOCATE (v_xc_tau)
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhodn_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rhodn_tot_gspace)
 
       ! Stress tensor - volume terms need to be stored,
       ! for a sign correction in QS at the end of qs_force
@@ -3162,10 +3160,9 @@ CONTAINS
          CALL pw_env_get(pw_env=pw_env, &
                          auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
-         CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                pw=rho_elec_rspace, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(pw=rho_elec_rspace, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
 
          IF (dft_control%nspins > 1) THEN
 
@@ -3202,7 +3199,7 @@ CONTAINS
          CALL entry_voronoi_or_bqb(should_print_voro, should_print_bqb, print_key_voro, print_key_bqb, &
                                    unit_nr_voro, qs_env, rho_elec_rspace)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace)
+         CALL auxbas_pw_pool%give_back_pw(rho_elec_rspace)
 
          IF (unit_nr_voro > 0) THEN
             CALL cp_print_key_finished_output(unit_nr_voro, logger, ec_section, "PRINT%VORONOI")

--- a/src/et_coupling_proj.F
+++ b/src/et_coupling_proj.F
@@ -60,9 +60,7 @@ MODULE et_coupling_proj
    USE physcon,                         ONLY: evolt
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -1348,10 +1346,10 @@ CONTAINS
       ! Grids for wavefunction
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! Calculate the grid values
       CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
@@ -1365,8 +1363,8 @@ CONTAINS
       CALL cp_print_key_finished_output(unit_nr, logger, input, 'MO_CUBES')
 
       ! Clean memory
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
 
    END SUBROUTINE save_mo_cube
 

--- a/src/ewald_methods_tb.F
+++ b/src/ewald_methods_tb.F
@@ -40,9 +40,7 @@ MODULE ewald_methods_tb
                                               pw_poisson_solve
    USE pw_poisson_types,                ONLY: greens_fn_type,&
                                               pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -169,7 +167,7 @@ CONTAINS
 
       NULLIFY (rhob_r)
       ALLOCATE (rhob_r)
-      CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
+      CALL pw_pool%create_pw(rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       CALL transfer_rs2pw(rden, rhob_r)
@@ -177,7 +175,7 @@ CONTAINS
       ! transform density to G space and add charge function
       NULLIFY (rhob_g)
       ALLOCATE (rhob_g)
-      CALL pw_pool_create_pw(pw_pool, rhob_g, use_data=COMPLEXDATA1D, &
+      CALL pw_pool%create_pw(rhob_g, use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
       ! update charge function
@@ -187,12 +185,12 @@ CONTAINS
 
       ! allocate intermediate arrays
       DO i = 1, 3
-         CALL pw_pool_create_pw(pw_pool, dphi_g(i), &
+         CALL pw_pool%create_pw(dphi_g(i), &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
       NULLIFY (phi_g)
       ALLOCATE (phi_g)
-      CALL pw_pool_create_pw(pw_pool, phi_g, &
+      CALL pw_pool%create_pw(phi_g, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       IF (use_virial) THEN
          CALL pw_poisson_solve(poisson_env, rhob_g, vgc, phi_g, dphi_g, h_stress=h_stress)
@@ -228,7 +226,7 @@ CONTAINS
 
                NULLIFY (phib_g)
                ALLOCATE (phib_g)
-               CALL pw_pool_create_pw(pw_pool, phib_g, &
+               CALL pw_pool%create_pw(phib_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                ffa = (0.5_dp/alpha)**2
                ffb = 1.0_dp/fourpi
@@ -262,20 +260,20 @@ CONTAINS
 
                   END DO
                END DO
-               CALL pw_pool_give_back_pw(pw_pool, phib_g)
+               CALL pw_pool%give_back_pw(phib_g)
                DEALLOCATE (phib_g)
 
             END IF
          END IF
       END IF
 
-      CALL pw_pool_give_back_pw(pw_pool, rhob_g)
+      CALL pw_pool%give_back_pw(rhob_g)
       DEALLOCATE (rhob_g)
 
       CALL rs_grid_zero(rpot)
       CALL pw_multiply_with(phi_g, green%p3m_charge)
       CALL pw_transfer(phi_g, rhob_r)
-      CALL pw_pool_give_back_pw(pw_pool, phi_g)
+      CALL pw_pool%give_back_pw(phi_g)
       DEALLOCATE (phi_g)
       CALL transfer_pw2rs(rpot, rhob_r)
 
@@ -305,15 +303,15 @@ CONTAINS
             CALL rs_grid_set_box(grid_spme, rs=drpot(i))
             CALL pw_multiply_with(dphi_g(i), green%p3m_charge)
             CALL pw_transfer(dphi_g(i), rhob_r)
-            CALL pw_pool_give_back_pw(pw_pool, dphi_g(i))
+            CALL pw_pool%give_back_pw(dphi_g(i))
             CALL transfer_pw2rs(drpot(i), rhob_r)
          END DO
       ELSE
          DO i = 1, 3
-            CALL pw_pool_give_back_pw(pw_pool, dphi_g(i))
+            CALL pw_pool%give_back_pw(dphi_g(i))
          END DO
       END IF
-      CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      CALL pw_pool%give_back_pw(rhob_r)
       DEALLOCATE (rhob_r)
 
       !----------------- FORCE CALCULATION ----------------
@@ -513,7 +511,7 @@ CONTAINS
 
       NULLIFY (rhob_r)
       ALLOCATE (rhob_r)
-      CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
+      CALL pw_pool%create_pw(rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       CALL transfer_rs2pw(rden, rhob_r)
@@ -521,7 +519,7 @@ CONTAINS
       ! transform density to G space and add charge function
       NULLIFY (rhob_g)
       ALLOCATE (rhob_g)
-      CALL pw_pool_create_pw(pw_pool, rhob_g, use_data=COMPLEXDATA1D, &
+      CALL pw_pool%create_pw(rhob_g, use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
       ! update charge function
@@ -531,25 +529,25 @@ CONTAINS
 
       ! allocate intermediate arrays
       DO i = 1, 3
-         CALL pw_pool_create_pw(pw_pool, dphi_g(i), &
+         CALL pw_pool%create_pw(dphi_g(i), &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
       NULLIFY (phi_g)
       ALLOCATE (phi_g)
-      CALL pw_pool_create_pw(pw_pool, phi_g, &
+      CALL pw_pool%create_pw(phi_g, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_poisson_solve(poisson_env, rhob_g, vgc, phi_g, dphi_g)
 
       CALL rs_grid_create(rpot, rs_desc)
       CALL rs_grid_set_box(grid_spme, rs=rpot)
 
-      CALL pw_pool_give_back_pw(pw_pool, rhob_g)
+      CALL pw_pool%give_back_pw(rhob_g)
       DEALLOCATE (rhob_g)
 
       CALL rs_grid_zero(rpot)
       CALL pw_multiply_with(phi_g, green%p3m_charge)
       CALL pw_transfer(phi_g, rhob_r)
-      CALL pw_pool_give_back_pw(pw_pool, phi_g)
+      CALL pw_pool%give_back_pw(phi_g)
       DEALLOCATE (phi_g)
       CALL transfer_pw2rs(rpot, rhob_r)
 
@@ -562,10 +560,10 @@ CONTAINS
          CALL rs_grid_set_box(grid_spme, rs=drpot(i))
          CALL pw_multiply_with(dphi_g(i), green%p3m_charge)
          CALL pw_transfer(dphi_g(i), rhob_r)
-         CALL pw_pool_give_back_pw(pw_pool, dphi_g(i))
+         CALL pw_pool%give_back_pw(dphi_g(i))
          CALL transfer_pw2rs(drpot(i), rhob_r)
       END DO
-      CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      CALL pw_pool%give_back_pw(rhob_r)
       DEALLOCATE (rhob_r)
 
       !----------------- FORCE CALCULATION ----------------

--- a/src/ewald_pw_methods.F
+++ b/src/ewald_pw_methods.F
@@ -28,7 +28,6 @@ MODULE ewald_pw_methods
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_change
    USE pw_poisson_methods,              ONLY: pw_poisson_set
-! CJM, pw_poisson_rebuild
    USE pw_poisson_read_input,           ONLY: pw_poisson_read_parameters
    USE pw_poisson_types,                ONLY: do_ewald_ewald,&
                                               do_ewald_none,&

--- a/src/ewald_pw_methods.F
+++ b/src/ewald_pw_methods.F
@@ -33,9 +33,7 @@ MODULE ewald_pw_methods
                                               do_ewald_none,&
                                               do_ewald_pme,&
                                               do_ewald_spme,&
-                                              pw_poisson_create,&
                                               pw_poisson_parameter_type,&
-                                              pw_poisson_release,&
                                               pw_poisson_type
    USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
@@ -94,7 +92,11 @@ CONTAINS
                            dg=dg, poisson_env=poisson_env)
          CALL pw_grid_change(cell_hmat, pw_big_pool%pw_grid)
          CALL ewald_pw_rho0_setup(ewald_env, pw_big_pool%pw_grid, dg)
-         CALL pw_poisson_release(poisson_env)
+         IF (ASSOCIATED(poisson_env)) THEN
+            CALL poisson_env%release()
+            DEALLOCATE (poisson_env)
+            NULLIFY (poisson_env)
+         END IF
          CALL ewald_pw_set(ewald_pw, pw_big_pool=pw_big_pool, &
                            poisson_env=poisson_env)
       CASE (do_ewald_pme)
@@ -102,7 +104,8 @@ CONTAINS
                            pw_small_pool=pw_small_pool, dg=dg, &
                            poisson_env=poisson_env)
          IF (.NOT. ASSOCIATED(poisson_env)) THEN
-            CALL pw_poisson_create(poisson_env)
+            ALLOCATE (poisson_env)
+            CALL poisson_env%create()
             CALL ewald_pw_set(ewald_pw, poisson_env=poisson_env)
          END IF
          CALL pw_grid_change(cell_hmat, pw_big_pool%pw_grid)
@@ -115,7 +118,8 @@ CONTAINS
          CALL ewald_pw_get(ewald_pw, pw_big_pool=pw_big_pool, &
                            poisson_env=poisson_env)
          IF (.NOT. ASSOCIATED(poisson_env)) THEN
-            CALL pw_poisson_create(poisson_env)
+            ALLOCATE (poisson_env)
+            CALL poisson_env%create()
          END IF
          CALL pw_grid_change(cell_hmat, pw_big_pool%pw_grid)
          CALL ewald_pw_set(ewald_pw, pw_big_pool=pw_big_pool, &

--- a/src/ewald_pw_types.F
+++ b/src/ewald_pw_types.F
@@ -36,9 +36,14 @@ MODULE ewald_pw_types
                                               pw_grid_setup
    USE pw_poisson_methods,              ONLY: pw_poisson_set
    USE pw_poisson_read_input,           ONLY: pw_poisson_read_parameters
-   USE pw_poisson_types,                ONLY: &
-        do_ewald_ewald, do_ewald_none, do_ewald_pme, do_ewald_spme, pw_poisson_create, &
-        pw_poisson_parameter_type, pw_poisson_release, pw_poisson_retain, pw_poisson_type
+   USE pw_poisson_types,                ONLY: do_ewald_ewald,&
+                                              do_ewald_none,&
+                                              do_ewald_pme,&
+                                              do_ewald_spme,&
+                                              pw_poisson_create,&
+                                              pw_poisson_parameter_type,&
+                                              pw_poisson_release,&
+                                              pw_poisson_type
    USE pw_pool_types,                   ONLY: pw_pool_create,&
                                               pw_pool_p_type,&
                                               pw_pool_release,&
@@ -368,9 +373,12 @@ CONTAINS
          ewald_pw%dg => dg
       END IF
       IF (PRESENT(poisson_env)) THEN
-         IF (ASSOCIATED(poisson_env)) &
-            CALL pw_poisson_retain(poisson_env)
-         CALL pw_poisson_release(ewald_pw%poisson_env)
+         IF (ASSOCIATED(ewald_pw%poisson_env)) THEN
+         IF (.NOT. ASSOCIATED(ewald_pw%poisson_env, poisson_env)) THEN
+            CALL pw_poisson_release(ewald_pw%poisson_env)
+            DEALLOCATE (ewald_pw%poisson_env)
+         END IF
+         END IF
          ewald_pw%poisson_env => poisson_env
       END IF
 

--- a/src/ewald_pw_types.F
+++ b/src/ewald_pw_types.F
@@ -40,9 +40,7 @@ MODULE ewald_pw_types
                                               do_ewald_none,&
                                               do_ewald_pme,&
                                               do_ewald_spme,&
-                                              pw_poisson_create,&
                                               pw_poisson_parameter_type,&
-                                              pw_poisson_release,&
                                               pw_poisson_type
    USE pw_pool_types,                   ONLY: pw_pool_create,&
                                               pw_pool_p_type,&
@@ -107,7 +105,10 @@ CONTAINS
       CALL pw_pool_release(ewald_pw%pw_small_pool)
       CALL pw_pool_release(ewald_pw%pw_big_pool)
       CALL rs_grid_release_descriptor(ewald_pw%rs_desc)
-      CALL pw_poisson_release(ewald_pw%poisson_env)
+      IF (ASSOCIATED(ewald_pw%poisson_env)) THEN
+         CALL ewald_pw%poisson_env%release()
+         DEALLOCATE (ewald_pw%poisson_env)
+      END IF
       CALL dg_release(ewald_pw%dg)
       DEALLOCATE (ewald_pw%dg)
 
@@ -192,7 +193,8 @@ CONTAINS
          logger => cp_get_default_logger()
          output_unit = cp_print_key_unit_nr(logger, print_section, "", extension=".Log")
          IF (.NOT. ASSOCIATED(ewald_pw%poisson_env)) THEN
-            CALL pw_poisson_create(ewald_pw%poisson_env)
+            ALLOCATE (ewald_pw%poisson_env)
+            CALL ewald_pw%poisson_env%create()
          END IF
          CALL pw_grid_create(pw_small_grid, mp_comm_self)
          CALL pw_grid_create(pw_big_grid, para_env)
@@ -255,7 +257,8 @@ CONTAINS
          logger => cp_get_default_logger()
          output_unit = cp_print_key_unit_nr(logger, print_section, "", extension=".Log")
          IF (.NOT. ASSOCIATED(ewald_pw%poisson_env)) THEN
-            CALL pw_poisson_create(ewald_pw%poisson_env)
+            ALLOCATE (ewald_pw%poisson_env)
+            CALL ewald_pw%poisson_env%create()
          END IF
          CALL pw_grid_create(pw_big_grid, para_env)
          npts_s = gmax
@@ -375,7 +378,7 @@ CONTAINS
       IF (PRESENT(poisson_env)) THEN
          IF (ASSOCIATED(ewald_pw%poisson_env)) THEN
          IF (.NOT. ASSOCIATED(ewald_pw%poisson_env, poisson_env)) THEN
-            CALL pw_poisson_release(ewald_pw%poisson_env)
+            CALL ewald_pw%poisson_env%release()
             DEALLOCATE (ewald_pw%poisson_env)
          END IF
          END IF

--- a/src/ewald_pw_types.F
+++ b/src/ewald_pw_types.F
@@ -42,7 +42,6 @@ MODULE ewald_pw_types
    USE pw_pool_types,                   ONLY: pw_pool_create,&
                                               pw_pool_p_type,&
                                               pw_pool_release,&
-                                              pw_pool_retain,&
                                               pw_pool_type
    USE realspace_grid_types,            ONLY: &
         realspace_grid_desc_type, realspace_grid_input_type, realspace_grid_type, rs_grid_create, &
@@ -350,12 +349,12 @@ CONTAINS
       TYPE(pw_poisson_type), OPTIONAL, POINTER           :: poisson_env
 
       IF (PRESENT(pw_big_pool)) THEN
-         CALL pw_pool_retain(pw_big_pool)
+         CALL pw_big_pool%retain()
          CALL pw_pool_release(ewald_pw%pw_big_pool)
          ewald_pw%pw_big_pool => pw_big_pool
       END IF
       IF (PRESENT(pw_small_pool)) THEN
-         CALL pw_pool_retain(pw_small_pool)
+         CALL pw_small_pool%retain()
          CALL pw_pool_release(ewald_pw%pw_small_pool)
          ewald_pw%pw_small_pool => pw_small_pool
       END IF

--- a/src/ewald_spline_util.F
+++ b/src/ewald_spline_util.F
@@ -31,8 +31,6 @@ MODULE ewald_spline_util
                                               pw_grid_setup
    USE pw_methods,                      ONLY: pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create,&
-                                              pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
                                               pw_pool_type
    USE pw_spline_utils,                 ONLY: &
         Eval_Interp_Spl3_pbc, Eval_d_Interp_Spl3_pbc, find_coeffs, pw_spline_do_precond, &
@@ -88,7 +86,7 @@ CONTAINS
       INTEGER                                            :: bo(2, 3), iounit
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_logger_type), POINTER                      :: logger
-      TYPE(pw_type), POINTER                             :: pw
+      TYPE(pw_type)                                      :: pw
 
 !
 ! Setting Up Fit Procedure
@@ -97,7 +95,7 @@ CONTAINS
       CPASSERT(.NOT. ASSOCIATED(pw_grid))
       CPASSERT(.NOT. ASSOCIATED(pw_pool))
       CPASSERT(.NOT. ASSOCIATED(coeff))
-      NULLIFY (cell, pw)
+      NULLIFY (cell)
 
       CALL cell_create(cell, hmat=hmat, periodic=(/1, 1, 1/))
       CALL pw_grid_create(pw_grid, para_env, local=.TRUE.)
@@ -112,14 +110,13 @@ CONTAINS
                                         "")
       ! pw_pool initialized
       CALL pw_pool_create(pw_pool, pw_grid=pw_grid)
-      ALLOCATE (pw, coeff)
-      CALL pw_pool_create_pw(pw_pool, pw, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, coeff, use_data=REALDATA3D, in_space=REALSPACE)
+      ALLOCATE (coeff)
+      CALL pw_pool%create_pw(pw, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(coeff, use_data=REALDATA3D, in_space=REALSPACE)
       ! Evaluate function on grid
       CALL eval_pw_TabLR(pw, pw_pool, coeff, Lg, gx, gy, gz, hmat_mm=hmat, &
                          param_section=param_section, tag=tag)
-      CALL pw_pool_give_back_pw(pw_pool, pw)
-      DEALLOCATE (pw)
+      CALL pw_pool%give_back_pw(pw)
       CALL cell_release(cell)
 
    END SUBROUTINE Setup_Ewald_Spline
@@ -143,7 +140,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE eval_pw_TabLR(grid, pw_pool, TabLR, Lg, gx, gy, gz, hmat_mm, &
                             param_section, tag)
-      TYPE(pw_type), POINTER                             :: grid
+      TYPE(pw_type), INTENT(INOUT)                       :: grid
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       TYPE(pw_type), POINTER                             :: TabLR
       REAL(KIND=dp), DIMENSION(:), POINTER               :: Lg, gx, gy, gz

--- a/src/exstates_types.F
+++ b/src/exstates_types.F
@@ -20,8 +20,7 @@ MODULE exstates_types
    USE input_section_types,             ONLY: section_vals_type,&
                                               section_vals_val_get
    USE kinds,                           ONLY: dp
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_local_rho_types,              ONLY: local_rho_set_release,&
                                               local_rho_type
 #include "./base/base_uses.f90"
@@ -142,25 +141,25 @@ CONTAINS
 
       IF (ASSOCIATED(ex_env)) THEN
          IF (ASSOCIATED(ex_env%vh_rspace%pw_grid)) THEN
-            CALL pw_release(ex_env%vh_rspace)
+            CALL ex_env%vh_rspace%release()
          END IF
          IF (ASSOCIATED(ex_env%vxc_rspace)) THEN
             DO iab = 1, SIZE(ex_env%vxc_rspace)
-               CALL pw_release(ex_env%vxc_rspace(iab))
+               CALL ex_env%vxc_rspace(iab)%release()
             END DO
             DEALLOCATE (ex_env%vxc_rspace)
             NULLIFY (ex_env%vxc_rspace)
          END IF
          IF (ASSOCIATED(ex_env%vtau_rspace)) THEN
             DO iab = 1, SIZE(ex_env%vtau_rspace)
-               CALL pw_release(ex_env%vtau_rspace(iab))
+               CALL ex_env%vtau_rspace(iab)%release()
             END DO
             DEALLOCATE (ex_env%vtau_rspace)
             NULLIFY (ex_env%vtau_rspace)
          END IF
          IF (ASSOCIATED(ex_env%vadmm_rspace)) THEN
             DO iab = 1, SIZE(ex_env%vadmm_rspace)
-               CALL pw_release(ex_env%vadmm_rspace(iab))
+               CALL ex_env%vadmm_rspace(iab)%release()
             END DO
             DEALLOCATE (ex_env%vadmm_rspace)
             NULLIFY (ex_env%vadmm_rspace)

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -136,7 +136,6 @@ MODULE force_env_methods
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE pwdft_environment,               ONLY: pwdft_calc_energy_force
    USE pwdft_environment_types,         ONLY: pwdft_environment_type
@@ -1492,12 +1491,12 @@ CONTAINS
                CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
                CALL pw_pool_give_back_pw(auxbas_pw_pool, embed_pot)
                IF (ASSOCIATED(embed_pot)) THEN
-                  CALL pw_release(embed_pot)
+                  CALL embed_pot%release()
                   DEALLOCATE (embed_pot)
                END IF
                IF (ASSOCIATED(spin_embed_pot)) THEN
                   CALL pw_pool_give_back_pw(auxbas_pw_pool, spin_embed_pot)
-                  CALL pw_release(spin_embed_pot)
+                  CALL spin_embed_pot%release()
                   DEALLOCATE (spin_embed_pot)
                END IF
             END IF
@@ -1841,10 +1840,10 @@ CONTAINS
             END IF
 
             ! Release embedding potential for subsystem
-            CALL pw_release(embed_pot_subsys)
+            CALL embed_pot_subsys%release()
             DEALLOCATE (embed_pot_subsys)
             IF (opt_embed%open_shell_embed) THEN
-               CALL pw_release(spin_embed_pot_subsys)
+               CALL spin_embed_pot_subsys%release()
                DEALLOCATE (spin_embed_pot_subsys)
             END IF
 
@@ -1914,9 +1913,9 @@ CONTAINS
       END IF
 
       ! Give away plane waves pools
-      CALL pw_release(diff_rho_r)
+      CALL diff_rho_r%release()
       IF (opt_embed%open_shell_embed) THEN
-         CALL pw_release(diff_rho_spin)
+         CALL diff_rho_spin%release()
       END IF
 
       CALL cp_print_key_finished_output(output_unit, logger, force_env%force_env_section, &
@@ -1954,10 +1953,10 @@ CONTAINS
       CALL release_opt_embed(opt_embed)
 
       ! Deallocate embedding potential
-      CALL pw_release(embed_pot)
+      CALL embed_pot%release()
       DEALLOCATE (embed_pot)
       IF (opt_embed%open_shell_embed) THEN
-         CALL pw_release(spin_embed_pot)
+         CALL spin_embed_pot%release()
          DEALLOCATE (spin_embed_pot)
       END IF
 

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -131,9 +131,7 @@ MODULE force_env_methods
                                               pw_copy,&
                                               pw_integral_ab,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -1489,13 +1487,13 @@ CONTAINS
                CALL get_qs_env(qs_env=force_env%sub_force_env(iforce_eval)%force_env%qs_env, &
                                embed_pot=embed_pot, spin_embed_pot=spin_embed_pot, pw_env=pw_env)
                CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, embed_pot)
+               CALL auxbas_pw_pool%give_back_pw(embed_pot)
                IF (ASSOCIATED(embed_pot)) THEN
                   CALL embed_pot%release()
                   DEALLOCATE (embed_pot)
                END IF
                IF (ASSOCIATED(spin_embed_pot)) THEN
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, spin_embed_pot)
+                  CALL auxbas_pw_pool%give_back_pw(spin_embed_pot)
                   CALL spin_embed_pot%release()
                   DEALLOCATE (spin_embed_pot)
                END IF
@@ -1664,14 +1662,14 @@ CONTAINS
 
       ! Prepare the pw object to store density differences
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, diff_rho_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(diff_rho_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
       CALL pw_zero(diff_rho_r)
       IF (opt_embed%open_shell_embed) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, diff_rho_spin, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(diff_rho_spin, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(diff_rho_spin)
       END IF
 

--- a/src/hfx_exx.F
+++ b/src/hfx_exx.F
@@ -58,8 +58,7 @@ MODULE hfx_exx
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_scale
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -474,11 +473,11 @@ CONTAINS
 
       ! Clean
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace)
+      CALL auxbas_pw_pool%give_back_pw(vh_rspace)
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rspace(ispin))
+         CALL auxbas_pw_pool%give_back_pw(vxc_rspace(ispin))
          IF (ASSOCIATED(vtau_rspace)) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vtau_rspace(ispin))
          END IF
       END DO
       DEALLOCATE (vxc_rspace)
@@ -487,7 +486,7 @@ CONTAINS
       IF (dft_control%do_admm) THEN
          DO ispin = 1, nspins
             IF (ASSOCIATED(vadmm_rspace)) THEN
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, vadmm_rspace(ispin))
+               CALL auxbas_pw_pool%give_back_pw(vadmm_rspace(ispin))
             END IF
          END DO
          IF (ASSOCIATED(vadmm_rspace)) DEALLOCATE (vadmm_rspace)
@@ -680,13 +679,13 @@ CONTAINS
 
       IF (ASSOCIATED(v_rspace_aux_fit)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_aux_fit(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_rspace_aux_fit(ispin))
          END DO
          DEALLOCATE (v_rspace_aux_fit)
       END IF
       IF (ASSOCIATED(v_dummy)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_dummy(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_dummy(ispin))
          END DO
          DEALLOCATE (v_dummy)
       END IF
@@ -712,13 +711,13 @@ CONTAINS
 
       IF (ASSOCIATED(v_rspace)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_rspace(ispin))
          END DO
          DEALLOCATE (v_rspace)
       END IF
       IF (ASSOCIATED(v_dummy)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_dummy(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_dummy(ispin))
          END DO
          DEALLOCATE (v_dummy)
       END IF

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -52,8 +52,6 @@ MODULE hfx_pw_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_create,&
-                                              pw_release,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -188,12 +186,12 @@ CONTAINS
          END IF
 
          DO iorb_block = 1, blocksize
-            CALL pw_create(rho_i(iorb_block), rho_r%pw_grid, &
-                           use_data=REALDATA3D, &
-                           in_space=REALSPACE)
-            CALL pw_create(rho_j(iorb_block), rho_r%pw_grid, &
-                           use_data=REALDATA3D, &
-                           in_space=REALSPACE)
+            CALL rho_i(iorb_block)%create(rho_r%pw_grid, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
+            CALL rho_j(iorb_block)%create(rho_r%pw_grid, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
          END DO
 
          exchange_energy = 0.0_dp
@@ -259,8 +257,8 @@ CONTAINS
          END DO
 
          DO iorb_block = 1, blocksize
-            CALL pw_release(rho_i(iorb_block))
-            CALL pw_release(rho_j(iorb_block))
+            CALL rho_i(iorb_block)%release()
+            CALL rho_j(iorb_block)%release()
          END DO
 
          CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r)

--- a/src/hfx_pw_methods.F
+++ b/src/hfx_pw_methods.F
@@ -45,9 +45,7 @@ MODULE hfx_pw_methods
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -135,22 +133,22 @@ CONTAINS
          CALL cp_fm_get_info(mo_coeff, ncol_global=norb)
          blocksize = MAX(1, MIN(blocksize, norb))
 
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, pot_g, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_r, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_g, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(pot_g, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
 
          ALLOCATE (rho_i(blocksize))
          ALLOCATE (rho_j(blocksize))
 
-         CALL pw_pool_create_pw(auxbas_pw_pool, greenfn, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(greenfn, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
          ip_section => section_vals_get_subs_vals(hfx_section, "INTERACTION_POTENTIAL")
          CALL section_vals_get(ip_section, explicit=explicit)
          potential_type = do_potential_coulomb
@@ -261,10 +259,10 @@ CONTAINS
             CALL rho_j(iorb_block)%release()
          END DO
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, greenfn)
+         CALL auxbas_pw_pool%give_back_pw(rho_r)
+         CALL auxbas_pw_pool%give_back_pw(rho_g)
+         CALL auxbas_pw_pool%give_back_pw(pot_g)
+         CALL auxbas_pw_pool%give_back_pw(greenfn)
 
          iw = cp_print_key_unit_nr(logger, hfx_section, "HF_INFO", &
                                    extension=".scfLog")

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -45,9 +45,7 @@ MODULE hirshfeld_methods
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_integrate_function
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -294,7 +292,7 @@ CONTAINS
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r, rho_r_valid=rho_r_valid)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhonorm, use_data=REALDATA3D, in_space=REALSPACE)
       ! loop over spins
       DO is = 1, SIZE(rho_r)
          IF (rho_r_valid) THEN
@@ -306,7 +304,7 @@ CONTAINS
          CALL hirshfeld_integration(qs_env, hirshfeld_env, rhonorm, charges(:, is))
          charges(:, is) = charges(:, is)*hirshfeld_env%charges(:)
       END DO
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhonorm)
+      CALL auxbas_pw_pool%give_back_pw(rhonorm)
 
    END SUBROUTINE comp_hirshfeld_charges
 ! **************************************************************************************************
@@ -382,7 +380,7 @@ CONTAINS
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r, rho_r_valid=rho_r_valid)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhonorm, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhonorm, use_data=REALDATA3D, in_space=REALSPACE)
       !
       DO iloop = 1, maxloop
 
@@ -421,7 +419,7 @@ CONTAINS
 
       END DO
       !
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhonorm)
+      CALL auxbas_pw_pool%give_back_pw(rhonorm)
 
    END SUBROUTINE comp_hirshfeld_i_charges
 
@@ -523,7 +521,7 @@ CONTAINS
          DEALLOCATE (fnorm)
       END IF
       ALLOCATE (fnorm)
-      CALL pw_pool_create_pw(auxbas_pw_pool, fnorm, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(fnorm, use_data=REALDATA3D, in_space=REALSPACE)
       CALL set_hirshfeld_info(hirshfeld_env, fnorm=fnorm)
 
       CALL transfer_rs2pw(rs_rho, fnorm)

--- a/src/hirshfeld_methods.F
+++ b/src/hirshfeld_methods.F
@@ -50,7 +50,6 @@ MODULE hirshfeld_methods
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -520,7 +519,7 @@ CONTAINS
       NULLIFY (fnorm)
       CALL get_hirshfeld_info(hirshfeld_env, fnorm=fnorm)
       IF (ASSOCIATED(fnorm)) THEN
-         CALL pw_release(fnorm)
+         CALL fnorm%release()
          DEALLOCATE (fnorm)
       END IF
       ALLOCATE (fnorm)

--- a/src/hirshfeld_types.F
+++ b/src/hirshfeld_types.F
@@ -17,8 +17,7 @@ MODULE hirshfeld_types
    USE input_constants,                 ONLY: radius_default,&
                                               shape_function_gaussian
    USE kinds,                           ONLY: dp
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -112,7 +111,7 @@ CONTAINS
          END IF
 
          IF (ASSOCIATED(hirshfeld_env%fnorm)) THEN
-            CALL pw_release(hirshfeld_env%fnorm)
+            CALL hirshfeld_env%fnorm%release()
             DEALLOCATE (hirshfeld_env%fnorm)
          END IF
 

--- a/src/iao_analysis.F
+++ b/src/iao_analysis.F
@@ -84,9 +84,7 @@ MODULE iao_analysis
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -990,8 +988,8 @@ CONTAINS
       END DO
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       nspins = SIZE(iao_coef)
       nstart = MIN(1, n_rep)
@@ -1028,8 +1026,8 @@ CONTAINS
          END DO
       END DO
       DEALLOCATE (blk_sizes, first_bas)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
 
    END SUBROUTINE print_iao_cubes
 
@@ -1072,8 +1070,8 @@ CONTAINS
       CALL qs_subsys_get(subsys, particles=particles)
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       nspins = SIZE(ibo_coef)
       nstart = MIN(1, n_rep)
@@ -1108,8 +1106,8 @@ CONTAINS
          END DO
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
 
    END SUBROUTINE print_ibo_cubes
 

--- a/src/kg_correction.F
+++ b/src/kg_correction.F
@@ -40,8 +40,7 @@ MODULE kg_correction
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_integral_ab,&
                                               pw_scale
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -263,7 +262,7 @@ CONTAINS
          CALL integrate_v_rspace(v_rspace=vxc_rho(ispin), &
                                  pmat=density_matrix(ispin), hmat=ks_matrix(ispin), &
                                  qs_env=qs_env, calculate_forces=calc_force)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin))
+         CALL auxbas_pw_pool%give_back_pw(vxc_rho(ispin))
       END DO
       DEALLOCATE (vxc_rho)
       ekin_mol = -ekin_imol
@@ -337,7 +336,7 @@ CONTAINS
                                     calculate_forces=calc_force, &
                                     task_list_external=kg_env%subset(isub)%task_list)
             ! clean up vxc_rho
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vxc_rho(ispin))
             IF (ASSOCIATED(vxc_tau)) THEN
                CALL pw_scale(vxc_tau(ispin), -alpha*vxc_tau(ispin)%pw_grid%dvol)
                CALL integrate_v_rspace(v_rspace=vxc_tau(ispin), &
@@ -348,7 +347,7 @@ CONTAINS
                                        calculate_forces=calc_force, &
                                        task_list_external=kg_env%subset(isub)%task_list)
                ! clean up vxc_rho
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_tau(ispin))
+               CALL auxbas_pw_pool%give_back_pw(vxc_tau(ispin))
             END IF
          END DO
          DEALLOCATE (vxc_rho)
@@ -477,7 +476,7 @@ CONTAINS
          CALL pw_scale(vxc_rho(ispin), vxc_rho(ispin)%pw_grid%dvol)
          lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
          CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, lri_v_int, calc_force, "LRI_AUX")
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin))
+         CALL auxbas_pw_pool%give_back_pw(vxc_rho(ispin))
       END DO
       DEALLOCATE (vxc_rho)
       ekin_mol = -ekin_imol
@@ -507,7 +506,7 @@ CONTAINS
                                                lri_v_int, calc_force, &
                                                "LRI_AUX", atomlist=atomlist)
             ! clean up vxc_rho
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vxc_rho(ispin))
          END DO
          DEALLOCATE (vxc_rho)
 
@@ -720,7 +719,7 @@ CONTAINS
             lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
          END IF
          CALL integrate_v_rspace_one_center(vxc_rho(ispin), qs_env, lri_v_int, calc_force, "LRI_AUX")
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin))
+         CALL auxbas_pw_pool%give_back_pw(vxc_rho(ispin))
       END DO
 
       DEALLOCATE (vxc_rho)
@@ -789,7 +788,7 @@ CONTAINS
                                                lri_v_int, calc_force, &
                                                "LRI_AUX", atomlist=atomlist)
             ! clean up vxc_rho
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rho(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vxc_rho(ispin))
          END DO
          DEALLOCATE (vxc_rho)
 

--- a/src/library_tests.F
+++ b/src/library_tests.F
@@ -93,8 +93,6 @@ MODULE library_tests
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_create,&
-                                              pw_release,&
                                               pw_type
    USE realspace_grid_types,            ONLY: &
         realspace_grid_desc_type, realspace_grid_input_type, realspace_grid_type, rs_grid_create, &
@@ -744,7 +742,7 @@ CONTAINS
       CALL pw_grid_setup(box%hmat, grid, grid_span=FULLSPACE, npts=np, fft_usage=.TRUE., iounit=iw)
       no = grid%npts
 
-      CALL pw_create(ca, grid, REALDATA3D, REALSPACE)
+      CALL ca%create(grid, REALDATA3D, REALSPACE)
       CALL pw_zero(ca)
 
       ! .. rs input setting type
@@ -791,7 +789,7 @@ CONTAINS
       !cleanup
       CALL rs_grid_release(rs_grid)
       CALL rs_grid_release_descriptor(rs_desc)
-      CALL pw_release(ca)
+      CALL ca%release()
       CALL pw_grid_release(grid)
       CALL cell_release(box)
       CALL finalize_fft(para_env, wisdom_file=globenv%fftw_wisdom_file_name)
@@ -940,9 +938,9 @@ CONTAINS
             ! note that the number of grid points might be different from what the user requested (fft-able needed)
             no = grid%npts
 
-            CALL pw_create(ca, grid, COMPLEXDATA1D, RECIPROCALSPACE)
-            CALL pw_create(cb, grid, COMPLEXDATA3D, REALSPACE)
-            CALL pw_create(cc, grid, COMPLEXDATA1D, RECIPROCALSPACE)
+            CALL ca%create(grid, COMPLEXDATA1D, RECIPROCALSPACE)
+            CALL cb%create(grid, COMPLEXDATA3D, REALSPACE)
+            CALL cc%create(grid, COMPLEXDATA1D, RECIPROCALSPACE)
 
             ! initialize data
             CALL pw_zero(ca)
@@ -998,9 +996,9 @@ CONTAINS
             END IF
 
             ! done with these grids
-            CALL pw_release(ca)
-            CALL pw_release(cb)
-            CALL pw_release(cc)
+            CALL ca%release()
+            CALL cb%release()
+            CALL cc%release()
             CALL pw_grid_release(grid)
 
          END DO

--- a/src/localization_tb.F
+++ b/src/localization_tb.F
@@ -30,9 +30,7 @@ MODULE localization_tb
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -180,12 +178,12 @@ CONTAINS
 
             CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-            CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(wf_r, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(wf_g, &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
 
             NULLIFY (marked_states, qs_loc_env_homo)
             ALLOCATE (qs_loc_env_homo)
@@ -212,8 +210,8 @@ CONTAINS
             IF (qs_loc_env_homo%do_localize) THEN
                CALL loc_dipole(qs_env%input, dft_control, qs_loc_env_homo, logger, qs_env)
             END IF
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+            CALL auxbas_pw_pool%give_back_pw(wf_g)
+            CALL auxbas_pw_pool%give_back_pw(wf_r)
             CALL qs_loc_env_release(qs_loc_env_homo)
             DEALLOCATE (qs_loc_env_homo)
             IF (ASSOCIATED(marked_states)) THEN

--- a/src/minbas_wfn_analysis.F
+++ b/src/minbas_wfn_analysis.F
@@ -64,9 +64,7 @@ MODULE minbas_wfn_analysis
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -522,8 +520,8 @@ CONTAINS
       END DO
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! loop over list of atoms
       CALL section_vals_val_get(minbas_section, "ATOM_LIST", n_rep_val=n_rep)
@@ -563,8 +561,8 @@ CONTAINS
          END DO
       END IF
       DEALLOCATE (blk_sizes, first_bas)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
 
    END SUBROUTINE post_minbas_cubes
 

--- a/src/mixed_cdft_methods.F
+++ b/src/mixed_cdft_methods.F
@@ -95,9 +95,7 @@ MODULE mixed_cdft_methods
    USE pw_methods,                      ONLY: pw_copy,&
                                               pw_scale,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE
    USE qs_cdft_types,                   ONLY: cdft_control_type
@@ -653,8 +651,8 @@ CONTAINS
       ! In principle, we could reduce the memory footprint of becke_pot by only transferring the nonzero portion
       ! of the potential, but this would require a custom integrate_v_rspace
       ALLOCATE (cdft_control_target%group(1)%weight)
-      CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control_target%group(1)%weight, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(cdft_control_target%group(1)%weight, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_zero(cdft_control_target%group(1)%weight)
       ! Assemble the recved slices
       DO j = 1, SIZE(mixed_cdft%source_list)
@@ -947,21 +945,20 @@ CONTAINS
             ! Weight function
             DO igroup = 1, SIZE(cdft_control_target%group)
                ALLOCATE (cdft_control_target%group(igroup)%weight)
-               CALL pw_pool_create_pw(auxbas_pw_pool_target, &
-                                      cdft_control_target%group(igroup)%weight, &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool_target%create_pw(cdft_control_target%group(igroup)%weight, &
+                                                    use_data=REALDATA3D, in_space=REALSPACE)
                ! We have ensured that the grids are consistent => no danger in using explicit copy
                CALL pw_copy(cdft_control_source%group(igroup)%weight, cdft_control_target%group(igroup)%weight)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%group(igroup)%weight)
+               CALL auxbas_pw_pool_source%give_back_pw(cdft_control_source%group(igroup)%weight)
                DEALLOCATE (cdft_control_source%group(igroup)%weight)
             END DO
             ! Cavity
             IF (cdft_control_source%type == outer_scf_becke_constraint) THEN
                IF (cdft_control_source%becke_control%cavity_confine) THEN
-                  CALL pw_pool_create_pw(auxbas_pw_pool_target, cdft_control_target%becke_control%cavity, &
-                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool_target%create_pw(cdft_control_target%becke_control%cavity, &
+                                                       use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_copy(cdft_control_source%becke_control%cavity, cdft_control_target%becke_control%cavity)
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%becke_control%cavity)
+                  CALL auxbas_pw_pool_source%give_back_pw(cdft_control_source%becke_control%cavity)
                END IF
             END IF
             ! Gradients
@@ -987,11 +984,10 @@ CONTAINS
                IF (.NOT. ASSOCIATED(cdft_control_target%charge)) &
                   ALLOCATE (cdft_control_target%charge(cdft_control_target%natoms))
                DO iatom = 1, cdft_control_target%natoms
-                  CALL pw_pool_create_pw(auxbas_pw_pool_target, &
-                                         cdft_control_target%charge(iatom), &
-                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool_target%create_pw(cdft_control_target%charge(iatom), &
+                                                       use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_copy(cdft_control_source%charge(iatom), cdft_control_target%charge(iatom))
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool_source, cdft_control_source%charge(iatom))
+                  CALL auxbas_pw_pool_source%give_back_pw(cdft_control_source%charge(iatom))
                END DO
             END IF
             ! Set some flags so the weight is not rebuilt during SCF
@@ -2585,8 +2581,8 @@ CONTAINS
             DEALLOCATE (cores)
          END DO
          DEALLOCATE (pab)
-         CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%becke_control%cavity, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(cdft_control%becke_control%cavity, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL transfer_rs2pw(rs_cavity, cdft_control%becke_control%cavity)
          CALL hfun_zero(cdft_control%becke_control%cavity%cr3d, &
                         cdft_control%becke_control%eps_cavity, &
@@ -2672,7 +2668,7 @@ CONTAINS
                                                                        bo(1, 2) + offset_dlb:bo(2, 2), &
                                                                        bo_conf(1, 3):bo_conf(2, 3))
          END IF
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%becke_control%cavity)
+         CALL auxbas_pw_pool%give_back_pw(cdft_control%becke_control%cavity)
       END IF
       IF (mixed_cdft%is_special) THEN
          DO i = 1, SIZE(mixed_cdft%dest_list)

--- a/src/mp2_cphf.F
+++ b/src/mp2_cphf.F
@@ -85,9 +85,7 @@ MODULE mp2_cphf
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -1506,8 +1504,8 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(vhxc_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
       IF (use_virial) h_stress = virial%pv_virial
       IF (debug_forces) THEN
          deb(1:3) = force(1)%rho_elec(1:3, 1)
@@ -1575,13 +1573,13 @@ CONTAINS
          END DO
       END IF
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rspace(ispin))
+         CALL auxbas_pw_pool%give_back_pw(vxc_rspace(ispin))
          IF (ASSOCIATED(vtau_rspace)) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vtau_rspace(ispin))
          END IF
       END DO
       DEALLOCATE (vxc_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace)
+      CALL auxbas_pw_pool%give_back_pw(vhxc_rspace)
       IF (ASSOCIATED(vtau_rspace)) DEALLOCATE (vtau_rspace)
 
       DO ispin = 1, nspins
@@ -1594,15 +1592,15 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! get some of the grids ready
-      CALL pw_pool_create_pw(auxbas_pw_pool, pot_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pot_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pot_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(pot_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_tot_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       CALL pw_zero(rho_tot_g)
 
@@ -1614,9 +1612,9 @@ CONTAINS
       IF (use_virial) THEN
          ALLOCATE (dvg(3))
          DO idir = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, dvg(idir), &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(dvg(idir), &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
          END DO
       END IF
 
@@ -1638,14 +1636,14 @@ CONTAINS
             IF (iounit > 0) WRITE (iounit, "(T3,A,T33,F16.8)") "DEBUG VIRIAL:: core      ", e_dummy
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace)
+      CALL auxbas_pw_pool%give_back_pw(vh_rspace)
 
       IF (use_virial) THEN
          ! update virial if necessary with the volume term
          ! first create pw auxiliary stuff
-         CALL pw_pool_create_pw(auxbas_pw_pool, temp_pw_g, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(temp_pw_g, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
 
          ! make a copy of the MP2 density in G space
          CALL pw_copy(rho_tot_g, temp_pw_g)
@@ -1676,9 +1674,9 @@ CONTAINS
          IF (debug_forces .AND. iounit > 0) WRITE (iounit, "(T3,A,T33,F16.8)") "DEBUG VIRIAL:: Hartree  ", third_tr(h_stress)
 
          ! free stuff
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, temp_pw_g)
+         CALL auxbas_pw_pool%give_back_pw(temp_pw_g)
          DO idir = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvg(idir))
+            CALL auxbas_pw_pool%give_back_pw(dvg(idir))
          END DO
          DEALLOCATE (dvg)
 
@@ -1877,7 +1875,7 @@ CONTAINS
                                              calculate_forces=.TRUE., basis_type="AUX_FIT", &
                                              task_list_external=task_list_aux_fit, pmat=rho_ao_aux(ispin))
                   END IF
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, vadmm_rspace(ispin))
+                  CALL auxbas_pw_pool%give_back_pw(vadmm_rspace(ispin))
                END DO
                IF (use_virial) virial%pv_ehartree = virial%pv_ehartree + (virial%pv_virial - h_stress)
                DEALLOCATE (vadmm_rspace)
@@ -1965,9 +1963,9 @@ CONTAINS
          END IF
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_g)
+      CALL auxbas_pw_pool%give_back_pw(pot_r)
+      CALL auxbas_pw_pool%give_back_pw(pot_g)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_g)
 
       ! Release linres stuff
       CALL p_env_release(p_env)

--- a/src/mp2_eri_gpw.F
+++ b/src/mp2_eri_gpw.F
@@ -44,9 +44,7 @@ MODULE mp2_eri_gpw
         pw_scale, pw_transfer, pw_truncated, pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -1028,18 +1026,18 @@ CONTAINS
                                  pw_env_external=pw_env_sub, sab_orb_external=sab_orb_sub)
 
       ! get some of the grids ready
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pot_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, psi_L, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pot_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(psi_L, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       ! run the FFT once, to set up buffers and to take into account the memory
       CALL pw_zero(rho_r)
@@ -1084,10 +1082,10 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       ! and now free the whole lot
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L)
+      CALL auxbas_pw_pool%give_back_pw(rho_r)
+      CALL auxbas_pw_pool%give_back_pw(rho_g)
+      CALL auxbas_pw_pool%give_back_pw(pot_g)
+      CALL auxbas_pw_pool%give_back_pw(psi_L)
 
       CALL deallocate_task_list(task_list_sub)
       CALL pw_env_release(pw_env_sub, para_env=para_env_sub)

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -50,7 +50,6 @@ MODULE mp2_gpw_method
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
    USE qs_environment_types,            ONLY: qs_environment_type
@@ -545,7 +544,7 @@ CONTAINS
       END DO
 
       DO i = my_I_occupied_start, my_I_occupied_end
-         CALL pw_release(psi_i(i))
+         CALL psi_i(i)%release()
       END DO
       DEALLOCATE (psi_i)
 

--- a/src/mp2_gpw_method.F
+++ b/src/mp2_gpw_method.F
@@ -46,8 +46,7 @@ MODULE mp2_gpw_method
                                               pw_transfer,&
                                               pw_zero
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -361,9 +360,9 @@ CONTAINS
 
       ALLOCATE (psi_i(my_I_occupied_start:my_I_occupied_end))
       DO i = my_I_occupied_start, my_I_occupied_end
-         CALL pw_pool_create_pw(auxbas_pw_pool, psi_i(i), &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(psi_i(i), &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL calculate_wavefunction(mo_coeff, i, psi_i(i), rho_g, atomic_kind_set, &
                                      qs_kind_set, cell, dft_control, particle_set, &
                                      pw_env_sub, external_vector=my_Cocc(:, i - my_I_occupied_start + 1))

--- a/src/mp2_ri_grad.F
+++ b/src/mp2_ri_grad.F
@@ -57,9 +57,7 @@ MODULE mp2_ri_grad
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_type
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
                                               pw_type
@@ -343,13 +341,13 @@ CONTAINS
          ! for calculate the MP2-volume contribution to the virial
          ! (hartree potential derivatives)
          IF (use_virial) THEN
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_copy, &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_g_copy, &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
             DO i = 1, 3
-               CALL pw_pool_create_pw(auxbas_pw_pool, dvg(i), &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(dvg(i), &
+                                             use_data=COMPLEXDATA1D, &
+                                             in_space=RECIPROCALSPACE)
             END DO
          END IF
 
@@ -407,9 +405,9 @@ CONTAINS
          DEALLOCATE (atom_of_kind)
 
          IF (use_virial) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_copy)
+            CALL auxbas_pw_pool%give_back_pw(rho_g_copy)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, dvg(i))
+               CALL auxbas_pw_pool%give_back_pw(dvg(i))
             END DO
          END IF
 

--- a/src/negf_env_types.F
+++ b/src/negf_env_types.F
@@ -53,9 +53,7 @@ MODULE negf_env_types
    USE particle_types,                  ONLY: particle_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -797,13 +795,13 @@ CONTAINS
          CALL dbcsr_copy(matrix_b=hmat%matrix, matrix_a=matrix_s_kp(1, 1)%matrix)
          CALL dbcsr_set(hmat%matrix, 0.0_dp)
 
-         CALL pw_pool_create_pw(pw_pool, v_hartree, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(v_hartree, use_data=REALDATA3D, in_space=REALSPACE)
          CALL negf_env_init_v_hartree(v_hartree, negf_env%contacts, negf_control%contacts)
 
          CALL integrate_v_rspace(v_rspace=v_hartree, hmat=hmat, qs_env=qs_env, &
                                  calculate_forces=.FALSE., compute_tau=.FALSE., gapw=.FALSE.)
 
-         CALL pw_pool_give_back_pw(pw_pool, v_hartree)
+         CALL pw_pool%give_back_pw(v_hartree)
 
          CALL negf_copy_sym_dbcsr_to_fm_submat(matrix=hmat%matrix, &
                                                fm=negf_env%v_hartree_s, &

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -74,7 +74,6 @@ MODULE optimize_embedding_potential
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_resp_all,&
                                               calculate_wavefunction
@@ -908,7 +907,7 @@ CONTAINS
 
       IF (ASSOCIATED(opt_embed%prev_subsys_dens)) THEN
          DO i_dens = 1, SIZE(opt_embed%prev_subsys_dens)
-            CALL pw_release(opt_embed%prev_subsys_dens(i_dens))
+            CALL opt_embed%prev_subsys_dens(i_dens)%release()
          END DO
          DEALLOCATE (opt_embed%prev_subsys_dens)
       END IF
@@ -917,26 +916,26 @@ CONTAINS
       DEALLOCATE (opt_embed%all_nspins)
 
       IF (ASSOCIATED(opt_embed%const_pot)) THEN
-         CALL pw_release(opt_embed%const_pot)
+         CALL opt_embed%const_pot%release()
          DEALLOCATE (opt_embed%const_pot)
       END IF
 
       IF (ASSOCIATED(opt_embed%pot_diff)) THEN
-         CALL pw_release(opt_embed%pot_diff)
+         CALL opt_embed%pot_diff%release()
          DEALLOCATE (opt_embed%pot_diff)
       END IF
 
       IF (ASSOCIATED(opt_embed%prev_embed_pot)) THEN
-         CALL pw_release(opt_embed%prev_embed_pot)
+         CALL opt_embed%prev_embed_pot%release()
          DEALLOCATE (opt_embed%prev_embed_pot)
       END IF
       IF (ASSOCIATED(opt_embed%prev_spin_embed_pot)) THEN
-         CALL pw_release(opt_embed%prev_spin_embed_pot)
+         CALL opt_embed%prev_spin_embed_pot%release()
          DEALLOCATE (opt_embed%prev_spin_embed_pot)
       END IF
       IF (ASSOCIATED(opt_embed%v_w)) THEN
          DO i_spin = 1, SIZE(opt_embed%v_w)
-            CALL pw_release(opt_embed%v_w(i_spin))
+            CALL opt_embed%v_w(i_spin)%release()
          END DO
          DEALLOCATE (opt_embed%v_w)
       END IF
@@ -1030,9 +1029,9 @@ CONTAINS
       CALL pw_copy(v_resp_rspace, v_rspace)
 
       ! Release plane waves
-      CALL pw_release(v_resp_gspace)
-      CALL pw_release(v_resp_rspace)
-      CALL pw_release(rho_resp)
+      CALL v_resp_gspace%release()
+      CALL v_resp_rspace%release()
+      CALL rho_resp%release()
 
       ! Deallocate map_index array
       DEALLOCATE (map_index)
@@ -2668,15 +2667,15 @@ CONTAINS
          CALL pw_scale(spin_embed_pot, a=0.5_dp)
 
          DO i_spin = 1, nspins
-            CALL pw_release(rho_n_1(i_spin))
-            CALL pw_release(temp_embed_pot(i_spin))
+            CALL rho_n_1(i_spin)%release()
+            CALL temp_embed_pot(i_spin)%release()
          END DO
          DEALLOCATE (rho_n_1)
          DEALLOCATE (temp_embed_pot)
       END IF
 
       DO i_spin = 1, nspins
-         CALL pw_release(new_embed_pot(i_spin))
+         CALL new_embed_pot(i_spin)%release()
       END DO
 
       DEALLOCATE (new_embed_pot)
@@ -2863,16 +2862,16 @@ CONTAINS
             CALL pw_scale(spin_embed_pot, a=0.5_dp)
 
             DO i_spin = 1, nspins
-               CALL pw_release(temp_embed_pot(i_spin))
+               CALL temp_embed_pot(i_spin)%release()
             END DO
             DEALLOCATE (temp_embed_pot)
 
          END IF
 
          DO i_spin = 1, nspins
-            CALL pw_release(curr_rho(i_spin))
-            CALL pw_release(new_embed_pot(i_spin))
-            CALL pw_release(v_w(i_spin))
+            CALL curr_rho(i_spin)%release()
+            CALL new_embed_pot(i_spin)%release()
+            CALL v_w(i_spin)%release()
          END DO
 
          DEALLOCATE (new_embed_pot)
@@ -3030,7 +3029,7 @@ CONTAINS
       CALL xc_rho_set_release(rho_set, pw_pool=auxbas_pw_pool)
 
       DO i_spin = 1, nspins
-         CALL pw_release(rho_g(i_spin))
+         CALL rho_g(i_spin)%release()
       END DO
       DEALLOCATE (rho_g)
 
@@ -3370,9 +3369,9 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%QS%OPT_EMBED%WRITE_SIMPLE_GRID")
          ! Release structures
-         CALL pw_release(pot_alpha)
+         CALL pot_alpha%release()
          IF (open_shell_embed) THEN
-            CALL pw_release(pot_beta)
+            CALL pot_beta%release()
          END IF
 
       END IF

--- a/src/optimize_embedding_potential.F
+++ b/src/optimize_embedding_potential.F
@@ -67,9 +67,7 @@ MODULE optimize_embedding_potential
         pw_transfer, pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -234,18 +232,18 @@ CONTAINS
       ! Create embedding potential and set to zero
       NULLIFY (embed_pot)
       ALLOCATE (embed_pot)
-      CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(embed_pot, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
       CALL pw_zero(embed_pot)
 
       ! Spin embedding potential if asked
       IF (open_shell_embed) THEN
          NULLIFY (spin_embed_pot)
          ALLOCATE (spin_embed_pot)
-         CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(spin_embed_pot, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(spin_embed_pot)
       END IF
 
@@ -253,9 +251,9 @@ CONTAINS
       IF (Coulomb_guess) THEN
          NULLIFY (pot_diff)
          ALLOCATE (pot_diff)
-         CALL pw_pool_create_pw(auxbas_pw_pool, pot_diff, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(pot_diff, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(pot_diff)
       END IF
 
@@ -264,9 +262,9 @@ CONTAINS
          ! Now the constant potential is the Coulomb one
          NULLIFY (const_pot)
          ALLOCATE (const_pot)
-         CALL pw_pool_create_pw(auxbas_pw_pool, const_pot, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(const_pot, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(const_pot)
       END IF
 
@@ -399,9 +397,9 @@ CONTAINS
       size_prev_dens = SUM(opt_embed%all_nspins(1:(SIZE(opt_embed%all_nspins) - 1)))
       ALLOCATE (opt_embed%prev_subsys_dens(size_prev_dens))
       DO i_dens = 1, size_prev_dens
-         CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_subsys_dens(i_dens), &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(opt_embed%prev_subsys_dens(i_dens), &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(opt_embed%prev_subsys_dens(i_dens))
       END DO
       ALLOCATE (opt_embed%max_subsys_dens_diff(size_prev_dens))
@@ -421,16 +419,16 @@ CONTAINS
       IF (opt_embed%fab) THEN
          NULLIFY (opt_embed%prev_embed_pot)
          ALLOCATE (opt_embed%prev_embed_pot)
-         CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_embed_pot, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(opt_embed%prev_embed_pot, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(opt_embed%prev_embed_pot)
          IF (opt_embed%open_shell_embed) THEN
             NULLIFY (opt_embed%prev_spin_embed_pot)
             ALLOCATE (opt_embed%prev_spin_embed_pot)
-            CALL pw_pool_create_pw(auxbas_pw_pool, opt_embed%prev_spin_embed_pot, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(opt_embed%prev_spin_embed_pot, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(opt_embed%prev_spin_embed_pot)
          END IF
       END IF
@@ -653,15 +651,15 @@ CONTAINS
       !CALL get_qs_env(qs_env=qs_env, &
       !                embed_pot=embed_pot)
       ALLOCATE (embed_pot)
-      CALL pw_pool_create_pw(auxbas_pw_pool_subsys, embed_pot, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool_subsys%create_pw(embed_pot, &
+                                           use_data=REALDATA3D, &
+                                           in_space=REALSPACE)
       IF (open_shell_embed) THEN
          ! Create spin embedding potential
          ALLOCATE (spin_embed_pot)
-         CALL pw_pool_create_pw(auxbas_pw_pool_subsys, spin_embed_pot, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool_subsys%create_pw(spin_embed_pot, &
+                                              use_data=REALDATA3D, &
+                                              in_space=REALSPACE)
       END IF
       ! Read the cubes
       CALL read_embed_pot_cube(embed_pot, spin_embed_pot, qs_section, open_shell_embed)
@@ -995,19 +993,17 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_resp_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_resp_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_resp_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_resp_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_resp, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_resp, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       ! Calculate charge density
       CALL pw_zero(rho_resp)
@@ -1073,9 +1069,9 @@ CONTAINS
       ! Create embedding potential and set to zero
       NULLIFY (embed_pot_subsys)
       ALLOCATE (embed_pot_subsys)
-      CALL pw_pool_create_pw(auxbas_pw_pool_subsys, embed_pot_subsys, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool_subsys%create_pw(embed_pot_subsys, &
+                                           use_data=REALDATA3D, &
+                                           in_space=REALSPACE)
 
       ! Hard copy the grid
       CALL pw_copy(embed_pot, embed_pot_subsys)
@@ -1083,9 +1079,9 @@ CONTAINS
       IF (open_shell_embed) THEN
          NULLIFY (spin_embed_pot_subsys)
          ALLOCATE (spin_embed_pot_subsys)
-         CALL pw_pool_create_pw(auxbas_pw_pool_subsys, spin_embed_pot_subsys, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool_subsys%create_pw(spin_embed_pot_subsys, &
+                                              use_data=REALDATA3D, &
+                                              in_space=REALSPACE)
          ! Hard copy the grid
          IF (change_spin_sign) THEN
             CALL pw_axpy(spin_embed_pot, spin_embed_pot_subsys, -1.0_dp, 0.0_dp, allow_noncompatible_grids=.TRUE.)
@@ -1413,21 +1409,21 @@ CONTAINS
       ! Get some of the grids ready
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, potential_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(potential_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, dr2_pot, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(dr2_pot, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, grid_reg, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(grid_reg, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, grid_reg_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(grid_reg_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
       CALL pw_zero(grid_reg_g)
 
       ! Transfer potential to the reciprocal space
@@ -1448,17 +1444,17 @@ CONTAINS
       ! Second, the contribution to the functional
       !
       DO i = 1, 3
-         CALL pw_pool_create_pw(auxbas_pw_pool, dpot(i), &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, dpot_g(i), &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(dpot(i), &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(dpot_g(i), &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
       END DO
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, square_norm_dpot, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(square_norm_dpot, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       DO i = 1, 3
          n(:) = 0
@@ -1490,14 +1486,14 @@ CONTAINS
       reg_term = 2*lambda*pw_integrate_function(fun=square_norm_dpot)
 
       ! Release
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, potential_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, dr2_pot)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, grid_reg)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, grid_reg_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, square_norm_dpot)
+      CALL auxbas_pw_pool%give_back_pw(potential_g)
+      CALL auxbas_pw_pool%give_back_pw(dr2_pot)
+      CALL auxbas_pw_pool%give_back_pw(grid_reg)
+      CALL auxbas_pw_pool%give_back_pw(grid_reg_g)
+      CALL auxbas_pw_pool%give_back_pw(square_norm_dpot)
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dpot(i))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dpot_g(i))
+         CALL auxbas_pw_pool%give_back_pw(dpot(i))
+         CALL auxbas_pw_pool%give_back_pw(dpot_g(i))
       END DO
 
    END SUBROUTINE grid_regularize
@@ -1795,13 +1791,13 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
       ! get some of the grids ready
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, psi_L, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(psi_L, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       ! Create wf_vector and auxiliary wave functions
       ALLOCATE (wf_vector(dimen_aux))
@@ -1913,8 +1909,8 @@ CONTAINS
 
       ! Deallocate memory and release objects
       DEALLOCATE (wf_vector)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, psi_L)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
+      CALL auxbas_pw_pool%give_back_pw(psi_L)
+      CALL auxbas_pw_pool%give_back_pw(rho_g)
 
       IF (open_shell_embed) THEN
          CALL cp_fm_release(embed_pot_coef_spin)
@@ -2548,9 +2544,9 @@ CONTAINS
       NULLIFY (new_embed_pot)
       ALLOCATE (new_embed_pot(nspins))
       DO i_spin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, new_embed_pot(i_spin), &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(new_embed_pot(i_spin), &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(new_embed_pot(i_spin))
       END DO
 
@@ -2584,13 +2580,13 @@ CONTAINS
          NULLIFY (temp_embed_pot)
          ALLOCATE (temp_embed_pot(nspins))
          DO i_spin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_n_1(i_spin), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_n_1(i_spin), &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(rho_n_1(i_spin))
-            CALL pw_pool_create_pw(auxbas_pw_pool, temp_embed_pot(i_spin), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(temp_embed_pot(i_spin), &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(temp_embed_pot(i_spin))
          END DO
          CALL pw_copy(diff_rho_r, rho_n_1(1))
@@ -2741,9 +2737,9 @@ CONTAINS
          NULLIFY (v_w_ref)
          ALLOCATE (v_w_ref(nspins))
          DO i_spin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_w_ref(i_spin), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_w_ref(i_spin), &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
          END DO
          CALL Von_Weizsacker(rho_r_ref, v_w_ref, qs_env, vw_cutoff, vw_smooth_cutoff_range)
          ! For the first step previous are set to current
@@ -2765,19 +2761,19 @@ CONTAINS
          NULLIFY (curr_rho)
          ALLOCATE (curr_rho(nspins))
          DO i_spin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, new_embed_pot(i_spin), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(new_embed_pot(i_spin), &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(new_embed_pot(i_spin))
 
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_w(i_spin), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_w(i_spin), &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(v_w(i_spin))
 
-            CALL pw_pool_create_pw(auxbas_pw_pool, curr_rho(i_spin), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(curr_rho(i_spin), &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(curr_rho(i_spin))
          END DO
 
@@ -2821,9 +2817,9 @@ CONTAINS
             ! Reconstruct corrent spin components of the potential
             ALLOCATE (temp_embed_pot(nspins))
             DO i_spin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, temp_embed_pot(i_spin), &
-                                      use_data=REALDATA3D, &
-                                      in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(temp_embed_pot(i_spin), &
+                                             use_data=REALDATA3D, &
+                                             in_space=REALSPACE)
                CALL pw_zero(temp_embed_pot(i_spin))
             END DO
             CALL pw_copy(embed_pot, temp_embed_pot(1))
@@ -2929,9 +2925,9 @@ CONTAINS
       NULLIFY (rho_g)
       ALLOCATE (rho_g(nspins))
       DO i_spin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(i_spin), &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_g(i_spin), &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
          CALL pw_transfer(rho_r(i_spin), rho_g(i_spin))
       END DO
 
@@ -3332,17 +3328,17 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
          ! Create embedding potential and set to zero
-         CALL pw_pool_create_pw(auxbas_pw_pool, pot_alpha, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(pot_alpha, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(pot_alpha)
 
          CALL pw_copy(embed_pot, pot_alpha)
 
          IF (open_shell_embed) THEN
-            CALL pw_pool_create_pw(auxbas_pw_pool, pot_beta, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(pot_beta, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_copy(embed_pot, pot_beta)
             ! Add spin potential to the alpha, and subtract from the beta part
             CALL pw_axpy(embed_pot_spin, pot_alpha, 1.0_dp)

--- a/src/pme.F
+++ b/src/pme.F
@@ -43,9 +43,7 @@ MODULE pme
                                               pw_transfer
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -167,10 +165,10 @@ CONTAINS
                                         allocate_centre=.TRUE.)
       END IF
 
-      CALL pw_pool_create_pw(pw_small_pool, rhos1, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_small_pool, rhos2, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_small_pool%create_pw(rhos1, &
+                                   use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_small_pool%create_pw(rhos2, &
+                                   use_data=REALDATA3D, in_space=REALSPACE)
 
       ALLOCATE (rden)
       CALL rs_grid_create(rden, rs_desc)
@@ -244,20 +242,20 @@ CONTAINS
          END DO
       END IF
 
-      CALL pw_pool_create_pw(pw_big_pool, rhob_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_big_pool%create_pw(rhob_r, use_data=REALDATA3D, in_space=REALSPACE)
       CALL transfer_rs2pw(rden, rhob_r)
 
       !-------------- ELECTROSTATIC CALCULATION -----------
 
       ! allocate intermediate arrays
       DO i = 1, 3
-         CALL pw_pool_create_pw(pw_big_pool, dphi_g(i), &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL pw_big_pool%create_pw(dphi_g(i), &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
       END DO
-      CALL pw_pool_create_pw(pw_big_pool, phi_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL pw_big_pool%create_pw(phi_r, &
+                                 use_data=REALDATA3D, &
+                                 in_space=REALSPACE)
 
       CALL pw_poisson_solve(poisson_env, rhob_r, vg_coulomb, phi_r, dphi_g, h_stress)
 
@@ -298,12 +296,12 @@ CONTAINS
             END IF
          END DO
          IF (atprop%stress) THEN
-            CALL pw_pool_create_pw(pw_big_pool, phi_g, &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
-            CALL pw_pool_create_pw(pw_big_pool, rhob_g, &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL pw_big_pool%create_pw(phi_g, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
+            CALL pw_big_pool%create_pw(rhob_g, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
             ffa = (0.5_dp/dg_rho0%zet(1))**2
             ffb = 1.0_dp/fourpi
             DO i = 1, 3
@@ -340,14 +338,14 @@ CONTAINS
                   END DO
                END DO
             END DO
-            CALL pw_pool_give_back_pw(pw_big_pool, phi_g)
-            CALL pw_pool_give_back_pw(pw_big_pool, rhob_g)
+            CALL pw_big_pool%give_back_pw(phi_g)
+            CALL pw_big_pool%give_back_pw(rhob_g)
          END IF
          CALL rs_grid_release(rpot)
          DEALLOCATE (rpot)
       END IF
 
-      CALL pw_pool_give_back_pw(pw_big_pool, phi_r)
+      CALL pw_big_pool%give_back_pw(phi_r)
 
       !---------- END OF ELECTROSTATIC CALCULATION --------
 
@@ -371,11 +369,11 @@ CONTAINS
          CALL rs_grid_create(drpot(i), rs_desc)
          CALL rs_grid_set_box(grid_b, rs=drpot(i))
          CALL pw_transfer(dphi_g(i), rhob_r)
-         CALL pw_pool_give_back_pw(pw_big_pool, dphi_g(i))
+         CALL pw_big_pool%give_back_pw(dphi_g(i))
          CALL transfer_pw2rs(drpot(i), rhob_r)
       END DO
 
-      CALL pw_pool_give_back_pw(pw_big_pool, rhob_r)
+      CALL pw_big_pool%give_back_pw(rhob_r)
 
       !----------------- FORCE CALCULATION ----------------
 
@@ -475,8 +473,8 @@ CONTAINS
          CALL rs_grid_release(drpot(i))
       END DO
 
-      CALL pw_pool_give_back_pw(pw_small_pool, rhos1)
-      CALL pw_pool_give_back_pw(pw_small_pool, rhos2)
+      CALL pw_small_pool%give_back_pw(rhos1)
+      CALL pw_small_pool%give_back_pw(rhos2)
       CALL structure_factor_deallocate(exp_igr)
 
       CALL timestop(handle)

--- a/src/post_scf_bandstructure_utils.F
+++ b/src/post_scf_bandstructure_utils.F
@@ -80,9 +80,7 @@ MODULE post_scf_bandstructure_utils
                                               post_scf_bandstructure_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -2136,8 +2134,8 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, LDOS_3d, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(LDOS_3d, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       i_x_start = LBOUND(LDOS_3d%cr3d, 1)
       i_x_end = UBOUND(LDOS_3d%cr3d, 1)
@@ -2243,8 +2241,8 @@ CONTAINS
       ! set back nimages
       dft_control%nimages = nimages
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, LDOS_3d)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
+      CALL auxbas_pw_pool%give_back_pw(LDOS_3d)
+      CALL auxbas_pw_pool%give_back_pw(rho_g)
 
       CALL cp_cfm_release(cfm_work)
       CALL cp_cfm_release(cfm_weighted_dm_ikp)

--- a/src/pw/dg_rho0_types.F
+++ b/src/pw/dg_rho0_types.F
@@ -20,8 +20,6 @@ MODULE dg_rho0_types
                                               do_ewald_spme
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_create,&
-                                              pw_release,&
                                               pw_type
 #include "../base/base_uses.f90"
 
@@ -145,7 +143,7 @@ CONTAINS
             DEALLOCATE (dg_rho0%zet)
          END IF
          IF (ASSOCIATED(dg_rho0%density)) THEN
-            CALL pw_release(dg_rho0%density)
+            CALL dg_rho0%density%release()
             DEALLOCATE (dg_rho0%density)
          END IF
          NULLIFY (dg_rho0%gcc)
@@ -165,16 +163,16 @@ CONTAINS
       TYPE(pw_grid_type), POINTER                        :: pw_grid
 
       IF (ASSOCIATED(dg_rho0%density)) THEN
-         CALL pw_release(dg_rho0%density)
+         CALL dg_rho0%density%release()
       ELSE
          ALLOCATE (dg_rho0%density)
       END IF
       SELECT CASE (dg_rho0%type)
       CASE (do_ewald_ewald)
-         CALL pw_create(dg_rho0%density, pw_grid, REALDATA3D, REALSPACE)
+         CALL dg_rho0%density%create(pw_grid, REALDATA3D, REALSPACE)
          CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
       CASE (do_ewald_pme)
-         CALL pw_create(dg_rho0%density, pw_grid, REALDATA3D, REALSPACE)
+         CALL dg_rho0%density%create(pw_grid, REALDATA3D, REALSPACE)
          CALL dg_rho0_pme_gauss(dg_rho0%density, dg_rho0%zet(1))
       CASE (do_ewald_spme)
          CPABORT('SPME type not implemented')

--- a/src/pw/dgs.F
+++ b/src/pw/dgs.F
@@ -31,8 +31,6 @@ MODULE dgs
                                               pw_multiply_with,&
                                               pw_zero
    USE pw_types,                        ONLY: COMPLEXDATA3D,&
-                                              pw_create,&
-                                              pw_release,&
                                               pw_type
    USE realspace_grid_types,            ONLY: realspace_grid_type
    USE structure_factors,               ONLY: structure_factor_evaluate
@@ -869,7 +867,7 @@ CONTAINS
 
       ALLOCATE (zs(nd(1)*nd(2)))
       zs = 0.0_dp
-      CALL pw_create(cd, rho0%pw_grid, COMPLEXDATA3D, rho0%in_space)
+      CALL cd%create(rho0%pw_grid, COMPLEXDATA3D, rho0%in_space)
       CALL pw_zero(cd)
 
       za = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
@@ -880,7 +878,7 @@ CONTAINS
       CALL pw_copy(cd, rhos1)
 
       DEALLOCATE (zs)
-      CALL pw_release(cd)
+      CALL cd%release()
 
    END SUBROUTINE dg_get_patch_1
 
@@ -915,7 +913,7 @@ CONTAINS
 
       ALLOCATE (zs(nd(1)*nd(2)))
       zs = 0.0_dp
-      CALL pw_create(cd, rhos1%pw_grid, COMPLEXDATA3D, rho0%in_space)
+      CALL cd%create(rhos1%pw_grid, COMPLEXDATA3D, rho0%in_space)
       CALL pw_zero(cd)
 
       za = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
@@ -929,7 +927,7 @@ CONTAINS
       CALL copy_cri(cd%cc3d, rhos1%cr3d, rhos2%cr3d)
 
       DEALLOCATE (zs)
-      CALL pw_release(cd)
+      CALL cd%release()
 
    END SUBROUTINE dg_get_patch_2
 

--- a/src/pw/dielectric_methods.F
+++ b/src/pw/dielectric_methods.F
@@ -27,8 +27,6 @@ MODULE dielectric_methods
                                               pw_transfer,&
                                               pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create,&
-                                              pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
                                               pw_pool_release,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
@@ -82,14 +80,14 @@ CONTAINS
          NULLIFY (dielectric%eps)
          NULLIFY (dielectric%deps_drho)
          ALLOCATE (dielectric%eps, dielectric%deps_drho)
-         CALL pw_pool_create_pw(pw_pool, dielectric%eps, &
+         CALL pw_pool%create_pw(dielectric%eps, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(pw_pool, dielectric%deps_drho, &
+         CALL pw_pool%create_pw(dielectric%deps_drho, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          dielectric%eps%cr3d = 1.0_dp
          CALL pw_zero(dielectric%deps_drho)
          DO i = 1, 3
-            CALL pw_pool_create_pw(pw_pool, dielectric%dln_eps(i), &
+            CALL pw_pool%create_pw(dielectric%dln_eps(i), &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dielectric%dln_eps(i))
          END DO
@@ -149,14 +147,14 @@ CONTAINS
                        "the dielectric constant function.")
       END IF
 
-      CALL pw_pool_create_pw(pw_pool, rho_elec_rs, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(rho_elec_rs, use_data=REALDATA3D, in_space=REALSPACE)
 
       ! for evaluating epsilon make sure rho is in the real space
       CALL pw_transfer(rho, rho_elec_rs)
 
       IF (PRESENT(rho_core)) THEN
          ! make sure rho_core is in the real space
-         CALL pw_pool_create_pw(pw_pool, rho_core_rs, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(rho_core_rs, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(rho_core, rho_core_rs)
          IF (dielectric%params%dielec_core_correction) THEN
             ! use (rho_elec - rho_core) to compute dielectric to avoid obtaining spurious
@@ -165,7 +163,7 @@ CONTAINS
          ELSE
             CALL pw_axpy(rho_core_rs, rho_elec_rs, -1.0_dp)
          END IF
-         CALL pw_pool_give_back_pw(pw_pool, rho_core_rs)
+         CALL pw_pool%give_back_pw(rho_core_rs)
       ELSE
          CPABORT("For dielectric constant larger than 1, rho_core has to be present.")
       END IF
@@ -190,17 +188,17 @@ CONTAINS
           ((dielec_functiontype .EQ. spatially_dependent) .AND. times_called .EQ. 0)) THEN
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
-            CALL pw_pool_create_pw(pw_pool, ln_eps, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool%create_pw(ln_eps, use_data=REALDATA3D, in_space=REALSPACE)
             ln_eps%cr3d = LOG(dielectric%eps%cr3d)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               CALL pw_pool_create_pw(pw_pool, deps(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool%create_pw(deps(i), use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_zero(deps(i))
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               CALL pw_pool_create_pw(pw_pool, deps(i), use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_pool_create_pw(pw_pool, drho(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool%create_pw(deps(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool%create_pw(drho(i), use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_zero(deps(i))
                CALL pw_zero(drho(i))
             END DO
@@ -247,20 +245,20 @@ CONTAINS
 
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
-            CALL pw_pool_give_back_pw(pw_pool, ln_eps)
+            CALL pw_pool%give_back_pw(ln_eps)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool, deps(i))
+               CALL pw_pool%give_back_pw(deps(i))
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool, drho(i))
-               CALL pw_pool_give_back_pw(pw_pool, deps(i))
+               CALL pw_pool%give_back_pw(drho(i))
+               CALL pw_pool%give_back_pw(deps(i))
             END DO
          END SELECT
       END IF
 
-      CALL pw_pool_give_back_pw(pw_pool, rho_elec_rs)
+      CALL pw_pool%give_back_pw(rho_elec_rs)
 
       dielectric%params%times_called = dielectric%params%times_called + 1
 
@@ -335,19 +333,19 @@ CONTAINS
       CALL pw_pool_create(pw_pool_xpndd, pw_grid=dct_pw_grid)
 
       ! make sure rho is in the real space
-      CALL pw_pool_create_pw(pw_pool_orig, rho_elec_rs, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_orig%create_pw(rho_elec_rs, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_transfer(rho, rho_elec_rs)
       ! expand rho_elec
-      CALL pw_pool_create_pw(pw_pool_xpndd, rho_elec_rs_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(rho_elec_rs_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_expand(neumann_directions, recv_msgs_bnds, dests_expand, srcs_expand, flipg_stat, bounds_shftd, &
                      rho_elec_rs, rho_elec_rs_xpndd)
 
       IF (PRESENT(rho_core)) THEN
          ! make sure rho_core is in the real space
-         CALL pw_pool_create_pw(pw_pool_orig, rho_core_rs, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool_orig%create_pw(rho_core_rs, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(rho_core, rho_core_rs)
          ! expand rho_core
-         CALL pw_pool_create_pw(pw_pool_xpndd, rho_core_rs_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool_xpndd%create_pw(rho_core_rs_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_expand(neumann_directions, recv_msgs_bnds, dests_expand, srcs_expand, flipg_stat, bounds_shftd, &
                         rho_core_rs, rho_core_rs_xpndd)
 
@@ -357,8 +355,8 @@ CONTAINS
          ELSE
             CALL pw_axpy(rho_core_rs_xpndd, rho_elec_rs_xpndd, -1.0_dp)
          END IF
-         CALL pw_pool_give_back_pw(pw_pool_orig, rho_core_rs)
-         CALL pw_pool_give_back_pw(pw_pool_xpndd, rho_core_rs_xpndd)
+         CALL pw_pool_orig%give_back_pw(rho_core_rs)
+         CALL pw_pool_xpndd%give_back_pw(rho_core_rs_xpndd)
       ELSE
          CPABORT("For dielectric constant larger than 1, rho_core has to be present.")
       END IF
@@ -383,17 +381,17 @@ CONTAINS
           ((dielec_functiontype .EQ. spatially_dependent) .AND. times_called .EQ. 0)) THEN
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
-            CALL pw_pool_create_pw(pw_pool_xpndd, ln_eps, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool_xpndd%create_pw(ln_eps, use_data=REALDATA3D, in_space=REALSPACE)
             ln_eps%cr3d = LOG(dielectric%eps%cr3d)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               CALL pw_pool_create_pw(pw_pool_xpndd, deps(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_xpndd%create_pw(deps(i), use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_zero(deps(i))
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               CALL pw_pool_create_pw(pw_pool_xpndd, deps(i), use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_pool_create_pw(pw_pool_xpndd, drho(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_xpndd%create_pw(deps(i), use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_xpndd%create_pw(drho(i), use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_zero(deps(i))
                CALL pw_zero(drho(i))
             END DO
@@ -440,21 +438,21 @@ CONTAINS
 
          SELECT CASE (derivative_method)
          CASE (derivative_cd3, derivative_cd5, derivative_cd7, derivative_fft)
-            CALL pw_pool_give_back_pw(pw_pool_xpndd, ln_eps)
+            CALL pw_pool_xpndd%give_back_pw(ln_eps)
          CASE (derivative_fft_use_deps)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool_xpndd, deps(i))
+               CALL pw_pool_xpndd%give_back_pw(deps(i))
             END DO
          CASE (derivative_fft_use_drho)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool_xpndd, drho(i))
-               CALL pw_pool_give_back_pw(pw_pool_xpndd, deps(i))
+               CALL pw_pool_xpndd%give_back_pw(drho(i))
+               CALL pw_pool_xpndd%give_back_pw(deps(i))
             END DO
          END SELECT
       END IF
 
-      CALL pw_pool_give_back_pw(pw_pool_orig, rho_elec_rs)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, rho_elec_rs_xpndd)
+      CALL pw_pool_orig%give_back_pw(rho_elec_rs)
+      CALL pw_pool_xpndd%give_back_pw(rho_elec_rs_xpndd)
       CALL pw_pool_release(pw_pool_xpndd)
 
       dielectric%params%times_called = dielectric%params%times_called + 1
@@ -590,7 +588,7 @@ CONTAINS
                        "the simulation cell.")
       END IF
 
-      CALL pw_pool_create_pw(pw_pool, eps_tmp, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(eps_tmp, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_copy(eps, eps_tmp)
 
       bounds_local = pw_grid%bounds_local
@@ -611,7 +609,7 @@ CONTAINS
       END DO
 
       CALL pw_mollifier(pw_pool, zeta, x_glbl, y_glbl, z_glbl, eps_tmp, eps)
-      CALL pw_pool_give_back_pw(pw_pool, eps_tmp)
+      CALL pw_pool%give_back_pw(eps_tmp)
 
       CALL timestop(handle)
 
@@ -686,7 +684,7 @@ CONTAINS
                        "the simulation cell.")
       END IF
 
-      CALL pw_pool_create_pw(pw_pool, eps_tmp, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(eps_tmp, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_copy(eps, eps_tmp)
 
       bounds_local = pw_grid%bounds_local
@@ -707,7 +705,7 @@ CONTAINS
       END DO
 
       CALL pw_mollifier(pw_pool, zeta, x_glbl, y_glbl, z_glbl, eps_tmp, eps)
-      CALL pw_pool_give_back_pw(pw_pool, eps_tmp)
+      CALL pw_pool%give_back_pw(eps_tmp)
 
       CALL timestop(handle)
 
@@ -812,9 +810,9 @@ CONTAINS
          CPABORT("The dielectric constant has to be greater than or equal to 1.")
       END IF
 
-      CALL pw_pool_create_pw(pw_pool, eps_sptldep, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, swch_func, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, dswch_func_drho, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(eps_sptldep, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(swch_func, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(dswch_func_drho, use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_zero(eps_sptldep)
       CALL pw_zero(swch_func)
       CALL pw_zero(dswch_func_drho)
@@ -826,9 +824,9 @@ CONTAINS
       eps%cr3d = ((swch_func%cr3d - 1.0_dp)*(eps_sptldep%cr3d - 1.0_dp)) + 1.0_dp
       deps_drho%cr3d = dswch_func_drho%cr3d*(eps_sptldep%cr3d - 1.0_dp)
 
-      CALL pw_pool_give_back_pw(pw_pool, dswch_func_drho)
-      CALL pw_pool_give_back_pw(pw_pool, swch_func)
-      CALL pw_pool_give_back_pw(pw_pool, eps_sptldep)
+      CALL pw_pool%give_back_pw(dswch_func_drho)
+      CALL pw_pool%give_back_pw(swch_func)
+      CALL pw_pool%give_back_pw(eps_sptldep)
 
       CALL timestop(handle)
 
@@ -855,7 +853,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       DO i = 1, 2
-         CALL pw_pool_create_pw(pw_pool, work_gs(i), &
+         CALL pw_pool%create_pw(work_gs(i), &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
 
@@ -869,7 +867,7 @@ CONTAINS
       END DO
 
       DO i = 1, 2
-         CALL pw_pool_give_back_pw(pw_pool, work_gs(i))
+         CALL pw_pool%give_back_pw(work_gs(i))
       END DO
 
       CALL timestop(handle)

--- a/src/pw/dielectric_types.F
+++ b/src/pw/dielectric_types.F
@@ -16,8 +16,7 @@ MODULE dielectric_types
    USE kinds,                           ONLY: dp
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
                                               pw_pool_type
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -102,11 +101,11 @@ CONTAINS
                CALL pw_pool_give_back_pw(pw_pool, dielectric%dln_eps(i))
             END DO
          ELSE
-            CALL pw_release(dielectric%eps)
-            CALL pw_release(dielectric%deps_drho)
+            CALL dielectric%eps%release()
+            CALL dielectric%deps_drho%release()
             DEALLOCATE (dielectric%eps, dielectric%deps_drho)
             DO i = 1, 3
-               CALL pw_release(dielectric%dln_eps(i))
+               CALL dielectric%dln_eps(i)%release()
             END DO
          END IF
          CALL dielectric_parameters_dealloc(dielectric%params)

--- a/src/pw/dielectric_types.F
+++ b/src/pw/dielectric_types.F
@@ -14,8 +14,7 @@
 MODULE dielectric_types
 
    USE kinds,                           ONLY: dp
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: pw_type
 #include "../base/base_uses.f90"
 
@@ -94,11 +93,11 @@ CONTAINS
          can_give_back = PRESENT(pw_pool)
          IF (can_give_back) can_give_back = ASSOCIATED(pw_pool)
          IF (can_give_back) THEN
-            CALL pw_pool_give_back_pw(pw_pool, dielectric%eps)
-            CALL pw_pool_give_back_pw(pw_pool, dielectric%deps_drho)
+            CALL pw_pool%give_back_pw(dielectric%eps)
+            CALL pw_pool%give_back_pw(dielectric%deps_drho)
             DEALLOCATE (dielectric%eps, dielectric%deps_drho)
             DO i = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool, dielectric%dln_eps(i))
+               CALL pw_pool%give_back_pw(dielectric%dln_eps(i))
             END DO
          ELSE
             CALL dielectric%eps%release()

--- a/src/pw/dirichlet_bc_methods.F
+++ b/src/pw/dirichlet_bc_methods.F
@@ -35,9 +35,7 @@ MODULE dirichlet_bc_methods
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_zero
    USE pw_poisson_types,                ONLY: pw_poisson_parameter_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -321,7 +319,7 @@ CONTAINS
          tile_maxvals = 0.0_dp
          DO k = 1, n_tiles
             ALLOCATE (dirichlet_bc%tiles(k)%tile%tile_pw)
-            CALL pw_pool_create_pw(pw_pool, dirichlet_bc%tiles(k)%tile%tile_pw, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool%create_pw(dirichlet_bc%tiles(k)%tile%tile_pw, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dirichlet_bc%tiles(k)%tile%tile_pw)
 
             IF ((unit_nr .GT. 0) .AND. verbose) THEN
@@ -354,12 +352,12 @@ CONTAINS
 
          NULLIFY (cylinder_pw)
          ALLOCATE (cylinder_pw)
-         CALL pw_pool_create_pw(pw_pool, cylinder_pw, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(cylinder_pw, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(cylinder_pw)
 
          DO k = 1, n_tiles
             ALLOCATE (dirichlet_bc%tiles(k)%tile%tile_pw)
-            CALL pw_pool_create_pw(pw_pool, dirichlet_bc%tiles(k)%tile%tile_pw, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool%create_pw(dirichlet_bc%tiles(k)%tile%tile_pw, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dirichlet_bc%tiles(k)%tile%tile_pw)
 
             IF ((unit_nr .GT. 0) .AND. verbose) THEN
@@ -387,7 +385,7 @@ CONTAINS
                           "one can increase DELTA_ALPHA (see the reference manual).")
          END IF
 
-         CALL pw_pool_give_back_pw(pw_pool, cylinder_pw)
+         CALL pw_pool%give_back_pw(cylinder_pw)
          DEALLOCATE (cylinder_pw)
 
          IF ((unit_nr .GT. 0) .AND. verbose) WRITE (unit_nr, '(T3,A)') REPEAT('=', 78)
@@ -405,7 +403,7 @@ CONTAINS
 
          DO k = 1, n_tiles
             ALLOCATE (dirichlet_bc%tiles(k)%tile%tile_pw)
-            CALL pw_pool_create_pw(pw_pool, dirichlet_bc%tiles(k)%tile%tile_pw, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool%create_pw(dirichlet_bc%tiles(k)%tile%tile_pw, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dirichlet_bc%tiles(k)%tile%tile_pw)
 
             IF ((unit_nr .GT. 0) .AND. verbose) THEN

--- a/src/pw/dirichlet_bc_types.F
+++ b/src/pw/dirichlet_bc_types.F
@@ -17,8 +17,7 @@ MODULE dirichlet_bc_types
    USE kinds,                           ONLY: dp
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
                                               pw_pool_type
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -214,7 +213,7 @@ CONTAINS
          DEALLOCATE (dbc%tiles)
       ELSE
          DO k = 1, n_tiles
-            CALL pw_release(dbc%tiles(k)%tile%tile_pw)
+            CALL dbc%tiles(k)%tile%tile_pw%release()
             DEALLOCATE (dbc%tiles(k)%tile%tile_pw)
             DEALLOCATE (dbc%tiles(k)%tile)
          END DO

--- a/src/pw/dirichlet_bc_types.F
+++ b/src/pw/dirichlet_bc_types.F
@@ -15,8 +15,7 @@
 MODULE dirichlet_bc_types
 
    USE kinds,                           ONLY: dp
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: pw_type
 #include "../base/base_uses.f90"
 
@@ -206,7 +205,7 @@ CONTAINS
       n_tiles = dbc%n_tiles
       IF (PRESENT(pw_pool)) THEN
          DO k = 1, n_tiles
-            CALL pw_pool_give_back_pw(pw_pool, dbc%tiles(k)%tile%tile_pw)
+            CALL pw_pool%give_back_pw(dbc%tiles(k)%tile%tile_pw)
             DEALLOCATE (dbc%tiles(k)%tile%tile_pw)
             DEALLOCATE (dbc%tiles(k)%tile)
          END DO

--- a/src/pw/mt_util.F
+++ b/src/pw/mt_util.F
@@ -18,8 +18,6 @@ MODULE mt_util
                                               pw_transfer,&
                                               pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create,&
-                                              pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
                                               pw_pool_release,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
@@ -81,7 +79,7 @@ CONTAINS
       END IF
       NULLIFY (screen_function)
       ALLOCATE (screen_function)
-      CALL pw_pool_create_pw(pw_pool, screen_function, use_data=COMPLEXDATA1D, &
+      CALL pw_pool%create_pw(screen_function, use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_zero(screen_function)
       SELECT CASE (method)
@@ -89,21 +87,21 @@ CONTAINS
          NULLIFY (Vloc, Vlocg)
          ALLOCATE (Vloc, Vlocg)
          IF (ASSOCIATED(pw_pool_aux)) THEN
-            CALL pw_pool_create_pw(pw_pool_aux, Vloc, use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(pw_pool_aux, Vlocg, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL pw_pool_aux%create_pw(Vloc, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool_aux%create_pw(Vlocg, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          ELSE
-            CALL pw_pool_create_pw(pw_pool, Vloc, use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(pw_pool, Vlocg, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL pw_pool%create_pw(Vloc, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool%create_pw(Vlocg, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END IF
          CALL mt0din(Vloc, alpha)
          CALL pw_transfer(Vloc, Vlocg)
          CALL pw_axpy(Vlocg, screen_function)
          IF (ASSOCIATED(pw_pool_aux)) THEN
-            CALL pw_pool_give_back_pw(pw_pool_aux, Vloc)
-            CALL pw_pool_give_back_pw(pw_pool_aux, Vlocg)
+            CALL pw_pool_aux%give_back_pw(Vloc)
+            CALL pw_pool_aux%give_back_pw(Vlocg)
          ELSE
-            CALL pw_pool_give_back_pw(pw_pool, Vloc)
-            CALL pw_pool_give_back_pw(pw_pool, Vlocg)
+            CALL pw_pool%give_back_pw(Vloc)
+            CALL pw_pool%give_back_pw(Vlocg)
          END IF
          DEALLOCATE (Vloc, Vlocg)
          !

--- a/src/pw/ps_implicit_methods.F
+++ b/src/pw/ps_implicit_methods.F
@@ -188,7 +188,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE implicit_poisson_solver_periodic(poisson_env, density, v_new, ehartree)
 
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_poisson_type), INTENT(IN)                  :: poisson_env
       TYPE(pw_type), INTENT(IN)                          :: density
       TYPE(pw_type), INTENT(INOUT)                       :: v_new
       REAL(dp), INTENT(OUT), OPTIONAL                    :: ehartree
@@ -321,7 +321,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE implicit_poisson_solver_neumann(poisson_env, density, v_new, ehartree)
 
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_poisson_type), INTENT(IN)                  :: poisson_env
       TYPE(pw_type), INTENT(IN)                          :: density
       TYPE(pw_type), INTENT(INOUT)                       :: v_new
       REAL(dp), INTENT(OUT), OPTIONAL                    :: ehartree
@@ -489,7 +489,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE implicit_poisson_solver_mixed_periodic(poisson_env, density, v_new, electric_enthalpy)
 
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_poisson_type), INTENT(IN)                  :: poisson_env
       TYPE(pw_type), INTENT(IN)                          :: density
       TYPE(pw_type), INTENT(INOUT)                       :: v_new
       REAL(dp), INTENT(OUT), OPTIONAL                    :: electric_enthalpy
@@ -514,7 +514,6 @@ CONTAINS
       TYPE(greens_fn_type), POINTER                      :: green
       TYPE(ps_implicit_type), POINTER                    :: ps_implicit_env
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_poisson_parameter_type), POINTER           :: poisson_params
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       TYPE(pw_type)                                      :: Axvbar, g, PxQAinvxres, QAinvxres, &
                                                             res_new, res_old, v_old
@@ -523,7 +522,6 @@ CONTAINS
 
       pw_pool => poisson_env%pw_pools(poisson_env%pw_level)%pool
       pw_grid => pw_pool%pw_grid
-      poisson_params => poisson_env%parameters
       dielectric => poisson_env%implicit_env%dielectric
       green => poisson_env%green_fft
       ps_implicit_env => poisson_env%implicit_env
@@ -532,10 +530,10 @@ CONTAINS
       ngpts = pw_grid%ngpts
       npts_local = pw_grid%npts_local
       bounds_local = pw_grid%bounds_local
-      tol = poisson_params%ps_implicit_params%tol
-      omega = poisson_params%ps_implicit_params%omega
-      max_iter = poisson_params%ps_implicit_params%max_iter
-      use_zero_initial_guess = poisson_params%ps_implicit_params%zero_initial_guess
+      tol = poisson_env%parameters%ps_implicit_params%tol
+      omega = poisson_env%parameters%ps_implicit_params%omega
+      max_iter = poisson_env%parameters%ps_implicit_params%max_iter
+      use_zero_initial_guess = poisson_env%parameters%ps_implicit_params%zero_initial_guess
       times_called = ps_implicit_env%times_called
 
       n_contacts = SIZE(ps_implicit_env%contacts)
@@ -676,7 +674,7 @@ CONTAINS
          END IF
 
 ! verbose output
-         IF (poisson_params%dbc_params%verbose_output) THEN
+         IF (poisson_env%parameters%dbc_params%verbose_output) THEN
             v_new1D(ps_implicit_env%idx_1dto3d) = RESHAPE(v_new%cr3d, (/data_size/))
             CALL DGEMV('N', n_tiles_tot, data_size, 1.0_dp, B, n_tiles_tot, v_new1D, 1, 0.0_dp, Bxv_new, 1)
             CALL pw_grid%para%group%sum(Bxv_new)
@@ -748,7 +746,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE implicit_poisson_solver_mixed(poisson_env, density, v_new, electric_enthalpy)
 
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_poisson_type), INTENT(IN)                  :: poisson_env
       TYPE(pw_type), INTENT(IN)                          :: density
       TYPE(pw_type), INTENT(INOUT)                       :: v_new
       REAL(dp), INTENT(OUT), OPTIONAL                    :: electric_enthalpy
@@ -774,7 +772,6 @@ CONTAINS
       TYPE(greens_fn_type), POINTER                      :: green
       TYPE(ps_implicit_type), POINTER                    :: ps_implicit_env
       TYPE(pw_grid_type), POINTER                        :: dct_pw_grid, pw_grid
-      TYPE(pw_poisson_parameter_type), POINTER           :: poisson_params
       TYPE(pw_pool_type), POINTER                        :: pw_pool, pw_pool_xpndd
       TYPE(pw_type)                                      :: Axvbar, density_xpndd, g, PxQAinvxres, &
                                                             QAinvxres, res_new, res_old, &
@@ -784,7 +781,6 @@ CONTAINS
 
       pw_pool => poisson_env%pw_pools(poisson_env%pw_level)%pool
       pw_grid => pw_pool%pw_grid
-      poisson_params => poisson_env%parameters
       dielectric => poisson_env%implicit_env%dielectric
       green => poisson_env%green_fft
       ps_implicit_env => poisson_env%implicit_env
@@ -795,11 +791,11 @@ CONTAINS
       ngpts = dct_pw_grid%ngpts
       npts_local = dct_pw_grid%npts_local
       bounds_local = dct_pw_grid%bounds_local
-      tol = poisson_params%ps_implicit_params%tol
-      omega = poisson_params%ps_implicit_params%omega
-      max_iter = poisson_params%ps_implicit_params%max_iter
-      use_zero_initial_guess = poisson_params%ps_implicit_params%zero_initial_guess
-      neumann_directions = poisson_params%ps_implicit_params%neumann_directions
+      tol = poisson_env%parameters%ps_implicit_params%tol
+      omega = poisson_env%parameters%ps_implicit_params%omega
+      max_iter = poisson_env%parameters%ps_implicit_params%max_iter
+      use_zero_initial_guess = poisson_env%parameters%ps_implicit_params%zero_initial_guess
+      neumann_directions = poisson_env%parameters%ps_implicit_params%neumann_directions
       times_called = ps_implicit_env%times_called
 
       SELECT CASE (neumann_directions)
@@ -962,7 +958,7 @@ CONTAINS
          END IF
 
 ! verbose output
-         IF (poisson_params%dbc_params%verbose_output) THEN
+         IF (poisson_env%parameters%dbc_params%verbose_output) THEN
             v_new1D(ps_implicit_env%idx_1dto3d) = RESHAPE(v_new_xpndd%cr3d, (/data_size/))
             CALL DGEMV('N', n_tiles_tot, data_size, 1.0_dp, B, n_tiles_tot, v_new1D, 1, 0.0_dp, Bxv_new, 1)
             CALL pw_grid%para%group%sum(Bxv_new)

--- a/src/pw/ps_implicit_methods.F
+++ b/src/pw/ps_implicit_methods.F
@@ -48,8 +48,6 @@ MODULE ps_implicit_methods
                                               pw_poisson_parameter_type,&
                                               pw_poisson_type
    USE pw_pool_types,                   ONLY: pw_pool_create,&
-                                              pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
                                               pw_pool_release,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
@@ -131,7 +129,7 @@ CONTAINS
 ! v_eps
          NULLIFY (ps_implicit_env%v_eps)
          ALLOCATE (ps_implicit_env%v_eps)
-         CALL pw_pool_create_pw(pw_pool, ps_implicit_env%v_eps, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(ps_implicit_env%v_eps, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(ps_implicit_env%v_eps)
 
 ! constraint charge
@@ -139,12 +137,12 @@ CONTAINS
          SELECT CASE (boundary_condition)
          CASE (MIXED_PERIODIC_BC)
             ALLOCATE (ps_implicit_env%cstr_charge)
-            CALL pw_pool_create_pw(pw_pool, ps_implicit_env%cstr_charge, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool%create_pw(ps_implicit_env%cstr_charge, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(ps_implicit_env%cstr_charge)
          CASE (MIXED_BC)
             CALL pw_pool_create(pw_pool_xpndd, pw_grid=dct_pw_grid)
             ALLOCATE (ps_implicit_env%cstr_charge)
-            CALL pw_pool_create_pw(pw_pool_xpndd, ps_implicit_env%cstr_charge, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool_xpndd%create_pw(ps_implicit_env%cstr_charge, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(ps_implicit_env%cstr_charge)
             CALL pw_pool_release(pw_pool_xpndd)
          END SELECT
@@ -225,12 +223,12 @@ CONTAINS
 ! check if this is the first scf iteration
       IF (times_called .EQ. 0) CALL ps_implicit_initial_guess_create(ps_implicit_env, pw_pool)
 
-      CALL pw_pool_create_pw(pw_pool, g, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, v_old, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, res_old, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, res_new, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, QAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, PxQAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(g, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(v_old, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(res_old, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(res_new, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(QAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(PxQAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
 
       IF (use_zero_initial_guess) THEN
          CALL pw_zero(v_old)
@@ -298,12 +296,12 @@ CONTAINS
 ! compute the extra contribution to the Hamiltonian due to the presence of dielectric
       CALL ps_implicit_compute_veps(pw_pool, dielectric, v_new, ps_implicit_env%v_eps)
 
-      CALL pw_pool_give_back_pw(pw_pool, g)
-      CALL pw_pool_give_back_pw(pw_pool, v_old)
-      CALL pw_pool_give_back_pw(pw_pool, res_old)
-      CALL pw_pool_give_back_pw(pw_pool, res_new)
-      CALL pw_pool_give_back_pw(pw_pool, QAinvxres)
-      CALL pw_pool_give_back_pw(pw_pool, PxQAinvxres)
+      CALL pw_pool%give_back_pw(g)
+      CALL pw_pool%give_back_pw(v_old)
+      CALL pw_pool%give_back_pw(res_old)
+      CALL pw_pool%give_back_pw(res_new)
+      CALL pw_pool%give_back_pw(QAinvxres)
+      CALL pw_pool%give_back_pw(PxQAinvxres)
 
       CALL timestop(handle)
 
@@ -375,15 +373,15 @@ CONTAINS
 ! check if this is the first scf iteration
       IF (times_called .EQ. 0) CALL ps_implicit_initial_guess_create(ps_implicit_env, pw_pool_xpndd)
 
-      CALL pw_pool_create_pw(pw_pool_xpndd, g, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, v_old, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, res_old, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, res_new, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, QAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, PxQAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, density_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, v_new_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, v_eps_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(g, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(v_old, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(res_old, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(res_new, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(QAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(PxQAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(density_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(v_new_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(v_eps_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
 
       IF (use_zero_initial_guess) THEN
          CALL pw_zero(v_old)
@@ -464,15 +462,15 @@ CONTAINS
       CALL pw_shrink(neumann_directions, dct_env%dests_shrink, dct_env%srcs_shrink, &
                      dct_env%bounds_local_shftd, v_eps_xpndd, ps_implicit_env%v_eps)
 
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, g)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, v_old)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, res_old)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, res_new)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, QAinvxres)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, PxQAinvxres)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, density_xpndd)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, v_new_xpndd)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, v_eps_xpndd)
+      CALL pw_pool_xpndd%give_back_pw(g)
+      CALL pw_pool_xpndd%give_back_pw(v_old)
+      CALL pw_pool_xpndd%give_back_pw(res_old)
+      CALL pw_pool_xpndd%give_back_pw(res_new)
+      CALL pw_pool_xpndd%give_back_pw(QAinvxres)
+      CALL pw_pool_xpndd%give_back_pw(PxQAinvxres)
+      CALL pw_pool_xpndd%give_back_pw(density_xpndd)
+      CALL pw_pool_xpndd%give_back_pw(v_new_xpndd)
+      CALL pw_pool_xpndd%give_back_pw(v_eps_xpndd)
       CALL pw_pool_release(pw_pool_xpndd)
 
       CALL timestop(handle)
@@ -585,13 +583,13 @@ CONTAINS
       ALLOCATE (v_new1D(data_size))
       ALLOCATE (Bxv_new(n_tiles_tot))
 
-      CALL pw_pool_create_pw(pw_pool, g, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, v_old, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, res_old, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, res_new, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, QAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, PxQAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, Axvbar, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(g, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(v_old, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(res_old, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(res_new, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(QAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(PxQAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(Axvbar, use_data=REALDATA3D, in_space=REALSPACE)
 
       IF (use_zero_initial_guess) THEN
          CALL pw_zero(v_old)
@@ -725,13 +723,13 @@ CONTAINS
 ! compute the extra contribution to the Hamiltonian due to the presence of dielectric
       CALL ps_implicit_compute_veps(pw_pool, dielectric, v_new, ps_implicit_env%v_eps)
 
-      CALL pw_pool_give_back_pw(pw_pool, g)
-      CALL pw_pool_give_back_pw(pw_pool, v_old)
-      CALL pw_pool_give_back_pw(pw_pool, res_old)
-      CALL pw_pool_give_back_pw(pw_pool, res_new)
-      CALL pw_pool_give_back_pw(pw_pool, QAinvxres)
-      CALL pw_pool_give_back_pw(pw_pool, PxQAinvxres)
-      CALL pw_pool_give_back_pw(pw_pool, Axvbar)
+      CALL pw_pool%give_back_pw(g)
+      CALL pw_pool%give_back_pw(v_old)
+      CALL pw_pool%give_back_pw(res_old)
+      CALL pw_pool%give_back_pw(res_new)
+      CALL pw_pool%give_back_pw(QAinvxres)
+      CALL pw_pool%give_back_pw(PxQAinvxres)
+      CALL pw_pool%give_back_pw(Axvbar)
 
       CALL timestop(handle)
 
@@ -860,16 +858,16 @@ CONTAINS
       ALLOCATE (v_new1D(data_size))
       ALLOCATE (Bxv_new(n_tiles_tot))
 
-      CALL pw_pool_create_pw(pw_pool_xpndd, g, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, v_old, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, res_old, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, res_new, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, QAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, PxQAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, Axvbar, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, density_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, v_new_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool_xpndd, v_eps_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(g, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(v_old, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(res_old, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(res_new, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(QAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(PxQAinvxres, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(Axvbar, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(density_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(v_new_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool_xpndd%create_pw(v_eps_xpndd, use_data=REALDATA3D, in_space=REALSPACE)
 
       IF (use_zero_initial_guess) THEN
          CALL pw_zero(v_old)
@@ -1016,16 +1014,16 @@ CONTAINS
       CALL pw_shrink(neumann_directions, dct_env%dests_shrink, dct_env%srcs_shrink, &
                      dct_env%bounds_local_shftd, v_eps_xpndd, ps_implicit_env%v_eps)
 
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, g)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, v_old)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, res_old)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, res_new)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, QAinvxres)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, PxQAinvxres)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, Axvbar)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, density_xpndd)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, v_new_xpndd)
-      CALL pw_pool_give_back_pw(pw_pool_xpndd, v_eps_xpndd)
+      CALL pw_pool_xpndd%give_back_pw(g)
+      CALL pw_pool_xpndd%give_back_pw(v_old)
+      CALL pw_pool_xpndd%give_back_pw(res_old)
+      CALL pw_pool_xpndd%give_back_pw(res_new)
+      CALL pw_pool_xpndd%give_back_pw(QAinvxres)
+      CALL pw_pool_xpndd%give_back_pw(PxQAinvxres)
+      CALL pw_pool_xpndd%give_back_pw(Axvbar)
+      CALL pw_pool_xpndd%give_back_pw(density_xpndd)
+      CALL pw_pool_xpndd%give_back_pw(v_new_xpndd)
+      CALL pw_pool_xpndd%give_back_pw(v_eps_xpndd)
       CALL pw_pool_release(pw_pool_xpndd)
 
       CALL timestop(handle)
@@ -1054,7 +1052,7 @@ CONTAINS
       n_tiles_tot = SIZE(ps_implicit_env%v_D)
       NULLIFY (ps_implicit_env%initial_guess)
       ALLOCATE (ps_implicit_env%initial_guess)
-      CALL pw_pool_create_pw(pw_pool, ps_implicit_env%initial_guess, &
+      CALL pw_pool%create_pw(ps_implicit_env%initial_guess, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_zero(ps_implicit_env%initial_guess)
       ALLOCATE (ps_implicit_env%initial_lambda(n_tiles_tot))
@@ -1199,7 +1197,7 @@ CONTAINS
             indx2 = indx1 + n_tiles - 1
             DO i = 1, n_tiles
 
-               CALL pw_pool_create_pw(pw_pool_xpndd, pw_in, use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_xpndd%create_pw(pw_in, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_expand(neumann_directions, &
                               dct_env%recv_msgs_bnds, dct_env%dests_expand, dct_env%srcs_expand, &
                               dct_env%flipg_stat, dct_env%bounds_shftd, &
@@ -1209,7 +1207,7 @@ CONTAINS
                CALL pw_scale(pw_in, 1.0_dp/(vol_scfac*tile_volume)) ! normalize tile_pw
                ps_implicit_env%Bt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_in%cr3d, (/data_size/))
 
-               CALL pw_pool_create_pw(pw_pool_xpndd, pw_out, use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_xpndd%create_pw(pw_out, use_data=REALDATA3D, in_space=REALSPACE)
                CALL apply_inv_laplace_operator_dct(pw_pool_xpndd, green, pw_in, pw_out)
                QAinvxBt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_out%cr3d, (/data_size/))
                ! the electrostatic potential has opposite sign by internal convention
@@ -1218,8 +1216,8 @@ CONTAINS
                ps_implicit_env%frequency(indx1 + i - 1) = ps_implicit_env%contacts(j)%dirichlet_bc%frequency
                ps_implicit_env%phase(indx1 + i - 1) = ps_implicit_env%contacts(j)%dirichlet_bc%phase
 
-               CALL pw_pool_give_back_pw(pw_pool_xpndd, pw_in)
-               CALL pw_pool_give_back_pw(pw_pool_xpndd, pw_out)
+               CALL pw_pool_xpndd%give_back_pw(pw_in)
+               CALL pw_pool_xpndd%give_back_pw(pw_out)
             END DO
             indx1 = indx2 + 1
          END DO
@@ -1331,14 +1329,14 @@ CONTAINS
             n_tiles = ps_implicit_env%contacts(j)%dirichlet_bc%n_tiles
             indx2 = indx1 + n_tiles - 1
             DO i = 1, n_tiles
-               CALL pw_pool_create_pw(pw_pool_orig, pw_in, use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_orig%create_pw(pw_in, use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_copy(ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw, pw_in)
 
                tile_volume = ps_implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%volume
                CALL pw_scale(pw_in, 1.0_dp/tile_volume) ! normalize tile_pw
                ps_implicit_env%Bt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_in%cr3d, (/data_size/))
 
-               CALL pw_pool_create_pw(pw_pool_orig, pw_out, use_data=REALDATA3D, in_space=REALSPACE)
+               CALL pw_pool_orig%create_pw(pw_out, use_data=REALDATA3D, in_space=REALSPACE)
                CALL apply_inv_laplace_operator_fft(pw_pool_orig, green, pw_in, pw_out)
                QAinvxBt(ps_implicit_env%idx_1dto3d, indx1 + i - 1) = RESHAPE(pw_out%cr3d, (/data_size/))
                ! the electrostatic potential has opposite sign by internal convention
@@ -1347,8 +1345,8 @@ CONTAINS
                ps_implicit_env%frequency(indx1 + i - 1) = ps_implicit_env%contacts(j)%dirichlet_bc%frequency
                ps_implicit_env%phase(indx1 + i - 1) = ps_implicit_env%contacts(j)%dirichlet_bc%phase
 
-               CALL pw_pool_give_back_pw(pw_pool_orig, pw_in)
-               CALL pw_pool_give_back_pw(pw_pool_orig, pw_out)
+               CALL pw_pool_orig%give_back_pw(pw_in)
+               CALL pw_pool_orig%give_back_pw(pw_out)
             END DO
             indx1 = indx2 + 1
          END DO
@@ -1444,7 +1442,7 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       DO i = 1, 3
-         CALL pw_pool_create_pw(pw_pool, dv(i), &
+         CALL pw_pool%create_pw(dv(i), &
                                 use_data=REALDATA3D, in_space=REALSPACE)
       END DO
 
@@ -1456,7 +1454,7 @@ CONTAINS
       END ASSOCIATE
 
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(pw_pool, dv(i))
+         CALL pw_pool%give_back_pw(dv(i))
       END DO
 
       CALL timestop(handle)
@@ -1495,7 +1493,7 @@ CONTAINS
       pw_grid => pw_pool%pw_grid
       ng = SIZE(pw_grid%gsq)
 
-      CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
+      CALL pw_pool%create_pw(pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       CALL pw_transfer(pw_in, pw_in_gs)
@@ -1504,7 +1502,7 @@ CONTAINS
       END DO
       CALL pw_transfer(pw_in_gs, pw_out)
 
-      CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
+      CALL pw_pool%give_back_pw(pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1544,7 +1542,7 @@ CONTAINS
       pw_grid => pw_pool%pw_grid
       ng = SIZE(pw_grid%gsq)
 
-      CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
+      CALL pw_pool%create_pw(pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       CALL pw_transfer(pw_in, pw_in_gs)
@@ -1553,7 +1551,7 @@ CONTAINS
       END DO
       CALL pw_transfer(pw_in_gs, pw_out)
 
-      CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
+      CALL pw_pool%give_back_pw(pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1593,7 +1591,7 @@ CONTAINS
       ng = SIZE(pw_in%pw_grid%gsq)
       have_g0 = green%influence_fn%pw_grid%have_g0
 
-      CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
+      CALL pw_pool%create_pw(pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       CALL pw_transfer(pw_in, pw_in_gs)
@@ -1608,7 +1606,7 @@ CONTAINS
 
       CALL pw_transfer(pw_in_gs, pw_out)
 
-      CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
+      CALL pw_pool%give_back_pw(pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1649,7 +1647,7 @@ CONTAINS
       ng = SIZE(pw_in%pw_grid%gsq)
       have_g0 = green%dct_influence_fn%pw_grid%have_g0
 
-      CALL pw_pool_create_pw(pw_pool, pw_in_gs, &
+      CALL pw_pool%create_pw(pw_in_gs, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       CALL pw_transfer(pw_in, pw_in_gs)
@@ -1664,7 +1662,7 @@ CONTAINS
 
       CALL pw_transfer(pw_in_gs, pw_out)
 
-      CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
+      CALL pw_pool%give_back_pw(pw_in_gs)
 
       CALL timestop(handle)
 
@@ -1696,14 +1694,14 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL pw_pool_create_pw(pw_pool, Pxv, &
+      CALL pw_pool%create_pw(Pxv, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL apply_P_operator(pw_pool, dielectric, v, Pxv)
       CALL apply_laplace_operator_fft(pw_pool, green, v, density)
       CALL pw_axpy(Pxv, density)
 
-      CALL pw_pool_give_back_pw(pw_pool, Pxv)
+      CALL pw_pool%give_back_pw(Pxv)
 
       CALL timestop(handle)
 
@@ -1737,14 +1735,14 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL pw_pool_create_pw(pw_pool, Pxv, &
+      CALL pw_pool%create_pw(Pxv, &
                              use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL apply_P_operator(pw_pool, dielectric, v, Pxv)
       CALL apply_laplace_operator_dct(pw_pool, green, v, density)
       CALL pw_axpy(Pxv, density)
 
-      CALL pw_pool_give_back_pw(pw_pool, Pxv)
+      CALL pw_pool%give_back_pw(Pxv)
 
       CALL timestop(handle)
 
@@ -1782,10 +1780,10 @@ CONTAINS
 
       eightpi = 2*fourpi
 
-      CALL pw_pool_create_pw(pw_pool, dv2, &
+      CALL pw_pool%create_pw(dv2, &
                              use_data=REALDATA3D, in_space=REALSPACE)
       DO i = 1, 3
-         CALL pw_pool_create_pw(pw_pool, dv(i), &
+         CALL pw_pool%create_pw(dv(i), &
                                 use_data=REALDATA3D, in_space=REALSPACE)
       END DO
 
@@ -1796,9 +1794,9 @@ CONTAINS
 
       v_eps%cr3d = -(1.0_dp/eightpi)*(dv2%cr3d*dielectric%deps_drho%cr3d)
 
-      CALL pw_pool_give_back_pw(pw_pool, dv2)
+      CALL pw_pool%give_back_pw(dv2)
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(pw_pool, dv(i))
+         CALL pw_pool%give_back_pw(dv(i))
       END DO
 
       CALL timestop(handle)

--- a/src/pw/ps_implicit_types.F
+++ b/src/pw/ps_implicit_types.F
@@ -21,8 +21,7 @@ MODULE ps_implicit_types
    USE dirichlet_bc_types,              ONLY: dbc_release,&
                                               dirichlet_bc_p_type
    USE kinds,                           ONLY: dp
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: pw_type
 #include "../base/base_uses.f90"
 
@@ -100,9 +99,9 @@ CONTAINS
          do_dbc_cube = ps_implicit_env%do_dbc_cube
 
          IF (can_give_back) THEN
-            CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%initial_guess)
-            CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%v_eps)
-            CALL pw_pool_give_back_pw(pw_pool, ps_implicit_env%cstr_charge)
+            CALL pw_pool%give_back_pw(ps_implicit_env%initial_guess)
+            CALL pw_pool%give_back_pw(ps_implicit_env%v_eps)
+            CALL pw_pool%give_back_pw(ps_implicit_env%cstr_charge)
             DEALLOCATE (ps_implicit_env%initial_guess, ps_implicit_env%v_eps, ps_implicit_env%cstr_charge)
             CALL dbc_release(ps_implicit_env%contacts, do_dbc_cube, pw_pool=pw_pool)
          ELSE

--- a/src/pw/ps_implicit_types.F
+++ b/src/pw/ps_implicit_types.F
@@ -23,8 +23,7 @@ MODULE ps_implicit_types
    USE kinds,                           ONLY: dp
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
                                               pw_pool_type
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -107,10 +106,10 @@ CONTAINS
             DEALLOCATE (ps_implicit_env%initial_guess, ps_implicit_env%v_eps, ps_implicit_env%cstr_charge)
             CALL dbc_release(ps_implicit_env%contacts, do_dbc_cube, pw_pool=pw_pool)
          ELSE
-            CALL pw_release(ps_implicit_env%initial_guess)
-            CALL pw_release(ps_implicit_env%v_eps)
+            CALL ps_implicit_env%initial_guess%release()
+            CALL ps_implicit_env%v_eps%release()
             IF (ASSOCIATED(ps_implicit_env%cstr_charge)) THEN
-               CALL pw_release(ps_implicit_env%cstr_charge)
+               CALL ps_implicit_env%cstr_charge%release()
                DEALLOCATE (ps_implicit_env%cstr_charge)
             END IF
             DEALLOCATE (ps_implicit_env%initial_guess, ps_implicit_env%v_eps)

--- a/src/pw/pw_poisson_methods.F
+++ b/src/pw/pw_poisson_methods.F
@@ -89,7 +89,6 @@ CONTAINS
       TYPE(pw_pool_type), POINTER                        :: pw_pool
 
       CPASSERT(ASSOCIATED(poisson_env))
-      CPASSERT(poisson_env%ref_count > 0)
 
       NULLIFY (pw_pool)
       IF (ASSOCIATED(poisson_env%pw_pools)) THEN
@@ -116,7 +115,6 @@ CONTAINS
       TYPE(ps_wavelet_type), POINTER                     :: wavelet
 
       CPASSERT(ASSOCIATED(poisson_env))
-      CPASSERT(poisson_env%ref_count > 0)
       CPASSERT(ASSOCIATED(poisson_env%pw_pools))
       CPASSERT(poisson_env%pw_level >= LBOUND(poisson_env%pw_pools, 1))
       CPASSERT(poisson_env%pw_level <= UBOUND(poisson_env%pw_pools, 1))
@@ -182,7 +180,6 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       CPASSERT(ASSOCIATED(poisson_env))
-      CPASSERT(poisson_env%ref_count > 0)
       CPASSERT(ASSOCIATED(poisson_env%pw_pools))
 
       IF (poisson_env%rebuild) THEN
@@ -265,7 +262,6 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       CPASSERT(ASSOCIATED(poisson_env))
-      CPASSERT(poisson_env%ref_count > 0)
       CALL pw_poisson_rebuild(poisson_env, density)
       poisson_params => poisson_env%parameters
 

--- a/src/pw/pw_poisson_methods.F
+++ b/src/pw/pw_poisson_methods.F
@@ -84,11 +84,9 @@ CONTAINS
 !>      none
 ! **************************************************************************************************
    SUBROUTINE pw_poisson_cleanup(poisson_env)
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_poisson_type), INTENT(INOUT)               :: poisson_env
 
       TYPE(pw_pool_type), POINTER                        :: pw_pool
-
-      CPASSERT(ASSOCIATED(poisson_env))
 
       NULLIFY (pw_pool)
       IF (ASSOCIATED(poisson_env%pw_pools)) THEN
@@ -108,13 +106,12 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE pw_poisson_check(poisson_env)
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_poisson_type), INTENT(INOUT)               :: poisson_env
 
       LOGICAL                                            :: rebuild
       TYPE(greens_fn_type), POINTER                      :: green
       TYPE(ps_wavelet_type), POINTER                     :: wavelet
 
-      CPASSERT(ASSOCIATED(poisson_env))
       CPASSERT(ASSOCIATED(poisson_env%pw_pools))
       CPASSERT(poisson_env%pw_level >= LBOUND(poisson_env%pw_pools, 1))
       CPASSERT(poisson_env%pw_level <= UBOUND(poisson_env%pw_pools, 1))
@@ -170,7 +167,7 @@ CONTAINS
 !>      rebuilds if poisson_env%rebuild is true
 ! **************************************************************************************************
    SUBROUTINE pw_poisson_rebuild(poisson_env, density)
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_poisson_type), INTENT(INOUT)               :: poisson_env
       TYPE(pw_type), INTENT(IN), OPTIONAL                :: density
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_poisson_rebuild'
@@ -179,7 +176,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CPASSERT(ASSOCIATED(poisson_env))
       CPASSERT(ASSOCIATED(poisson_env%pw_pools))
 
       IF (poisson_env%rebuild) THEN
@@ -238,7 +234,7 @@ CONTAINS
    SUBROUTINE pw_poisson_solve(poisson_env, density, ehartree, vhartree, &
                                dvhartree, h_stress, rho_core, greenfn, aux_density)
 
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_poisson_type), INTENT(INOUT)               :: poisson_env
       TYPE(pw_type), INTENT(IN)                          :: density
       REAL(kind=dp), INTENT(out), OPTIONAL               :: ehartree
       TYPE(pw_type), INTENT(INOUT), OPTIONAL             :: vhartree
@@ -254,18 +250,15 @@ CONTAINS
       LOGICAL                                            :: has_dielectric
       REAL(KIND=dp)                                      :: ffa
       TYPE(pw_grid_type), POINTER                        :: pw_grid
-      TYPE(pw_poisson_parameter_type), POINTER           :: poisson_params
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       TYPE(pw_type)                                      :: dvg(3), dvg_aux(3), influence_fn, rhog, &
                                                             rhog_aux, rhor, tmpg, vhartree_rs
 
       CALL timeset(routineN, handle)
 
-      CPASSERT(ASSOCIATED(poisson_env))
       CALL pw_poisson_rebuild(poisson_env, density)
-      poisson_params => poisson_env%parameters
 
-      has_dielectric = poisson_params%has_dielectric
+      has_dielectric = poisson_env%parameters%has_dielectric
 
       ! point pw
       pw_pool => poisson_env%pw_pools(poisson_env%pw_level)%pool
@@ -321,7 +314,7 @@ CONTAINS
          CASE (PS_IMPLICIT)
 
             IF (has_dielectric .AND. PRESENT(rho_core)) THEN
-               SELECT CASE (poisson_params%ps_implicit_params%boundary_condition)
+               SELECT CASE (poisson_env%parameters%ps_implicit_params%boundary_condition)
                CASE (PERIODIC_BC, MIXED_PERIODIC_BC)
                   CALL dielectric_compute(poisson_env%implicit_env%dielectric, &
                                           poisson_env%diel_rs_grid, &
@@ -332,7 +325,7 @@ CONTAINS
                                           poisson_env%diel_rs_grid, &
                                           poisson_env%pw_pools(poisson_env%pw_level)%pool, &
                                           poisson_env%dct_pw_grid, &
-                                          poisson_params%ps_implicit_params%neumann_directions, &
+                                          poisson_env%parameters%ps_implicit_params%neumann_directions, &
                                           poisson_env%implicit_env%dct_env%recv_msgs_bnds, &
                                           poisson_env%implicit_env%dct_env%dests_expand, &
                                           poisson_env%implicit_env%dct_env%srcs_expand, &
@@ -346,7 +339,7 @@ CONTAINS
             CALL pw_pool%create_pw(vhartree_rs, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(density, rhor)
 
-            SELECT CASE (poisson_params%ps_implicit_params%boundary_condition)
+            SELECT CASE (poisson_env%parameters%ps_implicit_params%boundary_condition)
             CASE (PERIODIC_BC)
                CALL implicit_poisson_solver_periodic(poisson_env, rhor, vhartree_rs, &
                                                      ehartree=ehartree)
@@ -540,7 +533,7 @@ CONTAINS
    SUBROUTINE pw_poisson_set(poisson_env, cell_hmat, parameters, pw_pools, use_level, &
                              mt_super_ref_pw_grid, dct_pw_grid, force_rebuild)
 
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      TYPE(pw_poisson_type), INTENT(INOUT)               :: poisson_env
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN), &
          OPTIONAL                                        :: cell_hmat
       TYPE(pw_poisson_parameter_type), INTENT(IN), &

--- a/src/pw/pw_poisson_methods.F
+++ b/src/pw/pw_poisson_methods.F
@@ -50,9 +50,7 @@ MODULE pw_poisson_methods
         greens_fn_type, pw_green_create, pw_green_release, pw_poisson_analytic, &
         pw_poisson_implicit, pw_poisson_mt, pw_poisson_multipole, pw_poisson_none, &
         pw_poisson_parameter_type, pw_poisson_periodic, pw_poisson_type, pw_poisson_wavelet
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type,&
                                               pw_pools_copy,&
                                               pw_pools_dealloc
@@ -281,9 +279,9 @@ CONTAINS
             CPABORT("vhartree has a different grid than the poisson solver")
       END IF
       ! density in G space
-      CALL pw_pool_create_pw(pw_pool, rhog, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool%create_pw(rhog, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       IF (PRESENT(aux_density)) THEN
-         CALL pw_pool_create_pw(pw_pool, rhog_aux, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL pw_pool%create_pw(rhog_aux, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END IF
 
       SELECT CASE (poisson_env%used_grid)
@@ -297,7 +295,7 @@ CONTAINS
                CALL pw_transfer(aux_density, rhog_aux)
             END IF
             IF (PRESENT(ehartree) .AND. (.NOT. PRESENT(vhartree))) THEN
-               CALL pw_pool_create_pw(pw_pool, tmpg, use_data=COMPLEXDATA1D, &
+               CALL pw_pool%create_pw(tmpg, use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
                CALL pw_copy(rhog, tmpg)
             END IF
@@ -321,7 +319,7 @@ CONTAINS
                END IF
             ELSE IF (PRESENT(ehartree)) THEN
                ehartree = 0.5_dp*pw_integral_ab(rhog, tmpg)
-               CALL pw_pool_give_back_pw(pw_pool, tmpg)
+               CALL pw_pool%give_back_pw(tmpg)
             END IF
 
          CASE (PS_IMPLICIT)
@@ -348,8 +346,8 @@ CONTAINS
                END SELECT
             END IF
 
-            CALL pw_pool_create_pw(pw_pool, rhor, use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(pw_pool, vhartree_rs, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool%create_pw(rhor, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool%create_pw(vhartree_rs, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(density, rhor)
 
             SELECT CASE (poisson_params%ps_implicit_params%boundary_condition)
@@ -373,8 +371,8 @@ CONTAINS
                CPABORT("No stress tensor is implemented for the implicit Poisson solver.")
             END IF
 
-            CALL pw_pool_give_back_pw(pw_pool, rhor)
-            CALL pw_pool_give_back_pw(pw_pool, vhartree_rs)
+            CALL pw_pool%give_back_pw(rhor)
+            CALL pw_pool%give_back_pw(vhartree_rs)
 
          CASE DEFAULT
             CALL cp_abort(__LOCATION__, &
@@ -384,7 +382,7 @@ CONTAINS
 
       CASE (use_rs_grid)
 
-         CALL pw_pool_create_pw(pw_pool, rhor, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(rhor, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(density, rhor)
          CALL cp2k_distribution_to_z_slices(rhor, poisson_env%wavelet, rhor%pw_grid)
          CALL ps_wavelet_solve(poisson_env%wavelet, rhor%pw_grid)
@@ -400,21 +398,21 @@ CONTAINS
          IF (PRESENT(h_stress) .OR. PRESENT(dvhartree)) THEN
             CALL pw_transfer(rhor, rhog)
          END IF
-         CALL pw_pool_give_back_pw(pw_pool, rhor)
+         CALL pw_pool%give_back_pw(rhor)
 
       END SELECT
 
       ! do we need to calculate the derivative of the potential?
       IF (PRESENT(h_stress) .OR. PRESENT(dvhartree)) THEN
          DO i = 1, 3
-            CALL pw_pool_create_pw(pw_pool, dvg(i), use_data=COMPLEXDATA1D, &
+            CALL pw_pool%create_pw(dvg(i), use_data=COMPLEXDATA1D, &
                                    in_space=RECIPROCALSPACE)
             n = 0
             n(i) = 1
             CALL pw_copy(rhog, dvg(i))
             CALL pw_derive(dvg(i), n)
             IF (PRESENT(aux_density)) THEN
-               CALL pw_pool_create_pw(pw_pool, dvg_aux(i), use_data=COMPLEXDATA1D, &
+               CALL pw_pool%create_pw(dvg_aux(i), use_data=COMPLEXDATA1D, &
                                       in_space=RECIPROCALSPACE)
                CALL pw_copy(rhog_aux, dvg_aux(i))
                CALL pw_derive(dvg_aux(i), n)
@@ -507,16 +505,16 @@ CONTAINS
          END IF
 
          DO i = 1, 3
-            CALL pw_pool_give_back_pw(pw_pool, dvg(i))
+            CALL pw_pool%give_back_pw(dvg(i))
             IF (PRESENT(aux_density)) THEN
-               CALL pw_pool_give_back_pw(pw_pool, dvg_aux(i))
+               CALL pw_pool%give_back_pw(dvg_aux(i))
             END IF
          END DO
 
       END IF
-      CALL pw_pool_give_back_pw(pw_pool, rhog)
+      CALL pw_pool%give_back_pw(rhog)
       IF (PRESENT(aux_density)) THEN
-         CALL pw_pool_give_back_pw(pw_pool, rhog_aux)
+         CALL pw_pool%give_back_pw(rhog_aux)
       END IF
 
       CALL timestop(handle)

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -61,8 +61,6 @@ MODULE pw_poisson_types
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'pw_poisson_types'
 
    PUBLIC :: pw_poisson_type
-   PUBLIC :: pw_poisson_create, &
-             pw_poisson_release
    PUBLIC :: greens_fn_type, pw_green_create, &
              pw_green_release
    PUBLIC :: pw_poisson_parameter_type
@@ -137,6 +135,9 @@ MODULE pw_poisson_types
       TYPE(ps_implicit_type), POINTER             :: implicit_env => NULL()
       TYPE(pw_grid_type), POINTER                 :: dct_pw_grid => NULL()
       TYPE(realspace_grid_type), POINTER          :: diel_rs_grid => NULL()
+   CONTAINS
+      PROCEDURE, PUBLIC, NON_OVERRIDABLE :: create => pw_poisson_create
+      PROCEDURE, PUBLIC, NON_OVERRIDABLE :: release => pw_poisson_release
    END TYPE pw_poisson_type
 
 ! **************************************************************************************************
@@ -564,10 +565,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_poisson_create(poisson_env)
 
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      CLASS(pw_poisson_type), INTENT(INOUT)              :: poisson_env
 
-      CPASSERT(.NOT. ASSOCIATED(poisson_env))
-      ALLOCATE (poisson_env)
+      ! Cleanup a potential previous poisson_env
+      CALL poisson_env%release()
 
    END SUBROUTINE pw_poisson_create
 
@@ -580,29 +581,25 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_poisson_release(poisson_env)
 
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
+      CLASS(pw_poisson_type), INTENT(INOUT)               :: poisson_env
 
-      IF (ASSOCIATED(poisson_env)) THEN
-         IF (ASSOCIATED(poisson_env%pw_pools)) THEN
-            CALL pw_pools_dealloc(poisson_env%pw_pools)
-         END IF
-
-         IF (ASSOCIATED(poisson_env%green_fft)) THEN
-            CALL pw_green_release(poisson_env%green_fft)
-            DEALLOCATE (poisson_env%green_fft)
-         END IF
-         CALL pw_grid_release(poisson_env%mt_super_ref_pw_grid)
-         CALL ps_wavelet_release(poisson_env%wavelet)
-         CALL ps_implicit_release(poisson_env%implicit_env, &
-                                  poisson_env%parameters%ps_implicit_params)
-         CALL pw_grid_release(poisson_env%dct_pw_grid)
-         IF (ASSOCIATED(poisson_env%diel_rs_grid)) THEN
-            CALL rs_grid_release(poisson_env%diel_rs_grid)
-            DEALLOCATE (poisson_env%diel_rs_grid)
-         END IF
-         DEALLOCATE (poisson_env)
+      IF (ASSOCIATED(poisson_env%pw_pools)) THEN
+         CALL pw_pools_dealloc(poisson_env%pw_pools)
       END IF
-      NULLIFY (poisson_env)
+
+      IF (ASSOCIATED(poisson_env%green_fft)) THEN
+         CALL pw_green_release(poisson_env%green_fft)
+         DEALLOCATE (poisson_env%green_fft)
+      END IF
+      CALL pw_grid_release(poisson_env%mt_super_ref_pw_grid)
+      CALL ps_wavelet_release(poisson_env%wavelet)
+      CALL ps_implicit_release(poisson_env%implicit_env, &
+                               poisson_env%parameters%ps_implicit_params)
+      CALL pw_grid_release(poisson_env%dct_pw_grid)
+      IF (ASSOCIATED(poisson_env%diel_rs_grid)) THEN
+         CALL rs_grid_release(poisson_env%diel_rs_grid)
+         DEALLOCATE (poisson_env%diel_rs_grid)
+      END IF
 
    END SUBROUTINE pw_poisson_release
 

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -61,7 +61,7 @@ MODULE pw_poisson_types
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'pw_poisson_types'
 
    PUBLIC :: pw_poisson_type
-   PUBLIC :: pw_poisson_create, pw_poisson_retain, &
+   PUBLIC :: pw_poisson_create, &
              pw_poisson_release
    PUBLIC :: greens_fn_type, pw_green_create, &
              pw_green_release
@@ -124,7 +124,6 @@ MODULE pw_poisson_types
 !> \author fawzi
 ! **************************************************************************************************
    TYPE pw_poisson_type
-      INTEGER :: ref_count = 0
       INTEGER :: pw_level = 0
       INTEGER :: method = pw_poisson_none
       INTEGER :: used_grid = 0
@@ -569,22 +568,8 @@ CONTAINS
 
       CPASSERT(.NOT. ASSOCIATED(poisson_env))
       ALLOCATE (poisson_env)
-      poisson_env%ref_count = 1
 
    END SUBROUTINE pw_poisson_create
-
-! **************************************************************************************************
-!> \brief retains the pw_poisson_env
-!> \param poisson_env ...
-!> \author fawzi
-! **************************************************************************************************
-   SUBROUTINE pw_poisson_retain(poisson_env)
-      TYPE(pw_poisson_type), POINTER                     :: poisson_env
-
-      CPASSERT(ASSOCIATED(poisson_env))
-      CPASSERT(poisson_env%ref_count > 0)
-      poisson_env%ref_count = poisson_env%ref_count + 1
-   END SUBROUTINE pw_poisson_retain
 
 ! **************************************************************************************************
 !> \brief releases the poisson solver
@@ -598,29 +583,24 @@ CONTAINS
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
 
       IF (ASSOCIATED(poisson_env)) THEN
-         CPASSERT(poisson_env%ref_count > 0)
-         poisson_env%ref_count = poisson_env%ref_count - 1
-         IF (poisson_env%ref_count == 0) THEN
-            IF (ASSOCIATED(poisson_env%pw_pools)) THEN
-               CALL pw_pools_dealloc(poisson_env%pw_pools)
-            END IF
-
-            IF (ASSOCIATED(poisson_env%green_fft)) THEN
-               CALL pw_green_release(poisson_env%green_fft)
-               DEALLOCATE (poisson_env%green_fft)
-            END IF
-            CALL pw_grid_release(poisson_env%mt_super_ref_pw_grid)
-            CALL ps_wavelet_release(poisson_env%wavelet)
-            CALL ps_implicit_release(poisson_env%implicit_env, &
-                                     poisson_env%parameters%ps_implicit_params)
-            CALL pw_grid_release(poisson_env%dct_pw_grid)
-            IF (ASSOCIATED(poisson_env%diel_rs_grid)) THEN
-               CALL rs_grid_release(poisson_env%diel_rs_grid)
-               DEALLOCATE (poisson_env%diel_rs_grid)
-            END IF
-            DEALLOCATE (poisson_env)
-
+         IF (ASSOCIATED(poisson_env%pw_pools)) THEN
+            CALL pw_pools_dealloc(poisson_env%pw_pools)
          END IF
+
+         IF (ASSOCIATED(poisson_env%green_fft)) THEN
+            CALL pw_green_release(poisson_env%green_fft)
+            DEALLOCATE (poisson_env%green_fft)
+         END IF
+         CALL pw_grid_release(poisson_env%mt_super_ref_pw_grid)
+         CALL ps_wavelet_release(poisson_env%wavelet)
+         CALL ps_implicit_release(poisson_env%implicit_env, &
+                                  poisson_env%parameters%ps_implicit_params)
+         CALL pw_grid_release(poisson_env%dct_pw_grid)
+         IF (ASSOCIATED(poisson_env%diel_rs_grid)) THEN
+            CALL rs_grid_release(poisson_env%diel_rs_grid)
+            DEALLOCATE (poisson_env%diel_rs_grid)
+         END IF
+         DEALLOCATE (poisson_env)
       END IF
       NULLIFY (poisson_env)
 

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -51,7 +51,6 @@ MODULE pw_poisson_types
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA1D,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE realspace_grid_types,            ONLY: realspace_grid_type,&
                                               rs_grid_release
@@ -445,17 +444,17 @@ CONTAINS
             DEALLOCATE (gftype%p3m_charge)
          END IF
       ELSE
-         CALL pw_release(gftype%influence_fn)
+         CALL gftype%influence_fn%release()
          IF (ASSOCIATED(gftype%dct_influence_fn)) THEN
-            CALL pw_release(gftype%dct_influence_fn)
+            CALL gftype%dct_influence_fn%release()
             DEALLOCATE (gftype%dct_influence_fn)
          END IF
          IF (ASSOCIATED(gftype%screen_fn)) THEN
-            CALL pw_release(gftype%screen_fn)
+            CALL gftype%screen_fn%release()
             DEALLOCATE (gftype%screen_fn)
          END IF
          IF (ASSOCIATED(gftype%p3m_charge)) THEN
-            CALL pw_release(gftype%p3m_charge)
+            CALL gftype%p3m_charge%release()
             DEALLOCATE (gftype%p3m_charge)
          END IF
       END IF

--- a/src/pw/pw_poisson_types.F
+++ b/src/pw/pw_poisson_types.F
@@ -42,8 +42,6 @@ MODULE pw_poisson_types
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_release
    USE pw_pool_types,                   ONLY: pw_pool_create,&
-                                              pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
                                               pw_pool_p_type,&
                                               pw_pool_release,&
                                               pw_pool_type,&
@@ -272,7 +270,7 @@ CONTAINS
       ! allocate influence function,...
       SELECT CASE (green%method)
       CASE (PERIODIC3D, ANALYTIC2D, ANALYTIC1D, ANALYTIC0D, MT2D, MT1D, MT0D, MULTIPOLE0D, PS_IMPLICIT)
-         CALL pw_pool_create_pw(pw_pool, green%influence_fn, &
+         CALL pw_pool%create_pw(green%influence_fn, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
          IF (poisson_params%ewald_type == do_ewald_spme) THEN
@@ -284,7 +282,7 @@ CONTAINS
             CALL spme_coeff_calculate(n, green%p3m_coeff)
             NULLIFY (green%p3m_charge)
             ALLOCATE (green%p3m_charge)
-            CALL pw_pool_create_pw(pw_pool, green%p3m_charge, use_data=REALDATA1D, &
+            CALL pw_pool%create_pw(green%p3m_charge, use_data=REALDATA1D, &
                                    in_space=RECIPROCALSPACE)
             CALL influence_factor(green)
             CALL calc_p3m_charge(green)
@@ -304,8 +302,8 @@ CONTAINS
                CALL pw_pool_create(pw_pool_xpndd, pw_grid=dct_pw_grid)
                NULLIFY (green%dct_influence_fn)
                ALLOCATE (green%dct_influence_fn)
-               CALL pw_pool_create_pw(pw_pool_xpndd, green%dct_influence_fn, &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL pw_pool_xpndd%create_pw(green%dct_influence_fn, &
+                                            use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                CALL pw_pool_release(pw_pool_xpndd)
             END IF
          END SELECT
@@ -430,17 +428,17 @@ CONTAINS
       can_give_back = PRESENT(pw_pool)
       IF (can_give_back) can_give_back = ASSOCIATED(pw_pool)
       IF (can_give_back) THEN
-         CALL pw_pool_give_back_pw(pw_pool, gftype%influence_fn)
+         CALL pw_pool%give_back_pw(gftype%influence_fn)
          IF (ASSOCIATED(gftype%dct_influence_fn)) THEN
-            CALL pw_pool_give_back_pw(pw_pool, gftype%dct_influence_fn)
+            CALL pw_pool%give_back_pw(gftype%dct_influence_fn)
             DEALLOCATE (gftype%dct_influence_fn)
          END IF
          IF (ASSOCIATED(gftype%screen_fn)) THEN
-            CALL pw_pool_give_back_pw(pw_pool, gftype%screen_fn)
+            CALL pw_pool%give_back_pw(gftype%screen_fn)
             DEALLOCATE (gftype%screen_fn)
          END IF
          IF (ASSOCIATED(gftype%p3m_charge)) THEN
-            CALL pw_pool_give_back_pw(pw_pool, gftype%p3m_charge)
+            CALL pw_pool%give_back_pw(gftype%p3m_charge)
             DEALLOCATE (gftype%p3m_charge)
          END IF
       ELSE

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -38,6 +38,8 @@ MODULE pw_pool_types
                                               COMPLEXDATA3D,&
                                               REALDATA1D,&
                                               REALDATA3D,&
+                                              REALSPACE,&
+                                              RECIPROCALSPACE,&
                                               pw_type
 #include "../base/base_uses.f90"
 
@@ -48,9 +50,7 @@ MODULE pw_pool_types
    INTEGER, PARAMETER :: default_max_cache = 75, max_max_cache = 150
 
    PUBLIC :: pw_pool_type, pw_pool_p_type
-   PUBLIC :: pw_pool_create, pw_pool_retain, pw_pool_release, &
-             pw_pool_create_pw, pw_pool_give_back_pw, &
-             pw_pool_create_cr3d, pw_pool_give_back_cr3d
+   PUBLIC :: pw_pool_create, pw_pool_retain, pw_pool_release
    PUBLIC :: pw_pools_copy, pw_pools_dealloc, &
              pw_pools_create_pws, pw_pools_give_back_pws
 
@@ -74,6 +74,11 @@ MODULE pw_pool_types
       TYPE(cp_sll_pw_type), POINTER :: real1d_pw => NULL(), real3d_pw => NULL(), &
                                        complex1d_pw => NULL(), complex3d_pw => NULL()
       TYPE(cp_sll_3d_r_type), POINTER :: real3d_array => NULL()
+   CONTAINS
+      PROCEDURE, PUBLIC, NON_OVERRIDABLE :: create_pw => pw_pool_create_pw
+      PROCEDURE, PUBLIC, NON_OVERRIDABLE :: give_back_pw => pw_pool_give_back_pw
+      PROCEDURE, PUBLIC, NON_OVERRIDABLE :: create_cr3d => pw_pool_create_cr3d
+      PROCEDURE, PUBLIC, NON_OVERRIDABLE :: give_back_cr3d => pw_pool_give_back_cr3d
    END TYPE pw_pool_type
 
 ! **************************************************************************************************
@@ -261,7 +266,7 @@ CONTAINS
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
    SUBROUTINE pw_pool_create_pw(pool, pw, use_data, in_space)
-      TYPE(pw_pool_type), INTENT(IN)                     :: pool
+      CLASS(pw_pool_type), INTENT(IN)                     :: pool
       TYPE(pw_type), INTENT(OUT)                         :: pw
       INTEGER, INTENT(in)                                :: use_data, in_space
 
@@ -303,6 +308,8 @@ CONTAINS
       ELSE
          pw = el
          DEALLOCATE (el)
+         IF (in_space /= REALSPACE .AND. in_space /= RECIPROCALSPACE) &
+            CPABORT("A PW grid either lives in real space or in reciprocal space!")
          pw%in_space = in_space
       END IF
 
@@ -319,7 +326,7 @@ CONTAINS
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
    SUBROUTINE pw_pool_give_back_pw(pool, pw)
-      TYPE(pw_pool_type), INTENT(IN)                     :: pool
+      CLASS(pw_pool_type), INTENT(IN)                     :: pool
       TYPE(pw_type), INTENT(INOUT)                       :: pw
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_pool_give_back_pw'
@@ -408,7 +415,7 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE pw_pool_create_cr3d(pw_pool, cr3d)
-      TYPE(pw_pool_type), INTENT(IN)                     :: pw_pool
+      CLASS(pw_pool_type), INTENT(IN)                     :: pw_pool
       REAL(kind=dp), DIMENSION(:, :, :), POINTER         :: cr3d
 
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -448,7 +455,7 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE pw_pool_give_back_cr3d(pw_pool, cr3d, accept_non_compatible)
-      TYPE(pw_pool_type), INTENT(IN)                     :: pw_pool
+      CLASS(pw_pool_type), INTENT(IN)                     :: pw_pool
       REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: cr3d
       LOGICAL, INTENT(in), OPTIONAL                      :: accept_non_compatible
@@ -505,8 +512,8 @@ CONTAINS
 
       ALLOCATE (pws(SIZE(pools)))
       DO i = 1, SIZE(pools)
-         CALL pw_pool_create_pw(pools(i)%pool, pws(i), use_data, &
-                                in_space=in_space)
+         CALL pools(i)%pool%create_pw(pws(i), use_data, &
+                                      in_space=in_space)
       END DO
    END SUBROUTINE pw_pools_create_pws
 
@@ -527,7 +534,7 @@ CONTAINS
 
       CPASSERT(SIZE(pws) == SIZE(pools))
       DO i = 1, SIZE(pools)
-         CALL pw_pool_give_back_pw(pools(i)%pool, pws(i))
+         CALL pools(i)%pool%give_back_pw(pws(i))
       END DO
       DEALLOCATE (pws)
    END SUBROUTINE pw_pools_give_back_pws

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -27,8 +27,6 @@ MODULE pw_pool_types
         cp_sll_3d_r_insert_el, cp_sll_3d_r_next, cp_sll_3d_r_rm_first_el, cp_sll_3d_r_type, &
         cp_sll_pw_dealloc, cp_sll_pw_get_first_el, cp_sll_pw_get_length, cp_sll_pw_insert_el, &
         cp_sll_pw_next, cp_sll_pw_rm_first_el, cp_sll_pw_type
-   USE cp_log_handling,                 ONLY: cp_get_default_logger,&
-                                              cp_logger_type
    USE kinds,                           ONLY: dp
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_compare,&
@@ -50,7 +48,7 @@ MODULE pw_pool_types
    INTEGER, PARAMETER :: default_max_cache = 75, max_max_cache = 150
 
    PUBLIC :: pw_pool_type, pw_pool_p_type
-   PUBLIC :: pw_pool_create, pw_pool_retain, pw_pool_release
+   PUBLIC :: pw_pool_create, pw_pool_release
    PUBLIC :: pw_pools_copy, pw_pools_dealloc, &
              pw_pools_create_pws, pw_pools_give_back_pws
 
@@ -75,6 +73,7 @@ MODULE pw_pool_types
                                        complex1d_pw => NULL(), complex3d_pw => NULL()
       TYPE(cp_sll_3d_r_type), POINTER :: real3d_array => NULL()
    CONTAINS
+      PROCEDURE, PUBLIC, NON_OVERRIDABLE :: retain => pw_pool_retain
       PROCEDURE, PUBLIC, NON_OVERRIDABLE :: create_pw => pw_pool_create_pw
       PROCEDURE, PUBLIC, NON_OVERRIDABLE :: give_back_pw => pw_pool_give_back_pw
       PROCEDURE, PUBLIC, NON_OVERRIDABLE :: create_cr3d => pw_pool_create_cr3d
@@ -108,10 +107,6 @@ CONTAINS
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       INTEGER, OPTIONAL                                  :: max_cache
 
-      TYPE(cp_logger_type), POINTER                      :: logger
-
-      logger => cp_get_default_logger()
-
       ALLOCATE (pool)
       pool%pw_grid => pw_grid
       CALL pw_grid_retain(pw_grid)
@@ -131,13 +126,8 @@ CONTAINS
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
    SUBROUTINE pw_pool_retain(pool)
-      TYPE(pw_pool_type), POINTER                        :: pool
+      CLASS(pw_pool_type), INTENT(INOUT)                  :: pool
 
-      TYPE(cp_logger_type), POINTER                      :: logger
-
-      logger => cp_get_default_logger()
-
-      CPASSERT(ASSOCIATED(pool))
       CPASSERT(pool%ref_count > 0)
 
       pool%ref_count = pool%ref_count + 1
@@ -155,14 +145,11 @@ CONTAINS
 
       REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: array_att
-      TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_sll_3d_r_type), POINTER                    :: array_iterator
       TYPE(cp_sll_pw_type), POINTER                      :: iterator
       TYPE(pw_type), POINTER                             :: pw_el
 
       NULLIFY (iterator, array_iterator, pw_el, array_att)
-      logger => cp_get_default_logger()
-
       iterator => pool%real1d_pw
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
@@ -214,10 +201,6 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE pw_pool_release(pool)
       TYPE(pw_pool_type), POINTER                        :: pool
-
-      TYPE(cp_logger_type), POINTER                      :: logger
-
-      logger => cp_get_default_logger()
 
       IF (ASSOCIATED(pool)) THEN
          CPASSERT(pool%ref_count > 0)
@@ -275,12 +258,10 @@ CONTAINS
       INTEGER                                            :: handle
       REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: cr3d_ptr
-      TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(pw_type), POINTER                             :: el
 
       CALL timeset(routineN, handle)
       NULLIFY (cr3d_ptr)
-      logger => cp_get_default_logger()
 
       SELECT CASE (use_data)
       CASE (REALDATA1D)
@@ -332,10 +313,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_pool_give_back_pw'
 
       INTEGER                                            :: handle
-      TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(pw_type), POINTER                             :: el
-
-      logger => cp_get_default_logger()
 
       CALL timeset(routineN, handle)
       IF (ASSOCIATED(pw%pw_grid)) THEN
@@ -418,12 +396,9 @@ CONTAINS
       CLASS(pw_pool_type), INTENT(IN)                     :: pw_pool
       REAL(kind=dp), DIMENSION(:, :, :), POINTER         :: cr3d
 
-      TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(pw_type), POINTER                             :: pw
 
       NULLIFY (pw)
-      logger => cp_get_default_logger()
-
       IF (ASSOCIATED(pw_pool%real3d_array)) THEN
          cr3d => cp_sll_3d_r_get_first_el(pw_pool%real3d_array)
          CALL cp_sll_3d_r_rm_first_el(pw_pool%real3d_array)
@@ -448,31 +423,22 @@ CONTAINS
 !>      REALDATA3D, allocating it if none is present in the pool
 !> \param pw_pool the pool that caches the cr3d
 !> \param cr3d the pointer that will contain the array
-!> \param accept_non_compatible if true deallocates the non compatible
-!>        arrays passed in, if false (the default) stops with an error
 !> \par History
 !>      11.2003 created [fawzi]
 !> \author fawzi
 ! **************************************************************************************************
-   SUBROUTINE pw_pool_give_back_cr3d(pw_pool, cr3d, accept_non_compatible)
+   SUBROUTINE pw_pool_give_back_cr3d(pw_pool, cr3d)
       CLASS(pw_pool_type), INTENT(IN)                     :: pw_pool
       REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: cr3d
-      LOGICAL, INTENT(in), OPTIONAL                      :: accept_non_compatible
 
-      LOGICAL                                            :: compatible, my_accept_non_compatible
-      TYPE(cp_logger_type), POINTER                      :: logger
-
-      my_accept_non_compatible = .FALSE.
-      logger => cp_get_default_logger()
-      IF (PRESENT(accept_non_compatible)) my_accept_non_compatible = accept_non_compatible
+      LOGICAL                                            :: compatible
 
       IF (ASSOCIATED(cr3d)) THEN
          compatible = ALL(MERGE(pw_pool%pw_grid%bounds_local(1, :) == LBOUND(cr3d) .AND. &
                                 pw_pool%pw_grid%bounds_local(2, :) == UBOUND(cr3d), &
                                 pw_pool%pw_grid%bounds_local(2, :) < pw_pool%pw_grid%bounds_local(1, :), &
                                 UBOUND(cr3d) >= LBOUND(cr3d)))
-         CPASSERT(compatible .OR. my_accept_non_compatible)
          IF (compatible) THEN
             IF (cp_sll_3d_r_get_length(pw_pool%real3d_array) < pw_pool%max_cache) THEN
                CALL cp_sll_3d_r_insert_el(pw_pool%real3d_array, el=cr3d)
@@ -484,8 +450,6 @@ CONTAINS
          ELSE
             DEALLOCATE (cr3d)
          END IF
-      ELSE
-         CPASSERT(my_accept_non_compatible)
       END IF
       NULLIFY (cr3d)
    END SUBROUTINE pw_pool_give_back_cr3d
@@ -556,7 +520,7 @@ CONTAINS
       ALLOCATE (target_pools(SIZE(source_pools)))
       DO i = 1, SIZE(source_pools)
          target_pools(i)%pool => source_pools(i)%pool
-         CALL pw_pool_retain(source_pools(i)%pool)
+         CALL source_pools(i)%pool%retain()
       END DO
    END SUBROUTINE pw_pools_copy
 

--- a/src/pw/pw_pool_types.F
+++ b/src/pw/pw_pool_types.F
@@ -38,8 +38,6 @@ MODULE pw_pool_types
                                               COMPLEXDATA3D,&
                                               REALDATA1D,&
                                               REALDATA3D,&
-                                              pw_create,&
-                                              pw_release,&
                                               pw_type
 #include "../base/base_uses.f90"
 
@@ -163,7 +161,7 @@ CONTAINS
       iterator => pool%real1d_pw
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
-         CALL pw_release(pw_el)
+         CALL pw_el%release()
          DEALLOCATE (pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%real1d_pw)
@@ -171,7 +169,7 @@ CONTAINS
       iterator => pool%real3d_pw
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
-         CALL pw_release(pw_el)
+         CALL pw_el%release()
          DEALLOCATE (pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%real3d_pw)
@@ -179,7 +177,7 @@ CONTAINS
       iterator => pool%complex1d_pw
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
-         CALL pw_release(pw_el)
+         CALL pw_el%release()
          DEALLOCATE (pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%complex1d_pw)
@@ -187,7 +185,7 @@ CONTAINS
       iterator => pool%complex3d_pw
       DO
          IF (.NOT. cp_sll_pw_next(iterator, el_att=pw_el)) EXIT
-         CALL pw_release(pw_el)
+         CALL pw_el%release()
          DEALLOCATE (pw_el)
       END DO
       CALL cp_sll_pw_dealloc(pool%complex3d_pw)
@@ -300,7 +298,7 @@ CONTAINS
       END SELECT
 
       IF (.NOT. ASSOCIATED(el)) THEN
-         CALL pw_create(pw, pool%pw_grid, use_data=use_data, &
+         CALL pw%create(pool%pw_grid, use_data=use_data, &
                         in_space=in_space, cr3d_ptr=cr3d_ptr)
       ELSE
          pw = el
@@ -335,7 +333,7 @@ CONTAINS
       CALL timeset(routineN, handle)
       IF (ASSOCIATED(pw%pw_grid)) THEN
          IF (.NOT. pw_grid_compare(pw%pw_grid, pool%pw_grid)) THEN
-            CALL pw_release(pw)
+            CALL pw%release()
          ELSE
             NULLIFY (el)
             ALLOCATE (el)
@@ -348,7 +346,7 @@ CONTAINS
                ELSE
                   IF (max_max_cache >= 0) &
                      CPWARN("hit max_cache")
-                  CALL pw_release(el)
+                  CALL el%release()
                   DEALLOCATE (el)
                END IF
             CASE (REALDATA3D)
@@ -358,11 +356,11 @@ CONTAINS
                   ELSE
                      IF (max_max_cache >= 0) &
                         CPWARN("hit max_cache")
-                     CALL pw_release(el)
+                     CALL el%release()
                      DEALLOCATE (el)
                   END IF
                ELSE
-                  CALL pw_release(el)
+                  CALL el%release()
                   DEALLOCATE (el)
                END IF
             CASE (COMPLEXDATA1D)
@@ -371,7 +369,7 @@ CONTAINS
                ELSE
                   IF (max_max_cache >= 0) &
                      CPWARN("hit max_cache")
-                  CALL pw_release(el)
+                  CALL el%release()
                   DEALLOCATE (el)
                END IF
             CASE (COMPLEXDATA3D)
@@ -380,7 +378,7 @@ CONTAINS
                ELSE
                   IF (max_max_cache >= 0) &
                      CPWARN("hit max_cache")
-                  CALL pw_release(el)
+                  CALL el%release()
                   DEALLOCATE (el)
                END IF
             CASE default
@@ -427,7 +425,7 @@ CONTAINS
          IF (ASSOCIATED(pw)) THEN
             cr3d => pw%cr3d
             NULLIFY (pw%cr3d)
-            CALL pw_release(pw)
+            CALL pw%release()
             DEALLOCATE (pw)
          END IF
       END IF

--- a/src/pw/pw_spline_utils.F
+++ b/src/pw/pw_spline_utils.F
@@ -29,9 +29,7 @@ MODULE pw_spline_utils
                                               pw_copy,&
                                               pw_integral_ab,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_release,&
+   USE pw_pool_types,                   ONLY: pw_pool_release,&
                                               pw_pool_retain,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
@@ -2693,10 +2691,10 @@ CONTAINS
 
       res = .FALSE.
       logger => cp_get_default_logger()
-      CALL pw_pool_create_pw(pool, r, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pool, z, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pool, p, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pool, Ap, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pool%create_pw(r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pool%create_pw(z, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pool%create_pw(p, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pool%create_pw(Ap, use_data=REALDATA3D, in_space=REALSPACE)
 
       !CALL cp_add_iter_level(logger%iter_info,level_name="SPLINE_FIND_COEFFS")
       ext_do: DO iiter = 1, max_iter, 10
@@ -2750,10 +2748,10 @@ CONTAINS
       END DO ext_do
       !CALL cp_rm_iter_level(logger%iter_info,level_name="SPLINE_FIND_COEFFS")
 
-      CALL pw_pool_give_back_pw(pool, r)
-      CALL pw_pool_give_back_pw(pool, z)
-      CALL pw_pool_give_back_pw(pool, p)
-      CALL pw_pool_give_back_pw(pool, Ap)
+      CALL pool%give_back_pw(r)
+      CALL pool%give_back_pw(z)
+      CALL pool%give_back_pw(p)
+      CALL pool%give_back_pw(Ap)
 
    END FUNCTION find_coeffs
 

--- a/src/pw/pw_spline_utils.F
+++ b/src/pw/pw_spline_utils.F
@@ -30,7 +30,6 @@ MODULE pw_spline_utils
                                               pw_integral_ab,&
                                               pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_release,&
-                                              pw_pool_retain,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -2497,7 +2496,7 @@ CONTAINS
       preconditioner%pool => pool
       preconditioner%pbc = pbc
       preconditioner%transpose = transpose
-      CALL pw_pool_retain(pool)
+      CALL pool%retain()
       CALL pw_spline_precond_set_kind(preconditioner, precond_kind)
    END SUBROUTINE pw_spline_precond_create
 

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -38,7 +38,6 @@ MODULE pw_types
 
    PRIVATE
    PUBLIC :: pw_type, pw_p_type
-   PUBLIC :: pw_release, pw_create
 
    ! Flags for the structure member 'in_use'
    ! NODATA only for internal use, we enforce a certain data type
@@ -62,6 +61,9 @@ MODULE pw_types
       INTEGER :: in_space = NOSPACE ! Real/Reciprocal space
 
       TYPE(pw_grid_type), POINTER :: pw_grid => NULL()
+   CONTAINS
+      PROCEDURE, PUBLIC, NON_OVERRIDABLE :: create => pw_create
+      PROCEDURE, PUBLIC, NON_OVERRIDABLE :: release => pw_release
    END TYPE pw_type
 
 ! **************************************************************************************************
@@ -84,7 +86,7 @@ CONTAINS
 !>      see doc/ReferenceCounting.html
 ! **************************************************************************************************
    SUBROUTINE pw_release(pw)
-      TYPE(pw_type), INTENT(INOUT)                       :: pw
+      CLASS(pw_type), INTENT(INOUT)                       :: pw
 
       SELECT CASE (pw%in_use)
       CASE (REALDATA1D)
@@ -118,7 +120,7 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE pw_create(pw, pw_grid, use_data, in_space, cr3d_ptr)
-      TYPE(pw_type), INTENT(OUT)                         :: pw
+      CLASS(pw_type), INTENT(OUT)                         :: pw
       TYPE(pw_grid_type), INTENT(IN), POINTER            :: pw_grid
       INTEGER, INTENT(in)                                :: use_data, in_space
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &

--- a/src/pw/pw_types.F
+++ b/src/pw/pw_types.F
@@ -120,7 +120,7 @@ CONTAINS
 !> \author fawzi
 ! **************************************************************************************************
    SUBROUTINE pw_create(pw, pw_grid, use_data, in_space, cr3d_ptr)
-      CLASS(pw_type), INTENT(OUT)                         :: pw
+      CLASS(pw_type), INTENT(INOUT)                         :: pw
       TYPE(pw_grid_type), INTENT(IN), POINTER            :: pw_grid
       INTEGER, INTENT(in)                                :: use_data, in_space
       REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
@@ -152,6 +152,9 @@ CONTAINS
             CPASSERT(use_data == REALDATA3D)
          END IF
       END IF
+
+      ! Ensure a clean grid to prevent memory leaks
+      CALL pw%release()
 
       pw%in_use = use_data
       pw%pw_grid => pw_grid

--- a/src/pw/rs_methods.F
+++ b/src/pw/rs_methods.F
@@ -19,9 +19,7 @@ MODULE rs_methods
                                               pw_scale,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -397,10 +395,10 @@ CONTAINS
       lb2 = bounds_local(1, 2); ub2 = bounds_local(2, 2)
       lb3 = bounds_local(1, 3); ub3 = bounds_local(2, 3)
 
-      CALL pw_pool_create_pw(pw_pool, G, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, G_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(pw_pool, pw_in_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(pw_pool, pw_out_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool%create_pw(G, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(G_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool%create_pw(pw_in_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool%create_pw(pw_out_gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       CALL pw_zero(G)
       xmin = x_glbl(bounds(1, 1)); xmax = x_glbl(bounds(2, 1))
@@ -453,10 +451,10 @@ CONTAINS
          END DO
       END DO
 
-      CALL pw_pool_give_back_pw(pw_pool, G)
-      CALL pw_pool_give_back_pw(pw_pool, G_gs)
-      CALL pw_pool_give_back_pw(pw_pool, pw_in_gs)
-      CALL pw_pool_give_back_pw(pw_pool, pw_out_gs)
+      CALL pw_pool%give_back_pw(G)
+      CALL pw_pool%give_back_pw(G_gs)
+      CALL pw_pool%give_back_pw(pw_in_gs)
+      CALL pw_pool%give_back_pw(pw_out_gs)
       CALL timestop(handle)
 
    END SUBROUTINE pw_mollifier

--- a/src/pw_env/cp_spline_utils.F
+++ b/src/pw_env/cp_spline_utils.F
@@ -18,9 +18,7 @@ MODULE cp_spline_utils
    USE pw_methods,                      ONLY: do_standard_sum,&
                                               pw_axpy,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_spline_utils,                 ONLY: &
         add_coarse2fine, add_fine2coarse, find_coeffs, pw_spline_do_precond, &
         pw_spline_precond_create, pw_spline_precond_release, pw_spline_precond_set_kind, &
@@ -93,8 +91,8 @@ CONTAINS
       pbc = (interp_kind == spline3_pbc_interp)
       CPASSERT(pbc .OR. interp_kind == spline3_nopbc_interp)
       bo = pw_coarse_out%pw_grid%bounds_local
-      CALL pw_pool_create_pw(coarse_pool, values, use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL coarse_pool%create_pw(values, use_data=REALDATA3D, &
+                                 in_space=REALSPACE)
       CALL pw_zero(values)
 
       CALL add_fine2coarse(fine_values_pw=pw_fine_in, &
@@ -103,8 +101,8 @@ CONTAINS
                            w_border1=spl3_1d_transf_border1/2._dp, pbc=pbc, &
                            safe_computation=safe_computation)
 
-      CALL pw_pool_create_pw(coarse_pool, coeffs, use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL coarse_pool%create_pw(coeffs, use_data=REALDATA3D, &
+                                 in_space=REALSPACE)
       CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                     pool=coarse_pool, pbc=pbc, transpose=.TRUE.)
       CALL pw_spline_do_precond(precond, values, coeffs)
@@ -123,8 +121,8 @@ CONTAINS
       CALL pw_zero(pw_coarse_out)
       CALL pw_axpy(coeffs, pw_coarse_out)
 
-      CALL pw_pool_give_back_pw(coarse_pool, values)
-      CALL pw_pool_give_back_pw(coarse_pool, coeffs)
+      CALL coarse_pool%give_back_pw(values)
+      CALL coarse_pool%give_back_pw(coeffs)
       CALL timestop(handle)
 
    END SUBROUTINE pw_restrict_s3
@@ -158,8 +156,8 @@ CONTAINS
 
       ifile = ifile + 1
       CALL timeset(routineN, handle)
-      CALL pw_pool_create_pw(coarse_pool, coeffs, use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL coarse_pool%create_pw(coeffs, use_data=REALDATA3D, &
+                                 in_space=REALSPACE)
       bo = pw_coarse_in%pw_grid%bounds_local
       CALL section_vals_val_get(param_section, "safe_computation", &
                                 l_val=safe_computation)
@@ -203,7 +201,7 @@ CONTAINS
                            w_border1=spl3_1d_transf_border1, &
                            pbc=pbc, safe_computation=safe_computation)
 
-      CALL pw_pool_give_back_pw(coarse_pool, coeffs)
+      CALL coarse_pool%give_back_pw(coeffs)
 
       CALL timestop(handle)
 

--- a/src/pw_env/pw_env_types.F
+++ b/src/pw_env/pw_env_types.F
@@ -19,8 +19,7 @@ MODULE pw_env_types
    USE input_section_types,             ONLY: section_vals_type
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_para_env_type
-   USE pw_poisson_types,                ONLY: pw_poisson_release,&
-                                              pw_poisson_type
+   USE pw_poisson_types,                ONLY: pw_poisson_type
    USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_release,&
                                               pw_pool_type,&
@@ -183,7 +182,10 @@ CONTAINS
          CPASSERT(pw_env%ref_count > 0)
          pw_env%ref_count = pw_env%ref_count - 1
          IF (pw_env%ref_count < 1) THEN
-            CALL pw_poisson_release(pw_env%poisson_env)
+            IF (ASSOCIATED(pw_env%poisson_env)) THEN
+               CALL pw_env%poisson_env%release()
+               DEALLOCATE (pw_env%poisson_env)
+            END IF
             CALL pw_pools_dealloc(pw_env%pw_pools)
             IF (ASSOCIATED(pw_env%gridlevel_info)) THEN
                CALL destroy_gaussian_gridlevel(pw_env%gridlevel_info, para_env)

--- a/src/pw_env_methods.F
+++ b/src/pw_env_methods.F
@@ -86,7 +86,6 @@ MODULE pw_env_methods
    USE pw_pool_types,                   ONLY: pw_pool_create,&
                                               pw_pool_p_type,&
                                               pw_pool_release,&
-                                              pw_pool_retain,&
                                               pw_pools_dealloc
    USE qs_dispersion_types,             ONLY: qs_dispersion_type
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -454,7 +453,7 @@ CONTAINS
          CALL pw_grid_release(xc_super_ref_grid)
       ELSE
          pw_env%xc_pw_pool => pw_pools(pw_env%auxbas_grid)%pool
-         CALL pw_pool_retain(pw_env%xc_pw_pool)
+         CALL pw_env%xc_pw_pool%retain()
       END IF
 
       ! init vdw_pool
@@ -481,7 +480,7 @@ CONTAINS
          CALL pw_grid_release(vdw_grid)
       ELSE
          pw_env%vdw_pw_pool => pw_pools(pw_env%auxbas_grid)%pool
-         CALL pw_pool_retain(pw_env%vdw_pw_pool)
+         CALL pw_env%vdw_pw_pool%retain()
       END IF
 
       IF (do_io) CALL cp_print_key_finished_output(iounit, logger, print_section, '')

--- a/src/pw_env_methods.F
+++ b/src/pw_env_methods.F
@@ -79,10 +79,14 @@ MODULE pw_env_methods
                                               pw_grid_setup
    USE pw_poisson_methods,              ONLY: pw_poisson_set
    USE pw_poisson_read_input,           ONLY: pw_poisson_read_parameters
-   USE pw_poisson_types,                ONLY: &
-        pw_poisson_analytic, pw_poisson_create, pw_poisson_implicit, pw_poisson_mt, &
-        pw_poisson_multipole, pw_poisson_none, pw_poisson_parameter_type, pw_poisson_periodic, &
-        pw_poisson_wavelet
+   USE pw_poisson_types,                ONLY: pw_poisson_analytic,&
+                                              pw_poisson_implicit,&
+                                              pw_poisson_mt,&
+                                              pw_poisson_multipole,&
+                                              pw_poisson_none,&
+                                              pw_poisson_parameter_type,&
+                                              pw_poisson_periodic,&
+                                              pw_poisson_wavelet
    USE pw_pool_types,                   ONLY: pw_pool_create,&
                                               pw_pool_p_type,&
                                               pw_pool_release,&
@@ -487,7 +491,8 @@ CONTAINS
 
       ! complete init of the poisson_env
       IF (.NOT. ASSOCIATED(pw_env%poisson_env)) THEN
-         CALL pw_poisson_create(pw_env%poisson_env)
+         ALLOCATE (pw_env%poisson_env)
+         CALL pw_env%poisson_env%create()
       END IF
       poisson_section => section_vals_get_subs_vals(input, "DFT%POISSON")
 

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -45,9 +45,7 @@ MODULE qmmm_gpw_forces
                                               pw_integral_ab,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type,&
                                               pw_pools_create_pws,&
                                               pw_pools_give_back_pws
@@ -208,9 +206,9 @@ CONTAINS
                          auxbas_pw_pool=auxbas_pool)
          NULLIFY (rho_tot_r)
          ALLOCATE (rho_tot_r)
-         CALL pw_pool_create_pw(auxbas_pool, rho_tot_r, &
-                                in_space=REALSPACE, &
-                                use_data=REALDATA3D)
+         CALL auxbas_pool%create_pw(rho_tot_r, &
+                                    in_space=REALSPACE, &
+                                    use_data=REALDATA3D)
          ! IF GAPW the core charge is replaced by the compensation charge
          IF (gapw) THEN
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
@@ -218,12 +216,12 @@ CONTAINS
                energy%qmmm_nu = pw_integral_ab(rho_tot_r, ks_qmmm_env_loc%v_qmmm_rspace)
                NULLIFY (rho_tot_r2)
                ALLOCATE (rho_tot_r2)
-               CALL pw_pool_create_pw(auxbas_pool, rho_tot_r2, &
-                                      in_space=REALSPACE, &
-                                      use_data=REALDATA3D)
+               CALL auxbas_pool%create_pw(rho_tot_r2, &
+                                          in_space=REALSPACE, &
+                                          use_data=REALDATA3D)
                CALL pw_transfer(rho0_s_gs, rho_tot_r2)
                CALL pw_axpy(rho_tot_r2, rho_tot_r)
-               CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_r2)
+               CALL auxbas_pool%give_back_pw(rho_tot_r2)
                DEALLOCATE (rho_tot_r2)
             ELSE
                CALL pw_transfer(rho0_s_gs, rho_tot_r)
@@ -317,7 +315,7 @@ CONTAINS
       ! Give back rho_tot_t to auxbas_pool only for GPW/GAPW
       IF ((.NOT. dft_control%qs_control%semi_empirical) .AND. &
           (.NOT. dft_control%qs_control%dftb) .AND. (.NOT. dft_control%qs_control%xtb)) THEN
-         CALL pw_pool_give_back_pw(auxbas_pool, rho_tot_r)
+         CALL auxbas_pool%give_back_pw(rho_tot_r)
          DEALLOCATE (rho_tot_r)
       END IF
       IF (iw > 0) THEN
@@ -1367,8 +1365,8 @@ CONTAINS
       logger => cp_get_default_logger()
       iw = cp_print_key_unit_nr(logger, print_section, "PROGRAM_RUN_INFO", extension=".qmmmLog")
       CALL pw_env_get(pw_env=pw_env, pw_pools=pw_pools)
-      CALL pw_pool_create_pw(pw_pools(1)%pool, v_qmmm_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pools(1)%pool%create_pw(v_qmmm_rspace, &
+                                      use_data=REALDATA3D, in_space=REALSPACE)
       ALLOCATE (Num_Forces(3, num_mm_atoms))
       ks_qmmm_env_loc => qs_env%ks_qmmm_env
       IF (iw > 0) WRITE (iw, '(/A)') "DEBUG SECTION:"
@@ -1446,7 +1444,7 @@ CONTAINS
       END SELECT
       CALL cp_print_key_finished_output(iw, logger, print_section, "PROGRAM_RUN_INFO")
 
-      CALL pw_pool_give_back_pw(pw_pools(1)%pool, v_qmmm_rspace)
+      CALL pw_pools(1)%pool%give_back_pw(v_qmmm_rspace)
       DEALLOCATE (Num_Forces)
       CALL timestop(handle)
 100   FORMAT(I5, 2F15.9, " ( ", F7.2, " ) ", 2F15.9, " ( ", F7.2, " ) ", 2F15.9, " ( ", F7.2, " ) ")

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -56,7 +56,6 @@ MODULE qmmm_image_charge
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qmmm_types_low,                  ONLY: qmmm_env_qm_type
    USE qs_collocate_density,            ONLY: calculate_rho_metal,&
@@ -289,12 +288,12 @@ CONTAINS
          iter_steps = iter_steps + 1
          ! SQRT(rsnew) < 1.0E-08
          IF (rsnew < 1.0E-16) THEN
-            CALL pw_release(auxpot_Ad_rspace)
+            CALL auxpot_Ad_rspace%release()
             EXIT
          END IF
          d = z + rsnew/rsold*d
          rsold = rsnew
-         CALL pw_release(auxpot_Ad_rspace)
+         CALL auxpot_Ad_rspace%release()
       END DO
 
       ! print iteration info
@@ -314,7 +313,7 @@ CONTAINS
          qs_env%calc_image_preconditioner = .TRUE.
       END IF
 
-      CALL pw_release(v_metal_rspace_guess)
+      CALL v_metal_rspace_guess%release()
       DEALLOCATE (pot_const)
       DEALLOCATE (vmetal_const)
       DEALLOCATE (r)
@@ -758,9 +757,9 @@ CONTAINS
          image_matrix(iatom + 1:natom, iatom) = int_res(iatom + 1:natom)
       END DO
 
-      CALL pw_release(vb_gspace)
-      CALL pw_release(vb_rspace)
-      CALL pw_release(rho_gb)
+      CALL vb_gspace%release()
+      CALL vb_rspace%release()
+      CALL rho_gb%release()
 
       DEALLOCATE (int_res)
 
@@ -930,8 +929,8 @@ CONTAINS
       CALL pw_zero(v_metal_rspace)
       CALL pw_transfer(v_metal_gspace, v_metal_rspace)
       CALL pw_scale(v_metal_rspace, v_metal_rspace%pw_grid%dvol)
-      CALL pw_release(v_metal_gspace)
-      CALL pw_release(rho_metal)
+      CALL v_metal_gspace%release()
+      CALL rho_metal%release()
 
       CALL timestop(handle)
 

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -50,8 +50,7 @@ MODULE qmmm_image_charge
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -722,18 +721,15 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_gb, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             vb_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             vb_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_gb, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(vb_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(vb_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       ! calculate vb only once for one reference atom
       iatom_ref = 1 !
@@ -894,20 +890,17 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_metal, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_metal, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_metal_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_metal_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_metal_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_metal_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       CALL pw_zero(rho_metal)
       CALL calculate_rho_metal(rho_metal, coeff, total_rho_metal=total_rho_metal, &

--- a/src/qmmm_types_low.F
+++ b/src/qmmm_types_low.F
@@ -28,8 +28,7 @@ MODULE qmmm_types_low
                                               particle_type
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_release
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_release,&
                                               pw_pool_type,&
                                               pw_pools_dealloc
@@ -540,7 +539,7 @@ CONTAINS
                DEALLOCATE (Per_Potentials(I)%Pot%mm_atom_index)
             END IF
             IF (ASSOCIATED(Per_Potentials(I)%Pot%TabLR)) THEN
-               CALL pw_pool_give_back_pw(Per_Potentials(I)%Pot%pw_pool, Per_Potentials(I)%Pot%TabLR)
+               CALL Per_Potentials(I)%Pot%pw_pool%give_back_pw(Per_Potentials(I)%Pot%TabLR)
                DEALLOCATE (Per_Potentials(I)%Pot%TabLR)
             END IF
             IF (ASSOCIATED(Per_Potentials(I)%Pot%pw_pool)) THEN

--- a/src/qs_2nd_kernel_ao.F
+++ b/src/qs_2nd_kernel_ao.F
@@ -39,8 +39,7 @@ MODULE qs_2nd_kernel_ao
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_scale
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -358,7 +357,7 @@ CONTAINS
          DEALLOCATE (work_hmat%matrix)
 
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
          END DO
          DEALLOCATE (v_xc)
 

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -94,9 +94,8 @@ MODULE qs_active_space_methods
                                pw_poisson_analytic, &
                                pw_poisson_periodic, &
                                pw_poisson_type
-   USE pw_pool_types, ONLY: pw_pool_create_pw, &
-                            pw_pool_give_back_pw, &
-                            pw_pool_type
+   USE pw_pool_types, ONLY: &
+      pw_pool_type
    USE pw_types, ONLY: COMPLEXDATA1D, &
                        REALDATA3D, &
                        REALSPACE, &
@@ -1406,8 +1405,8 @@ CONTAINS
          ! Copy the active space of the MOs into DBCSR matrices
       END IF
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, wfn_r, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wfn_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL get_qs_env(qs_env, qs_kind_set=qs_kind_set, cell=cell, &
                       particle_set=particle_set, atomic_kind_set=atomic_kind_set)
 
@@ -1429,9 +1428,9 @@ CONTAINS
             CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
             DO i1 = 1, SIZE(orbitals, 1)
                iwfn = orbitals(i1, ispin)
-               CALL pw_pool_create_pw(auxbas_pw_pool, wfn_a(iwfn, ispin), &
-                                      use_data=REALDATA3D, &
-                                      in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(wfn_a(iwfn, ispin), &
+                                             use_data=REALDATA3D, &
+                                             in_space=REALSPACE)
                CALL calculate_wavefunction(mo_coeff, iwfn, wfn_a(iwfn, ispin), rho_g, atomic_kind_set, &
                                            qs_kind_set, cell, dft_control, particle_set, pw_env_sub)
                IF (print2 .AND. iw > 0) THEN
@@ -1442,26 +1441,26 @@ CONTAINS
       ELSE
          ! Even if we do not store all WFNs, we still need containers for the functions to store
          ALLOCATE (wfn1, wfn2)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wfn1, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wfn2, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(wfn1, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(wfn2, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          IF (eri_env%method /= eri_method_gpw_ht) THEN
             ALLOCATE (wfn3, wfn4)
-            CALL pw_pool_create_pw(auxbas_pw_pool, wfn3, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, wfn4, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(wfn3, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(wfn4, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
          END IF
       END IF
 
       ! get some of the grids ready
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_r, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pot_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(pot_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! run the FFT once, to set up buffers and to take into account the memory
       CALL pw_zero(rho_r)
@@ -1662,10 +1661,10 @@ CONTAINS
             DEALLOCATE (wfn3, wfn4)
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wfn_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pot_g)
+      CALL auxbas_pw_pool%give_back_pw(wfn_r)
+      CALL auxbas_pw_pool%give_back_pw(rho_g)
+      CALL auxbas_pw_pool%give_back_pw(rho_r)
+      CALL auxbas_pw_pool%give_back_pw(pot_g)
       CALL mp_para_env_release(para_env_sub)
 
       IF (eri_env%method == eri_method_gpw_ht) THEN
@@ -1907,8 +1906,8 @@ CONTAINS
       CALL qs_subsys_get(subsys, particles=particles)
       !
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       !
       dft_section => section_vals_get_subs_vals(scf_input, "DFT")
       !
@@ -1970,8 +1969,8 @@ CONTAINS
          END DO
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
 
    END SUBROUTINE print_orbital_cubes
 

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -101,7 +101,6 @@ MODULE qs_active_space_methods
                        REALDATA3D, &
                        REALSPACE, &
                        RECIPROCALSPACE, &
-                       pw_release, &
                        pw_type
    USE qcschema, ONLY: qcschema_env_create, &
                        qcschema_env_release, &
@@ -1649,17 +1648,17 @@ CONTAINS
          DO ispin = 1, nspins
             DO i1 = 1, SIZE(orbitals, 1)
                iwfn = orbitals(i1, ispin)
-               CALL pw_release(wfn_a(iwfn, ispin))
+               CALL wfn_a(iwfn, ispin)%release()
             END DO
          END DO
          DEALLOCATE (wfn_a)
       ELSE
-         CALL pw_release(wfn1)
-         CALL pw_release(wfn2)
+         CALL wfn1%release()
+         CALL wfn2%release()
          DEALLOCATE (wfn1, wfn2)
          IF (eri_env%method /= eri_method_gpw_ht) THEN
-            CALL pw_release(wfn3)
-            CALL pw_release(wfn4)
+            CALL wfn3%release()
+            CALL wfn4%release()
             DEALLOCATE (wfn3, wfn4)
          END IF
       END IF

--- a/src/qs_cdft_methods.F
+++ b/src/qs_cdft_methods.F
@@ -47,9 +47,7 @@ MODULE qs_cdft_methods
                                               pw_integrate_function,&
                                               pw_set,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -756,19 +754,19 @@ CONTAINS
          ! Setup pw
          CALL pw_zero(cdft_control%group(igroup)%weight)
 
-         CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total_constraint, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(cdft_control%group(igroup)%hw_rho_total_constraint, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_set(cdft_control%group(igroup)%hw_rho_total_constraint, 1.0_dp)
 
          IF (igroup == 1) THEN
-            CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total, &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(cdft_control%group(igroup)%hw_rho_total, &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_set(cdft_control%group(igroup)%hw_rho_total, 1.0_dp)
 
             IF (hirshfeld_control%print_density) THEN
                DO iatom = 1, cdft_control%natoms
-                  CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic(iatom), &
-                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(cdft_control%group(igroup)%hw_rho_atomic(iatom), &
+                                                use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_set(cdft_control%group(igroup)%hw_rho_atomic(iatom), 1.0_dp)
                END DO
             END IF
@@ -787,8 +785,8 @@ CONTAINS
             END DO
 
             DO iatom = 1, cdft_control%natoms
-               CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic_charge(iatom), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(cdft_control%group(igroup)%hw_rho_atomic_charge(iatom), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_set(cdft_control%group(igroup)%hw_rho_atomic_charge(iatom), 1.0_dp)
             END DO
          END IF
@@ -923,16 +921,16 @@ CONTAINS
 
       DO igroup = 1, SIZE(cdft_control%group)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_total_constraint)
+         CALL auxbas_pw_pool%give_back_pw(cdft_control%group(igroup)%hw_rho_total_constraint)
 
          IF (.NOT. cdft_control%in_memory .AND. igroup == 1) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(1)%hw_rho_total)
+            CALL auxbas_pw_pool%give_back_pw(cdft_control%group(1)%hw_rho_total)
          END IF
 
          IF (hirshfeld_control%print_density .AND. igroup == 1) THEN
             DO i = 1, cdft_control%natoms
                CALL rs_grid_release(rs_single(i))
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic(i))
+               CALL auxbas_pw_pool%give_back_pw(cdft_control%group(igroup)%hw_rho_atomic(i))
             END DO
             DEALLOCATE (rs_single)
             DEALLOCATE (cdft_control%group(igroup)%hw_rho_atomic)
@@ -941,7 +939,7 @@ CONTAINS
          IF (cdft_control%atomic_charges .AND. igroup == 1) THEN
             DO i = 1, cdft_control%natoms
                CALL rs_grid_release(rs_single_charge(i))
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(igroup)%hw_rho_atomic_charge(i))
+               CALL auxbas_pw_pool%give_back_pw(cdft_control%group(igroup)%hw_rho_atomic_charge(i))
             END DO
             DEALLOCATE (rs_single_charge)
             DEALLOCATE (compute_charge)
@@ -975,8 +973,8 @@ CONTAINS
                ALLOCATE (rs_single_dr(num_species))
 
                DO i = 1, num_species
-                  CALL pw_pool_create_pw(auxbas_pw_pool, pw_single_dr(i), use_data=REALDATA3D, &
-                                         in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(pw_single_dr(i), use_data=REALDATA3D, &
+                                                in_space=REALSPACE)
                   CALL pw_zero(pw_single_dr(i))
                END DO
 
@@ -1063,7 +1061,7 @@ CONTAINS
                DO iatom = 1, num_species
                   atom_a = atom_list(iatom)
                   cdft_control%group(igroup)%gradients_x(atom_a, :, :, :) = pw_single_dr(iatom)%cr3d(:, :, :)
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_single_dr(iatom))
+                  CALL auxbas_pw_pool%give_back_pw(pw_single_dr(iatom))
                END DO
 
                DEALLOCATE (rs_single_dr)
@@ -1127,7 +1125,7 @@ CONTAINS
             END DO
 
             IF (igroup == 1) THEN
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(1)%hw_rho_total)
+               CALL auxbas_pw_pool%give_back_pw(cdft_control%group(1)%hw_rho_total)
             END IF
          END DO
       END IF
@@ -1668,33 +1666,33 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
       ! Total density (rho_alpha + rho_beta)
-      CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%fragments(1, 1), &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(cdft_control%fragments(1, 1), &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
       CALL cp_cube_to_pw(cdft_control%fragments(1, 1), &
                          cdft_control%fragment_a_fname, 1.0_dp)
-      CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%fragments(1, 2), &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(cdft_control%fragments(1, 2), &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
       CALL cp_cube_to_pw(cdft_control%fragments(1, 2), &
                          cdft_control%fragment_b_fname, 1.0_dp)
       ! Spin difference density (rho_alpha - rho_beta) if needed
       IF (needs_spin_density) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%fragments(2, 1), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(cdft_control%fragments(2, 1), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL cp_cube_to_pw(cdft_control%fragments(2, 1), &
                             cdft_control%fragment_a_spin_fname, multiplier(1))
-         CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%fragments(2, 2), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(cdft_control%fragments(2, 2), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL cp_cube_to_pw(cdft_control%fragments(2, 2), &
                             cdft_control%fragment_b_spin_fname, multiplier(2))
       END IF
       ! Sum up fragments
       DO i = 1, nfrag_spins
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_frag(i), use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_frag(i), use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_copy(cdft_control%fragments(i, 1), rho_frag(i))
          CALL pw_axpy(cdft_control%fragments(i, 2), rho_frag(i), 1.0_dp)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%fragments(i, 1))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%fragments(i, 2))
+         CALL auxbas_pw_pool%give_back_pw(cdft_control%fragments(i, 1))
+         CALL auxbas_pw_pool%give_back_pw(cdft_control%fragments(i, 2))
       END DO
       DEALLOCATE (cdft_control%fragments)
       ! Check that the number of electrons is consistent
@@ -1735,7 +1733,7 @@ CONTAINS
          CALL para_env%sum(cdft_control%charges_fragment)
       END IF
       DO i = 1, nfrag_spins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_frag(i))
+         CALL auxbas_pw_pool%give_back_pw(rho_frag(i))
       END DO
       DEALLOCATE (rho_frag)
       cdft_control%fragments_integrated = .TRUE.

--- a/src/qs_cdft_utils.F
+++ b/src/qs_cdft_utils.F
@@ -55,8 +55,7 @@ MODULE qs_cdft_utils
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE
    USE qs_cdft_types,                   ONLY: becke_constraint_type,&
@@ -391,8 +390,8 @@ CONTAINS
             DEALLOCATE (cores)
          END DO
          DEALLOCATE (pab)
-         CALL pw_pool_create_pw(auxbas_pw_pool, becke_control%cavity, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(becke_control%cavity, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL transfer_rs2pw(rs_cavity, becke_control%cavity)
          ! Grid points where the Gaussian density falls below eps_cavity are ignored
          ! We can calculate the smallest/largest values along z-direction outside

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -80,9 +80,7 @@ MODULE qs_collocate_density
                                               pw_integrate_function,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type,&
                                               pw_pools_create_pws,&
                                               pw_pools_give_back_pws
@@ -892,8 +890,8 @@ CONTAINS
       END IF
       DEALLOCATE (pab)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhoc_r, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL transfer_rs2pw(rs_rho, rhoc_r)
 
@@ -901,7 +899,7 @@ CONTAINS
 
       CALL pw_transfer(rhoc_r, rho_core)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      CALL auxbas_pw_pool%give_back_pw(rhoc_r)
 
       CALL timestop(handle)
 
@@ -1027,14 +1025,14 @@ CONTAINS
       END IF
       DEALLOCATE (pab)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhoc_r, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL transfer_rs2pw(rs_rho, rhoc_r)
 
       CALL pw_transfer(rhoc_r, drho_core)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      CALL auxbas_pw_pool%give_back_pw(rhoc_r)
 
       CALL timestop(handle)
 
@@ -1116,14 +1114,14 @@ CONTAINS
 
       DEALLOCATE (pab)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhoc_r, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL transfer_rs2pw(rs_rho, rhoc_r)
 
       CALL pw_transfer(rhoc_r, rho_gb)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      CALL auxbas_pw_pool%give_back_pw(rhoc_r)
 
       CALL timestop(handle)
 
@@ -1221,8 +1219,8 @@ CONTAINS
 
       DEALLOCATE (pab, cores)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhoc_r, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL transfer_rs2pw(rs_rho, rhoc_r)
 
@@ -1231,7 +1229,7 @@ CONTAINS
          total_rho_metal = pw_integrate_function(rhoc_r, isign=-1)
 
       CALL pw_transfer(rhoc_r, rho_metal)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      CALL auxbas_pw_pool%give_back_pw(rhoc_r)
 
       CALL timestop(handle)
 
@@ -1315,14 +1313,14 @@ CONTAINS
 
       DEALLOCATE (pab)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhoc_r, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL transfer_rs2pw(rs_rho, rhoc_r)
 
       CALL pw_transfer(rhoc_r, rho_gb)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      CALL auxbas_pw_pool%give_back_pw(rhoc_r)
 
       CALL timestop(handle)
 
@@ -1420,13 +1418,13 @@ CONTAINS
 
       DEALLOCATE (pab, cores)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoc_r, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhoc_r, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL transfer_rs2pw(rs_rho, rhoc_r)
 
       CALL pw_transfer(rhoc_r, rho_resp)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoc_r)
+      CALL auxbas_pw_pool%give_back_pw(rhoc_r)
 
       CALL timestop(handle)
 

--- a/src/qs_dcdr_ao.F
+++ b/src/qs_dcdr_ao.F
@@ -47,9 +47,7 @@ MODULE qs_dcdr_ao
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -241,17 +239,17 @@ CONTAINS
       ! Done with deriv_set and rho_set
 
       ALLOCATE (v_rspace_new(dcdr_env%nspins))
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       ! Calculate the Hartree potential on the total density
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho1_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       CALL qs_rho_get(perturbed_density, rho_g=rho1_g, rho_r=rho1_r, tau_r=tau1_r)
       CALL pw_copy(rho1_g(1), rho1_tot_gspace)
@@ -264,7 +262,7 @@ CONTAINS
                             v_hartree_gspace)
       CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rho1_tot_gspace)
 
       ! Calculate the second derivative of the exchange-correlation potential
       CALL xc_calc_2nd_deriv(v_xc, v_xc_tau, deriv_set, rho_set, &
@@ -298,10 +296,10 @@ CONTAINS
                                  calculate_forces=.FALSE.)
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
       DO ispin = 1, dcdr_env%nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_rspace_new(ispin))
       END DO
       DEALLOCATE (v_rspace_new)
 
@@ -313,7 +311,7 @@ CONTAINS
                                  compute_tau=.TRUE., &
                                  calculate_forces=.FALSE.)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(1))
+         CALL auxbas_pw_pool%give_back_pw(v_xc_tau(1))
          DEALLOCATE (v_xc_tau)
       END IF
 
@@ -366,17 +364,15 @@ CONTAINS
                       pw_pools=pw_pools)
 
       ! Create the Hartree potential grids in real and reciprocal space.
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_hartree_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
       ! Create the grid for the derivative of the core potential
-      CALL pw_pool_create_pw(auxbas_pw_pool, drho_g, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(drho_g, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       DO beta = 1, 3
          CALL pw_zero(v_hartree_gspace)
@@ -398,9 +394,9 @@ CONTAINS
                                  calculate_forces=.FALSE.)
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(drho_g)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
 
       CALL timestop(handle)
    END SUBROUTINE d_core_charge_density_dR
@@ -538,23 +534,23 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools, poisson_env=poisson_env)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       DO ispin = 1, dcdr_env%nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(ispin), &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(drho_r(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(drho_g(ispin), &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_total, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_total, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(drho_g_total, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(drho_r_total, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       DO idir = 1, 3
          CALL pw_zero(v_hartree_gspace)
@@ -608,19 +604,19 @@ CONTAINS
                                     calculate_forces=.FALSE.)
 
             ! v_xc gets allocated again in xc_calc_2nd_deriv
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
          END DO ! ispin
          DEALLOCATE (v_xc)
       END DO ! idir
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g_total)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r_total)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(drho_g_total)
+      CALL auxbas_pw_pool%give_back_pw(drho_r_total)
 
       DO ispin = 1, dcdr_env%nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_g(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(drho_g(ispin))
+         CALL auxbas_pw_pool%give_back_pw(drho_r(ispin))
       END DO
 
       DEALLOCATE (drho_g)
@@ -691,7 +687,7 @@ CONTAINS
                                  qs_env=qs_env, &
                                  lambda=dcdr_env%lambda)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hxc_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_hxc_r(ispin))
       END DO
 
       DEALLOCATE (v_hxc_r)

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -36,9 +36,7 @@ MODULE qs_dispersion_nonloc
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_derive,&
                                               pw_transfer
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -217,14 +215,14 @@ CONTAINS
       const = 1.0_dp/(3.0_dp*SQRT(pi)*b_value**1.5_dp)/(pi**0.75_dp)
 
       ! temporary arrays for FFT
-      CALL pw_pool_create_pw(pw_pool, tmp_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(pw_pool, tmp_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(tmp_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL pw_pool%create_pw(tmp_r, use_data=REALDATA3D, in_space=REALSPACE)
 
       ! get density derivatives
       ALLOCATE (drho_r(3, nspin))
       DO ispin = 1, nspin
          DO idir = 1, 3
-            CALL pw_pool_create_pw(pw_pool, drho_r(idir, ispin), &
+            CALL pw_pool%create_pw(drho_r(idir, ispin), &
                                    use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(rho_g(ispin), tmp_g)
             CALL pw_derive(tmp_g, nd(:, idir))
@@ -394,7 +392,7 @@ CONTAINS
             END DO
          END DO
 !$OMP END PARALLEL DO
-         CALL pw_pool_create_pw(pw_pool, thetas_g(i), use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL pw_pool%create_pw(thetas_g(i), use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_transfer(tmp_r, thetas_g(i))
       END DO
       grid => thetas_g(1)%pw_grid
@@ -475,7 +473,7 @@ CONTAINS
             potential(:) = (0.5_dp*potential(:) + beta)*dispersion_env%scale_rvv10
             hpot(:) = 0.5_dp*dispersion_env%scale_rvv10*hpot(:)
          END SELECT
-         CALL pw_pool_create_pw(pw_pool, vxc_r, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(vxc_r, use_data=REALDATA3D, in_space=REALSPACE)
          DO i = 1, 3
             lo(i) = LBOUND(vxc_r%cr3d, i)
             hi(i) = UBOUND(vxc_r%cr3d, i)
@@ -530,31 +528,31 @@ CONTAINS
             CALL pw_axpy(tmp_r, vxc_r, -1._dp)
          END DO
          CALL pw_transfer(vxc_r, tmp_g)
-         CALL pw_pool_give_back_pw(pw_pool, vxc_r)
-         CALL pw_pool_create_pw(xc_pw_pool, vxc_r, use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(xc_pw_pool, vxc_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL pw_pool%give_back_pw(vxc_r)
+         CALL xc_pw_pool%create_pw(vxc_r, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL xc_pw_pool%create_pw(vxc_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_transfer(tmp_g, vxc_g)
          CALL pw_transfer(vxc_g, vxc_r)
          DO ispin = 1, nspin
             CALL pw_axpy(vxc_r, vxc_rho(ispin), 1._dp)
          END DO
-         CALL pw_pool_give_back_pw(xc_pw_pool, vxc_r)
-         CALL pw_pool_give_back_pw(xc_pw_pool, vxc_g)
+         CALL xc_pw_pool%give_back_pw(vxc_r)
+         CALL xc_pw_pool%give_back_pw(vxc_g)
          DEALLOCATE (q0, dq0_drho, dq0_dgradrho)
       END IF
 
       DEALLOCATE (thetas)
 
       DO i = 1, dispersion_env%nqs
-         CALL pw_pool_give_back_pw(pw_pool, thetas_g(i))
+         CALL pw_pool%give_back_pw(thetas_g(i))
       END DO
       DO ispin = 1, nspin
          DO idir = 1, 3
-            CALL pw_pool_give_back_pw(pw_pool, drho_r(idir, ispin))
+            CALL pw_pool%give_back_pw(drho_r(idir, ispin))
          END DO
       END DO
-      CALL pw_pool_give_back_pw(pw_pool, tmp_r)
-      CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+      CALL pw_pool%give_back_pw(tmp_r)
+      CALL pw_pool%give_back_pw(tmp_g)
 
       DEALLOCATE (rho, drho, drho_r, thetas_g)
 

--- a/src/qs_electric_field_gradient.F
+++ b/src/qs_electric_field_gradient.F
@@ -46,9 +46,7 @@ MODULE qs_electric_field_gradient
                                               pw_transfer
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_spline_utils,                 ONLY: &
         Eval_Interp_Spl3_pbc, Eval_d_Interp_Spl3_pbc, find_coeffs, pw_spline_do_precond, &
         pw_spline_precond_create, pw_spline_precond_release, pw_spline_precond_set_kind, &
@@ -159,11 +157,11 @@ CONTAINS
       ELSEIF (ecut == -1._dp .AND. sigma == -1._dp) THEN
          smoothing = .TRUE.
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         CALL pw_pool_create_pw(auxbas_pw_pool, dvr2rs, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(dvr2rs, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          ecut = 2._dp*dvr2rs%pw_grid%cutoff*0.875_dp
          sigma = 2._dp*dvr2rs%pw_grid%cutoff*0.125_dp
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2rs)
+         CALL auxbas_pw_pool%give_back_pw(dvr2rs)
       ELSE
          smoothing = .TRUE.
       END IF
@@ -213,15 +211,15 @@ CONTAINS
       IF (gapw) CALL prepare_gapw_den(qs_env, do_rho0=.TRUE.)
 
       !calculate electrostatic potential
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
 
       CALL pw_poisson_solve(poisson_env, rho_tot_gspace, ehartree, &
                             v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
 
       ! smoothing of potential
       IF (smoothing) CALL pw_smoothing(v_hartree_gspace, ecut, sigma)
@@ -229,15 +227,15 @@ CONTAINS
       DO i = 1, 3
          DO j = 1, i
             ij = (i*(i - 1))/2 + j
-            CALL pw_pool_create_pw(auxbas_pw_pool, dvr2(ij), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(dvr2(ij), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL pw_dr2(v_hartree_gspace, dvr2(ij), i, j)
          END DO
       END DO
 
       IF (.NOT. efg_interpolation) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, structure_factor, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(structure_factor, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       ELSE
 
          interp_section => section_vals_get_subs_vals(dft_section, &
@@ -249,11 +247,11 @@ CONTAINS
          CALL section_vals_val_get(interp_section, "eps_r", r_val=eps_r)
          CALL section_vals_val_get(interp_section, "eps_x", r_val=eps_x)
 
-         CALL pw_pool_create_pw(auxbas_pw_pool, dvr2rs, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(dvr2rs, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          DO i = 1, 6
-            CALL pw_pool_create_pw(auxbas_pw_pool, dvspl(i), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(dvspl(i), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_transfer(dvr2(i), dvr2rs)
             ! calculate spline coefficients
             CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
@@ -265,9 +263,9 @@ CONTAINS
                                   eps_r=eps_r, eps_x=eps_x, max_iter=max_iter)
             CPASSERT(success)
             CALL pw_spline_precond_release(precond)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2(i))
+            CALL auxbas_pw_pool%give_back_pw(dvr2(i))
          END DO
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2rs)
+         CALL auxbas_pw_pool%give_back_pw(dvr2rs)
       END IF
 
       nkind = SIZE(qs_kind_set)
@@ -376,15 +374,15 @@ CONTAINS
          END IF
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
       IF (.NOT. efg_interpolation) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, structure_factor)
+         CALL auxbas_pw_pool%give_back_pw(structure_factor)
          DO i = 1, 6
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvr2(i))
+            CALL auxbas_pw_pool%give_back_pw(dvr2(i))
          END DO
       ELSE
          DO i = 1, 6
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvspl(i))
+            CALL auxbas_pw_pool%give_back_pw(dvspl(i))
          END DO
       END IF
 

--- a/src/qs_elf_methods.F
+++ b/src/qs_elf_methods.F
@@ -20,9 +20,7 @@ MODULE qs_elf_methods
    USE pw_methods,                      ONLY: pw_derive,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -111,17 +109,17 @@ CONTAINS
       ! We will not have further use for it, so we will need only one
       IF (.NOT. tau_r_valid) THEN
          ALLOCATE (tau_r)
-         CALL pw_pool_create_pw(auxbas_pw_pool, tau_r, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(tau_r, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
       END IF
       IF (.NOT. tau_r_valid .OR. .NOT. drho_r_valid) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, tmp_g, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(tmp_g, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END IF
       IF (.NOT. drho_r_valid) THEN
          DO idir = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(idir), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(drho_r(idir), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
          END DO
       END IF
 
@@ -186,15 +184,15 @@ CONTAINS
 
       IF (.NOT. drho_r_valid) THEN
          DO idir = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_r(idir))
+            CALL auxbas_pw_pool%give_back_pw(drho_r(idir))
          END DO
       END IF
       IF (.NOT. tau_r_valid) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, tau_r)
+         CALL auxbas_pw_pool%give_back_pw(tau_r)
          DEALLOCATE (tau_r)
       END IF
       IF (.NOT. tau_r_valid .OR. .NOT. drho_r_valid) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g)
+         CALL auxbas_pw_pool%give_back_pw(tmp_g)
       END IF
 
       CALL timestop(handle)

--- a/src/qs_energy_utils.F
+++ b/src/qs_energy_utils.F
@@ -38,9 +38,7 @@ MODULE qs_energy_utils
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_scale
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -317,18 +315,18 @@ CONTAINS
          END IF
 
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         CALL pw_pool_create_pw(auxbas_pw_pool, xc_den, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(xc_den, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          ALLOCATE (vxc(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, vxc(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(vxc(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
          END DO
          IF (needs%tau .OR. needs%tau_spin) THEN
             ALLOCATE (vtau(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, vtau(ispin), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(vtau(ispin), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
             END DO
          END IF
 
@@ -393,13 +391,13 @@ CONTAINS
          END DO
          DEALLOCATE (xcmat)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, xc_den)
+         CALL auxbas_pw_pool%give_back_pw(xc_den)
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vxc(ispin))
          END DO
          IF (needs%tau .OR. needs%tau_spin) THEN
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau(ispin))
+               CALL auxbas_pw_pool%give_back_pw(vtau(ispin))
             END DO
          END IF
 

--- a/src/qs_energy_window.F
+++ b/src/qs_energy_window.F
@@ -47,9 +47,7 @@ MODULE qs_energy_window
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_integrate_function
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -160,8 +158,8 @@ CONTAINS
       CALL cp_fm_create(S_minus_half_fm, ao_ao_fmstruct)
       CALL cp_fm_create(eigenvectors, ao_ao_fmstruct)
       CALL cp_fm_create(eigenvectors_nonorth, ao_ao_fmstruct)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_r, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_r, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_g, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       !calculate S_minus_half
       CALL matrix_sqrt_Newton_Schulz(S_half, S_minus_half, matrix_s(1)%matrix, filter_eps, &
@@ -317,8 +315,8 @@ CONTAINS
       CALL cp_fm_release(P_window_fm)
       CALL cp_fm_release(eigenvectors_nonorth)
       CALL cp_fm_release(S_minus_half_fm)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g)
+      CALL auxbas_pw_pool%give_back_pw(rho_r)
+      CALL auxbas_pw_pool%give_back_pw(rho_g)
       DEALLOCATE (eigenvalues)
       DEALLOCATE (STRIDE)
 

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -36,8 +36,7 @@ MODULE qs_environment_methods
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_release,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -246,8 +245,8 @@ CONTAINS
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
                ALLOCATE (rho_core)
                CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-               CALL pw_pool_create_pw(auxbas_pw_pool, rho_core, &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(rho_core, &
+                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                CALL set_ks_env(ks_env, rho_core=rho_core)
             END IF
             CALL get_qs_env(qs_env=qs_env, rho0_mpole=rho0_mpole)
@@ -278,8 +277,8 @@ CONTAINS
             END IF
             ALLOCATE (rho_core)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_core, &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_core, &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL set_ks_env(ks_env, rho_core=rho_core)
          END IF
 
@@ -293,7 +292,7 @@ CONTAINS
                ALLOCATE (vppl)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, vppl, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(vppl, use_data=REALDATA3D, in_space=REALSPACE)
             CALL set_ks_env(ks_env, vppl=vppl)
          END IF
 
@@ -310,7 +309,7 @@ CONTAINS
                ALLOCATE (rho_nlcc)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc, REALDATA3D, REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_nlcc, REALDATA3D, REALSPACE)
             CALL set_ks_env(ks_env, rho_nlcc=rho_nlcc)
             ! the g-space version
             NULLIFY (rho_nlcc_g)
@@ -321,7 +320,7 @@ CONTAINS
                ALLOCATE (rho_nlcc_g)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_nlcc_g, COMPLEXDATA1D, RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_nlcc_g, COMPLEXDATA1D, RECIPROCALSPACE)
             CALL set_ks_env(ks_env, rho_nlcc_g=rho_nlcc_g)
          END IF
 
@@ -335,7 +334,7 @@ CONTAINS
             END IF
             ALLOCATE (vee)
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, vee, REALDATA3D, REALSPACE)
+            CALL auxbas_pw_pool%create_pw(vee, REALDATA3D, REALSPACE)
             CALL set_ks_env(ks_env, vee=vee)
             dft_control%eval_external_potential = .TRUE.
          END IF
@@ -350,7 +349,7 @@ CONTAINS
                ALLOCATE (external_vxc)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, external_vxc, REALDATA3D, REALSPACE)
+            CALL auxbas_pw_pool%create_pw(external_vxc, REALDATA3D, REALSPACE)
             CALL set_qs_env(qs_env, external_vxc=external_vxc)
             dft_control%read_external_vxc = .TRUE.
          END IF
@@ -365,7 +364,7 @@ CONTAINS
                ALLOCATE (embed_pot)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, embed_pot, REALDATA3D, REALSPACE)
+            CALL auxbas_pw_pool%create_pw(embed_pot, REALDATA3D, REALSPACE)
             CALL set_qs_env(qs_env, embed_pot=embed_pot)
 
             NULLIFY (spin_embed_pot)
@@ -377,7 +376,7 @@ CONTAINS
                ALLOCATE (spin_embed_pot)
             END IF
             CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, spin_embed_pot, REALDATA3D, REALSPACE)
+            CALL auxbas_pw_pool%create_pw(spin_embed_pot, REALDATA3D, REALSPACE)
             CALL set_qs_env(qs_env, spin_embed_pot=spin_embed_pot)
          END IF
 
@@ -389,8 +388,8 @@ CONTAINS
          CALL get_qs_env(qs_env, pw_env=new_pw_env)
          CALL pw_env_get(new_pw_env, auxbas_pw_pool=auxbas_pw_pool)
          ALLOCATE (v_hartree_rspace)
-         CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                                REALDATA3D, REALSPACE)
+         CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                       REALDATA3D, REALSPACE)
          CALL set_ks_env(ks_env, v_hartree_rspace=v_hartree_rspace)
       END IF
 

--- a/src/qs_environment_methods.F
+++ b/src/qs_environment_methods.F
@@ -42,7 +42,6 @@ MODULE qs_environment_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qs_charges_types,                ONLY: qs_charges_create,&
                                               qs_charges_type
@@ -241,7 +240,7 @@ CONTAINS
          CPASSERT(ASSOCIATED(new_pw_env))
          IF (dft_control%qs_control%gapw) THEN
             IF (ASSOCIATED(rho_core)) THEN
-               CALL pw_release(rho_core)
+               CALL rho_core%release()
                DEALLOCATE (rho_core)
             END IF
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
@@ -274,7 +273,7 @@ CONTAINS
             END IF
          ELSE
             IF (ASSOCIATED(rho_core)) THEN
-               CALL pw_release(rho_core)
+               CALL rho_core%release()
                DEALLOCATE (rho_core)
             END IF
             ALLOCATE (rho_core)
@@ -289,7 +288,7 @@ CONTAINS
             NULLIFY (vppl)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, vppl=vppl)
             IF (ASSOCIATED(vppl)) THEN
-               CALL pw_release(vppl)
+               CALL vppl%release()
             ELSE
                ALLOCATE (vppl)
             END IF
@@ -306,7 +305,7 @@ CONTAINS
             NULLIFY (rho_nlcc)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, rho_nlcc=rho_nlcc)
             IF (ASSOCIATED(rho_nlcc)) THEN
-               CALL pw_release(rho_nlcc)
+               CALL rho_nlcc%release()
             ELSE
                ALLOCATE (rho_nlcc)
             END IF
@@ -317,7 +316,7 @@ CONTAINS
             NULLIFY (rho_nlcc_g)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, rho_nlcc_g=rho_nlcc_g)
             IF (ASSOCIATED(rho_nlcc_g)) THEN
-               CALL pw_release(rho_nlcc_g)
+               CALL rho_nlcc_g%release()
             ELSE
                ALLOCATE (rho_nlcc_g)
             END IF
@@ -331,7 +330,7 @@ CONTAINS
             NULLIFY (vee)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, vee=vee)
             IF (ASSOCIATED(vee)) THEN
-               CALL pw_release(vee)
+               CALL vee%release()
                DEALLOCATE (vee)
             END IF
             ALLOCATE (vee)
@@ -346,7 +345,7 @@ CONTAINS
             NULLIFY (external_vxc)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, external_vxc=external_vxc)
             IF (ASSOCIATED(external_vxc)) THEN
-               CALL pw_release(external_vxc)
+               CALL external_vxc%release()
             ELSE
                ALLOCATE (external_vxc)
             END IF
@@ -361,7 +360,7 @@ CONTAINS
             NULLIFY (embed_pot)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, embed_pot=embed_pot)
             IF (ASSOCIATED(embed_pot)) THEN
-               CALL pw_release(embed_pot)
+               CALL embed_pot%release()
             ELSE
                ALLOCATE (embed_pot)
             END IF
@@ -372,7 +371,7 @@ CONTAINS
             NULLIFY (spin_embed_pot)
             CALL get_qs_env(qs_env, pw_env=new_pw_env, spin_embed_pot=spin_embed_pot)
             IF (ASSOCIATED(spin_embed_pot)) THEN
-               CALL pw_release(spin_embed_pot)
+               CALL spin_embed_pot%release()
                DEALLOCATE (spin_embed_pot)
             ELSE
                ALLOCATE (spin_embed_pot)
@@ -384,7 +383,7 @@ CONTAINS
 
          CALL get_ks_env(ks_env, v_hartree_rspace=v_hartree_rspace)
          IF (ASSOCIATED(v_hartree_rspace)) THEN
-            CALL pw_release(v_hartree_rspace)
+            CALL v_hartree_rspace%release()
             DEALLOCATE (v_hartree_rspace)
          END IF
          CALL get_qs_env(qs_env, pw_env=new_pw_env)

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -83,8 +83,7 @@ MODULE qs_environment_types
    USE post_scf_bandstructure_types,    ONLY: bs_env_release,&
                                               post_scf_bandstructure_type
    USE pw_env_types,                    ONLY: pw_env_type
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qmmm_types_low,                  ONLY: qmmm_env_qm_type
    USE qs_active_space_types,           ONLY: active_space_type,&
                                               release_active_space_type
@@ -1463,11 +1462,11 @@ CONTAINS
          DEALLOCATE (qs_env%rho_external)
       END IF
       IF (ASSOCIATED(qs_env%external_vxc)) THEN
-         CALL pw_release(qs_env%external_vxc)
+         CALL qs_env%external_vxc%release()
          DEALLOCATE (qs_env%external_vxc)
       END IF
       IF (ASSOCIATED(qs_env%mask)) THEN
-         CALL pw_release(qs_env%mask)
+         CALL qs_env%mask%release()
          DEALLOCATE (qs_env%mask)
       END IF
       IF (ASSOCIATED(qs_env%active_space)) THEN
@@ -1475,10 +1474,10 @@ CONTAINS
       END IF
       ! Embedding potentials if provided as input
       IF (qs_env%given_embed_pot) THEN
-         CALL pw_release(qs_env%embed_pot)
+         CALL qs_env%embed_pot%release()
          DEALLOCATE (qs_env%embed_pot)
          IF (ASSOCIATED(qs_env%spin_embed_pot)) THEN
-            CALL pw_release(qs_env%spin_embed_pot)
+            CALL qs_env%spin_embed_pot%release()
             DEALLOCATE (qs_env%spin_embed_pot)
          END IF
       END IF
@@ -1685,11 +1684,11 @@ CONTAINS
          DEALLOCATE (qs_env%rho_external)
       END IF
       IF (ASSOCIATED(qs_env%external_vxc)) THEN
-         CALL pw_release(qs_env%external_vxc)
+         CALL qs_env%external_vxc%release()
          DEALLOCATE (qs_env%external_vxc)
       END IF
       IF (ASSOCIATED(qs_env%mask)) THEN
-         CALL pw_release(qs_env%mask)
+         CALL qs_env%mask%release()
          DEALLOCATE (qs_env%mask)
       END IF
       IF (ASSOCIATED(qs_env%active_space)) THEN
@@ -1697,10 +1696,10 @@ CONTAINS
       END IF
       ! Embedding potentials if provided as input
       IF (qs_env%given_embed_pot) THEN
-         CALL pw_release(qs_env%embed_pot)
+         CALL qs_env%embed_pot%release()
          DEALLOCATE (qs_env%embed_pot)
          IF (ASSOCIATED(qs_env%spin_embed_pot)) THEN
-            CALL pw_release(qs_env%spin_embed_pot)
+            CALL qs_env%spin_embed_pot%release()
             DEALLOCATE (qs_env%spin_embed_pot)
          END IF
       END IF

--- a/src/qs_epr_hyp.F
+++ b/src/qs_epr_hyp.F
@@ -42,9 +42,7 @@ MODULE qs_epr_hyp
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_dr2_gg,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
                                               pw_type
@@ -284,10 +282,9 @@ CONTAINS
       CALL pw_env_get(pw_env=pw_env, &
                       auxbas_pw_pool=auxbas_pw_pool)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rhototspin_elec_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhototspin_elec_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
       CALL pw_zero(rhototspin_elec_gspace)
 
       pw_grid => rhototspin_elec_gspace%pw_grid
@@ -298,10 +295,9 @@ CONTAINS
       CALL pw_axpy(rho_g(1), rhototspin_elec_gspace)
       CALL pw_axpy(rho_g(2), rhototspin_elec_gspace, alpha=-1._dp)
       ! grid to assemble anisotropic hyperfine terms
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             hypaniso_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(hypaniso_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       DO idir1 = 1, 3
          DO idir2 = idir1, 3 ! tensor symmetry
@@ -323,8 +319,8 @@ CONTAINS
          END DO ! idir2
       END DO ! idir1
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhototspin_elec_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, hypaniso_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rhototspin_elec_gspace)
+      CALL auxbas_pw_pool%give_back_pw(hypaniso_gspace)
 
       ! Multiply hyperfine matrices with constant*gyromagnetic ratio's
       ! to have it in units of Mhz.

--- a/src/qs_fxc.F
+++ b/src/qs_fxc.F
@@ -35,9 +35,7 @@ MODULE qs_fxc
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_scale,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -222,8 +220,8 @@ CONTAINS
             IF (.NOT. ASSOCIATED(fxc_rho)) THEN
                ALLOCATE (fxc_rho(nspins))
                DO ispin = 1, nspins
-                  CALL pw_pool_create_pw(auxbas_pw_pool, fxc_rho(ispin), &
-                                         in_space=REALSPACE, use_data=REALDATA3D)
+                  CALL auxbas_pw_pool%create_pw(fxc_rho(ispin), &
+                                                in_space=REALSPACE, use_data=REALDATA3D)
                   CALL pw_zero(fxc_rho(ispin))
                END DO
             END IF
@@ -231,15 +229,15 @@ CONTAINS
                CALL pw_axpy(vxc00(ispin), fxc_rho(ispin), ak(istep))
             END DO
             DO ispin = 1, SIZE(vxc00)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc00(ispin))
+               CALL auxbas_pw_pool%give_back_pw(vxc00(ispin))
             END DO
             DEALLOCATE (vxc00)
             IF (ASSOCIATED(v_tau_rspace)) THEN
                IF (.NOT. ASSOCIATED(fxc_tau)) THEN
                   ALLOCATE (fxc_tau(nspins))
                   DO ispin = 1, nspins
-                     CALL pw_pool_create_pw(auxbas_pw_pool, fxc_tau(ispin), &
-                                            in_space=REALSPACE, use_data=REALDATA3D)
+                     CALL auxbas_pw_pool%create_pw(fxc_tau(ispin), &
+                                                   in_space=REALSPACE, use_data=REALDATA3D)
                      CALL pw_zero(fxc_tau(ispin))
                   END DO
                END IF
@@ -247,7 +245,7 @@ CONTAINS
                   CALL pw_axpy(v_tau_rspace(ispin), fxc_tau(ispin), ak(istep))
                END DO
                DO ispin = 1, SIZE(v_tau_rspace)
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin))
+                  CALL auxbas_pw_pool%give_back_pw(v_tau_rspace(ispin))
                END DO
                DEALLOCATE (v_tau_rspace)
             END IF
@@ -366,16 +364,16 @@ CONTAINS
          IF (.NOT. ASSOCIATED(fxc_rho)) THEN
             ALLOCATE (fxc_rho(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, fxc_rho(ispin), &
-                                      in_space=REALSPACE, use_data=REALDATA3D)
+               CALL auxbas_pw_pool%create_pw(fxc_rho(ispin), &
+                                             in_space=REALSPACE, use_data=REALDATA3D)
                CALL pw_zero(fxc_rho(ispin))
             END DO
          END IF
          IF (.NOT. ASSOCIATED(gxc_rho)) THEN
             ALLOCATE (gxc_rho(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, gxc_rho(ispin), &
-                                      in_space=REALSPACE, use_data=REALDATA3D)
+               CALL auxbas_pw_pool%create_pw(gxc_rho(ispin), &
+                                             in_space=REALSPACE, use_data=REALDATA3D)
                CALL pw_zero(gxc_rho(ispin))
             END DO
          END IF
@@ -389,7 +387,7 @@ CONTAINS
             END IF
          END DO
          DO ispin = 1, SIZE(vxc00)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc00(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vxc00(ispin))
          END DO
          DEALLOCATE (vxc00)
 
@@ -428,25 +426,25 @@ CONTAINS
 
       IF (ASSOCIATED(fxc_rho)) THEN
          DO ispin = 1, SIZE(fxc_rho)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, fxc_rho(ispin))
+            CALL auxbas_pw_pool%give_back_pw(fxc_rho(ispin))
          END DO
          DEALLOCATE (fxc_rho)
       END IF
       IF (ASSOCIATED(fxc_tau)) THEN
          DO ispin = 1, SIZE(fxc_tau)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, fxc_tau(ispin))
+            CALL auxbas_pw_pool%give_back_pw(fxc_tau(ispin))
          END DO
          DEALLOCATE (fxc_tau)
       END IF
       IF (ASSOCIATED(gxc_rho)) THEN
          DO ispin = 1, SIZE(gxc_rho)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, gxc_rho(ispin))
+            CALL auxbas_pw_pool%give_back_pw(gxc_rho(ispin))
          END DO
          DEALLOCATE (gxc_rho)
       END IF
       IF (ASSOCIATED(gxc_tau)) THEN
          DO ispin = 1, SIZE(gxc_tau)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, gxc_tau(ispin))
+            CALL auxbas_pw_pool%give_back_pw(gxc_tau(ispin))
          END DO
          DEALLOCATE (gxc_tau)
       END IF

--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -20,9 +20,7 @@ MODULE qs_gspace_mixing
                                               pw_scale,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
                                               pw_type
@@ -107,10 +105,9 @@ CONTAINS
 
          IF (nspin == 2) THEN
             CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   rho_tmp, &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_tmp, &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
             CALL pw_zero(rho_tmp)
             CALL pw_copy(rho_g(1), rho_tmp)
             CALL pw_axpy(rho_g(2), rho_g(1), 1.0_dp)
@@ -144,7 +141,7 @@ CONTAINS
                CALL pw_scale(rho_g(1), 0.5_dp)
                CALL pw_axpy(rho_g(1), rho_g(2), -1.0_dp)
                CALL pw_scale(rho_g(2), -1.0_dp)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp)
+               CALL auxbas_pw_pool%give_back_pw(rho_tmp)
             END IF
             CALL timestop(handle)
             RETURN
@@ -177,7 +174,7 @@ CONTAINS
             CALL pw_scale(rho_g(1), 0.5_dp)
             CALL pw_axpy(rho_g(1), rho_g(2), -1.0_dp)
             CALL pw_scale(rho_g(2), -1.0_dp)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tmp)
+            CALL auxbas_pw_pool%give_back_pw(rho_tmp)
          END IF
 
          DO ispin = 1, nspin

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -64,8 +64,6 @@ MODULE qs_kpp1_env_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_create,&
-                                              pw_release,&
                                               pw_type
    USE qs_energy_types,                 ONLY: allocate_qs_energy,&
                                               deallocate_qs_energy,&
@@ -337,16 +335,16 @@ CONTAINS
          lsd = .TRUE.
          ALLOCATE (rho1_r_pw(2))
          DO ispin = 1, 2
-            CALL pw_create(rho1_r_pw(ispin), rho1_r(1)%pw_grid, &
-                           rho1_r(1)%in_use, rho1_r(1)%in_space)
+            CALL rho1_r_pw(ispin)%create(rho1_r(1)%pw_grid, &
+                                         rho1_r(1)%in_use, rho1_r(1)%in_space)
             CALL pw_transfer(rho1_r(1), rho1_r_pw(ispin))
          END DO
 
          IF (ASSOCIATED(tau1_r)) THEN
             ALLOCATE (tau1_r_pw(2))
             DO ispin = 1, 2
-               CALL pw_create(tau1_r_pw(ispin), tau1_r(1)%pw_grid, &
-                              tau1_r(1)%in_use, tau1_r(1)%in_space)
+               CALL tau1_r_pw(ispin)%create(tau1_r(1)%pw_grid, &
+                                            tau1_r(1)%in_use, tau1_r(1)%in_space)
                CALL pw_transfer(tau1_r(1), tau1_r_pw(ispin))
             END DO
          END IF
@@ -392,12 +390,12 @@ CONTAINS
       IF (nspins == 1 .AND. do_excitations .AND. &
           (lsd_singlets .OR. do_triplet)) THEN
          DO ispin = 1, SIZE(rho1_r_pw)
-            CALL pw_release(rho1_r_pw(ispin))
+            CALL rho1_r_pw(ispin)%release()
          END DO
          DEALLOCATE (rho1_r_pw)
          IF (ASSOCIATED(tau1_r_pw)) THEN
          DO ispin = 1, SIZE(tau1_r_pw)
-            CALL pw_release(tau1_r_pw(ispin))
+            CALL tau1_r_pw(ispin)%release()
          END DO
          DEALLOCATE (tau1_r_pw)
          END IF
@@ -745,12 +743,12 @@ CONTAINS
          IF (nspins == 1 .AND. (do_excitations .AND. &
                                 (lsd_singlets .OR. do_triplet))) THEN
             DO ispin = 1, SIZE(my_rho_r)
-               CALL pw_release(my_rho_r(ispin))
+               CALL my_rho_r(ispin)%release()
             END DO
             DEALLOCATE (my_rho_r)
             IF (ASSOCIATED(my_tau_r)) THEN
                DO ispin = 1, SIZE(my_tau_r)
-                  CALL pw_release(my_tau_r(ispin))
+                  CALL my_tau_r(ispin)%release()
                END DO
                DEALLOCATE (my_tau_r)
             END IF

--- a/src/qs_kpp1_env_methods.F
+++ b/src/qs_kpp1_env_methods.F
@@ -57,9 +57,7 @@ MODULE qs_kpp1_env_methods
                                               pw_transfer
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -276,17 +274,17 @@ CONTAINS
       CPASSERT(ASSOCIATED(pw_env))
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       IF (gapw .OR. gapw_xc) &
          CALL prepare_gapw_den(qs_env, p_env%local_rho_set, do_rho0=(.NOT. gapw_xc))
 
       ! *** calculate the hartree potential on the total density ***
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho1_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       CALL pw_copy(rho1_g(1), rho1_tot_gspace)
       DO ispin = 2, nspins
@@ -308,19 +306,19 @@ CONTAINS
       IF (.NOT. (nspins == 1 .AND. do_excitations .AND. do_triplet)) THEN
          BLOCK
             TYPE(pw_type) :: v_hartree_gspace
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
             CALL pw_poisson_solve(poisson_env, rho1_tot_gspace, &
                                   energy_hartree, &
                                   v_hartree_gspace)
             CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+            CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
          END BLOCK
          CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rho1_tot_gspace)
 
       ! *** calculate the xc potential ***
       IF (gapw_xc) THEN
@@ -368,7 +366,7 @@ CONTAINS
       END DO
       v_rspace_new => v_xc
       IF (SIZE(v_xc) /= nspins) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(2))
+         CALL auxbas_pw_pool%give_back_pw(v_xc(2))
       END IF
       NULLIFY (v_xc)
       IF (ASSOCIATED(v_xc_tau)) THEN
@@ -376,7 +374,7 @@ CONTAINS
          CALL pw_scale(v_xc_tau(ispin), v_xc_tau(ispin)%pw_grid%dvol)
       END DO
       IF (SIZE(v_xc_tau) /= nspins) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(2))
+         CALL auxbas_pw_pool%give_back_pw(v_xc_tau(2))
       END IF
       END IF
 
@@ -545,14 +543,14 @@ CONTAINS
                              rho_atom_external=p_env%local_rho_set%rho_atom_set)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
       DO ispin = 1, SIZE(v_rspace_new)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_rspace_new(ispin))
       END DO
       DEALLOCATE (v_rspace_new)
       IF (ASSOCIATED(v_xc_tau)) THEN
       DO ispin = 1, SIZE(v_xc_tau)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
       END DO
       DEALLOCATE (v_xc_tau)
       END IF
@@ -710,15 +708,15 @@ CONTAINS
                                 (lsd_singlets .OR. do_triplet))) THEN
             ALLOCATE (my_rho_r(2))
             DO ispin = 1, 2
-               CALL pw_pool_create_pw(auxbas_pw_pool, my_rho_r(ispin), &
-                                      use_data=rho_r(1)%in_use, in_space=rho_r(1)%in_space)
+               CALL auxbas_pw_pool%create_pw(my_rho_r(ispin), &
+                                             use_data=rho_r(1)%in_use, in_space=rho_r(1)%in_space)
                CALL pw_axpy(rho_r(1), my_rho_r(ispin), 0.5_dp, 0.0_dp)
             END DO
             IF (dft_control%use_kinetic_energy_density) THEN
                ALLOCATE (my_tau_r(2))
                DO ispin = 1, 2
-                  CALL pw_pool_create_pw(auxbas_pw_pool, my_tau_r(ispin), &
-                                         use_data=tau_r(1)%in_use, in_space=tau_r(1)%in_space)
+                  CALL auxbas_pw_pool%create_pw(my_tau_r(ispin), &
+                                                use_data=tau_r(1)%in_use, in_space=tau_r(1)%in_space)
                   CALL pw_axpy(tau_r(1), my_tau_r(ispin), 0.5_dp, 0.0_dp)
                END DO
             END IF

--- a/src/qs_ks_apply_restraints.F
+++ b/src/qs_ks_apply_restraints.F
@@ -22,8 +22,7 @@ MODULE qs_ks_apply_restraints
    USE message_passing,                 ONLY: mp_para_env_type
    USE mulliken,                        ONLY: mulliken_restraint
    USE pw_methods,                      ONLY: pw_scale
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE
    USE qs_cdft_methods,                 ONLY: becke_constraint,&
@@ -83,8 +82,8 @@ CONTAINS
                ! First SCF iteraration => allocate storage
                DO igroup = 1, SIZE(cdft_control%group)
                   ALLOCATE (cdft_control%group(igroup)%weight)
-                  CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%group(igroup)%weight, &
-                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(cdft_control%group(igroup)%weight, &
+                                                use_data=REALDATA3D, in_space=REALSPACE)
                   ! Sanity check
                   IF (cdft_control%group(igroup)%constraint_type /= cdft_charge_constraint &
                       .AND. dft_control%nspins == 1) &
@@ -95,8 +94,8 @@ CONTAINS
                   IF (.NOT. ASSOCIATED(cdft_control%charge)) &
                      ALLOCATE (cdft_control%charge(cdft_control%natoms))
                   DO iatom = 1, cdft_control%natoms
-                     CALL pw_pool_create_pw(auxbas_pw_pool, cdft_control%charge(iatom), &
-                                            use_data=REALDATA3D, in_space=REALSPACE)
+                     CALL auxbas_pw_pool%create_pw(cdft_control%charge(iatom), &
+                                                   use_data=REALDATA3D, in_space=REALSPACE)
                   END DO
                END IF
                ! Another sanity check

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -83,9 +83,7 @@ MODULE qs_ks_methods
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_implicit,&
                                               pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -346,14 +344,12 @@ CONTAINS
       END IF
 
       ! Calculate the Hartree potential
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_tot_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       scf_section => section_vals_get_subs_vals(input, "DFT%SCF")
       IF (BTEST(cp_print_key_should_output(logger%iter_info, scf_section, &
@@ -380,10 +376,9 @@ CONTAINS
          ! Self-consistent continuum solvation (SCCS) model
          NULLIFY (v_sccs_rspace)
          ALLOCATE (v_sccs_rspace)
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                v_sccs_rspace, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(v_sccs_rspace, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
 
          IF (poisson_env%parameters%solver .EQ. pw_poisson_implicit) THEN
             CPABORT("The implicit Poisson solver cannot be used together with SCCS.")
@@ -426,7 +421,7 @@ CONTAINS
             CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
 
       IF (dft_control%correct_surf_dip) THEN
          IF (dft_control%surf_dip_correct_switch) THEN
@@ -498,7 +493,7 @@ CONTAINS
                                          v_qmmm=qs_env%ks_qmmm_env%v_qmmm_rspace, scale=1.0_dp)
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
 
       ! calculate the density matrix for the fitted mo_coeffs
       IF (dft_control%do_admm) THEN
@@ -653,11 +648,11 @@ CONTAINS
                 (poisson_env%parameters%dielectric_params%dielec_core_correction)) THEN
                BLOCK
                   TYPE(pw_type) :: v_minus_veps
-                  CALL pw_pool_create_pw(auxbas_pw_pool, v_minus_veps, use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(v_minus_veps, use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_copy(v_hartree_rspace, v_minus_veps)
                   CALL pw_axpy(poisson_env%implicit_env%v_eps, v_minus_veps, -v_hartree_rspace%pw_grid%dvol)
                   CALL integrate_v_core_rspace(v_minus_veps, qs_env)
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, v_minus_veps)
+                  CALL auxbas_pw_pool%give_back_pw(v_minus_veps)
                END BLOCK
             ELSE
                CALL integrate_v_core_rspace(v_hartree_rspace, qs_env)
@@ -738,32 +733,32 @@ CONTAINS
       END IF ! .NOT. just energy
 
       IF (dft_control%qs_control%ddapc_explicit_potential) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_spin_ddapc_rest_r)
+         CALL auxbas_pw_pool%give_back_pw(v_spin_ddapc_rest_r)
          DEALLOCATE (v_spin_ddapc_rest_r)
       END IF
 
       IF (calculate_forces .AND. dft_control%qs_control%cdft) THEN
          IF (.NOT. cdft_control%transfer_pot) THEN
             DO iatom = 1, SIZE(cdft_control%group)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(iatom)%weight)
+               CALL auxbas_pw_pool%give_back_pw(cdft_control%group(iatom)%weight)
                DEALLOCATE (cdft_control%group(iatom)%weight)
             END DO
             IF (cdft_control%atomic_charges) THEN
                DO iatom = 1, cdft_control%natoms
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%charge(iatom))
+                  CALL auxbas_pw_pool%give_back_pw(cdft_control%charge(iatom))
                END DO
                DEALLOCATE (cdft_control%charge)
             END IF
             IF (cdft_control%type == outer_scf_becke_constraint .AND. &
                 cdft_control%becke_control%cavity_confine) THEN
                IF (.NOT. ASSOCIATED(cdft_control%becke_control%cavity_mat)) THEN
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%becke_control%cavity)
+                  CALL auxbas_pw_pool%give_back_pw(cdft_control%becke_control%cavity)
                ELSE
                   DEALLOCATE (cdft_control%becke_control%cavity_mat)
                END IF
             ELSE IF (cdft_control%type == outer_scf_hirshfeld_constraint) THEN
                IF (ASSOCIATED(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)) THEN
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%hirshfeld_control%hirshfeld_env%fnorm)
+                  CALL auxbas_pw_pool%give_back_pw(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)
                END IF
             END IF
             IF (ASSOCIATED(cdft_control%charges_fragment)) DEALLOCATE (cdft_control%charges_fragment)
@@ -774,7 +769,7 @@ CONTAINS
       END IF
 
       IF (dft_control%do_sccs) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_sccs_rspace)
+         CALL auxbas_pw_pool%give_back_pw(v_sccs_rspace)
          DEALLOCATE (v_sccs_rspace)
       END IF
 

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -90,7 +90,6 @@ MODULE qs_ks_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qmmm_image_charge,               ONLY: add_image_pot_to_hartree_pot,&
                                               calculate_image_pot,&
@@ -491,7 +490,7 @@ CONTAINS
                      qmmm_env=qs_env%qmmm_env_qm, qs_env=qs_env)
                END IF
             END IF
-            CALL pw_release(qs_env%ks_qmmm_env%v_metal_rspace)
+            CALL qs_env%ks_qmmm_env%v_metal_rspace%release()
             DEALLOCATE (qs_env%ks_qmmm_env%v_metal_rspace)
          END IF
          IF (.NOT. just_energy) THEN

--- a/src/qs_ks_qmmm_methods.F
+++ b/src/qs_ks_qmmm_methods.F
@@ -25,8 +25,7 @@ MODULE qs_ks_qmmm_methods
                                               pw_env_retain
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_integral_ab
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
@@ -110,8 +109,8 @@ CONTAINS
       ks_qmmm_env%pc_ener = 0.0_dp
       ks_qmmm_env%n_evals = 0
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, ks_qmmm_env%v_qmmm_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(ks_qmmm_env%v_qmmm_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       IF ((qmmm_env%qmmm_coupl_type == do_qmmm_gauss) .OR. (qmmm_env%qmmm_coupl_type == do_qmmm_swave)) THEN
          CALL init_d3_poly_module() ! a fairly arbitrary but sufficient spot to do this

--- a/src/qs_ks_qmmm_types.F
+++ b/src/qs_ks_qmmm_types.F
@@ -19,8 +19,7 @@ MODULE qs_ks_qmmm_types
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_release,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: pw_type
 #include "./base/base_uses.f90"
 
@@ -72,7 +71,7 @@ CONTAINS
       TYPE(pw_pool_type), POINTER                        :: pool
 
       CALL pw_env_get(ks_qmmm_env%pw_env, auxbas_pw_pool=pool)
-      CALL pw_pool_give_back_pw(pool, ks_qmmm_env%v_qmmm_rspace)
+      CALL pool%give_back_pw(ks_qmmm_env%v_qmmm_rspace)
       CALL pw_env_release(ks_qmmm_env%pw_env)
       IF (ASSOCIATED(ks_qmmm_env%cube_info)) THEN
          DO i = 1, SIZE(ks_qmmm_env%cube_info)

--- a/src/qs_ks_reference.F
+++ b/src/qs_ks_reference.F
@@ -42,8 +42,6 @@ MODULE qs_ks_reference
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_create,&
-                                              pw_release,&
                                               pw_type
    USE qs_core_energies,                ONLY: calculate_ecore_overlap,&
                                               calculate_ecore_self
@@ -204,11 +202,11 @@ CONTAINS
 
       ! allocate potentials
       IF (ASSOCIATED(vh_rspace%pw_grid)) THEN
-         CALL pw_release(vh_rspace)
+         CALL vh_rspace%release()
       END IF
       IF (ASSOCIATED(vxc_rspace)) THEN
          DO iab = 1, SIZE(vxc_rspace)
-            CALL pw_release(vxc_rspace(iab))
+            CALL vxc_rspace(iab)%release()
          END DO
       ELSE
          ALLOCATE (vxc_rspace(nspins))
@@ -216,7 +214,7 @@ CONTAINS
       IF (ASSOCIATED(v_tau_rspace)) THEN
          IF (ASSOCIATED(vtau_rspace)) THEN
             DO iab = 1, SIZE(vtau_rspace)
-               CALL pw_release(vtau_rspace(iab))
+               CALL vtau_rspace(iab)%release()
             END DO
          ELSE
             ALLOCATE (vtau_rspace(nspins))
@@ -227,7 +225,7 @@ CONTAINS
       IF (ASSOCIATED(v_admm_rspace)) THEN
          IF (ASSOCIATED(vadmm_rspace)) THEN
             DO iab = 1, SIZE(vadmm_rspace)
-               CALL pw_release(vadmm_rspace(iab))
+               CALL vadmm_rspace(iab)%release()
             END DO
          ELSE
             ALLOCATE (vadmm_rspace(nspins))
@@ -237,17 +235,17 @@ CONTAINS
       END IF
 
       pw_grid => v_hartree_rspace%pw_grid
-      CALL pw_create(vh_rspace, pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL vh_rspace%create(pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
       DO ispin = 1, nspins
-         CALL pw_create(vxc_rspace(ispin), pw_grid, &
-                        use_data=REALDATA3D, in_space=REALSPACE)
+         CALL vxc_rspace(ispin)%create(pw_grid, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          IF (ASSOCIATED(vtau_rspace)) THEN
-            CALL pw_create(vtau_rspace(ispin), pw_grid, &
-                           use_data=REALDATA3D, in_space=REALSPACE)
+            CALL vtau_rspace(ispin)%create(pw_grid, &
+                                           use_data=REALDATA3D, in_space=REALSPACE)
          END IF
          IF (ASSOCIATED(vadmm_rspace)) THEN
-            CALL pw_create(vadmm_rspace(ispin), pw_grid, &
-                           use_data=REALDATA3D, in_space=REALSPACE)
+            CALL vadmm_rspace(ispin)%create(pw_grid, &
+                                            use_data=REALDATA3D, in_space=REALSPACE)
          END IF
       END DO
       !

--- a/src/qs_ks_reference.F
+++ b/src/qs_ks_reference.F
@@ -35,9 +35,7 @@ MODULE qs_ks_reference
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -145,12 +143,12 @@ CONTAINS
                       poisson_env=poisson_env)
 
       ! Calculate the Hartree potential
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! Get the total density in g-space [ions + electrons]
       CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
@@ -160,8 +158,8 @@ CONTAINS
       CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
       CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
       !
       CALL calculate_ecore_self(qs_env, E_self_core=eself)
       CALL calculate_ecore_overlap(qs_env, para_env, PRESENT(h_stress), E_overlap_core=eovrl)
@@ -272,12 +270,12 @@ CONTAINS
       END IF
 
       ! return pw grids
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
       IF (ASSOCIATED(v_rspace)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_rspace(ispin))
             IF (ASSOCIATED(v_tau_rspace)) THEN
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_tau_rspace(ispin))
             END IF
          END DO
          DEALLOCATE (v_rspace)
@@ -285,7 +283,7 @@ CONTAINS
       IF (ASSOCIATED(v_tau_rspace)) DEALLOCATE (v_tau_rspace)
       IF (ASSOCIATED(v_admm_rspace)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_admm_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_admm_rspace(ispin))
          END DO
          DEALLOCATE (v_admm_rspace)
       END IF

--- a/src/qs_ks_types.F
+++ b/src/qs_ks_types.F
@@ -46,8 +46,7 @@ MODULE qs_ks_types
    USE pw_env_types,                    ONLY: pw_env_release,&
                                               pw_env_retain,&
                                               pw_env_type
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_force_types,                  ONLY: qs_force_type
    USE qs_kind_types,                   ONLY: qs_kind_type
@@ -716,7 +715,7 @@ CONTAINS
       TYPE(qs_ks_env_type), INTENT(INOUT)                :: ks_env
 
       IF (ASSOCIATED(ks_env%v_hartree_rspace)) THEN
-         CALL pw_release(ks_env%v_hartree_rspace)
+         CALL ks_env%v_hartree_rspace%release()
          DEALLOCATE (ks_env%v_hartree_rspace)
       END IF
 
@@ -750,23 +749,23 @@ CONTAINS
          CALL deallocate_task_list(ks_env%task_list_soft)
 
       IF (ASSOCIATED(ks_env%rho_nlcc_g)) THEN
-         CALL pw_release(ks_env%rho_nlcc_g)
+         CALL ks_env%rho_nlcc_g%release()
          DEALLOCATE (ks_env%rho_nlcc_g)
       END IF
       IF (ASSOCIATED(ks_env%rho_nlcc)) THEN
-         CALL pw_release(ks_env%rho_nlcc)
+         CALL ks_env%rho_nlcc%release()
          DEALLOCATE (ks_env%rho_nlcc)
       END IF
       IF (ASSOCIATED(ks_env%rho_core)) THEN
-         CALL pw_release(ks_env%rho_core)
+         CALL ks_env%rho_core%release()
          DEALLOCATE (ks_env%rho_core)
       END IF
       IF (ASSOCIATED(ks_env%vppl)) THEN
-         CALL pw_release(ks_env%vppl)
+         CALL ks_env%vppl%release()
          DEALLOCATE (ks_env%vppl)
       END IF
       IF (ASSOCIATED(ks_env%vee)) THEN
-         CALL pw_release(ks_env%vee)
+         CALL ks_env%vee%release()
          DEALLOCATE (ks_env%vee)
       END IF
       IF (ASSOCIATED(ks_env%dbcsr_dist)) THEN
@@ -818,7 +817,7 @@ CONTAINS
       TYPE(qs_ks_env_type), INTENT(INOUT)                :: ks_env
 
       IF (ASSOCIATED(ks_env%v_hartree_rspace)) THEN
-         CALL pw_release(ks_env%v_hartree_rspace)
+         CALL ks_env%v_hartree_rspace%release()
          DEALLOCATE (ks_env%v_hartree_rspace)
       END IF
 
@@ -848,23 +847,23 @@ CONTAINS
          CALL deallocate_task_list(ks_env%task_list_soft)
 
       IF (ASSOCIATED(ks_env%rho_nlcc_g)) THEN
-         CALL pw_release(ks_env%rho_nlcc_g)
+         CALL ks_env%rho_nlcc_g%release()
          DEALLOCATE (ks_env%rho_nlcc_g)
       END IF
       IF (ASSOCIATED(ks_env%rho_nlcc)) THEN
-         CALL pw_release(ks_env%rho_nlcc)
+         CALL ks_env%rho_nlcc%release()
          DEALLOCATE (ks_env%rho_nlcc)
       END IF
       IF (ASSOCIATED(ks_env%rho_core)) THEN
-         CALL pw_release(ks_env%rho_core)
+         CALL ks_env%rho_core%release()
          DEALLOCATE (ks_env%rho_core)
       END IF
       IF (ASSOCIATED(ks_env%vppl)) THEN
-         CALL pw_release(ks_env%vppl)
+         CALL ks_env%vppl%release()
          DEALLOCATE (ks_env%vppl)
       END IF
       IF (ASSOCIATED(ks_env%vee)) THEN
-         CALL pw_release(ks_env%vee)
+         CALL ks_env%vee%release()
          DEALLOCATE (ks_env%vee)
       END IF
 

--- a/src/qs_ks_utils.F
+++ b/src/qs_ks_utils.F
@@ -93,9 +93,7 @@ MODULE qs_ks_utils
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_implicit,&
                                               pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -316,16 +314,16 @@ CONTAINS
       ALLOCATE (rho_r(Nspin))
       ALLOCATE (rho_g(Nspin))
       DO ispin = 1, Nspin
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(ispin), &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(ispin), &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_r(ispin), &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_g(ispin), &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
       END DO
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_v_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(work_v_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       ! get mo matrices needed to construct the density matrices
       ! we will base all on the alpha spin matrix, obviously possible in ROKS
@@ -389,7 +387,7 @@ CONTAINS
                CALL pw_axpy(vxc(ispin), work_v_rspace, energy_scaling(iterm)*vxc(ispin)%pw_grid%dvol, 0.0_dp)
                CALL integrate_v_rspace(v_rspace=work_v_rspace, pmat=matrix_p(ispin), hmat=matrix_h(ispin), &
                                        qs_env=qs_env, calculate_forces=calculate_forces)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc(ispin))
+               CALL auxbas_pw_pool%give_back_pw(vxc(ispin))
             END DO
             DEALLOCATE (vxc)
 
@@ -436,8 +434,8 @@ CONTAINS
 
       ! release allocated memory
       DO ispin = 1, Nspin
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rho_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rho_g(ispin))
       END DO
       DEALLOCATE (rho_r, rho_g)
       CALL dbcsr_deallocate_matrix_set(matrix_p)
@@ -446,7 +444,7 @@ CONTAINS
          CALL dbcsr_deallocate_matrix_set(matrix_hfx)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_rspace)
+      CALL auxbas_pw_pool%give_back_pw(work_v_rspace)
 
       CALL dbcsr_release_p(fm_deriv)
       CALL dbcsr_release_p(fm_scaled)
@@ -618,24 +616,24 @@ CONTAINS
       END SELECT
 
       ! data needed for each of the orbs
-      CALL pw_pool_create_pw(auxbas_pw_pool, orb_rho_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, tmp_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, orb_rho_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, tmp_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_v_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_v_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(orb_rho_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(tmp_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(orb_rho_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(tmp_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(work_v_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(work_v_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       ALLOCATE (orb_density_matrix)
       CALL dbcsr_copy(orb_density_matrix, rho_ao(1)%matrix, &
@@ -730,20 +728,20 @@ CONTAINS
                            tmp_dbcsr(sic_orbital_list(3, iorb))%matrix, 1.0_dp, 1.0_dp)
             !
             ! need to deallocate vxc
-            CALL pw_pool_give_back_pw(xc_pw_pool, vxc(1))
-            CALL pw_pool_give_back_pw(xc_pw_pool, vxc(2))
+            CALL xc_pw_pool%give_back_pw(vxc(1))
+            CALL xc_pw_pool%give_back_pw(vxc(2))
             DEALLOCATE (vxc)
 
          END IF
 
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, orb_rho_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, orb_rho_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v_rspace)
+      CALL auxbas_pw_pool%give_back_pw(orb_rho_r)
+      CALL auxbas_pw_pool%give_back_pw(tmp_r)
+      CALL auxbas_pw_pool%give_back_pw(orb_rho_g)
+      CALL auxbas_pw_pool%give_back_pw(tmp_g)
+      CALL auxbas_pw_pool%give_back_pw(work_v_gspace)
+      CALL auxbas_pw_pool%give_back_pw(work_v_rspace)
 
       CALL dbcsr_deallocate_matrix(orb_density_matrix)
       CALL dbcsr_deallocate_matrix(orb_h)
@@ -803,12 +801,12 @@ CONTAINS
       ! OK, right now we like two spins to do sic, could be relaxed for AD
       CPASSERT(dft_control%nspins == 2)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_rho, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, work_v, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(work_rho, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(work_v, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       CALL qs_rho_get(rho, rho_g=rho_g)
 
@@ -879,16 +877,16 @@ CONTAINS
 
       IF (.NOT. just_energy) THEN
          ALLOCATE (v_sic_rspace)
-         CALL pw_pool_create_pw(auxbas_pw_pool, v_sic_rspace, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(v_sic_rspace, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_transfer(work_v, v_sic_rspace)
          ! also take into account the scaling (in addition to the volume element)
          CALL pw_scale(v_sic_rspace, &
                        dft_control%sic_scaling_a*v_sic_rspace%pw_grid%dvol)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_rho)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, work_v)
+      CALL auxbas_pw_pool%give_back_pw(work_rho)
+      CALL auxbas_pw_pool%give_back_pw(work_v)
 
    END SUBROUTINE calc_v_sic_rspace
 
@@ -1439,7 +1437,7 @@ CONTAINS
             ! DFT embedding
             IF (dft_control%apply_embed_pot) THEN
                CALL pw_axpy(v_rspace_embed(ispin), v_rspace_new(ispin), v_rspace_embed(ispin)%pw_grid%dvol)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_embed(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_rspace_embed(ispin))
             END IF
             IF (lrigpw) THEN
                lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
@@ -1482,13 +1480,13 @@ CONTAINS
                                        calculate_forces=calculate_forces, &
                                        gapw=gapw)
             END IF
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_rspace_new(ispin))
          END DO ! ispin
 
          SELECT CASE (dft_control%sic_method_id)
          CASE (sic_none)
          CASE (sic_mauri_us, sic_mauri_spz, sic_ad)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_sic_rspace)
+            CALL auxbas_pw_pool%give_back_pw(v_sic_rspace)
             DEALLOCATE (v_sic_rspace)
          END SELECT
          DEALLOCATE (v_rspace_new)
@@ -1510,7 +1508,7 @@ CONTAINS
             ! DFT embedding
             IF (dft_control%apply_embed_pot) THEN
                CALL pw_axpy(v_rspace_embed(ispin), v_rspace, v_rspace_embed(ispin)%pw_grid%dvol)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_embed(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_rspace_embed(ispin))
             END IF
             IF (lrigpw) THEN
                lri_v_int => lri_density%lri_coefs(ispin)%lri_kinds
@@ -1596,7 +1594,7 @@ CONTAINS
                                     qs_env=qs_env, &
                                     calculate_forces=calculate_forces, compute_tau=.TRUE., &
                                     gapw=gapw)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_tau_rspace(ispin))
          END DO
          DEALLOCATE (v_tau_rspace)
       END IF
@@ -1657,14 +1655,14 @@ CONTAINS
                                  matrix_ks_aux_fit(ispin, img)%matrix, 1.0_dp, -1.0_dp)
                END DO
 
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new_aux_fit(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_rspace_new_aux_fit(ispin))
             END DO
             DEALLOCATE (v_rspace_new_aux_fit)
          END IF
          ! Clean up v_tau_rspace_aux_fit, which is actually not needed
          IF (ASSOCIATED(v_tau_rspace_aux_fit)) THEN
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace_aux_fit(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_tau_rspace_aux_fit(ispin))
             END DO
             DEALLOCATE (v_tau_rspace_aux_fit)
          END IF
@@ -1734,10 +1732,10 @@ CONTAINS
       CALL qs_rho_get(rho, rho_r=rho_r, rho_g=rho_g)
       nspins = 1
       ALLOCATE (v_rspace_new(nspins))
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_rspace_new(1), &
-                             use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_xc_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=v_rspace_new(1), &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=v_xc_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL pw_zero(v_rspace_new(1))
       do_zmp_read = dft_control%apply_external_vxc
@@ -1749,14 +1747,12 @@ CONTAINS
          BLOCK
             REAL(KIND=dp)                                      :: factor
             TYPE(pw_type) :: rho_eff_gspace, v_xc_gspace
-            CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                   pw=rho_eff_gspace, &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
-            CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                   pw=v_xc_gspace, &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(pw=rho_eff_gspace, &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(pw=v_xc_gspace, &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
             CALL pw_zero(rho_eff_gspace)
             CALL pw_zero(v_xc_gspace)
             CALL pw_zero(v_xc_rspace)
@@ -1788,14 +1784,12 @@ CONTAINS
 !Note that this is not the xc energy but \int(\rho*v_xc)
 !Vxc---> v_rspace_new
 !Exc---> energy%exc
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, &
-                                      rho_eff_gspace)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, &
-                                      v_xc_gspace)
+            CALL auxbas_pw_pool%give_back_pw(rho_eff_gspace)
+            CALL auxbas_pw_pool%give_back_pw(v_xc_gspace)
          END BLOCK
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_rspace)
+      CALL auxbas_pw_pool%give_back_pw(v_xc_rspace)
 
       CALL timestop(handle)
 
@@ -1843,8 +1837,8 @@ CONTAINS
       embed_corr = 0.0_dp
 
       DO ispin = 1, dft_control%nspins
-         CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=v_rspace_embed(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(pw=v_rspace_embed(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(v_rspace_embed(ispin))
 
          CALL pw_copy(qs_env%embed_pot, v_rspace_embed(ispin))
@@ -1865,7 +1859,7 @@ CONTAINS
       ! If only energy requiested we delete the potential
       IF (just_energy) THEN
          DO ispin = 1, dft_control%nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_embed(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_rspace_embed(ispin))
          END DO
          DEALLOCATE (v_rspace_embed)
       END IF

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -83,9 +83,7 @@ MODULE qs_linres_current
                                               pw_integrate_function,&
                                               pw_scale,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -480,8 +478,8 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_rs_desc=auxbas_rs_desc, &
                          auxbas_pw_pool=auxbas_pw_pool)
          !
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(wf_r, use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          !
          DO idir = 1, 3
             CALL pw_zero(wf_r)
@@ -513,7 +511,7 @@ CONTAINS
                  &                            "PRINT%CURRENT_CUBES", mpi_io=mpi_io)
          END DO
          !
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+         CALL auxbas_pw_pool%give_back_pw(wf_r)
       END IF ! current cube
       !
       ! Integrated current response checksum

--- a/src/qs_linres_current_utils.F
+++ b/src/qs_linres_current_utils.F
@@ -75,8 +75,7 @@ MODULE qs_linres_current_utils
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -1264,11 +1263,11 @@ CONTAINS
          NULLIFY (rho_r, rho_g)
          ALLOCATE (rho_r(nspins), rho_g(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_r(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(rho_r(ispin))
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(ispin), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_g(ispin), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL pw_zero(rho_g(ispin))
          END DO
          NULLIFY (current_env%jrho1_set(idir)%rho)

--- a/src/qs_linres_epr_nablavks.F
+++ b/src/qs_linres_epr_nablavks.F
@@ -49,9 +49,7 @@ MODULE qs_linres_epr_nablavks
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -282,14 +280,14 @@ CONTAINS
 !   Add Hartree potential
 !   -------------------------------------
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gtemp, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rtemp, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gtemp, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rtemp, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       IF (gapw) THEN
          ! need to rebuild the coeff !
@@ -455,10 +453,10 @@ CONTAINS
       CALL pw_transfer(v_hartree_gtemp, v_hartree_rtemp)
       CALL pw_copy(v_hartree_rtemp, pwz)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gtemp)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rtemp)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gtemp)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rtemp)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
 
 !   -------------------------------------
 !   Add Coulomb potential
@@ -504,12 +502,12 @@ CONTAINS
 
             IF (gth_gspace) THEN
 
-               CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_gspace, &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-               CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_gtemp, &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-               CALL pw_pool_create_pw(auxbas_pw_pool, v_coulomb_rtemp, &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(v_coulomb_gspace, &
+                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(v_coulomb_gtemp, &
+                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(v_coulomb_rtemp, &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
 
                CALL pw_zero(v_coulomb_gspace)
 
@@ -605,9 +603,9 @@ CONTAINS
                CALL pw_transfer(v_coulomb_gtemp, v_coulomb_rtemp)
                CALL pw_axpy(v_coulomb_rtemp, pwz)
 
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_gspace)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_gtemp)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_coulomb_rtemp)
+               CALL auxbas_pw_pool%give_back_pw(v_coulomb_gspace)
+               CALL auxbas_pw_pool%give_back_pw(v_coulomb_gtemp)
+               CALL auxbas_pw_pool%give_back_pw(v_coulomb_rtemp)
             ELSE
 
                ! Attic of the atomic parallellisation
@@ -850,10 +848,10 @@ CONTAINS
 !   Add V_xc potential
 !   -------------------------------------
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_xc_gtemp, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_xc_rtemp, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_xc_gtemp, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_xc_rtemp, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       xc_section => section_vals_get_subs_vals(input, "PROPERTIES%LINRES%EPR%PRINT%G_TENSOR%XC")
       ! a possible vdW section in xc_section will be ignored
@@ -888,7 +886,7 @@ CONTAINS
             CALL qs_rho_get(nablavks_set(3, ispin)%rho, rho_r=rho_r)
             CALL pw_axpy(v_xc_rtemp, rho_r(1))
 
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_rspace_new(ispin))
 
          END DO
 
@@ -917,15 +915,15 @@ CONTAINS
             CALL qs_rho_get(nablavks_set(3, ispin)%rho, rho_r=rho_r)
             CALL pw_axpy(v_xc_rtemp, rho_r(1))
 
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_tau_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_tau_rspace(ispin))
 
          END DO
 
          DEALLOCATE (v_tau_rspace)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_gtemp)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_rtemp)
+      CALL auxbas_pw_pool%give_back_pw(v_xc_gtemp)
+      CALL auxbas_pw_pool%give_back_pw(v_xc_rtemp)
 
       IF (gapw .OR. gapw_xc) THEN
          CALL calculate_vxc_atom(qs_env=qs_env, energy_only=.FALSE., exc1=exc1, &
@@ -938,9 +936,9 @@ CONTAINS
 
       IF (BTEST(cp_print_key_should_output(logger%iter_info, lr_section, &
                                            "EPR%PRINT%NABLAVKS_CUBES"), cp_p_file)) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(wf_r, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          DO idir = 1, 3
             CALL pw_zero(wf_r)
             CALL qs_rho_get(nablavks_set(idir, 1)%rho, rho_r=rho_r)
@@ -960,7 +958,7 @@ CONTAINS
             CALL cp_print_key_finished_output(unit_nr, logger, lr_section, &
                                               "EPR%PRINT%NABLAVKS_CUBES", mpi_io=mpi_io)
          END DO
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+         CALL auxbas_pw_pool%give_back_pw(wf_r)
       END IF
 
       CALL cp_print_key_finished_output(output_unit, logger, lr_section, &

--- a/src/qs_linres_epr_ownutils.F
+++ b/src/qs_linres_epr_ownutils.F
@@ -37,9 +37,7 @@ MODULE qs_linres_epr_ownutils
                                               pw_scale,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_spline_utils,                 ONLY: Eval_Interp_Spl3_pbc,&
                                               find_coeffs,&
@@ -384,9 +382,8 @@ CONTAINS
 
          DO ispin = 1, nspins
             DO idir1 = 1, 3
-               CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                      vks_pw_spline(idir1, ispin), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(vks_pw_spline(idir1, ispin), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                ! calculate spline coefficients
                CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                              pool=auxbas_pw_pool, pbc=.TRUE., transpose=.FALSE.)
@@ -519,7 +516,7 @@ CONTAINS
 
          DO ispin = 1, nspins
             DO idir1 = 1, 3
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, vks_pw_spline(idir1, ispin))
+               CALL auxbas_pw_pool%give_back_pw(vks_pw_spline(idir1, ispin))
             END DO
          END DO
          DEALLOCATE (vks_pw_spline)
@@ -654,9 +651,8 @@ CONTAINS
          CALL section_vals_val_get(interp_section, "eps_x", r_val=eps_x)
 
          DO idir1 = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   bind_pw_spline(idir1, iB), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(bind_pw_spline(idir1, iB), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             ! calculate spline coefficients
             CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                           pool=auxbas_pw_pool, pbc=.TRUE., transpose=.FALSE.)
@@ -746,7 +742,7 @@ CONTAINS
          g_soo(iB, :) = g_soo(iB, :) + temp_soo_gapw(iB, :)
 
          DO idir1 = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, bind_pw_spline(idir1, iB))
+            CALL auxbas_pw_pool%give_back_pw(bind_pw_spline(idir1, iB))
          END DO
          DEALLOCATE (bind_pw_spline)
 
@@ -815,18 +811,18 @@ CONTAINS
       ALLOCATE (shift_pw_gspace(3, nspins))
       DO ispin = 1, nspins
          DO idir = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin), &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(shift_pw_gspace(idir, ispin), &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
             CALL pw_zero(shift_pw_gspace(idir, ispin))
          END DO
       END DO
-      CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(shift_pw_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_zero(shift_pw_rspace)
-      CALL pw_pool_create_pw(auxbas_pw_pool, pw_gspace_work, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw_gspace_work, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
       CALL pw_zero(pw_gspace_work)
       !
       CALL set_vecp(iB, iiB, iiiB)
@@ -867,14 +863,14 @@ CONTAINS
       END IF
       !
       ! Dellocate grids for the calculation of jrho and the shift
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_gspace_work)
+      CALL auxbas_pw_pool%give_back_pw(pw_gspace_work)
       DO ispin = 1, dft_control%nspins
          DO idir = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin))
+            CALL auxbas_pw_pool%give_back_pw(shift_pw_gspace(idir, ispin))
          END DO
       END DO
       DEALLOCATE (shift_pw_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_rspace)
+      CALL auxbas_pw_pool%give_back_pw(shift_pw_rspace)
       !
       ! Finalize
       CALL timestop(handle)

--- a/src/qs_linres_epr_utils.F
+++ b/src/qs_linres_epr_utils.F
@@ -37,8 +37,7 @@ MODULE qs_linres_epr_utils
                                               e_gfactor
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -186,10 +185,10 @@ CONTAINS
             ALLOCATE (epr_env%bind_set(idir, i_B)%rho)
             CALL qs_rho_create(epr_env%bind_set(idir, i_B)%rho)
             ALLOCATE (rho_r(1), rho_g(1))
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(1), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(1), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_r(1), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_g(1), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL qs_rho_set(epr_env%bind_set(idir, i_B)%rho, rho_r=rho_r, rho_g=rho_g)
          END DO
       END DO
@@ -202,10 +201,10 @@ CONTAINS
             ALLOCATE (epr_env%nablavks_set(idir, ispin)%rho)
             CALL qs_rho_create(epr_env%nablavks_set(idir, ispin)%rho)
             ALLOCATE (rho_r(1), rho_g(1))
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(1), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(1), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_r(1), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_g(1), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL qs_rho_set(epr_env%nablavks_set(idir, ispin)%rho, &
                             rho_r=rho_r, rho_g=rho_g)
          END DO

--- a/src/qs_linres_kernel.F
+++ b/src/qs_linres_kernel.F
@@ -66,9 +66,7 @@ MODULE qs_linres_kernel
                                               pw_transfer
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -277,20 +275,20 @@ CONTAINS
       CPASSERT(ASSOCIATED(pw_env))
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       IF (gapw .OR. gapw_xc) &
          CALL prepare_gapw_den(qs_env, p_env%local_rho_set, do_rho0=(.NOT. gapw_xc))
 
       ! *** calculate the hartree potential on the total density ***
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho1_tot_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho1_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       CALL qs_rho_get(rho1, rho_g=rho1_g)
       CALL pw_copy(rho1_g(1), rho1_tot_gspace)
@@ -307,7 +305,7 @@ CONTAINS
          CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho1_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rho1_tot_gspace)
 
       ! *** calculate the xc potential ***
       NULLIFY (rho1a)
@@ -534,15 +532,15 @@ CONTAINS
          END IF
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace_new(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_rspace_new(ispin))
       END DO
       DEALLOCATE (v_rspace_new)
       IF (ASSOCIATED(v_xc_tau)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
          END DO
          DEALLOCATE (v_xc_tau)
       END IF
@@ -952,7 +950,7 @@ CONTAINS
             END IF
 
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
             END DO
             DEALLOCATE (v_xc)
             CALL dbcsr_deallocate_matrix(xcmat%matrix)

--- a/src/qs_linres_nmr_epr_common_utils.F
+++ b/src/qs_linres_nmr_epr_common_utils.F
@@ -19,9 +19,7 @@ MODULE qs_linres_nmr_epr_common_utils
    USE mathconstants,                   ONLY: gaussi
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_methods,                      ONLY: pw_transfer
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
                                               pw_type
@@ -74,7 +72,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL pw_pool_create_pw(pw_pool, influence_fn, &
+      CALL pw_pool%create_pw(influence_fn, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       grid => influence_fn%pw_grid
@@ -90,7 +88,7 @@ CONTAINS
       funcG_times_rho%cc(1:ng) = funcG_times_rho%cc(1:ng)*influence_fn%cc(1:ng)
       IF (grid%have_g0) funcG_times_rho%cc(1) = my_chi
 
-      CALL pw_pool_give_back_pw(pw_pool, influence_fn)
+      CALL pw_pool%give_back_pw(influence_fn)
 
       CALL timestop(handle)
 

--- a/src/qs_linres_nmr_shift.F
+++ b/src/qs_linres_nmr_shift.F
@@ -41,9 +41,7 @@ MODULE qs_linres_nmr_shift
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_spline_utils,                 ONLY: Eval_Interp_Spl3_pbc,&
                                               find_coeffs,&
@@ -159,8 +157,8 @@ CONTAINS
       ALLOCATE (shift_pw_gspace(3, nspins))
       DO ispin = 1, nspins
          DO idir = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(shift_pw_gspace(idir, ispin), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL pw_zero(shift_pw_gspace(idir, ispin))
          END DO
       END DO
@@ -168,8 +166,8 @@ CONTAINS
       !
       CALL set_vecp(iB, iiB, iiiB)
       !
-      CALL pw_pool_create_pw(auxbas_pw_pool, pw_gspace_work, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw_gspace_work, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_zero(pw_gspace_work)
       DO ispin = 1, nspins
          !
@@ -193,12 +191,12 @@ CONTAINS
          END DO ! idir
       END DO ! ispin
       !
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, pw_gspace_work)
+      CALL auxbas_pw_pool%give_back_pw(pw_gspace_work)
       !
       ! compute shildings
       IF (interpolate_shift) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, shift_pw_rspace, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(shift_pw_rspace, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          DO ispin = 1, nspins
             DO idir = 1, 3
                ! Here first G->R and then interpolation to get the shifts.
@@ -209,7 +207,7 @@ CONTAINS
                                              iB, idir, nmr_section)
             END DO
          END DO
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_rspace)
+         CALL auxbas_pw_pool%give_back_pw(shift_pw_rspace)
       ELSE
          DO ispin = 1, nspins
             DO idir = 1, 3
@@ -232,7 +230,7 @@ CONTAINS
       ! Dellocate grids for the calculation of jrho and the shift
       DO ispin = 1, nspins
          DO idir = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, shift_pw_gspace(idir, ispin))
+            CALL auxbas_pw_pool%give_back_pw(shift_pw_gspace(idir, ispin))
          END DO
       END DO
       DEALLOCATE (shift_pw_gspace)
@@ -542,8 +540,8 @@ CONTAINS
 
       ! calculate spline coefficients
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, shiftspl, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(shiftspl, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       CALL pw_spline_precond_create(precond, precond_kind=aint_precond, &
                                     pool=auxbas_pw_pool, pbc=.TRUE., transpose=.FALSE.)
@@ -585,7 +583,7 @@ CONTAINS
          END DO
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, shiftspl)
+      CALL auxbas_pw_pool%give_back_pw(shiftspl)
 
       !
       CALL timestop(handle)

--- a/src/qs_loc_methods.F
+++ b/src/qs_loc_methods.F
@@ -85,9 +85,7 @@ MODULE qs_loc_methods
    USE physcon,                         ONLY: angstrom
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -823,12 +821,12 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       my_state0 = 0
       IF (PRESENT(state0)) my_state0 = state0
@@ -890,8 +888,8 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_out_c, logger, print_key, "", mpi_io=mpi_io)
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
       CALL timestop(handle)
    END SUBROUTINE qs_print_cubes
 

--- a/src/qs_local_properties.F
+++ b/src/qs_local_properties.F
@@ -38,9 +38,7 @@ MODULE qs_local_properties
                                               pw_multiply,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -127,9 +125,9 @@ CONTAINS
       ! get working arrays
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, band_density, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, hartree_density, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, xc_density, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(band_density, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(hartree_density, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(xc_density, use_data=REALDATA3D, in_space=REALSPACE)
 
       ! w matrix
       CALL get_qs_env(qs_env, matrix_w_kp=matrix_w)
@@ -151,14 +149,12 @@ CONTAINS
       ! band structure energy density
       CALL qs_energies_compute_w(qs_env, .TRUE.)
       CALL get_qs_env(qs_env, ks_env=ks_env, matrix_w_kp=matrix_w)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             edens_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             edens_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(edens_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(edens_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
       CALL pw_zero(band_density)
       DO ispin = 1, nspins
          rho_ao => matrix_w(ispin, :)
@@ -168,19 +164,17 @@ CONTAINS
                                  ks_env=ks_env, soft_valid=(gapw .OR. gapw_xc))
          CALL pw_axpy(edens_r, band_density)
       END DO
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, edens_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, edens_g)
+      CALL auxbas_pw_pool%give_back_pw(edens_r)
+      CALL auxbas_pw_pool%give_back_pw(edens_g)
 
       ! Hartree energy density correction = -0.5 * V_H(r) * [rho(r) - rho_core(r)]
       ALLOCATE (rho_tot_gspace, rho_tot_rspace)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_tot_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_tot_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_tot_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
       NULLIFY (rho_core)
       CALL get_qs_env(qs_env, &
                       v_hartree_rspace=v_hartree_rspace, &
@@ -198,8 +192,8 @@ CONTAINS
       CALL pw_zero(hartree_density)
       ovol = 0.5_dp/hartree_density%pw_grid%dvol
       CALL pw_multiply(hartree_density, v_hartree_rspace, rho_tot_rspace, alpha=ovol)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_rspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_rspace)
       DEALLOCATE (rho_tot_gspace, rho_tot_rspace)
 
       IF (dft_control%do_admm) THEN
@@ -243,9 +237,9 @@ CONTAINS
       END IF
 
       ! return temp arrays
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, band_density)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, hartree_density)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, xc_density)
+      CALL auxbas_pw_pool%give_back_pw(band_density)
+      CALL auxbas_pw_pool%give_back_pw(hartree_density)
+      CALL auxbas_pw_pool%give_back_pw(xc_density)
 
       CALL timestop(handle)
 
@@ -324,7 +318,7 @@ CONTAINS
       ! get working arrays
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-      CALL pw_pool_create_pw(auxbas_pw_pool, xc_density, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(xc_density, use_data=REALDATA3D, in_space=REALSPACE)
 
       ! init local stress tensor
       IF (do_stress) THEN
@@ -349,20 +343,20 @@ CONTAINS
 
       ! Electrical field terms
       CALL get_qs_env(qs_env, v_hartree_rspace=v_hartree_rspace)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_transfer(v_hartree_rspace, v_hartree_gspace)
       DO i = 1, 3
-         CALL pw_pool_create_pw(auxbas_pw_pool, efield(i), &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(efield(i), &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          CALL pw_copy(v_hartree_gspace, efield(i))
       END DO
       CALL pw_derive(efield(1), (/1, 0, 0/))
       CALL pw_derive(efield(2), (/0, 1, 0/))
       CALL pw_derive(efield(3), (/0, 0, 1/))
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, efield(i))
+         CALL auxbas_pw_pool%give_back_pw(efield(i))
       END DO
 
       pv_loc = 0.0_dp

--- a/src/qs_pdos.F
+++ b/src/qs_pdos.F
@@ -59,9 +59,7 @@ MODULE qs_pdos
    USE preconditioner_types,            ONLY: preconditioner_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -361,12 +359,12 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
 
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(wf_r, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(wf_g, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
          ALLOCATE (read_r(4, n_r_ldos))
          DO ildos = 1, n_r_ldos
             WRITE (r_ldos_index(ildos), '(I0)') ildos
@@ -900,8 +898,8 @@ CONTAINS
          DEALLOCATE (read_r)
          DEALLOCATE (r_ldos_p)
          DEALLOCATE (r_ldos_index)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+         CALL auxbas_pw_pool%give_back_pw(wf_r)
+         CALL auxbas_pw_pool%give_back_pw(wf_g)
       END IF
       IF (do_virt) THEN
          DEALLOCATE (evals_virt)

--- a/src/qs_resp.F
+++ b/src/qs_resp.F
@@ -78,7 +78,6 @@ MODULE qs_resp
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_resp_all,&
                                               calculate_rho_resp_single
@@ -983,9 +982,9 @@ CONTAINS
          END DO
       END DO
 
-      CALL pw_release(va_gspace)
-      CALL pw_release(va_rspace)
-      CALL pw_release(rho_ga)
+      CALL va_gspace%release()
+      CALL va_rspace%release()
+      CALL rho_ga%release()
 
       DO i = 1, natom
          DO j = 1, natom
@@ -1751,8 +1750,8 @@ CONTAINS
       IF (resp_env%use_repeat_method) THEN
          v_resp_rspace%cr3d(:, :, :) = v_resp_rspace%cr3d(:, :, :) - resp_env%offset*dvol
       END IF
-      CALL pw_release(v_resp_gspace)
-      CALL pw_release(rho_resp)
+      CALL v_resp_gspace%release()
+      CALL rho_resp%release()
 
       !***now print the v_resp_rspace%pw to a cube file if requested
       IF (BTEST(cp_print_key_should_output(logger%iter_info, resp_section, &
@@ -1807,7 +1806,7 @@ CONTAINS
             "(RRMS) error of RESP fit:", rrms
       END IF
 
-      CALL pw_release(v_resp_rspace)
+      CALL v_resp_rspace%release()
 
       CALL timestop(handle)
 

--- a/src/qs_resp.F
+++ b/src/qs_resp.F
@@ -71,9 +71,7 @@ MODULE qs_resp
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -945,18 +943,15 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_ga, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             va_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             va_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_ga, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(va_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(va_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       !get fitting points and store them in resp_env%fitpoints
       CALL get_fitting_points(qs_env, resp_env, rep_sys, particles=particles, &
@@ -1721,18 +1716,15 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             rho_resp, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_resp_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, &
-                             v_resp_rspace, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_resp, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_resp_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_resp_rspace, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       CALL pw_zero(rho_resp)
       CALL calculate_rho_resp_all(rho_resp, resp_env%rhs, natom, &
@@ -1756,9 +1748,9 @@ CONTAINS
       !***now print the v_resp_rspace%pw to a cube file if requested
       IF (BTEST(cp_print_key_should_output(logger%iter_info, resp_section, &
                                            "PRINT%V_RESP_CUBE"), cp_p_file)) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(aux_r, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          append_cube = section_get_lval(resp_section, "PRINT%V_RESP_CUBE%APPEND")
          my_pos_cube = "REWIND"
          IF (append_cube) THEN
@@ -1779,7 +1771,7 @@ CONTAINS
                             mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, resp_section, &
                                            "PRINT%V_RESP_CUBE", mpi_io=mpi_io)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
+         CALL auxbas_pw_pool%give_back_pw(aux_r)
       END IF
 
       !*** RMS and RRMS

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -42,7 +42,6 @@ MODULE qs_rho0_ggrid
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -287,7 +286,7 @@ CONTAINS
 
       ! rho0 density in real space
       IF (ASSOCIATED(rho0_mpole%rho0_s_rs)) THEN
-         CALL pw_release(rho0_mpole%rho0_s_rs)
+         CALL rho0_mpole%rho0_s_rs%release()
       ELSE
          ALLOCATE (rho0_mpole%rho0_s_rs)
       END IF
@@ -296,7 +295,7 @@ CONTAINS
 
       ! rho0 density in reciprocal space
       IF (ASSOCIATED(rho0_mpole%rho0_s_gs)) THEN
-         CALL pw_release(rho0_mpole%rho0_s_gs)
+         CALL rho0_mpole%rho0_s_gs%release()
       ELSE
          ALLOCATE (rho0_mpole%rho0_s_gs)
       END IF

--- a/src/qs_rho0_ggrid.F
+++ b/src/qs_rho0_ggrid.F
@@ -34,9 +34,7 @@ MODULE qs_rho0_ggrid
                                               pw_scale,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -157,9 +155,9 @@ CONTAINS
       CPASSERT(ASSOCIATED(pw_pool))
 
       IF (igrid /= auxbas_grid) THEN
-         CALL pw_pool_create_pw(pw_pool, coeff_rspace, use_data=REALDATA3D, &
+         CALL pw_pool%create_pw(coeff_rspace, use_data=REALDATA3D, &
                                 in_space=REALSPACE)
-         CALL pw_pool_create_pw(pw_pool, coeff_gspace, &
+         CALL pw_pool%create_pw(coeff_gspace, &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END IF
@@ -237,11 +235,11 @@ CONTAINS
 
          tot_rs_int = pw_integrate_function(coeff_rspace, isign=-1)
 
-         CALL pw_pool_give_back_pw(pw_pool, coeff_rspace)
-         CALL pw_pool_give_back_pw(pw_pool, coeff_gspace)
+         CALL pw_pool%give_back_pw(coeff_rspace)
+         CALL pw_pool%give_back_pw(coeff_gspace)
       ELSE
 
-         CALL pw_pool_create_pw(pw_pool, rho0_r_tmp, &
+         CALL pw_pool%create_pw(rho0_r_tmp, &
                                 use_data=REALDATA3D, in_space=REALSPACE)
 
          CALL transfer_rs2pw(rs_grid, rho0_r_tmp)
@@ -249,7 +247,7 @@ CONTAINS
          tot_rs_int = pw_integrate_function(rho0_r_tmp, isign=-1)
 
          CALL pw_transfer(rho0_r_tmp, rho0_s_rs)
-         CALL pw_pool_give_back_pw(pw_pool, rho0_r_tmp)
+         CALL pw_pool%give_back_pw(rho0_r_tmp)
 
          CALL pw_zero(rho0_s_gs)
          CALL pw_transfer(rho0_s_rs, rho0_s_gs)
@@ -290,8 +288,8 @@ CONTAINS
       ELSE
          ALLOCATE (rho0_mpole%rho0_s_rs)
       END IF
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho0_mpole%rho0_s_rs, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho0_mpole%rho0_s_rs, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       ! rho0 density in reciprocal space
       IF (ASSOCIATED(rho0_mpole%rho0_s_gs)) THEN
@@ -299,8 +297,8 @@ CONTAINS
       ELSE
          ALLOCATE (rho0_mpole%rho0_s_gs)
       END IF
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho0_mpole%rho0_s_gs, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho0_mpole%rho0_s_gs, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       ! Find the grid level suitable for rho0_soft
       rho0_mpole%igrid_zet0_s = gaussian_gridlevel(pw_env%gridlevel_info, 2.0_dp*rho0_mpole%zet0_h)
@@ -438,27 +436,27 @@ CONTAINS
       rs_desc => rs_descs(igrid)%rs_desc
       pw_pool => pw_pools(igrid)%pool
 
-      CALL pw_pool_create_pw(pw_pool, coeff_gspace, &
+      CALL pw_pool%create_pw(coeff_gspace, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
 
-      CALL pw_pool_create_pw(pw_pool, coeff_rspace, use_data=REALDATA3D, &
+      CALL pw_pool%create_pw(coeff_rspace, use_data=REALDATA3D, &
                              in_space=REALSPACE)
 
       IF (igrid /= auxbas_grid) THEN
          pw_aux => pw_pools(auxbas_grid)%pool
-         CALL pw_pool_create_pw(pw_aux, coeff_gaux, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL pw_aux%create_pw(coeff_gaux, &
+                               use_data=COMPLEXDATA1D, &
+                               in_space=RECIPROCALSPACE)
          CALL pw_transfer(v_rspace, coeff_gaux)
          CALL pw_copy(coeff_gaux, coeff_gspace)
          CALL pw_transfer(coeff_gspace, coeff_rspace)
-         CALL pw_pool_give_back_pw(pw_aux, coeff_gaux)
-         CALL pw_pool_create_pw(pw_aux, coeff_raux, use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL pw_aux%give_back_pw(coeff_gaux)
+         CALL pw_aux%create_pw(coeff_raux, use_data=REALDATA3D, &
+                               in_space=REALSPACE)
          fscale = coeff_rspace%pw_grid%dvol/coeff_raux%pw_grid%dvol
          CALL pw_scale(coeff_rspace, fscale)
-         CALL pw_pool_give_back_pw(pw_aux, coeff_raux)
+         CALL pw_aux%give_back_pw(coeff_raux)
       ELSE
 
          IF (coeff_gspace%pw_grid%spherical) THEN
@@ -468,14 +466,14 @@ CONTAINS
             CALL pw_copy(v_rspace, coeff_rspace)
          END IF
       END IF
-      CALL pw_pool_give_back_pw(pw_pool, coeff_gspace)
+      CALL pw_pool%give_back_pw(coeff_gspace)
 
       ! Setup the rs grid at level igrid
       CALL rs_grid_create(rs_v, rs_desc)
       CALL rs_grid_zero(rs_v)
       CALL transfer_pw2rs(rs_v, coeff_rspace)
 
-      CALL pw_pool_give_back_pw(pw_pool, coeff_rspace)
+      CALL pw_pool%give_back_pw(coeff_rspace)
 
       ! Now the potential is on the right grid => integration
 

--- a/src/qs_rho0_types.F
+++ b/src/qs_rho0_types.F
@@ -13,8 +13,7 @@ MODULE qs_rho0_types
                                               pi,&
                                               rootpi
    USE memory_utilities,                ONLY: reallocate
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_grid_atom,                    ONLY: grid_atom_type
    USE qs_rho_atom_types,               ONLY: rho_atom_coeff
    USE whittaker,                       ONLY: whittaker_c0a,&
@@ -376,12 +375,12 @@ CONTAINS
          END IF
 
          IF (ASSOCIATED(rho0%rho0_s_rs)) THEN
-            CALL pw_release(rho0%rho0_s_rs)
+            CALL rho0%rho0_s_rs%release()
             DEALLOCATE (rho0%rho0_s_rs)
          END IF
 
          IF (ASSOCIATED(rho0%rho0_s_gs)) THEN
-            CALL pw_release(rho0%rho0_s_gs)
+            CALL rho0%rho0_s_gs%release()
             DEALLOCATE (rho0%rho0_s_gs)
 
          END IF

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -37,8 +37,7 @@ MODULE qs_rho_methods
                                               pw_copy,&
                                               pw_scale,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -244,8 +243,8 @@ CONTAINS
          ALLOCATE (rho_r(nspins))
          CALL qs_rho_set(rho, rho_r=rho_r)
          DO i = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r(i), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_r(i), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
          END DO
       END IF
 
@@ -260,8 +259,8 @@ CONTAINS
          ALLOCATE (rho_g(nspins))
          CALL qs_rho_set(rho, rho_g=rho_g)
          DO i = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g(i), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_g(i), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
       END IF
 
@@ -274,9 +273,9 @@ CONTAINS
             END IF
             ALLOCATE (rho_r_sccs)
             CALL qs_rho_set(rho, rho_r_sccs=rho_r_sccs)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_r_sccs, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(rho_r_sccs)
          END IF
       END IF
@@ -297,8 +296,8 @@ CONTAINS
             CALL qs_rho_set(rho, drho_r=drho_r)
             DO j = 1, nspins
                DO i = 1, 3
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r(i, j), &
-                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(drho_r(i, j), &
+                                                use_data=REALDATA3D, in_space=REALSPACE)
                END DO
             END DO
          END IF
@@ -316,8 +315,8 @@ CONTAINS
             CALL qs_rho_set(rho, drho_g=drho_g)
             DO j = 1, nspins
                DO i = 1, 3
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g(i, j), &
-                                         use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+                  CALL auxbas_pw_pool%create_pw(drho_g(i, j), &
+                                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                END DO
             END DO
          END IF
@@ -336,8 +335,8 @@ CONTAINS
             ALLOCATE (tau_r(nspins))
             CALL qs_rho_set(rho, tau_r=tau_r)
             DO i = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, tau_r(i), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(tau_r(i), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
             END DO
          END IF
 
@@ -352,8 +351,8 @@ CONTAINS
             ALLOCATE (tau_g(nspins))
             CALL qs_rho_set(rho, tau_g=tau_g)
             DO i = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, tau_g(i), &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(tau_g(i), &
+                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             END DO
          END IF
       END IF ! use_kinetic_energy_density
@@ -883,15 +882,15 @@ CONTAINS
          CALL qs_rho_set(rho_output, rho_r=rho_r_out)
          IF (mspin > nspins) THEN
             DO i = 1, mspin
-               CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_out(i), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(rho_r_out(i), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_copy(rho_r_in(1), rho_r_out(i))
                CALL pw_scale(rho_r_out(i), ospin)
             END DO
          ELSE
             DO i = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_out(i), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(rho_r_out(i), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_copy(rho_r_in(i), rho_r_out(i))
             END DO
          END IF
@@ -905,17 +904,17 @@ CONTAINS
          CALL qs_rho_set(rho_output, rho_g=rho_g_out)
          IF (mspin > nspins) THEN
             DO i = 1, mspin
-               CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_out(i), &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(rho_g_out(i), &
+                                             use_data=COMPLEXDATA1D, &
+                                             in_space=RECIPROCALSPACE)
                CALL pw_copy(rho_g_in(1), rho_g_out(i))
                CALL pw_scale(rho_g_out(i), ospin)
             END DO
          ELSE
             DO i = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_out(i), &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(rho_g_out(i), &
+                                             use_data=COMPLEXDATA1D, &
+                                             in_space=RECIPROCALSPACE)
                CALL pw_copy(rho_g_in(i), rho_g_out(i))
             END DO
          END IF
@@ -924,9 +923,9 @@ CONTAINS
       ! SCCS
       IF (ASSOCIATED(rho_r_sccs_in)) THEN
          CALL qs_rho_set(rho_output, rho_r_sccs=rho_r_sccs_out)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out, &
-                                in_space=REALSPACE, &
-                                use_data=REALDATA3D)
+         CALL auxbas_pw_pool%create_pw(rho_r_sccs_out, &
+                                       in_space=REALSPACE, &
+                                       use_data=REALDATA3D)
          CALL pw_copy(rho_r_sccs_in, rho_r_sccs_out)
       END IF
 
@@ -939,8 +938,8 @@ CONTAINS
          IF (mspin > nspins) THEN
             DO j = 1, mspin
                DO i = 1, 3
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j), &
-                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(drho_r_out(i, j), &
+                                                use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_copy(drho_r_in(i, 1), drho_r_out(i, j))
                   CALL pw_scale(drho_r_out(i, j), ospin)
                END DO
@@ -948,8 +947,8 @@ CONTAINS
          ELSE
             DO j = 1, nspins
                DO i = 1, 3
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j), &
-                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(drho_r_out(i, j), &
+                                                use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_copy(drho_r_in(i, j), drho_r_out(i, j))
                END DO
             END DO
@@ -965,9 +964,9 @@ CONTAINS
          IF (mspin > nspins) THEN
             DO j = 1, mspin
                DO i = 1, 3
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j), &
-                                         use_data=COMPLEXDATA1D, &
-                                         in_space=RECIPROCALSPACE)
+                  CALL auxbas_pw_pool%create_pw(drho_g_out(i, j), &
+                                                use_data=COMPLEXDATA1D, &
+                                                in_space=RECIPROCALSPACE)
                   CALL pw_copy(drho_g_in(i, 1), drho_g_out(i, j))
                   CALL pw_scale(drho_g_out(i, j), ospin)
                END DO
@@ -975,9 +974,9 @@ CONTAINS
          ELSE
             DO j = 1, nspins
                DO i = 1, 3
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j), &
-                                         use_data=COMPLEXDATA1D, &
-                                         in_space=RECIPROCALSPACE)
+                  CALL auxbas_pw_pool%create_pw(drho_g_out(i, j), &
+                                                use_data=COMPLEXDATA1D, &
+                                                in_space=RECIPROCALSPACE)
                   CALL pw_copy(drho_g_in(i, j), drho_g_out(i, j))
                END DO
             END DO
@@ -992,15 +991,15 @@ CONTAINS
          CALL qs_rho_set(rho_output, tau_r=tau_r_out)
          IF (mspin > nspins) THEN
             DO i = 1, mspin
-               CALL pw_pool_create_pw(auxbas_pw_pool, tau_r_out(i), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(tau_r_out(i), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_copy(tau_r_in(1), tau_r_out(i))
                CALL pw_scale(tau_r_out(i), ospin)
             END DO
          ELSE
             DO i = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, tau_r_out(i), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(tau_r_out(i), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_copy(tau_r_in(i), tau_r_out(i))
             END DO
          END IF
@@ -1014,17 +1013,17 @@ CONTAINS
          CALL qs_rho_set(rho_output, tau_g=tau_g_out)
          IF (mspin > nspins) THEN
             DO i = 1, mspin
-               CALL pw_pool_create_pw(auxbas_pw_pool, tau_g_out(i), &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(tau_g_out(i), &
+                                             use_data=COMPLEXDATA1D, &
+                                             in_space=RECIPROCALSPACE)
                CALL pw_copy(tau_g_in(1), tau_g_out(i))
                CALL pw_scale(tau_g_out(i), ospin)
             END DO
          ELSE
             DO i = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, tau_g_out(i), &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(tau_g_out(i), &
+                                             use_data=COMPLEXDATA1D, &
+                                             in_space=RECIPROCALSPACE)
                CALL pw_copy(tau_g_in(i), tau_g_out(i))
             END DO
          END IF
@@ -1347,8 +1346,8 @@ CONTAINS
          ALLOCATE (rho_r_out(nspins))
          CALL qs_rho_set(rho_output, rho_r=rho_r_out)
          DO i = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_out(i), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_r_out(i), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_copy(rho_r_in(i), rho_r_out(i))
          END DO
       END IF
@@ -1358,9 +1357,9 @@ CONTAINS
          ALLOCATE (rho_g_out(nspins))
          CALL qs_rho_set(rho_output, rho_g=rho_g_out)
          DO i = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_out(i), &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_g_out(i), &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
             CALL pw_copy(rho_g_in(i), rho_g_out(i))
          END DO
       END IF
@@ -1368,9 +1367,9 @@ CONTAINS
       ! SCCS
       IF (ASSOCIATED(rho_r_sccs_in)) THEN
          CALL qs_rho_set(rho_output, rho_r_sccs=rho_r_sccs_out)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_sccs_out, &
-                                in_space=REALSPACE, &
-                                use_data=REALDATA3D)
+         CALL auxbas_pw_pool%create_pw(rho_r_sccs_out, &
+                                       in_space=REALSPACE, &
+                                       use_data=REALDATA3D)
          CALL pw_copy(rho_r_sccs_in, rho_r_sccs_out)
       END IF
 
@@ -1382,8 +1381,8 @@ CONTAINS
             CALL qs_rho_set(rho_output, drho_r=drho_r_out)
             DO j = 1, nspins
                DO i = 1, 3
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_r_out(i, j), &
-                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(drho_r_out(i, j), &
+                                                use_data=REALDATA3D, in_space=REALSPACE)
                   CALL pw_copy(drho_r_in(i, j), drho_r_out(i, j))
                END DO
             END DO
@@ -1395,9 +1394,9 @@ CONTAINS
             CALL qs_rho_set(rho_output, drho_g=drho_g_out)
             DO j = 1, nspins
                DO i = 1, 3
-                  CALL pw_pool_create_pw(auxbas_pw_pool, drho_g_out(i, j), &
-                                         use_data=COMPLEXDATA1D, &
-                                         in_space=RECIPROCALSPACE)
+                  CALL auxbas_pw_pool%create_pw(drho_g_out(i, j), &
+                                                use_data=COMPLEXDATA1D, &
+                                                in_space=RECIPROCALSPACE)
                   CALL pw_copy(drho_g_in(i, j), drho_g_out(i, j))
                END DO
             END DO
@@ -1413,8 +1412,8 @@ CONTAINS
             ALLOCATE (tau_r_out(nspins))
             CALL qs_rho_set(rho_output, tau_r=tau_r_out)
             DO i = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, tau_r_out(i), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(tau_r_out(i), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_copy(tau_r_in(i), tau_r_out(i))
             END DO
          END IF
@@ -1424,9 +1423,9 @@ CONTAINS
             ALLOCATE (tau_g_out(nspins))
             CALL qs_rho_set(rho_output, tau_g=tau_g_out)
             DO i = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, tau_g_out(i), &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(tau_g_out(i), &
+                                             use_data=COMPLEXDATA1D, &
+                                             in_space=RECIPROCALSPACE)
                CALL pw_copy(tau_g_in(i), tau_g_out(i))
             END DO
          END IF

--- a/src/qs_rho_methods.F
+++ b/src/qs_rho_methods.F
@@ -43,7 +43,6 @@ MODULE qs_rho_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_drho_elec,&
                                               calculate_rho_elec
@@ -238,7 +237,7 @@ CONTAINS
       IF (my_rebuild_grids .OR. .NOT. ASSOCIATED(rho_r)) THEN
          IF (ASSOCIATED(rho_r)) THEN
             DO i = 1, SIZE(rho_r)
-               CALL pw_release(rho_r(i))
+               CALL rho_r(i)%release()
             END DO
             DEALLOCATE (rho_r)
          END IF
@@ -254,7 +253,7 @@ CONTAINS
       IF (my_rebuild_grids .OR. .NOT. ASSOCIATED(rho_g)) THEN
          IF (ASSOCIATED(rho_g)) THEN
             DO i = 1, SIZE(rho_g)
-               CALL pw_release(rho_g(i))
+               CALL rho_g(i)%release()
             END DO
             DEALLOCATE (rho_g)
          END IF
@@ -270,7 +269,7 @@ CONTAINS
       IF (dft_control%do_sccs) THEN
          IF (my_rebuild_grids .OR. (.NOT. ASSOCIATED(rho_r_sccs))) THEN
             IF (ASSOCIATED(rho_r_sccs)) THEN
-               CALL pw_release(rho_r_sccs)
+               CALL rho_r_sccs%release()
                DEALLOCATE (rho_r_sccs)
             END IF
             ALLOCATE (rho_r_sccs)
@@ -289,7 +288,7 @@ CONTAINS
             IF (ASSOCIATED(drho_r)) THEN
                DO j = 1, SIZE(drho_r, 2)
                   DO i = 1, SIZE(drho_r, 1)
-                     CALL pw_release(drho_r(i, j))
+                     CALL drho_r(i, j)%release()
                   END DO
                END DO
                DEALLOCATE (drho_r)
@@ -308,7 +307,7 @@ CONTAINS
             IF (ASSOCIATED(drho_g)) THEN
                DO j = 1, SIZE(drho_g, 2)
                   DO i = 1, SIZE(drho_r, 1)
-                     CALL pw_release(drho_g(i, j))
+                     CALL drho_g(i, j)%release()
                   END DO
                END DO
                DEALLOCATE (drho_g)
@@ -330,7 +329,7 @@ CONTAINS
          IF (my_rebuild_grids .OR. .NOT. ASSOCIATED(tau_r)) THEN
             IF (ASSOCIATED(tau_r)) THEN
                DO i = 1, SIZE(tau_r)
-                  CALL pw_release(tau_r(i))
+                  CALL tau_r(i)%release()
                END DO
                DEALLOCATE (tau_r)
             END IF
@@ -346,7 +345,7 @@ CONTAINS
          IF (my_rebuild_grids .OR. .NOT. ASSOCIATED(tau_g)) THEN
             IF (ASSOCIATED(tau_g)) THEN
                DO i = 1, SIZE(tau_g)
-                  CALL pw_release(tau_g(i))
+                  CALL tau_g(i)%release()
                END DO
                DEALLOCATE (tau_g)
             END IF

--- a/src/qs_rho_types.F
+++ b/src/qs_rho_types.F
@@ -26,8 +26,7 @@ MODULE qs_rho_types
                                               set_2d_pointer
    USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
                                               pw_pool_type
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -128,14 +127,14 @@ CONTAINS
 
       IF (ASSOCIATED(rho_struct%rho_r)) THEN
          DO i = 1, SIZE(rho_struct%rho_r)
-            CALL pw_release(rho_struct%rho_r(i))
+            CALL rho_struct%rho_r(i)%release()
          END DO
          DEALLOCATE (rho_struct%rho_r)
       END IF
       IF (ASSOCIATED(rho_struct%drho_r)) THEN
          DO j = 1, SIZE(rho_struct%drho_r, 2)
             DO i = 1, SIZE(rho_struct%drho_r, 1)
-               CALL pw_release(rho_struct%drho_r(i, j))
+               CALL rho_struct%drho_r(i, j)%release()
             END DO
          END DO
          DEALLOCATE (rho_struct%drho_r)
@@ -143,31 +142,31 @@ CONTAINS
       IF (ASSOCIATED(rho_struct%drho_g)) THEN
          DO i = 1, SIZE(rho_struct%drho_g, 2)
             DO j = 1, SIZE(rho_struct%drho_g, 1)
-               CALL pw_release(rho_struct%drho_g(i, j))
+               CALL rho_struct%drho_g(i, j)%release()
             END DO
          END DO
          DEALLOCATE (rho_struct%drho_g)
       END IF
       IF (ASSOCIATED(rho_struct%tau_r)) THEN
          DO i = 1, SIZE(rho_struct%tau_r)
-            CALL pw_release(rho_struct%tau_r(i))
+            CALL rho_struct%tau_r(i)%release()
          END DO
          DEALLOCATE (rho_struct%tau_r)
       END IF
       IF (ASSOCIATED(rho_struct%rho_g)) THEN
          DO i = 1, SIZE(rho_struct%rho_g)
-            CALL pw_release(rho_struct%rho_g(i))
+            CALL rho_struct%rho_g(i)%release()
          END DO
          DEALLOCATE (rho_struct%rho_g)
       END IF
       IF (ASSOCIATED(rho_struct%tau_g)) THEN
          DO i = 1, SIZE(rho_struct%tau_g)
-            CALL pw_release(rho_struct%tau_g(i))
+            CALL rho_struct%tau_g(i)%release()
          END DO
          DEALLOCATE (rho_struct%tau_g)
       END IF
       IF (ASSOCIATED(rho_struct%rho_r_sccs)) THEN
-         CALL pw_release(rho_struct%rho_r_sccs)
+         CALL rho_struct%rho_r_sccs%release()
          DEALLOCATE (rho_struct%rho_r_sccs)
       END IF
 

--- a/src/qs_rho_types.F
+++ b/src/qs_rho_types.F
@@ -24,8 +24,7 @@ MODULE qs_rho_types
                                               kpoint_transitional_type,&
                                               set_1d_pointer,&
                                               set_2d_pointer
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: pw_type
 #include "./base/base_uses.f90"
 
@@ -351,14 +350,14 @@ CONTAINS
 
       IF (ASSOCIATED(rho_struct%rho_r)) THEN
          DO i = 1, SIZE(rho_struct%rho_r)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_struct%rho_r(i))
+            CALL auxbas_pw_pool%give_back_pw(rho_struct%rho_r(i))
          END DO
          DEALLOCATE (rho_struct%rho_r)
          NULLIFY (rho_struct%rho_r)
       END IF
       IF (ASSOCIATED(rho_struct%rho_g)) THEN
          DO i = 1, SIZE(rho_struct%rho_g)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_struct%rho_g(i))
+            CALL auxbas_pw_pool%give_back_pw(rho_struct%rho_g(i))
          END DO
          DEALLOCATE (rho_struct%rho_g)
          NULLIFY (rho_struct%rho_g)

--- a/src/qs_sccs.F
+++ b/src/qs_sccs.F
@@ -73,9 +73,7 @@ MODULE qs_sccs
    USE pw_poisson_types,                ONLY: pw_poisson_analytic,&
                                               pw_poisson_mt,&
                                               pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -271,10 +269,9 @@ CONTAINS
       ! Retrieve the total electronic density in r-space
       BLOCK
          TYPE(pw_type) :: rho_elec
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                rho_elec, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_elec, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
 
          ! Retrieve grid parameters
          ngpts = rho_elec%pw_grid%ngpts
@@ -291,14 +288,12 @@ CONTAINS
          tot_rho_elec = pw_integrate_function(rho_elec)
 
          ! Calculate the dielectric (smoothed) function of rho_elec in r-space
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                eps_elec, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                deps_elec, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(eps_elec, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(deps_elec, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          ! Relative permittivity or dielectric constant of the solvent (medium)
          epsilon_solvent = sccs_control%epsilon_solvent
          SELECT CASE (sccs_control%method_id)
@@ -350,10 +345,9 @@ CONTAINS
             BLOCK
                TYPE(pw_type) :: theta, norm_drho_elec
                TYPE(pw_type), DIMENSION(3)                        :: drho_elec
-               CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                      theta, &
-                                      use_data=REALDATA3D, &
-                                      in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(theta, &
+                                             use_data=REALDATA3D, &
+                                             in_space=REALSPACE)
                CALL pw_zero(theta)
 
                ! Calculate the (quantum) volume of the solute cavity
@@ -374,17 +368,15 @@ CONTAINS
                ! Calculate the derivative of the electronic density in r-space
                ! TODO: Could be retrieved from the QS environment
                DO i = 1, 3
-                  CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                         drho_elec(i), &
-                                         use_data=REALDATA3D, &
-                                         in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(drho_elec(i), &
+                                                use_data=REALDATA3D, &
+                                                in_space=REALSPACE)
                END DO
                CALL derive(rho_elec, drho_elec, sccs_derivative_fft, pw_env, input)
 
-               CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                      norm_drho_elec, &
-                                      use_data=REALDATA3D, &
-                                      in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(norm_drho_elec, &
+                                             use_data=REALDATA3D, &
+                                             in_space=REALSPACE)
 
                ! Calculate the norm of the gradient of the electronic density in r-space
 !$OMP    PARALLEL DO DEFAULT(NONE) &
@@ -449,25 +441,24 @@ CONTAINS
                cavity_surface = pw_integrate_function(theta)
 
                ! Release storage
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, theta)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, norm_drho_elec)
+               CALL auxbas_pw_pool%give_back_pw(theta)
+               CALL auxbas_pw_pool%give_back_pw(norm_drho_elec)
                DO i = 1, 3
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, drho_elec(i))
+                  CALL auxbas_pw_pool%give_back_pw(drho_elec(i))
                END DO
             END BLOCK
 
          END IF ! epsilon_solvent > 1
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec)
+         CALL auxbas_pw_pool%give_back_pw(rho_elec)
       END BLOCK
 
       BLOCK
          TYPE(pw_type) :: rho_tot, phi_tot, rho_solute, rho_tot_zero
          ! Retrieve the total charge density (core + elec) of the solute in r-space
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                rho_solute, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_solute, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(rho_solute)
          CALL pw_transfer(rho_tot_gspace, rho_solute)
          tot_rho_solute = pw_integrate_function(rho_solute)
@@ -485,10 +476,9 @@ CONTAINS
          END IF
 
          ! Reassign work storage to rho_tot_zero, because rho_elec is no longer needed
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                rho_tot_zero, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_tot_zero, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
 
          ! Build the initial (rho_iter = 0) total charge density (solute plus polarisation) in r-space
          ! eps_elec <- ln(eps_elec)
@@ -514,14 +504,13 @@ CONTAINS
 
          ! Build the derivative of LOG(eps_elec)
          DO i = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   dln_eps_elec(i), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(dln_eps_elec(i), &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(dln_eps_elec(i))
          END DO
          CALL derive(eps_elec, dln_eps_elec, sccs_control%derivative_method, pw_env, input)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, eps_elec)
+         CALL auxbas_pw_pool%give_back_pw(eps_elec)
 
          ! Print header for the SCCS cycle
          IF (should_output .AND. (output_unit > 0)) THEN
@@ -550,24 +539,21 @@ CONTAINS
 
          ! Get storage for the derivative of the total potential (field) in r-space
          DO i = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   dphi_tot(i), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(dphi_tot(i), &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
          END DO
 
          ! Initialise the total charge density in r-space rho_tot with rho_tot_zero + rho_iter_zero
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                rho_tot, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_tot, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_copy(rho_tot_zero, rho_tot)
          CALL pw_axpy(rho_pw_r_sccs, rho_tot)
 
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                phi_tot, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(phi_tot, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(phi_tot)
 
          ! Main SCCS iteration loop
@@ -657,9 +643,9 @@ CONTAINS
          END DO iter_loop
 
          ! Release work storage which is no longer needed
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_zero)
+         CALL auxbas_pw_pool%give_back_pw(rho_tot_zero)
          DO i = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dln_eps_elec(i))
+            CALL auxbas_pw_pool%give_back_pw(dln_eps_elec(i))
          END DO
 
          ! Optional output of the total charge density in cube file format
@@ -713,9 +699,9 @@ CONTAINS
          ! Calculate the Hartree energy and potential of the solute only
          BLOCK
             TYPE(pw_type) :: phi_solute
-            CALL pw_pool_create_pw(auxbas_pw_pool, phi_solute, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(phi_solute, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(phi_solute)
             CALL pw_poisson_solve(poisson_env=poisson_env, &
                                   density=rho_solute, &
@@ -725,7 +711,7 @@ CONTAINS
             ! Calculate the polarisation potential (store it in phi_tot)
             ! phi_pol = phi_tot - phi_solute
             CALL pw_axpy(phi_solute, phi_tot, alpha=-1.0_dp)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, phi_solute)
+            CALL auxbas_pw_pool%give_back_pw(phi_solute)
          END BLOCK
 
          ! Optional output of the SCCS polarisation potential in cube file format
@@ -791,9 +777,9 @@ CONTAINS
 
          ! Calculate SCCS polarisation energy
          energy%sccs_pol = 0.5_dp*pw_integral_ab(rho_solute, phi_tot)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_solute)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, phi_tot)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot)
+         CALL auxbas_pw_pool%give_back_pw(rho_solute)
+         CALL auxbas_pw_pool%give_back_pw(phi_tot)
+         CALL auxbas_pw_pool%give_back_pw(rho_tot)
       END BLOCK
 
       ! Calculate additional solvation terms
@@ -832,9 +818,9 @@ CONTAINS
       END DO
 !$OMP END PARALLEL DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, deps_elec)
+      CALL auxbas_pw_pool%give_back_pw(deps_elec)
       DO i = 1, 3
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, dphi_tot(i))
+         CALL auxbas_pw_pool%give_back_pw(dphi_tot(i))
       END DO
 
       ! Release the SCCS printout environment
@@ -1046,10 +1032,9 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          ! Get work storage for the 1d grids in g-space (derivative calculation)
          DO i = 1, SIZE(work_g1d)
-            CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                   work_g1d(i), &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(work_g1d(i), &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
          END DO
       END SELECT
 
@@ -1083,7 +1068,7 @@ CONTAINS
          CALL rs_grid_release_descriptor(rs_desc)
       CASE (sccs_derivative_fft)
          DO i = 1, SIZE(work_g1d)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_g1d(i))
+            CALL auxbas_pw_pool%give_back_pw(work_g1d(i))
          END DO
       END SELECT
 

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -101,8 +101,7 @@ MODULE qs_scf
                                               restart_preconditioner
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE qs_block_davidson_types,         ONLY: block_davidson_deallocate
    USE qs_cdft_scf_utils,               ONLY: build_diagonal_jacobian,&
                                               create_tmp_logger,&
@@ -1163,25 +1162,25 @@ CONTAINS
          CALL get_qs_env(qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          DO iatom = 1, SIZE(cdft_control%group)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%group(iatom)%weight)
+            CALL auxbas_pw_pool%give_back_pw(cdft_control%group(iatom)%weight)
             DEALLOCATE (cdft_control%group(iatom)%weight)
          END DO
          IF (cdft_control%atomic_charges) THEN
             DO iatom = 1, cdft_control%natoms
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%charge(iatom))
+               CALL auxbas_pw_pool%give_back_pw(cdft_control%charge(iatom))
             END DO
             DEALLOCATE (cdft_control%charge)
          END IF
          IF (cdft_control%type == outer_scf_becke_constraint .AND. &
              cdft_control%becke_control%cavity_confine) THEN
             IF (.NOT. ASSOCIATED(cdft_control%becke_control%cavity_mat)) THEN
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%becke_control%cavity)
+               CALL auxbas_pw_pool%give_back_pw(cdft_control%becke_control%cavity)
             ELSE
                DEALLOCATE (cdft_control%becke_control%cavity_mat)
             END IF
          ELSE IF (cdft_control%type == outer_scf_hirshfeld_constraint) THEN
             IF (ASSOCIATED(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)) THEN
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, cdft_control%hirshfeld_control%hirshfeld_env%fnorm)
+               CALL auxbas_pw_pool%give_back_pw(cdft_control%hirshfeld_control%hirshfeld_env%fnorm)
             END IF
          END IF
          IF (ASSOCIATED(cdft_control%charges_fragment)) DEALLOCATE (cdft_control%charges_fragment)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -117,9 +117,7 @@ MODULE qs_scf_post_gpw
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_implicit,&
                                               pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -453,12 +451,12 @@ CONTAINS
       IF (((do_mo_cubes .OR. do_wannier_cubes) .AND. (nlumo /= 0 .OR. nhomo /= 0)) .OR. p_loc) THEN
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(wf_r, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(wf_g, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
       END IF
 
       ! Makes the MOs eigenstates, computes eigenvalues, write cubes
@@ -726,8 +724,8 @@ CONTAINS
 
       ! Deallocate grids needed to compute wavefunctions
       IF (((do_mo_cubes .OR. do_wannier_cubes) .AND. (nlumo /= 0 .OR. nhomo /= 0)) .OR. p_loc) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+         CALL auxbas_pw_pool%give_back_pw(wf_r)
+         CALL auxbas_pw_pool%give_back_pw(wf_g)
       END IF
 
       ! Destroy the localization environment
@@ -1480,9 +1478,9 @@ CONTAINS
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                             pw_pools=pw_pools)
             DO ispin = 1, dft_control%nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, elf_r(ispin), &
-                                      use_data=REALDATA3D, &
-                                      in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(elf_r(ispin), &
+                                             use_data=REALDATA3D, &
+                                             in_space=REALSPACE)
                CALL pw_zero(elf_r(ispin))
             END DO
 
@@ -1522,7 +1520,7 @@ CONTAINS
                                   stride=section_get_ivals(elf_section, "STRIDE"), mpi_io=mpi_io)
                CALL cp_print_key_finished_output(unit_nr, logger, input, "DFT%PRINT%ELF_CUBE", mpi_io=mpi_io)
 
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, elf_r(ispin))
+               CALL auxbas_pw_pool%give_back_pw(elf_r(ispin))
             END DO
 
             ! deallocate
@@ -1824,15 +1822,15 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(wf_r, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_copy(rho_r(1), wf_r)
          CALL pw_axpy(rho_r(2), wf_r, alpha=-1._dp)
          total_abs_spin_dens = pw_integrate_function(wf_r, oprt="ABS")
          IF (output_unit > 0) WRITE (UNIT=output_unit, FMT='(/,(T3,A,T61,F20.10))') &
             "Integrated absolute spin density  : ", total_abs_spin_dens
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+         CALL auxbas_pw_pool%give_back_pw(wf_r)
          !
          ! XXX Fix Me XXX
          ! should be extended to the case where added MOs are present
@@ -1967,9 +1965,9 @@ CONTAINS
                          rho0_s_gs=rho0_s_gs)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          pw_pools=pw_pools)
-         CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(wf_r, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          IF (dft_control%qs_control%gapw) THEN
             CALL pw_transfer(rho0_s_gs, wf_r)
             IF (dft_control%qs_control%gapw_control%nopaw_as_gpw) THEN
@@ -1991,7 +1989,7 @@ CONTAINS
                             stride=section_get_ivals(dft_section, "PRINT%TOT_DENSITY_CUBE%STRIDE"), mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%TOT_DENSITY_CUBE", mpi_io=mpi_io)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+         CALL auxbas_pw_pool%give_back_pw(wf_r)
       END IF
 
       ! Write cube file with electron density
@@ -2131,15 +2129,13 @@ CONTAINS
             CALL pw_env_get(pw_env=pw_env, &
                             auxbas_pw_pool=auxbas_pw_pool, &
                             pw_pools=pw_pools)
-            CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                   pw=rho_elec_rspace, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(pw=rho_elec_rspace, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_zero(rho_elec_rspace)
-            CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                   pw=rho_elec_gspace, &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(pw=rho_elec_gspace, &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
             CALL pw_zero(rho_elec_gspace)
             CALL get_pw_grid_info(pw_grid=rho_elec_gspace%pw_grid, &
                                   dr=dr, &
@@ -2225,8 +2221,8 @@ CONTAINS
                CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                                  "DFT%PRINT%E_DENSITY_CUBE", mpi_io=mpi_io)
             END IF
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_gspace)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace)
+            CALL auxbas_pw_pool%give_back_pw(rho_elec_gspace)
+            CALL auxbas_pw_pool%give_back_pw(rho_elec_rspace)
          ELSE
             IF (dft_control%nspins > 1) THEN
                CALL get_qs_env(qs_env=qs_env, &
@@ -2234,10 +2230,9 @@ CONTAINS
                CALL pw_env_get(pw_env=pw_env, &
                                auxbas_pw_pool=auxbas_pw_pool, &
                                pw_pools=pw_pools)
-               CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                      pw=rho_elec_rspace, &
-                                      use_data=REALDATA3D, &
-                                      in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(pw=rho_elec_rspace, &
+                                             use_data=REALDATA3D, &
+                                             in_space=REALSPACE)
                CALL pw_copy(rho_r(1), rho_elec_rspace)
                CALL pw_axpy(rho_r(2), rho_elec_rspace)
                filename = "ELECTRON_DENSITY"
@@ -2284,7 +2279,7 @@ CONTAINS
                                   stride=section_get_ivals(dft_section, "PRINT%E_DENSITY_CUBE%STRIDE"), mpi_io=mpi_io)
                CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                                  "DFT%PRINT%E_DENSITY_CUBE", mpi_io=mpi_io)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace)
+               CALL auxbas_pw_pool%give_back_pw(rho_elec_rspace)
             ELSE
                filename = "ELECTRON_DENSITY"
                mpi_io = .TRUE.
@@ -2324,9 +2319,9 @@ CONTAINS
                          pw_env=pw_env, &
                          v_hartree_rspace=v_hartree_rspace)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(aux_r, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
 
          append_cube = section_get_lval(input, "DFT%PRINT%V_HARTREE_CUBE%APPEND")
          my_pos_cube = "REWIND"
@@ -2349,7 +2344,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%V_HARTREE_CUBE", mpi_io=mpi_io)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
+         CALL auxbas_pw_pool%give_back_pw(aux_r)
       END IF
 
       ! Print the external potential
@@ -2358,9 +2353,9 @@ CONTAINS
          IF (dft_control%apply_external_potential) THEN
             CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, vee=vee)
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-            CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(aux_r, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
 
             append_cube = section_get_lval(input, "DFT%PRINT%EXTERNAL_POTENTIAL_CUBE%APPEND")
             my_pos_cube = "REWIND"
@@ -2380,7 +2375,7 @@ CONTAINS
             CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                               "DFT%PRINT%EXTERNAL_POTENTIAL_CUBE", mpi_io=mpi_io)
 
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
+            CALL auxbas_pw_pool%give_back_pw(aux_r)
          END IF
       END IF
 
@@ -2390,12 +2385,12 @@ CONTAINS
 
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_g, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(aux_r, &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(aux_g, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
 
          append_cube = section_get_lval(input, "DFT%PRINT%EFIELD_CUBE%APPEND")
          my_pos_cube = "REWIND"
@@ -2427,8 +2422,8 @@ CONTAINS
                                               "DFT%PRINT%EFIELD_CUBE", mpi_io=mpi_io)
          END DO
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_g)
+         CALL auxbas_pw_pool%give_back_pw(aux_r)
+         CALL auxbas_pw_pool%give_back_pw(aux_g)
       END IF
 
       ! Write cube files from the local energy
@@ -2595,10 +2590,9 @@ CONTAINS
                                pw_pools=pw_pools)
                NULLIFY (mb_rho)
                ALLOCATE (mb_rho)
-               CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                      pw=mb_rho, &
-                                      use_data=REALDATA3D, &
-                                      in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(pw=mb_rho, &
+                                             use_data=REALDATA3D, &
+                                             in_space=REALSPACE)
                CALL pw_copy(rho_r(1), mb_rho)
                CALL pw_axpy(rho_r(2), mb_rho)
                !CALL voronoi_analysis(qs_env, rho_elec_rspace, print_key, unit_nr)
@@ -2628,7 +2622,7 @@ CONTAINS
                                       unit_nr_voro, qs_env, mb_rho)
 
             IF (dft_control%nspins > 1) THEN
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, mb_rho)
+               CALL auxbas_pw_pool%give_back_pw(mb_rho)
                DEALLOCATE (mb_rho)
             END IF
 
@@ -2915,7 +2909,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, subsys=subsys)
          CALL qs_subsys_get(subsys, particles=particles)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         CALL pw_pool_create_pw(auxbas_pw_pool, eden, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(eden, use_data=REALDATA3D, in_space=REALSPACE)
          !
          CALL qs_local_energy(qs_env, eden)
          !
@@ -2946,7 +2940,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%LOCAL_ENERGY_CUBE", mpi_io=mpi_io)
          !
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, eden)
+         CALL auxbas_pw_pool%give_back_pw(eden)
       END IF
       CALL timestop(handle)
 
@@ -2991,7 +2985,7 @@ CONTAINS
          CALL get_qs_env(qs_env=qs_env, pw_env=pw_env, subsys=subsys)
          CALL qs_subsys_get(subsys, particles=particles)
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
-         CALL pw_pool_create_pw(auxbas_pw_pool, stress, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(stress, use_data=REALDATA3D, in_space=REALSPACE)
          !
          ! use beta=0: kinetic energy density in symmetric form
          beta = 0.0_dp
@@ -3025,7 +3019,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%LOCAL_STRESS_CUBE", mpi_io=mpi_io)
          !
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, stress)
+         CALL auxbas_pw_pool%give_back_pw(stress)
       END IF
 
       CALL timestop(handle)
@@ -3089,7 +3083,7 @@ CONTAINS
                                         extension=".cube", middle_name="DIELECTRIC_CONSTANT", file_position=my_pos_cube, &
                                         mpi_io=mpi_io)
          CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(aux_r, use_data=REALDATA3D, in_space=REALSPACE)
 
          boundary_condition = pw_env%poisson_env%parameters%ps_implicit_params%boundary_condition
          SELECT CASE (boundary_condition)
@@ -3109,7 +3103,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE", mpi_io=mpi_io)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
+         CALL auxbas_pw_pool%give_back_pw(aux_r)
       END IF
 
       ! Write Dirichlet constraint charges into a cube file
@@ -3137,7 +3131,7 @@ CONTAINS
                                         extension=".cube", middle_name="dirichlet_cstr_charge", file_position=my_pos_cube, &
                                         mpi_io=mpi_io)
          CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(aux_r, use_data=REALDATA3D, in_space=REALSPACE)
 
          boundary_condition = pw_env%poisson_env%parameters%ps_implicit_params%boundary_condition
          SELECT CASE (boundary_condition)
@@ -3157,7 +3151,7 @@ CONTAINS
          CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                            "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE", mpi_io=mpi_io)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
+         CALL auxbas_pw_pool%give_back_pw(aux_r)
       END IF
 
       ! Write Dirichlet type constranits into cube files
@@ -3180,7 +3174,7 @@ CONTAINS
          tile_cubes = section_get_lval(input, "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%TILE_CUBES")
 
          CALL pw_env_get(pw_env, poisson_env=poisson_env, auxbas_pw_pool=auxbas_pw_pool)
-         CALL pw_pool_create_pw(auxbas_pw_pool, aux_r, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(aux_r, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(aux_r)
 
          IF (tile_cubes) THEN
@@ -3209,7 +3203,7 @@ CONTAINS
             ! a single cube file
             NULLIFY (dirichlet_tile)
             ALLOCATE (dirichlet_tile)
-            CALL pw_pool_create_pw(auxbas_pw_pool, dirichlet_tile, use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(dirichlet_tile, use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(dirichlet_tile)
             mpi_io = .TRUE.
             unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE", &
@@ -3230,11 +3224,11 @@ CONTAINS
                                mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, input, &
                                               "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE", mpi_io=mpi_io)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dirichlet_tile)
+            CALL auxbas_pw_pool%give_back_pw(dirichlet_tile)
             DEALLOCATE (dirichlet_tile)
          END IF
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, aux_r)
+         CALL auxbas_pw_pool%give_back_pw(aux_r)
       END IF
 
       CALL timestop(handle)
@@ -3388,14 +3382,12 @@ CONTAINS
 
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                          poisson_env=poisson_env)
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                v_hartree_gspace, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, &
-                                rho_tot_gspace, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
 
          CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
          CALL pw_poisson_solve(poisson_env, rho_tot_gspace, energy%hartree, &
@@ -3404,8 +3396,8 @@ CONTAINS
          CALL pw_transfer(v_hartree_gspace, v_hartree_rspace)
          CALL pw_scale(v_hartree_rspace, v_hartree_rspace%pw_grid%dvol)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+         CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+         CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
       END IF
 
    END SUBROUTINE update_hartree_with_mp2

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -90,9 +90,7 @@ MODULE qs_scf_post_tb
                                               pw_green_release,&
                                               pw_poisson_analytic,&
                                               pw_poisson_parameter_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -1060,10 +1058,9 @@ CONTAINS
          CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
          BLOCK
             TYPE(pw_type) :: rho_elec_rspace
-            CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                                   pw=rho_elec_rspace, &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(pw=rho_elec_rspace, &
+                                          use_data=REALDATA3D, &
+                                          in_space=REALSPACE)
             CALL pw_copy(rho_r(1), rho_elec_rspace)
             CALL pw_axpy(rho_r(2), rho_elec_rspace)
             filename = "ELECTRON_DENSITY"
@@ -1106,7 +1103,7 @@ CONTAINS
                                particles=particles, &
                                stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
             CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_elec_rspace)
+            CALL auxbas_pw_pool%give_back_pw(rho_elec_rspace)
          END BLOCK
       ELSE
          IF (iounit > 0) THEN
@@ -1218,10 +1215,9 @@ CONTAINS
 
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=rho_core, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=rho_core, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
       CALL calculate_rho_core(rho_core, total_rho_core_rspace, qs_env)
 
       IF (iounit > 0) THEN
@@ -1231,8 +1227,8 @@ CONTAINS
             "Integrated core density:", total_rho_core_rspace
       END IF
 
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=rho_tot_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=rho_tot_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
       CALL pw_transfer(rho_core, rho_tot_rspace)
       DO ispin = 1, dft_control%nspins
          CALL pw_axpy(rho_r(ispin), rho_tot_rspace)
@@ -1261,8 +1257,8 @@ CONTAINS
       IF (my_v_hartree .OR. my_efield) THEN
          BLOCK
             TYPE(pw_type) :: rho_tot_gspace
-            CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=rho_tot_gspace, &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(pw=rho_tot_gspace, &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             CALL pw_transfer(rho_tot_rspace, rho_tot_gspace)
             poisson_params%solver = pw_poisson_analytic
             poisson_params%periodic = cell%perd
@@ -1276,8 +1272,8 @@ CONTAINS
                CALL pw_green_release(green_fft, auxbas_pw_pool)
             END BLOCK
             IF (my_v_hartree) THEN
-               CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=vhartree, &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(pw=vhartree, &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                CALL pw_transfer(rho_tot_gspace, vhartree)
                filename = "V_HARTREE"
                mpi_io = .TRUE.
@@ -1297,11 +1293,11 @@ CONTAINS
                                   particles=particles, &
                                   stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
                CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, vhartree)
+               CALL auxbas_pw_pool%give_back_pw(vhartree)
             END IF
             IF (my_efield) THEN
-               CALL pw_pool_create_pw(pool=auxbas_pw_pool, pw=vhartree, &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(pw=vhartree, &
+                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                udvol = 1.0_dp/rho_tot_rspace%pw_grid%dvol
                DO id = 1, 3
                   CALL pw_transfer(rho_tot_gspace, vhartree)
@@ -1330,14 +1326,14 @@ CONTAINS
                                      stride=section_get_ivals(cube_section, "STRIDE"), mpi_io=mpi_io)
                   CALL cp_print_key_finished_output(unit_nr, logger, cube_section, '', mpi_io=mpi_io)
                END DO
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, vhartree)
+               CALL auxbas_pw_pool%give_back_pw(vhartree)
             END IF
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+            CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
          END BLOCK
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_core)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_rspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_core)
 
    END SUBROUTINE print_density_cubes
 
@@ -1396,9 +1392,9 @@ CONTAINS
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
       DO ispin = 1, dft_control%nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, elf_r(ispin), &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(elf_r(ispin), &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
          CALL pw_zero(elf_r(ispin))
       END DO
 
@@ -1434,7 +1430,7 @@ CONTAINS
                             stride=section_get_ivals(elf_section, "STRIDE"), mpi_io=mpi_io)
          CALL cp_print_key_finished_output(unit_nr, logger, elf_section, '', mpi_io=mpi_io)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, elf_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(elf_r(ispin))
       END DO
 
       DEALLOCATE (elf_r)
@@ -1518,12 +1514,12 @@ CONTAINS
 
       CALL get_qs_env(qs_env=qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       CALL get_qs_env(qs_env, subsys=subsys)
       CALL qs_subsys_get(subsys, particles=particles)
@@ -1595,8 +1591,8 @@ CONTAINS
          END DO
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
       IF (ASSOCIATED(list_index)) DEALLOCATE (list_index)
 
    END SUBROUTINE print_mo_cubes

--- a/src/qs_tddfpt2_fhxc.F
+++ b/src/qs_tddfpt2_fhxc.F
@@ -30,9 +30,7 @@ MODULE qs_tddfpt2_fhxc
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_scale,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -295,8 +293,8 @@ CONTAINS
                   CALL pw_env_get(sub_env%pw_env, auxbas_pw_pool=auxbas_pw_pool)
                   ALLOCATE (V_rspace_sub(nspins))
                   DO ispin = 1, nspins
-                     CALL pw_pool_create_pw(auxbas_pw_pool, V_rspace_sub(ispin), &
-                                            use_data=REALDATA3D, in_space=REALSPACE)
+                     CALL auxbas_pw_pool%create_pw(V_rspace_sub(ispin), &
+                                                   use_data=REALDATA3D, in_space=REALSPACE)
                      CALL pw_zero(V_rspace_sub(ispin))
                   END DO
 
@@ -357,7 +355,7 @@ CONTAINS
                   CALL dbcsr_release(dbwork)
                   DEALLOCATE (dbwork)
                   DO ispin = 1, nspins
-                     CALL pw_pool_give_back_pw(auxbas_pw_pool, V_rspace_sub(ispin))
+                     CALL auxbas_pw_pool%give_back_pw(V_rspace_sub(ispin))
                   END DO
                   DEALLOCATE (V_rspace_sub)
                   CALL cp_fm_release(work_aux_orb)

--- a/src/qs_tddfpt2_fhxc_forces.F
+++ b/src/qs_tddfpt2_fhxc_forces.F
@@ -86,9 +86,7 @@ MODULE qs_tddfpt2_fhxc_forces
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -395,13 +393,13 @@ CONTAINS
 
       ALLOCATE (rhox_r(nspins), rhox_g(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhox_r(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhox_g(ispin), &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rhox_r(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rhox_g(ispin), &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhox_tot_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhox_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       CALL pw_zero(rhox_tot_gspace)
       DO ispin = 1, nspins
@@ -416,10 +414,10 @@ CONTAINS
       IF (gapw_xc) THEN
          ALLOCATE (rhoxx_r(nspins), rhoxx_g(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rhoxx_r(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rhoxx_g(ispin), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rhoxx_r(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rhoxx_g(ispin), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
          DO ispin = 1, nspins
             IF (nspins == 2) CALL dbcsr_scale(matrix_px1(ispin)%matrix, 2.0_dp)
@@ -433,10 +431,10 @@ CONTAINS
       CALL get_qs_env(qs_env, matrix_s=matrix_s, force=force)
 
       IF (.NOT. is_rks_triplets) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, xv_hartree_rspace, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, xv_hartree_gspace, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(xv_hartree_rspace, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(xv_hartree_gspace, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          ! calculate associated hartree potential
          IF (gapw) THEN
             CALL pw_axpy(local_rho_set%rho0_mpole%rho0_s_gs, rhox_tot_gspace)
@@ -661,10 +659,10 @@ CONTAINS
             ! rhox_aux
             ALLOCATE (rhox_r_aux(nspins), rhox_g_aux(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, rhox_r_aux(ispin), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_pool_create_pw(auxbas_pw_pool, rhox_g_aux(ispin), &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(rhox_r_aux(ispin), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(rhox_g_aux(ispin), &
+                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             END DO
             DO ispin = 1, nspins
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=matrix_px1_admm(ispin)%matrix, &
@@ -693,8 +691,8 @@ CONTAINS
             DEALLOCATE (rhox_aux)
 
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_r_aux(ispin))
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_g_aux(ispin))
+               CALL auxbas_pw_pool%give_back_pw(rhox_r_aux(ispin))
+               CALL auxbas_pw_pool%give_back_pw(rhox_g_aux(ispin))
             END DO
             DEALLOCATE (rhox_r_aux, rhox_g_aux)
             fscal = 1.0_dp
@@ -841,21 +839,21 @@ CONTAINS
       END IF
 
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_r(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_g(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rhox_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rhox_g(ispin))
       END DO
       DEALLOCATE (rhox_r, rhox_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhox_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rhox_tot_gspace)
       IF (gapw_xc) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoxx_r(ispin))
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoxx_g(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rhoxx_r(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rhoxx_g(ispin))
          END DO
          DEALLOCATE (rhoxx_r, rhoxx_g)
       END IF
       IF (.NOT. is_rks_triplets) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, xv_hartree_rspace)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, xv_hartree_gspace)
+         CALL auxbas_pw_pool%give_back_pw(xv_hartree_rspace)
+         CALL auxbas_pw_pool%give_back_pw(xv_hartree_gspace)
       END IF
 
       ! HFX

--- a/src/qs_tddfpt2_forces.F
+++ b/src/qs_tddfpt2_forces.F
@@ -69,9 +69,7 @@ MODULE qs_tddfpt2_forces
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -708,27 +706,27 @@ CONTAINS
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(v_hartree_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       ALLOCATE (trho_r(nspins), trho_g(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, trho_r(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, trho_g(ispin), &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(trho_r(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(trho_g(ispin), &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
       IF (gapw_xc) THEN
          ALLOCATE (trho_xc_r(nspins), trho_xc_g(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, trho_xc_r(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, trho_xc_g(ispin), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(trho_xc_r(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(trho_xc_g(ispin), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
       END IF
 
@@ -883,25 +881,25 @@ CONTAINS
                              rho_atom_external=local_rho_set%rho_atom_set)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, trho_r(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, trho_g(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+         CALL auxbas_pw_pool%give_back_pw(trho_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(trho_g(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
       END DO
       DEALLOCATE (trho_r, trho_g, v_xc)
       IF (gapw_xc) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, trho_xc_r(ispin))
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, trho_xc_g(ispin))
+            CALL auxbas_pw_pool%give_back_pw(trho_xc_r(ispin))
+            CALL auxbas_pw_pool%give_back_pw(trho_xc_g(ispin))
          END DO
          DEALLOCATE (trho_xc_r, trho_xc_g)
       END IF
       IF (ASSOCIATED(v_xc_tau)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
          END DO
          DEALLOCATE (v_xc_tau)
       END IF
@@ -951,10 +949,10 @@ CONTAINS
             ! rhoz_aux
             ALLOCATE (rhoz_r_aux(nspins), rhoz_g_aux(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r_aux(ispin), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g_aux(ispin), &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(rhoz_r_aux(ispin), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(rhoz_g_aux(ispin), &
+                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             END DO
             DO ispin = 1, nspins
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpe(ispin, 1)%matrix, &
@@ -986,9 +984,9 @@ CONTAINS
                                        task_list_external=task_list)
             END DO
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r_aux(ispin))
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g_aux(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
+               CALL auxbas_pw_pool%give_back_pw(rhoz_r_aux(ispin))
+               CALL auxbas_pw_pool%give_back_pw(rhoz_g_aux(ispin))
             END DO
             DEALLOCATE (v_xc, rhoz_r_aux, rhoz_g_aux)
             !

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -77,9 +77,7 @@ MODULE qs_tddfpt2_properties
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -1276,12 +1274,12 @@ CONTAINS
 
       CALL get_qs_env(qs_env=qs_env, dft_control=dft_control, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, pw_pools=pw_pools)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       CALL get_qs_env(qs_env, subsys=subsys)
       CALL qs_subsys_get(subsys, particles=particles)
@@ -1322,8 +1320,8 @@ CONTAINS
          END DO
       END DO
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
 
    END SUBROUTINE print_nto_cubes
 

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -41,9 +41,7 @@ MODULE qs_tddfpt2_types
    USE message_passing,                 ONLY: mp_para_env_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE pw_env_types,                    ONLY: pw_env_get
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -414,15 +412,15 @@ CONTAINS
       ALLOCATE (work_matrices%wpw_gspace_sub(nspins), work_matrices%wpw_rspace_sub(nspins), &
                 work_matrices%wpw_tau_rspace_sub(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%A_ia_rspace_sub(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(work_matrices%A_ia_rspace_sub(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
 
-         CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%wpw_gspace_sub(ispin), &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%wpw_rspace_sub(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%wpw_tau_rspace_sub(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(work_matrices%wpw_gspace_sub(ispin), &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(work_matrices%wpw_rspace_sub(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(work_matrices%wpw_tau_rspace_sub(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
       END DO
 
       ! fxc kernel potential real space grid
@@ -430,8 +428,8 @@ CONTAINS
          ! we need spins: aa, ab, bb
          ALLOCATE (work_matrices%fxc_rspace_sub(3))
          DO ispin = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, work_matrices%fxc_rspace_sub(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(work_matrices%fxc_rspace_sub(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
          END DO
       ELSE
          NULLIFY (work_matrices%fxc_rspace_sub)
@@ -706,16 +704,16 @@ CONTAINS
       IF (ASSOCIATED(sub_env%pw_env)) THEN
          CALL pw_env_get(sub_env%pw_env, auxbas_pw_pool=auxbas_pw_pool)
          DO ispin = SIZE(work_matrices%wpw_rspace_sub), 1, -1
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%wpw_rspace_sub(ispin))
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%wpw_tau_rspace_sub(ispin))
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%wpw_gspace_sub(ispin))
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%A_ia_rspace_sub(ispin))
+            CALL auxbas_pw_pool%give_back_pw(work_matrices%wpw_rspace_sub(ispin))
+            CALL auxbas_pw_pool%give_back_pw(work_matrices%wpw_tau_rspace_sub(ispin))
+            CALL auxbas_pw_pool%give_back_pw(work_matrices%wpw_gspace_sub(ispin))
+            CALL auxbas_pw_pool%give_back_pw(work_matrices%A_ia_rspace_sub(ispin))
          END DO
          DEALLOCATE (work_matrices%A_ia_rspace_sub, work_matrices%wpw_gspace_sub, &
                      work_matrices%wpw_rspace_sub, work_matrices%wpw_tau_rspace_sub)
          IF (ASSOCIATED(work_matrices%fxc_rspace_sub)) THEN
             DO ispin = SIZE(work_matrices%fxc_rspace_sub), 1, -1
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, work_matrices%fxc_rspace_sub(ispin))
+               CALL auxbas_pw_pool%give_back_pw(work_matrices%fxc_rspace_sub(ispin))
             END DO
             DEALLOCATE (work_matrices%fxc_rspace_sub)
          END IF

--- a/src/qs_update_s_mstruct.F
+++ b/src/qs_update_s_mstruct.F
@@ -21,8 +21,7 @@ MODULE qs_update_s_mstruct
                                               kg_tnadd_embed,&
                                               kg_tnadd_embed_ri
    USE pw_methods,                      ONLY: pw_transfer
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_collocate_density,            ONLY: calculate_ppl_grid,&
                                               calculate_rho_core,&
                                               calculate_rho_nlcc
@@ -90,7 +89,7 @@ CONTAINS
                                     qs_env%qs_charges%total_rho_core_rspace, qs_env, only_nopaw=.TRUE.)
          ELSE
             IF (ASSOCIATED(rho_core)) THEN
-               CALL pw_release(rho_core)
+               CALL rho_core%release()
                DEALLOCATE (rho_core)
             END IF
          END IF

--- a/src/qs_vcd_ao.F
+++ b/src/qs_vcd_ao.F
@@ -44,9 +44,7 @@ MODULE qs_vcd_ao
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
                                               pw_type
@@ -1042,8 +1040,8 @@ CONTAINS
       IF (.NOT. ASSOCIATED(v_rspace)) THEN
          ALLOCATE (v_rspace(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_rspace(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_rspace(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             CALL pw_zero(v_rspace(ispin))
          END DO
       END IF
@@ -1062,7 +1060,7 @@ CONTAINS
 
       ! return pw grids
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_rspace(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_rspace(ispin))
       END DO
       DEALLOCATE (v_rspace)
 

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -44,7 +44,6 @@ MODULE qs_vxc
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qs_dispersion_nonloc,            ONLY: calculate_dispersion_nonloc
    USE qs_dispersion_types,             ONLY: qs_dispersion_type
@@ -412,8 +411,8 @@ CONTAINS
             IF (.NOT. my_just_energy) THEN
                CALL pw_axpy(my_vxc_rho(1), vxc_rho(1), -dft_control%sic_scaling_b)
                CALL pw_axpy(my_vxc_rho(1), vxc_rho(2), dft_control%sic_scaling_b)
-               CALL pw_release(my_vxc_rho(1))
-               CALL pw_release(my_vxc_rho(2))
+               CALL my_vxc_rho(1)%release()
+               CALL my_vxc_rho(2)%release()
                DEALLOCATE (my_vxc_rho)
             END IF
 
@@ -476,8 +475,8 @@ CONTAINS
                ! and take care of the potential only vxc_rho is taken into account
                IF (.NOT. my_just_energy) THEN
                   CALL pw_axpy(my_vxc_rho(1), vxc_rho(ispin), -dft_control%sic_scaling_b)
-                  CALL pw_release(my_vxc_rho(1))
-                  CALL pw_release(my_vxc_rho(2))
+                  CALL my_vxc_rho(1)%release()
+                  CALL my_vxc_rho(2)%release()
                   DEALLOCATE (my_vxc_rho)
                END IF
             END DO
@@ -523,8 +522,8 @@ CONTAINS
             IF (.NOT. my_just_energy) THEN
                ! both go to minority spin
                CALL pw_axpy(my_vxc_rho(1), vxc_rho(2), 2.0_dp*dft_control%sic_scaling_b)
-               CALL pw_release(my_vxc_rho(1))
-               CALL pw_release(my_vxc_rho(2))
+               CALL my_vxc_rho(1)%release()
+               CALL my_vxc_rho(2)%release()
                DEALLOCATE (my_vxc_rho)
             END IF
             DEALLOCATE (rho_r, rho_g)
@@ -738,17 +737,17 @@ CONTAINS
          ! remove arrays
          IF (ASSOCIATED(vxc_rho)) THEN
             DO ispin = 1, nspins
-               CALL pw_release(vxc_rho(ispin))
+               CALL vxc_rho(ispin)%release()
             END DO
             DEALLOCATE (vxc_rho)
          END IF
          IF (ASSOCIATED(vxc_tau)) THEN
             DO ispin = 1, nspins
-               CALL pw_release(vxc_tau(ispin))
+               CALL vxc_tau(ispin)%release()
             END DO
             DEALLOCATE (vxc_tau)
          END IF
-         CALL pw_release(exc_r)
+         CALL exc_r%release()
          !
       END IF
 

--- a/src/qs_vxc.F
+++ b/src/qs_vxc.F
@@ -37,9 +37,7 @@ MODULE qs_vxc
                                               pw_scale,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -249,13 +247,13 @@ CONTAINS
             ALLOCATE (rho_r(mspin))
             ALLOCATE (rho_g(mspin))
             DO ispin = 1, mspin
-               CALL pw_pool_create_pw(xc_pw_pool, rho_g(ispin), &
-                                      in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
+               CALL xc_pw_pool%create_pw(rho_g(ispin), &
+                                         in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
                CALL pw_transfer(rho_struct_g(ispin), rho_g(ispin))
             END DO
             DO ispin = 1, mspin
-               CALL pw_pool_create_pw(xc_pw_pool, rho_r(ispin), &
-                                      in_space=REALSPACE, use_data=REALDATA3D)
+               CALL xc_pw_pool%create_pw(rho_r(ispin), &
+                                         in_space=REALSPACE, use_data=REALDATA3D)
                CALL pw_transfer(rho_g(ispin), rho_r(ispin))
             END DO
             IF (tau_r_valid) THEN
@@ -356,12 +354,12 @@ CONTAINS
          END IF
          IF (uf_grid) THEN
             DO ispin = 1, SIZE(rho_r)
-               CALL pw_pool_give_back_pw(xc_pw_pool, rho_r(ispin))
+               CALL xc_pw_pool%give_back_pw(rho_r(ispin))
             END DO
             DEALLOCATE (rho_r)
             IF (ASSOCIATED(rho_g)) THEN
                DO ispin = 1, SIZE(rho_g)
-                  CALL pw_pool_give_back_pw(xc_pw_pool, rho_g(ispin))
+                  CALL xc_pw_pool%give_back_pw(rho_g(ispin))
                END DO
                DEALLOCATE (rho_g)
             END IF
@@ -370,23 +368,23 @@ CONTAINS
          ! compute again the xc but now for Exc(m,o) and the opposite sign
          IF (dft_control%sic_method_id .EQ. sic_mauri_spz .AND. .NOT. sic_scaling_b_zero) THEN
             ALLOCATE (rho_m_rspace(2), rho_m_gspace(2))
-            CALL pw_pool_create_pw(xc_pw_pool, rho_m_gspace(1), &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
-            CALL pw_pool_create_pw(xc_pw_pool, rho_m_rspace(1), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL xc_pw_pool%create_pw(rho_m_gspace(1), &
+                                      use_data=COMPLEXDATA1D, &
+                                      in_space=RECIPROCALSPACE)
+            CALL xc_pw_pool%create_pw(rho_m_rspace(1), &
+                                      use_data=REALDATA3D, &
+                                      in_space=REALSPACE)
             CALL pw_copy(rho_struct_r(1), rho_m_rspace(1))
             CALL pw_axpy(rho_struct_r(2), rho_m_rspace(1), alpha=-1._dp)
             CALL pw_copy(rho_struct_g(1), rho_m_gspace(1))
             CALL pw_axpy(rho_struct_g(2), rho_m_gspace(1), alpha=-1._dp)
             ! bit sad, these will be just zero...
-            CALL pw_pool_create_pw(xc_pw_pool, rho_m_gspace(2), &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
-            CALL pw_pool_create_pw(xc_pw_pool, rho_m_rspace(2), &
-                                   use_data=REALDATA3D, &
-                                   in_space=REALSPACE)
+            CALL xc_pw_pool%create_pw(rho_m_gspace(2), &
+                                      use_data=COMPLEXDATA1D, &
+                                      in_space=RECIPROCALSPACE)
+            CALL xc_pw_pool%create_pw(rho_m_rspace(2), &
+                                      use_data=REALDATA3D, &
+                                      in_space=REALSPACE)
             CALL pw_zero(rho_m_rspace(2))
             CALL pw_zero(rho_m_gspace(2))
 
@@ -417,8 +415,8 @@ CONTAINS
             END IF
 
             DO ispin = 1, 2
-               CALL pw_pool_give_back_pw(xc_pw_pool, rho_m_rspace(ispin))
-               CALL pw_pool_give_back_pw(xc_pw_pool, rho_m_gspace(ispin))
+               CALL xc_pw_pool%give_back_pw(rho_m_rspace(ispin))
+               CALL xc_pw_pool%give_back_pw(rho_m_gspace(ispin))
             END DO
             DEALLOCATE (rho_m_rspace)
             DEALLOCATE (rho_m_gspace)
@@ -433,12 +431,12 @@ CONTAINS
 
             ALLOCATE (rho_m_rspace(2), rho_m_gspace(2))
             DO ispin = 1, 2
-               CALL pw_pool_create_pw(xc_pw_pool, rho_m_gspace(ispin), &
-                                      use_data=COMPLEXDATA1D, &
-                                      in_space=RECIPROCALSPACE)
-               CALL pw_pool_create_pw(xc_pw_pool, rho_m_rspace(ispin), &
-                                      use_data=REALDATA3D, &
-                                      in_space=REALSPACE)
+               CALL xc_pw_pool%create_pw(rho_m_gspace(ispin), &
+                                         use_data=COMPLEXDATA1D, &
+                                         in_space=RECIPROCALSPACE)
+               CALL xc_pw_pool%create_pw(rho_m_rspace(ispin), &
+                                         use_data=REALDATA3D, &
+                                         in_space=REALSPACE)
             END DO
 
             DO ispin = 1, 2
@@ -482,8 +480,8 @@ CONTAINS
             END DO
 
             DO ispin = 1, 2
-               CALL pw_pool_give_back_pw(xc_pw_pool, rho_m_rspace(ispin))
-               CALL pw_pool_give_back_pw(xc_pw_pool, rho_m_gspace(ispin))
+               CALL xc_pw_pool%give_back_pw(rho_m_rspace(ispin))
+               CALL xc_pw_pool%give_back_pw(rho_m_gspace(ispin))
             END DO
             DEALLOCATE (rho_m_rspace)
             DEALLOCATE (rho_m_gspace)
@@ -536,39 +534,39 @@ CONTAINS
          IF (uf_grid .AND. (ASSOCIATED(vxc_rho) .OR. ASSOCIATED(vxc_tau))) THEN
             BLOCK
                TYPE(pw_type) :: tmp_pw, tmp_g, tmp_g2
-               CALL pw_pool_create_pw(xc_pw_pool, tmp_g, &
-                                      in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
-               CALL pw_pool_create_pw(auxbas_pw_pool, tmp_g2, &
-                                      in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
+               CALL xc_pw_pool%create_pw(tmp_g, &
+                                         in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
+               CALL auxbas_pw_pool%create_pw(tmp_g2, &
+                                             in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
                IF (ASSOCIATED(vxc_rho)) THEN
                   DO ispin = 1, SIZE(vxc_rho)
-                     CALL pw_pool_create_pw(auxbas_pw_pool, tmp_pw, &
-                                            in_space=REALSPACE, use_data=REALDATA3D)
+                     CALL auxbas_pw_pool%create_pw(tmp_pw, &
+                                                   in_space=REALSPACE, use_data=REALDATA3D)
                      CALL pw_transfer(vxc_rho(ispin), tmp_g)
                      CALL pw_transfer(tmp_g, tmp_g2)
                      CALL pw_transfer(tmp_g2, tmp_pw)
-                     CALL pw_pool_give_back_pw(xc_pw_pool, vxc_rho(ispin))
+                     CALL xc_pw_pool%give_back_pw(vxc_rho(ispin))
                      vxc_rho(ispin) = tmp_pw
                   END DO
                END IF
                IF (ASSOCIATED(vxc_tau)) THEN
                   DO ispin = 1, SIZE(vxc_tau)
-                     CALL pw_pool_create_pw(auxbas_pw_pool, tmp_pw, &
-                                            in_space=REALSPACE, use_data=REALDATA3D)
+                     CALL auxbas_pw_pool%create_pw(tmp_pw, &
+                                                   in_space=REALSPACE, use_data=REALDATA3D)
                      CALL pw_transfer(vxc_tau(ispin), tmp_g)
                      CALL pw_transfer(tmp_g, tmp_g2)
                      CALL pw_transfer(tmp_g2, tmp_pw)
-                     CALL pw_pool_give_back_pw(xc_pw_pool, vxc_tau(ispin))
+                     CALL xc_pw_pool%give_back_pw(vxc_tau(ispin))
                      vxc_tau(ispin) = tmp_pw
                   END DO
                END IF
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, tmp_g2)
-               CALL pw_pool_give_back_pw(xc_pw_pool, tmp_g)
+               CALL auxbas_pw_pool%give_back_pw(tmp_g2)
+               CALL xc_pw_pool%give_back_pw(tmp_g)
             END BLOCK
          END IF
          IF (ASSOCIATED(tau) .AND. uf_grid) THEN
             DO ispin = 1, SIZE(tau)
-               CALL pw_pool_give_back_pw(xc_pw_pool, tau(ispin))
+               CALL xc_pw_pool%give_back_pw(tau(ispin))
             END DO
             DEALLOCATE (tau)
          END IF

--- a/src/qs_wf_history_methods.F
+++ b/src/qs_wf_history_methods.F
@@ -61,9 +61,7 @@ MODULE qs_wf_history_methods
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_copy
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -196,8 +194,8 @@ CONTAINS
          IF (.NOT. ASSOCIATED(snapshot%rho_r)) THEN
             ALLOCATE (snapshot%rho_r(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, snapshot%rho_r(ispin), &
-                                      in_space=REALSPACE, use_data=REALDATA3D)
+               CALL auxbas_pw_pool%create_pw(snapshot%rho_r(ispin), &
+                                             in_space=REALSPACE, use_data=REALDATA3D)
             END DO
          END IF
          DO ispin = 1, nspins
@@ -205,7 +203,7 @@ CONTAINS
          END DO
       ELSE IF (ASSOCIATED(snapshot%rho_r)) THEN
          DO ispin = 1, SIZE(snapshot%rho_r)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, snapshot%rho_r(ispin))
+            CALL auxbas_pw_pool%give_back_pw(snapshot%rho_r(ispin))
          END DO
          DEALLOCATE (snapshot%rho_r)
       END IF
@@ -216,8 +214,8 @@ CONTAINS
          IF (.NOT. ASSOCIATED(snapshot%rho_g)) THEN
             ALLOCATE (snapshot%rho_g(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, snapshot%rho_g(ispin), &
-                                      in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
+               CALL auxbas_pw_pool%create_pw(snapshot%rho_g(ispin), &
+                                             in_space=RECIPROCALSPACE, use_data=COMPLEXDATA1D)
             END DO
          END IF
          DO ispin = 1, nspins
@@ -225,7 +223,7 @@ CONTAINS
          END DO
       ELSE IF (ASSOCIATED(snapshot%rho_g)) THEN
          DO ispin = 1, SIZE(snapshot%rho_g)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, snapshot%rho_g(ispin))
+            CALL auxbas_pw_pool%give_back_pw(snapshot%rho_g(ispin))
          END DO
          DEALLOCATE (snapshot%rho_g)
       END IF

--- a/src/response_solver.F
+++ b/src/response_solver.F
@@ -93,9 +93,7 @@ MODULE response_solver
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -1189,13 +1187,13 @@ CONTAINS
          ! compute soft GS potential
          ALLOCATE (rho_r_gs(nspins), rho_g_gs(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_gs(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_gs(ispin), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_r_gs(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_g_gs(ispin), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace_gs, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_tot_gspace_gs, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          ! compute soft GS density
          total_rho_gs = 0.0_dp
          CALL pw_zero(rho_tot_gspace_gs)
@@ -1213,10 +1211,10 @@ CONTAINS
             CALL get_rho0_mpole(local_rho_set_gs%rho0_mpole)
             CALL pw_axpy(local_rho_set_gs%rho0_mpole%rho0_s_gs, rho_tot_gspace_gs)
             ! compute GS potential
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace_gs, &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace_gs, &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_hartree_gspace_gs, &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_hartree_rspace_gs, &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             NULLIFY (hartree_local_gs)
             CALL hartree_local_create(hartree_local_gs)
             CALL init_coulomb_local(hartree_local_gs, natom)
@@ -1259,8 +1257,8 @@ CONTAINS
          END IF ! myfun
       END IF ! gapw
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(vhxc_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
       !
       ! Stress-tensor: integration contribution direct term
       ! int v_Hxc[n^in]*n^z
@@ -1337,19 +1335,19 @@ CONTAINS
          IF (ASSOCIATED(local_rho_set_t)) CALL local_rho_set_release(local_rho_set_t)
          IF (gapw) THEN
             IF (ASSOCIATED(hartree_local_gs)) CALL hartree_local_release(hartree_local_gs)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace_gs)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace_gs)
+            CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace_gs)
+            CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace_gs)
          END IF
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace_gs)
+         CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace_gs)
          IF (ASSOCIATED(rho_r_gs)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r_gs(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rho_r_gs(ispin))
          END DO
          DEALLOCATE (rho_r_gs)
          END IF
          IF (ASSOCIATED(rho_g_gs)) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_gs(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rho_g_gs(ispin))
          END DO
          DEALLOCATE (rho_g_gs)
          END IF
@@ -1377,7 +1375,7 @@ CONTAINS
                'STRESS| INT Pz*dVxc_tau   ', one_third_sum_diag(stdeb), det_3x3(stdeb)
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace)
+      CALL auxbas_pw_pool%give_back_pw(vhxc_rspace)
 
       ! Stress-tensor Pz*v_Hxc[Pin]
       IF (use_virial) THEN
@@ -1439,17 +1437,17 @@ CONTAINS
       !
       ALLOCATE (rhoz_r(nspins), rhoz_g(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin), &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rhoz_r(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rhoz_g(ispin), &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhoz_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(zv_hartree_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(zv_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       CALL pw_zero(rhoz_tot_gspace)
       DO ispin = 1, nspins
@@ -1462,10 +1460,10 @@ CONTAINS
          NULLIFY (tauz_r_xc)
          ALLOCATE (rhoz_r_xc(nspins), rhoz_g_xc(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r_xc(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g_xc(ispin), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rhoz_r_xc(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rhoz_g_xc(ispin), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
          DO ispin = 1, nspins
             CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpa(ispin)%matrix, &
@@ -1479,16 +1477,16 @@ CONTAINS
          BLOCK
             TYPE(pw_type) :: work_g
             ALLOCATE (tauz_r(nspins))
-            CALL pw_pool_create_pw(auxbas_pw_pool, work_g, &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(work_g, &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, tauz_r(ispin), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(tauz_r(ispin), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpa(ispin)%matrix, &
                                        rho=tauz_r(ispin), rho_gspace=work_g, &
                                        compute_tau=.TRUE.)
             END DO
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, work_g)
+            CALL auxbas_pw_pool%give_back_pw(work_g)
          END BLOCK
       END IF
 
@@ -1505,8 +1503,8 @@ CONTAINS
       IF (use_virial) THEN
 
          CALL get_qs_env(qs_env, rho=rho)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
          ! Get the total input density in g-space [ions + electrons]
          CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
@@ -1525,7 +1523,7 @@ CONTAINS
                                h_stress=h_stress, &
                                aux_density=rho_tot_gspace)  ! n_in
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+         CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
 
          ! Stress tensor Green function contribution
          virial%pv_ehartree = virial%pv_ehartree + 2.0_dp*h_stress/REAL(para_env%num_pe, dp)
@@ -1654,13 +1652,13 @@ CONTAINS
          ! compute response potential
          ALLOCATE (rho_r_t(nspins), rho_g_t(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_r_t(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_t(ispin), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_r_t(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_g_t(ispin), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace_t, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_tot_gspace_t, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          total_rho_t = 0.0_dp
          CALL pw_zero(rho_tot_gspace_t)
          DO ispin = 1, nspins
@@ -1676,10 +1674,10 @@ CONTAINS
             CALL get_rho0_mpole(local_rho_set_t%rho0_mpole)
             CALL pw_axpy(local_rho_set_t%rho0_mpole%rho0_s_gs, rho_tot_gspace_t)
             ! compute response Coulomb potential
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_gspace_t, &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, v_hartree_rspace_t, &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_hartree_gspace_t, &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(v_hartree_rspace_t, &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
             NULLIFY (hartree_local_t)
             CALL hartree_local_create(hartree_local_t)
             CALL init_coulomb_local(hartree_local_t, natom)
@@ -1836,13 +1834,13 @@ CONTAINS
          IF (ASSOCIATED(local_rho_set_gs)) CALL local_rho_set_release(local_rho_set_gs)
          IF (gapw) THEN
             IF (ASSOCIATED(hartree_local_t)) CALL hartree_local_release(hartree_local_t)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_gspace_t)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_hartree_rspace_t)
+            CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace_t)
+            CALL auxbas_pw_pool%give_back_pw(v_hartree_rspace_t)
          END IF
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace_t)
+         CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace_t)
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_r_t(ispin))
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_t(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rho_r_t(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rho_g_t(ispin))
          END DO
          DEALLOCATE (rho_r_t, rho_g_t)
       END IF ! gapw
@@ -1932,26 +1930,26 @@ CONTAINS
             END IF
          END IF
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(rhoz_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(zv_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(zv_hartree_rspace)
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rhoz_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rhoz_g(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
       END DO
       DEALLOCATE (rhoz_r, rhoz_g, v_xc)
       IF (gapw_xc) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r_xc(ispin))
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g_xc(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rhoz_r_xc(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rhoz_g_xc(ispin))
          END DO
          DEALLOCATE (rhoz_r_xc, rhoz_g_xc)
       END IF
       IF (ASSOCIATED(v_xc_tau)) THEN
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_r(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+         CALL auxbas_pw_pool%give_back_pw(tauz_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
       END DO
       DEALLOCATE (tauz_r, v_xc_tau)
       END IF
@@ -2066,10 +2064,10 @@ CONTAINS
             NULLIFY (rhoz_g_aux, rhoz_r_aux)
             ALLOCATE (rhoz_r_aux(nspins), rhoz_g_aux(nspins))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r_aux(ispin), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g_aux(ispin), &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(rhoz_r_aux(ispin), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(rhoz_g_aux(ispin), &
+                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             END DO
             DO ispin = 1, nspins
                CALL calculate_rho_elec(ks_env=ks_env, matrix_p=mpz(ispin, 1)%matrix, &
@@ -2155,9 +2153,9 @@ CONTAINS
                virial%pv_ehartree = virial%pv_ehartree + (virial%pv_virial - pv_loc)
             END IF
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r_aux(ispin))
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g_aux(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
+               CALL auxbas_pw_pool%give_back_pw(rhoz_r_aux(ispin))
+               CALL auxbas_pw_pool%give_back_pw(rhoz_g_aux(ispin))
             END DO
             DEALLOCATE (v_xc, rhoz_r_aux, rhoz_g_aux)
             !

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -110,9 +110,7 @@ MODULE rpa_gw
                                               pw_copy,&
                                               pw_scale,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -2219,12 +2217,12 @@ CONTAINS
       CALL calculate_E_gap_rspace(E_gap_rspace, E_VBM_rspace, E_CBM_rspace, rho_g_dummy, &
                                   LDOS, qs_env, Eigenval, gw_corr_lev_occ, gw_corr_lev_virt, homo, dft_gw_char)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, E_gap_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, E_VBM_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, E_CBM_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_dummy)
+      CALL auxbas_pw_pool%give_back_pw(E_gap_rspace)
+      CALL auxbas_pw_pool%give_back_pw(E_VBM_rspace)
+      CALL auxbas_pw_pool%give_back_pw(E_CBM_rspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_g_dummy)
       DO i_E = 1, SIZE(LDOS)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, LDOS(i_E))
+         CALL auxbas_pw_pool%give_back_pw(LDOS(i_E))
       END DO
       DEALLOCATE (LDOS)
 
@@ -2523,10 +2521,10 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, E_gap_rspace, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, E_VBM_rspace, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, E_CBM_rspace, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_dummy, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(E_gap_rspace, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(E_VBM_rspace, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(E_CBM_rspace, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(rho_g_dummy, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       n_E = INT(mp2_env%ri_g0w0%energy_window_print_loc_bandgap/ &
                 mp2_env%ri_g0w0%energy_spacing_print_loc_bandgap)
@@ -2534,7 +2532,7 @@ CONTAINS
       ALLOCATE (LDOS(n_E))
 
       DO i_E = 1, n_E
-         CALL pw_pool_create_pw(auxbas_pw_pool, LDOS(i_E), use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(LDOS(i_E), use_data=REALDATA3D, in_space=REALSPACE)
       END DO
 
       CALL timestop(handle)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -108,9 +108,7 @@ MODULE rpa_im_time_force_methods
                                               pw_zero
    USE pw_poisson_methods,              ONLY: pw_poisson_solve
    USE pw_poisson_types,                ONLY: pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -2449,17 +2447,17 @@ CONTAINS
       !Apply the kernel on the density saved in force_data%sum_YP_tau
       ALLOCATE (rhoz_r(nspins), rhoz_g(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin), &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rhoz_r(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(rhoz_g(ispin), &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       END DO
-      CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_gspace, &
-                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(rhoz_tot_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(zv_hartree_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(zv_hartree_gspace, &
+                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
       CALL pw_zero(rhoz_tot_gspace)
       DO ispin = 1, nspins
@@ -2479,16 +2477,16 @@ CONTAINS
          BLOCK
             TYPE(pw_type) :: tauz_g
             ALLOCATE (tauz_r(nspins))
-            CALL pw_pool_create_pw(auxbas_pw_pool, tauz_g, &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(tauz_g, &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(auxbas_pw_pool, tauz_r(ispin), &
-                                      use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(tauz_r(ispin), &
+                                             use_data=REALDATA3D, in_space=REALSPACE)
 
                CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=force_data%sum_YP_tau(ispin)%matrix, &
                                        rho=tauz_r(ispin), rho_gspace=tauz_g, compute_tau=.TRUE.)
             END DO
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_g)
+            CALL auxbas_pw_pool%give_back_pw(tauz_g)
          END BLOCK
       END IF
 
@@ -2510,11 +2508,11 @@ CONTAINS
                                  hmat=dbcsr_p_work(ispin), &
                                  calculate_forces=.FALSE.)
 
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+         CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
       END DO
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rhoz_tot_gspace)
+      CALL auxbas_pw_pool%give_back_pw(zv_hartree_rspace)
+      CALL auxbas_pw_pool%give_back_pw(zv_hartree_gspace)
       DEALLOCATE (v_xc)
 
       IF (do_tau) THEN
@@ -2525,7 +2523,7 @@ CONTAINS
                                     hmat=dbcsr_p_work(ispin), &
                                     compute_tau=.TRUE., &
                                     calculate_forces=.FALSE.)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
          END DO
          DEALLOCATE (v_xc_tau)
       END IF
@@ -2577,8 +2575,8 @@ CONTAINS
             IF (do_tau_admm) THEN
                BLOCK
                   TYPE(pw_type) :: tauz_g
-                  CALL pw_pool_create_pw(auxbas_pw_pool, tauz_g, &
-                                         use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+                  CALL auxbas_pw_pool%create_pw(tauz_g, &
+                                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                   DO ispin = 1, nspins
                      CALL pw_zero(tauz_r(ispin))
                      CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=ker_tau_admm(ispin)%matrix, &
@@ -2586,7 +2584,7 @@ CONTAINS
                                              basis_type="AUX_FIT", task_list_external=task_list_aux_fit, &
                                              compute_tau=.TRUE.)
                   END DO
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_g)
+                  CALL auxbas_pw_pool%give_back_pw(tauz_g)
                END BLOCK
             END IF
 
@@ -2601,7 +2599,7 @@ CONTAINS
                                        calculate_forces=.FALSE., &
                                        basis_type="AUX_FIT", &
                                        task_list_external=task_list_aux_fit)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
             END DO
             DEALLOCATE (v_xc)
 
@@ -2615,7 +2613,7 @@ CONTAINS
                                           basis_type="AUX_FIT", &
                                           task_list_external=task_list_aux_fit, &
                                           compute_tau=.TRUE.)
-                  CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+                  CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
                END DO
                DEALLOCATE (v_xc_tau)
             END IF
@@ -2623,14 +2621,14 @@ CONTAINS
       END IF
 
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rhoz_r(ispin))
+         CALL auxbas_pw_pool%give_back_pw(rhoz_g(ispin))
       END DO
       DEALLOCATE (rhoz_r, rhoz_g)
 
       IF (do_tau) THEN
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_r(ispin))
+            CALL auxbas_pw_pool%give_back_pw(tauz_r(ispin))
          END DO
          DEALLOCATE (tauz_r)
       END IF
@@ -2806,13 +2804,13 @@ CONTAINS
                        auxbas_pw_pool, poisson_env, task_list_ext, rho_r, rho_g, pot_g, psi_L, sab_orb)
 
       IF (use_virial) THEN
-         CALL pw_pool_create_pw(auxbas_pw_pool, rho_g_copy, &
-                                use_data=COMPLEXDATA1D, &
-                                in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rho_g_copy, &
+                                       use_data=COMPLEXDATA1D, &
+                                       in_space=RECIPROCALSPACE)
          DO i_xyz = 1, 3
-            CALL pw_pool_create_pw(auxbas_pw_pool, dvg(i_xyz), &
-                                   use_data=COMPLEXDATA1D, &
-                                   in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(dvg(i_xyz), &
+                                          use_data=COMPLEXDATA1D, &
+                                          in_space=RECIPROCALSPACE)
          END DO
       END IF
 
@@ -2970,9 +2968,9 @@ CONTAINS
       END DO !jatom
 
       IF (use_virial) THEN
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_g_copy)
+         CALL auxbas_pw_pool%give_back_pw(rho_g_copy)
          DO i_xyz = 1, 3
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, dvg(i_xyz))
+            CALL auxbas_pw_pool%give_back_pw(dvg(i_xyz))
          END DO
       END IF
 
@@ -3284,8 +3282,8 @@ CONTAINS
       CALL get_qs_env(qs_env, pw_env=pw_env)
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       poisson_env=poisson_env)
-      CALL pw_pool_create_pw(auxbas_pw_pool, vhxc_rspace, &
-                             use_data=REALDATA3D, in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(vhxc_rspace, &
+                                    use_data=REALDATA3D, in_space=REALSPACE)
 
       IF (use_virial) pv_loc = virial%pv_virial
 
@@ -3322,7 +3320,7 @@ CONTAINS
             END IF
          END DO
       END IF
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vhxc_rspace)
+      CALL auxbas_pw_pool%give_back_pw(vhxc_rspace)
 
       IF (use_virial) virial%pv_ehartree = virial%pv_ehartree + (virial%pv_virial - pv_loc)
 
@@ -3482,17 +3480,17 @@ CONTAINS
          !The core-denstiy derivative
          ALLOCATE (rhoz_r(nspins), rhoz_g(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_r(ispin), &
-                                   use_data=REALDATA3D, in_space=REALSPACE)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_g(ispin), &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rhoz_r(ispin), &
+                                          use_data=REALDATA3D, in_space=REALSPACE)
+            CALL auxbas_pw_pool%create_pw(rhoz_g(ispin), &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END DO
-         CALL pw_pool_create_pw(auxbas_pw_pool, rhoz_tot_gspace, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_rspace, &
-                                use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(auxbas_pw_pool, zv_hartree_gspace, &
-                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(rhoz_tot_gspace, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(zv_hartree_rspace, &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(zv_hartree_gspace, &
+                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
          CALL pw_zero(rhoz_tot_gspace)
          DO ispin = 1, nspins
@@ -3504,8 +3502,8 @@ CONTAINS
          IF (use_virial) THEN
 
             CALL get_qs_env(qs_env, rho=rho)
-            CALL pw_pool_create_pw(auxbas_pw_pool, rho_tot_gspace, &
-                                   use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+            CALL auxbas_pw_pool%create_pw(rho_tot_gspace, &
+                                          use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
             CALL calc_rho_tot_gspace(rho_tot_gspace, qs_env, rho)
 
@@ -3517,7 +3515,7 @@ CONTAINS
                                   h_stress=h_stress, &
                                   aux_density=rho_tot_gspace)
 
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rho_tot_gspace)
+            CALL auxbas_pw_pool%give_back_pw(rho_tot_gspace)
 
             !Green contribution
             virial%pv_ehartree = virial%pv_ehartree + 2.0_dp*h_stress/REAL(para_env%num_pe, dp)
@@ -3535,17 +3533,17 @@ CONTAINS
          IF (do_tau) THEN
             BLOCK
                TYPE(pw_type) :: tauz_g
-               CALL pw_pool_create_pw(auxbas_pw_pool, tauz_g, &
-                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(tauz_g, &
+                                             use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                ALLOCATE (tauz_r(nspins))
                DO ispin = 1, nspins
-                  CALL pw_pool_create_pw(auxbas_pw_pool, tauz_r(ispin), &
-                                         use_data=REALDATA3D, in_space=REALSPACE)
+                  CALL auxbas_pw_pool%create_pw(tauz_r(ispin), &
+                                                use_data=REALDATA3D, in_space=REALSPACE)
 
                   CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=current_density(ispin)%matrix, &
                                           rho=tauz_r(ispin), rho_gspace=tauz_g, compute_tau=.TRUE.)
                END DO
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_g)
+               CALL auxbas_pw_pool%give_back_pw(tauz_g)
             END BLOCK
          END IF
 
@@ -3608,11 +3606,11 @@ CONTAINS
                                     hmat=current_mat_h(ispin), &
                                     pmat=dbcsr_work_p(ispin, 1), &
                                     calculate_forces=.TRUE.)
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+            CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
          END DO
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_tot_gspace)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_rspace)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, zv_hartree_gspace)
+         CALL auxbas_pw_pool%give_back_pw(rhoz_tot_gspace)
+         CALL auxbas_pw_pool%give_back_pw(zv_hartree_rspace)
+         CALL auxbas_pw_pool%give_back_pw(zv_hartree_gspace)
          DEALLOCATE (v_xc)
 
          IF (do_tau) THEN
@@ -3624,7 +3622,7 @@ CONTAINS
                                        pmat=dbcsr_work_p(ispin, 1), &
                                        compute_tau=.TRUE., &
                                        calculate_forces=.TRUE.)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+               CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
             END DO
             DEALLOCATE (v_xc_tau)
          END IF
@@ -3651,8 +3649,8 @@ CONTAINS
                   IF (do_tau_admm) THEN
                      BLOCK
                         TYPE(pw_type) :: tauz_g
-                        CALL pw_pool_create_pw(auxbas_pw_pool, tauz_g, &
-                                               use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+                        CALL auxbas_pw_pool%create_pw(tauz_g, &
+                                                      use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                         DO ispin = 1, nspins
                            CALL pw_zero(tauz_r(ispin))
                            CALL calculate_rho_elec(ks_env=qs_env%ks_env, matrix_p=current_density(ispin)%matrix, &
@@ -3660,7 +3658,7 @@ CONTAINS
                                                    basis_type="AUX_FIT", task_list_external=task_list_aux_fit, &
                                                    compute_tau=.TRUE.)
                         END DO
-                        CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_g)
+                        CALL auxbas_pw_pool%give_back_pw(tauz_g)
                      END BLOCK
                   END IF
 
@@ -3700,7 +3698,7 @@ CONTAINS
                                              calculate_forces=.TRUE., &
                                              basis_type="AUX_FIT", &
                                              task_list_external=task_list_aux_fit)
-                     CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc(ispin))
+                     CALL auxbas_pw_pool%give_back_pw(v_xc(ispin))
                   END DO
                   DEALLOCATE (v_xc)
 
@@ -3715,7 +3713,7 @@ CONTAINS
                                                 basis_type="AUX_FIT", &
                                                 task_list_external=task_list_aux_fit, &
                                                 compute_tau=.TRUE.)
-                        CALL pw_pool_give_back_pw(auxbas_pw_pool, v_xc_tau(ispin))
+                        CALL auxbas_pw_pool%give_back_pw(v_xc_tau(ispin))
                      END DO
                      DEALLOCATE (v_xc_tau)
                   END IF
@@ -3758,14 +3756,14 @@ CONTAINS
          END IF !do_hfx
 
          DO ispin = 1, nspins
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_r(ispin))
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, rhoz_g(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rhoz_r(ispin))
+            CALL auxbas_pw_pool%give_back_pw(rhoz_g(ispin))
          END DO
          DEALLOCATE (rhoz_r, rhoz_g)
 
          IF (do_tau) THEN
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, tauz_r(ispin))
+               CALL auxbas_pw_pool%give_back_pw(tauz_r(ispin))
             END DO
             DEALLOCATE (tauz_r)
          END IF
@@ -3815,15 +3813,15 @@ CONTAINS
       IF (use_virial) virial%pv_calculate = .FALSE.
 
       !clean-up
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vh_rspace)
+      CALL auxbas_pw_pool%give_back_pw(vh_rspace)
 
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_rspace(ispin))
+         CALL auxbas_pw_pool%give_back_pw(vxc_rspace(ispin))
          IF (ASSOCIATED(vtau_rspace)) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vtau_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vtau_rspace(ispin))
          END IF
          IF (ASSOCIATED(vadmm_rspace)) THEN
-            CALL pw_pool_give_back_pw(auxbas_pw_pool, vadmm_rspace(ispin))
+            CALL auxbas_pw_pool%give_back_pw(vadmm_rspace(ispin))
          END IF
       END DO
       DEALLOCATE (vxc_rspace)

--- a/src/rpa_rse.F
+++ b/src/rpa_rse.F
@@ -51,8 +51,7 @@ MODULE rpa_rse
    USE message_passing,                 ONLY: mp_para_env_type
    USE mp2_types,                       ONLY: mp2_type
    USE parallel_gemm_api,               ONLY: parallel_gemm
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -446,7 +445,7 @@ CONTAINS
          CALL compute_matrix_vxc(qs_env=qs_env, v_rspace=v_rspace, matrix_vxc=matrix_vxc)
 
          DO i = 1, SIZE(v_rspace)
-            CALL pw_release(v_rspace(i))
+            CALL v_rspace(i)%release()
          END DO
          DEALLOCATE (v_rspace)
 

--- a/src/spme.F
+++ b/src/spme.F
@@ -42,9 +42,7 @@ MODULE spme
                                               pw_poisson_solve
    USE pw_poisson_types,                ONLY: greens_fn_type,&
                                               pw_poisson_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -222,13 +220,13 @@ CONTAINS
 
       NULLIFY (rhob_r)
       ALLOCATE (rhob_r)
-      CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
+      CALL pw_pool%create_pw(rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       CALL transfer_rs2pw(rden, rhob_r)
       ! transform density to G space and add charge function
       NULLIFY (rhob_g)
       ALLOCATE (rhob_g)
-      CALL pw_pool_create_pw(pw_pool, rhob_g, &
+      CALL pw_pool%create_pw(rhob_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
@@ -238,13 +236,13 @@ CONTAINS
       !-------------- ELECTROSTATIC CALCULATION -----------
       ! allocate intermediate arrays
       DO i = 1, 3
-         CALL pw_pool_create_pw(pw_pool, dphi_g(i), &
+         CALL pw_pool%create_pw(dphi_g(i), &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
       NULLIFY (phi_g)
       ALLOCATE (phi_g)
-      CALL pw_pool_create_pw(pw_pool, phi_g, &
+      CALL pw_pool%create_pw(phi_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_poisson_solve(poisson_env, rhob_g, vg_coulomb, phi_g, dphi_g, &
@@ -344,8 +342,8 @@ CONTAINS
          DEALLOCATE (rpot)
       END IF
 
-      CALL pw_pool_give_back_pw(pw_pool, phi_g)
-      CALL pw_pool_give_back_pw(pw_pool, rhob_g)
+      CALL pw_pool%give_back_pw(phi_g)
+      CALL pw_pool%give_back_pw(rhob_g)
       DEALLOCATE (phi_g, rhob_g)
 
       !------------- STRESS TENSOR CALCULATION ------------
@@ -368,11 +366,11 @@ CONTAINS
          CALL rs_grid_set_box(grid_spme, rs=drpot(i))
          CALL pw_multiply_with(dphi_g(i), green%p3m_charge)
          CALL pw_transfer(dphi_g(i), rhob_r)
-         CALL pw_pool_give_back_pw(pw_pool, dphi_g(i))
+         CALL pw_pool%give_back_pw(dphi_g(i))
          CALL transfer_pw2rs(drpot(i), rhob_r)
       END DO
 
-      CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      CALL pw_pool%give_back_pw(rhob_r)
       DEALLOCATE (rhob_r)
       !----------------- FORCE CALCULATION ----------------
       ! initialize the forces
@@ -547,13 +545,13 @@ CONTAINS
 
       NULLIFY (rhob_r)
       ALLOCATE (rhob_r)
-      CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
+      CALL pw_pool%create_pw(rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       CALL transfer_rs2pw(rden, rhob_r)
       ! transform density to G space and add charge function
       NULLIFY (rhob_g)
       ALLOCATE (rhob_g)
-      CALL pw_pool_create_pw(pw_pool, rhob_g, &
+      CALL pw_pool%create_pw(rhob_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
@@ -564,7 +562,7 @@ CONTAINS
       ! allocate intermediate arrays
       NULLIFY (phi_g)
       ALLOCATE (phi_g)
-      CALL pw_pool_create_pw(pw_pool, phi_g, &
+      CALL pw_pool%create_pw(phi_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_poisson_solve(poisson_env, density=rhob_g, vhartree=phi_g)
@@ -590,9 +588,9 @@ CONTAINS
       END DO
 
       !------------------CLEANING UP ----------------------
-      CALL pw_pool_give_back_pw(pw_pool, phi_g)
-      CALL pw_pool_give_back_pw(pw_pool, rhob_g)
-      CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      CALL pw_pool%give_back_pw(phi_g)
+      CALL pw_pool%give_back_pw(rhob_g)
+      CALL pw_pool%give_back_pw(rhob_r)
       DEALLOCATE (phi_g, rhob_g, rhob_r)
       CALL rs_grid_release(rden)
       DEALLOCATE (rden)
@@ -696,13 +694,13 @@ CONTAINS
 
       NULLIFY (rhob_r)
       ALLOCATE (rhob_r)
-      CALL pw_pool_create_pw(pw_pool, rhob_r, use_data=REALDATA3D, &
+      CALL pw_pool%create_pw(rhob_r, use_data=REALDATA3D, &
                              in_space=REALSPACE)
       CALL transfer_rs2pw(rden, rhob_r)
       ! transform density to G space and add charge function
       NULLIFY (rhob_g)
       ALLOCATE (rhob_g)
-      CALL pw_pool_create_pw(pw_pool, rhob_g, &
+      CALL pw_pool%create_pw(rhob_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_transfer(rhob_r, rhob_g)
@@ -712,13 +710,13 @@ CONTAINS
       !-------------- ELECTROSTATIC CALCULATION -----------
       ! allocate intermediate arrays
       DO i = 1, 3
-         CALL pw_pool_create_pw(pw_pool, dphi_g(i), &
+         CALL pw_pool%create_pw(dphi_g(i), &
                                 use_data=COMPLEXDATA1D, &
                                 in_space=RECIPROCALSPACE)
       END DO
       NULLIFY (phi_g)
       ALLOCATE (phi_g)
-      CALL pw_pool_create_pw(pw_pool, phi_g, &
+      CALL pw_pool%create_pw(phi_g, &
                              use_data=COMPLEXDATA1D, &
                              in_space=RECIPROCALSPACE)
       CALL pw_poisson_solve(poisson_env, density=rhob_g, vhartree=phi_g, &
@@ -731,7 +729,7 @@ CONTAINS
          CALL rs_grid_set_box(grid_spme, rs=drpot(i))
          CALL pw_multiply_with(dphi_g(i), green%p3m_charge)
          CALL pw_transfer(dphi_g(i), rhob_r)
-         CALL pw_pool_give_back_pw(pw_pool, dphi_g(i))
+         CALL pw_pool%give_back_pw(dphi_g(i))
          CALL transfer_pw2rs(drpot(i), rhob_r)
       END DO
       !----------------- FORCE CALCULATION ----------------
@@ -754,9 +752,9 @@ CONTAINS
       DO i = 1, 3
          CALL rs_grid_release(drpot(i))
       END DO
-      CALL pw_pool_give_back_pw(pw_pool, phi_g)
-      CALL pw_pool_give_back_pw(pw_pool, rhob_g)
-      CALL pw_pool_give_back_pw(pw_pool, rhob_r)
+      CALL pw_pool%give_back_pw(phi_g)
+      CALL pw_pool%give_back_pw(rhob_g)
+      CALL pw_pool%give_back_pw(rhob_r)
       DEALLOCATE (phi_g, rhob_g, rhob_r)
       CALL rs_grid_release(rden)
       DEALLOCATE (rden)

--- a/src/stm_images.F
+++ b/src/stm_images.F
@@ -43,9 +43,7 @@ MODULE stm_images
    USE particle_list_types,             ONLY: particle_list_type
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
@@ -159,12 +157,12 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       nspin = SIZE(mos, 1)
       ALLOCATE (nadd_unocc(nspin))
@@ -221,8 +219,8 @@ CONTAINS
       DEALLOCATE (occupation)
 
       CALL dbcsr_deallocate_matrix(stm_density_ao)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_g)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_g)
 
       DEALLOCATE (stm_th_torb)
       DEALLOCATE (nadd_unocc)

--- a/src/surface_dipole.F
+++ b/src/surface_dipole.F
@@ -22,9 +22,7 @@ MODULE surface_dipole
                                               pw_scale,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_p_type,&
+   USE pw_pool_types,                   ONLY: pw_pool_p_type,&
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
@@ -100,12 +98,12 @@ CONTAINS
 
       CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool, &
                       pw_pools=pw_pools)
-      CALL pw_pool_create_pw(auxbas_pw_pool, wf_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, vdip_r, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(wf_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(vdip_r, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
 
       IF (dft_control%qs_control%gapw) THEN
          CALL pw_transfer(rho0_s_gs, wf_r)
@@ -268,8 +266,8 @@ CONTAINS
 !    Add the dipole potential to the hartree potential on the realspace grid
       CALL pw_axpy(vdip_r, v_hartree_rspace)
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, wf_r)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, vdip_r)
+      CALL auxbas_pw_pool%give_back_pw(wf_r)
+      CALL auxbas_pw_pool%give_back_pw(vdip_r)
 
       CALL timestop(handle)
 

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -29,9 +29,7 @@ MODULE tip_scan_methods
                                               pw_structure_factor,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -128,11 +126,11 @@ CONTAINS
          CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
          NULLIFY (vtip)
          ALLOCATE (vtip)
-         CALL pw_pool_create_pw(auxbas_pw_pool, vtip, REALDATA3D, REALSPACE)
+         CALL auxbas_pw_pool%create_pw(vtip, REALDATA3D, REALSPACE)
          CALL pw_zero(vtip)
-         CALL pw_pool_create_pw(auxbas_pw_pool, vref, COMPLEXDATA1D, RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(vref, COMPLEXDATA1D, RECIPROCALSPACE)
          CALL pw_zero(vref)
-         CALL pw_pool_create_pw(auxbas_pw_pool, sf, COMPLEXDATA1D, RECIPROCALSPACE)
+         CALL auxbas_pw_pool%create_pw(sf, COMPLEXDATA1D, RECIPROCALSPACE)
 
          ! get the reference tip potential and store it in reciprocal space (vref)
          CALL pw_transfer(scan_env%tip_pw_g, vref)
@@ -195,9 +193,9 @@ CONTAINS
             NULLIFY (vee)
             CALL set_ks_env(ks_env, vee=vee)
          END IF
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vtip)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vref)
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, sf)
+         CALL auxbas_pw_pool%give_back_pw(vtip)
+         CALL auxbas_pw_pool%give_back_pw(vref)
+         CALL auxbas_pw_pool%give_back_pw(sf)
          DEALLOCATE (vtip)
 
          logger%iter_info%print_level = plevel

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -36,7 +36,6 @@ MODULE tip_scan_methods
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_create,&
                                               pw_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -294,12 +293,12 @@ CONTAINS
       NULLIFY (pw_grid)
       CALL pw_grid_create(pw_grid, para_env)
       CALL pw_grid_setup(dcell, pw_grid, npts=npts)
-      CALL pw_create(scan_env%tip_pw_r, pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL scan_env%tip_pw_r%create(pw_grid, use_data=REALDATA3D, in_space=REALSPACE)
 !deb
       scaling = 0.1_dp
 !deb
       CALL cp_cube_to_pw(scan_env%tip_pw_r, scan_env%tip_cube_file, scaling, silent=.TRUE.)
-      CALL pw_create(scan_env%tip_pw_g, pw_grid, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+      CALL scan_env%tip_pw_g%create(pw_grid, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_transfer(scan_env%tip_pw_r, scan_env%tip_pw_g)
       CALL pw_grid_release(pw_grid)
 

--- a/src/tip_scan_types.F
+++ b/src/tip_scan_types.F
@@ -10,8 +10,7 @@ MODULE tip_scan_types
                                               section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
-   USE pw_types,                        ONLY: pw_release,&
-                                              pw_type
+   USE pw_types,                        ONLY: pw_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -157,11 +156,11 @@ CONTAINS
          DEALLOCATE (scan_info%tip_pos)
       END IF
       IF (ASSOCIATED(scan_info%tip_pw_r)) THEN
-         CALL pw_release(scan_info%tip_pw_r)
+         CALL scan_info%tip_pw_r%release()
          DEALLOCATE (scan_info%tip_pw_r)
       END IF
       IF (ASSOCIATED(scan_info%tip_pw_g)) THEN
-         CALL pw_release(scan_info%tip_pw_g)
+         CALL scan_info%tip_pw_g%release()
          DEALLOCATE (scan_info%tip_pw_g)
       END IF
 

--- a/src/transport.F
+++ b/src/transport.F
@@ -61,9 +61,7 @@ MODULE transport
    USE pw_env_types,                    ONLY: pw_env_get,&
                                               pw_env_type
    USE pw_methods,                      ONLY: pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -696,8 +694,8 @@ CONTAINS
                current_env%gauge = -1
                current_env%gauge_init = .FALSE.
 
-               CALL pw_pool_create_pw(auxbas_pw_pool, rs, use_data=REALDATA3D, in_space=REALSPACE)
-               CALL pw_pool_create_pw(auxbas_pw_pool, gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+               CALL auxbas_pw_pool%create_pw(rs, use_data=REALDATA3D, in_space=REALSPACE)
+               CALL auxbas_pw_pool%create_pw(gs, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
 
                NULLIFY (zero)
                ALLOCATE (zero)
@@ -732,8 +730,8 @@ CONTAINS
                END DO
 
                CALL dbcsr_deallocate_matrix(zero)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, rs)
-               CALL pw_pool_give_back_pw(auxbas_pw_pool, gs)
+               CALL auxbas_pw_pool%give_back_pw(rs)
+               CALL auxbas_pw_pool%give_back_pw(gs)
             END IF
          END IF
 

--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -50,7 +50,6 @@ MODULE xc
                        REALSPACE, &
                        RECIPROCALSPACE, &
                        pw_p_type, &
-                       pw_release, &
                        pw_type
    USE xc_derivative_desc, ONLY: &
       deriv_rho, deriv_rhoa, deriv_rhob, &
@@ -1412,7 +1411,7 @@ CONTAINS
          IF (PRESENT(exc_r)) THEN
             exc_r = v_drho_r
          ELSE
-            CALL pw_release(v_drho_r)
+            CALL v_drho_r%release()
          END IF
       ELSE
          exc = 0.0_dp
@@ -1746,12 +1745,12 @@ CONTAINS
                END IF
             END DO
             DO ispin = 1, nspins
-               CALL pw_release(vxc_rho(ispin))
+               CALL vxc_rho(ispin)%release()
             END DO
             DEALLOCATE (vxc_rho)
             IF (ASSOCIATED(vxc_tau)) THEN
                DO ispin = 1, nspins
-                  CALL pw_release(vxc_tau(ispin))
+                  CALL vxc_tau(ispin)%release()
                END DO
                DEALLOCATE (vxc_tau)
             END IF
@@ -1797,12 +1796,12 @@ CONTAINS
                CALL pw_axpy(vxc_tau(1), v_tau(1), weight)
             END IF
             DO ispin = 1, 2
-               CALL pw_release(vxc_rho(ispin))
+               CALL vxc_rho(ispin)%release()
             END DO
             DEALLOCATE (vxc_rho)
             IF (ASSOCIATED(vxc_tau)) THEN
             DO ispin = 1, 2
-               CALL pw_release(vxc_tau(ispin))
+               CALL vxc_tau(ispin)%release()
             END DO
             DEALLOCATE (vxc_tau)
             END IF
@@ -1830,12 +1829,12 @@ CONTAINS
                CALL pw_axpy(vxc_tau(1), v_tau(1), weight)
             END IF
             DO ispin = 1, 2
-               CALL pw_release(vxc_rho(ispin))
+               CALL vxc_rho(ispin)%release()
             END DO
             DEALLOCATE (vxc_rho)
             IF (ASSOCIATED(vxc_tau)) THEN
             DO ispin = 1, 2
-               CALL pw_release(vxc_tau(ispin))
+               CALL vxc_tau(ispin)%release()
             END DO
             DEALLOCATE (vxc_tau)
             END IF
@@ -1869,10 +1868,10 @@ CONTAINS
             IF (ASSOCIATED(vxc_tau) .AND. ASSOCIATED(v_tau)) THEN
                CALL pw_axpy(vxc_tau(1), v_tau(1), weight)
             END IF
-            CALL pw_release(vxc_rho(1))
+            CALL vxc_rho(1)%release()
             DEALLOCATE (vxc_rho)
             IF (ASSOCIATED(vxc_tau)) THEN
-               CALL pw_release(vxc_tau(1))
+               CALL vxc_tau(1)%release()
                DEALLOCATE (vxc_tau)
             END IF
          END DO
@@ -3073,6 +3072,8 @@ CONTAINS
       ELSE
          ALLOCATE (pw%cr3d(bo(1, 1):bo(2, 1), bo(1, 2):bo(2, 2), bo(1, 3):bo(2, 3)))
          pw%cr3d = 0.0_dp
+         pw%in_use = REALDATA3D
+         pw%in_space = REALSPACE
       END IF
 
    END SUBROUTINE allocate_pw
@@ -3089,7 +3090,7 @@ CONTAINS
       IF (ASSOCIATED(pw_pool)) THEN
          CALL pw_pool_give_back_pw(pw_pool, pw)
       ELSE
-         DEALLOCATE (pw%cr3d)
+         CALL pw%release()
       END IF
 
    END SUBROUTINE deallocate_pw

--- a/src/xc/xc.F
+++ b/src/xc/xc.F
@@ -41,10 +41,8 @@ MODULE xc
                          pw_scale, &
                          pw_transfer, &
                          pw_zero, pw_integrate_function
-   USE pw_pool_types, ONLY: pw_pool_create_pw, &
-                            pw_pool_give_back_cr3d, &
-                            pw_pool_give_back_pw, &
-                            pw_pool_type
+   USE pw_pool_types, ONLY: &
+      pw_pool_type
    USE pw_types, ONLY: COMPLEXDATA1D, &
                        REALDATA3D, &
                        REALSPACE, &
@@ -246,7 +244,7 @@ CONTAINS
 
       ALLOCATE (rho2_r(2))
       DO ispin = 1, 2
-         CALL pw_pool_create_pw(pw_pool, rho2_r(ispin), in_space=REALSPACE, &
+         CALL pw_pool%create_pw(rho2_r(ispin), in_space=REALSPACE, &
                                 use_data=REALDATA3D)
       END DO
       DO k = bo(1, 3), bo(2, 3)
@@ -262,7 +260,7 @@ CONTAINS
       IF (ASSOCIATED(tau)) THEN
          ALLOCATE (tau2(2))
          DO ispin = 1, 2
-            CALL pw_pool_create_pw(pw_pool, tau2(ispin), in_space=REALSPACE, &
+            CALL pw_pool%create_pw(tau2(ispin), in_space=REALSPACE, &
                                    use_data=REALDATA3D)
          END DO
 
@@ -518,10 +516,10 @@ CONTAINS
       CALL xc_dset_release(dSet2)
       CALL xc_dset_release(dSet1)
       DO ispin = 1, 2
-         CALL pw_pool_give_back_pw(pw_pool, rho2_r(ispin))
-         CALL pw_pool_give_back_pw(pw_pool, vxc_rho2(ispin))
+         CALL pw_pool%give_back_pw(rho2_r(ispin))
+         CALL pw_pool%give_back_pw(vxc_rho2(ispin))
          IF (ASSOCIATED(vxc_tau2)) THEN
-            CALL pw_pool_give_back_pw(pw_pool, vxc_tau2(ispin))
+            CALL pw_pool%give_back_pw(vxc_tau2(ispin))
          END IF
       END DO
       DEALLOCATE (vxc_rho2, rho2_r, rho2_g)
@@ -1233,7 +1231,7 @@ CONTAINS
 
          CPASSERT(ASSOCIATED(deriv_data))
          IF (use_virial) THEN
-            CALL pw_pool_create_pw(pw_pool, virial_pw, &
+            CALL pw_pool%create_pw(virial_pw, &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
             CALL pw_zero(virial_pw)
@@ -1248,7 +1246,7 @@ CONTAINS
                   virial_xc(jdir, idir) = virial_xc(idir, jdir)
                END DO
             END DO
-            CALL pw_pool_give_back_pw(pw_pool, virial_pw)
+            CALL pw_pool%give_back_pw(virial_pw)
          END IF ! use_virial
          DO idir = 1, 3
             CPASSERT(ASSOCIATED(pw_to_deriv_rho(idir)%cr3d))
@@ -1258,15 +1256,15 @@ CONTAINS
          END DO
 
          ! Deallocate pw to save memory
-         CALL pw_pool_give_back_cr3d(pw_pool, deriv_att%deriv_data)
+         CALL pw_pool%give_back_cr3d(deriv_att%deriv_data)
 
       END IF
 
       IF ((has_gradient .AND. xc_requires_tmp_g(xc_deriv_method_id)) .OR. pw_grid%spherical) THEN
-         CALL pw_pool_create_pw(pw_pool, vxc_g, &
+         CALL pw_pool%create_pw(vxc_g, &
                                 use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          IF (.NOT. pw_grid%spherical) THEN
-            CALL pw_pool_create_pw(pw_pool, tmp_g, &
+            CALL pw_pool%create_pw(tmp_g, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          END IF
       END IF
@@ -1292,7 +1290,7 @@ CONTAINS
                CALL xc_derivative_get(deriv_att, deriv_data=deriv_data)
 
                IF (use_virial) THEN
-                  CALL pw_pool_create_pw(pw_pool, virial_pw, &
+                  CALL pw_pool%create_pw(virial_pw, &
                                          use_data=REALDATA3D, &
                                          in_space=REALSPACE)
                   CALL pw_zero(virial_pw)
@@ -1307,7 +1305,7 @@ CONTAINS
                         virial_xc(jdir, idir) = virial_xc(idir, jdir)
                      END DO
                   END DO
-                  CALL pw_pool_give_back_pw(pw_pool, virial_pw)
+                  CALL pw_pool%give_back_pw(virial_pw)
                END IF ! use_virial
 
                DO idir = 1, 3
@@ -1332,7 +1330,7 @@ CONTAINS
                   CALL pw_axpy(pw_to_deriv_rho(idir), pw_to_deriv(idir))
                   IF (ispin == 2) THEN
                      IF (dealloc_pw_to_deriv_rho) THEN
-                        CALL pw_pool_give_back_pw(pw_pool, pw_to_deriv_rho(idir))
+                        CALL pw_pool%give_back_pw(pw_to_deriv_rho(idir))
                      END IF
                   END IF
                END DO
@@ -1348,7 +1346,7 @@ CONTAINS
 
             IF (dealloc_pw_to_deriv) THEN
             DO idir = 1, 3
-               CALL pw_pool_give_back_pw(pw_pool, pw_to_deriv(idir))
+               CALL pw_pool%give_back_pw(pw_to_deriv(idir))
             END DO
             END IF
          END IF
@@ -1373,7 +1371,7 @@ CONTAINS
 
             CALL pw_axpy(pw_to_deriv(1), vxc_rho(ispin))
 
-            CALL pw_pool_give_back_pw(pw_pool, pw_to_deriv(1))
+            CALL pw_pool%give_back_pw(pw_to_deriv(1))
          END IF
 
          IF (pw_grid%spherical) THEN
@@ -1386,14 +1384,14 @@ CONTAINS
                             rho_smooth_cutoff_range=density_smooth_cut_range)
 
          v_drho_r = vxc_rho(ispin)
-         CALL pw_pool_create_pw(pw_pool, vxc_rho(ispin), &
+         CALL pw_pool%create_pw(vxc_rho(ispin), &
                                 use_data=REALDATA3D, in_space=REALSPACE)
          CALL xc_pw_smooth(v_drho_r, vxc_rho(ispin), xc_rho_smooth_id)
-         CALL pw_pool_give_back_pw(pw_pool, v_drho_r)
+         CALL pw_pool%give_back_pw(v_drho_r)
       END DO
 
-      CALL pw_pool_give_back_pw(pw_pool, vxc_g)
-      CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+      CALL pw_pool%give_back_pw(vxc_g)
+      CALL pw_pool%give_back_pw(tmp_g)
 
       ! 0-deriv -> value of exc
       ! this has to be kept consistent with xc_exc_calc
@@ -1582,7 +1580,7 @@ CONTAINS
       NULLIFY (v_xc, v_xc_tau)
       ALLOCATE (v_xc(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(pw_pool, v_xc(ispin), &
+         CALL pw_pool%create_pw(v_xc(ispin), &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          CALL pw_zero(v_xc(ispin))
@@ -1596,7 +1594,7 @@ CONTAINS
             CPABORT("Tau-dependent functionals requires allocated kinetic energy density grid")
          ALLOCATE (v_xc_tau(nspins))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(pw_pool, v_xc_tau(ispin), &
+            CALL pw_pool%create_pw(v_xc_tau(ispin), &
                                    use_data=REALDATA3D, &
                                    in_space=REALSPACE)
             CALL pw_zero(v_xc_tau(ispin))
@@ -1723,12 +1721,12 @@ CONTAINS
          NULLIFY (vxc_rho, rho_g, vxc_tau)
          ALLOCATE (rho_r(2))
          DO ispin = 1, nspins
-            CALL pw_pool_create_pw(pw_pool, rho_r(ispin), in_space=REALSPACE, use_data=REALDATA3D)
+            CALL pw_pool%create_pw(rho_r(ispin), in_space=REALSPACE, use_data=REALDATA3D)
          END DO
          IF (ASSOCIATED(tau1_r) .AND. ASSOCIATED(v_tau)) THEN
             ALLOCATE (tau_r(2))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(pw_pool, tau_r(ispin), in_space=REALSPACE, use_data=REALDATA3D)
+               CALL pw_pool%create_pw(tau_r(ispin), in_space=REALSPACE, use_data=REALDATA3D)
             END DO
          END IF
          CALL xc_rho_set_get(rho_set, can_return_null=.TRUE., rhoa=rhoa, rhob=rhob, tau_a=tau_a, tau_b=tau_b)
@@ -1759,12 +1757,12 @@ CONTAINS
          NULLIFY (vxc_rho, vxc_tau, rho_g)
          ALLOCATE (rho_r(2))
          DO ispin = 1, 2
-            CALL pw_pool_create_pw(pw_pool, rho_r(ispin), in_space=REALSPACE, use_data=REALDATA3D)
+            CALL pw_pool%create_pw(rho_r(ispin), in_space=REALSPACE, use_data=REALDATA3D)
          END DO
          IF (ASSOCIATED(tau1_r) .AND. ASSOCIATED(v_tau)) THEN
             ALLOCATE (tau_r(2))
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(pw_pool, tau_r(ispin), in_space=REALSPACE, use_data=REALDATA3D)
+               CALL pw_pool%create_pw(tau_r(ispin), in_space=REALSPACE, use_data=REALDATA3D)
             END DO
          END IF
          CALL xc_rho_set_get(rho_set, can_return_null=.TRUE., rhoa=rhoa, rhob=rhob, tau_a=tau_a, tau_b=tau_b)
@@ -1842,10 +1840,10 @@ CONTAINS
       ELSE
          NULLIFY (vxc_rho, rho_r, rho_g, vxc_tau, tau_r, tau)
          ALLOCATE (rho_r(1))
-         CALL pw_pool_create_pw(pw_pool, rho_r(1), in_space=REALSPACE, use_data=REALDATA3D)
+         CALL pw_pool%create_pw(rho_r(1), in_space=REALSPACE, use_data=REALDATA3D)
          IF (ASSOCIATED(tau1_r) .AND. ASSOCIATED(v_tau)) THEN
             ALLOCATE (tau_r(1))
-            CALL pw_pool_create_pw(pw_pool, tau_r(1), in_space=REALSPACE, use_data=REALDATA3D)
+            CALL pw_pool%create_pw(tau_r(1), in_space=REALSPACE, use_data=REALDATA3D)
          END IF
          CALL xc_rho_set_get(rho_set, can_return_null=.TRUE., rho=rho, tau=tau)
          DO istep = -nsteps, nsteps
@@ -2262,13 +2260,13 @@ CONTAINS
       END IF
 
       DO ispin = 1, SIZE(rho_r)
-         CALL pw_pool_give_back_pw(pw_pool, rho_r(ispin))
+         CALL pw_pool%give_back_pw(rho_r(ispin))
       END DO
       DEALLOCATE (rho_r)
 
       IF (ASSOCIATED(tau_r)) THEN
       DO ispin = 1, SIZE(tau_r)
-         CALL pw_pool_give_back_pw(pw_pool, tau_r(ispin))
+         CALL pw_pool%give_back_pw(tau_r(ispin))
       END DO
       DEALLOCATE (tau_r)
       END IF
@@ -2722,9 +2720,9 @@ CONTAINS
 
          IF (xc_requires_tmp_g(xc_deriv_method_id) .AND. .NOT. my_gapw) THEN
             IF (ASSOCIATED(pw_pool)) THEN
-               CALL pw_pool_create_pw(pw_pool, tmp_g, &
+               CALL pw_pool%create_pw(tmp_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-               CALL pw_pool_create_pw(pw_pool, vxc_g, &
+               CALL pw_pool%create_pw(vxc_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             ELSE
                ! remember to refix for gapw
@@ -3039,11 +3037,11 @@ CONTAINS
       END IF
 
       IF (ASSOCIATED(tmp_g%pw_grid) .AND. ASSOCIATED(pw_pool)) THEN
-         CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+         CALL pw_pool%give_back_pw(tmp_g)
       END IF
 
       IF (ASSOCIATED(vxc_g%pw_grid) .AND. ASSOCIATED(pw_pool)) THEN
-         CALL pw_pool_give_back_pw(pw_pool, vxc_g)
+         CALL pw_pool%give_back_pw(vxc_g)
       END IF
 
       IF (my_compute_virial .AND. (gradient_f .OR. laplace_f)) THEN
@@ -3065,7 +3063,7 @@ CONTAINS
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bo
 
       IF (ASSOCIATED(pw_pool)) THEN
-         CALL pw_pool_create_pw(pw_pool, pw, &
+         CALL pw_pool%create_pw(pw, &
                                 use_data=REALDATA3D, &
                                 in_space=REALSPACE)
          CALL pw_zero(pw)
@@ -3088,7 +3086,7 @@ CONTAINS
       TYPE(pw_pool_type), INTENT(IN), POINTER            :: pw_pool
 
       IF (ASSOCIATED(pw_pool)) THEN
-         CALL pw_pool_give_back_pw(pw_pool, pw)
+         CALL pw_pool%give_back_pw(pw)
       ELSE
          CALL pw%release()
       END IF
@@ -3181,12 +3179,12 @@ CONTAINS
 
       NULLIFY (virial_pw, tmp_g, rho_g)
       ALLOCATE (virial_pw, tmp_g, rho_g)
-      CALL pw_pool_create_pw(pw_pool, virial_pw, &
+      CALL pw_pool%create_pw(virial_pw, &
                              use_data=REALDATA3D, &
                              in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, tmp_g, &
+      CALL pw_pool%create_pw(tmp_g, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-      CALL pw_pool_create_pw(pw_pool, rho_g, &
+      CALL pw_pool%create_pw(rho_g, &
                              use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
       CALL pw_zero(virial_pw)
       CALL pw_transfer(rho_r, rho_g)
@@ -3206,9 +3204,9 @@ CONTAINS
             virial_xc(jdir, idir) = virial_xc(idir, jdir)
          END DO
       END DO
-      CALL pw_pool_give_back_pw(pw_pool, virial_pw)
-      CALL pw_pool_give_back_pw(pw_pool, tmp_g)
-      CALL pw_pool_give_back_pw(pw_pool, rho_g)
+      CALL pw_pool%give_back_pw(virial_pw)
+      CALL pw_pool%give_back_pw(tmp_g)
+      CALL pw_pool%give_back_pw(rho_g)
       DEALLOCATE (virial_pw, tmp_g, rho_g)
 
       CALL timestop(handle)

--- a/src/xc/xc_derivative_set_types.F
+++ b/src/xc/xc_derivative_set_types.F
@@ -24,7 +24,6 @@ MODULE xc_derivative_set_types
    USE pw_methods,                      ONLY: pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create,&
                                               pw_pool_release,&
-                                              pw_pool_retain,&
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
@@ -123,7 +122,7 @@ CONTAINS
 
       IF (PRESENT(pw_pool)) THEN
          derivative_set%pw_pool => pw_pool
-         CALL pw_pool_retain(pw_pool)
+         CALL pw_pool%retain()
          IF (PRESENT(local_bounds)) THEN
             IF (ANY(pw_pool%pw_grid%bounds_local /= local_bounds)) &
                CPABORT("incompatible local_bounds and pw_pool")

--- a/src/xc/xc_derivative_set_types.F
+++ b/src/xc/xc_derivative_set_types.F
@@ -23,8 +23,6 @@ MODULE xc_derivative_set_types
                                               pw_grid_release
    USE pw_methods,                      ONLY: pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create,&
-                                              pw_pool_create_cr3d,&
-                                              pw_pool_create_pw,&
                                               pw_pool_release,&
                                               pw_pool_retain,&
                                               pw_pool_type
@@ -97,7 +95,7 @@ CONTAINS
          END IF
       END DO
       IF (.NOT. ASSOCIATED(res) .AND. my_allocate_deriv) THEN
-         CALL pw_pool_create_cr3d(derivative_set%pw_pool, cr3d_ptr)
+         CALL derivative_set%pw_pool%create_cr3d(cr3d_ptr)
          cr3d_ptr = 0.0_dp
          ALLOCATE (res)
          CALL xc_derivative_create(res, std_deriv_desc, &
@@ -210,7 +208,7 @@ CONTAINS
                         use_data=REALDATA3D, in_space=REALSPACE)
          NULLIFY (deriv_att%deriv_data)
       ELSE IF (PRESENT(pw_pool)) THEN
-         CALL pw_pool_create_pw(pw_pool, pw, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(pw, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(pw)
       END IF
 

--- a/src/xc/xc_derivative_set_types.F
+++ b/src/xc/xc_derivative_set_types.F
@@ -30,7 +30,6 @@ MODULE xc_derivative_set_types
                                               pw_pool_type
    USE pw_types,                        ONLY: REALDATA3D,&
                                               REALSPACE,&
-                                              pw_create,&
                                               pw_type
    USE xc_derivative_desc,              ONLY: standardize_desc
    USE xc_derivative_types,             ONLY: xc_derivative_create,&
@@ -207,7 +206,7 @@ CONTAINS
 
       deriv_att => xc_dset_get_derivative(deriv_set, description)
       IF (ASSOCIATED(deriv_att)) THEN
-         CALL pw_create(pw, pw_grid=pw_grid, cr3d_ptr=deriv_att%deriv_data, &
+         CALL pw%create(pw_grid=pw_grid, cr3d_ptr=deriv_att%deriv_data, &
                         use_data=REALDATA3D, in_space=REALSPACE)
          NULLIFY (deriv_att%deriv_data)
       ELSE IF (PRESENT(pw_pool)) THEN

--- a/src/xc/xc_derivative_types.F
+++ b/src/xc/xc_derivative_types.F
@@ -12,8 +12,7 @@
 MODULE xc_derivative_types
 
    USE kinds,                           ONLY: dp
-   USE pw_pool_types,                   ONLY: pw_pool_give_back_cr3d,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE xc_derivative_desc,              ONLY: create_split_desc
 #include "../base/base_uses.f90"
 
@@ -80,7 +79,7 @@ CONTAINS
 
       IF (PRESENT(pw_pool)) THEN
          IF (ASSOCIATED(pw_pool)) THEN
-            CALL pw_pool_give_back_cr3d(pw_pool, derivative%deriv_data, &
+            CALL pw_pool%give_back_cr3d(derivative%deriv_data, &
                                         accept_non_compatible=.TRUE.)
          END IF
       END IF

--- a/src/xc/xc_derivative_types.F
+++ b/src/xc/xc_derivative_types.F
@@ -79,8 +79,7 @@ CONTAINS
 
       IF (PRESENT(pw_pool)) THEN
          IF (ASSOCIATED(pw_pool)) THEN
-            CALL pw_pool%give_back_cr3d(derivative%deriv_data, &
-                                        accept_non_compatible=.TRUE.)
+            CALL pw_pool%give_back_cr3d(derivative%deriv_data)
          END IF
       END IF
       IF (ASSOCIATED(derivative%deriv_data)) THEN

--- a/src/xc/xc_fxc_kernel.F
+++ b/src/xc/xc_fxc_kernel.F
@@ -17,9 +17,7 @@ MODULE xc_fxc_kernel
                                               pw_copy,&
                                               pw_scale,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -97,8 +95,8 @@ CONTAINS
       CALL xc_rho_cflags_setall(needs, .FALSE.)
       CALL fxc_kernel_info(fxc_name, needs, lsd)
 
-      CALL pw_pool_create_pw(pw_pool, rhoa, use_data=REALDATA3D, in_space=REALSPACE)
-      CALL pw_pool_create_pw(pw_pool, rhob, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(rhoa, use_data=REALDATA3D, in_space=REALSPACE)
+      CALL pw_pool%create_pw(rhob, use_data=REALDATA3D, in_space=REALSPACE)
       IF (lsd) THEN
          CALL pw_copy(rho_r(1), rhoa)
          CALL pw_copy(rho_r(2), rhob)
@@ -114,12 +112,12 @@ CONTAINS
       IF (needs%norm_drho) THEN
          ! deriv rho
          DO idir = 1, 3
-            CALL pw_pool_create_pw(pw_pool, drhoa(idir), use_data=REALDATA3D, in_space=REALSPACE)
+            CALL pw_pool%create_pw(drhoa(idir), use_data=REALDATA3D, in_space=REALSPACE)
          END DO
-         CALL pw_pool_create_pw(pw_pool, norm_drhoa, use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(pw_pool, norm_drhob, use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(pw_pool, rhog, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
-         CALL pw_pool_create_pw(pw_pool, tmpg, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL pw_pool%create_pw(norm_drhoa, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(norm_drhob, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(rhog, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
+         CALL pw_pool%create_pw(tmpg, use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
          IF (lsd) THEN
             CALL pw_copy(rho_g(1), rhog)
          ELSE IF (triplet) THEN
@@ -157,8 +155,8 @@ CONTAINS
          ELSE
             norm_drhob%cr3d(:, :, :) = norm_drhoa%cr3d(:, :, :)
          END IF
-         CALL pw_pool_give_back_pw(pw_pool, rhog)
-         CALL pw_pool_give_back_pw(pw_pool, tmpg)
+         CALL pw_pool%give_back_pw(rhog)
+         CALL pw_pool%give_back_pw(tmpg)
       END IF
       IF (needs%tau) THEN
          MARK_USED(tau_r)
@@ -205,8 +203,8 @@ CONTAINS
          CALL b97_fxc_eval(rhob, norm_drhob, fxc_rspace(3), g_ab(3), ccaa, eps_rho)
          CALL b97_fcc_eval(rhoa, rhob, norm_drhoa, norm_drhob, fxc_rspace(2), g_ab(2), ccab, eps_rho)
          ! exchange
-         CALL pw_pool_create_pw(pw_pool, fxa, use_data=REALDATA3D, in_space=REALSPACE)
-         CALL pw_pool_create_pw(pw_pool, fxb, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(fxa, use_data=REALDATA3D, in_space=REALSPACE)
+         CALL pw_pool%create_pw(fxb, use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(fxa)
          CALL pw_zero(fxb)
          CALL xalpha_fxc_eval(rhoa, rhob, fxa, fxb, scalex, eps_rho)
@@ -214,8 +212,8 @@ CONTAINS
          CALL b97_fxc_eval(rhob, norm_drhob, fxb, g_ab(1), cxaa, eps_rho)
          CALL pw_axpy(fxa, fxc_rspace(1))
          CALL pw_axpy(fxb, fxc_rspace(3))
-         CALL pw_pool_give_back_pw(pw_pool, fxa)
-         CALL pw_pool_give_back_pw(pw_pool, fxb)
+         CALL pw_pool%give_back_pw(fxa)
+         CALL pw_pool%give_back_pw(fxb)
       CASE ("NONE")
          CALL pw_zero(fxc_rspace(1))
          CALL pw_zero(fxc_rspace(2))
@@ -224,13 +222,13 @@ CONTAINS
          CPABORT("Fxc Kernel functional is defined incorrectly")
       END SELECT
 
-      CALL pw_pool_give_back_pw(pw_pool, rhoa)
-      CALL pw_pool_give_back_pw(pw_pool, rhob)
+      CALL pw_pool%give_back_pw(rhoa)
+      CALL pw_pool%give_back_pw(rhob)
       IF (needs%norm_drho) THEN
-         CALL pw_pool_give_back_pw(pw_pool, norm_drhoa)
-         CALL pw_pool_give_back_pw(pw_pool, norm_drhob)
+         CALL pw_pool%give_back_pw(norm_drhoa)
+         CALL pw_pool%give_back_pw(norm_drhob)
          DO idir = 1, 3
-            CALL pw_pool_give_back_pw(pw_pool, drhoa(idir))
+            CALL pw_pool%give_back_pw(drhoa(idir))
          END DO
       END IF
 

--- a/src/xc/xc_rho_set_types.F
+++ b/src/xc/xc_rho_set_types.F
@@ -17,11 +17,8 @@ MODULE xc_rho_set_types
    USE pw_grid_types, ONLY: pw_grid_type
    USE pw_methods, ONLY: pw_copy, &
                          pw_transfer
-   USE pw_pool_types, ONLY: pw_pool_create_cr3d, &
-                            pw_pool_create_pw, &
-                            pw_pool_give_back_cr3d, &
-                            pw_pool_give_back_pw, &
-                            pw_pool_type
+   USE pw_pool_types, ONLY: &
+      pw_pool_type
    USE pw_spline_utils, ONLY: pw_spline_scale_deriv
    USE pw_types, ONLY: COMPLEXDATA1D, &
                        REALDATA3D, &
@@ -485,7 +482,7 @@ CONTAINS
                                   use_data=REALDATA3D, in_space=REALSPACE)
                NULLIFY (rho)
             ELSE IF (PRESENT(rhoa) .AND. PRESENT(rhob)) THEN
-               CALL pw_pool_create_pw(pw_pool, rho_pw, &
+               CALL pw_pool%create_pw(rho_pw, &
                                       use_data=REALDATA3D, in_space=REALSPACE)
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(rho_pw,rhoa,rhob)
                rho_pw%cr3d(:, :, :) = rhoa(:, :, :) + rhob(:, :, :)
@@ -511,20 +508,20 @@ CONTAINS
             INTEGER                                            :: idir
 
             IF (rho_set%owns%rho) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%rho, &
+               CALL pw_pool%give_back_cr3d(rho_set%rho, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%rho)
             END IF
             IF (rho_set%owns%rho_1_3) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%rho_1_3, &
+               CALL pw_pool%give_back_cr3d(rho_set%rho_1_3, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%rho_1_3)
             END IF
             IF (rho_set%owns%drho) THEN
                DO idir = 1, 3
-                  CALL pw_pool_give_back_cr3d(pw_pool, rho_set%drho(idir)%array, &
+                  CALL pw_pool%give_back_cr3d(rho_set%drho(idir)%array, &
                                               accept_non_compatible=.TRUE.)
                END DO
             ELSE
@@ -533,44 +530,44 @@ CONTAINS
                END DO
             END IF
             IF (rho_set%owns%norm_drho) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%norm_drho, &
+               CALL pw_pool%give_back_cr3d(rho_set%norm_drho, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%norm_drho)
             END IF
             IF (rho_set%owns%laplace_rho) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%laplace_rho, &
+               CALL pw_pool%give_back_cr3d(rho_set%laplace_rho, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%laplace_rho)
             END IF
             IF (rho_set%owns%tau) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%tau, &
+               CALL pw_pool%give_back_cr3d(rho_set%tau, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%tau)
             END IF
             IF (rho_set%owns%rho_spin) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%rhoa, &
+               CALL pw_pool%give_back_cr3d(rho_set%rhoa, &
                                            accept_non_compatible=.TRUE.)
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%rhob, &
+               CALL pw_pool%give_back_cr3d(rho_set%rhob, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%rhoa, rho_set%rhob)
             END IF
             IF (rho_set%owns%rho_spin_1_3) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%rhoa_1_3, &
+               CALL pw_pool%give_back_cr3d(rho_set%rhoa_1_3, &
                                            accept_non_compatible=.TRUE.)
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%rhob_1_3, &
+               CALL pw_pool%give_back_cr3d(rho_set%rhob_1_3, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%rhoa_1_3, rho_set%rhob_1_3)
             END IF
             IF (rho_set%owns%drho_spin) THEN
                DO idir = 1, 3
-                  CALL pw_pool_give_back_cr3d(pw_pool, rho_set%drhoa(idir)%array, &
+                  CALL pw_pool%give_back_cr3d(rho_set%drhoa(idir)%array, &
                                               accept_non_compatible=.TRUE.)
-                  CALL pw_pool_give_back_cr3d(pw_pool, rho_set%drhob(idir)%array, &
+                  CALL pw_pool%give_back_cr3d(rho_set%drhob(idir)%array, &
                                               accept_non_compatible=.TRUE.)
                END DO
             ELSE
@@ -579,25 +576,25 @@ CONTAINS
                END DO
             END IF
             IF (rho_set%owns%laplace_rho_spin) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%laplace_rhoa, &
+               CALL pw_pool%give_back_cr3d(rho_set%laplace_rhoa, &
                                            accept_non_compatible=.TRUE.)
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%laplace_rhob, &
+               CALL pw_pool%give_back_cr3d(rho_set%laplace_rhob, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%laplace_rhoa, rho_set%laplace_rhob)
             END IF
             IF (rho_set%owns%norm_drho_spin) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%norm_drhoa, &
+               CALL pw_pool%give_back_cr3d(rho_set%norm_drhoa, &
                                            accept_non_compatible=.TRUE.)
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%norm_drhob, &
+               CALL pw_pool%give_back_cr3d(rho_set%norm_drhob, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%norm_drhoa, rho_set%norm_drhob)
             END IF
             IF (rho_set%owns%tau_spin) THEN
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%tau_a, &
+               CALL pw_pool%give_back_cr3d(rho_set%tau_a, &
                                            accept_non_compatible=.TRUE.)
-               CALL pw_pool_give_back_cr3d(pw_pool, rho_set%tau_b, &
+               CALL pw_pool%give_back_cr3d(rho_set%tau_b, &
                                            accept_non_compatible=.TRUE.)
             ELSE
                NULLIFY (rho_set%tau_a, rho_set%tau_b)
@@ -689,11 +686,11 @@ CONTAINS
             END IF
 
             IF (needs_rho_g) THEN
-               CALL pw_pool_create_pw(pw_pool, tmp_g, &
+               CALL pw_pool%create_pw(tmp_g, &
                                       use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             END IF
             DO ispin = 1, nspins
-               CALL pw_pool_create_pw(pw_pool, my_rho_r(ispin), &
+               CALL pw_pool%create_pw(my_rho_r(ispin), &
                                       use_data=REALDATA3D, in_space=REALSPACE)
                ! introduce a smoothing kernel on the density
                IF (xc_rho_smooth_id == xc_rho_no_smooth) THEN
@@ -714,26 +711,26 @@ CONTAINS
                   ! (for the partial integration)
                   ! deriv rho
                   DO idir = 1, 3
-                     CALL pw_pool_create_pw(pw_pool, drho_r(idir, ispin), &
+                     CALL pw_pool%create_pw(drho_r(idir, ispin), &
                                             use_data=REALDATA3D, in_space=REALSPACE)
                   END DO
                   IF (needs_rho_g) THEN
                      IF (.NOT. ASSOCIATED(my_rho_g%pw_grid)) THEN
                         my_rho_g_local = .TRUE.
-                        CALL pw_pool_create_pw(pw_pool, my_rho_g, &
+                        CALL pw_pool%create_pw(my_rho_g, &
                                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                         CALL pw_transfer(my_rho_r(ispin), my_rho_g)
                      END IF
                      IF (.NOT. my_rho_g_local .AND. (xc_deriv_method_id == xc_deriv_spline2 .OR. &
                                                      xc_deriv_method_id == xc_deriv_spline3)) THEN
-                        CALL pw_pool_create_pw(pw_pool, my_rho_g, &
+                        CALL pw_pool%create_pw(my_rho_g, &
                                                use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
                         my_rho_g_local = .TRUE.
                         CALL pw_copy(rho_g(ispin), my_rho_g)
                      END IF
                   END IF
                   IF (needs%laplace_rho .OR. needs%laplace_rho_spin) THEN
-                     CALL pw_pool_create_pw(pw_pool, laplace_rho_r(ispin), &
+                     CALL pw_pool%create_pw(laplace_rho_r(ispin), &
                                             use_data=REALDATA3D, in_space=REALSPACE)
                      CALL xc_pw_laplace(my_rho_g, pw_pool, xc_deriv_method_id, laplace_rho_r(ispin), tmp_g=tmp_g)
                   END IF
@@ -742,7 +739,7 @@ CONTAINS
                   IF (needs_rho_g) THEN
                      IF (my_rho_g_local) THEN
                         my_rho_g_local = .FALSE.
-                        CALL pw_pool_give_back_pw(pw_pool, my_rho_g)
+                        CALL pw_pool%give_back_pw(my_rho_g)
                      END IF
                   END IF
 
@@ -755,13 +752,13 @@ CONTAINS
             END DO
 
             IF (ASSOCIATED(tmp_g%pw_grid)) THEN
-               CALL pw_pool_give_back_pw(pw_pool, tmp_g)
+               CALL pw_pool%give_back_pw(tmp_g)
             END IF
 
             SELECT CASE (nspins)
             CASE (1)
                IF (needs%rho_1_3) THEN
-                  CALL pw_pool_create_cr3d(pw_pool, rho_set%rho_1_3)
+                  CALL pw_pool%create_cr3d(rho_set%rho_1_3)
 !$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(i,j,k) SHARED(rho_set,my_rho_r)
                   DO k = rho_set%local_bounds(1, 3), rho_set%local_bounds(2, 3)
                      DO j = rho_set%local_bounds(1, 2), rho_set%local_bounds(2, 2)
@@ -780,7 +777,7 @@ CONTAINS
                   rho_set%has%rho = .TRUE.
                END IF
                IF (needs%norm_drho) THEN
-                  CALL pw_pool_create_cr3d(pw_pool, rho_set%norm_drho)
+                  CALL pw_pool%create_cr3d(rho_set%norm_drho)
 !$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(i,j,k) SHARED(rho_set,drho_r)
                   DO k = rho_set%local_bounds(1, 3), rho_set%local_bounds(2, 3)
                      DO j = rho_set%local_bounds(1, 2), rho_set%local_bounds(2, 2)
@@ -812,7 +809,7 @@ CONTAINS
                END IF
             CASE (2)
                IF (needs%rho_spin_1_3) THEN
-                  CALL pw_pool_create_cr3d(pw_pool, rho_set%rhoa_1_3)
+                  CALL pw_pool%create_cr3d(rho_set%rhoa_1_3)
                   !assume that the bounds are the same?
 !$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(i,j,k) SHARED(rho_set,my_rho_r)
                   DO k = rho_set%local_bounds(1, 3), rho_set%local_bounds(2, 3)
@@ -822,7 +819,7 @@ CONTAINS
                         END DO
                      END DO
                   END DO
-                  CALL pw_pool_create_cr3d(pw_pool, rho_set%rhob_1_3)
+                  CALL pw_pool%create_cr3d(rho_set%rhob_1_3)
                   !assume that the bounds are the same?
 !$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(i,j,k) SHARED(rho_set,my_rho_r)
                   DO k = rho_set%local_bounds(1, 3), rho_set%local_bounds(2, 3)
@@ -837,7 +834,7 @@ CONTAINS
                END IF
                IF (needs%norm_drho) THEN
 
-                  CALL pw_pool_create_cr3d(pw_pool, rho_set%norm_drho)
+                  CALL pw_pool%create_cr3d(rho_set%norm_drho)
 !$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(i,j,k) SHARED(rho_set,drho_r)
                   DO k = rho_set%local_bounds(1, 3), rho_set%local_bounds(2, 3)
                      DO j = rho_set%local_bounds(1, 2), rho_set%local_bounds(2, 2)
@@ -866,7 +863,7 @@ CONTAINS
                END IF
                IF (needs%norm_drho_spin) THEN
 
-                  CALL pw_pool_create_cr3d(pw_pool, rho_set%norm_drhoa)
+                  CALL pw_pool%create_cr3d(rho_set%norm_drhoa)
 !$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(i,j,k) SHARED(rho_set,drho_r)
                   DO k = rho_set%local_bounds(1, 3), rho_set%local_bounds(2, 3)
                      DO j = rho_set%local_bounds(1, 2), rho_set%local_bounds(2, 2)
@@ -879,7 +876,7 @@ CONTAINS
                      END DO
                   END DO
 
-                  CALL pw_pool_create_cr3d(pw_pool, rho_set%norm_drhob)
+                  CALL pw_pool%create_cr3d(rho_set%norm_drhob)
                   rho_set%owns%norm_drho_spin = .TRUE.
 !$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(i,j,k) SHARED(rho_set,drho_r)
                   DO k = rho_set%local_bounds(1, 3), rho_set%local_bounds(2, 3)
@@ -920,14 +917,14 @@ CONTAINS
             ! post cleanup
             DO ispin = 1, nspins
                IF (needs%laplace_rho .OR. needs%laplace_rho_spin) THEN
-                  CALL pw_pool_give_back_pw(pw_pool, laplace_rho_r(ispin))
+                  CALL pw_pool%give_back_pw(laplace_rho_r(ispin))
                END IF
                DO idir = 1, 3
-                  CALL pw_pool_give_back_pw(pw_pool, drho_r(idir, ispin))
+                  CALL pw_pool%give_back_pw(drho_r(idir, ispin))
                END DO
             END DO
             DO ispin = 1, nspins
-               CALL pw_pool_give_back_pw(pw_pool, my_rho_r(ispin))
+               CALL pw_pool%give_back_pw(my_rho_r(ispin))
             END DO
 
             ! tau part

--- a/src/xc/xc_rho_set_types.F
+++ b/src/xc/xc_rho_set_types.F
@@ -28,7 +28,7 @@ MODULE xc_rho_set_types
                        REALSPACE, &
                        RECIPROCALSPACE, &
                        pw_p_type, &
-                       pw_type, pw_create
+                       pw_type
    USE xc_input_constants, ONLY: xc_deriv_pw, &
                                  xc_deriv_spline2, &
                                  xc_deriv_spline3, &
@@ -480,9 +480,9 @@ CONTAINS
             REAL(KIND=dp), DIMENSION(:, :, :), POINTER, OPTIONAL :: rhoa, rhob
 
             IF (ASSOCIATED(rho)) THEN
-               CALL pw_create(rho_pw, pw_grid=pw_grid, &
-                              cr3d_ptr=rho, &
-                              use_data=REALDATA3D, in_space=REALSPACE)
+               CALL rho_pw%create(pw_grid=pw_grid, &
+                                  cr3d_ptr=rho, &
+                                  use_data=REALDATA3D, in_space=REALSPACE)
                NULLIFY (rho)
             ELSE IF (PRESENT(rhoa) .AND. PRESENT(rhob)) THEN
                CALL pw_pool_create_pw(pw_pool, rho_pw, &

--- a/src/xc/xc_rho_set_types.F
+++ b/src/xc/xc_rho_set_types.F
@@ -508,21 +508,18 @@ CONTAINS
             INTEGER                                            :: idir
 
             IF (rho_set%owns%rho) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%rho, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%rho)
             ELSE
                NULLIFY (rho_set%rho)
             END IF
             IF (rho_set%owns%rho_1_3) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%rho_1_3, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%rho_1_3)
             ELSE
                NULLIFY (rho_set%rho_1_3)
             END IF
             IF (rho_set%owns%drho) THEN
                DO idir = 1, 3
-                  CALL pw_pool%give_back_cr3d(rho_set%drho(idir)%array, &
-                                              accept_non_compatible=.TRUE.)
+                  CALL pw_pool%give_back_cr3d(rho_set%drho(idir)%array)
                END DO
             ELSE
                DO idir = 1, 3
@@ -530,45 +527,36 @@ CONTAINS
                END DO
             END IF
             IF (rho_set%owns%norm_drho) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%norm_drho, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%norm_drho)
             ELSE
                NULLIFY (rho_set%norm_drho)
             END IF
             IF (rho_set%owns%laplace_rho) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%laplace_rho, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%laplace_rho)
             ELSE
                NULLIFY (rho_set%laplace_rho)
             END IF
             IF (rho_set%owns%tau) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%tau, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%tau)
             ELSE
                NULLIFY (rho_set%tau)
             END IF
             IF (rho_set%owns%rho_spin) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%rhoa, &
-                                           accept_non_compatible=.TRUE.)
-               CALL pw_pool%give_back_cr3d(rho_set%rhob, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%rhoa)
+               CALL pw_pool%give_back_cr3d(rho_set%rhob)
             ELSE
                NULLIFY (rho_set%rhoa, rho_set%rhob)
             END IF
             IF (rho_set%owns%rho_spin_1_3) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%rhoa_1_3, &
-                                           accept_non_compatible=.TRUE.)
-               CALL pw_pool%give_back_cr3d(rho_set%rhob_1_3, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%rhoa_1_3)
+               CALL pw_pool%give_back_cr3d(rho_set%rhob_1_3)
             ELSE
                NULLIFY (rho_set%rhoa_1_3, rho_set%rhob_1_3)
             END IF
             IF (rho_set%owns%drho_spin) THEN
                DO idir = 1, 3
-                  CALL pw_pool%give_back_cr3d(rho_set%drhoa(idir)%array, &
-                                              accept_non_compatible=.TRUE.)
-                  CALL pw_pool%give_back_cr3d(rho_set%drhob(idir)%array, &
-                                              accept_non_compatible=.TRUE.)
+                  CALL pw_pool%give_back_cr3d(rho_set%drhoa(idir)%array)
+                  CALL pw_pool%give_back_cr3d(rho_set%drhob(idir)%array)
                END DO
             ELSE
                DO idir = 1, 3
@@ -576,26 +564,20 @@ CONTAINS
                END DO
             END IF
             IF (rho_set%owns%laplace_rho_spin) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%laplace_rhoa, &
-                                           accept_non_compatible=.TRUE.)
-               CALL pw_pool%give_back_cr3d(rho_set%laplace_rhob, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%laplace_rhoa)
+               CALL pw_pool%give_back_cr3d(rho_set%laplace_rhob)
             ELSE
                NULLIFY (rho_set%laplace_rhoa, rho_set%laplace_rhob)
             END IF
             IF (rho_set%owns%norm_drho_spin) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%norm_drhoa, &
-                                           accept_non_compatible=.TRUE.)
-               CALL pw_pool%give_back_cr3d(rho_set%norm_drhob, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%norm_drhoa)
+               CALL pw_pool%give_back_cr3d(rho_set%norm_drhob)
             ELSE
                NULLIFY (rho_set%norm_drhoa, rho_set%norm_drhob)
             END IF
             IF (rho_set%owns%tau_spin) THEN
-               CALL pw_pool%give_back_cr3d(rho_set%tau_a, &
-                                           accept_non_compatible=.TRUE.)
-               CALL pw_pool%give_back_cr3d(rho_set%tau_b, &
-                                           accept_non_compatible=.TRUE.)
+               CALL pw_pool%give_back_cr3d(rho_set%tau_a)
+               CALL pw_pool%give_back_cr3d(rho_set%tau_b)
             ELSE
                NULLIFY (rho_set%tau_a, rho_set%tau_b)
             END IF

--- a/src/xc/xc_util.F
+++ b/src/xc/xc_util.F
@@ -18,9 +18,7 @@ MODULE xc_util
                                               pw_laplace,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_spline_utils,                 ONLY: &
         nn10_coeffs, nn10_deriv_coeffs, nn50_coeffs, nn50_deriv_coeffs, pw_nn_deriv_r, &
         pw_nn_smear_r, pw_spline2_deriv_g, pw_spline2_interpolate_values_g, pw_spline3_deriv_g, &
@@ -159,7 +157,7 @@ CONTAINS
 
          owns_tmp_g = .FALSE.
          IF (.NOT. ASSOCIATED(my_tmp_g%pw_grid)) THEN
-            CALL pw_pool_create_pw(pw_pool, my_tmp_g, &
+            CALL pw_pool%create_pw(my_tmp_g, &
                                    use_data=COMPLEXDATA1D, in_space=RECIPROCALSPACE)
             owns_tmp_g = .TRUE.
          END IF
@@ -174,7 +172,7 @@ CONTAINS
             CALL pw_transfer(my_tmp_g, pw)
          END IF
          IF (owns_tmp_g) THEN
-            CALL pw_pool_give_back_pw(pw_pool, my_tmp_g)
+            CALL pw_pool%give_back_pw(my_tmp_g)
          END IF
       CASE default
          CPABORT("Unsupported derivative method")

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -54,7 +54,6 @@ MODULE xc_pot_saop
                                               REALDATA3D,&
                                               REALSPACE,&
                                               RECIPROCALSPACE,&
-                                              pw_release,&
                                               pw_type
    USE qs_collocate_density,            ONLY: calculate_rho_elec
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -470,8 +469,8 @@ CONTAINS
       DO ispin = 1, nspins
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_SAOP(ispin))
          CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_GLLB(ispin))
-         CALL pw_release(vxc_LB(ispin))
-         CALL pw_release(vxc_tmp(ispin))
+         CALL vxc_LB(ispin)%release()
+         CALL vxc_tmp(ispin)%release()
       END DO
       DEALLOCATE (vxc_GLLB, vxc_LB, vxc_tmp, orbital_density_matrix)
 

--- a/src/xc_pot_saop.F
+++ b/src/xc_pot_saop.F
@@ -47,9 +47,7 @@ MODULE xc_pot_saop
                                               pw_copy,&
                                               pw_scale,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               REALDATA3D,&
                                               REALSPACE,&
@@ -295,9 +293,9 @@ CONTAINS
 
       ALLOCATE (vxc_GLLB(nspins))
       DO ispin = 1, nspins
-         CALL pw_pool_create_pw(auxbas_pw_pool, vxc_GLLB(ispin), &
-                                use_data=REALDATA3D, &
-                                in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(vxc_GLLB(ispin), &
+                                       use_data=REALDATA3D, &
+                                       in_space=REALSPACE)
       END DO
 
       DO ispin = 1, nspins
@@ -306,12 +304,12 @@ CONTAINS
 
       CALL xc_dset_release(deriv_set)
 
-      CALL pw_pool_create_pw(auxbas_pw_pool, orbital, &
-                             use_data=REALDATA3D, &
-                             in_space=REALSPACE)
-      CALL pw_pool_create_pw(auxbas_pw_pool, orbital_g, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(orbital, &
+                                    use_data=REALDATA3D, &
+                                    in_space=REALSPACE)
+      CALL auxbas_pw_pool%create_pw(orbital_g, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       DO ispin = 1, nspins
 
@@ -383,8 +381,8 @@ CONTAINS
                          mo_coeff=mo_coeff, &
                          eigenvalues=mo_eigenvalues, &
                          homo=homo)
-         CALL pw_pool_create_pw(auxbas_pw_pool, vxc_SAOP(ispin), &
-                                use_data=REALDATA3D, in_space=REALSPACE)
+         CALL auxbas_pw_pool%create_pw(vxc_SAOP(ispin), &
+                                       use_data=REALDATA3D, in_space=REALSPACE)
          CALL pw_zero(vxc_SAOP(ispin))
 
          ALLOCATE (coeff_col(nrow(ispin), 1))
@@ -444,8 +442,8 @@ CONTAINS
       CALL cp_fm_release(single_mo_coeff)
 
       CALL xc_rho_set_release(rho_set, auxbas_pw_pool)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, orbital)
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, orbital_g)
+      CALL auxbas_pw_pool%give_back_pw(orbital)
+      CALL auxbas_pw_pool%give_back_pw(orbital_g)
 
       !--------------------!
       ! Do the integration !
@@ -467,8 +465,8 @@ CONTAINS
       END DO
 
       DO ispin = 1, nspins
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_SAOP(ispin))
-         CALL pw_pool_give_back_pw(auxbas_pw_pool, vxc_GLLB(ispin))
+         CALL auxbas_pw_pool%give_back_pw(vxc_SAOP(ispin))
+         CALL auxbas_pw_pool%give_back_pw(vxc_GLLB(ispin))
          CALL vxc_LB(ispin)%release()
          CALL vxc_tmp(ispin)%release()
       END DO

--- a/src/xray_diffraction.F
+++ b/src/xray_diffraction.F
@@ -46,9 +46,7 @@ MODULE xray_diffraction
                                               pw_scale,&
                                               pw_transfer,&
                                               pw_zero
-   USE pw_pool_types,                   ONLY: pw_pool_create_pw,&
-                                              pw_pool_give_back_pw,&
-                                              pw_pool_type
+   USE pw_pool_types,                   ONLY: pw_pool_type
    USE pw_types,                        ONLY: COMPLEXDATA1D,&
                                               RECIPROCALSPACE,&
                                               pw_type
@@ -163,10 +161,9 @@ CONTAINS
 
       ! Plane waves grid to assemble the total electronic density
 
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=rhotot_elec_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=rhotot_elec_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
       CALL pw_zero(rhotot_elec_gspace)
 
       CALL get_pw_grid_info(pw_grid=rhotot_elec_gspace%pw_grid, &
@@ -467,8 +464,7 @@ CONTAINS
          DEALLOCATE (q_shell_gather)
       END IF
 
-      CALL pw_pool_give_back_pw(auxbas_pw_pool, &
-                                rhotot_elec_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rhotot_elec_gspace)
 
       CALL timestop(handle)
 
@@ -565,10 +561,9 @@ CONTAINS
 
       ! Load the soft contribution of the electronic density
 
-      CALL pw_pool_create_pw(pool=auxbas_pw_pool, &
-                             pw=rho_elec_gspace, &
-                             use_data=COMPLEXDATA1D, &
-                             in_space=RECIPROCALSPACE)
+      CALL auxbas_pw_pool%create_pw(pw=rho_elec_gspace, &
+                                    use_data=COMPLEXDATA1D, &
+                                    in_space=RECIPROCALSPACE)
 
       CALL pw_zero(rhotot_elec_gspace)
 
@@ -586,8 +581,7 @@ CONTAINS
       ! Release the auxiliary PW grid for the calculation of the soft
       ! contribution
 
-      CALL pw_pool_give_back_pw(pool=auxbas_pw_pool, &
-                                pw=rho_elec_gspace)
+      CALL auxbas_pw_pool%give_back_pw(rho_elec_gspace)
 
       rho_soft = pw_integrate_function(rhotot_elec_gspace, isign=-1)
 


### PR DESCRIPTION
Within this PR,
- the PW creation and release routines are bound to the pw_type and the pw_pool_type
- removes the reference counting from the pw_poisson_type