### PR TITLE
Cp2k hp margherita

### DIFF
--- a/src/cp_control_types.F
+++ b/src/cp_control_types.F
@@ -29,19 +29,18 @@ MODULE cp_control_types
 
    PRIVATE
 
-!MARGHERITA 
 !***************************************************************************************************
-!\Control parameters for Hair Probes 
+!\brief Control parameters for a Hairy Probes DFT calculation
 !***************************************************************************************************
-   TYPE hair_probes_type 
-      REAL(kind=dp)                        :: alpha          !8th implementation - parameter      
+   TYPE hairy_probes_type 
+      REAL(kind=dp)                        :: alpha          !parameter for solution probes
       REAL(kind=dp)                        :: mu             !chemical potenatial of electron in reservoir 
       REAL(kind=dp)                        :: T              !temperature of electrons in reservoir 
       REAL(kind=dp)                        :: eps_hp         !tolerance for accuracy checks on occupation numbers 
-                                                             !calculated with hair_probes
+                                                             !calculated with hairy_probes
       INTEGER                              :: natoms, last_ao, first_ao
       INTEGER,DIMENSION(:),POINTER         :: atom_ids      !atom ids to which the probes are attached
-   END TYPE hair_probes_type 
+   END TYPE hairy_probes_type 
 !***************************************************************************************************
 
 ! **************************************************************************************************
@@ -581,8 +580,8 @@ MODULE cp_control_types
       TYPE(xas_control_type), POINTER      :: xas_control => NULL()
       TYPE(expot_control_type), POINTER    :: expot_control => NULL()
       TYPE(maxwell_control_type), POINTER  :: maxwell_control => NULL()
-      TYPE(hair_probes_type), POINTER, &
-              DIMENSION(:)                 :: probe => NULL() !MARGHERITA      
+      TYPE(hairy_probes_type), POINTER, &
+              DIMENSION(:)                 :: probe => NULL()     
       TYPE(efield_p_type), POINTER, &
          DIMENSION(:)                      :: efield_fields => NULL()
       INTEGER                              :: nspins = 0, &
@@ -636,7 +635,7 @@ MODULE cp_control_types
                                               do_sccs = .FALSE., &
                                               apply_embed_pot = .FALSE., &
                                               apply_dmfet_pot = .FALSE., &
-                                              hair_probes = .FALSE. !MARGHERITA
+                                              hairy_probes = .FALSE. 
    END TYPE dft_control_type
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'cp_control_types'
@@ -662,7 +661,7 @@ MODULE cp_control_types
              rtp_control_type, &
              sccs_control_type, &
              stda_control_type, &
-             hair_probes_type !MARGHERITA
+             hairy_probes_type 
 
    ! Public subroutines
 
@@ -795,11 +794,11 @@ CONTAINS
       NULLIFY (dft_control%maxwell_control)
       NULLIFY (dft_control%rtp_control)
       NULLIFY (dft_control%sccs_control)
-      NULLIFY (dft_control%probe) !MARGHERITA
+      NULLIFY (dft_control%probe) 
       dft_control%do_sccs = .FALSE.
       dft_control%apply_embed_pot = .FALSE.
       dft_control%apply_dmfet_pot = .FALSE.
-      dft_control%hair_probes = .FALSE. !MARGHERITA 
+      dft_control%hairy_probes = .FALSE. 
       CALL qs_control_create(dft_control%qs_control)
       CALL tddfpt2_control_create(dft_control%tddfpt2_control)
    END SUBROUTINE dft_control_create

--- a/src/cp_control_types.F
+++ b/src/cp_control_types.F
@@ -29,6 +29,21 @@ MODULE cp_control_types
 
    PRIVATE
 
+!MARGHERITA 
+!***************************************************************************************************
+!\Control parameters for Hair Probes 
+!***************************************************************************************************
+   TYPE hair_probes_type 
+      REAL(kind=dp)                        :: alpha          !8th implementation - parameter      
+      REAL(kind=dp)                        :: mu             !chemical potenatial of electron in reservoir 
+      REAL(kind=dp)                        :: T              !temperature of electrons in reservoir 
+      REAL(kind=dp)                        :: eps_hp         !tolerance for accuracy checks on occupation numbers 
+                                                             !calculated with hair_probes
+      INTEGER                              :: natoms, last_ao, first_ao
+      INTEGER,DIMENSION(:),POINTER         :: atom_ids      !atom ids to which the probes are attached
+   END TYPE hair_probes_type 
+!***************************************************************************************************
+
 ! **************************************************************************************************
 ! \brief Control parameters for pw grids
 ! **************************************************************************************************
@@ -566,6 +581,8 @@ MODULE cp_control_types
       TYPE(xas_control_type), POINTER      :: xas_control => NULL()
       TYPE(expot_control_type), POINTER    :: expot_control => NULL()
       TYPE(maxwell_control_type), POINTER  :: maxwell_control => NULL()
+      TYPE(hair_probes_type), POINTER, &
+              DIMENSION(:)                 :: probe => NULL() !MARGHERITA      
       TYPE(efield_p_type), POINTER, &
          DIMENSION(:)                      :: efield_fields => NULL()
       INTEGER                              :: nspins = 0, &
@@ -618,7 +635,8 @@ MODULE cp_control_types
                                               correct_el_density_dip = .FALSE., &
                                               do_sccs = .FALSE., &
                                               apply_embed_pot = .FALSE., &
-                                              apply_dmfet_pot = .FALSE.
+                                              apply_dmfet_pot = .FALSE., &
+                                              hair_probes = .FALSE. !MARGHERITA
    END TYPE dft_control_type
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'cp_control_types'
@@ -643,7 +661,8 @@ MODULE cp_control_types
              expot_control_type, &
              rtp_control_type, &
              sccs_control_type, &
-             stda_control_type
+             stda_control_type, &
+             hair_probes_type !MARGHERITA
 
    ! Public subroutines
 
@@ -776,9 +795,11 @@ CONTAINS
       NULLIFY (dft_control%maxwell_control)
       NULLIFY (dft_control%rtp_control)
       NULLIFY (dft_control%sccs_control)
+      NULLIFY (dft_control%probe) !MARGHERITA
       dft_control%do_sccs = .FALSE.
       dft_control%apply_embed_pot = .FALSE.
       dft_control%apply_dmfet_pot = .FALSE.
+      dft_control%hair_probes = .FALSE. !MARGHERITA 
       CALL qs_control_create(dft_control%qs_control)
       CALL tddfpt2_control_create(dft_control%tddfpt2_control)
    END SUBROUTINE dft_control_create

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -19,7 +19,7 @@ MODULE cp_control_utils
         dft_control_create, dft_control_type, efield_type, expot_control_create, &
         maxwell_control_create, qs_control_type, tddfpt2_control_type, tddfpt_control_create, &
         tddfpt_control_type, xtb_control_type, &
-        hair_probes_type !MARGHERITA
+        hairy_probes_type 
    USE cp_files,                        ONLY: close_file,&
                                               open_file
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
@@ -116,7 +116,7 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: maxwell_section, sccs_section, &
                                                             scf_section, tmp_section, &
                                                             xc_fun_section, xc_section, &
-                                                            hair_probes_section !MARGHERITA
+                                                            hairy_probes_section 
 
       was_present = .FALSE.
 
@@ -382,19 +382,18 @@ CONTAINS
                           "unrestricted Kohn-Sham (UKS) calculations")
       END IF
 
-!MARGHERITA 
 !***************************************************************************************************
-!\Control parameters for Hair Probes 
+!\Control parameters for a Hairy Probes DFT calculation
 !***************************************************************************************************
-    ! Read the HAIR PROBES input section if present
-      hair_probes_section => section_vals_get_subs_vals(dft_section, "HAIR_PROBES")
-      CALL section_vals_get(hair_probes_section, n_repetition=nrep, explicit=is_present)
+    ! Read the HAIRY PROBES input section if present
+      hairy_probes_section => section_vals_get_subs_vals(dft_section, "HAIRY_PROBES")
+      CALL section_vals_get(hairy_probes_section, n_repetition=nrep, explicit=is_present)
       !> n_repetitions: number of repetitions of the section
   
       IF (is_present) THEN
-         dft_control%hair_probes = .true. 
+         dft_control%hairy_probes = .true. 
          ALLOCATE (dft_control%probe(nrep))
-         CALL read_hair_probes_sections(dft_control, hair_probes_section)
+         CALL read_hairy_probes_sections(dft_control, hairy_probes_section)
   
       END IF 
   
@@ -1595,7 +1594,8 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'write_dft_control'
 
       CHARACTER(LEN=20)                                  :: tmpStr
-      INTEGER                                            :: handle, output_unit
+      INTEGER                                            :: handle, output_unit, &
+                                                            i, n_rep, i_rep !parameters for hairy probes
       REAL(kind=dp)                                      :: density_cut, density_smooth_cut_range, &
                                                             gradient_cut, tau_cut
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -1603,7 +1603,6 @@ CONTAINS
       TYPE(keyword_type), POINTER                        :: keyword
       TYPE(section_type), POINTER                        :: section
       TYPE(section_vals_type), POINTER                   :: xc_section
-      INTEGER :: i, n_rep, i_rep !MARGHERITA
 
       IF (dft_control%qs_control%semi_empirical) RETURN
       IF (dft_control%qs_control%dftb) RETURN
@@ -1814,10 +1813,8 @@ CONTAINS
 
       END IF
 
-!**************************************************************************************
-!MARGHERITA 
-!**************************************************************************************
-      IF (dft_control%hair_probes .eqv. .true.) THEN
+      !hairy probes DFT calculatio
+      IF (dft_control%hairy_probes .eqv. .true.) THEN
          n_rep = SIZE(dft_control%probe) 
          IF (output_unit > 0) THEN
                  DO i_rep = 1, n_rep 
@@ -1836,8 +1833,6 @@ CONTAINS
          END IF       
  END IF  
  
-!**************************************************************************************      
-
       CALL cp_print_key_finished_output(output_unit, logger, dft_section, &
                                         "PRINT%DFT_CONTROL_PARAMETERS")
 
@@ -2551,25 +2546,24 @@ CONTAINS
    END SUBROUTINE read_admm_block_list
 
 ! **************************************************************************************************
-!> \brief 
+!> \brief Reads the HAIRY PROBES section in the imput
 !> \param 
 !> \param 
 ! **************************************************************************************************
-!MARGHERITA 
-   SUBROUTINE read_hair_probes_sections(dft_control, hair_probes_section)
+   SUBROUTINE read_hairy_probes_sections(dft_control, hairy_probes_section)
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(section_vals_type), POINTER                   :: hair_probes_section
+      TYPE(section_vals_type), POINTER                   :: hairy_probes_section
    
       INTEGER                                           :: i, j, jj, kk, n_rep
-      INTEGER, DIMENSION(:), POINTER                     :: tmplist          !MARGHERITA 
+      INTEGER, DIMENSION(:), POINTER                     :: tmplist           
    
       DO i = 1, SIZE(dft_control%probe)
          NULLIFY (dft_control%probe(i)%atom_ids)
    
-         CALL section_vals_val_get(hair_probes_section,"ATOM_IDS", i_rep_section=i, n_rep_val=n_rep)
+         CALL section_vals_val_get(hairy_probes_section,"ATOM_IDS", i_rep_section=i, n_rep_val=n_rep)
          jj = 0 
          DO kk = 1, n_rep
-            CALL section_vals_val_get(hair_probes_section,"ATOM_IDS", i_rep_section=i, i_rep_val=kk, i_vals=tmplist)
+            CALL section_vals_val_get(hairy_probes_section,"ATOM_IDS", i_rep_section=i, i_rep_val=kk, i_vals=tmplist)
             jj = jj + SIZE(tmplist)
          END DO
    
@@ -2580,26 +2574,23 @@ CONTAINS
    
          jj = 0
          DO kk = 1, n_rep
-            CALL section_vals_val_get(hair_probes_section,"ATOM_IDS", i_rep_section=i, i_rep_val=kk, i_vals=tmplist)
+            CALL section_vals_val_get(hairy_probes_section,"ATOM_IDS", i_rep_section=i, i_rep_val=kk, i_vals=tmplist)
             DO j = 1, SIZE(tmplist)
                jj = jj + 1 
                dft_control%probe(i)%atom_ids(jj) = tmplist(j)
             END DO               
          END DO 
       
-         CALL section_vals_val_get(hair_probes_section,"MU", i_rep_section=i, r_val=dft_control%probe(i)%mu)
+         CALL section_vals_val_get(hairy_probes_section,"MU", i_rep_section=i, r_val=dft_control%probe(i)%mu)
      
-         CALL section_vals_val_get(hair_probes_section,"T", i_rep_section=i, r_val=dft_control%probe(i)%T) 
+         CALL section_vals_val_get(hairy_probes_section,"T", i_rep_section=i, r_val=dft_control%probe(i)%T) 
          
-         CALL section_vals_val_get(hair_probes_section,"ALPHA", i_rep_section=i, r_val=dft_control%probe(i)%alpha) !8th implementation
-   
-   !      CALL section_vals_val_get(hair_probes_section,"SOLUTION_PROBE", i_rep_section=i, &
-   !              l_val=dft_control%probe(i)%solution_probe) !8th implementation
-   
-         CALL section_vals_val_get(hair_probes_section,"eps_hp", i_rep_section=i, r_val=dft_control%probe(i)%eps_hp) 
+         CALL section_vals_val_get(hairy_probes_section,"ALPHA", i_rep_section=i, r_val=dft_control%probe(i)%alpha) !8th implementation
+
+         CALL section_vals_val_get(hairy_probes_section,"eps_hp", i_rep_section=i, r_val=dft_control%probe(i)%eps_hp) 
       END DO 
    
-   END SUBROUTINE read_hair_probes_sections
+   END SUBROUTINE read_hairy_probes_sections
 ! **************************************************************************************************
    
 END MODULE cp_control_utils

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -18,7 +18,8 @@ MODULE cp_control_utils
         admm_control_create, admm_control_type, ddapc_control_create, ddapc_restraint_type, &
         dft_control_create, dft_control_type, efield_type, expot_control_create, &
         maxwell_control_create, qs_control_type, tddfpt2_control_type, tddfpt_control_create, &
-        tddfpt_control_type, xtb_control_type
+        tddfpt_control_type, xtb_control_type, &
+        hair_probes_type !MARGHERITA
    USE cp_files,                        ONLY: close_file,&
                                               open_file
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
@@ -114,7 +115,8 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(section_vals_type), POINTER                   :: maxwell_section, sccs_section, &
                                                             scf_section, tmp_section, &
-                                                            xc_fun_section, xc_section
+                                                            xc_fun_section, xc_section, &
+                                                            hair_probes_section !MARGHERITA
 
       was_present = .FALSE.
 
@@ -380,6 +382,24 @@ CONTAINS
                           "unrestricted Kohn-Sham (UKS) calculations")
       END IF
 
+!MARGHERITA 
+!***************************************************************************************************
+!\Control parameters for Hair Probes 
+!***************************************************************************************************
+    ! Read the HAIR PROBES input section if present
+      hair_probes_section => section_vals_get_subs_vals(dft_section, "HAIR_PROBES")
+      CALL section_vals_get(hair_probes_section, n_repetition=nrep, explicit=is_present)
+      !> n_repetitions: number of repetitions of the section
+  
+      IF (is_present) THEN
+         dft_control%hair_probes = .true. 
+         ALLOCATE (dft_control%probe(nrep))
+         CALL read_hair_probes_sections(dft_control, hair_probes_section)
+  
+      END IF 
+  
+!***************************************************************************************************
+            
       ! check for the presence of the low spin roks section
       tmp_section => section_vals_get_subs_vals(dft_section, "LOW_SPIN_ROKS")
       CALL section_vals_get(tmp_section, explicit=dft_control%low_spin_roks)
@@ -1583,6 +1603,7 @@ CONTAINS
       TYPE(keyword_type), POINTER                        :: keyword
       TYPE(section_type), POINTER                        :: section
       TYPE(section_vals_type), POINTER                   :: xc_section
+      INTEGER :: i, n_rep, i_rep !MARGHERITA
 
       IF (dft_control%qs_control%semi_empirical) RETURN
       IF (dft_control%qs_control%dftb) RETURN
@@ -1792,6 +1813,30 @@ CONTAINS
          WRITE (UNIT=output_unit, FMT="(A)") ""
 
       END IF
+
+!**************************************************************************************
+!MARGHERITA 
+!**************************************************************************************
+      IF (dft_control%hair_probes .eqv. .true.) THEN
+         n_rep = SIZE(dft_control%probe) 
+         IF (output_unit > 0) THEN
+                 DO i_rep = 1, n_rep 
+                     WRITE (UNIT=output_unit, FMT="(T2,A,I5)") &
+                           "HP | hair probe set", i_rep 
+                     WRITE (UNIT=output_unit, FMT="(T2,A,T61,*(I5))") &
+                           "HP| atom indexes", &
+                           (dft_control%probe(i_rep)%atom_ids(i), i=1,dft_control%probe(i_rep)%natoms)
+                     WRITE (UNIT=output_unit, FMT="(T2,A,T61,ES20.6)") &
+                           "HP| potential", dft_control%probe(i_rep)%mu 
+                     WRITE (UNIT=output_unit, FMT="(T2,A,T61,F20.2)") &
+                           "HP| temperature", dft_control%probe(i_rep)%T
+                     WRITE (UNIT=output_unit, FMT="(T2,A,T61,ES20.6)") &
+                           "HP| eps_hp", dft_control%probe(i_rep)%eps_hp
+                END DO 
+         END IF       
+ END IF  
+ 
+!**************************************************************************************      
 
       CALL cp_print_key_finished_output(output_unit, logger, dft_section, &
                                         "PRINT%DFT_CONTROL_PARAMETERS")
@@ -2505,4 +2550,56 @@ CONTAINS
 
    END SUBROUTINE read_admm_block_list
 
+! **************************************************************************************************
+!> \brief 
+!> \param 
+!> \param 
+! **************************************************************************************************
+!MARGHERITA 
+   SUBROUTINE read_hair_probes_sections(dft_control, hair_probes_section)
+      TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(section_vals_type), POINTER                   :: hair_probes_section
+   
+      INTEGER                                           :: i, j, jj, kk, n_rep
+      INTEGER, DIMENSION(:), POINTER                     :: tmplist          !MARGHERITA 
+   
+      DO i = 1, SIZE(dft_control%probe)
+         NULLIFY (dft_control%probe(i)%atom_ids)
+   
+         CALL section_vals_val_get(hair_probes_section,"ATOM_IDS", i_rep_section=i, n_rep_val=n_rep)
+         jj = 0 
+         DO kk = 1, n_rep
+            CALL section_vals_val_get(hair_probes_section,"ATOM_IDS", i_rep_section=i, i_rep_val=kk, i_vals=tmplist)
+            jj = jj + SIZE(tmplist)
+         END DO
+   
+         dft_control%probe(i)%natoms = jj
+         IF (dft_control%probe(i)%natoms < 1) &
+            CPABORT("Need at least 1 atom to use hair probes formalism")
+         ALLOCATE(dft_control%probe(i)%atom_ids(dft_control%probe(i)%natoms))
+   
+         jj = 0
+         DO kk = 1, n_rep
+            CALL section_vals_val_get(hair_probes_section,"ATOM_IDS", i_rep_section=i, i_rep_val=kk, i_vals=tmplist)
+            DO j = 1, SIZE(tmplist)
+               jj = jj + 1 
+               dft_control%probe(i)%atom_ids(jj) = tmplist(j)
+            END DO               
+         END DO 
+      
+         CALL section_vals_val_get(hair_probes_section,"MU", i_rep_section=i, r_val=dft_control%probe(i)%mu)
+     
+         CALL section_vals_val_get(hair_probes_section,"T", i_rep_section=i, r_val=dft_control%probe(i)%T) 
+         
+         CALL section_vals_val_get(hair_probes_section,"ALPHA", i_rep_section=i, r_val=dft_control%probe(i)%alpha) !8th implementation
+   
+   !      CALL section_vals_val_get(hair_probes_section,"SOLUTION_PROBE", i_rep_section=i, &
+   !              l_val=dft_control%probe(i)%solution_probe) !8th implementation
+   
+         CALL section_vals_val_get(hair_probes_section,"eps_hp", i_rep_section=i, r_val=dft_control%probe(i)%eps_hp) 
+      END DO 
+   
+   END SUBROUTINE read_hair_probes_sections
+! **************************************************************************************************
+   
 END MODULE cp_control_utils

--- a/src/hair_probes.F
+++ b/src/hair_probes.F
@@ -1,0 +1,644 @@
+MODULE hair_probes
+ 
+        USE atomic_kind_types,               ONLY: atomic_kind_type,&
+                                                   get_atomic_kind,&
+                                                   get_atomic_kind_set
+        USE basis_set_types,                 ONLY: get_gto_basis_set,&
+                                                   gto_basis_set_type
+        USE cp_control_types,                ONLY: hair_probes_type  
+        USE kinds,                           ONLY: dp
+        USE orbital_pointers,                ONLY: indco,&
+                                                   nco,&  !Number of Cartesian orbitals for the 
+                                                          !angular momentum quantum number l
+                                                   nso    !Number of spherical orbitals for the 
+                                                          !angular momentum quantum number l
+        USE particle_types,                  ONLY: particle_type
+        USE qs_kind_types,                   ONLY: get_qs_kind,&
+                                                   get_qs_kind_set,&
+                                                   qs_kind_type
+        USE qs_environment_types,            ONLY: get_qs_env,& !??
+                                                   qs_environment_type
+ 
+        USE cp_log_handling,                 ONLY: cp_get_default_logger,&
+                                                   cp_logger_get_default_io_unit,&
+                                                   cp_logger_type,&
+                                                   cp_to_string
+        USE orbital_transformation_matrices, ONLY: orbtramat
+        USE qs_mo_types,                     ONLY: mo_set_p_type,&
+                                                   mo_set_type, &
+                                                   get_mo_set !14.06
+        USE cp_fm_types,                     ONLY: cp_fm_get_info,&
+                                                   cp_fm_get_submatrix,&
+                                                   cp_fm_type
+
+!        USE fermi_utils,                      ONLY: Fermi
+        USE cp_units,                         ONLY: cp_unit_from_cp2k
+        USE kahan_sum,                       ONLY: accurate_sum
+
+#include "./base/base_uses.f90"
+
+        IMPLICIT NONE 
+        PRIVATE
+        
+        CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'hair_probes'
+
+        INTEGER, PARAMETER, PRIVATE          :: BISECT_MAX_ITER = 400
+        PUBLIC :: probe_occupancy, probe_occupancy_kp, AO_boundaries
+
+CONTAINS
+
+!**************************************************************************************
+!> \brief subroutine to calculate occupation number and 'Fermi' level using the 
+!> \biref HAIR PROBE approach; gamma point calculation.
+!> \param occ(:): occupation numbers
+!> \param kTS: entropic energy contribution 
+!> \param fermi: fermi level
+!> \param probe(np): hair probe 
+!> \param atomic_kind_set(:) 
+!> \param particle_set(:)
+!> \param qs_kind_set(:)
+!> \param coeff: MOs coefficient 
+!> \param energies(:): MOs eigenvalues 
+!> \param maxocc: maximum allowed occupation number of an MO (1 or 2)
+!> \param N: number of electrons
+!> \param nAO: number of atomic orbitals (# rows in coeff)
+!> \param nMO: number of molecular orbitals (# cols in coeff)
+!
+!> \var smatrix(:,:): spherical MOs matrix 
+!> \var nrow_global, ncol_global: # rows and columns in smatrix (~should coincide 
+!>                                with nAO and nMO)
+!> \var fermi_min, fermi_max, fermi_fit: temporary fermi level needed to apply  
+!>                                       bisection method to find 'fermi'
+!> \var N_min, N_max, N_now: temoprary number of electrons needed to apply the 
+!>                           bisection method to find 'fermi'
+!> \var ip, np, iter: cycle indexes 
+!**************************************************************************************
+SUBROUTINE probe_occupancy ( occ, fermi, kTS, energies, coeff, maxocc, probe, N )
+
+        !Parameters 
+        !CHARACTER(len=*), PARAMETER :: routineN = 'probe_occupancy'!, & 
+                                       !routineP=moduleN//':'//routineN
+
+        !i/o variables and arrays
+        REAL(KIND=dp), INTENT(out)                        :: occ(:), kTS, fermi
+        TYPE(hair_probes_type), INTENT(INOUT)             :: probe(:) 
+        TYPE(cp_fm_type), INTENT(IN), POINTER             :: coeff       !from get_mo_set  
+        REAL(KIND=dp), INTENT(IN)                         :: energies(:), maxocc, N !from get_mo_set  
+                                                             !nAO: number of atomic orbitals (# rows in mo_coeff)                                                             
+        !subroutine variables and arrays 
+        REAL(KIND=dp), POINTER                            :: smatrix(:,:) !smatrix: Spherical MOs matrix 
+        REAL(KIND=dp), ALLOCATABLE                        :: smatrix_squared(:,:) !squared Spherical MOs matrix 
+        REAL(KIND=dp)                                     :: fermi_min, fermi_max, fermi_half, fermi_fit, &
+                                                            & N_fit, N_min, N_max, N_half, delta_fermi, &
+                                                            & h, y0, y1, y2, de, N_now
+        INTEGER                                           :: nrow_global, ncol_global, iter 
+        REAL(KIND=dp), PARAMETER                          :: epsocc = 1.0e-12_dp
+
+        CALL cp_fm_get_info(coeff, &
+                             nrow_global=nrow_global, &
+                             ncol_global=ncol_global)
+        ALLOCATE (smatrix(nrow_global, ncol_global))
+        CALL cp_fm_get_submatrix(coeff, smatrix)
+
+        ALLOCATE(smatrix_squared(nrow_global, ncol_global))
+        smatrix_squared(:,:) = smatrix(:,:)**2.0d0 
+
+!**************************************************************************************
+!1)calculate Fermi energy using the hair probe formula
+!**************************************************************************************
+         de = probe(1)%T *LOG((1.0_dp - epsocc)/epsocc) !FIX probe(1)%T
+         de = MAX(de, 0.5_dp)
+         fermi_max = MAXVAL(probe%mu) + de 
+         fermi_min = MINVAL(probe%mu) - de 
+
+         CALL HP_occupancy(probe=probe, matrix=smatrix_squared, energies=energies, &
+                           maxocc=maxocc, fermi=fermi_max, occupancy=occ, kTS=kTS)
+         N_max = accurate_sum(occ)
+
+         CALL HP_occupancy(probe=probe, matrix=smatrix_squared, energies=energies, &
+                           maxocc=maxocc, fermi=fermi_min, occupancy=occ, kTS=kTS)
+         N_min = accurate_sum(occ)
+
+         iter = 0
+         DO WHILE (ABS(N_max - N_min) > N*epsocc)
+            iter = iter + 1
+          
+            fermi_half = (fermi_max + fermi_min)/2.0_dp
+            CALL HP_occupancy(probe=probe, matrix=smatrix_squared, energies=energies, &
+                  maxocc=maxocc, fermi=fermi_half, occupancy=occ, kTS=kTS)
+            N_half = accurate_sum(occ)
+
+            h = fermi_half - fermi_min
+            IF ( h .gt. N*epsocc*100 ) THEN 
+               y0 = N_min - N
+               y1 = N_half - N
+               y2 = N_max - N
+
+               CALL three_point_zero(y0,y1,y2,h,delta_fermi)
+               fermi_fit = fermi_min + delta_fermi 
+         
+               CALL HP_occupancy(probe=probe, matrix=smatrix_squared, energies=energies, &
+                              maxocc=maxocc, fermi=fermi_fit, occupancy=occ, kTS=kTS)
+               N_fit = accurate_sum(occ) 
+            END IF
+            
+            !define 1st bracked using fermi_half
+            IF (N_half < N) THEN
+               fermi_min = fermi_half
+               N_min = N_half
+            ELSE IF ( N_half > N ) THEN 
+               fermi_max = fermi_half
+               N_max = N_half
+            ELSE 
+               fermi_min = fermi_half
+               N_min = N_half
+               fermi_max = fermi_half
+               N_max = N_half
+               h = 0.0d0
+            ENDIF
+  
+            !define 2nd bracker using fermi_fit
+            IF ( h .gt. N*epsocc*100 ) THEN 
+               IF ( fermi_fit .ge. fermi_min .and. fermi_fit .le. fermi_max ) THEN 
+                  IF (N_fit < N) THEN
+                     fermi_min = fermi_fit
+                     N_min = N_fit
+                  ELSE IF ( N_fit > N ) THEN 
+                     fermi_max = fermi_fit
+                     N_max = N_fit
+                  ENDIF   
+               END IF 
+            END IF 
+
+            IF ( ABS(N_max - N) < N*epsocc ) THEN 
+                fermi = fermi_max
+                EXIT 
+            ELSE IF (  ABS(N_min - N ) < N*epsocc ) THEN 
+                fermi = fermi_min 
+                EXIT 
+            END IF  
+
+            IF (iter > BISECT_MAX_ITER) THEN
+               CPWARN("Maximum number of iterations reached while finding the Fermi energy")
+               EXIT
+            ENDIF
+         ENDDO
+
+!**************************************************************************************
+!2)calculate occupation numbers according to hair probe formula 
+!**************************************************************************************         
+         occ(:) = 0.0_dp
+         N_now = 0.0_dp
+         CALL HP_occupancy(probe=probe, matrix=smatrix_squared, energies=energies, &
+                           maxocc=maxocc, fermi=fermi, occupancy=occ, kTS=kTS)
+         N_now = accurate_sum(occ)
+
+         IF (ABS(N_now - N) > N*epsocc) CPWARN("Total number of electrons is not accurate - HP")
+
+         DEALLOCATE(smatrix,smatrix_squared)
+
+END SUBROUTINE probe_occupancy 
+
+!**************************************************************************************
+!> \brief subroutine to calculate occupation number and 'Fermi' level using the 
+!> \biref HAIR PROBE approach; kpoints calculation.
+!> \param occ(nMO,nkp): occupation numbers
+!> \param kTS: entropic energy contribution 
+!> \param fermi: fermi level
+!> \param probe(np): hair probe 
+!> \param atomic_kind_set(:) 
+!> \param particle_set(:)
+!> \param qs_kind_set(:)
+!> \param coeff(nkp): MOs coefficient 
+!> \param energies(nMO,nkp): MOs eigenvalues 
+!> \param wk(nkp): weight of kpoints
+!> \param maxocc: maximum allowed occupation number of an MO (1 or 2)
+!> \param N: number of electrons
+!> \param nAO: number of atomic orbitals (# rows in coeff)
+!> \param nMO: number of molecular orbitals (# cols in coeff)
+!
+!> \var coeff_kp: pointer to elements of coeff(ikp) 
+!> \var smatrix(:,:): spherical MOs matrix 
+!> \var kTS_kp: entropic contribution per kpoint
+!> \var nrow_global, ncol_global: # rows and columns in smatrix (~should coincide 
+!>                                with nAO and nMO)
+!> \var fermi_min, fermi_max, fermi_now: temporary fermi level needed to apply  
+!>                                       bisection method to find 'fermi'
+!> \var N_now: temoprary number of electrons needed to apply the bisection method
+!>             to find 'fermi'
+!> \var ip, np, ikp, nkpo, iter: cycle indexes 
+!**************************************************************************************
+SUBROUTINE probe_occupancy_kp ( occ, fermi, kTS, energies, rcoeff, icoeff, maxocc, probe, N, wk )
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'probe_occupancy_kp'
+
+      REAL(KIND=dp),INTENT(OUT)                         :: occ(:,:,:), fermi, kTS 
+      TYPE(hair_probes_type), INTENT(IN)                :: probe(:) 
+      REAL(KIND=dp), INTENT(IN)                         :: energies(:,:,:), wk(:)
+      REAL(KIND=dp), INTENT(IN)                         :: rcoeff(:,:,:,:), icoeff(:,:,:,:)
+      REAL(KIND=dp), INTENT(IN)                         :: maxocc, N
+
+      REAL(KIND=dp)                                     :: kTS_kp, de, h, fermi_max, fermi_min, fermi_half, fermi_fit, &
+                                                           & N_max, N_min, N_half, N_fit, N_now, &
+                                                           & y0, y1, y2, delta_fermi
+      REAL(KIND=dp), ALLOCATABLE                        :: coeff_squared(:,:,:,:)
+      INTEGER                                           :: nMO, nAO, iter, ikp, nkp, ispin, nspin 
+
+      REAL(KIND=dp), PARAMETER                          :: epsocc = 1.0e-12_dp
+
+      INTEGER :: handle 
+
+      CALL timeset(routineN, handle)
+
+!**************************************************************************************
+!1)calculate Fermi energy using the hair probe formula
+!**************************************************************************************
+!     rcoeff(nao, nmo, nkp, nspin), icoeff(nao, nmo, nkp, nspin))
+      nAO=SIZE(rcoeff, 1)
+      nMO=SIZE(rcoeff, 2)
+      nkp=SIZE(rcoeff, 3)
+      nspin=SIZE(rcoeff, 4)
+
+      ALLOCATE(coeff_squared(nAO,nMO,nkp,nspin))
+      coeff_squared(:,:,:,:) = rcoeff(:,:,:,:)**2.0d0 + icoeff(:,:,:,:)**2.0d0        
+
+      occ(:,:,:)=0.0_dp
+  
+      !define initial brackets 
+      de = probe(1)%T *LOG((1.0_dp - epsocc)/epsocc) !FIX probe(1)%T
+      de = MAX(de, 0.5_dp)
+      fermi_max = MAXVAL(probe%mu) + de 
+      fermi_min = MINVAL(probe%mu) - de 
+
+      N_max = 0.0_dp
+      kTS = 0.0_dp
+      !***HP 
+      DO ispin = 1, nspin
+         DO ikp = 1, nkp
+            CALL HP_occupancy(probe,coeff_squared(:,:,ikp,ispin),energies(:,ikp,ispin), &
+                              maxocc,fermi_max,occ(:,ikp,ispin),kTS_kp)
+
+            kTS = kTS + kTS_kp * wk(ikp) !entropic contribution
+            N_max = N_max + accurate_sum(occ(1:nMo,ikp,ispin))*wk(ikp) 
+         END DO
+      END DO 
+      !***HP 
+
+      N_min = 0.0_dp
+      kTS = 0.0_dp
+      !***HP 
+      DO ispin = 1, nspin
+         DO ikp = 1, nkp
+            CALL HP_occupancy(probe,coeff_squared(:,:,ikp,ispin),energies(:,ikp,ispin), &
+                              maxocc,fermi_min,occ(:,ikp,ispin),kTS_kp)
+
+            kTS = kTS + kTS_kp * wk(ikp) !entropic contribution
+            N_min = N_min + accurate_sum(occ(1:nMo,ikp,ispin))*wk(ikp) 
+         END DO
+      END DO 
+      !***HP 
+
+      iter = 0
+      DO WHILE (ABS(N_max - N_min) > N*epsocc)
+         iter = iter + 1
+         fermi_half = (fermi_max + fermi_min)/2.0_dp
+         N_half = 0.0_dp
+         kTS = 0.0_dp
+         !***HP 
+         DO ispin = 1, nspin
+            DO ikp = 1, nkp
+               CALL HP_occupancy(probe,coeff_squared(:,:,ikp,ispin),energies(:,ikp,ispin), &
+                                 maxocc,fermi_half,occ(:,ikp,ispin),kTS_kp)
+
+               kTS = kTS + kTS_kp * wk(ikp) !entropic contribution
+               N_half = N_half + accurate_sum(occ(1:nMo,ikp,ispin))*wk(ikp) 
+            END DO
+         END DO 
+         !***HP 
+
+         h = fermi_half - fermi_min
+         IF ( h .gt. N*epsocc*100 ) THEN 
+            y0 = N_min - N
+            y1 = N_half - N
+            y2 = N_max - N
+
+            CALL three_point_zero(y0,y1,y2,h,delta_fermi)
+            fermi_fit = fermi_min + delta_fermi 
+            N_fit = 0.0_dp
+            kTS = 0.0_dp
+                 
+            !***HP
+            DO ispin = 1, nspin
+               DO ikp = 1, nkp
+                  CALL HP_occupancy(probe,coeff_squared(:,:,ikp,ispin),energies(:,ikp,ispin), &
+                                 maxocc,fermi_fit,occ(:,ikp,ispin),kTS_kp)
+
+                  kTS = kTS + kTS_kp * wk(ikp) !entropic contribution
+                  N_fit = N_fit + accurate_sum(occ(1:nMo,ikp,ispin))*wk(ikp) 
+               END DO
+            END DO 
+            !***HP
+
+         END IF
+
+         !define 1st bracked using fermi_half
+         IF (N_half < N) THEN
+            fermi_min = fermi_half
+            N_min = N_half
+         ELSE IF ( N_half > N ) THEN 
+            fermi_max = fermi_half
+            N_max = N_half
+         ELSE 
+            fermi_min = fermi_half
+            N_min = N_half
+            fermi_max = fermi_half
+            N_max = N_half
+            h = 0.0d0
+         ENDIF
+  
+         !define 2nd bracker using fermi_fit
+         IF ( h .gt. N*epsocc*100 ) THEN 
+            IF ( fermi_fit .ge. fermi_min .and. fermi_fit .le. fermi_max ) THEN 
+               IF (N_fit < N) THEN
+                  fermi_min = fermi_fit
+                  N_min = N_fit
+               ELSE IF ( N_fit > N ) THEN 
+                  fermi_max = fermi_fit
+                  N_max = N_fit
+               ENDIF   
+            END IF 
+         END IF 
+
+         IF ( ABS(N_max - N) < N*epsocc ) THEN 
+             fermi = fermi_max
+             EXIT 
+         ELSE IF (  ABS(N_min - N ) < N*epsocc ) THEN 
+             fermi = fermi_min 
+             EXIT 
+         END IF  
+
+         IF (iter > BISECT_MAX_ITER) THEN
+            CPWARN("Maximum number of iterations reached while finding the Fermi energy")
+            EXIT
+         ENDIF
+      ENDDO
+
+!**************************************************************************************
+!3)calculate occupation numbers using the hair probe formula
+!**************************************************************************************
+      N_now = 0.0_dp
+      kTS = 0.0_dp
+
+      !***HP 
+      DO ispin = 1, nspin
+         DO ikp = 1, nkp
+            CALL HP_occupancy(probe,coeff_squared(:,:,ikp,ispin),energies(:,ikp,ispin), &
+                              maxocc,fermi,occ(:,ikp,ispin),kTS_kp)
+
+            kTS = kTS + kTS_kp * wk(ikp) !entropic contribution
+            N_now = N_now + accurate_sum(occ(1:nMo,ikp,ispin))*wk(ikp) 
+         END DO
+      END DO 
+      !***HP 
+      
+      DEALLOCATE(coeff_squared)
+
+      CALL timestop(handle)
+END SUBROUTINE probe_occupancy_kp 
+
+!**************************************************************************************
+!
+!
+!
+!**************************************************************************************
+SUBROUTINE HP_occupancy(probe, matrix, energies, maxocc, fermi, occupancy, kTS)
+        IMPLICIT NONE 
+
+        REAL(KIND=dp), INTENT(OUT)                 :: occupancy(:), kTS
+        TYPE(hair_probes_type), INTENT(IN)         :: probe(:)
+        REAL(KIND=dp), INTENT(IN)                  :: matrix(:,:) !squared coefficient matrix
+        REAL(KIND=dp), INTENT(IN)                  :: energies(:), fermi, maxocc
+
+        INTEGER :: iMO, ip, np, nMO!, nAO
+        REAL(KIND=dp) :: mu, fermi_fun, fermi_fun_sol, sum_fermi_fun, sum_coeff, &
+                         & sum_fermi_fun_sol, sum_coeff_sol, C, s, f
+
+        !tmp 
+        !INTEGER, PARAMETER :: nout = 2222
+        !CHARACTER(len=20), PARAMETER :: debug = 'debug.dat'
+
+        !OPEN(unit=nout,action='write',file=debug,status='replace')
+        nMO = SIZE(matrix, 2)
+        np = SIZE(probe)
+
+        kTS = 0.0_dp
+        ! kTS is the entropic contribution to the energy i.e. -TS
+
+        mos2: do iMO = 1, nMO
+
+           sum_fermi_fun = 0.0_dp
+           sum_coeff = 0.0_dp 
+
+           sum_fermi_fun_sol = 0.0_dp
+           sum_coeff_sol = 0.0_dp 
+
+           probes2: DO ip = 1, np
+              IF ( probe(ip)%alpha .lt. 1.0_dp ) THEN 
+                 !fermi distribution, solution probes 
+                 CALL fermi_distribution ( energies(iMO), fermi, probe(ip)%T, fermi_fun_sol )                        
+                 !sum of coefficients, solution probes 
+                 sum_coeff_sol = sum_coeff_sol + SUM(matrix(probe(ip)%first_ao:probe(ip)%last_ao,iMO))
+
+              ELSE  
+                 C = SUM(matrix(probe(ip)%first_ao:probe(ip)%last_ao,iMO))  
+                 !bias probes 
+                 mu = fermi - probe(ip)%mu 
+                 !fermi distribution, main probes                   
+                 CALL fermi_distribution ( energies(iMO), mu, probe(ip)%T, fermi_fun )                        
+                 !sum fermi distribution * coefficients
+                 sum_fermi_fun = sum_fermi_fun + ( fermi_fun * C )
+                 !sum cofficients 
+                 sum_coeff = sum_coeff + C 
+              END IF 
+           END DO probes2
+
+           sum_fermi_fun_sol = probe(np)%alpha * fermi_fun_sol * sum_coeff_sol
+           sum_coeff_sol = probe(np)%alpha * sum_coeff_sol                       
+           f = ( sum_fermi_fun_sol + sum_fermi_fun ) / ( sum_coeff_sol + sum_coeff ) 
+           occupancy(iMO) = f * maxocc
+
+           !entropy kTS= kT*[f ln f + (1-f) ln (1-f)]
+           IF ( f .eq. 0.0d0 .or. f .eq. 1.0d0 ) THEN
+              s = 0.0d0
+           ELSE 
+              s = f * LOG(f) + (1.0d0-f) * LOG(1.0d0-f) 
+           END IF 
+           kTS = kTS + probe(np)%T*maxocc*s 
+           !write(nout,*) occupancy(iMO), f, s, kTS
+        END DO MOs2
+
+        !CLOSE(nout)
+END SUBROUTINE HP_occupancy
+
+!**************************************************************************************
+!
+!
+!
+!**************************************************************************************
+SUBROUTINE AO_boundaries (probe, atomic_kind_set, qs_kind_set, particle_set, nAO)
+        IMPLICIT NONE 
+        
+        TYPE(hair_probes_type), INTENT(INOUT)           :: probe
+        TYPE(atomic_kind_type), INTENT(IN), POINTER     :: atomic_kind_set(:) !from get_atomic_kind_set 
+        TYPE(particle_type), INTENT(IN), POINTER        :: particle_set(:)    !from get_atomic_kind
+        TYPE(qs_kind_type), INTENT(IN), POINTER         :: qs_kind_set(:)     !from get_qs_kind_set
+        INTEGER, INTENT(IN) :: nAO
+ 
+        !subroutine variables and arrays 
+        TYPE(gto_basis_set_type), POINTER               :: orb_basis_set   !from get_qs_kind 
+        INTEGER, DIMENSION(:), POINTER                  :: nshell          !from get_gto_basis_set 
+        INTEGER, DIMENSION(:, :), POINTER               :: l               !from get_gto_basis_set 
+        INTEGER                                         :: nset            !from get_gto_basis_set 
+                                                           !nset : Number of exponent sets
+                                                           !nshell(l) : Number of shells for angular momentum quantum number l
+        INTEGER                                         :: lshell      
+        INTEGER                                         :: natom, nsgf
+
+        INTEGER :: p_atom, isgf, iatom, ii, ikind, iset, ishell 
+
+        !get sets from different modules: 
+        CALL get_atomic_kind_set ( atomic_kind_set=atomic_kind_set, natom=natom )
+        CALL get_qs_kind_set ( qs_kind_set=qs_kind_set, nsgf=nsgf ) !indexes for orbital symbols 
+
+        !get iAO boundaries:
+        p_atom = SIZE ( probe%atom_ids )
+        probe%first_ao = nsgf !nAO
+        probe%last_ao = 1
+        isgf = 0
+        
+        atoms: DO iatom = 1, natom 
+                NULLIFY ( orb_basis_set ) 
+                !1) iatom is used to find the correct atom kind and its index (ikind) is the particle set 
+                CALL get_atomic_kind ( particle_set(iatom)%atomic_kind, kind_number=ikind )        
+
+                !2) ikind is used to find the basis set associate to that atomic kind
+                CALL get_qs_kind ( qs_kind_set(ikind), basis_set=orb_basis_set )
+
+                !3) orb_basis_set is used to get the gto basis set variables 
+                IF ( ASSOCIATED ( orb_basis_set ) ) THEN 
+                        CALL get_gto_basis_set ( gto_basis_set=orb_basis_set, &
+                                nset=nset, nshell=nshell, l=l ) !? ,cgf_symbol=bcgf_symbol )
+                END IF
+                 
+                !4) get iAO boundaries                 
+                sets: DO iset = 1, nset 
+
+                        shells: DO ishell = 1, nshell(iset) 
+                                lshell = l ( ishell, iset ) 
+
+                                isgf = isgf + nso(lshell)
+
+                                        boundaries: DO ii = 1, p_atom 
+                                                IF ( iatom .ne. probe%atom_ids(ii) ) THEN                                          
+                                                        CYCLE boundaries
+                                                ELSE 
+                                                        !defines iAO boundaries***********
+                                                        probe%first_ao = MIN ( probe%first_ao, isgf )
+                                                        probe%last_ao = MAX ( probe%last_ao, isgf )
+                                                END IF
+                                        END DO boundaries 
+                                        
+                        END DO shells
+                END DO sets
+        END DO atoms                            
+
+        IF ( isgf .ne. nAO ) CPWARN("row count does not correspond to nAO, number of rows in mo_coeff")
+
+ END SUBROUTINE AO_boundaries 
+
+!*******************************************************************************************************
+!*******************************************************************************************************
+
+SUBROUTINE fermi_distribution (E, pot, temp, f_p)
+      IMPLICIT NONE 
+
+      REAL(kind=dp),INTENT(OUT) :: f_p
+      REAL(kind=dp),INTENT(IN) :: E
+      REAL(kind=dp),INTENT(IN) :: pot, temp
+
+      REAL(KIND=dp)            :: arg, exponential, exponential_plus_1, f, one_minus_f!, &
+                                 ! & s_term1, s_term2, logarithm
+
+      ! have the result of exp go to zero instead of overflowing  
+      IF (E > pot) THEN                                           
+         arg = -(E - pot)/temp                                    
+         ! exponential is smaller than 1                                  
+         exponential = EXP(arg)                                           
+         exponential_plus_1 = exponential + 1.0_dp                                      
+
+         one_minus_f = exponential/exponential_plus_1                                                      
+         f = 1.0_dp/exponential_plus_1                                       
+
+         ! log(1+eps), might need to be written more accurately   
+         !logarithm = -LOG(exponential_plus_1)                                      
+         !s_term1 = one_minus_f*(arg + logarithm) ![1-f]*log[1-f] 
+         !s_term2 = f*logarithm !f*logf                                     
+
+         f_p = one_minus_f
+      ELSE                                                        
+         arg = (E - pot)/temp                                     
+         ! exponential is smaller than 1                                  
+         exponential = EXP(arg)                                           
+         exponential_plus_1 = exponential + 1.0_dp                                      
+
+         f = 1.0_dp/exponential_plus_1                                                   
+         one_minus_f = exponential/exponential_plus_1                                          
+
+         !logarithm = -LOG(exponential_plus_1)                                      
+         !s_term1 = f*logarithm                                         
+         !s_term2 = one_minus_f*(arg + logarithm)                              
+
+         f_p = f 
+      END IF                                                      
+                                       
+      !s_p = s_term1 + s_term2        
+END SUBROUTINE fermi_distribution                                        
+
+!*******************************************************************************************************
+!*******************************************************************************************************
+SUBROUTINE three_point_zero(y0,y1,y2,h,delta)
+   IMPLICIT NONE 
+
+   REAL(kind=dp), INTENT(IN) :: y0, y1, y2, h
+   REAL(kind=dp), INTENT(OUT) :: delta 
+
+   REAL(kind=dp) :: a, b, c, d 
+   REAL(kind=dp) :: u0
+
+   a = ( y2 - 2.0_dp*y1 + y0 ) / ( 2.0_dp * h * h )
+   b = ( 4.0_dp*y1 - 3.0_dp*y0 - y2 ) / ( 2.0_dp * h )
+   c = y0
+
+   d = sqrt( b * b - 4.0_dp*a*c )
+   
+   u0 = ( -b + d ) / ( 2.0_dp * a )
+
+   IF ( u0 .ge. 0.0_dp .and. u0 .le. 2.0_dp*h ) THEN
+      delta = u0 
+      !RETURN
+   ELSE 
+      u0 = ( -b - d ) / ( 2.0_dp * a )
+      IF ( u0 .ge. 0.0_dp .and. u0 .le. 2.0_dp*h ) THEN
+         delta = u0
+         !RETURN
+      ELSE
+         IF ( y1 .lt. 0.0_dp ) delta = 2.0_dp*h
+         IF ( y1 .ge. 0.0_dp ) delta = 0.0_dp
+      END IF
+   END IF 
+
+   
+END SUBROUTINE three_point_zero
+
+
+END MODULE hair_probes 

--- a/src/hairy_probes.F
+++ b/src/hairy_probes.F
@@ -1,22 +1,20 @@
-MODULE hair_probes
+MODULE hairy_probes
  
         USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                                    get_atomic_kind,&
                                                    get_atomic_kind_set
         USE basis_set_types,                 ONLY: get_gto_basis_set,&
                                                    gto_basis_set_type
-        USE cp_control_types,                ONLY: hair_probes_type  
+        USE cp_control_types,                ONLY: hairy_probes_type  
         USE kinds,                           ONLY: dp
         USE orbital_pointers,                ONLY: indco,&
-                                                   nco,&  !Number of Cartesian orbitals for the 
-                                                          !angular momentum quantum number l
-                                                   nso    !Number of spherical orbitals for the 
-                                                          !angular momentum quantum number l
+                                                   nco,&                                                     
+                                                   nso                                                              
         USE particle_types,                  ONLY: particle_type
         USE qs_kind_types,                   ONLY: get_qs_kind,&
                                                    get_qs_kind_set,&
                                                    qs_kind_type
-        USE qs_environment_types,            ONLY: get_qs_env,& !??
+        USE qs_environment_types,            ONLY: get_qs_env,& 
                                                    qs_environment_type
  
         USE cp_log_handling,                 ONLY: cp_get_default_logger,&
@@ -26,13 +24,11 @@ MODULE hair_probes
         USE orbital_transformation_matrices, ONLY: orbtramat
         USE qs_mo_types,                     ONLY: mo_set_p_type,&
                                                    mo_set_type, &
-                                                   get_mo_set !14.06
+                                                   get_mo_set 
         USE cp_fm_types,                     ONLY: cp_fm_get_info,&
                                                    cp_fm_get_submatrix,&
                                                    cp_fm_type
-
-!        USE fermi_utils,                      ONLY: Fermi
-        USE cp_units,                         ONLY: cp_unit_from_cp2k
+        USE cp_units,                        ONLY: cp_unit_from_cp2k
         USE kahan_sum,                       ONLY: accurate_sum
 
 #include "./base/base_uses.f90"
@@ -40,7 +36,7 @@ MODULE hair_probes
         IMPLICIT NONE 
         PRIVATE
         
-        CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'hair_probes'
+        CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'hairy_probes'
 
         INTEGER, PARAMETER, PRIVATE          :: BISECT_MAX_ITER = 400
         PUBLIC :: probe_occupancy, probe_occupancy_kp, AO_boundaries
@@ -53,7 +49,7 @@ CONTAINS
 !> \param occ(:): occupation numbers
 !> \param kTS: entropic energy contribution 
 !> \param fermi: fermi level
-!> \param probe(np): hair probe 
+!> \param probe(np): hairy probe 
 !> \param atomic_kind_set(:) 
 !> \param particle_set(:)
 !> \param qs_kind_set(:)
@@ -75,24 +71,21 @@ CONTAINS
 !**************************************************************************************
 SUBROUTINE probe_occupancy ( occ, fermi, kTS, energies, coeff, maxocc, probe, N )
 
-        !Parameters 
-        !CHARACTER(len=*), PARAMETER :: routineN = 'probe_occupancy'!, & 
-                                       !routineP=moduleN//':'//routineN
-
         !i/o variables and arrays
-        REAL(KIND=dp), INTENT(out)                        :: occ(:), kTS, fermi
-        TYPE(hair_probes_type), INTENT(INOUT)             :: probe(:) 
-        TYPE(cp_fm_type), INTENT(IN), POINTER             :: coeff       !from get_mo_set  
-        REAL(KIND=dp), INTENT(IN)                         :: energies(:), maxocc, N !from get_mo_set  
-                                                             !nAO: number of atomic orbitals (# rows in mo_coeff)                                                             
+        REAL(KIND=dp), INTENT(out)                          :: occ(:), kTS, fermi
+        TYPE(hairy_probes_type), INTENT(INOUT)              :: probe(:) 
+        TYPE(cp_fm_type), INTENT(IN), POINTER               :: coeff         
+        REAL(KIND=dp), INTENT(IN)                           :: energies(:), maxocc, N  
+                                                                                                                          
         !subroutine variables and arrays 
-        REAL(KIND=dp), POINTER                            :: smatrix(:,:) !smatrix: Spherical MOs matrix 
-        REAL(KIND=dp), ALLOCATABLE                        :: smatrix_squared(:,:) !squared Spherical MOs matrix 
-        REAL(KIND=dp)                                     :: fermi_min, fermi_max, fermi_half, fermi_fit, &
-                                                            & N_fit, N_min, N_max, N_half, delta_fermi, &
-                                                            & h, y0, y1, y2, de, N_now
-        INTEGER                                           :: nrow_global, ncol_global, iter 
-        REAL(KIND=dp), PARAMETER                          :: epsocc = 1.0e-12_dp
+        REAL(KIND=dp), POINTER                              :: smatrix(:,:) !smatrix: Spherical MOs matrix 
+        REAL(KIND=dp), ALLOCATABLE                          :: smatrix_squared(:,:) !squared Spherical MOs matrix 
+        REAL(KIND=dp)                                       :: fermi_min, fermi_max, fermi_half, fermi_fit, &
+                                                               & N_fit, N_min, N_max, N_half, delta_fermi, &
+                                                               & h, y0, y1, y2, de, N_now
+        INTEGER                                             :: nrow_global, ncol_global, iter 
+
+        REAL(KIND=dp), PARAMETER                            :: epsocc = 1.0e-12_dp
 
         CALL cp_fm_get_info(coeff, &
                              nrow_global=nrow_global, &
@@ -104,7 +97,7 @@ SUBROUTINE probe_occupancy ( occ, fermi, kTS, energies, coeff, maxocc, probe, N 
         smatrix_squared(:,:) = smatrix(:,:)**2.0d0 
 
 !**************************************************************************************
-!1)calculate Fermi energy using the hair probe formula
+!1)calculate Fermi energy using the hairy probe formula
 !**************************************************************************************
          de = probe(1)%T *LOG((1.0_dp - epsocc)/epsocc) !FIX probe(1)%T
          de = MAX(de, 0.5_dp)
@@ -185,7 +178,7 @@ SUBROUTINE probe_occupancy ( occ, fermi, kTS, energies, coeff, maxocc, probe, N 
          ENDDO
 
 !**************************************************************************************
-!2)calculate occupation numbers according to hair probe formula 
+!2)calculate occupation numbers according to hairy probe formula 
 !**************************************************************************************         
          occ(:) = 0.0_dp
          N_now = 0.0_dp
@@ -205,7 +198,7 @@ END SUBROUTINE probe_occupancy
 !> \param occ(nMO,nkp): occupation numbers
 !> \param kTS: entropic energy contribution 
 !> \param fermi: fermi level
-!> \param probe(np): hair probe 
+!> \param probe(np): hairy probe 
 !> \param atomic_kind_set(:) 
 !> \param particle_set(:)
 !> \param qs_kind_set(:)
@@ -232,28 +225,27 @@ SUBROUTINE probe_occupancy_kp ( occ, fermi, kTS, energies, rcoeff, icoeff, maxoc
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'probe_occupancy_kp'
 
-      REAL(KIND=dp),INTENT(OUT)                         :: occ(:,:,:), fermi, kTS 
-      TYPE(hair_probes_type), INTENT(IN)                :: probe(:) 
-      REAL(KIND=dp), INTENT(IN)                         :: energies(:,:,:), wk(:)
-      REAL(KIND=dp), INTENT(IN)                         :: rcoeff(:,:,:,:), icoeff(:,:,:,:)
-      REAL(KIND=dp), INTENT(IN)                         :: maxocc, N
+      REAL(KIND=dp),INTENT(OUT)                          :: occ(:,:,:), fermi, kTS 
+      TYPE(hairy_probes_type), INTENT(IN)                :: probe(:) 
+      REAL(KIND=dp), INTENT(IN)                          :: energies(:,:,:), wk(:)
+      REAL(KIND=dp), INTENT(IN)                          :: rcoeff(:,:,:,:), icoeff(:,:,:,:)
+      REAL(KIND=dp), INTENT(IN)                          :: maxocc, N
 
-      REAL(KIND=dp)                                     :: kTS_kp, de, h, fermi_max, fermi_min, fermi_half, fermi_fit, &
-                                                           & N_max, N_min, N_half, N_fit, N_now, &
-                                                           & y0, y1, y2, delta_fermi
-      REAL(KIND=dp), ALLOCATABLE                        :: coeff_squared(:,:,:,:)
-      INTEGER                                           :: nMO, nAO, iter, ikp, nkp, ispin, nspin 
+      REAL(KIND=dp)                                      :: kTS_kp, de, h, fermi_max, fermi_min, fermi_half, fermi_fit, &
+                                                            & N_max, N_min, N_half, N_fit, N_now, &
+                                                            & y0, y1, y2, delta_fermi
+      REAL(KIND=dp), ALLOCATABLE                         :: coeff_squared(:,:,:,:)
+      INTEGER                                            :: nMO, nAO, iter, ikp, nkp, ispin, nspin 
 
-      REAL(KIND=dp), PARAMETER                          :: epsocc = 1.0e-12_dp
+      REAL(KIND=dp), PARAMETER                           :: epsocc = 1.0e-12_dp
 
       INTEGER :: handle 
 
       CALL timeset(routineN, handle)
 
 !**************************************************************************************
-!1)calculate Fermi energy using the hair probe formula
+!1)calculate Fermi energy using the hairy probe formula
 !**************************************************************************************
-!     rcoeff(nao, nmo, nkp, nspin), icoeff(nao, nmo, nkp, nspin))
       nAO=SIZE(rcoeff, 1)
       nMO=SIZE(rcoeff, 2)
       nkp=SIZE(rcoeff, 3)
@@ -384,7 +376,7 @@ SUBROUTINE probe_occupancy_kp ( occ, fermi, kTS, energies, rcoeff, icoeff, maxoc
       ENDDO
 
 !**************************************************************************************
-!3)calculate occupation numbers using the hair probe formula
+!3)calculate occupation numbers using the hairy probe formula
 !**************************************************************************************
       N_now = 0.0_dp
       kTS = 0.0_dp
@@ -415,7 +407,7 @@ SUBROUTINE HP_occupancy(probe, matrix, energies, maxocc, fermi, occupancy, kTS)
         IMPLICIT NONE 
 
         REAL(KIND=dp), INTENT(OUT)                 :: occupancy(:), kTS
-        TYPE(hair_probes_type), INTENT(IN)         :: probe(:)
+        TYPE(hairy_probes_type), INTENT(IN)         :: probe(:)
         REAL(KIND=dp), INTENT(IN)                  :: matrix(:,:) !squared coefficient matrix
         REAL(KIND=dp), INTENT(IN)                  :: energies(:), fermi, maxocc
 
@@ -423,16 +415,11 @@ SUBROUTINE HP_occupancy(probe, matrix, energies, maxocc, fermi, occupancy, kTS)
         REAL(KIND=dp) :: mu, fermi_fun, fermi_fun_sol, sum_fermi_fun, sum_coeff, &
                          & sum_fermi_fun_sol, sum_coeff_sol, C, s, f
 
-        !tmp 
-        !INTEGER, PARAMETER :: nout = 2222
-        !CHARACTER(len=20), PARAMETER :: debug = 'debug.dat'
-
-        !OPEN(unit=nout,action='write',file=debug,status='replace')
         nMO = SIZE(matrix, 2)
         np = SIZE(probe)
 
         kTS = 0.0_dp
-        ! kTS is the entropic contribution to the energy i.e. -TS
+        ! kTS is the entropic contribution to the electronic energy
 
         mos2: do iMO = 1, nMO
 
@@ -474,10 +461,8 @@ SUBROUTINE HP_occupancy(probe, matrix, energies, maxocc, fermi, occupancy, kTS)
               s = f * LOG(f) + (1.0d0-f) * LOG(1.0d0-f) 
            END IF 
            kTS = kTS + probe(np)%T*maxocc*s 
-           !write(nout,*) occupancy(iMO), f, s, kTS
         END DO MOs2
 
-        !CLOSE(nout)
 END SUBROUTINE HP_occupancy
 
 !**************************************************************************************
@@ -488,21 +473,21 @@ END SUBROUTINE HP_occupancy
 SUBROUTINE AO_boundaries (probe, atomic_kind_set, qs_kind_set, particle_set, nAO)
         IMPLICIT NONE 
         
-        TYPE(hair_probes_type), INTENT(INOUT)           :: probe
-        TYPE(atomic_kind_type), INTENT(IN), POINTER     :: atomic_kind_set(:) !from get_atomic_kind_set 
-        TYPE(particle_type), INTENT(IN), POINTER        :: particle_set(:)    !from get_atomic_kind
-        TYPE(qs_kind_type), INTENT(IN), POINTER         :: qs_kind_set(:)     !from get_qs_kind_set
+        TYPE(hairy_probes_type), INTENT(INOUT)           :: probe
+        TYPE(atomic_kind_type), INTENT(IN), POINTER      :: atomic_kind_set(:) !from get_atomic_kind_set 
+        TYPE(particle_type), INTENT(IN), POINTER         :: particle_set(:)    !from get_atomic_kind
+        TYPE(qs_kind_type), INTENT(IN), POINTER          :: qs_kind_set(:)     !from get_qs_kind_set
         INTEGER, INTENT(IN) :: nAO
  
         !subroutine variables and arrays 
-        TYPE(gto_basis_set_type), POINTER               :: orb_basis_set   !from get_qs_kind 
-        INTEGER, DIMENSION(:), POINTER                  :: nshell          !from get_gto_basis_set 
-        INTEGER, DIMENSION(:, :), POINTER               :: l               !from get_gto_basis_set 
-        INTEGER                                         :: nset            !from get_gto_basis_set 
+        TYPE(gto_basis_set_type), POINTER                :: orb_basis_set   !from get_qs_kind 
+        INTEGER, DIMENSION(:), POINTER                   :: nshell          !from get_gto_basis_set 
+        INTEGER, DIMENSION(:, :), POINTER                :: l               !from get_gto_basis_set 
+        INTEGER                                          :: nset            !from get_gto_basis_set 
                                                            !nset : Number of exponent sets
                                                            !nshell(l) : Number of shells for angular momentum quantum number l
-        INTEGER                                         :: lshell      
-        INTEGER                                         :: natom, nsgf
+        INTEGER                                          :: lshell      
+        INTEGER                                          :: natom, nsgf
 
         INTEGER :: p_atom, isgf, iatom, ii, ikind, iset, ishell 
 
@@ -566,8 +551,7 @@ SUBROUTINE fermi_distribution (E, pot, temp, f_p)
       REAL(kind=dp),INTENT(IN) :: E
       REAL(kind=dp),INTENT(IN) :: pot, temp
 
-      REAL(KIND=dp)            :: arg, exponential, exponential_plus_1, f, one_minus_f!, &
-                                 ! & s_term1, s_term2, logarithm
+      REAL(KIND=dp)            :: arg, exponential, exponential_plus_1, f, one_minus_f
 
       ! have the result of exp go to zero instead of overflowing  
       IF (E > pot) THEN                                           
@@ -578,12 +562,6 @@ SUBROUTINE fermi_distribution (E, pot, temp, f_p)
 
          one_minus_f = exponential/exponential_plus_1                                                      
          f = 1.0_dp/exponential_plus_1                                       
-
-         ! log(1+eps), might need to be written more accurately   
-         !logarithm = -LOG(exponential_plus_1)                                      
-         !s_term1 = one_minus_f*(arg + logarithm) ![1-f]*log[1-f] 
-         !s_term2 = f*logarithm !f*logf                                     
-
          f_p = one_minus_f
       ELSE                                                        
          arg = (E - pot)/temp                                     
@@ -593,15 +571,9 @@ SUBROUTINE fermi_distribution (E, pot, temp, f_p)
 
          f = 1.0_dp/exponential_plus_1                                                   
          one_minus_f = exponential/exponential_plus_1                                          
-
-         !logarithm = -LOG(exponential_plus_1)                                      
-         !s_term1 = f*logarithm                                         
-         !s_term2 = one_minus_f*(arg + logarithm)                              
-
          f_p = f 
       END IF                                                      
                                        
-      !s_p = s_term1 + s_term2        
 END SUBROUTINE fermi_distribution                                        
 
 !*******************************************************************************************************
@@ -641,4 +613,4 @@ SUBROUTINE three_point_zero(y0,y1,y2,h,delta)
 END SUBROUTINE three_point_zero
 
 
-END MODULE hair_probes 
+END MODULE hairy_probes 

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -517,7 +517,87 @@ CONTAINS
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
 
+!####################################################################################
+!MARGHERITA
+      CALL create_hair_probes_section(subsection)
+      CALL section_add_subsection(section, subsection)
+      CALL section_release(subsection)
+!####################################################################################      
+
    END SUBROUTINE create_dft_section
+
+!####################################################################################
+!MARGHERITA 
+! **************************************************************************************************
+!> \brief Hair Probe Model
+!> \param section ...
+!> \author 
+! **************************************************************************************************
+
+   SUBROUTINE create_hair_probes_section(section)
+      TYPE(section_type), POINTER                        :: section
+      TYPE(keyword_type), POINTER                        :: keyword
+      TYPE(section_type), POINTER                        :: print_key, subsection
+
+      NULLIFY (keyword, subsection, print_key)
+      CPASSERT(.NOT. ASSOCIATED(section))
+      CALL section_create(section, __LOCATION__, &
+                          name="HAIR_PROBES", &
+                          description="Sets up a Hairy Probe calculation. ", &                                      
+                          n_keywords=0, n_subsections=0, repeats=.TRUE.)
+
+      CALL keyword_create(keyword, __LOCATION__, &
+                          name="_SECTION_PARAMETERS_", &
+                          description="Controls the activation of hairy probe", &
+                          usage="&HAIR_PROBES ON", &
+                          default_l_val=.FALSE., &
+                          lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+
+      CALL keyword_create(keyword, __LOCATION__, name="ATOM_IDS", &
+                          description="Indexes of the atoms to which the probes are attached;"// &
+                                      "expects a list of integers. ", &
+                          usage="ATOM_IDS <INTEGER> .. <INTEGER>", &
+                          type_of_var=integer_t, n_var=-1)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="T", &
+                          description="Electronic temperature [K]", &
+                          usage="T <REAL>", &
+                          default_r_val=cp_unit_to_cp2k(value=300.0_dp, unit_str="K"), &
+                          unit_str="K")
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="MU", &
+                          description="Chemical potential of the electrons in the probes [eV] ", &
+                          usage="MU <REAL>", &
+                          default_r_val=cp_unit_to_cp2k(value=0.0_dp, unit_str="eV"), &
+                          unit_str="eV")
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      !****8th implementation 
+      CALL keyword_create(keyword, __LOCATION__, name="ALPHA", &
+                          description="Parameter for solution probes ", &
+                          usage="ALPHA <REAL>", &
+                          default_r_val=1.0_dp) 
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+     !****8th implementation 
+
+      CALL keyword_create(keyword, __LOCATION__, name="EPS_HP", &
+                          description=" Tolerance for accuracy checks on occupation numbers "// &
+                                      "calculated using hair-probes. ", &
+                          usage="EPS_HP <REAL>", &
+                          default_r_val=1.0E-5_dp )
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+   END SUBROUTINE create_hair_probes_section
+!####################################################################################   
 
 ! **************************************************************************************************
 !> \brief Implicit Solvation Model

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -517,24 +517,18 @@ CONTAINS
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
 
-!####################################################################################
-!MARGHERITA
-      CALL create_hair_probes_section(subsection)
+      CALL create_hairy_probes_section(subsection)
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
-!####################################################################################      
 
    END SUBROUTINE create_dft_section
 
-!####################################################################################
-!MARGHERITA 
 ! **************************************************************************************************
-!> \brief Hair Probe Model
+!> \brief Hairy Probe Model
 !> \param section ...
 !> \author 
 ! **************************************************************************************************
-
-   SUBROUTINE create_hair_probes_section(section)
+   SUBROUTINE create_hairy_probes_section(section)
       TYPE(section_type), POINTER                        :: section
       TYPE(keyword_type), POINTER                        :: keyword
       TYPE(section_type), POINTER                        :: print_key, subsection
@@ -542,14 +536,14 @@ CONTAINS
       NULLIFY (keyword, subsection, print_key)
       CPASSERT(.NOT. ASSOCIATED(section))
       CALL section_create(section, __LOCATION__, &
-                          name="HAIR_PROBES", &
+                          name="HAIRY_PROBES", &
                           description="Sets up a Hairy Probe calculation. ", &                                      
                           n_keywords=0, n_subsections=0, repeats=.TRUE.)
 
       CALL keyword_create(keyword, __LOCATION__, &
                           name="_SECTION_PARAMETERS_", &
                           description="Controls the activation of hairy probe", &
-                          usage="&HAIR_PROBES ON", &
+                          usage="&HAIRY_PROBES ON", &
                           default_l_val=.FALSE., &
                           lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
@@ -580,14 +574,12 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
-      !****8th implementation 
       CALL keyword_create(keyword, __LOCATION__, name="ALPHA", &
                           description="Parameter for solution probes ", &
                           usage="ALPHA <REAL>", &
                           default_r_val=1.0_dp) 
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
-     !****8th implementation 
 
       CALL keyword_create(keyword, __LOCATION__, name="EPS_HP", &
                           description=" Tolerance for accuracy checks on occupation numbers "// &
@@ -596,7 +588,7 @@ CONTAINS
                           default_r_val=1.0E-5_dp )
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
-   END SUBROUTINE create_hair_probes_section
+   END SUBROUTINE create_hairy_probes_section
 !####################################################################################   
 
 ! **************************************************************************************************

--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -28,7 +28,8 @@ MODULE kpoint_methods
    USE cp_fm_struct,                    ONLY: cp_fm_struct_type
    USE cp_fm_types,                     ONLY: &
         copy_info_type, cp_fm_cleanup_copy_general, cp_fm_create, cp_fm_finish_copy_general, &
-        cp_fm_get_info, cp_fm_release, cp_fm_start_copy_general, cp_fm_to_fm, cp_fm_type
+        cp_fm_get_info, cp_fm_release, cp_fm_start_copy_general, cp_fm_to_fm, cp_fm_type, &
+        cp_fm_get_info, cp_fm_get_submatrix !MARGHERITA
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
    USE cryssym,                         ONLY: apply_rotation_coord,&
                                               crys_sym_gen,&
@@ -78,6 +79,8 @@ MODULE kpoint_methods
                                               neighbor_list_set_p_type
    USE scf_control_types,               ONLY: smear_type
    USE util,                            ONLY: get_limit
+   USE hair_probes,                     ONLY: probe_occupancy_kp !MARGHERITA 
+   USE cp_control_types,                ONLY: hair_probes_type   !MARGHERITA    
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -875,7 +878,8 @@ CONTAINS
 !> \param kpoint  Kpoint environment
 !> \param smear   Smearing information
 ! **************************************************************************************************
-   SUBROUTINE kpoint_set_mo_occupation(kpoint, smear)
+   SUBROUTINE kpoint_set_mo_occupation(kpoint, smear, &
+                                       probe ) !MARGHERITA
 
       TYPE(kpoint_type), POINTER                         :: kpoint
       TYPE(smear_type), POINTER                          :: smear
@@ -890,6 +894,11 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation, wkp
       TYPE(kpoint_env_type), POINTER                     :: kp
       TYPE(mo_set_type), POINTER                         :: mo_set
+      INTEGER ::  nao, nrow_global, ncol_global  !MARGHERITA  
+      TYPE(cp_fm_type), POINTER             :: mo_coeff       !MARGHERITA  
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:,:,:)   :: rcoeff, icoeff       !MARGHERITA  
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:)   :: smatrix     !MARGHERITA  
+      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA      
       TYPE(mp_para_env_type), POINTER                    :: para_env_inter_kp
 
       CALL timeset(routineN, handle)
@@ -899,7 +908,8 @@ CONTAINS
       kp => kpoint%kp_env(1)%kpoint_env
       nspin = SIZE(kp%mos, 2)
       mo_set => kp%mos(1, 1)
-      CALL get_mo_set(mo_set, nmo=nmo, nelectron=nelectron)
+      CALL get_mo_set(mo_set, nmo=nmo, nao=nao, nelectron=nelectron)  !MARGHERITA 
+      !CALL get_mo_set(mo_set, nmo=nmo, nelectron=nelectron)
       ne_a = nelectron
       IF (nspin == 2) THEN
          CALL get_mo_set(kp%mos(1, 2), nmo=nb, nelectron=ne_b)
@@ -908,6 +918,15 @@ CONTAINS
       ALLOCATE (weig(nmo, nkp, nspin), wocc(nmo, nkp, nspin))
       weig = 0.0_dp
       wocc = 0.0_dp
+
+      !MARGHERITA **********************************************************************************
+      IF (PRESENT(probe)) THEN 
+         ALLOCATE (rcoeff(nao, nmo, nkp, nspin), icoeff(nao, nmo, nkp, nspin)) !MARGHERITA   
+         rcoeff = 0.0_dp !MARGHERITA; coeff, real part
+         icoeff = 0.0_dp !MARGHERITA; coeff, imaginary part
+      END IF
+      !MARGHERITA **********************************************************************************      
+
       CALL get_kpoint_info(kpoint, kp_range=kp_range)
       kplocal = kp_range(2) - kp_range(1) + 1
       DO ikpgr = 1, kplocal
@@ -917,65 +936,171 @@ CONTAINS
             mo_set => kp%mos(1, ispin)
             CALL get_mo_set(mo_set, eigenvalues=eigenvalues)
             weig(1:nmo, ik, ispin) = eigenvalues(1:nmo)
+            !MARGHERITA **********************************************************************************
+            IF (PRESENT(probe)) THEN 
+               CALL get_mo_set(mo_set, mo_coeff=mo_coeff)
+               CALL cp_fm_get_info(mo_coeff, &
+                          nrow_global=nrow_global, &
+                          ncol_global=ncol_global)
+               ALLOCATE (smatrix(nrow_global, ncol_global))
+               CALL cp_fm_get_submatrix(mo_coeff, smatrix)
+
+               rcoeff(1:nao, 1:nmo, ik, ispin) = smatrix(1:nrow_global, 1:ncol_global)
+
+               DEALLOCATE(smatrix)
+               
+               mo_set => kp%mos(2, ispin)
+
+               CALL get_mo_set(mo_set, mo_coeff=mo_coeff)
+               CALL cp_fm_get_info(mo_coeff, &
+                          nrow_global=nrow_global, &
+                          ncol_global=ncol_global)
+               ALLOCATE (smatrix(nrow_global, ncol_global))
+               CALL cp_fm_get_submatrix(mo_coeff, smatrix)
+
+               icoeff(1:nao, 1:nmo, ik, ispin) = smatrix(1:nrow_global, 1:ncol_global)
+
+               mo_set => kp%mos(1, ispin)
+
+               DEALLOCATE(smatrix)
+
+            END IF 
+            !MARGHERITA **********************************************************************************
          END DO
       END DO
       CALL get_kpoint_info(kpoint, para_env_inter_kp=para_env_inter_kp)
       CALL para_env_inter_kp%sum(weig)
+      !CALL mp_sum(weig, para_env_inter_kp%group)
+      !MARGHERITA **********************************************************************************
+      IF (PRESENT(probe)) THEN 
+         !CALL mp_sum(rcoeff, para_env_inter_kp%group) !MARGHERITA, NEW 03.07
+         !CALL mp_sum(icoeff, para_env_inter_kp%group) !MARGHERITA, NEW 03.07
+         CALL para_env_inter_kp%sum(rcoeff) !MARGHERITA, NEW 03.07
+         CALL para_env_inter_kp%sum(icoeff) !MARGHERITA, NEW 03.07
+      END IF 
+      !MARGHERITA **********************************************************************************   
 
       CALL get_kpoint_info(kpoint, wkp=wkp)
-      IF (smear%do_smear) THEN
-         ! finite electronic temperature
-         SELECT CASE (smear%method)
-         CASE (smear_fermi_dirac)
+
+!********************************************************************************************************
+!MARGHERITA 
+!********************************************************************************************************
+!calling of HP module HERE, before smear 
+      IF (PRESENT(probe)) THEN             
+         smear%do_smear = .false. !ensures smearing is switched off
+ 
+         IF (nspin == 1) THEN 
+            nel = REAL(nelectron, KIND=dp)
+            CALL probe_occupancy_kp(wocc(:,:,:), mus(1), kTS, weig(:,:,:), rcoeff(:,:,:,:), icoeff(:,:,:,:), 2.0d0, & 
+                                   probe, nel, wkp)
+         ELSE 
+            nel = REAL(ne_a, KIND=dp) + REAL(ne_b, KIND=dp)
+            CALL probe_occupancy_kp(wocc(:,:,:), mu, kTS, weig(:,:,:), rcoeff(:,:,:,:), icoeff(:,:,:,:), 1.0d0, & 
+                                   probe, nel, wkp) 
+            kTS = kTS/2._dp
+            mus(1:2) = mu
+         END IF
+ 
+         DO ikpgr = 1, kplocal
+            ik = kp_range(1) + ikpgr - 1
+            kp => kpoint%kp_env(ikpgr)%kpoint_env
+            DO ispin = 1, nspin
+               mo_set => kp%mos(1, ispin)
+               CALL get_mo_set(mo_set, eigenvalues=eigenvalues, occupation_numbers=occupation) 
+               eigenvalues(1:nmo) = weig(1:nmo, ik, ispin)
+               occupation(1:nmo) = wocc(1:nmo, ik, ispin)
+               mo_set%kTS = kTS
+               mo_set%mu = mus(ispin)
+ 
+               CALL get_mo_set(mo_set, mo_coeff=mo_coeff) 
+               !get smatrix for kpoint_env ikp 
+               CALL cp_fm_get_info(mo_coeff, &
+                          nrow_global=nrow_global, &
+                          ncol_global=ncol_global)
+               ALLOCATE (smatrix(nrow_global, ncol_global))
+               CALL cp_fm_get_submatrix(mo_coeff, smatrix)
+ 
+               smatrix(1:nrow_global, 1:ncol_global) = rcoeff(1:nao, 1:nmo, ik, ispin) 
+               DEALLOCATE(smatrix)
+ 
+               mo_set => kp%mos(2, ispin)
+ 
+               CALL get_mo_set(mo_set, mo_coeff=mo_coeff) 
+               !get smatrix for kpoint_env ikp 
+               CALL cp_fm_get_info(mo_coeff, &
+                          nrow_global=nrow_global, &
+                          ncol_global=ncol_global)
+               ALLOCATE (smatrix(nrow_global, ncol_global))
+               CALL cp_fm_get_submatrix(mo_coeff, smatrix)
+ 
+               smatrix(1:nrow_global, 1:ncol_global) = icoeff(1:nao, 1:nmo, ik, ispin) 
+               DEALLOCATE(smatrix)
+ 
+               mo_set => kp%mos(1, ispin)
+ 
+            END DO
+         END DO
+ 
+         DEALLOCATE (weig, wocc, rcoeff, icoeff)
+ 
+      END IF
+!********************************************************************************************************
+      
+      IF (PRESENT(probe) .eqv. .false. ) THEN !MARGHERITA
+         IF (smear%do_smear) THEN
+            ! finite electronic temperature
+            SELECT CASE (smear%method)
+            CASE (smear_fermi_dirac)
+               IF (nspin == 1) THEN
+                  nel = REAL(nelectron, KIND=dp)
+                  CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
+                               smear%electronic_temperature, 2.0_dp)
+               ELSE IF (smear%fixed_mag_mom > 0.0_dp) THEN
+                  CPABORT("kpoints: Smearing with fixed magnetic moments not (yet) supported")
+                  nel = REAL(ne_a, KIND=dp)
+                  CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
+                               smear%electronic_temperature, 1.0_dp)
+                  nel = REAL(ne_b, KIND=dp)
+                  CALL Fermikp(wocc(:, :, 2), mus(2), kTS, weig(:, :, 2), nel, wkp, &
+                               smear%electronic_temperature, 1.0_dp)
+               ELSE
+                  nel = REAL(ne_a, KIND=dp) + REAL(ne_b, KIND=dp)
+                  CALL Fermikp2(wocc(:, :, :), mu, kTS, weig(:, :, :), nel, wkp, &
+                                smear%electronic_temperature)
+                  kTS = kTS/2._dp
+                  mus(1:2) = mu
+               END IF
+            CASE DEFAULT
+               CPABORT("kpoints: Selected smearing not (yet) supported")
+            END SELECT
+         ELSE
+            ! fixed occupations (2/1)
             IF (nspin == 1) THEN
                nel = REAL(nelectron, KIND=dp)
-               CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
-                            smear%electronic_temperature, 2.0_dp)
-            ELSE IF (smear%fixed_mag_mom > 0.0_dp) THEN
-               CPABORT("kpoints: Smearing with fixed magnetic moments not (yet) supported")
-               nel = REAL(ne_a, KIND=dp)
-               CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
-                            smear%electronic_temperature, 1.0_dp)
-               nel = REAL(ne_b, KIND=dp)
-               CALL Fermikp(wocc(:, :, 2), mus(2), kTS, weig(:, :, 2), nel, wkp, &
-                            smear%electronic_temperature, 1.0_dp)
+               CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, 0.0_dp, 2.0_dp)
             ELSE
-               nel = REAL(ne_a, KIND=dp) + REAL(ne_b, KIND=dp)
-               CALL Fermikp2(wocc(:, :, :), mu, kTS, weig(:, :, :), nel, wkp, &
-                             smear%electronic_temperature)
-               kTS = kTS/2._dp
-               mus(1:2) = mu
+               nel = REAL(ne_a, KIND=dp)
+               CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, 0.0_dp, 1.0_dp)
+               nel = REAL(ne_b, KIND=dp)
+               CALL Fermikp(wocc(:, :, 2), mus(2), kTS, weig(:, :, 2), nel, wkp, 0.0_dp, 1.0_dp)
             END IF
-         CASE DEFAULT
-            CPABORT("kpoints: Selected smearing not (yet) supported")
-         END SELECT
-      ELSE
-         ! fixed occupations (2/1)
-         IF (nspin == 1) THEN
-            nel = REAL(nelectron, KIND=dp)
-            CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, 0.0_dp, 2.0_dp)
-         ELSE
-            nel = REAL(ne_a, KIND=dp)
-            CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, 0.0_dp, 1.0_dp)
-            nel = REAL(ne_b, KIND=dp)
-            CALL Fermikp(wocc(:, :, 2), mus(2), kTS, weig(:, :, 2), nel, wkp, 0.0_dp, 1.0_dp)
          END IF
-      END IF
-      DO ikpgr = 1, kplocal
-         ik = kp_range(1) + ikpgr - 1
-         kp => kpoint%kp_env(ikpgr)%kpoint_env
-         DO ispin = 1, nspin
-            mo_set => kp%mos(1, ispin)
-            CALL get_mo_set(mo_set, eigenvalues=eigenvalues, occupation_numbers=occupation)
-            eigenvalues(1:nmo) = weig(1:nmo, ik, ispin)
-            occupation(1:nmo) = wocc(1:nmo, ik, ispin)
-            mo_set%kTS = kTS
-            mo_set%mu = mus(ispin)
+         DO ikpgr = 1, kplocal
+            ik = kp_range(1) + ikpgr - 1
+            kp => kpoint%kp_env(ikpgr)%kpoint_env
+            DO ispin = 1, nspin
+               mo_set => kp%mos(1, ispin)
+               CALL get_mo_set(mo_set, eigenvalues=eigenvalues, occupation_numbers=occupation)
+               eigenvalues(1:nmo) = weig(1:nmo, ik, ispin)
+               occupation(1:nmo) = wocc(1:nmo, ik, ispin)
+               mo_set%kTS = kTS
+               mo_set%mu = mus(ispin)
+            END DO
          END DO
-      END DO
 
-      DEALLOCATE (weig, wocc)
+         DEALLOCATE (weig, wocc)
 
+      END IF !MARGHERITA
       CALL timestop(handle)
 
    END SUBROUTINE kpoint_set_mo_occupation

--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -29,7 +29,7 @@ MODULE kpoint_methods
    USE cp_fm_types,                     ONLY: &
         copy_info_type, cp_fm_cleanup_copy_general, cp_fm_create, cp_fm_finish_copy_general, &
         cp_fm_get_info, cp_fm_release, cp_fm_start_copy_general, cp_fm_to_fm, cp_fm_type, &
-        cp_fm_get_info, cp_fm_get_submatrix !MARGHERITA
+        cp_fm_get_info, cp_fm_get_submatrix 
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
    USE cryssym,                         ONLY: apply_rotation_coord,&
                                               crys_sym_gen,&
@@ -79,8 +79,8 @@ MODULE kpoint_methods
                                               neighbor_list_set_p_type
    USE scf_control_types,               ONLY: smear_type
    USE util,                            ONLY: get_limit
-   USE hair_probes,                     ONLY: probe_occupancy_kp !MARGHERITA 
-   USE cp_control_types,                ONLY: hair_probes_type   !MARGHERITA    
+   USE hairy_probes,                    ONLY: probe_occupancy_kp 
+   USE cp_control_types,                ONLY: hairy_probes_type    
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -878,8 +878,7 @@ CONTAINS
 !> \param kpoint  Kpoint environment
 !> \param smear   Smearing information
 ! **************************************************************************************************
-   SUBROUTINE kpoint_set_mo_occupation(kpoint, smear, &
-                                       probe ) !MARGHERITA
+   SUBROUTINE kpoint_set_mo_occupation(kpoint, smear, probe ) 
 
       TYPE(kpoint_type), POINTER                         :: kpoint
       TYPE(smear_type), POINTER                          :: smear
@@ -887,18 +886,19 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_set_mo_occupation'
 
       INTEGER                                            :: handle, ik, ikpgr, ispin, kplocal, nb, &
-                                                            ne_a, ne_b, nelectron, nkp, nmo, nspin
+                                                            ne_a, ne_b, nelectron, nkp, nmo, nspin, &
+                                                            nao, nrow_global, ncol_global !hairy probes calculation
       INTEGER, DIMENSION(2)                              :: kp_range
       REAL(KIND=dp)                                      :: kTS, mu, mus(2), nel
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: weig, wocc
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:,:,:)     :: rcoeff, icoeff 
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:)         :: smatrix 
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation, wkp
       TYPE(kpoint_env_type), POINTER                     :: kp
       TYPE(mo_set_type), POINTER                         :: mo_set
-      INTEGER ::  nao, nrow_global, ncol_global  !MARGHERITA  
-      TYPE(cp_fm_type), POINTER             :: mo_coeff       !MARGHERITA  
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:,:,:)   :: rcoeff, icoeff       !MARGHERITA  
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:)   :: smatrix     !MARGHERITA  
-      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA      
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff         
+      TYPE(hairy_probes_type), DIMENSION(:), &
+            OPTIONAL, POINTER                            :: probe       
       TYPE(mp_para_env_type), POINTER                    :: para_env_inter_kp
 
       CALL timeset(routineN, handle)
@@ -908,8 +908,7 @@ CONTAINS
       kp => kpoint%kp_env(1)%kpoint_env
       nspin = SIZE(kp%mos, 2)
       mo_set => kp%mos(1, 1)
-      CALL get_mo_set(mo_set, nmo=nmo, nao=nao, nelectron=nelectron)  !MARGHERITA 
-      !CALL get_mo_set(mo_set, nmo=nmo, nelectron=nelectron)
+      CALL get_mo_set(mo_set, nmo=nmo, nao=nao, nelectron=nelectron)   
       ne_a = nelectron
       IF (nspin == 2) THEN
          CALL get_mo_set(kp%mos(1, 2), nmo=nb, nelectron=ne_b)
@@ -919,13 +918,11 @@ CONTAINS
       weig = 0.0_dp
       wocc = 0.0_dp
 
-      !MARGHERITA **********************************************************************************
       IF (PRESENT(probe)) THEN 
-         ALLOCATE (rcoeff(nao, nmo, nkp, nspin), icoeff(nao, nmo, nkp, nspin)) !MARGHERITA   
-         rcoeff = 0.0_dp !MARGHERITA; coeff, real part
-         icoeff = 0.0_dp !MARGHERITA; coeff, imaginary part
+         ALLOCATE (rcoeff(nao, nmo, nkp, nspin), icoeff(nao, nmo, nkp, nspin)) 
+         rcoeff = 0.0_dp !coeff, real part
+         icoeff = 0.0_dp !coeff, imaginary part
       END IF
-      !MARGHERITA **********************************************************************************      
 
       CALL get_kpoint_info(kpoint, kp_range=kp_range)
       kplocal = kp_range(2) - kp_range(1) + 1
@@ -936,7 +933,7 @@ CONTAINS
             mo_set => kp%mos(1, ispin)
             CALL get_mo_set(mo_set, eigenvalues=eigenvalues)
             weig(1:nmo, ik, ispin) = eigenvalues(1:nmo)
-            !MARGHERITA **********************************************************************************
+
             IF (PRESENT(probe)) THEN 
                CALL get_mo_set(mo_set, mo_coeff=mo_coeff)
                CALL cp_fm_get_info(mo_coeff, &
@@ -965,27 +962,18 @@ CONTAINS
                DEALLOCATE(smatrix)
 
             END IF 
-            !MARGHERITA **********************************************************************************
          END DO
       END DO
       CALL get_kpoint_info(kpoint, para_env_inter_kp=para_env_inter_kp)
       CALL para_env_inter_kp%sum(weig)
-      !CALL mp_sum(weig, para_env_inter_kp%group)
-      !MARGHERITA **********************************************************************************
       IF (PRESENT(probe)) THEN 
-         !CALL mp_sum(rcoeff, para_env_inter_kp%group) !MARGHERITA, NEW 03.07
-         !CALL mp_sum(icoeff, para_env_inter_kp%group) !MARGHERITA, NEW 03.07
-         CALL para_env_inter_kp%sum(rcoeff) !MARGHERITA, NEW 03.07
-         CALL para_env_inter_kp%sum(icoeff) !MARGHERITA, NEW 03.07
+         CALL para_env_inter_kp%sum(rcoeff) 
+         CALL para_env_inter_kp%sum(icoeff) 
       END IF 
-      !MARGHERITA **********************************************************************************   
 
       CALL get_kpoint_info(kpoint, wkp=wkp)
 
-!********************************************************************************************************
-!MARGHERITA 
-!********************************************************************************************************
-!calling of HP module HERE, before smear 
+      !calling of HP module HERE, before smear 
       IF (PRESENT(probe)) THEN             
          smear%do_smear = .false. !ensures smearing is switched off
  
@@ -1044,9 +1032,8 @@ CONTAINS
          DEALLOCATE (weig, wocc, rcoeff, icoeff)
  
       END IF
-!********************************************************************************************************
       
-      IF (PRESENT(probe) .eqv. .false. ) THEN !MARGHERITA
+      IF (PRESENT(probe) .eqv. .false. ) THEN !switches off regular smearing for HP calculation
          IF (smear%do_smear) THEN
             ! finite electronic temperature
             SELECT CASE (smear%method)
@@ -1100,7 +1087,7 @@ CONTAINS
 
          DEALLOCATE (weig, wocc)
 
-      END IF !MARGHERITA
+      END IF 
       CALL timestop(handle)
 
    END SUBROUTINE kpoint_set_mo_occupation

--- a/src/qs_mo_methods.F
+++ b/src/qs_mo_methods.F
@@ -53,6 +53,7 @@ MODULE qs_mo_methods
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_type
    USE scf_control_types,               ONLY: scf_control_type
+   USE cp_control_types,                ONLY: hair_probes_type !MARGHERITA      
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -813,7 +814,8 @@ CONTAINS
 !>         02.2013 moved from qs_scf_post_gpw
 !>
 ! **************************************************************************************************
-   SUBROUTINE make_mo_eig(mos, nspins, ks_rmpv, scf_control, mo_derivs, admm_env)
+   SUBROUTINE make_mo_eig(mos, nspins, ks_rmpv, scf_control, mo_derivs, admm_env, &
+                           hair_probes, probe) !MARGHERITA
 
       TYPE(mo_set_type), DIMENSION(:), INTENT(INOUT)     :: mos
       INTEGER, INTENT(IN)                                :: nspins
@@ -828,6 +830,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_deriv
+      LOGICAL, OPTIONAL   :: hair_probes !MARGHERITA 
+      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA
 
       CALL timeset(routineN, handle)
 
@@ -868,8 +872,18 @@ CONTAINS
          ELSE
             IF (output_unit > 0) WRITE (output_unit, '(4(1X,1F16.8))') mo_eigenvalues(1:homo)
          END IF
-         IF (.NOT. scf_control%diagonalization%mom) &
-            CALL set_mo_occupation(mo_set=mos(ispin), smear=scf_control%smear)
+         IF (.NOT. scf_control%diagonalization%mom) THEN
+         !MARGHERITA###########################################################################
+            IF (PRESENT(hair_probes) .eqv. .true.) THEN
+               scf_control%smear%do_smear = .false. !maybe not necessary
+               CALL set_mo_occupation(mo_set=mos(ispin), &
+                              smear=scf_control%smear, &
+                              probe=probe )
+            ELSE 
+               CALL set_mo_occupation(mo_set=mos(ispin), smear=scf_control%smear)
+            END IF
+         !#####################################################################################
+         END IF 
          IF (output_unit > 0) WRITE (output_unit, '(T2,A,F12.6)') &
             "Fermi Energy [eV] :", mos(ispin)%mu*evolt
       END DO

--- a/src/qs_mo_methods.F
+++ b/src/qs_mo_methods.F
@@ -53,7 +53,7 @@ MODULE qs_mo_methods
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_type
    USE scf_control_types,               ONLY: scf_control_type
-   USE cp_control_types,                ONLY: hair_probes_type !MARGHERITA      
+   USE cp_control_types,                ONLY: hairy_probes_type     
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -815,7 +815,7 @@ CONTAINS
 !>
 ! **************************************************************************************************
    SUBROUTINE make_mo_eig(mos, nspins, ks_rmpv, scf_control, mo_derivs, admm_env, &
-                           hair_probes, probe) !MARGHERITA
+                           hairy_probes, probe) 
 
       TYPE(mo_set_type), DIMENSION(:), INTENT(INOUT)     :: mos
       INTEGER, INTENT(IN)                                :: nspins
@@ -830,8 +830,10 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_deriv
-      LOGICAL, OPTIONAL   :: hair_probes !MARGHERITA 
-      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA
+      
+      TYPE(hairy_probes_type), DIMENSION(:), &
+            OPTIONAL, POINTER                            :: probe 
+      LOGICAL, OPTIONAL                                  :: hairy_probes 
 
       CALL timeset(routineN, handle)
 
@@ -873,8 +875,7 @@ CONTAINS
             IF (output_unit > 0) WRITE (output_unit, '(4(1X,1F16.8))') mo_eigenvalues(1:homo)
          END IF
          IF (.NOT. scf_control%diagonalization%mom) THEN
-         !MARGHERITA###########################################################################
-            IF (PRESENT(hair_probes) .eqv. .true.) THEN
+            IF (PRESENT(hairy_probes) .eqv. .true.) THEN
                scf_control%smear%do_smear = .false. !maybe not necessary
                CALL set_mo_occupation(mo_set=mos(ispin), &
                               smear=scf_control%smear, &
@@ -882,7 +883,6 @@ CONTAINS
             ELSE 
                CALL set_mo_occupation(mo_set=mos(ispin), smear=scf_control%smear)
             END IF
-         !#####################################################################################
          END IF 
          IF (output_unit > 0) WRITE (output_unit, '(T2,A,F12.6)') &
             "Fermi Energy [eV] :", mos(ispin)%mu*evolt

--- a/src/qs_mo_occupation.F
+++ b/src/qs_mo_occupation.F
@@ -30,11 +30,11 @@ MODULE qs_mo_occupation
    USE util,                            ONLY: sort
    USE xas_env_types,                   ONLY: get_xas_env,&
                                               xas_environment_type
-   USE hair_probes,                     ONLY: probe_occupancy              !MARGHERITA 
-   USE cp_control_types,                ONLY: hair_probes_type,&           !MARGHERITA
-                                              dft_control_type             !MARGHERITA
-   USE input_section_types,             ONLY: section_vals_get_subs_vals,& !MARGHERITA
-                                              section_vals_type            !MARGHERITA                                              
+   USE hairy_probes,                     ONLY: probe_occupancy           
+   USE cp_control_types,                ONLY: hairy_probes_type,&        
+                                              dft_control_type          
+   USE input_section_types,             ONLY: section_vals_get_subs_vals, &
+                                              section_vals_type                                                      
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -205,7 +205,8 @@ CONTAINS
       TYPE(smear_type), POINTER                          :: smear
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: eval_deriv
       REAL(KIND=dp), OPTIONAL                            :: tot_zeff_corr
-      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA      
+      TYPE(hairy_probes_type), DIMENSION(:), &
+            OPTIONAL, POINTER                            :: probe       
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_mo_occupation_2'
 
@@ -219,10 +220,8 @@ CONTAINS
 
       ! Fall back for the case that we have only one MO set
       IF (SIZE(mo_array) == 1) THEN
-         !MARGHERITA********************************************************************************************
          IF (PRESENT(probe)) THEN                                                       
             CALL set_mo_occupation_1(mo_array(1), smear=smear, probe=probe )  
-         !*****************************************************************************************************
          ELSE IF (PRESENT(eval_deriv)) THEN
 ! Change of MO occupancy to account for CORE_CORRECTION is not yet implemented
             CALL set_mo_occupation_1(mo_array(1), smear=smear, eval_deriv=eval_deriv)
@@ -236,15 +235,11 @@ CONTAINS
          CALL timestop(handle)
          RETURN
       END IF
-
-!********************************************************************************************************
-!MARGHERITA 
-!********************************************************************************************************
+ 
       IF (PRESENT(probe)) THEN 
          CALL set_mo_occupation_1(mo_array(1), smear=smear, probe=probe ) 
          CALL set_mo_occupation_1(mo_array(2), smear=smear, probe=probe ) 
      END IF 
-!********************************************************************************************************      
 
       IF (smear%do_smear) THEN
          IF (smear%fixed_mag_mom < 0.0_dp) THEN
@@ -281,11 +276,9 @@ CONTAINS
 
       IF (.NOT. ((mo_array(1)%flexible_electron_count > 0.0_dp) .AND. &
                  (mo_array(2)%flexible_electron_count > 0.0_dp))) THEN
-         !MARGHERITA********************************************************************************************
          IF (PRESENT(probe)) THEN                                                            
             CALL set_mo_occupation_1(mo_array(1), smear=smear, probe=probe ) 
             CALL set_mo_occupation_1(mo_array(2), smear=smear, probe=probe ) 
-         !******************************************************************************************************         
          ELSE IF (PRESENT(eval_deriv)) THEN
             CALL set_mo_occupation_1(mo_array(1), smear=smear, eval_deriv=eval_deriv)
             CALL set_mo_occupation_1(mo_array(2), smear=smear, eval_deriv=eval_deriv)
@@ -375,11 +368,9 @@ CONTAINS
                       "Multiplicity changed from "// &
                       TRIM(ADJUSTL(cp_to_string(multiplicity_old)))//" to "// &
                       TRIM(ADJUSTL(cp_to_string(multiplicity_new))))
-      !MARGHERITA********************************************************************************************
       IF (PRESENT(probe)) THEN                                                            
          CALL set_mo_occupation_1(mo_array(1), smear=smear, probe=probe ) 
          CALL set_mo_occupation_1(mo_array(2), smear=smear, probe=probe ) 
-      !******************************************************************************************************
       ELSE IF (PRESENT(eval_deriv)) THEN
          CALL set_mo_occupation_1(mo_array(1), smear=smear, eval_deriv=eval_deriv)
          CALL set_mo_occupation_1(mo_array(2), smear=smear, eval_deriv=eval_deriv)
@@ -423,7 +414,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: eval_deriv
       TYPE(xas_environment_type), OPTIONAL, POINTER      :: xas_env
       REAL(KIND=dp), OPTIONAL                            :: tot_zeff_corr
-      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA      
+      TYPE(hairy_probes_type), DIMENSION(:), &
+            OPTIONAL, POINTER                            :: probe      
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_mo_occupation_1'
 
@@ -543,9 +535,6 @@ CONTAINS
          CPASSERT(equal_size)
       END IF
       
-!********************************************************************************************************
-!MARGHERITA 
-!********************************************************************************************************
 !calling of HP module HERE, before smear 
       IF (PRESENT(probe)) THEN             
          i_first = 1
@@ -560,7 +549,7 @@ CONTAINS
          CALL probe_occupancy(mo_set%occupation_numbers, mo_set%mu, mo_set%kTS, &
                               mo_set%eigenvalues, mo_set%mo_coeff, mo_set%maxocc, &
                               probe, N=nelec)
-         !NB: mu and T are taken from the hair_probe type (defined in cp_control_types.F); these values are set in the input
+         !NB: mu and T are taken from the hairy_probe type (defined in cp_control_types.F); these values are set in the input
 
          ! Find the lowest fractional occupied MO (LFOMO)
          DO imo = i_first, nmo

--- a/src/qs_mo_occupation.F
+++ b/src/qs_mo_occupation.F
@@ -30,6 +30,11 @@ MODULE qs_mo_occupation
    USE util,                            ONLY: sort
    USE xas_env_types,                   ONLY: get_xas_env,&
                                               xas_environment_type
+   USE hair_probes,                     ONLY: probe_occupancy              !MARGHERITA 
+   USE cp_control_types,                ONLY: hair_probes_type,&           !MARGHERITA
+                                              dft_control_type             !MARGHERITA
+   USE input_section_types,             ONLY: section_vals_get_subs_vals,& !MARGHERITA
+                                              section_vals_type            !MARGHERITA                                              
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -193,12 +198,14 @@ CONTAINS
 !> \author  Matthias Krack (MK)
 !> \version 1.0
 ! **************************************************************************************************
-   SUBROUTINE set_mo_occupation_2(mo_array, smear, eval_deriv, tot_zeff_corr)
+   SUBROUTINE set_mo_occupation_2(mo_array, smear, eval_deriv, tot_zeff_corr, &
+                                    probe )
 
       TYPE(mo_set_type), DIMENSION(:), INTENT(INOUT)     :: mo_array
       TYPE(smear_type), POINTER                          :: smear
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: eval_deriv
       REAL(KIND=dp), OPTIONAL                            :: tot_zeff_corr
+      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA      
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_mo_occupation_2'
 
@@ -212,7 +219,11 @@ CONTAINS
 
       ! Fall back for the case that we have only one MO set
       IF (SIZE(mo_array) == 1) THEN
-         IF (PRESENT(eval_deriv)) THEN
+         !MARGHERITA********************************************************************************************
+         IF (PRESENT(probe)) THEN                                                       
+            CALL set_mo_occupation_1(mo_array(1), smear=smear, probe=probe )  
+         !*****************************************************************************************************
+         ELSE IF (PRESENT(eval_deriv)) THEN
 ! Change of MO occupancy to account for CORE_CORRECTION is not yet implemented
             CALL set_mo_occupation_1(mo_array(1), smear=smear, eval_deriv=eval_deriv)
          ELSE
@@ -225,6 +236,15 @@ CONTAINS
          CALL timestop(handle)
          RETURN
       END IF
+
+!********************************************************************************************************
+!MARGHERITA 
+!********************************************************************************************************
+      IF (PRESENT(probe)) THEN 
+         CALL set_mo_occupation_1(mo_array(1), smear=smear, probe=probe ) 
+         CALL set_mo_occupation_1(mo_array(2), smear=smear, probe=probe ) 
+     END IF 
+!********************************************************************************************************      
 
       IF (smear%do_smear) THEN
          IF (smear%fixed_mag_mom < 0.0_dp) THEN
@@ -261,7 +281,12 @@ CONTAINS
 
       IF (.NOT. ((mo_array(1)%flexible_electron_count > 0.0_dp) .AND. &
                  (mo_array(2)%flexible_electron_count > 0.0_dp))) THEN
-         IF (PRESENT(eval_deriv)) THEN
+         !MARGHERITA********************************************************************************************
+         IF (PRESENT(probe)) THEN                                                            
+            CALL set_mo_occupation_1(mo_array(1), smear=smear, probe=probe ) 
+            CALL set_mo_occupation_1(mo_array(2), smear=smear, probe=probe ) 
+         !******************************************************************************************************         
+         ELSE IF (PRESENT(eval_deriv)) THEN
             CALL set_mo_occupation_1(mo_array(1), smear=smear, eval_deriv=eval_deriv)
             CALL set_mo_occupation_1(mo_array(2), smear=smear, eval_deriv=eval_deriv)
          ELSE
@@ -350,8 +375,12 @@ CONTAINS
                       "Multiplicity changed from "// &
                       TRIM(ADJUSTL(cp_to_string(multiplicity_old)))//" to "// &
                       TRIM(ADJUSTL(cp_to_string(multiplicity_new))))
-
-      IF (PRESENT(eval_deriv)) THEN
+      !MARGHERITA********************************************************************************************
+      IF (PRESENT(probe)) THEN                                                            
+         CALL set_mo_occupation_1(mo_array(1), smear=smear, probe=probe ) 
+         CALL set_mo_occupation_1(mo_array(2), smear=smear, probe=probe ) 
+      !******************************************************************************************************
+      ELSE IF (PRESENT(eval_deriv)) THEN
          CALL set_mo_occupation_1(mo_array(1), smear=smear, eval_deriv=eval_deriv)
          CALL set_mo_occupation_1(mo_array(2), smear=smear, eval_deriv=eval_deriv)
       ELSE
@@ -386,13 +415,15 @@ CONTAINS
 !> \author  Matthias Krack
 !> \version 1.1
 ! **************************************************************************************************
-   SUBROUTINE set_mo_occupation_1(mo_set, smear, eval_deriv, xas_env, tot_zeff_corr)
+   SUBROUTINE set_mo_occupation_1(mo_set, smear, eval_deriv, xas_env, tot_zeff_corr, &
+                                    probe)
 
       TYPE(mo_set_type), INTENT(INOUT)                   :: mo_set
       TYPE(smear_type), OPTIONAL, POINTER                :: smear
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: eval_deriv
       TYPE(xas_environment_type), OPTIONAL, POINTER      :: xas_env
       REAL(KIND=dp), OPTIONAL                            :: tot_zeff_corr
+      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA      
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_mo_occupation_1'
 
@@ -511,6 +542,58 @@ CONTAINS
          equal_size = (SIZE(mo_set%occupation_numbers, 1) == SIZE(eval_deriv, 1))
          CPASSERT(equal_size)
       END IF
+      
+!********************************************************************************************************
+!MARGHERITA 
+!********************************************************************************************************
+!calling of HP module HERE, before smear 
+      IF (PRESENT(probe)) THEN             
+         i_first = 1
+         IF (smear%fixed_mag_mom == -1.0_dp) THEN
+            nelec = REAL(mo_set%nelectron, dp)
+         ELSE
+            nelec = mo_set%n_el_f
+         END IF
+
+         mo_set%occupation_numbers(:) = 0.0_dp
+
+         CALL probe_occupancy(mo_set%occupation_numbers, mo_set%mu, mo_set%kTS, &
+                              mo_set%eigenvalues, mo_set%mo_coeff, mo_set%maxocc, &
+                              probe, N=nelec)
+         !NB: mu and T are taken from the hair_probe type (defined in cp_control_types.F); these values are set in the input
+
+         ! Find the lowest fractional occupied MO (LFOMO)
+         DO imo = i_first, nmo
+            IF (mo_set%occupation_numbers(imo) < mo_set%maxocc) THEN
+               mo_set%lfomo = imo
+               EXIT
+            END IF
+         END DO
+         is_large = ABS(MAXVAL(mo_set%occupation_numbers) - mo_set%maxocc) > probe(1)%eps_hp 
+         ! this is not a real problem, but the temperature might be a bit large
+         IF (is_large) &
+             CPWARN("Hair-probes occupancy distribution includes the first MO")
+
+         ! Find the highest (fractional) occupied MO which will be now the HOMO
+         DO imo = nmo, mo_set%lfomo, -1
+            IF (mo_set%occupation_numbers(imo) > probe(1)%eps_hp) THEN 
+               mo_set%homo = imo
+               EXIT
+            END IF
+         END DO
+         is_large = ABS(MINVAL(mo_set%occupation_numbers)) > probe(1)%eps_hp 
+         IF (is_large) &
+            CALL cp_warn(__LOCATION__, &
+                         "Hair-probes occupancy distribution includes the last MO => "// &
+                         "Add more MOs for proper smearing.")
+
+         ! check that the total electron count is accurate
+         is_large = (ABS(nelec - accurate_sum(mo_set%occupation_numbers(:))) > probe(1)%eps_hp*nelec)
+         IF (is_large) &
+            CPWARN("Total number of electrons is not accurate")
+
+      END IF
+!********************************************************************************************************      
 
       ! Quick return, if no smearing information is supplied (TO BE FIXED, smear should become non-optional...)
       IF (.NOT. PRESENT(smear)) THEN

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -47,7 +47,7 @@
 MODULE qs_scf
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE cp_control_types,                ONLY: dft_control_type, &
-                                              hair_probes_type !MARGHERITA
+                                              hairy_probes_type 
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               dbcsr_deallocate_matrix_set
    USE cp_files,                        ONLY: close_file
@@ -492,18 +492,15 @@ CONTAINS
 
             IF (do_kpoints) THEN
                ! kpoints
-               !MARGHERITA################################################################################### 
-               IF (dft_control%hair_probes .eqv. .true.) THEN 
+               IF (dft_control%hairy_probes .eqv. .true.) THEN 
                   scf_control%smear%do_smear = .false. 
                   CALL qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step, dft_control%probe)
                ELSE 
                   CALL qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step)
                END IF 
-               !##############################################################################################               
             ELSE
                ! Gamma points only
-               !MARGHERITA################################################################################### 
-               IF (dft_control%hair_probes .eqv. .true.) THEN 
+               IF (dft_control%hairy_probes .eqv. .true.) THEN 
                   scf_control%smear%do_smear = .false. 
                   CALL qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step, energy_only, &
                               dft_control%probe)  
@@ -700,10 +697,10 @@ CONTAINS
       DO ispin = 1, dft_control%nspins
          ! do not reset mo_occupations if the maximum overlap method is in use
          IF (.NOT. scf_control%diagonalization%mom) THEN
-            !MARGHERITA: if the hair probes section is present, this sends hair_probes to set_mo_occupation subroutine 
+            !if the hairY probes section is present, this sends hairy_probes to set_mo_occupation subroutine 
             !and switches off the standard smearing
-            IF (dft_control%hair_probes .eqv. .true.) THEN !MARGHERITA 
-               scf_control%smear%do_smear = .false. !MARGHERITA 
+            IF (dft_control%hairy_probes .eqv. .true.) THEN  
+               scf_control%smear%do_smear = .false.  
                CALL set_mo_occupation(mo_set=mos(ispin), &
                                     smear=scf_control%smear, &
                                     probe=dft_control%probe) 

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -46,7 +46,8 @@
 ! **************************************************************************************************
 MODULE qs_scf
    USE atomic_kind_types,               ONLY: atomic_kind_type
-   USE cp_control_types,                ONLY: dft_control_type
+   USE cp_control_types,                ONLY: dft_control_type, &
+                                              hair_probes_type !MARGHERITA
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               dbcsr_deallocate_matrix_set
    USE cp_files,                        ONLY: close_file
@@ -491,10 +492,25 @@ CONTAINS
 
             IF (do_kpoints) THEN
                ! kpoints
-               CALL qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step)
+               !MARGHERITA################################################################################### 
+               IF (dft_control%hair_probes .eqv. .true.) THEN 
+                  scf_control%smear%do_smear = .false. 
+                  CALL qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step, dft_control%probe)
+               ELSE 
+                  CALL qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step)
+               END IF 
+               !##############################################################################################               
             ELSE
                ! Gamma points only
-               CALL qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step, energy_only)
+               !MARGHERITA################################################################################### 
+               IF (dft_control%hair_probes .eqv. .true.) THEN 
+                  scf_control%smear%do_smear = .false. 
+                  CALL qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step, energy_only, &
+                              dft_control%probe)  
+               ELSE 
+                  CALL qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step, energy_only)
+               END IF 
+               !##############################################################################################                              
             END IF
 
             ! Print requested MO information (can be computationally expensive with OT)
@@ -683,9 +699,19 @@ CONTAINS
       ! this just guarantees that all mo_occupations match the eigenvalues, if smear
       DO ispin = 1, dft_control%nspins
          ! do not reset mo_occupations if the maximum overlap method is in use
-         IF (.NOT. scf_control%diagonalization%mom) &
-            CALL set_mo_occupation(mo_set=mos(ispin), &
-                                   smear=scf_control%smear)
+         IF (.NOT. scf_control%diagonalization%mom) THEN
+            !MARGHERITA: if the hair probes section is present, this sends hair_probes to set_mo_occupation subroutine 
+            !and switches off the standard smearing
+            IF (dft_control%hair_probes .eqv. .true.) THEN !MARGHERITA 
+               scf_control%smear%do_smear = .false. !MARGHERITA 
+               CALL set_mo_occupation(mo_set=mos(ispin), &
+                                    smear=scf_control%smear, &
+                                    probe=dft_control%probe) 
+            ELSE 
+               CALL set_mo_occupation(mo_set=mos(ispin), &
+                                    smear=scf_control%smear)          
+            END IF                                     
+         END IF                           
       END DO
 
       SELECT CASE (scf_env%method)

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -117,7 +117,7 @@ MODULE qs_scf_diagonalization
    USE qs_scf_types,                    ONLY: qs_scf_env_type,&
                                               subspace_env_type
    USE scf_control_types,               ONLY: scf_control_type
-   USE cp_control_types,                ONLY: hair_probes_type !MARGHERITA   
+   USE cp_control_types,                ONLY: hairy_probes_type    
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -318,7 +318,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE do_general_diag(scf_env, mos, matrix_ks, &
                               matrix_s, scf_control, scf_section, &
-                              diis_step, probe) !MARGHERITA
+                              diis_step, probe) 
 
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(mo_set_type), DIMENSION(:), INTENT(INOUT)     :: mos
@@ -329,7 +329,8 @@ CONTAINS
 
       INTEGER                                            :: ispin, nspin
       REAL(KIND=dp)                                      :: total_zeff_corr
-      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA      
+      TYPE(hairy_probes_type), DIMENSION(:),& 
+            OPTIONAL, POINTER                            :: probe       
 
       nspin = SIZE(matrix_ks)
 
@@ -343,7 +344,6 @@ CONTAINS
          CALL set_mo_occupation(mo_array=mos, &
                                 smear=scf_control%smear, tot_zeff_corr=total_zeff_corr)
       ELSE
-         !MARGHERITA###########################################################################
          IF (PRESENT(probe) .eqv. .true.) THEN
             scf_control%smear%do_smear = .false. !maybe not necessary
             CALL set_mo_occupation(mo_array=mos, &
@@ -353,7 +353,6 @@ CONTAINS
             CALL set_mo_occupation(mo_array=mos, &
                            smear=scf_control%smear)
          ENDIF
-         !#####################################################################################
       END IF
 
       DO ispin = 1, nspin
@@ -382,7 +381,7 @@ CONTAINS
 !>      08.2014 created [JGH]
 ! **************************************************************************************************
    SUBROUTINE do_general_diag_kp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, update_p, &
-                                 diis_step, diis_error, qs_env, probe) !MARGHERITA
+                                 diis_step, diis_error, qs_env, probe) 
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks, matrix_s
       TYPE(kpoint_type), POINTER                         :: kpoints
@@ -421,7 +420,8 @@ CONTAINS
          POINTER                                         :: sab_nl
       TYPE(qs_matrix_pools_type), POINTER                :: mpools
       TYPE(section_vals_type), POINTER                   :: scf_section
-      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA
+      TYPE(hairy_probes_type), DIMENSION(:), &
+            OPTIONAL, POINTER                            :: probe 
 
       CALL timeset(routineN, handle)
 
@@ -691,7 +691,6 @@ CONTAINS
 
       IF (update_p) THEN
          ! MO occupations
-         !MARGHERITA###########################################################################
          IF (PRESENT(probe) .eqv. .true.) THEN
             scf_control%smear%do_smear = .false. !maybe not necessary
             CALL kpoint_set_mo_occupation(kpoints, scf_control%smear, &
@@ -699,7 +698,6 @@ CONTAINS
          ELSE
             CALL kpoint_set_mo_occupation(kpoints, scf_control%smear)
          ENDIF
-         !#####################################################################################
 
          ! density matrices
          CALL kpoint_density_matrices(kpoints)

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -117,6 +117,7 @@ MODULE qs_scf_diagonalization
    USE qs_scf_types,                    ONLY: qs_scf_env_type,&
                                               subspace_env_type
    USE scf_control_types,               ONLY: scf_control_type
+   USE cp_control_types,                ONLY: hair_probes_type !MARGHERITA   
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -317,7 +318,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE do_general_diag(scf_env, mos, matrix_ks, &
                               matrix_s, scf_control, scf_section, &
-                              diis_step)
+                              diis_step, probe) !MARGHERITA
 
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(mo_set_type), DIMENSION(:), INTENT(INOUT)     :: mos
@@ -328,6 +329,7 @@ CONTAINS
 
       INTEGER                                            :: ispin, nspin
       REAL(KIND=dp)                                      :: total_zeff_corr
+      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA      
 
       nspin = SIZE(matrix_ks)
 
@@ -341,8 +343,17 @@ CONTAINS
          CALL set_mo_occupation(mo_array=mos, &
                                 smear=scf_control%smear, tot_zeff_corr=total_zeff_corr)
       ELSE
-         CALL set_mo_occupation(mo_array=mos, &
-                                smear=scf_control%smear)
+         !MARGHERITA###########################################################################
+         IF (PRESENT(probe) .eqv. .true.) THEN
+            scf_control%smear%do_smear = .false. !maybe not necessary
+            CALL set_mo_occupation(mo_array=mos, &
+                              smear=scf_control%smear, &
+                              probe=probe)
+         ELSE
+            CALL set_mo_occupation(mo_array=mos, &
+                           smear=scf_control%smear)
+         ENDIF
+         !#####################################################################################
       END IF
 
       DO ispin = 1, nspin
@@ -371,7 +382,7 @@ CONTAINS
 !>      08.2014 created [JGH]
 ! **************************************************************************************************
    SUBROUTINE do_general_diag_kp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, update_p, &
-                                 diis_step, diis_error, qs_env)
+                                 diis_step, diis_error, qs_env, probe) !MARGHERITA
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks, matrix_s
       TYPE(kpoint_type), POINTER                         :: kpoints
@@ -410,6 +421,7 @@ CONTAINS
          POINTER                                         :: sab_nl
       TYPE(qs_matrix_pools_type), POINTER                :: mpools
       TYPE(section_vals_type), POINTER                   :: scf_section
+      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA
 
       CALL timeset(routineN, handle)
 
@@ -679,7 +691,15 @@ CONTAINS
 
       IF (update_p) THEN
          ! MO occupations
-         CALL kpoint_set_mo_occupation(kpoints, scf_control%smear)
+         !MARGHERITA###########################################################################
+         IF (PRESENT(probe) .eqv. .true.) THEN
+            scf_control%smear%do_smear = .false. !maybe not necessary
+            CALL kpoint_set_mo_occupation(kpoints, scf_control%smear, &
+                              probe=probe)
+         ELSE
+            CALL kpoint_set_mo_occupation(kpoints, scf_control%smear)
+         ENDIF
+         !#####################################################################################
 
          ! density matrices
          CALL kpoint_density_matrices(kpoints)

--- a/src/qs_scf_initialization.F
+++ b/src/qs_scf_initialization.F
@@ -44,10 +44,10 @@ MODULE qs_scf_initialization
                                               dbcsr_type_no_symmetry,&
                                               dbcsr_type_real_default
    USE input_constants,                 ONLY: &
-        broy_mix, cholesky_dbcsr, cholesky_inverse, cholesky_off, diag_block_davidson, &
-        diag_block_krylov, diag_filter_matrix, diag_ot, diag_standard, direct_p_mix, kerker_mix, &
-        multisec_mix, no_mix, ot2cdft, outer_scf_none, plus_u_lowdin, pulay_mix, &
-        wfi_frozen_method_nr, wfi_ps_method_nr, wfi_use_guess_method_nr
+        broy_mix, broy_mix_new, cholesky_dbcsr, cholesky_inverse, cholesky_off, &
+        diag_block_davidson, diag_block_krylov, diag_filter_matrix, diag_ot, diag_standard, &
+        direct_p_mix, kerker_mix, multisec_mix, no_mix, ot2cdft, outer_scf_none, plus_u_lowdin, &
+        pulay_mix, wfi_frozen_method_nr, wfi_ps_method_nr, wfi_use_guess_method_nr
    USE input_section_types,             ONLY: section_vals_get_subs_vals,&
                                               section_vals_type,&
                                               section_vals_val_get
@@ -109,6 +109,10 @@ MODULE qs_scf_initialization
    USE scf_control_types,               ONLY: scf_control_type
    USE xas_env_types,                   ONLY: xas_environment_type
    USE xas_restart,                     ONLY: xas_initialize_rho
+   USE cp_control_types,                ONLY: hair_probes_type !MARGHERITA
+   USE atomic_kind_types,               ONLY: atomic_kind_type !MARGHERITA 
+   USE particle_types,                  ONLY: particle_type !MARGHERITA
+   USE hair_probes,                     ONLY: AO_boundaries !MARGHERITA      
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -139,7 +143,25 @@ CONTAINS
       TYPE(scf_control_type), POINTER                    :: my_scf_control
       TYPE(section_vals_type), POINTER                   :: dft_section, input, my_scf_section
 
+      TYPE(mo_set_type), DIMENSION(:), POINTER         :: mos !MARGHERITA 
+      TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:) !MARGHERITA               
+      TYPE(particle_type), POINTER                       :: particle_set(:)   !MARGHERITA          
+      TYPE(qs_kind_type), POINTER                        :: qs_kind_set(:)     !MARGHERITA          
+      INTEGER :: ip, np !MARGHERITA
+
       CALL get_qs_env(qs_env, input=input, dft_control=dft_control)
+
+      !MARGHERITA: Initialize Hairy Probe calculation
+      IF (dft_control%hair_probes .eqv. .true.) THEN
+         CALL get_qs_env(qs_env, mos=mos, &
+                atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, particle_set=particle_set) 
+         np = SIZE(dft_control%probe) 
+         DO ip = 1, np 
+            CALL AO_boundaries (probe=dft_control%probe(ip), atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
+                    particle_set=particle_set, nAO=mos(1)%nao ) !FIX THIS! 
+         END DO 
+      END IF 
+      !MARGHERITA ***********************************
 
       IF (PRESENT(scf_control)) THEN
          my_scf_control => scf_control
@@ -239,7 +261,7 @@ CONTAINS
       ELSE
          ! Reallocate mixing store, if the g space grid (cell) has changed
          SELECT CASE (scf_env%mixing_method)
-         CASE (kerker_mix, pulay_mix, broy_mix, multisec_mix)
+         CASE (kerker_mix, pulay_mix, broy_mix, broy_mix_new, multisec_mix)
             IF (ASSOCIATED(scf_env%mixing_store)) THEN
                ! The current mixing_store data structure does not allow for an unique
                ! grid comparison, but the probability that the 1d lengths of the old and
@@ -676,7 +698,7 @@ CONTAINS
       CASE (no_mix)
          scf_env%mixing_method = no_mixing_nr
          scf_env%p_mix_alpha = 1.0_dp
-      CASE (direct_p_mix, kerker_mix, pulay_mix, broy_mix, multisec_mix)
+      CASE (direct_p_mix, kerker_mix, pulay_mix, broy_mix, broy_mix_new, multisec_mix)
          scf_env%mixing_method = scf_control%mixing_method
          mixing_section => section_vals_get_subs_vals(scf_section, "MIXING")
          IF (.NOT. ASSOCIATED(scf_env%mixing_store)) THEN
@@ -1079,8 +1101,16 @@ CONTAINS
             DO ispin = 1, SIZE(mos)
                CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
                CALL reorthogonalize_vectors(qs_env, v_matrix=mo_coeff, n_col=nmo)
-               CALL set_mo_occupation(mo_set=mos(ispin), &
-                                      smear=scf_control%smear)
+               !MARGHERITA ###########################################################################
+               IF (dft_control%hair_probes .eqv. .true. ) THEN
+                  scf_control%smear%do_smear = .false.
+                  CALL set_mo_occupation(mo_set=mos(ispin), &
+                           smear=scf_control%smear, probe=dft_control%probe )
+               ELSE
+                  CALL set_mo_occupation(mo_set=mos(ispin), &
+                                          smear=scf_control%smear)
+               END IF 
+               !######################################################################################                       
             END DO
          END IF
       END IF

--- a/src/qs_scf_initialization.F
+++ b/src/qs_scf_initialization.F
@@ -109,10 +109,10 @@ MODULE qs_scf_initialization
    USE scf_control_types,               ONLY: scf_control_type
    USE xas_env_types,                   ONLY: xas_environment_type
    USE xas_restart,                     ONLY: xas_initialize_rho
-   USE cp_control_types,                ONLY: hair_probes_type !MARGHERITA
-   USE atomic_kind_types,               ONLY: atomic_kind_type !MARGHERITA 
-   USE particle_types,                  ONLY: particle_type !MARGHERITA
-   USE hair_probes,                     ONLY: AO_boundaries !MARGHERITA      
+   USE cp_control_types,                ONLY: hairy_probes_type
+   USE atomic_kind_types,               ONLY: atomic_kind_type 
+   USE particle_types,                  ONLY: particle_type 
+   USE hairy_probes,                    ONLY: AO_boundaries 
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -143,16 +143,16 @@ CONTAINS
       TYPE(scf_control_type), POINTER                    :: my_scf_control
       TYPE(section_vals_type), POINTER                   :: dft_section, input, my_scf_section
 
-      TYPE(mo_set_type), DIMENSION(:), POINTER         :: mos !MARGHERITA 
-      TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:) !MARGHERITA               
-      TYPE(particle_type), POINTER                       :: particle_set(:)   !MARGHERITA          
-      TYPE(qs_kind_type), POINTER                        :: qs_kind_set(:)     !MARGHERITA          
-      INTEGER :: ip, np !MARGHERITA
+      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos 
+      TYPE(atomic_kind_type), POINTER                    :: atomic_kind_set(:)         
+      TYPE(particle_type), POINTER                       :: particle_set(:)      
+      TYPE(qs_kind_type), POINTER                        :: qs_kind_set(:)        
+      INTEGER :: ip, np 
 
       CALL get_qs_env(qs_env, input=input, dft_control=dft_control)
 
-      !MARGHERITA: Initialize Hairy Probe calculation
-      IF (dft_control%hair_probes .eqv. .true.) THEN
+      !Initialize Hairy Probe calculation
+      IF (dft_control%hairy_probes .eqv. .true.) THEN
          CALL get_qs_env(qs_env, mos=mos, &
                 atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, particle_set=particle_set) 
          np = SIZE(dft_control%probe) 
@@ -161,7 +161,6 @@ CONTAINS
                     particle_set=particle_set, nAO=mos(1)%nao ) !FIX THIS! 
          END DO 
       END IF 
-      !MARGHERITA ***********************************
 
       IF (PRESENT(scf_control)) THEN
          my_scf_control => scf_control
@@ -1101,8 +1100,7 @@ CONTAINS
             DO ispin = 1, SIZE(mos)
                CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
                CALL reorthogonalize_vectors(qs_env, v_matrix=mo_coeff, n_col=nmo)
-               !MARGHERITA ###########################################################################
-               IF (dft_control%hair_probes .eqv. .true. ) THEN
+               IF (dft_control%hairy_probes .eqv. .true. ) THEN
                   scf_control%smear%do_smear = .false.
                   CALL set_mo_occupation(mo_set=mos(ispin), &
                            smear=scf_control%smear, probe=dft_control%probe )
@@ -1110,7 +1108,6 @@ CONTAINS
                   CALL set_mo_occupation(mo_set=mos(ispin), &
                                           smear=scf_control%smear)
                END IF 
-               !######################################################################################                       
             END DO
          END IF
       END IF

--- a/src/qs_scf_loop_utils.F
+++ b/src/qs_scf_loop_utils.F
@@ -64,6 +64,7 @@ MODULE qs_scf_loop_utils
                                               special_diag_method_nr
    USE scf_control_types,               ONLY: scf_control_type,&
                                               smear_type
+   USE cp_control_types,                ONLY: hair_probes_type    !MARGHERITA                                              
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -119,7 +120,7 @@ CONTAINS
 !> \param energy_only ...
 ! **************************************************************************************************
    SUBROUTINE qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step, &
-                             energy_only)
+                             energy_only, probe) !MARGHERITA
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(scf_control_type), POINTER                    :: scf_control
@@ -136,6 +137,7 @@ CONTAINS
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
+      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA
 
       CALL timeset(routineN, handle)
 
@@ -207,9 +209,18 @@ CONTAINS
                                 matrix_s, scf_control, scf_section, &
                                 diis_step)
             ELSE
-               CALL do_general_diag(scf_env, mos, matrix_ks, &
-                                    matrix_s, scf_control, scf_section, &
-                                    diis_step)
+            !MARGHERITA ###########################################################################
+               IF (dft_control%hair_probes .eqv. .true.) THEN
+                  CALL do_general_diag(scf_env, mos, matrix_ks, &
+                               matrix_s, scf_control, scf_section, &
+                               diis_step, &
+                               probe)  !MARGHERITA                           
+               ELSE 
+                  CALL do_general_diag(scf_env, mos, matrix_ks, &
+                               matrix_s, scf_control, scf_section, &
+                               diis_step)
+               END IF 
+            !######################################################################################            
             END IF
             IF (scf_control%do_diag_sub) THEN
                skip_diag_sub = (scf_env%subspace_env%eps_diag_sub > 0.0_dp) .AND. &
@@ -289,7 +300,8 @@ CONTAINS
 !> \param scf_control ...
 !> \param diis_step ...
 ! **************************************************************************************************
-   SUBROUTINE qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step)
+   SUBROUTINE qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step, &
+                              probe) !MARGHERITA
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(scf_control_type), POINTER                    :: scf_control
@@ -305,6 +317,7 @@ CONTAINS
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:, :), POINTER        :: mos
       TYPE(qs_energy_type), POINTER                      :: energy
+      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA
 
       CALL timeset(routineN, handle)
 
@@ -324,8 +337,18 @@ CONTAINS
       CASE (general_diag_method_nr)
          ! Diagonlization in non orthonormal case
          CALL get_qs_env(qs_env, matrix_ks_kp=matrix_ks, matrix_s_kp=matrix_s)
-         CALL do_general_diag_kp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, .TRUE., &
-                                 diis_step, diis_error, qs_env)
+         !MARGHERITA ###########################################################################
+         IF (dft_control%hair_probes .eqv. .true.) THEN
+            scf_control%smear%do_smear = .false. 
+            CALL do_general_diag_kp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, .TRUE., &
+                                    diis_step, diis_error, qs_env, probe) 
+         ELSE 
+            CALL do_general_diag_kp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, .TRUE., &
+                                    diis_step, diis_error, qs_env)
+         END IF 
+         !######################################################################################
+         !CALL do_general_diag_kp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, .TRUE., &
+         !                        diis_step, diis_error, qs_env)
          IF (diis_step) THEN
             scf_env%iter_param = diis_error
             scf_env%iter_method = "DIIS/Diag."

--- a/src/qs_scf_loop_utils.F
+++ b/src/qs_scf_loop_utils.F
@@ -64,7 +64,7 @@ MODULE qs_scf_loop_utils
                                               special_diag_method_nr
    USE scf_control_types,               ONLY: scf_control_type,&
                                               smear_type
-   USE cp_control_types,                ONLY: hair_probes_type    !MARGHERITA                                              
+   USE cp_control_types,                ONLY: hairy_probes_type                                             
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -120,7 +120,7 @@ CONTAINS
 !> \param energy_only ...
 ! **************************************************************************************************
    SUBROUTINE qs_scf_new_mos(qs_env, scf_env, scf_control, scf_section, diis_step, &
-                             energy_only, probe) !MARGHERITA
+                             energy_only, probe)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(scf_control_type), POINTER                    :: scf_control
@@ -137,7 +137,8 @@ CONTAINS
       TYPE(qs_energy_type), POINTER                      :: energy
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho
-      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA
+      TYPE(hairy_probes_type), DIMENSION(:), &
+            OPTIONAL, POINTER                            :: probe 
 
       CALL timeset(routineN, handle)
 
@@ -209,12 +210,11 @@ CONTAINS
                                 matrix_s, scf_control, scf_section, &
                                 diis_step)
             ELSE
-            !MARGHERITA ###########################################################################
-               IF (dft_control%hair_probes .eqv. .true.) THEN
+               IF (dft_control%hairy_probes .eqv. .true.) THEN
                   CALL do_general_diag(scf_env, mos, matrix_ks, &
                                matrix_s, scf_control, scf_section, &
                                diis_step, &
-                               probe)  !MARGHERITA                           
+                               probe)                             
                ELSE 
                   CALL do_general_diag(scf_env, mos, matrix_ks, &
                                matrix_s, scf_control, scf_section, &
@@ -301,7 +301,7 @@ CONTAINS
 !> \param diis_step ...
 ! **************************************************************************************************
    SUBROUTINE qs_scf_new_mos_kp(qs_env, scf_env, scf_control, diis_step, &
-                              probe) !MARGHERITA
+                                 probe) 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(scf_control_type), POINTER                    :: scf_control
@@ -317,7 +317,8 @@ CONTAINS
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:, :), POINTER        :: mos
       TYPE(qs_energy_type), POINTER                      :: energy
-      TYPE(hair_probes_type), DIMENSION(:), OPTIONAL, POINTER  :: probe !MARGHERITA
+      TYPE(hairy_probes_type), DIMENSION(:), &
+            OPTIONAL, POINTER                            :: probe 
 
       CALL timeset(routineN, handle)
 
@@ -337,8 +338,7 @@ CONTAINS
       CASE (general_diag_method_nr)
          ! Diagonlization in non orthonormal case
          CALL get_qs_env(qs_env, matrix_ks_kp=matrix_ks, matrix_s_kp=matrix_s)
-         !MARGHERITA ###########################################################################
-         IF (dft_control%hair_probes .eqv. .true.) THEN
+         IF (dft_control%hairy_probes .eqv. .true.) THEN
             scf_control%smear%do_smear = .false. 
             CALL do_general_diag_kp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, .TRUE., &
                                     diis_step, diis_error, qs_env, probe) 
@@ -346,9 +346,7 @@ CONTAINS
             CALL do_general_diag_kp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, .TRUE., &
                                     diis_step, diis_error, qs_env)
          END IF 
-         !######################################################################################
-         !CALL do_general_diag_kp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, .TRUE., &
-         !                        diis_step, diis_error, qs_env)
+
          IF (diis_step) THEN
             scf_env%iter_param = diis_error
             scf_env%iter_method = "DIIS/Diag."

--- a/src/qs_scf_output.F
+++ b/src/qs_scf_output.F
@@ -748,14 +748,12 @@ CONTAINS
                   "GAPW_XC| Exc from hard and soft atomic rho1:      ", exc1_energy
             END IF
          END IF
-         !MARGHERITA
-         IF (dft_control%hair_probes .eqv. .true.) THEN
+         IF (dft_control%hairy_probes .eqv. .true.) THEN
             WRITE (UNIT=output_unit, FMT="((T3,A,T56,F25.14))") &
             "Electronic entropic energy:", energy%kTS
          WRITE (UNIT=output_unit, FMT="((T3,A,T56,F25.14))") &
             "Fermi energy:", energy%efermi
          END IF
-         !MARGHERITA
          IF (dft_control%smear) THEN
             WRITE (UNIT=output_unit, FMT="((T3,A,T56,F25.14))") &
                "Electronic entropic energy:", energy%kTS

--- a/src/qs_scf_output.F
+++ b/src/qs_scf_output.F
@@ -748,6 +748,14 @@ CONTAINS
                   "GAPW_XC| Exc from hard and soft atomic rho1:      ", exc1_energy
             END IF
          END IF
+         !MARGHERITA
+         IF (dft_control%hair_probes .eqv. .true.) THEN
+            WRITE (UNIT=output_unit, FMT="((T3,A,T56,F25.14))") &
+            "Electronic entropic energy:", energy%kTS
+         WRITE (UNIT=output_unit, FMT="((T3,A,T56,F25.14))") &
+            "Fermi energy:", energy%efermi
+         END IF
+         !MARGHERITA
          IF (dft_control%smear) THEN
             WRITE (UNIT=output_unit, FMT="((T3,A,T56,F25.14))") &
                "Electronic entropic energy:", energy%kTS

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -197,8 +197,8 @@ MODULE qs_scf_post_gpw
    USE voronoi_interface,               ONLY: entry_voronoi_or_bqb
    USE xray_diffraction,                ONLY: calculate_rhotot_elec_gspace,&
                                               xray_diffraction_spectrum
-   USE cp_control_types,                ONLY: hair_probes_type !MARGHERITA
-   USE qs_kind_types,                   ONLY: qs_kind_type !MARGHERITA                                                  
+   USE cp_control_types,                ONLY: hairy_probes_type
+   USE qs_kind_types,                   ONLY: qs_kind_type                                                 
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -478,16 +478,14 @@ CONTAINS
                   CALL get_qs_env(qs_env, admm_env=admm_env)
                   CALL make_mo_eig(mos, dft_control%nspins, ks_rmpv, scf_control, mo_derivs, admm_env=admm_env)
                ELSE
-               !MARGHERITA ###########################################################################
-                  IF (dft_control%hair_probes) THEN      
-                     scf_control%smear%do_smear = .false. !MARGHERITA 
+                  IF (dft_control%hairy_probes) THEN      
+                     scf_control%smear%do_smear = .false.  
                      CALL make_mo_eig(mos, dft_control%nspins, ks_rmpv, scf_control, mo_derivs, &
-                                    hair_probes=dft_control%hair_probes, &
-                                    probe=dft_control%probe) !MARGHERITA 
+                                    hairy_probes=dft_control%hairy_probes, &
+                                    probe=dft_control%probe)  
                   ELSE 
                      CALL make_mo_eig(mos, dft_control%nspins, ks_rmpv, scf_control, mo_derivs)
                   END IF
-               !######################################################################################                  
                END IF
             END IF
             DO ispin = 1, dft_control%nspins

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -197,6 +197,8 @@ MODULE qs_scf_post_gpw
    USE voronoi_interface,               ONLY: entry_voronoi_or_bqb
    USE xray_diffraction,                ONLY: calculate_rhotot_elec_gspace,&
                                               xray_diffraction_spectrum
+   USE cp_control_types,                ONLY: hair_probes_type !MARGHERITA
+   USE qs_kind_types,                   ONLY: qs_kind_type !MARGHERITA                                                  
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -476,7 +478,16 @@ CONTAINS
                   CALL get_qs_env(qs_env, admm_env=admm_env)
                   CALL make_mo_eig(mos, dft_control%nspins, ks_rmpv, scf_control, mo_derivs, admm_env=admm_env)
                ELSE
-                  CALL make_mo_eig(mos, dft_control%nspins, ks_rmpv, scf_control, mo_derivs)
+               !MARGHERITA ###########################################################################
+                  IF (dft_control%hair_probes) THEN      
+                     scf_control%smear%do_smear = .false. !MARGHERITA 
+                     CALL make_mo_eig(mos, dft_control%nspins, ks_rmpv, scf_control, mo_derivs, &
+                                    hair_probes=dft_control%hair_probes, &
+                                    probe=dft_control%probe) !MARGHERITA 
+                  ELSE 
+                     CALL make_mo_eig(mos, dft_control%nspins, ks_rmpv, scf_control, mo_derivs)
+                  END IF
+               !######################################################################################                  
                END IF
             END IF
             DO ispin = 1, dft_control%nspins


### PR DESCRIPTION
Modules for Hairy Probes DFT calculations added (list of modules modified: cp_control_types.F, cp_control_utils.F, input_cp2k_dft.F, qs_mo_occupation.F, qs_scf.F, qs_scf_diagonalization.F, qs_scf_loop_utils.F, qs_scf_initialization.F, qs_mo_methods.F, qs_scf_post_gpw.F, kpoint_methods.F, qs_scf_output.F ; list of new modules added: hairy_probes.F).
