### PR TITLE
Drop testing of Sirius on Piz Daint (daint-gpu)

### DIFF
--- a/arch/CRAY-XC50-gnu.psmp
+++ b/arch/CRAY-XC50-gnu.psmp
@@ -6,14 +6,13 @@
 #              Cray-FFTW 3.3.8.10, COSMA 2.6.6, ELPA 2023.05.001,
 #              HDF5 1.14.2, LIBINT 2.6.0, LIBPEXSI 1.2.0,
 #              LIBXC 6.2.2, LIBVORI 220621, LIBXSMM 1.17,
-#              PLUMED 2.9.0, SIRIUS 7.5.2, SPGLIB 1.16.2,
-#              LIBGRPP 20231215
+#              PLUMED 2.9.0, SPGLIB 1.16.2, LIBGRPP 20231215
 #
 # Usage: Source this arch file and then run make as instructed.
 #        A full toolchain installation is performed as default.
 #        Replace or adapt the "module add" commands below if needed.
 #
-# Last update: 15.01.2024
+# Last update: 25.01.2024
 #
 # \
    if [ "${0}" = "${BASH_SOURCE}" ]; then \
@@ -49,7 +48,7 @@
    echo "To load the required modules in your batch job script, use:"; \
    echo "   module restore cp2k_gpu_gnu_psmp"; \
    cd tools/toolchain; \
-   ./install_cp2k_toolchain.sh --enable-cuda=yes --gpu-ver=P100 -j${maxtasks} --no-arch-files --with-gcc=system --with-libvdwxc --with-pexsi --with-plumed; \
+   ./install_cp2k_toolchain.sh --enable-cuda=yes --gpu-ver=P100 -j${maxtasks} --no-arch-files --with-gcc=system --with-libvdwxc --with-pexsi --with-plumed --with-sirius=no; \
    cd ../..; \
    printf "Sourcing ${PWD}/tools/toolchain/install/setup ... "; \
    source ${PWD}/tools/toolchain/install/setup; \
@@ -81,12 +80,12 @@ USE_LIBXSMM    := 1.17
 USE_PLUMED     := 2.9.0
 #USE_QUIP       := 0.9.10
 #USE_DEEPMD     := 2.2.7
-USE_SIRIUS     := 7.5.2
+#USE_SIRIUS     := 7.5.2
 USE_SPGLIB     := 1.16.2
 # Only needed for SIRIUS
-LIBVDWXC_VER   := 0.4.0
-SPFFT_VER      := 1.0.6
-SPLA_VER       := 1.5.5
+#LIBVDWXC_VER   := 0.4.0
+#SPFFT_VER      := 1.0.6
+#SPLA_VER       := 1.5.5
 # Only needed for LIBPEXSI
 SCOTCH_VER     := 6.0.0
 SUPERLU_VER    := 6.1.0


### PR DESCRIPTION
Sirius >= 7.5.2 requires cuda >= 11.4 which is not available on Piz Daint (see #3228).