### PR TITLE
AS: Perform second contraction step using FM instead of DBCSR

### DIFF
--- a/src/input_constants.F
+++ b/src/input_constants.F
@@ -1220,7 +1220,8 @@ MODULE input_constants
                                                eri_operator_yukawa = 2, &
                                                eri_operator_erf = 3, &
                                                eri_operator_erfc = 4, &
-                                               eri_operator_gaussian = 5
+                                               eri_operator_gaussian = 5, &
+                                               eri_operator_trunc = 6
 
    INTEGER, PARAMETER, PUBLIC               :: do_eri_gpw = 0, &
                                                do_eri_mme = 1, &

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -67,7 +67,7 @@ MODULE input_cp2k_dft
       do_se_lr_ewald_gks, do_se_lr_ewald_r3, do_se_lr_none, do_spin_density, do_taylor, &
       ehrenfest, embed_diff, embed_fa, embed_grid_angstrom, embed_grid_bohr, embed_level_shift, &
       embed_none, embed_quasi_newton, embed_resp, embed_steep_desc, eri_method_full_gpw, &
-      eri_method_gpw_ht, eri_operator_coulomb, eri_operator_erf, eri_operator_erfc, &
+      eri_method_gpw_ht, eri_operator_trunc, eri_operator_coulomb, eri_operator_erf, eri_operator_erfc, &
       eri_operator_gaussian, eri_operator_yukawa, gapw_1c_large, gapw_1c_medium, gapw_1c_orb, &
       gapw_1c_small, gapw_1c_very_large, gaussian, general_roks, gto_cartesian, gto_spherical, &
       hf_model, high_spin_roks, history_guess, jacobian_fd1, jacobian_fd1_backward, &
@@ -9412,14 +9412,15 @@ CONTAINS
                           description="Operator used in ERI calculation.", &
                           usage="OPERATOR <1/R>", &
                           enum_c_vals=s2a("<1/R>", "<EXP(-A*R)/R>", "<ERF(A*R)/R>", &
-                                          "<ERFC(A*R)/R>", "<EXP(-A*R2)/R>"), &
+                                          "<ERFC(A*R)/R>", "<EXP(-A*R2)/R>", "<H(A-R)/R>"), &
                           enum_i_vals=(/eri_operator_coulomb, eri_operator_yukawa, &
-                                        eri_operator_erf, eri_operator_erfc, eri_operator_gaussian/), &
+                                        eri_operator_erf, eri_operator_erfc, eri_operator_gaussian, eri_operator_trunc/), &
                           enum_desc=s2a("Coulomb operator", &
                                         "Yukawa potential operator", &
                                         "Error function potential operator", &
                                         "Complementary error function potential operator", &
-                                        "Gaussian potential operator"), &
+                                        "Gaussian potential operator", &
+                                        "Truncated Coulomb potential"), &
                           default_i_val=eri_operator_coulomb)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/mp2_gpw.F
+++ b/src/mp2_gpw.F
@@ -682,18 +682,21 @@ CONTAINS
       CALL grep_rows_in_subgroups(para_env, para_env_sub, mo_coeff, gd_array, C)
 
       ! create and fill mo_coeff_o, mo_coeff_v and mo_coeff_all
+      ALLOCATE (mo_coeff_o)
       CALL build_dbcsr_from_rows(para_env_sub, mo_coeff_o, C(:, 1:homo), &
                                  mat_munu, gd_array, eps_filter)
 
+      ALLOCATE (mo_coeff_v)
       CALL build_dbcsr_from_rows(para_env_sub, mo_coeff_v, C(:, homo + 1:dimen), &
                                  mat_munu, gd_array, eps_filter)
 
       IF (my_do_gw) THEN
-
+         ALLOCATE (mo_coeff_gw)
          CALL build_dbcsr_from_rows(para_env_sub, mo_coeff_gw, C(:, homo - gw_corr_lev_occ + 1:homo + gw_corr_lev_virt), &
                                     mat_munu, gd_array, eps_filter)
 
          ! all levels
+         ALLOCATE (mo_coeff_all)
          CALL build_dbcsr_from_rows(para_env_sub, mo_coeff_all, C, &
                                     mat_munu, gd_array, eps_filter)
 
@@ -844,7 +847,7 @@ CONTAINS
    SUBROUTINE build_dbcsr_from_rows(para_env_sub, mo_coeff_to_build, Cread, &
                                     mat_munu, gd_array, eps_filter)
       TYPE(mp_para_env_type), INTENT(IN)                 :: para_env_sub
-      TYPE(dbcsr_type), POINTER                          :: mo_coeff_to_build
+      TYPE(dbcsr_type)                                   :: mo_coeff_to_build
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: Cread
       TYPE(dbcsr_type), INTENT(INOUT)                    :: mat_munu
       TYPE(group_dist_d1_type), INTENT(IN)               :: gd_array
@@ -865,8 +868,6 @@ CONTAINS
 
       CALL get_group_dist(gd_array, para_env_sub%mepos, my_mu_start, my_mu_end)
 
-      NULLIFY (mo_coeff_to_build)
-      CALL dbcsr_init_p(mo_coeff_to_build)
       CALL cp_dbcsr_m_by_n_from_row_template(mo_coeff_to_build, template=mat_munu, n=ncol_global, &
                                              sym=dbcsr_type_no_symmetry, data_type=dbcsr_type_real_default)
       CALL dbcsr_reserve_all_blocks(mo_coeff_to_build)

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -27,7 +27,7 @@ MODULE qs_active_space_methods
    USE cp_dbcsr_operations, ONLY: cp_dbcsr_plus_fm_fm_t, &
                                   cp_dbcsr_sm_fm_multiply, &
                                   dbcsr_allocate_matrix_set, &
-                                  cp_dbcsr_m_by_n_from_template
+                                  cp_dbcsr_m_by_n_from_template, copy_dbcsr_to_fm
    USE cp_files, ONLY: close_file, &
                        file_exists, &
                        open_file
@@ -49,7 +49,7 @@ MODULE qs_active_space_methods
       dbcsr_copy, dbcsr_csr_create, dbcsr_csr_type, dbcsr_p_type, dbcsr_type, dbcsr_release, &
       dbcsr_type_no_symmetry, dbcsr_create, dbcsr_set, dbcsr_multiply, dbcsr_iterator_next_block, &
       dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_blocks_left, &
-      dbcsr_iterator_type, dbcsr_type_symmetric, dbcsr_get_occupation
+      dbcsr_iterator_type, dbcsr_type_symmetric, dbcsr_get_occupation, dbcsr_get_info
    USE group_dist_types, ONLY: get_group_dist, release_group_dist, group_dist_d1_type
    USE input_constants, ONLY: &
       casci_canonical, dmft_model, eri_method_full_gpw, eri_method_gpw_ht, eri_operator_coulomb, &
@@ -1195,25 +1195,26 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'calculate_eri_gpw'
 
-      INTEGER :: blk, col, col_offset, col_size, color, handle, i1, i2, i3, i4, i_multigrid, &
-         icount2, intcount, irange(2), irange_sub(2), isp, isp1, isp2, ispin, iwa1, iwa12, iwa2, &
-         iwb1, iwb12, iwb2, iwbs, iwbt, iwfn, n_multigrid, nmm, nmo, nmo1, nmo2, nspins, &
-         number_of_subgroups, nx, r, row, row_offset, row_size, s, stored_integrals
+      INTEGER :: col_local, color, handle, i1, i2, i3, i4, i_multigrid, icount2, intcount, &
+         irange(2), irange_sub(2), isp, isp1, isp2, ispin, iwa1, iwa12, iwa2, iwb1, iwb12, iwb2, &
+         iwbs, iwbt, iwfn, n_multigrid, ncol_global, ncol_local, nmm, nmo, nmo1, nmo2, &
+         nrow_global, nrow_local, nspins, number_of_subgroups, nx, row_local, stored_integrals
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: eri_index
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: print1, print2, &
                                                             skip_load_balance_distributed
       REAL(KIND=dp)                                      :: dvol, erint, pair_int, &
                                                             progression_factor, rc, rsize
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eri
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_block
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env, blacs_env_sub
+      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
+      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_matrix_pq_rnu, fm_matrix_pq_rs, &
+                                                            fm_mo_coeff_as
       TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff1, mo_coeff2
-      TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_p_type)                                 :: mat_munu
-      TYPE(dbcsr_p_type), ALLOCATABLE, DIMENSION(:)      :: mo_coeff_as
-      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: matrix_pq_rnu, matrix_pq_rs
+      TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: matrix_pq_rnu, mo_coeff_as
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(mp_comm_type)                                 :: mp_group
       TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_sub
@@ -1376,7 +1377,8 @@ CONTAINS
          ! Create sparse matrices carrying the matrix products, Code borrowed from the MP2 GPW method
          ! Create equal distributions for them (no sparsity present)
          ! We use the routines from mp2 suggesting that one may replicate the grids later for better performance
-         ALLOCATE (mo_coeff_as(nspins), matrix_pq_rnu(nspins), matrix_pq_rs(nspins))
+         ALLOCATE (mo_coeff_as(nspins), matrix_pq_rnu(nspins), &
+                   fm_matrix_pq_rnu(nspins), fm_mo_coeff_as(nspins), fm_matrix_pq_rs(nspins))
          DO ispin = 1, nspins
             BLOCK
                REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE :: C
@@ -1385,20 +1387,32 @@ CONTAINS
                CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
                CALL grep_rows_in_subgroups(para_env, para_env_sub, mo_coeff, gd_array, C)
 
-               CALL build_dbcsr_from_rows(para_env_sub, mo_coeff_as(ispin)%matrix, &
+               CALL build_dbcsr_from_rows(para_env_sub, mo_coeff_as(ispin), &
                                           C(:, MINVAL(orbitals(:, ispin)):MAXVAL(orbitals(:, ispin))), &
                                           mat_munu%matrix, gd_array, eri_env%eri_gpw%eps_filter)
                CALL release_group_dist(gd_array)
                DEALLOCATE (C)
             END BLOCK
 
-            CALL dbcsr_create(matrix_pq_rnu(ispin), template=mo_coeff_as(ispin)%matrix)
-            CALL cp_dbcsr_m_by_n_from_template(matrix_pq_rs(ispin), template=mo_coeff_as(ispin)%matrix, &
-                                               m=SIZE(orbitals, 1), n=SIZE(orbitals, 1), &
-                                               sym=dbcsr_type_no_symmetry)
-
+            CALL dbcsr_create(matrix_pq_rnu(ispin), template=mo_coeff_as(ispin))
             CALL dbcsr_set(matrix_pq_rnu(ispin), 0.0_dp)
-            CALL dbcsr_set(matrix_pq_rs(ispin), 0.0_dp)
+
+            CALL dbcsr_get_info(matrix_pq_rnu(ispin), nfullrows_total=nrow_global, nfullcols_total=ncol_global)
+
+            NULLIFY (fm_struct)
+            CALL cp_fm_struct_create(fm_struct, context=blacs_env, para_env=para_env_sub, &
+                                     nrow_global=nrow_global, ncol_global=ncol_global)
+            CALL cp_fm_create(fm_matrix_pq_rnu(ispin), fm_struct)
+            CALL cp_fm_create(fm_mo_coeff_as(ispin), fm_struct)
+            CALL cp_fm_struct_release(fm_struct)
+
+            CALL copy_dbcsr_to_fm(mo_coeff_as(ispin), fm_mo_coeff_as(ispin))
+
+            NULLIFY (fm_struct)
+            CALL cp_fm_struct_create(fm_struct, context=blacs_env, para_env=para_env_sub, &
+                                     nrow_global=ncol_global, ncol_global=ncol_global)
+            CALL cp_fm_create(fm_matrix_pq_rs(ispin), fm_struct)
+            CALL cp_fm_struct_release(fm_struct)
          END DO
 
          ! Copy the active space of the MOs into DBCSR matrices
@@ -1519,26 +1533,31 @@ CONTAINS
                                              calculate_forces=.FALSE., compute_tau=.FALSE., gapw=.FALSE., &
                                              pw_env_external=pw_env_sub, task_list_external=task_list_sub)
 
-                     CALL dbcsr_multiply("N", "N", 1.0_dp, mat_munu%matrix, mo_coeff_as(isp2)%matrix, &
+                     CALL dbcsr_multiply("N", "N", 1.0_dp, mat_munu%matrix, mo_coeff_as(isp2), &
                                          0.0_dp, matrix_pq_rnu(isp2), filter_eps=eri_env%eri_gpw%eps_filter)
-                     CALL dbcsr_multiply("T", "N", 0.5_dp, matrix_pq_rnu(isp2), mo_coeff_as(isp2)%matrix, &
-                                         0.0_dp, matrix_pq_rs(isp2), filter_eps=eri_env%eri_gpw%eps_filter)
-                     CALL dbcsr_multiply("T", "N", 0.5_dp, mo_coeff_as(isp2)%matrix, matrix_pq_rnu(isp2), &
-                                         1.0_dp, matrix_pq_rs(isp2), filter_eps=eri_env%eri_gpw%eps_filter)
+                     CALL copy_dbcsr_to_fm(matrix_pq_rnu(isp2), fm_matrix_pq_rnu(isp2))
+
+                     CALL cp_fm_get_info(fm_matrix_pq_rnu(isp2), ncol_global=ncol_global, nrow_global=nrow_global)
+
+                     CALL parallel_gemm("T", "N", ncol_global, ncol_global, nrow_global, 0.5_dp, &
+                                        fm_matrix_pq_rnu(isp2), fm_mo_coeff_as(isp2), &
+                                        0.0_dp, fm_matrix_pq_rs(isp2))
+                     CALL parallel_gemm("T", "N", ncol_global, ncol_global, nrow_global, 0.5_dp, &
+                                        fm_mo_coeff_as(isp2), fm_matrix_pq_rnu(isp2), &
+                                        1.0_dp, fm_matrix_pq_rs(isp2))
+
+                     CALL cp_fm_get_info(fm_matrix_pq_rs(isp2), ncol_local=ncol_local, nrow_local=nrow_local, &
+                                         col_indices=col_indices, row_indices=row_indices)
 
                      icount2 = 0
-                     CALL dbcsr_iterator_start(iter, matrix_pq_rs(isp2))
-                     DO WHILE (dbcsr_iterator_blocks_left(iter))
-                        CALL dbcsr_iterator_next_block(iter, row, col, data_block, blk, &
-                                                       row_size=row_size, col_size=col_size, &
-                                                       row_offset=row_offset, col_offset=col_offset)
-                        DO s = 1, col_size
-                        DO r = 1, row_size
-                           iwb1 = orbitals(row_offset - 1 + r, isp2)
-                           iwb2 = orbitals(col_offset - 1 + s, isp2)
+                     DO col_local = 1, ncol_local
+                        iwb2 = orbitals(col_indices(col_local), isp2)
+                        DO row_local = 1, nrow_local
+                           iwb1 = orbitals(row_indices(row_local), isp2)
+
                            IF (iwb1 <= iwb2) THEN
                               iwb12 = csr_idx_to_combined(iwb1, iwb2, nmo2)
-                              erint = data_block(r, s)
+                              erint = fm_matrix_pq_rs(isp2)%local_data(row_local, col_local)
                               IF (ABS(erint) > eri_env%eps_integral .AND. (iwa12 <= iwb12 .OR. isp1 /= isp2)) THEN
                                  icount2 = icount2 + 1
                                  eri(icount2) = erint
@@ -1546,9 +1565,7 @@ CONTAINS
                               END IF
                            END IF
                         END DO
-                        END DO
                      END DO
-                     CALL dbcsr_iterator_stop(iter)
                      stored_integrals = stored_integrals + icount2
                      !
                      isp = (isp1 - 1)*isp2 + (isp2 - isp1 + 1)
@@ -1658,12 +1675,14 @@ CONTAINS
 
       IF (eri_env%method == eri_method_gpw_ht) THEN
          DO ispin = 1, nspins
-            CALL dbcsr_release(mo_coeff_as(ispin)%matrix)
-            DEALLOCATE (mo_coeff_as(ispin)%matrix)
+            CALL dbcsr_release(mo_coeff_as(ispin))
             CALL dbcsr_release(matrix_pq_rnu(ispin))
-            CALL dbcsr_release(matrix_pq_rs(ispin))
+            CALL cp_fm_release(fm_mo_coeff_as(ispin))
+            CALL cp_fm_release(fm_matrix_pq_rnu(ispin))
+            CALL cp_fm_release(fm_matrix_pq_rs(ispin))
          END DO
-         DEALLOCATE (mo_coeff_as, matrix_pq_rnu, matrix_pq_rs)
+         DEALLOCATE (mo_coeff_as, matrix_pq_rnu, &
+                     fm_mo_coeff_as, fm_matrix_pq_rnu, fm_matrix_pq_rs)
          CALL deallocate_task_list(task_list_sub)
          CALL dbcsr_release(mat_munu%matrix)
          DEALLOCATE (mat_munu%matrix)

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -53,7 +53,7 @@ MODULE qs_active_space_methods
    USE group_dist_types, ONLY: get_group_dist, release_group_dist, group_dist_d1_type
    USE input_constants, ONLY: &
       casci_canonical, dmft_model, eri_method_full_gpw, eri_method_gpw_ht, eri_operator_coulomb, &
-      eri_operator_erf, eri_operator_erfc, eri_operator_gaussian, eri_operator_yukawa, hf_model, &
+      eri_operator_trunc, eri_operator_erf, eri_operator_erfc, eri_operator_gaussian, eri_operator_yukawa, hf_model, &
       manual_selection, mao_projection, no_solver, qiskit_solver, rsdft_model, wannier_projection
    USE input_section_types, ONLY: section_vals_get, &
                                   section_vals_get_subs_vals, &
@@ -862,6 +862,9 @@ CONTAINS
             WRITE (iw, '(T3,A,T66,F14.3)') "ERI operator parameter", eri_op_param
          CASE (eri_operator_gaussian)
             WRITE (iw, '(T3,A,T41,A)') "ERI operator", "Gaussian attenuated <EXP(-a*R^2)/R>"
+            WRITE (iw, '(T3,A,T66,F14.3)') "ERI operator parameter", eri_op_param
+         CASE (eri_operator_trunc)
+            WRITE (iw, '(T3,A,T53,A)') "ERI operator", "Truncated Coulomb <H(a-R)/R>"
             WRITE (iw, '(T3,A,T66,F14.3)') "ERI operator parameter", eri_op_param
          CASE DEFAULT
             CPABORT("Unknown ERI operator")
@@ -1749,6 +1752,18 @@ CONTAINS
                   gf%array(ig) = fourpi/g2*(1._dp - EXP(ga))
                END DO
                IF (grid%have_g0) gf%array(1) = 0.25_dp*fourpi/a
+            CASE (eri_operator_trunc)
+               a = eri_env%operator_parameter
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  ga = SQRT(g2)*a
+                  IF (ga >= 0.005_dp) THEN
+                     gf%array(ig) = fourpi/g2*(1.0_dp - COS(ga))
+                  ELSE
+                     gf%array(ig) = fourpi/g2*ga**2/2.0_dp*(1.0_dp - ga**2/12.0_dp)
+                  END IF
+               END DO
+               IF (grid%have_g0) gf%array(1) = 0.0_dp
             CASE (eri_operator_gaussian)
                CPABORT("")
             CASE DEFAULT
@@ -1799,6 +1814,18 @@ CONTAINS
                   gf%array(ig) = fourpi/g2*(1._dp - EXP(ga))*(1.0_dp - COS(rlength*gg))
                END DO
                IF (grid%have_g0) gf%array(1) = 0._dp
+            CASE (eri_operator_trunc)
+               a = eri_env%operator_parameter
+               DO ig = grid%first_gne0, grid%ngpts_cut_local
+                  g2 = grid%gsq(ig)
+                  ga = SQRT(g2)*a
+                  IF (ga >= 0.005_dp) THEN
+                     gf%array(ig) = fourpi/g2*(1.0_dp - COS(ga))
+                  ELSE
+                     gf%array(ig) = fourpi/g2*ga**2/2.0_dp*(1.0_dp - ga**2/12.0_dp)
+                  END IF
+               END DO
+               IF (grid%have_g0) gf%array(1) = 0.0_dp
             CASE (eri_operator_gaussian)
                CPABORT("")
             CASE DEFAULT


### PR DESCRIPTION
This change significantly improves the performance of the half-transformed GPW method (Si 1x1x1: factor of 3 in total runtime).
I added supported for the truncated Coulomb potential.