### PR TITLE
DBM: Avoid calling dgemm on zero-sized blocks

### DIFF
--- a/src/dbm/dbm_multiply.c
+++ b/src/dbm/dbm_multiply.c
@@ -260,9 +260,12 @@ static void multiply_packs(const bool transa, const bool transb,
             }
 
             // Count flops.
-            assert(m * n * k >= 0);
-            flop_sum += 2 * m * n * k;
             dbm_library_counter_increment(m, n, k);
+            const int task_flops = 2 * m * n * k;
+            flop_sum += task_flops;
+            if (task_flops == 0) {
+              continue;
+            }
 
             // Add block multiplication to batch.
             batch[ntasks].m = m;


### PR DESCRIPTION
Follow up to #2993.