### PR TITLE
Reduced intermediate/temporary memory consumption of abc_contract

### DIFF
--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -106,8 +106,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'abc_contract'
 
       INTEGER                                            :: handle, i, m1, m2, m3, msphia, msphib, &
-                                                            msphic
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: cpc, cpp
+                                                            msphic, mx
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: tmp
 
       CALL timeset(routineN, handle)
 
@@ -121,18 +121,20 @@ CONTAINS
       m1 = SIZE(sabc, 1)
       m2 = SIZE(sabc, 2)
       m3 = SIZE(sabc, 3)
+      mx = MAX(m2, nsgfb)
 
-      ALLOCATE (cpp(nsgfa, m2, m3), cpc(nsgfa, nsgfb, m3))
+      ! ALLOCATE (cpp(nsgfa, m2, m3), cpc(nsgfa, nsgfb, m3))
+      ALLOCATE (tmp(nsgfa, mx, m3 + 1))
 
-      CALL dgemm("T", "N", nsgfa, m2*m3, ncoa, 1._dp, sphi_a, msphia, sabc, m1, 0.0_dp, cpp, nsgfa)
+      CALL dgemm("T", "N", nsgfa, m2*m3, ncoa, 1._dp, sphi_a, msphia, sabc, m1, 0.0_dp, tmp(:, :, 2), nsgfa)
       DO i = 1, m3
-         CALL dgemm("N", "N", nsgfa, nsgfb, ncob, 1._dp, cpp(:, :, i), nsgfa, sphi_b, msphib, &
-                    0.0_dp, cpc(:, :, i), nsgfa)
+         CALL dgemm("N", "N", nsgfa, nsgfb, ncob, 1._dp, tmp(:, :, i + 1), nsgfa, sphi_b, msphib, &
+                    0.0_dp, tmp(:, :, i), nsgfa)
       END DO
-      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, 1._dp, cpc, nsgfa*nsgfb, sphi_c, msphic, 0.0_dp, &
+      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, 1._dp, tmp, nsgfa*mx, sphi_c, msphic, 0.0_dp, &
                  abcint, nsgfa*nsgfb)
 
-      DEALLOCATE (cpp, cpc)
+      DEALLOCATE (tmp)
 
       CALL timestop(handle)
 


### PR DESCRIPTION
The original idea was to preserve `cpp` and `cpc` buffers at least as POINTER/name. However, it's a bit intriguing to preserve the dimensionality if one just wants an offset on one of the three dimensions like `cpp => tmp(:, :, 2)`.