### PR TITLE
Rename reference Graml2023 to Graml2024

### DIFF
--- a/docs/methods/properties/bandstructure_gw.md
+++ b/docs/methods/properties/bandstructure_gw.md
@@ -225,7 +225,7 @@ convergence is found, the code terminates earlier. "SC_GW0_ITER 1" corresponds t
 
 ## 5. GW for 2D materials: Example monolayer MoS2
 
-There is also a periodic GW implementation [](#Graml2023) in CP2K that targets large cells of 2D
+There is also a periodic GW implementation [](#Graml2024) in CP2K that targets large cells of 2D
 materials, for example defects or moiré structures.
 
 For computing the G0W0@LDA quasiparticle energy levels of monolayer MoS2, please use the input file
@@ -350,9 +350,9 @@ Some remarks:
 
 - The computational parameters from the input file reach numerical convergence of the band gap
   within ~ 50 meV (TZVP basis set, 10 time/frequency points). Detailed convergence test is available
-  in the SI, Table S1 of [](#Graml2023) (SI is an ancillary file that can be downloaded via
-  [arXiv:2306.16066v1](https://arxiv.org/format/2306.16066) "Download source"). We recommend the
-  numerical parameters from the input file for large-scale GW calculations.
+  in the SI, Table S1 of [](#Graml2024) (SI is an ancillary file that can be downloaded
+  [here](https://ndownloader.figstatic.com/files/44545568)). We recommend the numerical parameters
+  from the input file for large-scale GW calculations.
 
 - The code also outputs SOC splittings of the levels based on the SOC parameters from
   Hartwigsen-Goedecker-Hutter pseudopotentials [](#Hartwigsen1998). DFT eigenvalues with SOC are

--- a/src/common/bibliography.F
+++ b/src/common/bibliography.F
@@ -89,8 +89,9 @@ MODULE bibliography
                             Wilhelm2016a, Wilhelm2016b, Wilhelm2017, Wilhelm2018, Wilhelm2021, Lass2018, &
                             cp2kqs2020, Behler2007, Behler2011, Schran2020a, Schran2020b, &
                             Rycroft2009, Thomas2015, Brehm2018, Brehm2020, Shigeta2001, Heinecke2016, &
-                            Brehm2021, Bussy2021a, Bussy2021b, Ditler2021, Ditler2022, Mattiat2019, Mattiat2022, &
-                            Belleflamme2023, Knizia2013, Musaelian2023, Eriksen2020, Graml2023, Bussy2023, Wang2018, Zeng2023
+                            Brehm2021, Bussy2021a, Bussy2021b, Ditler2021, Ditler2022, Mattiat2019, &
+                            Mattiat2022, Belleflamme2023, Knizia2013, Musaelian2023, Eriksen2020, &
+                            Bussy2023, Wang2018, Zeng2023, Graml2024
 
 CONTAINS
 
@@ -4890,7 +4891,7 @@ CONTAINS
                          "ER"), &
                          DOI="10.1063/5.0030764")
 
-      CALL add_reference(key=Graml2023, ISI_record=s2a( &
+      CALL add_reference(key=Graml2024, ISI_record=s2a( &
                          "AU Graml, Maximilian", &
                          "   Zollner, Klaus", &
                          "   Hernangómez-Pérez, Daniel", &

--- a/src/gw_utils.F
+++ b/src/gw_utils.F
@@ -14,7 +14,7 @@ MODULE gw_utils
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind_set
    USE basis_set_types,                 ONLY: gto_basis_set_type
-   USE bibliography,                    ONLY: Graml2023,&
+   USE bibliography,                    ONLY: Graml2024,&
                                               cite_reference
    USE cell_types,                      ONLY: cell_type,&
                                               pbc
@@ -122,7 +122,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL cite_reference(Graml2023)
+      CALL cite_reference(Graml2024)
 
       CALL read_gw_input_parameters(bs_env, bs_sec)
 


### PR DESCRIPTION
Follow up to #3290.