### PR TITLE
Minor cosmetic changes

### DIFF
--- a/src/common/bibliography.F
+++ b/src/common/bibliography.F
@@ -90,7 +90,7 @@ MODULE bibliography
                             cp2kqs2020, Behler2007, Behler2011, Schran2020a, Schran2020b, &
                             Rycroft2009, Thomas2015, Brehm2018, Brehm2020, Shigeta2001, Heinecke2016, &
                             Brehm2021, Bussy2021a, Bussy2021b, Ditler2021, Ditler2022, Mattiat2019, Mattiat2022, &
-                            Belleflamme2023, Knizia2013, Musaelian2023, Eriksen2020, Graml2023
+                            Belleflamme2023, Knizia2013, Musaelian2023, Eriksen2020, Graml2023, Bussy2023
 
 CONTAINS
 
@@ -4700,6 +4700,24 @@ CONTAINS
                          "DI 10.1063/5.0058124 ", &
                          "ER"), &
                          DOI="10.1063/5.0058124")
+
+      CALL add_reference(key=Bussy2023, ISI_record=s2a( &
+                         "TI Sparse tensor based nuclear gradients for periodic Hartree-Fock ", &
+                         "   and low-scaling correlated wave function methods in the CP2K software ", &
+                         "   package: A massively parallel and GPU accelerated implementation.", &
+                         "AU Bussy, Augustin", &
+                         "   Schuett, Ole", &
+                         "   Hutter, Juerg", &
+                         "PY 2023", &
+                         "SP 164109", &
+                         "JF The Journal of Chemical Physics", &
+                         "SO J. Chem. Phys.", &
+                         "VL 158", &
+                         "IS 16", &
+                         "PB American Institute of Physics", &
+                         "DI 10.1063/5.0144493 ", &
+                         "ER"), &
+                         DOI="10.1063/5.0144493")
 
       CALL add_reference(key=Heinecke2016, ISI_record=s2a( &
                          "PT S", &

--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -19,7 +19,8 @@ MODULE hfx_types
    USE basis_set_types,                 ONLY: get_gto_basis_set,&
                                               gto_basis_set_p_type,&
                                               gto_basis_set_type
-   USE bibliography,                    ONLY: cite_reference,&
+   USE bibliography,                    ONLY: bussy2023,&
+                                              cite_reference,&
                                               guidon2008,&
                                               guidon2009
    USE cell_types,                      ONLY: cell_type,&
@@ -1210,6 +1211,8 @@ CONTAINS
       TYPE(gto_basis_set_p_type), ALLOCATABLE, &
          DIMENSION(:)                                    :: basis_set_AO, basis_set_RI
       TYPE(mp_cart_type)                                 :: mp_comm_3d
+
+      CALL cite_reference(Bussy2023)
 
       CALL timeset(routineN, handle)
 

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -309,7 +309,7 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="AUTO_BASIS", &
-                          description="Specify size of automatically generated auxiliary basis sets: "// &
+                          description="Specify size of automatically generated auxiliary (RI) basis sets: "// &
                           "Options={small,medium,large,huge}", &
                           usage="AUTO_BASIS {basis_type} {basis_size}", &
                           type_of_var=char_t, repeats=.TRUE., n_var=-1, default_c_vals=(/"X", "X"/))

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -940,8 +940,6 @@ CONTAINS
                                 basis_type="RI_AUX")
                IF (.NOT. (ASSOCIATED(ri_aux_basis_set))) THEN
                   ! RI_AUX basis set is not yet loaded
-                  CALL cp_warn(__LOCATION__, "Automatic Generation of RI_AUX basis. "// &
-                               "This is experimental code.")
                   ! Generate a default basis
                   CALL create_ri_aux_basis_set(ri_aux_basis_set, qs_kind, dft_control%auto_basis_ri_aux, basis_sort=sort_basis)
                   CALL add_basis_set_to_container(qs_kind%basis_sets, ri_aux_basis_set, "RI_AUX")
@@ -959,8 +957,6 @@ CONTAINS
             qs_kind => qs_kind_set(ikind)
             CALL get_qs_kind(qs_kind, basis_Set=ri_xas_basis, basis_type="RI_XAS")
             IF (.NOT. ASSOCIATED(ri_xas_basis)) THEN
-               CALL cp_warn(__LOCATION__, "Automatic Generation of RI_XAS basis. "// &
-                            "This is experimental code.")
                ! Generate a default basis
                CALL create_ri_aux_basis_set(ri_xas_basis, qs_kind, dft_control%auto_basis_ri_xas)
                CALL add_basis_set_to_container(qs_kind%basis_sets, ri_xas_basis, "RI_XAS")

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -18,6 +18,8 @@ MODULE rpa_im_time_force_methods
                                               get_atomic_kind_set
    USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
                                               gto_basis_set_type
+   USE bibliography,                    ONLY: Bussy2023,&
+                                              cite_reference
    USE cell_types,                      ONLY: cell_type,&
                                               pbc
    USE core_ae,                         ONLY: build_core_ae
@@ -240,6 +242,8 @@ CONTAINS
 
       NULLIFY (dft_control, para_env, particle_set, qs_kind_set, dist_2d, nl_2c, blacs_env, matrix_s, &
                rho, rho_ao, cell, qs_section, orb_basis, ri_basis, virial)
+
+      CALL cite_reference(Bussy2023)
 
       CALL timeset(routineN, handle)
 


### PR DESCRIPTION
- Added literature reference for RI-HFX and low-scaling post-HF gradients
- Removed experimental code warning for `AUTO_BASIS` with RI-HFX, XAS_TDP and post-HF, as this has been used for years by now