### PR TITLE
Enable compilation without deepmd (unused arguments)

### DIFF
--- a/src/deepmd_wrapper.F
+++ b/src/deepmd_wrapper.F
@@ -81,6 +81,7 @@ CONTAINS
 #if(__DEEPMD)
       pot = dp_deep_pot_c(c_model=TRIM(model)//C_NULL_CHAR)
 #else
+      MARK_USED(model)
       pot = C_NULL_PTR
 #endif
    END FUNCTION dp_deep_pot

--- a/src/manybody_deepmd.F
+++ b/src/manybody_deepmd.F
@@ -233,6 +233,7 @@ CONTAINS
       MARK_USED(fist_nonbond_env)
       MARK_USED(force)
       MARK_USED(pv_nonbond)
+      MARK_USED(use_virial)
 #else
       CALL fist_nonbond_env_get(fist_nonbond_env, deepmd_data=deepmd_data)
 


### PR DESCRIPTION
`MARK_USED` for unused arguments when compiling without deepmd.