### PR TITLE
Docker: Install dependencies for CMake test via Spack

### DIFF
--- a/tools/docker/Dockerfile.test_cmake
+++ b/tools/docker/Dockerfile.test_cmake
@@ -5,64 +5,58 @@
 
 FROM ubuntu:22.04
 
-# Install requirements for the toolchain.
-WORKDIR /opt/cp2k-toolchain
-COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:22.04
+# Install common dependencies as pre-built Ubuntu packages.
+RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+    autoconf \
+    autogen \
+    automake \
+    autotools-dev \
+    bzip2 \
+    ca-certificates \
+    g++ \
+    gcc \
+    gfortran \
+    git \
+    less \
+    libtool \
+    libtool-bin \
+    make \
+    nano \
+    ninja-build \
+    patch \
+    pkgconf \
+    python3 \
+    unzip \
+    wget \
+    xxd \
+    zlib1g-dev \
+    cmake \
+    gnupg \
+    m4 \
+    xz-utils \
+    libssl-dev \
+    libssh-dev \
+    mpich \
+    libmpich-dev \
+   && rm -rf /var/lib/apt/lists/*
 
-# Install the toolchain.
-RUN mkdir scripts
-COPY ./tools/toolchain/scripts/VERSION \
-     ./tools/toolchain/scripts/parse_if.py \
-     ./tools/toolchain/scripts/tool_kit.sh \
-     ./tools/toolchain/scripts/common_vars.sh \
-     ./tools/toolchain/scripts/signal_trap.sh \
-     ./tools/toolchain/scripts/get_openblas_arch.sh \
-     ./scripts/
-COPY ./tools/toolchain/install_cp2k_toolchain.sh .
-RUN ./install_cp2k_toolchain.sh \
-    --install-all \
-    --with-gcc=system \
-    --dry-run
+# Install a recent developer version of Spack.
+WORKDIR /opt/spack
+RUN git init --quiet && \
+    git remote add origin https://github.com/spack/spack.git && \
+    git fetch --quiet --depth 1 origin 8bcb1f8766ffbf097ec685bdafad53bc8b6e9e30 && \
+    git checkout --quiet FETCH_HEAD
+ENV PATH="/opt/spack/bin:${PATH}"
 
-# Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
-COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
-RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
+# Find all external packages and compilers.
+RUN spack external find --all --not-buildable
+RUN spack compiler find
 
-COPY ./tools/toolchain/scripts/stage1/ ./scripts/stage1/
-RUN  ./scripts/stage1/install_stage1.sh && rm -rf ./build
-
-COPY ./tools/toolchain/scripts/stage2/ ./scripts/stage2/
-RUN  ./scripts/stage2/install_stage2.sh && rm -rf ./build
-
-COPY ./tools/toolchain/scripts/stage3/ ./scripts/stage3/
-RUN  ./scripts/stage3/install_stage3.sh && rm -rf ./build
-
-COPY ./tools/toolchain/scripts/stage4/ ./scripts/stage4/
-RUN  ./scripts/stage4/install_stage4.sh && rm -rf ./build
-
-COPY ./tools/toolchain/scripts/stage5/ ./scripts/stage5/
-RUN  ./scripts/stage5/install_stage5.sh && rm -rf ./build
-
-COPY ./tools/toolchain/scripts/stage6/ ./scripts/stage6/
-RUN  ./scripts/stage6/install_stage6.sh && rm -rf ./build
-
-COPY ./tools/toolchain/scripts/stage7/ ./scripts/stage7/
-RUN  ./scripts/stage7/install_stage7.sh && rm -rf ./build
-
-COPY ./tools/toolchain/scripts/stage8/ ./scripts/stage8/
-RUN  ./scripts/stage8/install_stage8.sh && rm -rf ./build
-
-COPY ./tools/toolchain/scripts/arch_base.tmpl \
-     ./tools/toolchain/scripts/generate_arch_files.sh \
-     ./scripts/
-RUN ./scripts/generate_arch_files.sh && rm -rf ./build
-
-# Install DBCSR.
-WORKDIR /opt/dbcsr
-COPY ./tools/docker/scripts/install_dbcsr.sh .
-RUN ./install_dbcsr.sh
+# Install CP2K's dependencies via Spack.
+WORKDIR /
+COPY ./tools/spack/cp2k-dependencies.yaml .
+RUN spack env create myenv ./cp2k-dependencies.yaml
+RUN spack --env=myenv install
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/spack/cp2k-dependencies.yaml
+++ b/tools/spack/cp2k-dependencies.yaml
@@ -1,0 +1,40 @@
+# This is a Spack Environment file for developing CP2K.
+
+spack:
+  specs:
+   - "cmake @3.22:"  # external
+   - "mpi @4"  # external
+   - "openblas @0.3.24 +fortran threads=openmp"
+   - "dbcsr@2.6.0 +openmp +mpi"
+   - "netlib-scalapack @2.2.0"
+   - "libxsmm @1.17"
+   - "fftw @3.3.10 +openmp"
+   - "libxc @6.2.2"
+   - "spglib @1.16.2"
+
+   # Unfortunately, ScaLAPACK 2.2.1 has not yet been packaged by Spack.
+   # https://github.com/Reference-ScaLAPACK/scalapack/tree/v2.2.1
+   # which contains https://github.com/Reference-ScaLAPACK/scalapack/pull/26
+
+   # TODO:
+   # - "libint @2.6.0 +fortran tune=cp2k-lmax-5" # build takes 16 min
+   # - "sirius @7.4.3 +fortran +shared +openmp" # build fails
+   # - "plumed @2.9.0 +shared +mpi optional_modules=all" # requires cython
+   # - "libvori @220621" # is not recompile with -fPIC
+   # - "cosma @2.6.6"
+   # - "elpa @2023.05.001 +openmp"
+   #
+   # scotch_6.0.0.tar.gz
+   # superlu_dist_6.1.0.tar.gz: OK
+   # pexsi_v1.2.0.tar.gz: OK
+   # QUIP-0.9.10.tar.gz
+   # hdf5-1.14.2.tar.bz2: OK
+   # libvdwxc-0.4.0.tar.gz: OK
+   # libtorch-cxx11-abi-shared-with-deps-1.12.1+cpu.zip: OK
+   # SpLA-1.5.5.tar.gz: OK
+
+  view: true
+  concretizer:
+    unify: true
+
+#EOF


### PR DESCRIPTION
I decided to use [Spack environments](https://spack.readthedocs.io/en/latest/environments.html) instead of a dummy package with `install --only=dependencies` because it's simpler and more explicit. Later we can add more environment files for other common configurations like CUDA.

One remaining major issue is the build time of libint. In the old toolchain we address this by [pre-generating](https://github.com/cp2k/libint-cp2k) it.