### PR TITLE
bump DeePMD-kit to 2.2.9 and fix memory leaks

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -470,6 +470,7 @@ DeePMD-kit - Deep Potential Molecular Dyanmics. Support for DeePMD-kit can be en
 
 - DeePMD-kit C interface can be downloaded from
   <https://docs.deepmodeling.com/projects/deepmd/en/master/install/install-from-c-library.html>
+  (v2.2.9 or above).
 - For more information see <https://github.com/deepmodeling/deepmd-kit.git>.
 
 ## 3. Compile

--- a/arch/CRAY-XC50-gnu.psmp
+++ b/arch/CRAY-XC50-gnu.psmp
@@ -71,7 +71,7 @@
 DO_CHECKS      := no
 USE_ACC        := yes
 USE_COSMA      := 2.6.6
-#USE_DEEPMD     := 2.2.7
+#USE_DEEPMD     := 2.2.9
 USE_ELPA       := 2023.05.001
 USE_HDF5       := 1.14.2
 USE_LIBGRPP    := 20231215

--- a/src/deepmd_wrapper.F
+++ b/src/deepmd_wrapper.F
@@ -159,7 +159,10 @@ CONTAINS
          END SUBROUTINE
       END INTERFACE
 
+#if defined(__DEEPMD)
       CALL DeleteDeepPot(model%c_ptr)
+#endif
+      model%c_ptr = C_NULL_PTR
    END SUBROUTINE deepmd_model_release
 
 END MODULE deepmd_wrapper

--- a/src/deepmd_wrapper.F
+++ b/src/deepmd_wrapper.F
@@ -156,7 +156,7 @@ CONTAINS
             IMPORT :: C_PTR
             IMPLICIT NONE
             TYPE(C_PTR)  :: model
-         END SUBROUTINE
+         END SUBROUTINE DeleteDeepPot
       END INTERFACE
 
 #if defined(__DEEPMD)

--- a/src/deepmd_wrapper.F
+++ b/src/deepmd_wrapper.F
@@ -150,7 +150,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE deepmd_model_release(model)
       TYPE(deepmd_model_type)                            :: model
+  
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'deepmd_model_release'
 
+      INTEGER                                            :: handle
       INTERFACE
          SUBROUTINE DeleteDeepPot(model) BIND(C, name="DP_DeleteDeepPot")
             IMPORT :: C_PTR
@@ -158,6 +161,8 @@ CONTAINS
             TYPE(C_PTR)  :: model
          END SUBROUTINE DeleteDeepPot
       END INTERFACE
+
+      CALL timeset(routineN, handle)
 
 #if defined(__DEEPMD)
       CALL DeleteDeepPot(model%c_ptr)

--- a/src/deepmd_wrapper.F
+++ b/src/deepmd_wrapper.F
@@ -150,8 +150,15 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE deepmd_model_release(model)
       TYPE(deepmd_model_type)                            :: model
+      INTERFACE
+         FUNCTION DP_DeleteDeepPot(dp) BIND(C, name="DP_DeleteDeepPot")
+            IMPORT :: C_PTR
+            IMPLICIT NONE
+            TYPE(C_PTR)  :: dp
+         END FUNCTION
+      END INTERFACE
 
-      model%c_ptr = C_NULL_PTR
+      CALL DP_DeleteDeepPot(model%c_ptr)
    END SUBROUTINE deepmd_model_release
 
 END MODULE deepmd_wrapper

--- a/src/deepmd_wrapper.F
+++ b/src/deepmd_wrapper.F
@@ -152,10 +152,10 @@ CONTAINS
       TYPE(deepmd_model_type)                            :: model
 
       INTERFACE
-         SUBROUTINE DeleteDeepPot(dp) BIND(C, name="DP_DeleteDeepPot")
+         SUBROUTINE DeleteDeepPot(model) BIND(C, name="DP_DeleteDeepPot")
             IMPORT :: C_PTR
             IMPLICIT NONE
-            TYPE(C_PTR)  :: dp
+            TYPE(C_PTR)  :: model
          END SUBROUTINE
       END INTERFACE
 

--- a/src/deepmd_wrapper.F
+++ b/src/deepmd_wrapper.F
@@ -150,15 +150,16 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE deepmd_model_release(model)
       TYPE(deepmd_model_type)                            :: model
+
       INTERFACE
-         FUNCTION DP_DeleteDeepPot(dp) BIND(C, name="DP_DeleteDeepPot")
+         SUBROUTINE DeleteDeepPot(dp) BIND(C, name="DP_DeleteDeepPot")
             IMPORT :: C_PTR
             IMPLICIT NONE
             TYPE(C_PTR)  :: dp
-         END FUNCTION
+         END SUBROUTINE
       END INTERFACE
 
-      CALL DP_DeleteDeepPot(model%c_ptr)
+      CALL DeleteDeepPot(model%c_ptr)
    END SUBROUTINE deepmd_model_release
 
 END MODULE deepmd_wrapper

--- a/src/deepmd_wrapper.F
+++ b/src/deepmd_wrapper.F
@@ -150,8 +150,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE deepmd_model_release(model)
       TYPE(deepmd_model_type)                            :: model
-  
-      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'deepmd_model_release'
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'deepmd_model_release'
 
       INTEGER                                            :: handle
       INTERFACE

--- a/tools/toolchain/scripts/stage6/install_deepmd.sh
+++ b/tools/toolchain/scripts/stage6/install_deepmd.sh
@@ -89,6 +89,7 @@ export CP_CFLAGS="\${CP_CFLAGS} ${DEEPMD_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${DEEPMD_LDFLAGS}"
 export CP_LIBS="\${CP_LIBS} ${DEEPMD_LIBS}"
 EOF
+fi
 
 load "${BUILDDIR}/setup_deepmd"
 write_toolchain_env "${INSTALLDIR}"

--- a/tools/toolchain/scripts/stage6/install_deepmd.sh
+++ b/tools/toolchain/scripts/stage6/install_deepmd.sh
@@ -89,6 +89,10 @@ export CP_CFLAGS="\${CP_CFLAGS} ${DEEPMD_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${DEEPMD_LDFLAGS}"
 export CP_LIBS="\${CP_LIBS} ${DEEPMD_LIBS}"
 EOF
+  cat << EOF >> "${INSTALLDIR}/lsan.supp"
+# leaks related to DeePMD-kit and TensorFlow
+leak:deepmd::AtomMap::AtomMap
+EOF
 fi
 
 load "${BUILDDIR}/setup_deepmd"

--- a/tools/toolchain/scripts/stage6/install_deepmd.sh
+++ b/tools/toolchain/scripts/stage6/install_deepmd.sh
@@ -6,9 +6,9 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-deepmd_ver="2.2.7"
+deepmd_ver="2.2.9"
 deepmd_pkg="libdeepmd_c-${deepmd_ver}.tar.gz"
-deepmd_sha256="605bbb0c3bcc847ecbfe7326bac9ff4cac5690accc8083122e3735290bb923ae"
+deepmd_sha256="01157fb3f8bbdeec7a25b72abc34cb26c1a46a1fff61625ec9585066c2233456"
 
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}"/common_vars.sh
@@ -89,12 +89,6 @@ export CP_CFLAGS="\${CP_CFLAGS} ${DEEPMD_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${DEEPMD_LDFLAGS}"
 export CP_LIBS="\${CP_LIBS} ${DEEPMD_LIBS}"
 EOF
-  cat << EOF >> "${INSTALLDIR}/lsan.supp"
-# leaks related to DeePMD-kit and TensorFlow
-leak:DP_NewDeepPot
-leak:deepmd::AtomMap::AtomMap
-EOF
-fi
 
 load "${BUILDDIR}/setup_deepmd"
 write_toolchain_env "${INSTALLDIR}"

--- a/tools/toolchain/scripts/stage6/install_deepmd.sh
+++ b/tools/toolchain/scripts/stage6/install_deepmd.sh
@@ -37,7 +37,11 @@ case "$with_deepmd" in
       if [ -f ${deepmd_pkg} ]; then
         echo "${deepmd_pkg} is found"
       else
-        download_pkg_from_cp2k_org "${deepmd_sha256}" "${deepmd_pkg}"
+        # download_pkg_from_cp2k_org "${deepmd_sha256}" "${deepmd_pkg}"
+        # TODO: saved to cp2k.org
+        wget ${DOWNLOADER_FLAGS} --quiet \
+          https://github.com/deepmodeling/deepmd-kit/releases/download/v${deepmd_ver}/libdeepmd_c.tar.gz \
+          -O "${deepmd_pkg}"
       fi
       [ -d libdeepmd_c ] && rm -rf libdeepmd_c
       echo "Installing from scratch into ${pkg_install_dir}"

--- a/tools/toolchain/scripts/stage6/install_deepmd.sh
+++ b/tools/toolchain/scripts/stage6/install_deepmd.sh
@@ -37,11 +37,7 @@ case "$with_deepmd" in
       if [ -f ${deepmd_pkg} ]; then
         echo "${deepmd_pkg} is found"
       else
-        # download_pkg_from_cp2k_org "${deepmd_sha256}" "${deepmd_pkg}"
-        # TODO: saved to cp2k.org
-        wget ${DOWNLOADER_FLAGS} --quiet \
-          https://github.com/deepmodeling/deepmd-kit/releases/download/v${deepmd_ver}/libdeepmd_c.tar.gz \
-          -O "${deepmd_pkg}"
+        download_pkg_from_cp2k_org "${deepmd_sha256}" "${deepmd_pkg}"
       fi
       [ -d libdeepmd_c ] && rm -rf libdeepmd_c
       echo "Installing from scratch into ${pkg_install_dir}"


### PR DESCRIPTION
We recently fixed all memory leaks in DeePMD-kit in https://github.com/deepmodeling/deepmd-kit/pull/3223 and released it as v2.2.9. So I bumped the DeePMD-kit version to 2.2.9, call `DP_DeleteDeepPot`, and removed the addition to `lsan.supp`, and I'd like to see whether it works.