### PR TITLE
fix some warning issues when NDEBUG is used

### DIFF
--- a/src/dbm/dbm_matrix.c
+++ b/src/dbm/dbm_matrix.c
@@ -326,7 +326,10 @@ void dbm_reserve_blocks(dbm_matrix_t *matrix, const int nblocks,
                         const int rows[], const int cols[]) {
   assert(omp_get_num_threads() == omp_get_max_threads() &&
          "Please call dbm_reserve_blocks within an OpenMP parallel region.");
+#ifndef NDEBUG
   const int my_rank = matrix->dist->my_rank;
+#endif
+  
   for (int i = 0; i < nblocks; i++) {
     const int ishard = dbm_get_shard_index(matrix, rows[i], cols[i]);
     dbm_shard_t *shard = &matrix->shards[ishard];

--- a/src/dbm/dbm_multiply.c
+++ b/src/dbm/dbm_multiply.c
@@ -172,8 +172,10 @@ static void multiply_packs(const bool transa, const bool transb,
 
   const int *sum_index_sizes_a =
       (transa) ? matrix_a->row_sizes : matrix_a->col_sizes;
+#ifndef NDEBUG
   const int *sum_index_sizes_b =
       (transb) ? matrix_b->col_sizes : matrix_b->row_sizes;
+#endif
   const int *free_index_sizes_a =
       (transa) ? matrix_a->col_sizes : matrix_a->row_sizes;
   const int *free_index_sizes_b =
@@ -304,6 +306,7 @@ void dbm_multiply(const bool transa, const bool transb, const double alpha,
 
   assert(omp_get_num_threads() == 1);
 
+#ifndef NDEBUG
   // Throughout the matrix multiplication code the "sum_index" and "free_index"
   // denote the summation (aka dummy) and free index from the Einstein notation.
   const int num_sum_index_a = (transa) ? matrix_a->nrows : matrix_a->ncols;
@@ -315,6 +318,7 @@ void dbm_multiply(const bool transa, const bool transb, const double alpha,
   assert(num_sum_index_a == num_sum_index_b);
   assert(num_free_index_a == matrix_c->nrows);
   assert(num_free_index_b == matrix_c->ncols);
+#endif
 
   // Prepare matrix_c.
   dbm_scale(matrix_c, beta);

--- a/src/dbm/dbm_multiply_comm.c
+++ b/src/dbm/dbm_multiply_comm.c
@@ -193,9 +193,12 @@ static void fill_send_buffers(
     {
       icumsum(nranks, blks_send_count, blks_send_displ);
       icumsum(nranks, data_send_count, data_send_displ);
+
+#ifndef NDEBUG
       const int m = nranks - 1;
       assert(nblks_send == blks_send_displ[m] + blks_send_count[m]);
       assert(ndata_send == data_send_displ[m] + data_send_count[m]);
+#endif
     }
 #pragma omp barrier
 

--- a/src/grid/cpu/grid_cpu_collint.h
+++ b/src/grid/cpu/grid_cpu_collint.h
@@ -398,8 +398,10 @@ ortho_cxyz_to_grid(const int lp, const double zetp, const double dh[3][3],
       const int offset =
           modulo(cubecenter[i] + lb_cube[i] - shift_local[i], npts_global[i]) -
           lb_cube[i];
-      assert(offset + ub_cube[i] < npts_local[i]);
-      assert(offset + lb_cube[i] >= 0);
+      if (offset + ub_cube[i] >= npts_local[i])
+        abort();
+      if (offset + lb_cube[i] < 0)
+        abort();
     }
   }
 

--- a/src/grid/ref/grid_ref_collint.h
+++ b/src/grid/ref/grid_ref_collint.h
@@ -248,8 +248,10 @@ ortho_cxyz_to_grid(const int lp, const double zetp, const double dh[3][3],
       const int offset =
           modulo(cubecenter[i] + lb_cube[i] - shift_local[i], npts_global[i]) -
           lb_cube[i];
-      assert(offset + ub_cube[i] < npts_local[i]);
-      assert(offset + lb_cube[i] >= 0);
+      if (offset + ub_cube[i] >= npts_local[i])
+        abort();
+      if (offset + lb_cube[i] < 0)
+        abort();
     }
   }
 


### PR DESCRIPTION
some cosmetics removing warning when NDEBUG is used. 

Note that the use of assert should be avoided if the test is a hard test as NDEBUG will simply define the assert macro as empty. 
