### PR TITLE
Avoid invariant hash-calculation

### DIFF
--- a/src/core_ppnl.F
+++ b/src/core_ppnl.F
@@ -564,6 +564,9 @@ CONTAINS
 
             ! loop over all kinds for projector atom
             IF (ASSOCIATED(h_block)) THEN
+!$             iatom8 = INT(iatom - 1, int_8)*INT(natom, int_8) + INT(jatom, int_8)
+!$             hash = INT(MOD(iatom8, INT(nlock, int_8)) + 1)
+
                DO kkind = 1, nkind
                   iac = ikind + nkind*(kkind - 1)
                   ibc = jkind + nkind*(kkind - 1)
@@ -589,8 +592,6 @@ CONTAINS
                            na = SIZE(acint, 1)
                            np = SIZE(acint, 2)
                            nb = SIZE(bcint, 1)
-!$                         iatom8 = INT(iatom - 1, int_8)*INT(natom, int_8) + INT(jatom, int_8)
-!$                         hash = INT(MOD(iatom8, INT(nlock, int_8)) + 1)
 !$                         CALL omp_set_lock(locks(hash))
                            IF (.NOT. do_dR) THEN
                               IF (iatom <= jatom) THEN


### PR DESCRIPTION
- This resolves a common issue when running CP2K built with no optimizations aka debug (-O0).
- With O0, GNU Fortran of course omits to perform Loop-Invariant-Code-Motion (LICM).
- Code in question previously caused checks claiming negative bounds (lock array).
- Now hoisting hash calculation in the outer possible loop (also more beautiful).