### PR TITLE
Synchronize with Fedora downstream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,10 +2,12 @@ specfile_path: tools/fedora/cp2k.spec
 files_to_sync:
   - src: tools/fedora/
     dest: ./
+    delete: true
     filters:
-      - "- plans/main.fmf.dist-git"
-  - src: tools/fedora/plans/main.fmf.dist-git
-    dest: plans/main.fmf
+      - "protect .git*"
+      - "protect sources"
+      - "protect changelog"
+      - "- tests/"
   - src: .fmf/
     dest: .fmf/
   - .packit.yaml
@@ -19,54 +21,47 @@ test_command:
   default_identifier: smoke
 
 jobs:
-  - job: copr_build
-    trigger: commit
-    branch: master
-    owner: lecris
-    project: nightly
-    additional_repos:
-      - copr://@scikit-build/release
-    targets:
-      - fedora-development-x86_64
-      - fedora-development-aarch64
-  - job: tests
-    trigger: commit
-    targets:
-      - fedora-development-x86_64
-      - fedora-development-aarch64
-    tmt_plan: .*/smoke
-  - job: copr_build
+  - &copr_build
+    job: copr_build
     trigger: release
     owner: lecris
     project: release
     targets:
+      # TODO: Match F40 release
       - fedora-development-x86_64
       - fedora-development-aarch64
-  - job: copr_build
+      - fedora-latest-x86_64
+      - fedora-latest-aarch64
+  - <<: *copr_build
+    trigger: commit
+    branch: master
+    project: nightly
+    additional_repos:
+      - copr://@scikit-build/release
+  - &tests
+    job: tests
+    trigger: commit
+    targets:
+      # TODO: Match F40 release
+      - fedora-development-x86_64
+      - fedora-development-aarch64
+      - fedora-latest-x86_64
+      - fedora-latest-aarch64
+    tmt_plan: .*/smoke
+  - <<: *copr_build
     trigger: pull_request
     manual_trigger: true
-    owner: lecris
     project: cp2k
     update_release: true
     release_suffix: "{PACKIT_RPMSPEC_RELEASE}"
-    targets:
-      - fedora-development-x86_64
-      - fedora-development-aarch64
-  - job: tests
+  - <<: *tests
     identifier: smoke
     trigger: pull_request
     manual_trigger: true
-    targets:
-      - fedora-development-x86_64
-      - fedora-development-aarch64
-    tmt_plan: .*/smoke
-  - job: tests
+  - <<: *tests
     identifier: full
     trigger: pull_request
     manual_trigger: true
-    targets:
-      - fedora-development-x86_64
-      - fedora-development-aarch64
     tmt_plan: .*/full
   - job: propose_downstream
     trigger: release

--- a/tools/fedora/plans/main.fmf
+++ b/tools/fedora/plans/main.fmf
@@ -1,0 +1,7 @@
+adjust:
+  # TODO: use initiator == fedora-ci instead
+  when: initiator is not defined or initiator != packit
+  discover:
+    how: fmf
+    dist-git-source: true
+    dist-git-extract: cp2k-*/

--- a/tools/fedora/plans/main.fmf.dist-git
+++ b/tools/fedora/plans/main.fmf.dist-git
@@ -1,4 +1,0 @@
-discover:
-  how: fmf
-  dist-git-source: true
-  dist-git-extract: cp2k-*/

--- a/tools/fedora/tests/do_regtest.sh
+++ b/tools/fedora/tests/do_regtest.sh
@@ -7,9 +7,11 @@ rlJournalStart
   rlPhaseStartTest
     [[ -z "${CP2K_VARIANT}" ]] && rlDie "No CP2K_VARIANT environment variable set"
 
-    rlRun "cd ../../../tests" 0 "cd to cp2k tests folder"
+    rlRun "cd ${TMT_TREE}/tests" 0 "cd to cp2k tests folder"
 
-    rlRun "args=\"--maxtasks $(nproc) --ompthreads 2 --skip_unittests\"" 0 "Set base arguments"
+    rlRun "args=\"--maxtasks $(nproc) --ompthreads 2\"" 0 "Set base arguments"
+    [[ "${CP2K_SKIP_UNITTEST,,}" == "true" ]] && rlRun "args=\"\$args --skip_unittests\"" 0 "Skip unit tests"
+    [[ "${CP2K_SKIP_REGTEST,,}" == "true" ]] && rlRun "args=\"\$args --skip_regtests\"" 0 "Skip regression tests"
     [[ "${CP2K_SMOKE_ONLY,,}" == "true" ]] && rlRun "args=\"\$args --smoketest\"" 0 "Set smoketest flag"
 
     if [[ "${CP2K_VARIANT}" != "serial" ]]; then
@@ -17,7 +19,7 @@ rlJournalStart
       rlRun "module load mpi/${CP2K_VARIANT}" 0 "Load MPI module: ${CP2K_VARIANT}"
       rlRun "export CP2K_STEM=$MPI_BIN/cp2k" 0 "Export CP2K_STEM"
       rlRun "args=\"\$args --mpiranks 2\"" 0 "Set MPI arguments"
-      rlRun "args=\"\$args local-${CP2K_VARIANT} psmp\"" 0 "Set run specific arguments"
+      rlRun "args=\"\$args local_${CP2K_VARIANT} psmp\"" 0 "Set run specific arguments"
     else
       rlRun "export CP2K_STEM=/usr/bin/cp2k" 0 "Export CP2K_STEM"
       rlRun "args=\"\$args local ssmp\"" 0 "Set run specific arguments"

--- a/tools/fedora/tests/regression.fmf
+++ b/tools/fedora/tests/regression.fmf
@@ -3,6 +3,9 @@ framework: beakerlib
 test: ./do_regtest.sh
 # TODO: Reduce the tests duration
 duration: 2h
+environment+:
+  # Cannot run unittest outside of the build environment
+  CP2K_SKIP_UNITTEST: true
 
 /serial:
   summary+: (serial)


### PR DESCRIPTION
Working on porting these changes to upstream since it is starting to fail with `elpa` being dropped: https://src.fedoraproject.org/rpms/cp2k/pull-request/6

Have a few fixes to port back here