### PR TITLE
doc: add DeePMD-kit document

### DIFF
--- a/docs/methods/machine_learning/deepmd.md
+++ b/docs/methods/machine_learning/deepmd.md
@@ -1,0 +1,44 @@
+# DeePMD-kit
+
+DeePMD-kit is a package written in Python/C++, designed to minimize the effort required to build
+deep learning-based models of interatomic potential energy and force field and to perform molecular
+dynamics (MD). This brings new hopes to addressing the accuracy-versus-efficiency dilemma in
+molecular simulations. Applications of DeePMD-kit span from finite molecules to extended systems and
+from metallic systems to chemically bonded systems.
+
+## Input Section
+
+Inference in CP2K is performed through the
+[DEEPMD](#CP2K_INPUT.FORCE_EVAL.MM.FORCEFIELD.NONBONDED.DEEPMD) section. As an example, the relevant
+section for DeePMD-kit is:
+
+```none
+&DEEPMD
+  ATOMS W
+  ATOMS_DEEPMD_TYPE 0
+  POT_FILE_NAME DeePMD/W.pb
+&END DEEPMD
+```
+
+where the `W.pb` refers to the DeePMD model that was deployed using DeePMD-kit. An example for the
+full input file can be found and on the regtests, see
+[DeePMD_W.inp](https://github.com/cp2k/cp2k/blob/master/tests/Fist/regtest-deepmd/DeePMD_W.inp)
+
+### Input details
+
+The tag [ATOMS](#CP2K_INPUT.FORCE_EVAL.MM.FORCEFIELD.NONBONDED.DEEPMD.ATOMS) expects a list of
+elements/kinds (`ATOMS`) and a list of their index (`ATOMS_DEEPMD_TYPE`) that is consistent with the
+`type_map` in DeePMD-kit parameters. If this is not done unphysical results will be obtained.
+Spotting such issues is quite straightforward as the energy is significantly wrong.
+
+## Compiling CP2K with Libdeepmd_c
+
+Running with DeePMD-kit requires compiling CP2K with the libdeepmd_c library. For the CP2K binaries
+installing the toolchain using the flag `--with-deepmd` is enough.
+
+## Further Resources
+
+For additional references on Deep Potential and DeePMD-kit see:
+
+- DeepMD paper [](#Wang2018), [](#Zeng2023) and code <https://github.com/deepmodeling/deepmd-kit>
+- [DeepModeling documentations](https://docs.deepmodeling.com/)

--- a/docs/methods/machine_learning/deepmd.md
+++ b/docs/methods/machine_learning/deepmd.md
@@ -26,15 +26,17 @@ full input file can be found and on the regtests, see
 
 ### Input details
 
-The tag [ATOMS](#CP2K_INPUT.FORCE_EVAL.MM.FORCEFIELD.NONBONDED.DEEPMD.ATOMS) expects a list of
-elements/kinds (`ATOMS`) and a list of their index (`ATOMS_DEEPMD_TYPE`) that is consistent with the
-`type_map` in DeePMD-kit parameters. If this is not done unphysical results will be obtained.
-Spotting such issues is quite straightforward as the energy is significantly wrong.
+The tag [ATOMS](#CP2K_INPUT.FORCE_EVAL.MM.FORCEFIELD.NONBONDED.DEEPMD.ATOMS) expects a list of elements/kinds 
+and [ATOMS_DEEPMD_TYPE](#CP2K_INPUT.FORCE_EVAL.MM.FORCEFIELD.NONBONDED.DEEPMD.ATOMS_DEEPMD_TYPE)
+expects a list of their index that is consistent with the `type_map` in DeePMD-kit parameters. 
+If this is not done unphysical results will be obtained. Spotting such issues is quite 
+straightforward as the energy is significantly wrong.
 
 ## Compiling CP2K with Libdeepmd_c
 
-Running with DeePMD-kit requires compiling CP2K with the libdeepmd_c library. For the CP2K binaries
-installing the toolchain using the flag `--with-deepmd` is enough.
+Running with DeePMD-kit requires compiling CP2K with the libdeepmd_c library. For the CP2K binaries, 
+please install the toolchain using the flag `--with-deepmd`, which would download libdeepmd_c from 
+DeePMD-kit Github release and compile. GPU support is enabled when CUDA envrionment exists.
 
 ## Further Resources
 

--- a/docs/methods/machine_learning/deepmd.md
+++ b/docs/methods/machine_learning/deepmd.md
@@ -26,16 +26,17 @@ full input file can be found and on the regtests, see
 
 ### Input details
 
-The tag [ATOMS](#CP2K_INPUT.FORCE_EVAL.MM.FORCEFIELD.NONBONDED.DEEPMD.ATOMS) expects a list of elements/kinds 
-and [ATOMS_DEEPMD_TYPE](#CP2K_INPUT.FORCE_EVAL.MM.FORCEFIELD.NONBONDED.DEEPMD.ATOMS_DEEPMD_TYPE)
-expects a list of their index that is consistent with the `type_map` in DeePMD-kit parameters. 
-If this is not done unphysical results will be obtained. Spotting such issues is quite 
-straightforward as the energy is significantly wrong.
+The tag [ATOMS](#CP2K_INPUT.FORCE_EVAL.MM.FORCEFIELD.NONBONDED.DEEPMD.ATOMS) expects a list of
+elements/kinds and
+[ATOMS_DEEPMD_TYPE](#CP2K_INPUT.FORCE_EVAL.MM.FORCEFIELD.NONBONDED.DEEPMD.ATOMS_DEEPMD_TYPE) expects
+a list of their index that is consistent with the `type_map` in DeePMD-kit parameters. If this is
+not done unphysical results will be obtained. Spotting such issues is quite straightforward as the
+energy is significantly wrong.
 
 ## Compiling CP2K with Libdeepmd_c
 
-Running with DeePMD-kit requires compiling CP2K with the libdeepmd_c library. For the CP2K binaries, 
-please install the toolchain using the flag `--with-deepmd`, which would download libdeepmd_c from 
+Running with DeePMD-kit requires compiling CP2K with the libdeepmd_c library. For the CP2K binaries,
+please install the toolchain using the flag `--with-deepmd`, which would download libdeepmd_c from
 DeePMD-kit Github release and compile. GPU support is enabled when CUDA envrionment exists.
 
 ## Further Resources

--- a/docs/methods/machine_learning/index.md
+++ b/docs/methods/machine_learning/index.md
@@ -8,4 +8,5 @@ maxdepth: 1
 nequip
 nnp
 pao-ml
+deepmd
 ```


### PR DESCRIPTION
As mentioned in #3145, add a single document for DeePMD-kit in Machine Learning section, following the pattern of NequiP.