### PR TITLE
MPI: Remove CONTIGUOUS from mp_free_mem to work around Flang bug

### DIFF
--- a/src/mpiwrap/message_passing.fypp
+++ b/src/mpiwrap/message_passing.fypp
@@ -4711,8 +4711,8 @@
 !> \param[out] stat      (optional) allocation status result
 ! **************************************************************************************************
    SUBROUTINE mp_free_mem_${nametype1}$ (DATA, stat)
-      ${type1}$, CONTIGUOUS, DIMENSION(:), &
-         POINTER, ASYNCHRONOUS                                :: DATA
+      ${type1}$, DIMENSION(:), &
+         POINTER, ASYNCHRONOUS                 :: DATA
       INTEGER, INTENT(OUT), OPTIONAL           :: stat
 
 #if defined(__parallel)


### PR DESCRIPTION
@fstein93 do you think this is reasonable? I'd expect that `free` fails in any case if the wrong pointer is passed.