### PR TITLE
Revised tensor contractions

### DIFF
--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -9,13 +9,13 @@
 !> \brief Contraction of integrals over primitive Cartesian Gaussians based on the contraction
 !>        matrix sphi which is part of the gto_basis_set_type
 !> \par History
-!>      -added libxsmm_abc_contract routine, A. Bussy (04.2020)
+!>      -added abc_contract_xsmm routine, A. Bussy (04.2020)
 !> \author Dorothea Golze (05.2016)
 ! **************************************************************************************************
 MODULE ai_contraction_sphi
 
    USE kinds, ONLY: dp
-#if(__LIBXSMM)
+#if defined(__LIBXSMM)
    USE libxsmm, ONLY: LIBXSMM_PREFETCH_NONE, &
                       libxsmm_blasint_kind, &
                       libxsmm_dgemm, &
@@ -33,7 +33,7 @@ MODULE ai_contraction_sphi
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'ai_contraction_sphi'
 
-   PUBLIC :: ab_contract, abc_contract, abcd_contract, libxsmm_abc_contract
+   PUBLIC :: ab_contract, abc_contract, abcd_contract, abc_contract_xsmm
 
 CONTAINS
 
@@ -229,7 +229,7 @@ CONTAINS
 !>        the LIBXSMM library to be initialized somewhere before this routine is called.
 !> \param abcint contracted integrals
 !> \param sabc uncontracted integrals
-!> \param tsphi_a assumed to have dimensions nsgfa x ncoa
+!> \param sphi_a assumed to have dimensions nsgfa x ncoa
 !> \param sphi_b assumed to have dimensions ncob x nsgfb
 !> \param sphi_c assumed to have dimensions ncoc x nsgfc
 !> \param ncoa ...
@@ -238,71 +238,97 @@ CONTAINS
 !> \param nsgfa ...
 !> \param nsgfb ...
 !> \param nsgfc ...
-!> \param cpp_buffer ...
-!> \param ccp_buffer ...
+!> \param cpp_buffer Temporary buffer used for intermediate results.
+!> \param ccp_buffer Temporary buffer used for intermediate results.
+!> \param alpha Prefactor which is finally multiplied into abcint (GEMM's Alpha).
+!> \param beta Factor determining how initial abcint is preserved (GEMM's Beta).
 !> \note tested from version 1.9.0 of libxsmm
 ! **************************************************************************************************
-   SUBROUTINE libxsmm_abc_contract(abcint, sabc, tsphi_a, sphi_b, sphi_c, ncoa, ncob, ncoc, &
-                                   nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer)
+   SUBROUTINE abc_contract_xsmm(abcint, sabc, sphi_a, sphi_b, sphi_c, ncoa, ncob, ncoc, &
+                                nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer, alpha, beta)
 
-      REAL(dp), DIMENSION(*)                             :: abcint, sabc
-      REAL(dp), DIMENSION(:, :)                          :: tsphi_a, sphi_b, sphi_c
-      INTEGER, INTENT(IN)                                :: ncoa, ncob, ncoc, nsgfa, nsgfb, nsgfc
-      REAL(dp), DIMENSION(nsgfa*ncob)                    :: cpp_buffer
-      REAL(dp), DIMENSION(nsgfa*nsgfb*ncoc)              :: ccp_buffer
+      REAL(KIND=dp), DIMENSION(*)                             :: abcint
+      REAL(KIND=dp), DIMENSION(*), INTENT(IN)                 :: sabc
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)              :: sphi_a, sphi_b, sphi_c
+      INTEGER, INTENT(IN)                                     :: ncoa, ncob, ncoc, nsgfa, nsgfb, nsgfc
+      REAL(KIND=dp), DIMENSION(nsgfa*ncob), INTENT(OUT)       :: cpp_buffer
+      REAL(KIND=dp), DIMENSION(nsgfa*nsgfb*ncoc), INTENT(OUT) :: ccp_buffer
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                     :: alpha, beta
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'libxsmm_abc_contract'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'abc_contract_xsmm'
 
-      INTEGER                                            :: handle, i
-      LOGICAL                                            :: libxsmm_kernels_available
-#if(__LIBXSMM)
-      INTEGER(libxsmm_blasint_kind)                      :: m, n, k
-      TYPE(libxsmm_dmmfunction)                          :: xmm1, xmm2
+      REAL(KIND=dp)                                           :: prefac, pstfac
+      INTEGER                                                 :: handle, i
+      LOGICAL                                                 :: uv
+#if defined(__LIBXSMM)
+      TYPE(libxsmm_dmmfunction)                               :: xmm1, xmm2
 #endif
 
-      CALL timeset(routineN, handle)
-      libxsmm_kernels_available = .FALSE.
+      ! M*N*K FLOPS can be used to decide if contracting (UV)W vs U(VW)
+      ! uv = (nsgfa*ncob*(ncoa + nsgfb)) <= (ncoa*nsgfb*(ncob + nsgfa))
+      ! however, current interface dictates size of cpp_buffer
+      uv = (nsgfa*ncob) < (ncoa*nsgfb) .OR. (ncoa + nsgfb) <= (ncob + nsgfa)
 
-#if(__LIBXSMM)
-      !We make use of libxsmm code dispatching feature and call the same kernel multiple times
-      !We loop over the last index of the matrix and call libxsmm each time
+      CALL timeset(routineN//MERGE("_uv", "_vw", uv), handle)
 
-      !pre-fetch the kernels
-      m = nsgfa; n = ncob; k = ncoa
-      CALL libxsmm_dispatch(xmm1, m, n, k, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
-      m = nsgfa; n = nsgfb; k = ncob
-      CALL libxsmm_dispatch(xmm2, m, n, k, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
+      prefac = 1.0_dp
+      IF (PRESENT(alpha)) prefac = alpha
 
-      libxsmm_kernels_available = libxsmm_available(xmm1) .AND. libxsmm_available(xmm2)
+      pstfac = 0.0_dp
+      IF (PRESENT(beta)) pstfac = beta
 
-      IF (libxsmm_kernels_available) THEN
-         ! contractions over a and b
-         DO i = 1, ncoc
-            CALL libxsmm_dmmcall(xmm1, tsphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
-            CALL libxsmm_dmmcall(xmm2, cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
-         END DO
+      ! loop over the last index of the matrix and call LIBXSMM/BLAS to contract over a and b
+#if defined(__LIBXSMM)
+      IF (uv) THEN ! (UV)W: dispatch kernels
+         CALL libxsmm_dispatch(xmm1, nsgfa, ncob, ncoa, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
+         CALL libxsmm_dispatch(xmm2, nsgfa, nsgfb, ncob, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
+      ELSE ! U(VW): dispatch kernels
+         CALL libxsmm_dispatch(xmm1, ncoa, nsgfb, ncob, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
+         CALL libxsmm_dispatch(xmm2, nsgfa, nsgfb, ncoa, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
+      END IF
+
+      IF (libxsmm_available(xmm1) .AND. libxsmm_available(xmm2)) THEN
+         IF (uv) THEN ! (UV)W
+            DO i = 1, ncoc ! contractions over a and b
+               ! [nsgfa,ncoa] x [ncoa,ncob] -> [nsgfa,ncob]
+               CALL libxsmm_dmmcall(xmm1, sphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
+               ! [nsgfa,ncob] x [ncob,nsgfb] -> [nsgfa,nsgfb]
+               CALL libxsmm_dmmcall(xmm2, cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
+            END DO
+         ELSE ! U(VW)
+            DO i = 1, ncoc ! contractions over a and b
+               ! [ncoa,ncob] x [ncob,nsgfb] -> [ncoa,nsgfb]
+               CALL libxsmm_dmmcall(xmm1, sabc((i - 1)*ncoa*ncob + 1), sphi_b, cpp_buffer)
+               ! [nsgfa,ncoa] x [ncoa,nsgfb] -> [nsgfa,nsgfb]
+               CALL libxsmm_dmmcall(xmm2, sphi_a, cpp_buffer, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
+            END DO
+         END IF
       ELSE
-         CPWARN("libxsmm available, but kernels are not, fallback to dgemm")
+#endif
+         IF (uv) THEN ! (UV)W
+            DO i = 1, ncoc ! contractions over a and b
+               CALL dgemm("N", "N", nsgfa, ncob, ncoa, 1.0_dp, sphi_a, nsgfa, sabc((i - 1)*ncoa*ncob + 1), &
+                          ncoa, 0.0_dp, cpp_buffer, nsgfa)
+               CALL dgemm("N", "N", nsgfa, nsgfb, ncob, 1.0_dp, cpp_buffer, nsgfa, sphi_b, ncob, 0.0_dp, &
+                          ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
+            END DO
+         ELSE ! U(VW)
+            DO i = 1, ncoc ! contractions over a and b
+               CALL dgemm("N", "N", ncoa, nsgfb, ncob, 1.0_dp, sabc((i - 1)*ncoa*ncob + 1), nsgfa, sphi_b, &
+                          ncoa, 0.0_dp, cpp_buffer, nsgfa)
+               CALL dgemm("N", "N", nsgfa, nsgfb, ncoa, 1.0_dp, sphi_a, nsgfa, cpp_buffer, ncob, 0.0_dp, &
+                          ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
+            END DO
+         END IF
+#if defined(__LIBXSMM)
       END IF
 #endif
-
-      IF (.NOT. libxsmm_kernels_available) THEN
-         ! we follow the same flow as for libxsmm above, but use BLAS dgemm
-         ! contractions over a and b
-         DO i = 1, ncoc
-            CALL dgemm("N", "N", nsgfa, ncob, ncoa, 1.0_dp, tsphi_a, nsgfa, sabc((i - 1)*ncoa*ncob + 1), &
-                       ncoa, 0.0_dp, cpp_buffer, nsgfa)
-            CALL dgemm("N", "N", nsgfa, nsgfb, ncob, 1.0_dp, cpp_buffer, nsgfa, sphi_b, ncob, 0.0_dp, &
-                       ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
-         END DO
-      END IF
-
-      ! last contraction, over c, as a larger MM
-      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, 1.0_dp, ccp_buffer, nsgfa*nsgfb, sphi_c, ncoc, &
-                 0.0_dp, abcint, nsgfa*nsgfb)
+      ! last contraction, over c (larger MM using BLAS)
+      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, prefac, ccp_buffer, nsgfa*nsgfb, sphi_c, ncoc, &
+                 pstfac, abcint, nsgfa*nsgfb)
 
       CALL timestop(handle)
 
-   END SUBROUTINE libxsmm_abc_contract
+   END SUBROUTINE abc_contract_xsmm
 
 END MODULE ai_contraction_sphi

--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -259,17 +259,17 @@ CONTAINS
 
       REAL(KIND=dp)                                           :: prefac, pstfac
       INTEGER                                                 :: handle, i
-      LOGICAL                                                 :: uv
+      LOGICAL                                                 :: ab
 #if defined(__LIBXSMM)
       TYPE(libxsmm_dmmfunction)                               :: xmm1, xmm2
 #endif
 
-      ! M*N*K FLOPS can be used to decide if contracting (UV)W vs U(VW)
-      ! uv = (nsgfa*ncob*(ncoa + nsgfb)) <= (ncoa*nsgfb*(ncob + nsgfa))
+      ! M*N*K FLOPS can be used to decide if contracting (AB)C vs A(BC)
+      ! ab = (nsgfa*ncob*(ncoa + nsgfb)) <= (ncoa*nsgfb*(ncob + nsgfa))
       ! however, current interface dictates size of cpp_buffer
-      uv = (nsgfa*ncob) < (ncoa*nsgfb) .OR. (ncoa + nsgfb) <= (ncob + nsgfa)
+      ab = (nsgfa*ncob) < (ncoa*nsgfb) .OR. (ncoa + nsgfb) <= (ncob + nsgfa)
 
-      CALL timeset(routineN//MERGE("_uv", "_vw", uv), handle)
+      CALL timeset(routineN//MERGE("_ab", "_bc", ab), handle)
 
       prefac = 1.0_dp
       IF (PRESENT(alpha)) prefac = alpha
@@ -279,23 +279,23 @@ CONTAINS
 
       ! loop over the last index of the matrix and call LIBXSMM/BLAS to contract over a and b
 #if defined(__LIBXSMM)
-      IF (uv) THEN ! (UV)W: dispatch kernels
+      IF (ab) THEN ! (AB)C: dispatch kernels
          CALL libxsmm_dispatch(xmm1, nsgfa, ncob, ncoa, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
          CALL libxsmm_dispatch(xmm2, nsgfa, nsgfb, ncob, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
-      ELSE ! U(VW): dispatch kernels
+      ELSE ! A(BC): dispatch kernels
          CALL libxsmm_dispatch(xmm1, ncoa, nsgfb, ncob, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
          CALL libxsmm_dispatch(xmm2, nsgfa, nsgfb, ncoa, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
       END IF
 
       IF (libxsmm_available(xmm1) .AND. libxsmm_available(xmm2)) THEN
-         IF (uv) THEN ! (UV)W
+         IF (ab) THEN ! (AB)C
             DO i = 1, ncoc ! contractions over a and b
                ! [nsgfa,ncoa] x [ncoa,ncob] -> [nsgfa,ncob]
                CALL libxsmm_dmmcall(xmm1, sphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
                ! [nsgfa,ncob] x [ncob,nsgfb] -> [nsgfa,nsgfb]
                CALL libxsmm_dmmcall(xmm2, cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
             END DO
-         ELSE ! U(VW)
+         ELSE ! A(BC)
             DO i = 1, ncoc ! contractions over a and b
                ! [ncoa,ncob] x [ncob,nsgfb] -> [ncoa,nsgfb]
                CALL libxsmm_dmmcall(xmm1, sabc((i - 1)*ncoa*ncob + 1), sphi_b, cpp_buffer)
@@ -305,14 +305,14 @@ CONTAINS
          END IF
       ELSE
 #endif
-         IF (uv) THEN ! (UV)W
+         IF (ab) THEN ! (AB)C
             DO i = 1, ncoc ! contractions over a and b
                CALL dgemm("N", "N", nsgfa, ncob, ncoa, 1.0_dp, sphi_a, nsgfa, sabc((i - 1)*ncoa*ncob + 1), &
                           ncoa, 0.0_dp, cpp_buffer, nsgfa)
                CALL dgemm("N", "N", nsgfa, nsgfb, ncob, 1.0_dp, cpp_buffer, nsgfa, sphi_b, ncob, 0.0_dp, &
                           ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
             END DO
-         ELSE ! U(VW)
+         ELSE ! A(BC)
             DO i = 1, ncoc ! contractions over a and b
                CALL dgemm("N", "N", ncoa, nsgfb, ncob, 1.0_dp, sabc((i - 1)*ncoa*ncob + 1), nsgfa, sphi_b, &
                           ncoa, 0.0_dp, cpp_buffer, nsgfa)

--- a/src/qs_tensors.F
+++ b/src/qs_tensors.F
@@ -13,7 +13,7 @@ MODULE qs_tensors
                                               omp_get_thread_num
    USE ai_contraction,                  ONLY: block_add
    USE ai_contraction_sphi,             ONLY: ab_contract,&
-                                              libxsmm_abc_contract
+                                              abc_contract_xsmm
    USE atomic_kind_types,               ONLY: atomic_kind_type
    USE basis_set_types,                 ONLY: get_gto_basis_set,&
                                               gto_basis_set_p_type,&
@@ -1683,10 +1683,10 @@ CONTAINS
                         IF (der_j_zero(i_xyz)) CYCLE
 
                         block_j_not_zero(i_xyz) = .TRUE.
-                        CALL libxsmm_abc_contract(dijk_contr, dijk_j(:, :, :, i_xyz), tspj(jset, jkind)%array, &
-                                                  spk(kset, kkind)%array, spi(iset, ikind)%array, &
-                                                  ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                                  nsgfi(iset), cpp_buffer, ccp_buffer)
+                        CALL abc_contract_xsmm(dijk_contr, dijk_j(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                                               spk(kset, kkind)%array, spi(iset, ikind)%array, &
+                                               ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
+                                               nsgfi(iset), cpp_buffer, ccp_buffer, prefac)
 
                         block_t_j(block_start_j:block_end_j, &
                                   block_start_k:block_end_k, &
@@ -1694,7 +1694,7 @@ CONTAINS
                            block_t_j(block_start_j:block_end_j, &
                                      block_start_k:block_end_k, &
                                      block_start_i:block_end_i, i_xyz) + &
-                           prefac*dijk_contr(:, :, :)
+                           dijk_contr(:, :, :)
 
                      END DO
 
@@ -1702,10 +1702,10 @@ CONTAINS
                         IF (der_k_zero(i_xyz)) CYCLE
 
                         block_k_not_zero(i_xyz) = .TRUE.
-                        CALL libxsmm_abc_contract(dijk_contr, dijk_k(:, :, :, i_xyz), tspj(jset, jkind)%array, &
-                                                  spk(kset, kkind)%array, spi(iset, ikind)%array, &
-                                                  ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                                  nsgfi(iset), cpp_buffer, ccp_buffer)
+                        CALL abc_contract_xsmm(dijk_contr, dijk_k(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                                               spk(kset, kkind)%array, spi(iset, ikind)%array, &
+                                               ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
+                                               nsgfi(iset), cpp_buffer, ccp_buffer, prefac)
 
                         block_t_k(block_start_j:block_end_j, &
                                   block_start_k:block_end_k, &
@@ -1713,7 +1713,7 @@ CONTAINS
                            block_t_k(block_start_j:block_end_j, &
                                      block_start_k:block_end_k, &
                                      block_start_i:block_end_i, i_xyz) + &
-                           prefac*dijk_contr(:, :, :)
+                           dijk_contr(:, :, :)
 
                      END DO
 
@@ -2241,10 +2241,10 @@ CONTAINS
                         IF (der_j_zero(i_xyz)) CYCLE
 
                         block_j_not_zero(i_xyz) = .TRUE.
-                        CALL libxsmm_abc_contract(dijk_contr, dijk_j(:, :, :, i_xyz), tspj(jset, jkind)%array, &
-                                                  spk(kset, kkind)%array, spi(iset, ikind)%array, &
-                                                  ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                                  nsgfi(iset), cpp_buffer, ccp_buffer)
+                        CALL abc_contract_xsmm(dijk_contr, dijk_j(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                                               spk(kset, kkind)%array, spi(iset, ikind)%array, &
+                                               ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
+                                               nsgfi(iset), cpp_buffer, ccp_buffer)
 
                         block_t_j(block_start_j:block_end_j, &
                                   block_start_k:block_end_k, &
@@ -2260,10 +2260,10 @@ CONTAINS
                         IF (der_k_zero(i_xyz)) CYCLE
 
                         block_k_not_zero(i_xyz) = .TRUE.
-                        CALL libxsmm_abc_contract(dijk_contr, dijk_k(:, :, :, i_xyz), tspj(jset, jkind)%array, &
-                                                  spk(kset, kkind)%array, spi(iset, ikind)%array, &
-                                                  ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                                  nsgfi(iset), cpp_buffer, ccp_buffer)
+                        CALL abc_contract_xsmm(dijk_contr, dijk_k(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                                               spk(kset, kkind)%array, spi(iset, ikind)%array, &
+                                               ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
+                                               nsgfi(iset), cpp_buffer, ccp_buffer)
 
                         block_t_k(block_start_j:block_end_j, &
                                   block_start_k:block_end_k, &
@@ -2841,10 +2841,10 @@ CONTAINS
 
                   block_not_zero = .TRUE.
                   ALLOCATE (sijk_contr(nsgfj(jset), nsgfk(kset), nsgfi(iset)))
-                  CALL libxsmm_abc_contract(sijk_contr, sijk, tspj(jset, jkind)%array, &
-                                            spk(kset, kkind)%array, spi(iset, ikind)%array, &
-                                            ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                            nsgfi(iset), cpp_buffer, ccp_buffer)
+                  CALL abc_contract_xsmm(sijk_contr, sijk, tspj(jset, jkind)%array, &
+                                         spk(kset, kkind)%array, spi(iset, ikind)%array, &
+                                         ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
+                                         nsgfi(iset), cpp_buffer, ccp_buffer, prefac)
                   DEALLOCATE (sijk)
 
                   sgfj = first_sgf_j(1, jset)
@@ -2863,7 +2863,7 @@ CONTAINS
                      block_t(block_start_j:block_end_j, &
                              block_start_k:block_end_k, &
                              block_start_i:block_end_i) + &
-                     prefac*sijk_contr(:, :, :)
+                     sijk_contr(:, :, :)
                   DEALLOCATE (sijk_contr)
 
                END DO

--- a/src/xas_tdp_integrals.F
+++ b/src/xas_tdp_integrals.F
@@ -11,90 +11,90 @@
 ! **************************************************************************************************
 
 MODULE xas_tdp_integrals
-   USE OMP_LIB,                         ONLY: omp_get_max_threads,&
-                                              omp_get_num_threads,&
-                                              omp_get_thread_num
-   USE ai_contraction_sphi,             ONLY: ab_contract,&
-                                              libxsmm_abc_contract
-   USE atomic_kind_types,               ONLY: atomic_kind_type
-   USE basis_set_types,                 ONLY: get_gto_basis_set,&
-                                              gto_basis_set_p_type,&
-                                              gto_basis_set_type
-   USE cell_types,                      ONLY: cell_type
-   USE constants_operator,              ONLY: operator_coulomb
-   USE cp_array_utils,                  ONLY: cp_1d_i_p_type,&
-                                              cp_2d_r_p_type
-   USE cp_blacs_env,                    ONLY: cp_blacs_env_type
-   USE cp_dbcsr_operations,             ONLY: cp_dbcsr_dist2d_to_dist
-   USE cp_eri_mme_interface,            ONLY: cp_eri_mme_param,&
-                                              cp_eri_mme_set_params
-   USE cp_files,                        ONLY: close_file,&
-                                              open_file
-   USE dbcsr_api,                       ONLY: dbcsr_distribution_get,&
-                                              dbcsr_distribution_release,&
-                                              dbcsr_distribution_type
-   USE dbt_api,                         ONLY: &
-        dbt_create, dbt_distribution_destroy, dbt_distribution_new, dbt_distribution_type, &
-        dbt_finalize, dbt_pgrid_create, dbt_pgrid_destroy, dbt_pgrid_type, dbt_put_block, &
-        dbt_reserve_blocks, dbt_type
-   USE distribution_1d_types,           ONLY: distribution_1d_type
-   USE distribution_2d_types,           ONLY: distribution_2d_create,&
-                                              distribution_2d_type
-   USE eri_mme_integrate,               ONLY: eri_mme_2c_integrate
-   USE eri_mme_types,                   ONLY: eri_mme_init,&
-                                              eri_mme_release
-   USE gamma,                           ONLY: init_md_ftable
-   USE generic_os_integrals,            ONLY: int_operators_r12_ab_os
-   USE input_constants,                 ONLY: do_potential_coulomb,&
-                                              do_potential_id,&
-                                              do_potential_short,&
-                                              do_potential_truncated
-   USE input_section_types,             ONLY: section_vals_val_get
-   USE kinds,                           ONLY: dp
-   USE libint_2c_3c,                    ONLY: cutoff_screen_factor,&
-                                              eri_2center,&
-                                              eri_3center,&
-                                              libint_potential_type
-   USE libint_wrapper,                  ONLY: cp_libint_cleanup_2eri,&
-                                              cp_libint_cleanup_3eri,&
-                                              cp_libint_init_2eri,&
-                                              cp_libint_init_3eri,&
-                                              cp_libint_set_contrdepth,&
-                                              cp_libint_t
-   USE mathlib,                         ONLY: invmat_symm
-   USE message_passing,                 ONLY: mp_comm_type,&
-                                              mp_para_env_type
-   USE molecule_types,                  ONLY: molecule_type
-   USE orbital_pointers,                ONLY: ncoset
-   USE particle_methods,                ONLY: get_particle_set
-   USE particle_types,                  ONLY: particle_type
-   USE qs_environment_types,            ONLY: get_qs_env,&
-                                              qs_environment_type
-   USE qs_integral_utils,               ONLY: basis_set_list_setup
-   USE qs_kind_types,                   ONLY: get_qs_kind,&
-                                              qs_kind_type
-   USE qs_neighbor_list_types,          ONLY: &
-        get_iterator_info, get_neighbor_list_set_p, neighbor_list_iterate, &
-        neighbor_list_iterator_create, neighbor_list_iterator_p_type, &
-        neighbor_list_iterator_release, neighbor_list_set_p_type, nl_set_sub_iterator, &
-        nl_sub_iterate, release_neighbor_list_sets
-   USE qs_neighbor_lists,               ONLY: atom2d_build,&
-                                              atom2d_cleanup,&
-                                              build_neighbor_lists,&
-                                              local_atoms_type,&
-                                              pair_radius_setup
-   USE qs_o3c_types,                    ONLY: get_o3c_iterator_info,&
-                                              init_o3c_container,&
-                                              o3c_container_type,&
-                                              o3c_iterate,&
-                                              o3c_iterator_create,&
-                                              o3c_iterator_release,&
-                                              o3c_iterator_type,&
-                                              release_o3c_container
-   USE t_c_g0,                          ONLY: get_lmax_init,&
-                                              init
-   USE xas_tdp_types,                   ONLY: xas_tdp_control_type,&
-                                              xas_tdp_env_type
+   USE OMP_LIB, ONLY: omp_get_max_threads, &
+                      omp_get_num_threads, &
+                      omp_get_thread_num
+   USE ai_contraction_sphi, ONLY: ab_contract, &
+                                  abc_contract_xsmm
+   USE atomic_kind_types, ONLY: atomic_kind_type
+   USE basis_set_types, ONLY: get_gto_basis_set, &
+                              gto_basis_set_p_type, &
+                              gto_basis_set_type
+   USE cell_types, ONLY: cell_type
+   USE constants_operator, ONLY: operator_coulomb
+   USE cp_array_utils, ONLY: cp_1d_i_p_type, &
+                             cp_2d_r_p_type
+   USE cp_blacs_env, ONLY: cp_blacs_env_type
+   USE cp_dbcsr_operations, ONLY: cp_dbcsr_dist2d_to_dist
+   USE cp_eri_mme_interface, ONLY: cp_eri_mme_param, &
+                                   cp_eri_mme_set_params
+   USE cp_files, ONLY: close_file, &
+                       open_file
+   USE dbcsr_api, ONLY: dbcsr_distribution_get, &
+                        dbcsr_distribution_release, &
+                        dbcsr_distribution_type
+   USE dbt_api, ONLY: &
+      dbt_create, dbt_distribution_destroy, dbt_distribution_new, dbt_distribution_type, &
+      dbt_finalize, dbt_pgrid_create, dbt_pgrid_destroy, dbt_pgrid_type, dbt_put_block, &
+      dbt_reserve_blocks, dbt_type
+   USE distribution_1d_types, ONLY: distribution_1d_type
+   USE distribution_2d_types, ONLY: distribution_2d_create, &
+                                    distribution_2d_type
+   USE eri_mme_integrate, ONLY: eri_mme_2c_integrate
+   USE eri_mme_types, ONLY: eri_mme_init, &
+                            eri_mme_release
+   USE gamma, ONLY: init_md_ftable
+   USE generic_os_integrals, ONLY: int_operators_r12_ab_os
+   USE input_constants, ONLY: do_potential_coulomb, &
+                              do_potential_id, &
+                              do_potential_short, &
+                              do_potential_truncated
+   USE input_section_types, ONLY: section_vals_val_get
+   USE kinds, ONLY: dp
+   USE libint_2c_3c, ONLY: cutoff_screen_factor, &
+                           eri_2center, &
+                           eri_3center, &
+                           libint_potential_type
+   USE libint_wrapper, ONLY: cp_libint_cleanup_2eri, &
+                             cp_libint_cleanup_3eri, &
+                             cp_libint_init_2eri, &
+                             cp_libint_init_3eri, &
+                             cp_libint_set_contrdepth, &
+                             cp_libint_t
+   USE mathlib, ONLY: invmat_symm
+   USE message_passing, ONLY: mp_comm_type, &
+                              mp_para_env_type
+   USE molecule_types, ONLY: molecule_type
+   USE orbital_pointers, ONLY: ncoset
+   USE particle_methods, ONLY: get_particle_set
+   USE particle_types, ONLY: particle_type
+   USE qs_environment_types, ONLY: get_qs_env, &
+                                   qs_environment_type
+   USE qs_integral_utils, ONLY: basis_set_list_setup
+   USE qs_kind_types, ONLY: get_qs_kind, &
+                            qs_kind_type
+   USE qs_neighbor_list_types, ONLY: &
+      get_iterator_info, get_neighbor_list_set_p, neighbor_list_iterate, &
+      neighbor_list_iterator_create, neighbor_list_iterator_p_type, &
+      neighbor_list_iterator_release, neighbor_list_set_p_type, nl_set_sub_iterator, &
+      nl_sub_iterate, release_neighbor_list_sets
+   USE qs_neighbor_lists, ONLY: atom2d_build, &
+                                atom2d_cleanup, &
+                                build_neighbor_lists, &
+                                local_atoms_type, &
+                                pair_radius_setup
+   USE qs_o3c_types, ONLY: get_o3c_iterator_info, &
+                           init_o3c_container, &
+                           o3c_container_type, &
+                           o3c_iterate, &
+                           o3c_iterator_create, &
+                           o3c_iterator_release, &
+                           o3c_iterator_type, &
+                           release_o3c_container
+   USE t_c_g0, ONLY: get_lmax_init, &
+                     init
+   USE xas_tdp_types, ONLY: xas_tdp_control_type, &
+                            xas_tdp_env_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -611,9 +611,9 @@ CONTAINS
 
                   ALLOCATE (work(nsgfa(iset), nsgfb(jset), nsgfc(kset)))
 
-                  CALL libxsmm_abc_contract(work, sabc, tspa(iset, ikind)%array, spb(jset, jkind)%array, &
-                                            spc(kset, kkind)%array, ncoa, ncob, ncoc, nsgfa(iset), &
-                                            nsgfb(jset), nsgfc(kset), cpp_buffer, ccp_buffer)
+                  CALL abc_contract_xsmm(work, sabc, tspa(iset, ikind)%array, spb(jset, jkind)%array, &
+                                         spc(kset, kkind)%array, ncoa, ncob, ncoc, nsgfa(iset), &
+                                         nsgfb(jset), nsgfc(kset), cpp_buffer, ccp_buffer)
 
                   iabc(sgfa:egfa, sgfb:egfb, sgfc:egfc) = work(:, :, :)
                   DEALLOCATE (sabc, work)

--- a/src/xas_tdp_integrals.F
+++ b/src/xas_tdp_integrals.F
@@ -11,90 +11,90 @@
 ! **************************************************************************************************
 
 MODULE xas_tdp_integrals
-   USE OMP_LIB, ONLY: omp_get_max_threads, &
-                      omp_get_num_threads, &
-                      omp_get_thread_num
-   USE ai_contraction_sphi, ONLY: ab_contract, &
-                                  abc_contract_xsmm
-   USE atomic_kind_types, ONLY: atomic_kind_type
-   USE basis_set_types, ONLY: get_gto_basis_set, &
-                              gto_basis_set_p_type, &
-                              gto_basis_set_type
-   USE cell_types, ONLY: cell_type
-   USE constants_operator, ONLY: operator_coulomb
-   USE cp_array_utils, ONLY: cp_1d_i_p_type, &
-                             cp_2d_r_p_type
-   USE cp_blacs_env, ONLY: cp_blacs_env_type
-   USE cp_dbcsr_operations, ONLY: cp_dbcsr_dist2d_to_dist
-   USE cp_eri_mme_interface, ONLY: cp_eri_mme_param, &
-                                   cp_eri_mme_set_params
-   USE cp_files, ONLY: close_file, &
-                       open_file
-   USE dbcsr_api, ONLY: dbcsr_distribution_get, &
-                        dbcsr_distribution_release, &
-                        dbcsr_distribution_type
-   USE dbt_api, ONLY: &
-      dbt_create, dbt_distribution_destroy, dbt_distribution_new, dbt_distribution_type, &
-      dbt_finalize, dbt_pgrid_create, dbt_pgrid_destroy, dbt_pgrid_type, dbt_put_block, &
-      dbt_reserve_blocks, dbt_type
-   USE distribution_1d_types, ONLY: distribution_1d_type
-   USE distribution_2d_types, ONLY: distribution_2d_create, &
-                                    distribution_2d_type
-   USE eri_mme_integrate, ONLY: eri_mme_2c_integrate
-   USE eri_mme_types, ONLY: eri_mme_init, &
-                            eri_mme_release
-   USE gamma, ONLY: init_md_ftable
-   USE generic_os_integrals, ONLY: int_operators_r12_ab_os
-   USE input_constants, ONLY: do_potential_coulomb, &
-                              do_potential_id, &
-                              do_potential_short, &
-                              do_potential_truncated
-   USE input_section_types, ONLY: section_vals_val_get
-   USE kinds, ONLY: dp
-   USE libint_2c_3c, ONLY: cutoff_screen_factor, &
-                           eri_2center, &
-                           eri_3center, &
-                           libint_potential_type
-   USE libint_wrapper, ONLY: cp_libint_cleanup_2eri, &
-                             cp_libint_cleanup_3eri, &
-                             cp_libint_init_2eri, &
-                             cp_libint_init_3eri, &
-                             cp_libint_set_contrdepth, &
-                             cp_libint_t
-   USE mathlib, ONLY: invmat_symm
-   USE message_passing, ONLY: mp_comm_type, &
-                              mp_para_env_type
-   USE molecule_types, ONLY: molecule_type
-   USE orbital_pointers, ONLY: ncoset
-   USE particle_methods, ONLY: get_particle_set
-   USE particle_types, ONLY: particle_type
-   USE qs_environment_types, ONLY: get_qs_env, &
-                                   qs_environment_type
-   USE qs_integral_utils, ONLY: basis_set_list_setup
-   USE qs_kind_types, ONLY: get_qs_kind, &
-                            qs_kind_type
-   USE qs_neighbor_list_types, ONLY: &
-      get_iterator_info, get_neighbor_list_set_p, neighbor_list_iterate, &
-      neighbor_list_iterator_create, neighbor_list_iterator_p_type, &
-      neighbor_list_iterator_release, neighbor_list_set_p_type, nl_set_sub_iterator, &
-      nl_sub_iterate, release_neighbor_list_sets
-   USE qs_neighbor_lists, ONLY: atom2d_build, &
-                                atom2d_cleanup, &
-                                build_neighbor_lists, &
-                                local_atoms_type, &
-                                pair_radius_setup
-   USE qs_o3c_types, ONLY: get_o3c_iterator_info, &
-                           init_o3c_container, &
-                           o3c_container_type, &
-                           o3c_iterate, &
-                           o3c_iterator_create, &
-                           o3c_iterator_release, &
-                           o3c_iterator_type, &
-                           release_o3c_container
-   USE t_c_g0, ONLY: get_lmax_init, &
-                     init
-   USE xas_tdp_types, ONLY: xas_tdp_control_type, &
-                            xas_tdp_env_type
+   USE OMP_LIB,                         ONLY: omp_get_max_threads,&
+                                              omp_get_num_threads,&
+                                              omp_get_thread_num
+   USE ai_contraction_sphi,             ONLY: ab_contract,&
+                                              abc_contract_xsmm
+   USE atomic_kind_types,               ONLY: atomic_kind_type
+   USE basis_set_types,                 ONLY: get_gto_basis_set,&
+                                              gto_basis_set_p_type,&
+                                              gto_basis_set_type
+   USE cell_types,                      ONLY: cell_type
+   USE constants_operator,              ONLY: operator_coulomb
+   USE cp_array_utils,                  ONLY: cp_1d_i_p_type,&
+                                              cp_2d_r_p_type
+   USE cp_blacs_env,                    ONLY: cp_blacs_env_type
+   USE cp_dbcsr_operations,             ONLY: cp_dbcsr_dist2d_to_dist
+   USE cp_eri_mme_interface,            ONLY: cp_eri_mme_param,&
+                                              cp_eri_mme_set_params
+   USE cp_files,                        ONLY: close_file,&
+                                              open_file
+   USE dbcsr_api,                       ONLY: dbcsr_distribution_get,&
+                                              dbcsr_distribution_release,&
+                                              dbcsr_distribution_type
+   USE dbt_api,                         ONLY: &
+        dbt_create, dbt_distribution_destroy, dbt_distribution_new, dbt_distribution_type, &
+        dbt_finalize, dbt_pgrid_create, dbt_pgrid_destroy, dbt_pgrid_type, dbt_put_block, &
+        dbt_reserve_blocks, dbt_type
+   USE distribution_1d_types,           ONLY: distribution_1d_type
+   USE distribution_2d_types,           ONLY: distribution_2d_create,&
+                                              distribution_2d_type
+   USE eri_mme_integrate,               ONLY: eri_mme_2c_integrate
+   USE eri_mme_types,                   ONLY: eri_mme_init,&
+                                              eri_mme_release
+   USE gamma,                           ONLY: init_md_ftable
+   USE generic_os_integrals,            ONLY: int_operators_r12_ab_os
+   USE input_constants,                 ONLY: do_potential_coulomb,&
+                                              do_potential_id,&
+                                              do_potential_short,&
+                                              do_potential_truncated
+   USE input_section_types,             ONLY: section_vals_val_get
+   USE kinds,                           ONLY: dp
+   USE libint_2c_3c,                    ONLY: cutoff_screen_factor,&
+                                              eri_2center,&
+                                              eri_3center,&
+                                              libint_potential_type
+   USE libint_wrapper,                  ONLY: cp_libint_cleanup_2eri,&
+                                              cp_libint_cleanup_3eri,&
+                                              cp_libint_init_2eri,&
+                                              cp_libint_init_3eri,&
+                                              cp_libint_set_contrdepth,&
+                                              cp_libint_t
+   USE mathlib,                         ONLY: invmat_symm
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_para_env_type
+   USE molecule_types,                  ONLY: molecule_type
+   USE orbital_pointers,                ONLY: ncoset
+   USE particle_methods,                ONLY: get_particle_set
+   USE particle_types,                  ONLY: particle_type
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
+   USE qs_integral_utils,               ONLY: basis_set_list_setup
+   USE qs_kind_types,                   ONLY: get_qs_kind,&
+                                              qs_kind_type
+   USE qs_neighbor_list_types,          ONLY: &
+        get_iterator_info, get_neighbor_list_set_p, neighbor_list_iterate, &
+        neighbor_list_iterator_create, neighbor_list_iterator_p_type, &
+        neighbor_list_iterator_release, neighbor_list_set_p_type, nl_set_sub_iterator, &
+        nl_sub_iterate, release_neighbor_list_sets
+   USE qs_neighbor_lists,               ONLY: atom2d_build,&
+                                              atom2d_cleanup,&
+                                              build_neighbor_lists,&
+                                              local_atoms_type,&
+                                              pair_radius_setup
+   USE qs_o3c_types,                    ONLY: get_o3c_iterator_info,&
+                                              init_o3c_container,&
+                                              o3c_container_type,&
+                                              o3c_iterate,&
+                                              o3c_iterator_create,&
+                                              o3c_iterator_release,&
+                                              o3c_iterator_type,&
+                                              release_o3c_container
+   USE t_c_g0,                          ONLY: get_lmax_init,&
+                                              init
+   USE xas_tdp_types,                   ONLY: xas_tdp_control_type,&
+                                              xas_tdp_env_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE


### PR DESCRIPTION
* Tensor contractions in CP2K currently leave some perf on the table; see https://github.com/cp2k/cp2k/pull/3380#issuecomment-2085573897
  - Other contraction routines can follow a similar flow and can probably be stream-lined (even names)
  - All contraction routines may be better called contract_xyz_something ("contract" in front).
  - Renamed libxsmm_abc_contract to abc_contract_xsmm (first shot/rename).
  - Interfaces to be revised like external/optional buffer allocation,
    allowing minimal/exact buffer size according to best code-path.
  - Arguments to allow more flexible result format like leading dimension.

* libxsmm_abc_contract (abc_contract_xsmm)
  - Implemented faster-path contraction if current interface permits
    like temporary/intermediate buffer being large enough.
  - Adjusted timeset to show which path was taken (uv vs vw).
  - Let abc_contract_xsmm support alpha and beta (pre/post-factor).
  - Revised code format and specified INTENT.
  - Documented subroutine arguments.