### PR TITLE
Fix format in benchmark input file

### DIFF
--- a/benchmarks/QS_pao_ml_tio2/pao_ml_tio2.inp
+++ b/benchmarks/QS_pao_ml_tio2/pao_ml_tio2.inp
@@ -100,8 +100,8 @@
           PRIOR MEAN
           TOLERANCE 1000.0
           &TRAINING_SET
-            ./test-1_0.pao
-            ./test2-1_0.pao
+            test-1_0.pao
+            test2-1_0.pao
           &END TRAINING_SET
         &END MACHINE_LEARNING
         &PRINT


### PR DESCRIPTION
Fix small format issue in benchmarks/QS_pao_ml_tio2/pao_ml_tio2.inp. The benchmark runs still fine after this.

This seems atypical compared to the other input files included in the repo. And it triggers a complicated bug in the cp2k-input-tools https://github.com/cp2k/cp2k-input-tools. I think it is correct to fix this here.


Please advice what the best way would be. I'm pretty certain that the modified input is correct. I'm somewhat certain that the './' should not be in front of include file in the same dir. But I'd like to trust your feeling how it should be and how the CP2K community expects things.