### PR TITLE
Internalize allocation in abc_contract_xsmm

### DIFF
--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -14,7 +14,7 @@
 ! **************************************************************************************************
 MODULE ai_contraction_sphi
 
-   USE kinds, ONLY: dp
+   USE kinds, ONLY: dp, int_8
 #if defined(__LIBXSMM)
    USE libxsmm, ONLY: LIBXSMM_PREFETCH_NONE, &
                       libxsmm_blasint_kind, &
@@ -230,9 +230,10 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief 3-center contraction routine from primitive cartesian Gaussians to spherical Gaussian
-!>        functions. Exploits LIBXSMM for performance, falls back to BLAS if LIBXSMM is not available.
-!>        Requires pre-allocation of work buffers and pre-transposition of the sphi_a array. Requires
-!>        the LIBXSMM library to be initialized somewhere before this routine is called.
+!>        functions; can use LIBXSMM (falls back to BLAS otherwise).
+!>        Requires pre-transposition of the sphi_a array. The call-side shall DEALLOCATE buffers
+!>        end of scope or after last use. This function ALLOCATEs or grows the work buffers
+!>        as necessary. LIBXSMM may be initialized upfront (elsewhere).
 !> \param abcint contracted integrals
 !> \param sabc uncontracted integrals
 !> \param sphi_a assumed to have dimensions nsgfa x ncoa
@@ -244,44 +245,63 @@ CONTAINS
 !> \param nsgfa ...
 !> \param nsgfb ...
 !> \param nsgfc ...
-!> \param cpp_buffer Temporary buffer used for intermediate results.
-!> \param ccp_buffer Temporary buffer used for intermediate results.
+!> \param cpp_buffer Buffer used for intermediate results (automatically allocated).
+!> \param ccp_buffer Buffer used for intermediate results (automatically allocated).
 !> \param prefac Prefactor which is finally multiplied into abcint.
 !> \note tested from version 1.9.0 of libxsmm
 ! **************************************************************************************************
    SUBROUTINE abc_contract_xsmm(abcint, sabc, sphi_a, sphi_b, sphi_c, ncoa, ncob, ncoc, &
                                 nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer, prefac)
 
-      REAL(KIND=dp), DIMENSION(*)                             :: abcint
-      REAL(KIND=dp), DIMENSION(*), INTENT(IN)                 :: sabc
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)              :: sphi_a, sphi_b, sphi_c
-      INTEGER, INTENT(IN)                                     :: ncoa, ncob, ncoc, nsgfa, nsgfb, nsgfc
-      REAL(KIND=dp), DIMENSION(nsgfa*ncob), INTENT(OUT)       :: cpp_buffer
-      REAL(KIND=dp), DIMENSION(nsgfa*nsgfb*ncoc), INTENT(OUT) :: ccp_buffer
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                     :: prefac
+      REAL(KIND=dp), DIMENSION(*)                 :: abcint
+      REAL(KIND=dp), DIMENSION(*), INTENT(IN)     :: sabc
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)  :: sphi_a, sphi_b, sphi_c
+      INTEGER, INTENT(IN)                         :: ncoa, ncob, ncoc, nsgfa, nsgfb, nsgfc
+      REAL(KIND=dp), DIMENSION(:), ALLOCATABLE    :: cpp_buffer, ccp_buffer
+      REAL(KIND=dp), INTENT(IN), OPTIONAL         :: prefac
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'abc_contract_xsmm'
 
       REAL(KIND=dp)                                           :: alpha
+      INTEGER(KIND=int_8)                                     :: cpp_size, ccp_size
       INTEGER                                                 :: handle, i
-      LOGICAL                                                 :: ab
+      LOGICAL                                                 :: ab_first
 #if defined(__LIBXSMM)
       TYPE(libxsmm_dmmfunction)                               :: xmm1, xmm2
 #endif
-
-      ! M*N*K FLOPS can be used to decide if contracting (AB)C vs A(BC)
-      ! ab = (nsgfa*ncob*(ncoa + nsgfb)) <= (ncoa*nsgfb*(ncob + nsgfa))
-      ! however, current interface dictates size of cpp_buffer
-      ab = (nsgfa*ncob) < (ncoa*nsgfb) .OR. (ncoa + nsgfb) <= (ncob + nsgfa)
 
       CALL timeset(routineN, handle)
 
       alpha = 1.0_dp
       IF (PRESENT(prefac)) alpha = prefac
 
+      ! M*N*K FLOPS are used to decide if contracting (AB)C vs A(BC)
+      IF ((nsgfa*ncob*(ncoa + nsgfb)) <= (ncoa*nsgfb*(ncob + nsgfa))) THEN
+         cpp_size = nsgfa*ncob
+         ab_first = .TRUE.
+      ELSE
+         cpp_size = ncoa*nsgfb
+         ab_first = .FALSE.
+      END IF
+      ccp_size = nsgfa*nsgfb*ncoc
+
+      IF (.NOT. ALLOCATED(ccp_buffer)) THEN
+         ALLOCATE (ccp_buffer(ccp_size))
+      ELSE IF (SIZE(ccp_buffer) < ccp_size) THEN
+         DEALLOCATE (ccp_buffer)
+         ALLOCATE (ccp_buffer(ccp_size))
+      END IF
+
+      IF (.NOT. ALLOCATED(cpp_buffer)) THEN
+         ALLOCATE (cpp_buffer(cpp_size))
+      ELSE IF (SIZE(cpp_buffer) < cpp_size) THEN
+         DEALLOCATE (cpp_buffer)
+         ALLOCATE (cpp_buffer(cpp_size))
+      END IF
+
       ! loop over the last index of the matrix and call LIBXSMM/BLAS to contract over a and b
 #if defined(__LIBXSMM)
-      IF (ab) THEN ! (AB)C: dispatch kernels
+      IF (ab_first) THEN ! (AB)C: dispatch kernels
          CALL libxsmm_dispatch(xmm1, nsgfa, ncob, ncoa, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
          CALL libxsmm_dispatch(xmm2, nsgfa, nsgfb, ncob, beta=0.0_dp, prefetch=LIBXSMM_PREFETCH_NONE)
       ELSE ! A(BC): dispatch kernels
@@ -290,7 +310,7 @@ CONTAINS
       END IF
 
       IF (libxsmm_available(xmm1) .AND. libxsmm_available(xmm2)) THEN
-         IF (ab) THEN ! (AB)C
+         IF (ab_first) THEN ! (AB)C
             DO i = 1, ncoc ! contractions over a and b
                ! [nsgfa,ncoa] x [ncoa,ncob] -> [nsgfa,ncob]
                CALL libxsmm_dmmcall(xmm1, sphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
@@ -307,7 +327,7 @@ CONTAINS
          END IF
       ELSE
 #endif
-         IF (ab) THEN ! (AB)C
+         IF (ab_first) THEN ! (AB)C
             DO i = 1, ncoc ! contractions over a and b
                CALL dgemm("N", "N", nsgfa, ncob, ncoa, 1.0_dp, sphi_a, nsgfa, sabc((i - 1)*ncoa*ncob + 1), &
                           ncoa, 0.0_dp, cpp_buffer, nsgfa)

--- a/src/qs_tensors.F
+++ b/src/qs_tensors.F
@@ -1162,10 +1162,10 @@ CONTAINS
 
       INTEGER :: block_end_i, block_end_j, block_end_k, block_start_i, block_start_j, &
          block_start_k, egfi, handle, handle2, i, i_img, i_xyz, iatom, ibasis, ikind, ilist, imax, &
-         iset, j_img, jatom, jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoi, &
-         max_ncoj, max_ncok, max_nset, max_nsgfi, max_nsgfj, max_nsgfk, maxli, maxlj, maxlk, &
-         mepos, natom, nbasis, ncell_RI, ncoi, ncoj, ncok, nimg, nseti, nsetj, nsetk, nthread, &
-         op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
+         iset, j_img, jatom, jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoj, &
+         max_nset, max_nsgfi, maxli, maxlj, maxlk, mepos, natom, nbasis, ncell_RI, ncoi, ncoj, &
+         ncok, nimg, nseti, nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, &
+         unit_id
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: img_to_RI_cell_prv
       INTEGER, DIMENSION(2)                              :: bo
       INTEGER, DIMENSION(3)                              :: blk_idx, blk_size, cell_j, cell_k, &
@@ -1330,7 +1330,6 @@ CONTAINS
       !Need the max l for each basis for libint and max nset, nco and nsgf for LIBXSMM contraction
       nbasis = SIZE(basis_i)
       max_nsgfi = 0
-      max_ncoi = 0
       max_nset = 0
       maxli = 0
       DO ibasis = 1, nbasis
@@ -1339,9 +1338,7 @@ CONTAINS
          maxli = MAX(maxli, imax)
          max_nset = MAX(max_nset, iset)
          max_nsgfi = MAX(max_nsgfi, MAXVAL(nsgfi))
-         max_ncoi = MAX(max_ncoi, MAXVAL(npgfi)*ncoset(maxli))
       END DO
-      max_nsgfj = 0
       max_ncoj = 0
       maxlj = 0
       DO ibasis = 1, nbasis
@@ -1349,19 +1346,14 @@ CONTAINS
                                 nset=jset, nsgf_set=nsgfj, npgf=npgfj)
          maxlj = MAX(maxlj, imax)
          max_nset = MAX(max_nset, jset)
-         max_nsgfj = MAX(max_nsgfj, MAXVAL(nsgfj))
          max_ncoj = MAX(max_ncoj, MAXVAL(npgfj)*ncoset(maxlj))
       END DO
-      max_nsgfk = 0
-      max_ncok = 0
       maxlk = 0
       DO ibasis = 1, nbasis
          CALL get_gto_basis_set(gto_basis_set=basis_k(ibasis)%gto_basis_set, maxl=imax, &
                                 nset=kset, nsgf_set=nsgfk, npgf=npgfk)
          maxlk = MAX(maxlk, imax)
          max_nset = MAX(max_nset, kset)
-         max_nsgfk = MAX(max_nsgfk, MAXVAL(nsgfk))
-         max_ncok = MAX(max_ncok, MAXVAL(npgfk)*ncoset(maxlk))
       END DO
       m_max = maxli + maxlj + maxlk + 1
 
@@ -1435,9 +1427,8 @@ CONTAINS
 !$OMP PARALLEL DEFAULT(NONE) &
 !$OMP SHARED (nthread,do_kpoints_prv,kp_index_lbounds,kp_index_ubounds,maxli,maxlk,maxlj,bounds_i,&
 !$OMP         bounds_j,bounds_k,nimg,basis_i,basis_j,basis_k,dr_ij,dr_jk,dr_ik,ncoset,op_pos_prv,&
-!$OMP         potential_parameter,der_eps,tspj,spi,spk,cell_to_index,max_ncoi,max_nsgfk,RI_range,&
-!$OMP         max_nsgfj,max_ncok,natom,nl_3c,t3c_der_i,t3c_der_k,t3c_der_j,ncell_RI,&
-!$OMP         img_to_RI_cell_prv,do_hfx_kpoints_prv) &
+!$OMP         potential_parameter,der_eps,tspj,spi,spk,cell_to_index,RI_range,natom,nl_3c,&
+!$OMP         t3c_der_i,t3c_der_k,t3c_der_j,ncell_RI,img_to_RI_cell_prv,do_hfx_kpoints_prv) &
 !$OMP PRIVATE (lib,nl_3c_iter,ikind,jkind,kkind,iatom,jatom,katom,rij,rjk,rik,cell_j,cell_k,&
 !$OMP          prefac,jcell,kcell,first_sgf_i,lmax_i,lmin_i,npgfi,nseti,nsgfi,rpgf_i,set_radius_i,&
 !$OMP          sphi_i,zeti,kind_radius_i,first_sgf_j,lmax_j,lmin_j,npgfj,nsetj,nsgfj,rpgf_j,&
@@ -1454,10 +1445,6 @@ CONTAINS
 
       CALL cp_libint_init_3eri1(lib, MAX(maxli, maxlj, maxlk))
       CALL cp_libint_set_contrdepth(lib, 1)
-
-      !pre-allocate contraction buffers
-      ALLOCATE (cpp_buffer(max_nsgfj*max_ncok), ccp_buffer(max_nsgfj*max_nsgfk*max_ncoi))
-
       CALL neighbor_list_3c_iterator_create(nl_3c_iter, nl_3c)
 
       !We split the provided bounds among the threads such that each threads works on a different set of atoms
@@ -1875,9 +1862,9 @@ CONTAINS
 
       INTEGER :: block_end_i, block_end_j, block_end_k, block_start_i, block_start_j, &
          block_start_k, egfi, handle, i, i_xyz, iatom, ibasis, ikind, ilist, imax, iset, j_xyz, &
-         jatom, jkind, jset, katom, kkind, kset, m_max, max_ncoi, max_ncoj, max_ncok, max_nset, &
-         max_nsgfi, max_nsgfj, max_nsgfk, maxli, maxlj, maxlk, mepos, natom, nbasis, ncoi, ncoj, &
-         ncok, nseti, nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
+         jatom, jkind, jset, katom, kkind, kset, m_max, max_ncoj, max_nset, max_nsgfi, maxli, &
+         maxlj, maxlk, mepos, natom, nbasis, ncoi, ncoj, ncok, nseti, nsetj, nsetk, nthread, &
+         op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
       INTEGER, DIMENSION(2)                              :: bo
       INTEGER, DIMENSION(3)                              :: blk_size, sp
       INTEGER, DIMENSION(:), POINTER                     :: lmax_i, lmax_j, lmax_k, lmin_i, lmin_j, &
@@ -1960,7 +1947,6 @@ CONTAINS
       !Need the max l for each basis for libint and max nset, nco and nsgf for LIBXSMM contraction
       nbasis = SIZE(basis_i)
       max_nsgfi = 0
-      max_ncoi = 0
       max_nset = 0
       maxli = 0
       DO ibasis = 1, nbasis
@@ -1969,9 +1955,7 @@ CONTAINS
          maxli = MAX(maxli, imax)
          max_nset = MAX(max_nset, iset)
          max_nsgfi = MAX(max_nsgfi, MAXVAL(nsgfi))
-         max_ncoi = MAX(max_ncoi, MAXVAL(npgfi)*ncoset(maxli))
       END DO
-      max_nsgfj = 0
       max_ncoj = 0
       maxlj = 0
       DO ibasis = 1, nbasis
@@ -1979,19 +1963,14 @@ CONTAINS
                                 nset=jset, nsgf_set=nsgfj, npgf=npgfj)
          maxlj = MAX(maxlj, imax)
          max_nset = MAX(max_nset, jset)
-         max_nsgfj = MAX(max_nsgfj, MAXVAL(nsgfj))
          max_ncoj = MAX(max_ncoj, MAXVAL(npgfj)*ncoset(maxlj))
       END DO
-      max_nsgfk = 0
-      max_ncok = 0
       maxlk = 0
       DO ibasis = 1, nbasis
          CALL get_gto_basis_set(gto_basis_set=basis_k(ibasis)%gto_basis_set, maxl=imax, &
                                 nset=kset, nsgf_set=nsgfk, npgf=npgfk)
          maxlk = MAX(maxlk, imax)
          max_nset = MAX(max_nset, kset)
-         max_nsgfk = MAX(max_nsgfk, MAXVAL(nsgfk))
-         max_ncok = MAX(max_ncok, MAXVAL(npgfk)*ncoset(maxlk))
       END DO
       m_max = maxli + maxlj + maxlk + 1
 
@@ -2059,30 +2038,23 @@ CONTAINS
 !$    nthread = omp_get_max_threads()
 
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP SHARED (nthread,maxli,maxlk,maxlj,i,work_virial,pref,&
-!$OMP         basis_i,basis_j,basis_k,dr_ij,dr_jk,dr_ik,ncoset,&
-!$OMP         potential_parameter,der_eps,tspj,spi,spk,max_ncoi,max_nsgfk,&
-!$OMP         max_nsgfj,max_ncok,natom,nl_3c,t3c_trace,cell,particle_set) &
-!$OMP PRIVATE (lib,nl_3c_iter,ikind,jkind,kkind,iatom,jatom,katom,rij,rjk,rik,i_xyz,j_xyz,&
-!$OMP          first_sgf_i,lmax_i,lmin_i,npgfi,nseti,nsgfi,rpgf_i,set_radius_i,&
-!$OMP          sphi_i,zeti,kind_radius_i,first_sgf_j,lmax_j,lmin_j,npgfj,nsetj,nsgfj,rpgf_j,&
-!$OMP          set_radius_j,sphi_j,zetj,kind_radius_j,first_sgf_k,lmax_k,lmin_k,npgfk,nsetk,nsgfk,&
-!$OMP          rpgf_k,set_radius_k,sphi_k,zetk,kind_radius_k,djk,dij,dik,ncoi,ncoj,ncok,sgfi,sgfj,&
-!$OMP          sgfk,dijk_j,dijk_k,ri,rj,rk,max_contraction_i,max_contraction_j,tmp_block,&
-!$OMP          max_contraction_k,iset,jset,kset,block_t_i,blk_size,dijk_contr,cpp_buffer,ccp_buffer,&
-!$OMP          block_start_j,block_end_j,block_start_k,block_end_k,block_start_i,block_end_i,found,&
-!$OMP          sp,mepos,bo,block_t_k,der_ext_i,der_ext_j,der_ext_k,ablock,force,scoord,&
-!$OMP          block_k_not_zero,der_k_zero,skip,der_j_zero,block_t_j,block_j_not_zero)
+!$OMP SHARED (nthread,maxli,maxlk,maxlj,i,work_virial,pref,basis_i,basis_j,basis_k,dr_ij,dr_jk,dr_ik,&
+!$OMP         ncoset,potential_parameter,der_eps,tspj,spi,spk,natom,nl_3c,t3c_trace,cell,particle_set) &
+!$OMP PRIVATE (lib,nl_3c_iter,ikind,jkind,kkind,iatom,jatom,katom,rij,rjk,rik,i_xyz,j_xyz,first_sgf_i,&
+!$OMP          lmax_i,lmin_i,npgfi,nseti,nsgfi,rpgf_i,set_radius_i,sphi_i,zeti,kind_radius_i,first_sgf_j,&
+!$OMP          lmax_j,lmin_j,npgfj,nsetj,nsgfj,rpgf_j,set_radius_j,sphi_j,zetj,kind_radius_j,first_sgf_k,&
+!$OMP          lmax_k,lmin_k,npgfk,nsetk,nsgfk,rpgf_k,set_radius_k,sphi_k,zetk,kind_radius_k,djk,dij,dik,&
+!$OMP          ncoi,ncoj,ncok,sgfi,sgfj,sgfk,dijk_j,dijk_k,ri,rj,rk,max_contraction_i,max_contraction_j,&
+!$OMP          tmp_block,max_contraction_k,iset,jset,kset,block_t_i,blk_size,dijk_contr,found,sp,mepos,&
+!$OMP          block_start_j,block_end_j,block_start_k,block_end_k,block_start_i,block_end_i,block_t_k,&
+!$OMP          bo,der_ext_i,der_ext_j,der_ext_k,ablock,force,scoord,skip,cpp_buffer,ccp_buffer,&
+!$OMP          block_k_not_zero,der_k_zero,der_j_zero,block_t_j,block_j_not_zero)
 
       mepos = 0
 !$    mepos = omp_get_thread_num()
 
       CALL cp_libint_init_3eri1(lib, MAX(maxli, maxlj, maxlk))
       CALL cp_libint_set_contrdepth(lib, 1)
-
-      !pre-allocate contraction buffers
-      ALLOCATE (cpp_buffer(max_nsgfj*max_ncok), ccp_buffer(max_nsgfj*max_nsgfk*max_ncoi))
-
       CALL neighbor_list_3c_iterator_create(nl_3c_iter, nl_3c)
 
       !We split the provided bounds among the threads such that each threads works on a different set of atoms
@@ -2385,10 +2357,9 @@ CONTAINS
 
       INTEGER :: block_end_i, block_end_j, block_end_k, block_start_i, block_start_j, &
          block_start_k, egfi, handle, handle2, i, iatom, ibasis, ikind, ilist, imax, iset, jatom, &
-         jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoi, max_ncoj, max_ncok, &
-         max_nset, max_nsgfi, max_nsgfj, max_nsgfk, maxli, maxlj, maxlk, mepos, natom, nbasis, &
-         ncell_RI, ncoi, ncoj, ncok, nimg, nseti, nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, &
-         sgfi, sgfj, sgfk, unit_id
+         jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoj, max_nset, max_nsgfi, &
+         maxli, maxlj, maxlk, mepos, natom, nbasis, ncell_RI, ncoi, ncoj, ncok, nimg, nseti, &
+         nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: img_to_RI_cell_prv
       INTEGER, DIMENSION(2)                              :: bo
       INTEGER, DIMENSION(3)                              :: blk_idx, blk_size, cell_j, cell_k, &
@@ -2525,7 +2496,6 @@ CONTAINS
       !Need the max l for each basis for libint and max nset, nco and nsgf for LIBXSMM contraction
       nbasis = SIZE(basis_i)
       max_nsgfi = 0
-      max_ncoi = 0
       max_nset = 0
       maxli = 0
       DO ibasis = 1, nbasis
@@ -2534,9 +2504,7 @@ CONTAINS
          maxli = MAX(maxli, imax)
          max_nset = MAX(max_nset, iset)
          max_nsgfi = MAX(max_nsgfi, MAXVAL(nsgfi))
-         max_ncoi = MAX(max_ncoi, MAXVAL(npgfi)*ncoset(maxli))
       END DO
-      max_nsgfj = 0
       max_ncoj = 0
       maxlj = 0
       DO ibasis = 1, nbasis
@@ -2544,19 +2512,14 @@ CONTAINS
                                 nset=jset, nsgf_set=nsgfj, npgf=npgfj)
          maxlj = MAX(maxlj, imax)
          max_nset = MAX(max_nset, jset)
-         max_nsgfj = MAX(max_nsgfj, MAXVAL(nsgfj))
          max_ncoj = MAX(max_ncoj, MAXVAL(npgfj)*ncoset(maxlj))
       END DO
-      max_nsgfk = 0
-      max_ncok = 0
       maxlk = 0
       DO ibasis = 1, nbasis
          CALL get_gto_basis_set(gto_basis_set=basis_k(ibasis)%gto_basis_set, maxl=imax, &
                                 nset=kset, nsgf_set=nsgfk, npgf=npgfk)
          maxlk = MAX(maxlk, imax)
          max_nset = MAX(max_nset, kset)
-         max_nsgfk = MAX(max_nsgfk, MAXVAL(nsgfk))
-         max_ncok = MAX(max_ncok, MAXVAL(npgfk)*ncoset(maxlk))
       END DO
       m_max = maxli + maxlj + maxlk
 
@@ -2632,10 +2595,9 @@ CONTAINS
 
 !$OMP PARALLEL DEFAULT(NONE) &
 !$OMP SHARED (nthread,do_kpoints_prv,kp_index_lbounds,kp_index_ubounds,maxli,maxlk,maxlj,bounds_i,&
-!$OMP         bounds_j,bounds_k,nimg,basis_i,basis_j,basis_k,dr_ij,dr_jk,dr_ik,ncoset,&
-!$OMP         potential_parameter,int_eps,t3c,tspj,spi,spk,debug,cell_to_index,max_ncoi,max_nsgfk,&
-!$OMP         max_nsgfj,max_ncok,natom,nl_3c,cell,op_pos_prv,do_hfx_kpoints_prv,RI_range,ncell_RI, &
-!$OMP         img_to_RI_cell_prv) &
+!$OMP         bounds_j,bounds_k,nimg,basis_i,basis_j,basis_k,dr_ij,dr_jk,dr_ik,ncoset,int_eps,t3c,&
+!$OMP         tspj,spi,spk,debug,cell_to_index,natom,nl_3c,cell,op_pos_prv,do_hfx_kpoints_prv,&
+!$OMP         RI_range,ncell_RI,img_to_RI_cell_prv,potential_parameter) &
 !$OMP PRIVATE (lib,nl_3c_iter,ikind,jkind,kkind,iatom,jatom,katom,rij,rjk,rik,cell_j,cell_k,&
 !$OMP          prefac,jcell,kcell,first_sgf_i,lmax_i,lmin_i,npgfi,nseti,nsgfi,rpgf_i,set_radius_i,&
 !$OMP          sphi_i,zeti,kind_radius_i,first_sgf_j,lmax_j,lmin_j,npgfj,nsetj,nsgfj,rpgf_j,&
@@ -2651,10 +2613,6 @@ CONTAINS
 
       CALL cp_libint_init_3eri(lib, MAX(maxli, maxlj, maxlk))
       CALL cp_libint_set_contrdepth(lib, 1)
-
-      !pre-allocate contraction buffers
-      ALLOCATE (cpp_buffer(max_nsgfj*max_ncok), ccp_buffer(max_nsgfj*max_nsgfk*max_ncoi))
-
       CALL neighbor_list_3c_iterator_create(nl_3c_iter, nl_3c)
 
       !We split the provided bounds among the threads such that each threads works on a different set of atoms

--- a/src/qs_tensors.F
+++ b/src/qs_tensors.F
@@ -1365,8 +1365,8 @@ CONTAINS
       END DO
       m_max = maxli + maxlj + maxlk + 1
 
-      !To minimize expensive memory opsand generally optimize contraction, pre-allocate
-      !contiguous sphi arrays (and transposed in the cas of sphi_i)
+      !To minimize expensive memory ops and generally optimize contraction, pre-allocate
+      !contiguous sphi arrays (and transposed in the case of sphi_i)
 
       NULLIFY (tspj, spi, spk)
       ALLOCATE (spi(max_nset, nbasis), tspj(max_nset, nbasis), spk(max_nset, nbasis))
@@ -1375,7 +1375,6 @@ CONTAINS
          DO iset = 1, max_nset
             NULLIFY (spi(iset, ibasis)%array)
             NULLIFY (tspj(iset, ibasis)%array)
-
             NULLIFY (spk(iset, ibasis)%array)
          END DO
       END DO
@@ -1737,22 +1736,7 @@ CONTAINS
                                RESHAPE(block_t_i(:, :, :, i_xyz), SHAPE=sp, ORDER=[2, 3, 1]), &
                                summation=.TRUE.)
          END DO
-!$OMP END CRITICAL
-!$OMP CRITICAL
-         IF (nl_3c%sym == symmetric_jk) THEN
 
-            sp = SHAPE(block_t_j(:, :, :, 1))
-            sp([2, 3, 1]) = sp
-
-            DO i_xyz = 1, 3
-               IF (.NOT. block_j_not_zero(i_xyz)) CYCLE
-               CALL dbt_put_block(t3c_der_j(jcell, kcell, i_xyz), blk_idx, sp, &
-                                  RESHAPE(block_t_j(:, :, :, i_xyz), SHAPE=sp, ORDER=[2, 3, 1]), &
-                                  summation=.TRUE.)
-            END DO
-         END IF
-!$OMP END CRITICAL
-!$OMP CRITICAL
          sp = SHAPE(block_t_k(:, :, :, 1))
          sp([2, 3, 1]) = sp
 
@@ -1764,17 +1748,29 @@ CONTAINS
          END DO
 !$OMP END CRITICAL
 
+         IF (nl_3c%sym == symmetric_jk) THEN
+            sp = SHAPE(block_t_j(:, :, :, 1))
+            sp([2, 3, 1]) = sp
+!$OMP CRITICAL
+            DO i_xyz = 1, 3
+               IF (.NOT. block_j_not_zero(i_xyz)) CYCLE
+               CALL dbt_put_block(t3c_der_j(jcell, kcell, i_xyz), blk_idx, sp, &
+                                  RESHAPE(block_t_j(:, :, :, i_xyz), SHAPE=sp, ORDER=[2, 3, 1]), &
+                                  summation=.TRUE.)
+            END DO
+!$OMP END CRITICAL
+         END IF
+
          CALL timestop(handle2)
 
-         DEALLOCATE (block_t_i)
-         DEALLOCATE (block_t_j)
-         DEALLOCATE (block_t_k)
-
+         DEALLOCATE (block_t_i, block_t_j, block_t_k)
          DEALLOCATE (max_contraction_i, max_contraction_j, max_contraction_k)
       END DO
 
-      CALL cp_libint_cleanup_3eri1(lib)
+      IF (ALLOCATED(ccp_buffer)) DEALLOCATE (ccp_buffer)
+      IF (ALLOCATED(cpp_buffer)) DEALLOCATE (cpp_buffer)
 
+      CALL cp_libint_cleanup_3eri1(lib)
       CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
 !$OMP END PARALLEL
 
@@ -1835,7 +1831,6 @@ CONTAINS
          DO ibasis = 1, nbasis
             IF (ASSOCIATED(spi(iset, ibasis)%array)) DEALLOCATE (spi(iset, ibasis)%array)
             IF (ASSOCIATED(tspj(iset, ibasis)%array)) DEALLOCATE (tspj(iset, ibasis)%array)
-
             IF (ASSOCIATED(spk(iset, ibasis)%array)) DEALLOCATE (spk(iset, ibasis)%array)
          END DO
       END DO
@@ -2316,12 +2311,12 @@ CONTAINS
             END DO
          END DO
 
-         DEALLOCATE (block_t_i)
-         DEALLOCATE (block_t_j)
-         DEALLOCATE (block_t_k)
-
+         DEALLOCATE (block_t_i, block_t_j, block_t_k)
          DEALLOCATE (max_contraction_i, max_contraction_j, max_contraction_k, ablock)
       END DO
+
+      IF (ALLOCATED(ccp_buffer)) DEALLOCATE (ccp_buffer)
+      IF (ALLOCATED(cpp_buffer)) DEALLOCATE (cpp_buffer)
 
       CALL cp_libint_cleanup_3eri1(lib)
       CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
@@ -2331,7 +2326,6 @@ CONTAINS
          DO ibasis = 1, nbasis
             IF (ASSOCIATED(spi(iset, ibasis)%array)) DEALLOCATE (spi(iset, ibasis)%array)
             IF (ASSOCIATED(tspj(iset, ibasis)%array)) DEALLOCATE (tspj(iset, ibasis)%array)
-
             IF (ASSOCIATED(spk(iset, ibasis)%array)) DEALLOCATE (spk(iset, ibasis)%array)
          END DO
       END DO
@@ -2894,8 +2888,10 @@ CONTAINS
          DEALLOCATE (max_contraction_j, max_contraction_k)
       END DO
 
-      CALL cp_libint_cleanup_3eri(lib)
+      IF (ALLOCATED(ccp_buffer)) DEALLOCATE (ccp_buffer)
+      IF (ALLOCATED(cpp_buffer)) DEALLOCATE (cpp_buffer)
 
+      CALL cp_libint_cleanup_3eri(lib)
       CALL neighbor_list_3c_iterator_destroy(nl_3c_iter)
 !$OMP END PARALLEL
 
@@ -2956,7 +2952,6 @@ CONTAINS
          DO ibasis = 1, nbasis
             IF (ASSOCIATED(spi(iset, ibasis)%array)) DEALLOCATE (spi(iset, ibasis)%array)
             IF (ASSOCIATED(tspj(iset, ibasis)%array)) DEALLOCATE (tspj(iset, ibasis)%array)
-
             IF (ASSOCIATED(spk(iset, ibasis)%array)) DEALLOCATE (spk(iset, ibasis)%array)
          END DO
       END DO
@@ -3197,8 +3192,8 @@ CONTAINS
       END DO
 
       CALL cp_libint_cleanup_2eri1(lib)
-
       CALL neighbor_list_iterator_release(nl_iterator)
+
       DO img = 1, nimg
          DO i_xyz = 1, 3
             CALL dbcsr_finalize(t2c_der(img, i_xyz))
@@ -3376,8 +3371,8 @@ CONTAINS
             END DO
          END DO
       END DO
-      CALL neighbor_list_iterator_release(nl_iterator)
 
+      CALL neighbor_list_iterator_release(nl_iterator)
       CALL cp_libint_cleanup_2eri1(lib)
 
       CALL timestop(handle)

--- a/src/xas_tdp_integrals.F
+++ b/src/xas_tdp_integrals.F
@@ -630,6 +630,9 @@ CONTAINS
          DEALLOCATE (iabc)
       END DO !o3c_iterator
 
+      IF (ALLOCATED(ccp_buffer)) DEALLOCATE (ccp_buffer)
+      IF (ALLOCATED(cpp_buffer)) DEALLOCATE (cpp_buffer)
+
       CALL cp_libint_cleanup_3eri(lib)
 
 !$OMP END PARALLEL

--- a/src/xas_tdp_integrals.F
+++ b/src/xas_tdp_integrals.F
@@ -288,9 +288,8 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'fill_pqX_tensor'
 
       INTEGER :: egfa, egfb, egfc, handle, i, iatom, ibasis, ikind, ilist, imax, iset, jatom, &
-         jkind, jset, katom, kkind, kset, m_max, max_ncob, max_ncoc, max_nset, max_nsgfa, &
-         max_nsgfb, maxli, maxlj, maxlk, mepos, nbasis, ncoa, ncob, ncoc, ni, nj, nk, nseta, &
-         nsetb, nsetc, nthread, sgfa, sgfb, sgfc, unit_id
+         jkind, jset, katom, kkind, kset, m_max, max_nset, maxli, maxlj, maxlk, mepos, nbasis, &
+         ncoa, ncob, ncoc, ni, nj, nk, nseta, nsetb, nsetc, nthread, sgfa, sgfb, sgfc, unit_id
       INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, lb_max, lb_min, lc_max, &
                                                             lc_min, npgfa, npgfb, npgfc, nsgfa, &
                                                             nsgfb, nsgfc
@@ -324,7 +323,6 @@ CONTAINS
 
       !Need the max l for each basis for libint (and overall max #of sets for screening)
       nbasis = SIZE(basis_set_list_a)
-      max_nsgfa = 0
       max_nset = 0
       maxli = 0
       DO ibasis = 1, nbasis
@@ -332,27 +330,20 @@ CONTAINS
                                 maxl=imax, nset=iset, nsgf_set=nsgfa)
          maxli = MAX(maxli, imax)
          max_nset = MAX(max_nset, iset)
-         max_nsgfa = MAX(max_nsgfa, MAXVAL(nsgfa))
       END DO
-      max_nsgfb = 0
-      max_ncob = 0
       maxlj = 0
       DO ibasis = 1, nbasis
          CALL get_gto_basis_set(gto_basis_set=basis_set_list_b(ibasis)%gto_basis_set, &
                                 maxl=imax, nset=iset, nsgf_set=nsgfb, npgf=npgfb)
          maxlj = MAX(maxlj, imax)
          max_nset = MAX(max_nset, iset)
-         max_nsgfb = MAX(max_nsgfb, MAXVAL(nsgfb))
-         max_ncob = MAX(max_ncob, MAXVAL(npgfb)*ncoset(maxlj))
       END DO
       maxlk = 0
-      max_ncoc = 0
       DO ibasis = 1, nbasis
          CALL get_gto_basis_set(gto_basis_set=basis_set_list_c(ibasis)%gto_basis_set, &
                                 maxl=imax, nset=iset, npgf=npgfc)
          maxlk = MAX(maxlk, imax)
          max_nset = MAX(max_nset, iset)
-         max_ncoc = MAX(max_ncoc, MAXVAL(npgfc)*ncoset(maxlk))
       END DO
       m_max = maxli + maxlj + maxlk
 
@@ -483,26 +474,18 @@ CONTAINS
       CALL o3c_iterator_create(o3c, o3c_iterator, nthread=nthread)
 
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP SHARED (pq_X,do_screen,max_nset,basis_set_list_a,max_contra,max_contrb,max_contrc,max_nsgfa,&
-!$OMP         basis_set_list_b, basis_set_list_c,ncoset,screen_radius,potential_parameter,max_ncob,&
-!$OMP         my_eps_screen,maxli,maxlj,maxlk,my_sort_bc,nthread,o3c,o3c_iterator,tspa,spb,spc,&
-!$OMP         max_ncoc,max_nsgfb) &
-!$OMP PRIVATE (lib,i,mepos,work,iset,ncoa,sgfa,egfa,nseta,&
-!$OMP          iatom,ikind,jatom,jkind,katom,kkind,rij,rik,rjk,basis_set_a,nsetb,&
-!$OMP          la_max,la_min,lb_max,lb_min,lc_max,lc_min,npgfa,npgfb,npgfc,nsgfa,nsgfb,nsgfc,ri,rk,&
-!$OMP          first_sgfa,first_sgfb,first_sgfc,set_radius_a,set_radius_b,set_radius_c, nsetc,rj,&
-!$OMP          rpgf_a,rpgf_b,rpgf_c,zeta,zetb,zetc,basis_set_b,basis_set_c,dij,dik,djk,ni,nj,nk,&
-!$OMP          iabc,sabc,jset,kset,ncob,ncoc,sgfb,sgfc,egfb,egfc,sabc_ext,cpp_buffer,ccp_buffer)
+!$OMP SHARED (pq_X,do_screen,max_nset,basis_set_list_a,max_contra,max_contrb,max_contrc,&
+!$OMP         basis_set_list_b, basis_set_list_c,ncoset,screen_radius,potential_parameter,&
+!$OMP         my_eps_screen,maxli,maxlj,maxlk,my_sort_bc,nthread,o3c,o3c_iterator,tspa,spb,spc) &
+!$OMP PRIVATE (lib,i,mepos,work,iset,ncoa,sgfa,egfa,nseta,iatom,ikind,jatom,jkind,katom,kkind,&
+!$OMP          rij,rik,rjk,basis_set_a,nsetb,la_max,la_min,lb_max,lb_min,lc_max,lc_min,npgfa,&
+!$OMP          npgfb,npgfc,nsgfa,nsgfb,nsgfc,ri,rk,first_sgfa,first_sgfb,first_sgfc,nsetc,&
+!$OMP          set_radius_a,set_radius_b,set_radius_c,rj,rpgf_a,rpgf_b,rpgf_c,zeta,zetb,&
+!$OMP          zetc,basis_set_b,basis_set_c,dij,dik,djk,ni,nj,nk,iabc,sabc,jset,kset,&
+!$OMP          ncob,ncoc,sgfb,sgfc,egfb,egfc,sabc_ext,cpp_buffer,ccp_buffer)
 
       mepos = 0
 !$    mepos = omp_get_thread_num()
-
-      !pre-allocate work buffers for LIBXSMM contract in order to avoid memory ops
-      ALLOCATE (cpp_buffer(max_nsgfa*max_ncob))
-      ALLOCATE (ccp_buffer(max_nsgfa*max_nsgfb*max_ncoc))
-
-      !note: we do not initalize libxsmm here, because we assume that if the flag is there, then it
-      !      is done in dbcsr already
 
       !each thread need its own libint object (internals may change at different rates)
       CALL cp_libint_init_3eri(lib, MAX(maxli, maxlj, maxlk))


### PR DESCRIPTION
* Deallocate ccp_buffer and cpp_buffer (although ALLOCATABLEs are deallocated when scope of declaration is left).
* Adjust abc_contract_xsmm to always follow an optimal contraction flow (independent of buffer size).
* Streamlined/combined two critical sections and made one critical section conditional.
* Code/format cleanup.