### PR TITLE
Fixed leading dimensions of #3380 in BLAS based code-path

### DIFF
--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -223,8 +223,8 @@ CONTAINS
    END SUBROUTINE abcd_contract
 
 ! **************************************************************************************************
-!> \brief 3-center contraction routine from primitive cartesain Gaussians to spherical Gaussian
-!>        functions. Exploits LIBXSMM for performance, falls back to BLAS if LIBXSMM not available.
+!> \brief 3-center contraction routine from primitive cartesian Gaussians to spherical Gaussian
+!>        functions. Exploits LIBXSMM for performance, falls back to BLAS if LIBXSMM is not available.
 !>        Requires pre-allocation of work buffers and pre-transposition of the sphi_a array. Requires
 !>        the LIBXSMM library to be initialized somewhere before this routine is called.
 !> \param abcint contracted integrals
@@ -240,12 +240,11 @@ CONTAINS
 !> \param nsgfc ...
 !> \param cpp_buffer Temporary buffer used for intermediate results.
 !> \param ccp_buffer Temporary buffer used for intermediate results.
-!> \param alpha Prefactor which is finally multiplied into abcint (GEMM's Alpha).
-!> \param beta Factor determining how initial abcint is preserved (GEMM's Beta).
+!> \param prefac Prefactor which is finally multiplied into abcint.
 !> \note tested from version 1.9.0 of libxsmm
 ! **************************************************************************************************
    SUBROUTINE abc_contract_xsmm(abcint, sabc, sphi_a, sphi_b, sphi_c, ncoa, ncob, ncoc, &
-                                nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer, alpha, beta)
+                                nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer, prefac)
 
       REAL(KIND=dp), DIMENSION(*)                             :: abcint
       REAL(KIND=dp), DIMENSION(*), INTENT(IN)                 :: sabc
@@ -253,11 +252,11 @@ CONTAINS
       INTEGER, INTENT(IN)                                     :: ncoa, ncob, ncoc, nsgfa, nsgfb, nsgfc
       REAL(KIND=dp), DIMENSION(nsgfa*ncob), INTENT(OUT)       :: cpp_buffer
       REAL(KIND=dp), DIMENSION(nsgfa*nsgfb*ncoc), INTENT(OUT) :: ccp_buffer
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                     :: alpha, beta
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                     :: prefac
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'abc_contract_xsmm'
 
-      REAL(KIND=dp)                                           :: prefac, pstfac
+      REAL(KIND=dp)                                           :: alpha
       INTEGER                                                 :: handle, i
       LOGICAL                                                 :: ab
 #if defined(__LIBXSMM)
@@ -269,13 +268,10 @@ CONTAINS
       ! however, current interface dictates size of cpp_buffer
       ab = (nsgfa*ncob) < (ncoa*nsgfb) .OR. (ncoa + nsgfb) <= (ncob + nsgfa)
 
-      CALL timeset(routineN//MERGE("_ab", "_bc", ab), handle)
+      CALL timeset(routineN, handle)
 
-      prefac = 1.0_dp
-      IF (PRESENT(alpha)) prefac = alpha
-
-      pstfac = 0.0_dp
-      IF (PRESENT(beta)) pstfac = beta
+      alpha = 1.0_dp
+      IF (PRESENT(prefac)) alpha = prefac
 
       ! loop over the last index of the matrix and call LIBXSMM/BLAS to contract over a and b
 #if defined(__LIBXSMM)
@@ -314,9 +310,9 @@ CONTAINS
             END DO
          ELSE ! A(BC)
             DO i = 1, ncoc ! contractions over a and b
-               CALL dgemm("N", "N", ncoa, nsgfb, ncob, 1.0_dp, sabc((i - 1)*ncoa*ncob + 1), nsgfa, sphi_b, &
-                          ncoa, 0.0_dp, cpp_buffer, nsgfa)
-               CALL dgemm("N", "N", nsgfa, nsgfb, ncoa, 1.0_dp, sphi_a, nsgfa, cpp_buffer, ncob, 0.0_dp, &
+               CALL dgemm("N", "N", ncoa, nsgfb, ncob, 1.0_dp, sabc((i - 1)*ncoa*ncob + 1), ncoa, sphi_b, &
+                          ncob, 0.0_dp, cpp_buffer, ncoa)
+               CALL dgemm("N", "N", nsgfa, nsgfb, ncoa, 1.0_dp, sphi_a, nsgfa, cpp_buffer, ncoa, 0.0_dp, &
                           ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
             END DO
          END IF
@@ -324,8 +320,8 @@ CONTAINS
       END IF
 #endif
       ! last contraction, over c (larger MM using BLAS)
-      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, prefac, ccp_buffer, nsgfa*nsgfb, sphi_c, ncoc, &
-                 pstfac, abcint, nsgfa*nsgfb)
+      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, alpha, ccp_buffer, nsgfa*nsgfb, sphi_c, ncoc, &
+                 0.0_dp, abcint, nsgfa*nsgfb)
 
       CALL timestop(handle)
 


### PR DESCRIPTION
* Removed support for beta in abc_contract_xsmm. Avoid code-path based name in timeset.
* Fixed typos in comments.