### PR TITLE
MP2: Fix block size

### DIFF
--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -1554,7 +1554,7 @@ CONTAINS
          END IF
          END IF
       END IF
-      block_size = best_block_size
+      block_size = MAX(1, best_block_size)
 
       IF (unit_nr > 0) THEN
          WRITE (UNIT=unit_nr, FMT="(T3,A,T75,i6)") &


### PR DESCRIPTION
This commit fixes a bug in which the RI-MP2 block size is determined to be zero leading to divisions by zero.