### PR TITLE
DEBUG: Oscillator strength for TDDFT+SOC within length and velocity r…

### DIFF
--- a/src/qs_tddfpt2_soc.F
+++ b/src/qs_tddfpt2_soc.F
@@ -78,7 +78,9 @@ MODULE qs_tddfpt2_soc
                                               soc_env_create,&
                                               soc_env_release,&
                                               soc_env_type
-   USE qs_tddfpt2_soc_utils,            ONLY: soc_contract_evect,&
+   USE qs_tddfpt2_soc_utils,            ONLY: dip_vel_op,&
+                                              resort_evects,&
+                                              soc_contract_evect,&
                                               soc_dipole_operator
    USE qs_tddfpt2_types,                ONLY: tddfpt_ground_state_mos
    USE soc_pseudopotential_methods,     ONLY: V_SOC_xyz_from_pseudopotential
@@ -206,7 +208,7 @@ CONTAINS
    SUBROUTINE tddfpt_soc_rcs(qs_env, evals_sing, evals_trip, evects_sing, evects_trip, log_unit, gs_mos)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      REAL(kind=dp), DIMENSION(:), INTENT(in), TARGET    :: evals_sing, evals_trip
+      REAL(kind=dp), DIMENSION(:), INTENT(IN), TARGET    :: evals_sing, evals_trip
       TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects_sing, evects_trip
       INTEGER                                            :: log_unit
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
@@ -214,17 +216,17 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'tddfpt_soc_rcs'
 
-      CHARACTER(len=1)                                   :: mult
+      CHARACTER(len=3)                                   :: mult
       INTEGER                                            :: dipole_form, group, handle, iex, ii, &
                                                             isg, istate, itp, jj, nactive, nao, &
                                                             nex, npcols, nprows, nsg, ntot, ntp
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: evects_sort
       INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist, row_dist_new
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       LOGICAL                                            :: print_ev, print_some, print_splitting, &
                                                             print_wn
-      REAL(dp)                                           :: eps_filter, soc_gst, sqrt2, tmp, &
-                                                            unit_scale
+      REAL(dp)                                           :: eps_filter, soc_gst, sqrt2, unit_scale
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: diag, tmp_evals
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: img_tmp, real_tmp
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:, :)        :: gstp_block, mo_soc_x, mo_soc_y, mo_soc_z
@@ -251,8 +253,6 @@ CONTAINS
       TYPE(soc_atom_env_type), POINTER                   :: soc_atom_env
       TYPE(soc_env_type), TARGET                         :: soc_env
 
-!! OUTPUT structures
-
       CALL timeset(routineN, handle)
 
       NULLIFY (logger, pgrid, row_dist, row_dist_new)
@@ -273,7 +273,7 @@ CONTAINS
 
       ! Initzialize Working environment
       CALL inititialize_soc(qs_env, soc_atom_env, soc_env, &
-                            evects_sing, evects_trip, dipole_form)
+                            evects_sing, evects_trip, dipole_form, gs_mos)
 
       NULLIFY (mos)
       CALL get_qs_env(qs_env, mos=mos, para_env=para_env, blacs_env=blacs_env)
@@ -427,7 +427,6 @@ CONTAINS
       !  Only have SOC between singlet-triplet triplet-triplet and ground_state-triplet, the resulting
       !  matrix is Hermitian i.e. the real part is symmetric and the imaginary part is anti-symmetric.
       !  Can only fill upper half
-
       IF (log_unit > 0 .AND. debug_this_module) THEN
          WRITE (log_unit, '(A)') "Starting Ground-State contributions..."
       END IF
@@ -902,6 +901,7 @@ CONTAINS
 
       !! save convertion unit into different varible for cleaner code
       IF (print_wn) THEN
+         print_ev = .FALSE.
          unit_scale = wavenumbers
       ELSE IF (print_ev) THEN
          unit_scale = evolt
@@ -977,7 +977,8 @@ CONTAINS
       soc_env%evals_a => evals_sing
       soc_env%evals_b => evals_trip
       CALL soc_dipol(qs_env, dbcsr_soc_package, soc_env, &
-                     evecs_cfm, eps_filter, dipole_form, gs_mos)
+                     evecs_cfm, eps_filter, dipole_form, gs_mos, &
+                     evects_sing, evects_trip)
 
       !Create final output
       !! Output unit is choosen by the keyword "UNIT_eV" and "UNIT_wn" in "SOC_PRINT" section
@@ -1000,65 +1001,62 @@ CONTAINS
          END IF
          WRITE (log_unit, '(A)') "------------------------------------------------------------------------------"
          DO istate = 1, SIZE(soc_env%soc_evals)
-            WRITE (log_unit, '(6X,I3,11X,2F16.5)') istate, soc_env%soc_evals(istate)*unit_scale, soc_env%soc_osc(istate)
+            WRITE (log_unit, '(6X,I5,11X,2F16.5)') istate, soc_env%soc_evals(istate)*unit_scale, &
+               soc_env%soc_osc(istate)
          END DO
          !! This is used for regtesting
-         WRITE (log_unit, '(A,F10.6)') "TDDFT+SOC : CheckSum (eV) ", SUM(soc_env%soc_evals)*evolt
+         WRITE (log_unit, '(A,F18.8)') "TDDFT+SOC : CheckSum (eV) ", SUM(soc_env%soc_evals)*evolt
       END IF
 
       !! We may be interested in the differenz between the SOC and
       !! TDDFPT Eigenvalues
       !! Activated with the "SPLITTING" keyword in "SOC_PRINT" section
-      IF (log_unit > 0 .AND. (print_splitting .OR. debug_this_module)) THEN
-         isg = 1
-         itp = 1
-         iex = 1
-         tmp = 0.0
-         mult = ""
-         WRITE (log_unit, '(A)') "------------------------------------------------------------------------"
-         WRITE (log_unit, '(A)') "-                            Splittings                                -"
-         WRITE (log_unit, '(A)') "------------------------------------------------------------------------"
-         IF (print_ev) THEN
-            WRITE (log_unit, '(A)') "-  STATE   MULT     exc.energies[eV]    splittings[eV]                 -"
-         ELSE IF (print_wn) THEN
-            WRITE (log_unit, '(A)') "-  STATE   MULT     exc.energies[cm-1]  splittings[cm-1]               -"
-         ELSE
-            WRITE (log_unit, '(A)') "-  STATE   MULT     exc.energies[Hartree]  splittings[Hartree]         -"
-         END IF
-         WRITE (log_unit, '(A)') "------------------------------------------------------------------------"
-         DO WHILE (iex <= SIZE(soc_env%soc_evals))
-            IF (itp < SIZE(evals_trip) .AND. isg < SIZE(evals_sing)) THEN
-               IF (evals_sing(isg) < evals_trip(itp)) THEN
-                  tmp = soc_env%soc_evals(iex) - evals_sing(isg)
-                  mult = "S"
-                  isg = isg + 1
-               ELSE
-                  tmp = soc_env%soc_evals(iex) - evals_trip(itp)
-                  mult = "T"
-                  itp = itp + 1
-               END IF
-            ELSE IF (itp > SIZE(evals_trip)) THEN
-               tmp = soc_env%soc_evals(iex) - evals_sing(isg)
-               mult = "S"
-               isg = isg + 1
+      IF (print_splitting .OR. debug_this_module) THEN
+         CALL resort_evects(evecs_cfm, evects_sort)
+         IF (log_unit > 0) THEN
+            WRITE (log_unit, '(A)') "-----------------------------------------------------------------------------"
+            WRITE (log_unit, '(A)') "-                              Splittings                                   -"
+            WRITE (log_unit, '(A)') "-----------------------------------------------------------------------------"
+            IF (print_ev) THEN
+               WRITE (log_unit, '(A)') "-     STATE          exc.energies[eV]          splittings[eV]               -"
+            ELSE IF (print_wn) THEN
+               WRITE (log_unit, '(A)') "-     STATE          exc.energies[cm-1]        splittings[cm-1]             -"
             ELSE
-               tmp = soc_env%soc_evals(iex) - evals_trip(itp)
-               mult = "T"
-               itp = itp + 1
+               WRITE (log_unit, '(A)') "-     STATE          exc.energies[Hartree]     splittings[Hartree]          -"
             END IF
-            WRITE (log_unit, '(3X,I3,7X,A,7X,F16.8,7X,F16.8)') iex, mult, &
-               soc_env%soc_evals(iex)*unit_scale, tmp*unit_scale
-            iex = iex + 1
-            IF (mult == "T") THEN
-               DO ii = 1, 2
-                  tmp = soc_env%soc_evals(iex) - evals_trip(itp - 1)
-                  WRITE (log_unit, '(3X,I3,7X,A,7X,F16.8,7X,F16.8)') iex, mult, &
-                     soc_env%soc_evals(iex)*unit_scale, tmp*unit_scale
-                  iex = iex + 1
-               END DO
-            END IF
-         END DO
-         WRITE (log_unit, '(A)') "------------------------------------------------------------------------"
+            WRITE (log_unit, '(A)') "-----------------------------------------------------------------------------"
+            mult = "   "
+            DO iex = 1, SIZE(soc_env%soc_evals)
+               IF (evects_sort(iex + 1) .GT. nsg + ntp*2 + 1) THEN
+                  mult = "T+1"
+               ELSE IF (evects_sort(iex + 1) .GT. nsg + ntp + 1) THEN
+                  mult = "T0"
+               ELSE IF (evects_sort(iex + 1) .GT. nsg + 1) THEN
+                  mult = "T-1"
+               ELSE
+                  mult = "S  "
+               END IF
+               IF (mult == "T-1") THEN
+                  WRITE (log_unit, "(5X,A,I5,6X,F18.10,6X,F18.10)") mult, &
+                     evects_sort(iex + 1) - (1 + nsg), soc_env%soc_evals(iex)*unit_scale, &
+                     (soc_env%soc_evals(iex) - evals_trip(evects_sort(iex + 1) - (1 + nsg)))*unit_scale
+               ELSE IF (mult == "T0") THEN
+                  WRITE (log_unit, "(5X,A,I5,6X,F18.10,6X,F18.10)") mult, &
+                     evects_sort(iex + 1) - (1 + nsg + ntp), soc_env%soc_evals(iex)*unit_scale, &
+                     (soc_env%soc_evals(iex) - evals_trip(evects_sort(iex + 1) - (1 + nsg + ntp)))*unit_scale
+               ELSE IF (mult == "T+1") THEN
+                  WRITE (log_unit, "(5X,A,I5,6X,F18.10,6X,F18.10)") mult, &
+                     evects_sort(iex + 1) - (1 + nsg + ntp*2), soc_env%soc_evals(iex)*unit_scale, &
+                     (soc_env%soc_evals(iex) - evals_trip(evects_sort(iex + 1) - (1 + nsg + ntp*2)))*unit_scale
+               ELSE IF (mult == "S  ") THEN
+                  WRITE (log_unit, "(5X,A,I5,6X,F18.10,6X,F18.10)") mult, &
+                     evects_sort(iex + 1), soc_env%soc_evals(iex)*unit_scale, &
+                     (soc_env%soc_evals(iex) - evals_sing(evects_sort(iex + 1) - 1))*unit_scale
+               END IF
+            END DO
+            WRITE (log_unit, '(A)') "----------------------------------------------------------------------------"
+            DEALLOCATE (evects_sort)
+         END IF
       END IF
 
       !! clean up
@@ -1078,6 +1076,7 @@ CONTAINS
          CALL dbcsr_release(dbcsr_dummy)
          DEALLOCATE (dbcsr_dummy)
       END IF
+
       DEALLOCATE (dbcsr_work, dbcsr_prod, dbcsr_ovlp, dbcsr_tmp)
       DEALLOCATE (coeffs_dist, prod_dist, col_dist, col_blk_size, row_dist_new)
       DEALLOCATE (dbcsr_sg, dbcsr_tp, tmp_evals)
@@ -1094,16 +1093,19 @@ CONTAINS
 !> \param evects_a singlet Eigenvectors
 !> \param evects_b triplet eigenvectors
 !> \param dipole_form choosen dipole-form from TDDFPT-Section
+!> \param gs_mos ...
 ! **************************************************************************************************
    SUBROUTINE inititialize_soc(qs_env, soc_atom_env, soc_env, &
                                evects_a, evects_b, &
-                               dipole_form)
+                               dipole_form, gs_mos)
       !! Different Types
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       TYPE(soc_atom_env_type), INTENT(OUT), POINTER      :: soc_atom_env
       TYPE(soc_env_type), INTENT(OUT), TARGET            :: soc_env
       TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects_a, evects_b
       INTEGER                                            :: dipole_form
+      TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
+         INTENT(in)                                      :: gs_mos
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'inititialize_soc'
 
@@ -1130,11 +1132,10 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (qs_kind_set, particle_set, blacs_env, para_env, &
-               a_coeff, b_coeff, tddfpt_control)
+               a_coeff, b_coeff, tddfpt_control, soc_section)
 
       !! Open_shell is not implemented yet
       do_os = .FALSE.
-      !IF (SIZE(evects_a,1) > 1) do_os=.TRUE.
 
       !! soc_env will pass most of the larger matrices to the different modules
       CALL soc_env_create(soc_env)
@@ -1148,7 +1149,6 @@ CONTAINS
       tddfpt_control => dft_control%tddfpt2_control
       dipole_form = tddfpt_control%dipole_form
 
-      NULLIFY (soc_section)
       soc_section => section_vals_get_subs_vals(qs_env%input, "PROPERTIES%TDDFPT%SOC")
 
       !! We may want to use a bigger grid then default
@@ -1162,15 +1162,16 @@ CONTAINS
          grid_info(irep, :) = k_list
       END DO
 
-      CALL soc_dipole_operator(soc_env%dipmat, tddfpt_control, qs_env)
+      CALL soc_dipole_operator(soc_env, tddfpt_control, qs_env, gs_mos)
 
-      !! We need to change and create structures for the exitation vectors.
-      !! All excited states shall be written in one matrix, oneafter the other
-      nstates = SIZE(evects_a, 2)
       nspins = SIZE(evects_a, 1)
       DO ispin = 1, nspins
          CALL cp_fm_get_info(evects_a(ispin, 1), nrow_global=nao, ncol_global=nactive)
       END DO
+
+      !! We need to change and create structures for the exitation vectors.
+      !! All excited states shall be written in one matrix, oneafter the other
+      nstates = SIZE(evects_a, 2)
 
       a_coeff => soc_env%a_coeff
       b_coeff => soc_env%b_coeff
@@ -1209,7 +1210,6 @@ CONTAINS
          CALL V_SOC_xyz_from_pseudopotential(qs_env, soc_atom_env%soc_pp)
       END IF
 
-      !  IF (all_potential_present) THEN
       !! Prepare the atomic grid we need to calculate the SOC Operator in an Atomic basis
       !! copied from init_xas_atom_grid_harmo for convenience
       CALL init_atom_grid(soc_atom_env, grid_info, qs_env)
@@ -1218,7 +1218,6 @@ CONTAINS
          NULLIFY (soc_atom_env%orb_sphi_so(ikind)%array)
          CALL compute_sphi_so(ikind, "ORB", soc_atom_env%orb_sphi_so(ikind)%array, qs_env)
       END DO !ikind
-      !  ENDIF
 
       DEALLOCATE (grid_info)
 
@@ -1412,10 +1411,13 @@ CONTAINS
 !> \param eps_filter ...
 !> \param dipole_form ...
 !> \param gs_mos ...
+!> \param evects_sing ...
+!> \param evects_trip ...
 ! **************************************************************************************************
    SUBROUTINE soc_dipol(qs_env, dbcsr_soc_package, soc_env, &
-                        soc_evecs_cfm, eps_filter, dipole_form, gs_mos)
-      TYPE(qs_environment_type)                          :: qs_env
+                        soc_evecs_cfm, eps_filter, dipole_form, gs_mos, &
+                        evects_sing, evects_trip)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(dbcsr_soc_package_type)                       :: dbcsr_soc_package
       TYPE(soc_env_type), TARGET                         :: soc_env
       TYPE(cp_cfm_type), INTENT(in)                      :: soc_evecs_cfm
@@ -1423,6 +1425,7 @@ CONTAINS
       INTEGER                                            :: dipole_form
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          POINTER                                         :: gs_mos
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects_sing, evects_trip
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'soc_dipol'
 
@@ -1462,7 +1465,8 @@ CONTAINS
       ALLOCATE (transdip(ntot, 1))
 
       CALL get_rcs_amew_op(amew_dip, soc_env, dbcsr_soc_package, &
-                           eps_filter, qs_env, gs_mos)
+                           eps_filter, qs_env, gs_mos, &
+                           evects_sing, evects_trip)
 
       DO i = 1, 3 !cartesian coord x, y, z
 
@@ -1496,7 +1500,7 @@ CONTAINS
       IF (dipole_form == tddfpt_dipole_length) THEN
          osc_str(:) = 2.0_dp/3.0_dp*soc_evals(:)*osc_str(:)
       ELSE
-         osc_str(:) = 2.0_dp/3.0_dp/soc_evals(:)*osc_str(:)
+         osc_str(:) = 2.0_dp/3.0_dp*soc_evals(:)*osc_str(:)
       END IF
 
       !clean-up
@@ -1521,22 +1525,27 @@ CONTAINS
 !> \param eps_filter ...
 !> \param qs_env ...
 !> \param gs_mos ...
+!> \param evects_sing ...
+!> \param evects_trip ...
 ! **************************************************************************************************
-   SUBROUTINE get_rcs_amew_op(amew_op, soc_env, dbcsr_soc_package, eps_filter, qs_env, gs_mos)
+   SUBROUTINE get_rcs_amew_op(amew_op, soc_env, dbcsr_soc_package, eps_filter, qs_env, gs_mos, &
+                              evects_sing, evects_trip)
 
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:), &
          INTENT(OUT)                                     :: amew_op
       TYPE(soc_env_type), TARGET                         :: soc_env
       TYPE(dbcsr_soc_package_type)                       :: dbcsr_soc_package
       REAL(dp), INTENT(IN)                               :: eps_filter
-      TYPE(qs_environment_type)                          :: qs_env
+      TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
          POINTER                                         :: gs_mos
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evects_sing, evects_trip
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'get_rcs_amew_op'
 
       INTEGER                                            :: dim_op, handle, i, isg, nactive, nao, &
                                                             nex, nsg, ntot, ntp
+      LOGICAL                                            :: vel_rep
       REAL(dp)                                           :: op, sqrt2
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: diag, gs_diag, gsgs_op
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: mo_op, sggs_block
@@ -1562,7 +1571,14 @@ CONTAINS
       NULLIFY (dbcsr_tp, dbcsr_sg, dbcsr_ovlp, dbcsr_work, dbcsr_tmp, dbcsr_prod)
 
       ! Initialization
-      ao_op => soc_env%dipmat
+      !! Fist case for length, secound for velocity-representation
+      IF (ASSOCIATED(soc_env%dipmat)) THEN
+         ao_op => soc_env%dipmat
+         vel_rep = .FALSE.
+      ELSE
+         ao_op => soc_env%dipmat_ao
+         vel_rep = .TRUE.
+      END IF
       nsg = SIZE(soc_env%evals_a)
       ntp = nsg; nex = nsg !all the same by construction, keep them separate for clarity
       ntot = 1 + nsg + 3*ntp
@@ -1605,7 +1621,6 @@ CONTAINS
       DO i = 1, dim_op
 
          ao_op_i => ao_op(i)%matrix
-
          CALL cp_dbcsr_sm_fm_multiply(ao_op_i, gs_coeffs, work_fm, ncol=nactive)
          CALL parallel_gemm('T', 'N', nactive, nactive, nao, &
                             1.0_dp, gs_coeffs, work_fm, 0.0_dp, gs_fm)
@@ -1650,8 +1665,14 @@ CONTAINS
          CALL cp_fm_get_submatrix(gs_fm, mo_op)  ! instead of prod_fm
 
          ! Compute the ground-state/singlet components. ao_op*gs_coeffs already stored in vec_op
-         CALL parallel_gemm('T', 'N', nactive*nsg, nactive, nao, &
-                            1.0_dp, soc_env%a_coeff, vec_op, 0.0_dp, sggs_fm)
+         IF (vel_rep) THEN
+            CALL dip_vel_op(soc_env, qs_env, evects_sing, dbcsr_prod, i, .FALSE., &
+                            gs_coeffs, sggs_fm)
+         ELSE
+            CALL parallel_gemm('T', 'N', nactive*nsg, nactive, nao, &
+                               1.0_dp, soc_env%a_coeff, vec_op, 0.0_dp, sggs_fm)
+         END IF
+
          DO isg = 1, nsg
             CALL cp_fm_get_submatrix(fm=sggs_fm, &
                                      target_m=sggs_block, &
@@ -1675,15 +1696,19 @@ CONTAINS
                              0.0_dp, dbcsr_ovlp, &
                              filter_eps=eps_filter)
 
-         !then the operator in the LR orbital basis
-         CALL dbcsr_multiply('N', 'N', 1.0_dp, &
-                             ao_op_i, dbcsr_sg, &
-                             0.0_dp, dbcsr_work, &
-                             filter_eps=eps_filter)
-         CALL dbcsr_multiply('T', 'N', 1.0_dp, &
-                             dbcsr_sg, dbcsr_work, &
-                             0.0_dp, dbcsr_prod, &
-                             filter_eps=eps_filter)
+         IF (vel_rep) THEN
+            CALL dip_vel_op(soc_env, qs_env, evects_sing, dbcsr_prod, i, .FALSE.)
+         ELSE
+            !then the operator in the LR orbital basis
+            CALL dbcsr_multiply('N', 'N', 1.0_dp, &
+                                ao_op_i, dbcsr_sg, &
+                                0.0_dp, dbcsr_work, &
+                                filter_eps=eps_filter)
+            CALL dbcsr_multiply('T', 'N', 1.0_dp, &
+                                dbcsr_sg, dbcsr_work, &
+                                0.0_dp, dbcsr_prod, &
+                                filter_eps=eps_filter)
+         END IF
 
          !use the soc routine, it is compatible
          CALL rcs_amew_soc_elements(dbcsr_tmp, &
@@ -1693,7 +1718,7 @@ CONTAINS
                                     pref_trace=-1.0_dp, &
                                     pref_overall=1.0_dp, &
                                     pref_diags=gsgs_op(i), &
-                                    symmetric=.TRUE.)  !!FOR DEBUG
+                                    symmetric=.TRUE.)
 
          CALL copy_dbcsr_to_fm(dbcsr_tmp, tmp_fm)
          CALL cp_fm_to_fm_submat(msource=tmp_fm, &
@@ -1718,14 +1743,18 @@ CONTAINS
                              filter_eps=eps_filter)
 
          !the operator in the LR orbital basis
-         CALL dbcsr_multiply('N', 'N', 1.0_dp, &
-                             ao_op_i, dbcsr_sg, &
-                             0.0_dp, dbcsr_work, &
-                             filter_eps=eps_filter)
-         CALL dbcsr_multiply('T', 'N', 1.0_dp, &
-                             dbcsr_sg, dbcsr_work, &
-                             0.0_dp, dbcsr_prod, &
-                             filter_eps=eps_filter)
+         IF (vel_rep) THEN
+            CALL dip_vel_op(soc_env, qs_env, evects_trip, dbcsr_prod, i, .TRUE.)
+         ELSE
+            CALL dbcsr_multiply('N', 'N', 1.0_dp, &
+                                ao_op_i, dbcsr_tp, &
+                                0.0_dp, dbcsr_work, &
+                                filter_eps=eps_filter)
+            CALL dbcsr_multiply('T', 'N', 1.0_dp, &
+                                dbcsr_tp, dbcsr_work, &
+                                0.0_dp, dbcsr_prod, &
+                                filter_eps=eps_filter)
+         END IF
 
          CALL rcs_amew_soc_elements(dbcsr_tmp, &
                                     dbcsr_prod, &
@@ -1734,7 +1763,7 @@ CONTAINS
                                     pref_trace=-1.0_dp, &
                                     pref_overall=1.0_dp, &
                                     pref_diags=gsgs_op(i), &
-                                    symmetric=.TRUE.)  !!FOR DEBUG
+                                    symmetric=.TRUE.)
 
          CALL copy_dbcsr_to_fm(dbcsr_tmp, tmp_fm)
          !<T^-1|op|T^-1>

--- a/src/qs_tddfpt2_soc_types.F
+++ b/src/qs_tddfpt2_soc_types.F
@@ -49,9 +49,12 @@ MODULE qs_tddfpt2_soc_types
    TYPE soc_env_type
       !! a :: singlet or spin-conserving b :: triplet or spin flip
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER       :: orb_soc => Null()
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER       :: dipmat_ao => Null()
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER       :: dipmat => Null()
       REAL(dp), POINTER, DIMENSION(:)                 :: evals_a => Null(), &
                                                          evals_b => Null()
+      TYPE(cp_fm_type), DIMENSION(:, :), ALLOCATABLE   :: CdS
+      TYPE(cp_fm_type), DIMENSION(:), ALLOCATABLE     :: SC, ediff
       TYPE(cp_fm_type)                                :: a_coeff = cp_fm_type(), &
                                                          b_coeff = cp_fm_type()
       REAL(dp), ALLOCATABLE, DIMENSION(:)             :: soc_evals, &
@@ -86,7 +89,7 @@ CONTAINS
       NULLIFY (soc_env%orb_soc)
       NULLIFY (soc_env%evals_a)
       NULLIFY (soc_env%evals_b)
-      NULLIFY (soc_env%dipmat)
+      NULLIFY (soc_env%dipmat, soc_env%dipmat_ao)
 
    END SUBROUTINE soc_env_create
 
@@ -97,7 +100,7 @@ CONTAINS
    SUBROUTINE soc_env_release(soc_env)
       TYPE(soc_env_type), TARGET                         :: soc_env
 
-      INTEGER                                            :: i
+      INTEGER                                            :: i, j
 
       IF (ASSOCIATED(soc_env%orb_soc)) THEN
          DO i = 1, SIZE(soc_env%orb_soc)
@@ -118,8 +121,30 @@ CONTAINS
          END DO
          DEALLOCATE (soc_env%dipmat)
       END IF
+      IF (ASSOCIATED(soc_env%dipmat_ao)) THEN
+         DO i = 1, SIZE(soc_env%dipmat_ao)
+            CALL dbcsr_release(soc_env%dipmat_ao(i)%matrix)
+            DEALLOCATE (soc_env%dipmat_ao(i)%matrix)
+         END DO
+         DEALLOCATE (soc_env%dipmat_ao)
+      END IF
       IF (ALLOCATED(soc_env%soc_evals)) DEALLOCATE (soc_env%soc_evals)
       IF (ALLOCATED(soc_env%soc_osc)) DEALLOCATE (soc_env%soc_osc)
+      IF (ALLOCATED(soc_env%CdS)) THEN
+         DO i = 1, SIZE(soc_env%CdS, 1)
+            DO j = 1, SIZE(soc_env%CdS, 2)
+               CALL cp_fm_release(soc_env%CdS(i, j))
+            END DO
+         END DO
+         DEALLOCATE (soc_env%CdS)
+      END IF
+      IF (ALLOCATED(soc_env%SC)) THEN
+         DO i = 1, SIZE(soc_env%SC)
+            CALL cp_fm_release(soc_env%SC(i))
+            CALL cp_fm_release(soc_env%ediff(i))
+         END DO
+         DEALLOCATE (soc_env%SC, soc_env%ediff)
+      END IF
 
    END SUBROUTINE soc_env_release
 

--- a/src/qs_tddfpt2_soc_utils.F
+++ b/src/qs_tddfpt2_soc_utils.F
@@ -6,31 +6,55 @@
 !--------------------------------------------------------------------------------------------------!
 
 ! **************************************************************************************************
-!> \brief Utilities for X-ray absorption spectroscopy using TDDFPT
-!> \author AB (01.2018)
-!> This subroutine was directly copied from xas_tdp_utils to prevent a
-!> circular dependency during the debug-Phase
+!> \brief Utilities absorption spectroscopy using TDDFPT with SOC
+!> \author JRVogt (12.2023)
 ! **************************************************************************************************
 
 MODULE qs_tddfpt2_soc_utils
+   USE cp_blacs_env,                    ONLY: cp_blacs_env_type
+   USE cp_cfm_types,                    ONLY: cp_cfm_get_info,&
+                                              cp_cfm_get_submatrix,&
+                                              cp_cfm_type
    USE cp_control_types,                ONLY: tddfpt2_control_type
-   USE cp_fm_types,                     ONLY: cp_fm_get_info,&
+   USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
+                                              copy_fm_to_dbcsr,&
+                                              cp_dbcsr_sm_fm_multiply,&
+                                              dbcsr_allocate_matrix_set,&
+                                              dbcsr_deallocate_matrix_set
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_schur_product
+   USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
+                                              cp_fm_struct_release,&
+                                              cp_fm_struct_type
+   USE cp_fm_types,                     ONLY: cp_fm_create,&
+                                              cp_fm_get_info,&
+                                              cp_fm_release,&
                                               cp_fm_set_all,&
+                                              cp_fm_to_fm,&
                                               cp_fm_to_fm_submat,&
                                               cp_fm_type
    USE dbcsr_api,                       ONLY: dbcsr_copy,&
+                                              dbcsr_create,&
+                                              dbcsr_desymmetrize,&
                                               dbcsr_get_info,&
                                               dbcsr_p_type,&
+                                              dbcsr_release,&
                                               dbcsr_type
    USE input_constants,                 ONLY: tddfpt_dipole_berry,&
                                               tddfpt_dipole_length,&
                                               tddfpt_dipole_velocity
    USE kinds,                           ONLY: dp
+   USE message_passing,                 ONLY: mp_para_env_type
    USE moments_utils,                   ONLY: get_reference_point
+   USE parallel_gemm_api,               ONLY: parallel_gemm
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
+   USE qs_ks_types,                     ONLY: qs_ks_env_type
+   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
    USE qs_operators_ao,                 ONLY: p_xyz_ao,&
                                               rRc_xyz_ao
+   USE qs_overlap,                      ONLY: build_overlap_matrix
+   USE qs_tddfpt2_soc_types,            ONLY: soc_env_type
+   USE qs_tddfpt2_types,                ONLY: tddfpt_ground_state_mos
 
 !$ USE OMP_LIB, ONLY: omp_get_max_threads, omp_get_thread_num
 #include "./base/base_uses.f90"
@@ -40,7 +64,7 @@ MODULE qs_tddfpt2_soc_utils
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_tddfpt2_soc_utils'
 
-   PUBLIC :: soc_dipole_operator, soc_contract_evect
+   PUBLIC :: soc_dipole_operator, soc_contract_evect, resort_evects, dip_vel_op
 
    !A helper type for SOC
    TYPE dbcsr_soc_package_type
@@ -58,15 +82,17 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Build the atomic dipole operator
-!> \param dipmat dipole operator
+!> \param soc_env ...
 !> \param tddfpt_control informations on how to build the operaot
 !> \param qs_env Qucikstep environment
+!> \param gs_mos ...
 ! **************************************************************************************************
-   SUBROUTINE soc_dipole_operator(dipmat, tddfpt_control, qs_env)
-      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(OUT), &
-         POINTER                                         :: dipmat
+   SUBROUTINE soc_dipole_operator(soc_env, tddfpt_control, qs_env, gs_mos)
+      TYPE(soc_env_type), TARGET                         :: soc_env
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
+      TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
+         INTENT(in)                                      :: gs_mos
 
       CHARACTER(len=*), PARAMETER :: routineN = 'soc_dipole_operator'
 
@@ -90,14 +116,12 @@ CONTAINS
       CALL get_qs_env(qs_env, matrix_s=matrix_s)
       CALL dbcsr_get_info(matrix_s(1)%matrix, nfullrows_total=nao)
 
-      !NULLIFY (dipmat)
-      ALLOCATE (dipmat(dim_op))
+      ALLOCATE (soc_env%dipmat_ao(dim_op))
       DO i_dim = 1, dim_op
-         ALLOCATE (dipmat(i_dim)%matrix)
-         CALL dbcsr_copy(dipmat(i_dim)%matrix, &
+         ALLOCATE (soc_env%dipmat_ao(i_dim)%matrix)
+         CALL dbcsr_copy(soc_env%dipmat_ao(i_dim)%matrix, &
                          matrix_s(1)%matrix, &
                          name="dipole operator matrix")
-         !CALL dbcsr_set(dipmat(i_dim)%matrix, 0.0_dp) !!This line needs to go for qs_tddfpt_properties like ao_op
       END DO
 
       SELECT CASE (tddfpt_control%dipole_form)
@@ -109,12 +133,16 @@ CONTAINS
                                   reference=tddfpt_control%dipole_reference, &
                                   ref_point=tddfpt_control%dipole_ref_point)
 
-         CALL rRc_xyz_ao(op=dipmat, qs_env=qs_env, rc=reference_point, order=1, &
+         CALL rRc_xyz_ao(op=soc_env%dipmat_ao, qs_env=qs_env, rc=reference_point, order=1, &
                          minimum_image=.FALSE., soft=.FALSE.)
+         !! This will lead to S C^virt C^virt,T Q_q (vgl Strand et al., J. Chem Phys. 150, 044702, 2019)
+         CALL length_rep(qs_env, gs_mos, soc_env)
       CASE (tddfpt_dipole_velocity)
-                  !!This Routine calcluates the dipole OPerator within the velocity-form within the ao basis
-                  !!This Operation is only used in xas_tdp and qs_tddfpt_soc, lines uses rmc_x_p_xyz_ao
-         CALL p_xyz_ao(dipmat, qs_env, minimum_image=.FALSE.)
+         !!This Routine calcluates the dipole Operator within the velocity-form within the ao basis
+         !!This Operation is only used in xas_tdp and qs_tddfpt_soc, lines uses rmc_x_p_xyz_ao
+         CALL p_xyz_ao(soc_env%dipmat_ao, qs_env, minimum_image=.FALSE.)
+         !! This will precomute SC^virt, (omega^a-omega^i)^-1 and C^virt dS/dq
+         CALL velocity_rep(qs_env, gs_mos, soc_env)
       CASE DEFAULT
          CPABORT("Unimplemented form of the dipole operator")
       END SELECT
@@ -122,6 +150,298 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE soc_dipole_operator
+
+! **************************************************************************************************
+!> \brief ...
+!> \param qs_env ...
+!> \param gs_mos ...
+!> \param soc_env ...
+! **************************************************************************************************
+   SUBROUTINE length_rep(qs_env, gs_mos, soc_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
+         INTENT(in)                                      :: gs_mos
+      TYPE(soc_env_type), TARGET                         :: soc_env
+
+      INTEGER                                            :: ideriv, ispin, nao, nderivs, nspins
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: nmo_virt
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(cp_fm_struct_type), POINTER                   :: dip_struct, fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: S_mos_virt
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: dipole_op_mos_occ
+      TYPE(cp_fm_type), POINTER                          :: dipmat_tmp, wfm_ao_ao
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+      TYPE(dbcsr_type), POINTER                          :: symm_tmp
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+
+      CALL get_qs_env(qs_env, matrix_s=matrix_s, blacs_env=blacs_env, para_env=para_env)
+
+      nderivs = 3
+      nspins = 1  !!We only account for rcs, will be changed in the future
+      CALL dbcsr_get_info(matrix_s(1)%matrix, nfullrows_total=nao)
+      ALLOCATE (S_mos_virt(nspins), dipole_op_mos_occ(3, nspins), &
+                wfm_ao_ao, nmo_virt(nspins), symm_tmp, dipmat_tmp)
+
+      CALL cp_fm_struct_create(dip_struct, context=blacs_env, ncol_global=nao, nrow_global=nao, para_env=para_env)
+
+      CALL dbcsr_allocate_matrix_set(soc_env%dipmat, nderivs)
+      CALL dbcsr_desymmetrize(matrix_s(1)%matrix, symm_tmp)
+      DO ideriv = 1, nderivs
+         ALLOCATE (soc_env%dipmat(ideriv)%matrix)
+         CALL dbcsr_create(soc_env%dipmat(ideriv)%matrix, template=symm_tmp, &
+                           name="contracted operator", matrix_type="N")
+         DO ispin = 1, nspins
+            CALL cp_fm_create(dipole_op_mos_occ(ideriv, ispin), matrix_struct=dip_struct)
+         END DO
+      END DO
+
+      CALL dbcsr_release(symm_tmp)
+      DEALLOCATE (symm_tmp)
+
+      DO ispin = 1, nspins
+         nmo_virt(ispin) = SIZE(gs_mos(ispin)%evals_virt)
+         CALL cp_fm_get_info(gs_mos(ispin)%mos_virt, matrix_struct=fm_struct)
+         CALL cp_fm_create(wfm_ao_ao, dip_struct)
+         CALL cp_fm_create(S_mos_virt(ispin), fm_struct)
+
+         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, &
+                                      gs_mos(ispin)%mos_virt, &
+                                      S_mos_virt(ispin), &
+                                      ncol=nmo_virt(ispin), alpha=1.0_dp, beta=0.0_dp)
+         CALL parallel_gemm('N', 'T', nao, nao, nmo_virt(ispin), &
+                            1.0_dp, S_mos_virt(ispin), gs_mos(ispin)%mos_virt, &
+                            0.0_dp, wfm_ao_ao)
+
+         DO ideriv = 1, nderivs
+            CALL cp_fm_create(dipmat_tmp, dip_struct)
+            CALL copy_dbcsr_to_fm(soc_env%dipmat_ao(ideriv)%matrix, dipmat_tmp)
+            CALL parallel_gemm('N', 'T', nao, nao, nao, &
+                               1.0_dp, wfm_ao_ao, dipmat_tmp, &
+                               0.0_dp, dipole_op_mos_occ(ideriv, ispin))
+            CALL copy_fm_to_dbcsr(dipole_op_mos_occ(ideriv, ispin), soc_env%dipmat(ideriv)%matrix)
+            CALL cp_fm_release(dipmat_tmp)
+         END DO
+         CALL cp_fm_release(wfm_ao_ao)
+         DEALLOCATE (wfm_ao_ao)
+      END DO
+
+      CALL cp_fm_struct_release(dip_struct)
+      DO ispin = 1, nspins
+         CALL cp_fm_release(S_mos_virt(ispin))
+         DO ideriv = 1, nderivs
+            CALL cp_fm_release(dipole_op_mos_occ(ideriv, ispin))
+         END DO
+      END DO
+      DEALLOCATE (S_mos_virt, dipole_op_mos_occ, nmo_virt, dipmat_tmp)
+
+   END SUBROUTINE length_rep
+
+! **************************************************************************************************
+!> \brief ...
+!> \param qs_env ...
+!> \param gs_mos ...
+!> \param soc_env ...
+! **************************************************************************************************
+   SUBROUTINE velocity_rep(qs_env, gs_mos, soc_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(tddfpt_ground_state_mos), DIMENSION(:), &
+         INTENT(in)                                      :: gs_mos
+      TYPE(soc_env_type), TARGET                         :: soc_env
+
+      INTEGER                                            :: icol, ideriv, irow, ispin, n_occ, &
+                                                            n_virt, nao, ncols_local, nderivs, &
+                                                            nrows_local, nspins
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
+      REAL(kind=dp)                                      :: eval_occ
+      REAL(kind=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: local_data_ediff, local_data_wfm
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(cp_fm_struct_type), POINTER                   :: ao_cvirt_struct, ao_nocc_struct, &
+                                                            cvirt_ao_struct, fm_struct, scrm_struct
+      TYPE(cp_fm_type)                                   :: scrm_fm, wfm_mo_virt_mo_occ
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, scrm
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_orb
+      TYPE(qs_ks_env_type), POINTER                      :: ks_env
+
+      NULLIFY (scrm, scrm_struct, blacs_env, matrix_s, ao_cvirt_struct, ao_nocc_struct, cvirt_ao_struct)
+      nspins = 1
+      nderivs = 3
+      ALLOCATE (soc_env%SC(nspins), soc_env%CdS(nspins, nderivs), soc_env%ediff(nspins))
+
+      CALL get_qs_env(qs_env, ks_env=ks_env, sab_orb=sab_orb, blacs_env=blacs_env, matrix_s=matrix_s)
+      CALL dbcsr_get_info(matrix_s(1)%matrix, nfullrows_total=nao)
+      CALL cp_fm_struct_create(scrm_struct, nrow_global=nao, ncol_global=nao, &
+                               context=blacs_env)
+      CALL cp_fm_get_info(gs_mos(1)%mos_virt, matrix_struct=ao_cvirt_struct)
+      CALL cp_fm_get_info(gs_mos(1)%mos_occ, matrix_struct=ao_nocc_struct)
+
+      CALL build_overlap_matrix(ks_env, matrix_s=scrm, nderivative=1, &
+                                basis_type_a="ORB", basis_type_b="ORB", &
+                                sab_nl=sab_orb)
+
+      DO ispin = 1, nspins
+         NULLIFY (fm_struct)
+         n_occ = SIZE(gs_mos(ispin)%evals_occ)
+         n_virt = SIZE(gs_mos(ispin)%evals_virt)
+         CALL cp_fm_struct_create(fm_struct, nrow_global=n_virt, &
+                                  ncol_global=n_occ, context=blacs_env)
+         CALL cp_fm_struct_create(cvirt_ao_struct, nrow_global=n_virt, &
+                                  ncol_global=nao, context=blacs_env)
+         CALL cp_fm_create(soc_env%ediff(ispin), fm_struct)
+         CALL cp_fm_create(wfm_mo_virt_mo_occ, fm_struct)
+         CALL cp_fm_create(soc_env%SC(ispin), ao_cvirt_struct)
+
+         CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, &
+                                      gs_mos(ispin)%mos_virt, &
+                                      soc_env%SC(ispin), &
+                                      ncol=n_virt, alpha=1.0_dp, beta=0.0_dp)
+
+         CALL cp_fm_get_info(soc_env%ediff(ispin), nrow_local=nrows_local, ncol_local=ncols_local, &
+                             row_indices=row_indices, col_indices=col_indices, local_data=local_data_ediff)
+         CALL cp_fm_get_info(wfm_mo_virt_mo_occ, local_data=local_data_wfm)
+
+!$OMP       PARALLEL DO DEFAULT(NONE), &
+!$OMP                PRIVATE(eval_occ, icol, irow), &
+!$OMP                SHARED(col_indices, gs_mos, ispin, local_data_ediff, ncols_local, nrows_local, row_indices)
+         DO icol = 1, ncols_local
+            ! E_occ_i ; imo_occ = col_indices(icol)
+            eval_occ = gs_mos(ispin)%evals_occ(col_indices(icol))
+
+            DO irow = 1, nrows_local
+               ! ediff_inv_weights(a, i) = 1.0 / (E_virt_a - E_occ_i)
+               ! imo_virt = row_indices(irow)
+               local_data_ediff(irow, icol) = 1.0_dp/(gs_mos(ispin)%evals_virt(row_indices(irow)) - eval_occ)
+            END DO
+         END DO
+!$OMP       END PARALLEL DO
+
+         DO ideriv = 1, nderivs
+            CALL cp_fm_create(soc_env%CdS(ispin, ideriv), cvirt_ao_struct)
+            CALL cp_fm_create(scrm_fm, scrm_struct)
+            CALL copy_dbcsr_to_fm(scrm(ideriv + 1)%matrix, scrm_fm)
+            CALL parallel_gemm('T', 'N', n_virt, nao, nao, 1.0_dp, gs_mos(ispin)%mos_virt, &
+                               scrm_fm, 0.0_dp, soc_env%CdS(ispin, ideriv))
+            CALL cp_fm_release(scrm_fm)
+
+         END DO
+
+         CALL cp_fm_release(wfm_mo_virt_mo_occ)
+         CALL cp_fm_struct_release(fm_struct)
+      END DO
+      CALL dbcsr_deallocate_matrix_set(scrm)
+      CALL cp_fm_struct_release(scrm_struct)
+      CALL cp_fm_struct_release(cvirt_ao_struct)
+
+   END SUBROUTINE velocity_rep
+
+! **************************************************************************************************
+!> \brief This routine will construct the dipol operator within velocity representation
+!> \param soc_env ..
+!> \param qs_env ...
+!> \param evec_fm ...
+!> \param op ...
+!> \param ideriv ...
+!> \param tp ...
+!> \param gs_coeffs ...
+!> \param sggs_fm ...
+! **************************************************************************************************
+   SUBROUTINE dip_vel_op(soc_env, qs_env, evec_fm, op, ideriv, tp, gs_coeffs, sggs_fm)
+      TYPE(soc_env_type), TARGET                         :: soc_env
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(cp_fm_type), DIMENSION(:, :), INTENT(IN)      :: evec_fm
+      TYPE(dbcsr_type), INTENT(INOUT)                    :: op
+      INTEGER, INTENT(IN)                                :: ideriv
+      LOGICAL, INTENT(IN)                                :: tp
+      TYPE(cp_fm_type), OPTIONAL, POINTER                :: gs_coeffs
+      TYPE(cp_fm_type), INTENT(INOUT), OPTIONAL          :: sggs_fm
+
+      INTEGER                                            :: iex, ispin, n_occ, n_virt, nao, nex
+      LOGICAL                                            :: sggs
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(cp_fm_struct_type), POINTER                   :: op_struct, virt_occ_struct
+      TYPE(cp_fm_type)                                   :: CdSC, op_fm, SCWCdSC, WCdSC
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: WCdSC_tmp
+      TYPE(cp_fm_type), POINTER                          :: coeff
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+
+      NULLIFY (virt_occ_struct, virt_occ_struct, op_struct, blacs_env, para_env, coeff)
+
+      IF (tp) THEN
+         coeff => soc_env%b_coeff
+      ELSE
+         coeff => soc_env%a_coeff
+      END IF
+
+      sggs = .FALSE.
+      IF (PRESENT(gs_coeffs)) sggs = .TRUE.
+
+      ispin = 1 !! only rcs availble
+      nex = SIZE(evec_fm, 2)
+      IF (.NOT. sggs) ALLOCATE (WCdSC_tmp(ispin, nex))
+      CALL get_qs_env(qs_env, blacs_env=blacs_env, para_env=para_env)
+      CALL cp_fm_get_info(soc_env%CdS(ispin, ideriv), ncol_global=nao, nrow_global=n_virt)
+      CALL cp_fm_get_info(evec_fm(1, 1), ncol_global=n_occ)
+
+      IF (sggs) THEN
+         CALL cp_fm_struct_create(virt_occ_struct, context=blacs_env, para_env=para_env, nrow_global=n_virt, &
+                                  ncol_global=n_occ)
+         CALL cp_fm_struct_create(op_struct, context=blacs_env, para_env=para_env, nrow_global=n_occ*nex, &
+                                  ncol_global=n_occ)
+      ELSE
+         CALL cp_fm_struct_create(virt_occ_struct, context=blacs_env, para_env=para_env, nrow_global=n_virt, &
+                                  ncol_global=n_occ*nex)
+         CALL cp_fm_struct_create(op_struct, context=blacs_env, para_env=para_env, nrow_global=n_occ*nex, &
+                                  ncol_global=n_occ*nex)
+      END IF
+
+      CALL cp_fm_create(CdSC, soc_env%ediff(ispin)%matrix_struct)
+      CALL cp_fm_create(op_fm, op_struct)
+
+      IF (sggs) THEN
+         CALL cp_fm_create(SCWCdSC, gs_coeffs%matrix_struct)
+         CALL cp_fm_create(WCdSC, soc_env%ediff(ispin)%matrix_struct)
+         CALL parallel_gemm('N', 'N', n_virt, n_occ, nao, 1.0_dp, soc_env%CdS(ispin, ideriv), &
+                            gs_coeffs, 0.0_dp, CdSC)
+         CALL cp_fm_schur_product(CdSC, soc_env%ediff(ispin), WCdSC)
+      ELSE
+         CALL cp_fm_create(SCWCdSC, coeff%matrix_struct)
+         DO iex = 1, nex
+            CALL cp_fm_create(WCdSC_tmp(ispin, iex), soc_env%ediff(ispin)%matrix_struct)
+            CALL parallel_gemm('N', 'N', n_virt, n_occ, nao, 1.0_dp, soc_env%CdS(ispin, ideriv), &
+                               evec_fm(ispin, iex), 0.0_dp, CdSC)
+            CALL cp_fm_schur_product(CdSC, soc_env%ediff(ispin), WCdSC_tmp(ispin, iex))
+         END DO
+         CALL cp_fm_create(WCdSC, virt_occ_struct)
+         CALL soc_contract_evect(WCdSC_tmp, WCdSC)
+         DO iex = 1, nex
+            CALL cp_fm_release(WCdSC_tmp(ispin, iex))
+         END DO
+         DEALLOCATE (WCdSC_tmp)
+      END IF
+
+      IF (sggs) THEN
+         CALL parallel_gemm('N', 'N', nao, n_occ, n_virt, 1.0_dp, soc_env%SC(ispin), WCdSC, 0.0_dp, SCWCdSC)
+         CALL parallel_gemm('T', 'N', n_occ*nex, n_occ, nao, 1.0_dp, soc_env%a_coeff, SCWCdSC, 0.0_dp, op_fm)
+      ELSE
+         CALL parallel_gemm('N', 'N', nao, n_occ*nex, n_virt, 1.0_dp, soc_env%SC(ispin), WCdSC, 0.0_dp, SCWCdSC)
+         CALL parallel_gemm('T', 'N', n_occ*nex, n_occ*nex, nao, 1.0_dp, coeff, SCWCdSC, 0.0_dp, op_fm)
+      END IF
+
+      IF (sggs) THEN
+         CALL cp_fm_to_fm(op_fm, sggs_fm)
+      ELSE
+         CALL copy_fm_to_dbcsr(op_fm, op)
+      END IF
+
+      CALL cp_fm_release(op_fm)
+      CALL cp_fm_release(WCdSC)
+      CALL cp_fm_release(SCWCdSC)
+      CALL cp_fm_release(CdSC)
+      CALL cp_fm_struct_release(virt_occ_struct)
+      CALL cp_fm_struct_release(op_struct)
+
+   END SUBROUTINE dip_vel_op
 
 ! **************************************************************************************************
 !> \brief ...
@@ -160,4 +480,94 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE soc_contract_evect
+
+! **************************************************************************************************
+!> \brief ...
+!> \param vec ...
+!> \param new_entry ...
+!> \param res ...
+!> \param res_int ...
+! **************************************************************************************************
+   SUBROUTINE test_repetition(vec, new_entry, res, res_int)
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: vec
+      INTEGER, INTENT(IN)                                :: new_entry
+      LOGICAL, INTENT(OUT)                               :: res
+      INTEGER, INTENT(OUT), OPTIONAL                     :: res_int
+
+      INTEGER                                            :: i
+
+      res = .TRUE.
+      IF (PRESENT(res_int)) res_int = -1
+
+      DO i = 1, SIZE(vec)
+         IF (vec(i) == new_entry) THEN
+            res = .FALSE.
+            IF (PRESENT(res_int)) res_int = i
+            EXIT
+         END IF
+      END DO
+
+   END SUBROUTINE test_repetition
+
+! **************************************************************************************************
+!> \brief Used to find out, which state has which spin-multiplicity
+!> \param evects_cfm ...
+!> \param sort ...
+! **************************************************************************************************
+   SUBROUTINE resort_evects(evects_cfm, sort)
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: evects_cfm
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: sort
+
+      COMPLEX(dp), ALLOCATABLE, DIMENSION(:, :)          :: cpl_tmp
+      INTEGER                                            :: i_rep, ii, jj, ntot, tmp
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: rep_int
+      LOGICAL                                            :: rep
+      REAL(dp)                                           :: max_dev, max_wfn, wfn_sq
+
+      CALL cp_cfm_get_info(evects_cfm, nrow_global=ntot)
+      ALLOCATE (cpl_tmp(ntot, ntot))
+      ALLOCATE (sort(ntot), rep_int(ntot))
+      cpl_tmp = 0_dp
+      sort = 0
+      max_dev = 0.5
+      CALL cp_cfm_get_submatrix(evects_cfm, cpl_tmp)
+
+      DO jj = 1, ntot
+         rep_int = 0
+         tmp = 0
+         max_wfn = 0_dp
+         DO ii = 1, ntot
+            wfn_sq = ABS(REAL(cpl_tmp(ii, jj)**2 - AIMAG(cpl_tmp(ii, jj)**2)))
+            IF (max_wfn .LE. wfn_sq) THEN
+               CALL test_repetition(sort, ii, rep, rep_int(ii))
+               IF (rep) THEN
+                  max_wfn = wfn_sq
+                  tmp = ii
+               END IF
+            END IF
+         END DO
+         IF (tmp > 0) THEN
+            sort(jj) = tmp
+         ELSE
+            DO i_rep = 1, ntot
+               IF (rep_int(i_rep) > 0) THEN
+                  max_wfn = ABS(REAL(cpl_tmp(sort(i_rep), jj)**2 - AIMAG(cpl_tmp(sort(i_rep), jj)**2))) - max_dev
+                  DO ii = 1, ntot
+                     wfn_sq = ABS(REAL(cpl_tmp(ii, jj)**2 - AIMAG(cpl_tmp(ii, jj)**2)))
+                     IF ((max_wfn - wfn_sq)/max_wfn .LE. max_dev) THEN
+                        CALL test_repetition(sort, ii, rep)
+                        IF (rep .AND. ii /= i_rep) THEN
+                           sort(jj) = sort(i_rep)
+                           sort(i_rep) = ii
+                        END IF
+                     END IF
+                  END DO
+               END IF
+            END DO
+         END IF
+      END DO
+
+      DEALLOCATE (cpl_tmp, rep_int)
+
+   END SUBROUTINE resort_evects
 END MODULE qs_tddfpt2_soc_utils


### PR DESCRIPTION
Removed a mistake from the oscillator strength for the TDDFT+SOC code. For light molecules with nearly no spin-orbit couplings, the code is now consistent with the qs_tddfpt2 module regarding the velocity and length representation. 