### PR TITLE
PW: Refactor communicators and normalization factors

### DIFF
--- a/src/cp_ddapc_types.F
+++ b/src/cp_ddapc_types.F
@@ -306,7 +306,7 @@ CONTAINS
             CALL Setup_Ewald_Spline(pw_grid=cp_ddapc_ewald%pw_grid_qm, pw_pool=cp_ddapc_ewald%pw_pool_qm, &
                                     coeff=cp_ddapc_ewald%coeff_qm, LG=LG, gx=gx, gy=gy, gz=gz, hmat=hmat, npts=npts, &
                                     param_section=multipole_section, tag="ddapc", &
-                                    para_env=para_env, print_section=grid_print_section)
+                                    print_section=grid_print_section)
             DEALLOCATE (LG)
             DEALLOCATE (gx)
             DEALLOCATE (gy)
@@ -320,7 +320,7 @@ CONTAINS
                grid_print_section => section_vals_get_subs_vals(force_env_section, "PRINT%GRID_INFORMATION")
                CALL Setup_Ewald_Spline(pw_grid=cp_ddapc_ewald%pw_grid_mm, pw_pool=cp_ddapc_ewald%pw_pool_mm, &
                                        coeff=cp_ddapc_ewald%coeff_mm, LG=LG, gx=gx, gy=gy, gz=gz, hmat=hmat, npts=npts, &
-                                       param_section=multipole_section, tag="ddapc", para_env=para_env, &
+                                       param_section=multipole_section, tag="ddapc", &
                                        print_section=grid_print_section)
                DEALLOCATE (LG)
                DEALLOCATE (gx)

--- a/src/cp_realspace_grid_cube.F
+++ b/src/cp_realspace_grid_cube.F
@@ -122,7 +122,7 @@ CONTAINS
       ! Parallel routine falls back to stream read in serial mode,
       ! but it has slight overhead compared to sequential read
       ! Therefore, we use sequential version in serial mode
-      IF (grid%pw_grid%para%group_size == 1) parallel_read = .FALSE.
+      IF (grid%pw_grid%para%group%num_pe == 1) parallel_read = .FALSE.
       ! Check if MPI I/O was disabled in GLOBAL section
       IF (.NOT. cp_mpi_io_get()) parallel_read = .FALSE.
 

--- a/src/environment.F
+++ b/src/environment.F
@@ -48,7 +48,8 @@ MODULE environment
                                               low_print_level,&
                                               medium_print_level,&
                                               silent_print_level
-   USE fft_tools,                       ONLY: fft3d,&
+   USE fft_tools,                       ONLY: FWFFT,&
+                                              fft3d,&
                                               finalize_fft,&
                                               init_fft
    USE force_env_types,                 ONLY: multiple_fe_list
@@ -1022,7 +1023,7 @@ CONTAINS
                     plan_style=globenv%fftw_plan_type)
 
       ! Check for FFT library
-      CALL fft3d(1, n, zz, status=stat)
+      CALL fft3d(FWFFT, n, zz, status=stat)
       IF (stat /= 0) THEN
          IF (try_fftw) THEN
             message = "FFT library "//TRIM(globenv%default_fft_library)// &
@@ -1036,7 +1037,7 @@ CONTAINS
                           wisdom_file=globenv%fftw_wisdom_file_name, &
                           plan_style=globenv%fftw_plan_type)
 
-            CALL fft3d(1, n, zz, status=stat)
+            CALL fft3d(FWFFT, n, zz, status=stat)
          END IF
          IF (stat /= 0) THEN
             message = "FFT library "//TRIM(globenv%default_fft_library)// &
@@ -1050,7 +1051,7 @@ CONTAINS
                           wisdom_file=globenv%fftw_wisdom_file_name, &
                           plan_style=globenv%fftw_plan_type)
 
-            CALL fft3d(1, n, zz, status=stat)
+            CALL fft3d(FWFFT, n, zz, status=stat)
             IF (stat /= 0) THEN
                CPABORT("FFT library FFTSG does not work. No FFT library available.")
             END IF

--- a/src/ewald_pw_types.F
+++ b/src/ewald_pw_types.F
@@ -32,8 +32,7 @@ MODULE ewald_pw_types
    USE pw_grid_types,                   ONLY: HALFSPACE,&
                                               pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_create,&
-                                              pw_grid_release,&
-                                              pw_grid_setup
+                                              pw_grid_release
    USE pw_poisson_methods,              ONLY: pw_poisson_set
    USE pw_poisson_read_input,           ONLY: pw_poisson_read_parameters
    USE pw_poisson_types,                ONLY: do_ewald_ewald,&
@@ -173,15 +172,14 @@ CONTAINS
          ! set up Classic EWALD sum
          logger => cp_get_default_logger()
          output_unit = cp_print_key_unit_nr(logger, print_section, "", extension=".Log")
-         CALL pw_grid_create(pw_big_grid, mp_comm_self)
 
          IF (ANY(gmax == 2*(gmax/2))) THEN
             CPABORT("gmax has to be odd.")
          END IF
          bo(1, :) = -gmax/2
          bo(2, :) = +gmax/2
-         CALL pw_grid_setup(cell_ref%hmat, pw_big_grid, grid_span=HALFSPACE, bounds=bo, spherical=.TRUE., &
-                            fft_usage=.FALSE., iounit=output_unit)
+         CALL pw_grid_create(pw_big_grid, mp_comm_self, cell_ref%hmat, grid_span=HALFSPACE, bounds=bo, spherical=.TRUE., &
+                             fft_usage=.FALSE., iounit=output_unit)
          NULLIFY (pw_pool)
          CALL pw_pool_create(pw_pool, pw_grid=pw_big_grid)
          ewald_pw%pw_big_pool => pw_pool
@@ -196,8 +194,6 @@ CONTAINS
             ALLOCATE (ewald_pw%poisson_env)
             CALL ewald_pw%poisson_env%create()
          END IF
-         CALL pw_grid_create(pw_small_grid, mp_comm_self)
-         CALL pw_grid_create(pw_big_grid, para_env)
          IF (ns_max == 2*(ns_max/2)) THEN
             CPABORT("ns_max has to be odd.")
          END IF
@@ -208,7 +204,7 @@ CONTAINS
          cutoff_radius = exp_radius(0, 2.0_dp*alphasq, epsilon, norm)
 
          CALL dg_pme_grid_setup(cell_ref%hmat, npts_s, cutoff_radius, &
-                                pw_small_grid, pw_big_grid, rs_dims=(/para_env%num_pe, 1/), &
+                                pw_small_grid, pw_big_grid, para_env, rs_dims=(/para_env%num_pe, 1/), &
                                 iounit=output_unit, fft_usage=.TRUE.)
          ! Write some useful info
          IF (output_unit > 0) THEN
@@ -260,10 +256,9 @@ CONTAINS
             ALLOCATE (ewald_pw%poisson_env)
             CALL ewald_pw%poisson_env%create()
          END IF
-         CALL pw_grid_create(pw_big_grid, para_env)
          npts_s = gmax
-         CALL pw_grid_setup(cell_ref%hmat, pw_big_grid, grid_span=HALFSPACE, npts=npts_s, spherical=.TRUE., &
-                            rs_dims=(/para_env%num_pe, 1/), iounit=output_unit, fft_usage=.TRUE.)
+         CALL pw_grid_create(pw_big_grid, para_env, cell_ref%hmat, grid_span=HALFSPACE, npts=npts_s, spherical=.TRUE., &
+                             rs_dims=(/para_env%num_pe, 1/), iounit=output_unit, fft_usage=.TRUE.)
 
          ! pw pools initialized
          NULLIFY (pw_pool)

--- a/src/ewald_spline_util.F
+++ b/src/ewald_spline_util.F
@@ -217,15 +217,15 @@ CONTAINS
 
       !NB use DGEMM to compute sum over kg for each i, j, k
       ! number of elements per node, round down
-      NLg_loc = SIZE(Lg)/grid%pw_grid%para%group_size
+      NLg_loc = SIZE(Lg)/grid%pw_grid%para%group%num_pe
       ! number of extra elements not yet accounted for
-      n_extra = MOD(SIZE(Lg), grid%pw_grid%para%group_size)
+      n_extra = MOD(SIZE(Lg), grid%pw_grid%para%group%num_pe)
       ! first n_extra nodes get NLg_loc+1, remaining get NLg_loc
-      IF (grid%pw_grid%para%my_pos < n_extra) THEN
-         Lg_loc_min = (NLg_loc + 1)*grid%pw_grid%para%my_pos + 1
+      IF (grid%pw_grid%para%group%mepos < n_extra) THEN
+         Lg_loc_min = (NLg_loc + 1)*grid%pw_grid%para%group%mepos + 1
          Lg_loc_max = Lg_loc_min + (NLg_loc + 1) - 1
       ELSE
-         Lg_loc_min = (NLg_loc + 1)*n_extra + NLg_loc*(grid%pw_grid%para%my_pos - n_extra) + 1
+         Lg_loc_min = (NLg_loc + 1)*n_extra + NLg_loc*(grid%pw_grid%para%group%mepos - n_extra) + 1
          Lg_loc_max = Lg_loc_min + NLg_loc - 1
       END IF
       ! shouldn't be necessary

--- a/src/ewald_spline_util.F
+++ b/src/ewald_spline_util.F
@@ -24,11 +24,10 @@ MODULE ewald_spline_util
                                               section_vals_type,&
                                               section_vals_val_get
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_para_env_type
+   USE message_passing,                 ONLY: mp_comm_self
    USE pw_grid_types,                   ONLY: HALFSPACE,&
                                               pw_grid_type
-   USE pw_grids,                        ONLY: pw_grid_create,&
-                                              pw_grid_setup
+   USE pw_grids,                        ONLY: pw_grid_create
    USE pw_methods,                      ONLY: pw_zero
    USE pw_pool_types,                   ONLY: pw_pool_create,&
                                               pw_pool_type
@@ -63,13 +62,12 @@ CONTAINS
 !> \param param_section ...
 !> \param tag ...
 !> \param print_section ...
-!> \param para_env ...
 !> \par History
 !>      12.2005 created [tlaino]
 !> \author Teodoro Laino
 ! **************************************************************************************************
    SUBROUTINE Setup_Ewald_Spline(pw_grid, pw_pool, coeff, LG, gx, gy, gz, hmat, npts, &
-                                 param_section, tag, print_section, para_env)
+                                 param_section, tag, print_section)
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       TYPE(pw_pool_type), POINTER                        :: pw_pool
       TYPE(pw_r3d_rs_type), POINTER                      :: coeff
@@ -79,7 +77,6 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: param_section
       CHARACTER(LEN=*), INTENT(IN)                       :: tag
       TYPE(section_vals_type), POINTER                   :: print_section
-      TYPE(mp_para_env_type), POINTER                    :: para_env
 
       INTEGER                                            :: bo(2, 3), iounit
       TYPE(cell_type), POINTER                           :: cell
@@ -96,13 +93,12 @@ CONTAINS
       NULLIFY (cell)
 
       CALL cell_create(cell, hmat=hmat, periodic=(/1, 1, 1/))
-      CALL pw_grid_create(pw_grid, para_env, local=.TRUE.)
       logger => cp_get_default_logger()
       iounit = cp_print_key_unit_nr(logger, print_section, "", &
                                     extension=".Log")
       bo(1, 1:3) = 0
       bo(2, 1:3) = npts(1:3) - 1
-      CALL pw_grid_setup(cell%hmat, pw_grid, grid_span=HALFSPACE, bounds=bo, iounit=iounit)
+      CALL pw_grid_create(pw_grid, mp_comm_self, cell%hmat, grid_span=HALFSPACE, bounds=bo, iounit=iounit)
 
       CALL cp_print_key_finished_output(iounit, logger, print_section, &
                                         "")

--- a/src/library_tests.F
+++ b/src/library_tests.F
@@ -84,8 +84,7 @@ MODULE library_tests
                                               HALFSPACE,&
                                               pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_create,&
-                                              pw_grid_release,&
-                                              pw_grid_setup
+                                              pw_grid_release
    USE pw_methods,                      ONLY: pw_transfer,&
                                               pw_zero
    USE pw_types,                        ONLY: pw_c1d_gs_type,&
@@ -735,8 +734,7 @@ CONTAINS
       NULLIFY (grid)
       CALL section_vals_val_get(rs_pw_transfer_section, "GRID", i_vals=i_vals)
       np = i_vals
-      CALL pw_grid_create(grid, para_env)
-      CALL pw_grid_setup(box%hmat, grid, grid_span=FULLSPACE, npts=np, fft_usage=.TRUE., iounit=iw)
+      CALL pw_grid_create(grid, para_env, box%hmat, grid_span=FULLSPACE, npts=np, fft_usage=.TRUE., iounit=iw)
       no = grid%npts
 
       CALL ca%create(grid)
@@ -894,8 +892,6 @@ CONTAINS
 
             distribution_layout = layouts(:, i_layout)
 
-            CALL pw_grid_create(grid, para_env)
-
             CALL section_vals_val_get(pw_transfer_section, "PW_GRID", i_rep_section=i_rep, i_val=itmp)
 
             ! from cp_control_utils
@@ -927,9 +923,9 @@ CONTAINS
             END IF
 
             ! actual setup
-            CALL pw_grid_setup(box%hmat, grid, grid_span=grid_span, odd=odd, spherical=spherical, &
-                               blocked=blocked_id, npts=np, fft_usage=.TRUE., &
-                               rs_dims=distribution_layout, iounit=iw)
+            CALL pw_grid_create(grid, para_env, box%hmat, grid_span=grid_span, odd=odd, spherical=spherical, &
+                                blocked=blocked_id, npts=np, fft_usage=.TRUE., &
+                                rs_dims=distribution_layout, iounit=iw)
 
             IF (iw > 0) CALL m_flush(iw)
 

--- a/src/library_tests.F
+++ b/src/library_tests.F
@@ -618,7 +618,7 @@ CONTAINS
                tstart = m_walltime()
                DO j = 1, ntim
                   CALL fft3d(FWFFT, n, ca)
-                  CALL fft3d(BWFFT, n, ca, SCALE=scale)
+                  CALL fft3d(BWFFT, n, ca)
                END DO
                tend = m_walltime()
                t = tend - tstart + threshold

--- a/src/library_tests.F
+++ b/src/library_tests.F
@@ -596,7 +596,7 @@ CONTAINS
          END SELECT
          n = 4
          zz = 0.0_dp
-         CALL fft3d(1, n, zz, status=stat)
+         CALL fft3d(FWFFT, n, zz, status=stat)
          IF (stat == 0) THEN
             DO it = 1, 3
                radix_in = ndate(it)

--- a/src/maxwell_solver_interface.F
+++ b/src/maxwell_solver_interface.F
@@ -101,8 +101,8 @@ CONTAINS
       logger => cp_get_default_logger()
       iounit = cp_logger_get_default_io_unit(logger)
 
-      my_rank = v_ee%pw_grid%para%my_pos
-      num_pe = v_ee%pw_grid%para%group_size
+      my_rank = v_ee%pw_grid%para%group%mepos
+      num_pe = v_ee%pw_grid%para%group%num_pe
       gid = v_ee%pw_grid%para%group
       tag = 1
 

--- a/src/mixed_cdft_utils.F
+++ b/src/mixed_cdft_utils.F
@@ -91,8 +91,7 @@ MODULE mixed_cdft_utils
                                               pw_grid_type
    USE pw_grids,                        ONLY: do_pw_grid_blocked_false,&
                                               pw_grid_create,&
-                                              pw_grid_release,&
-                                              pw_grid_setup
+                                              pw_grid_release
    USE pw_pool_types,                   ONLY: pw_pool_create,&
                                               pw_pool_p_type,&
                                               pw_pool_type
@@ -688,7 +687,6 @@ CONTAINS
       ! Init structures only needed when the CDFT states are treated in parallel
       IF (mixed_cdft%run_type == mixed_cdft_parallel) THEN
          ! Start building the mixed auxbas_pw_pool
-         CALL pw_grid_create(pw_grid, force_env%para_env)
          CALL pw_env_create(mixed_cdft%pw_env)
          ! Decide what kind of layout to use and setup the grid
          ! Processor mappings currently supported:
@@ -727,12 +725,12 @@ CONTAINS
             CALL get_qs_env(force_env_qs%qmmm_env%qs_env, &
                             cell=cell_mix)
          END IF
-         CALL pw_grid_setup(cell_mix%hmat, pw_grid, grid_span=settings%grid_span(1), &
-                            npts=settings%npts(:, 1), cutoff=settings%cutoff(1), &
-                            spherical=settings%is_spherical, odd=settings%is_odd, &
-                            fft_usage=.TRUE., ncommensurate=0, icommensurate=1, &
-                            blocked=do_pw_grid_blocked_false, rs_dims=mixed_rs_dims, &
-                            iounit=iounit)
+         CALL pw_grid_create(pw_grid, force_env%para_env, cell_mix%hmat, grid_span=settings%grid_span(1), &
+                             npts=settings%npts(:, 1), cutoff=settings%cutoff(1), &
+                             spherical=settings%is_spherical, odd=settings%is_odd, &
+                             fft_usage=.TRUE., ncommensurate=0, icommensurate=1, &
+                             blocked=do_pw_grid_blocked_false, rs_dims=mixed_rs_dims, &
+                             iounit=iounit)
          ! Check if the layout was successfully created
          IF (mixed_cdft%is_special) THEN
             IF (.NOT. pw_grid%para%rs_dims(2) /= 1) is_match = .FALSE.

--- a/src/mixed_cdft_utils.F
+++ b/src/mixed_cdft_utils.F
@@ -223,7 +223,7 @@ CONTAINS
             settings%cutoff(iforce_eval) = auxbas_pw_pool%pw_grid%cutoff
             settings%rel_cutoff(iforce_eval) = dft_control%qs_control%relative_cutoff
             IF (auxbas_pw_pool%pw_grid%spherical) settings%spherical(iforce_eval) = 1
-            settings%rs_dims(:, iforce_eval) = auxbas_pw_pool%pw_grid%para%rs_dims
+            settings%rs_dims(:, iforce_eval) = auxbas_pw_pool%pw_grid%para%group%num_pe_cart
             IF (auxbas_pw_pool%pw_grid%grid_span == HALFSPACE) settings%odd(iforce_eval) = 1
             ! Becke constraint atoms/coeffs
             IF (cdft_control%natoms .GT. SIZE(settings%atoms, 1)) &
@@ -733,11 +733,11 @@ CONTAINS
                              iounit=iounit)
          ! Check if the layout was successfully created
          IF (mixed_cdft%is_special) THEN
-            IF (.NOT. pw_grid%para%rs_dims(2) /= 1) is_match = .FALSE.
+            IF (.NOT. pw_grid%para%group%num_pe_cart(2) /= 1) is_match = .FALSE.
          ELSE IF (mixed_cdft%is_pencil) THEN
-            IF (.NOT. pw_grid%para%rs_dims(1) == mixed_rs_dims(1)) is_match = .FALSE.
+            IF (.NOT. pw_grid%para%group%num_pe_cart(1) == mixed_rs_dims(1)) is_match = .FALSE.
          ELSE
-            IF (.NOT. pw_grid%para%rs_dims(2) == 1) is_match = .FALSE.
+            IF (.NOT. pw_grid%para%group%num_pe_cart(2) == 1) is_match = .FALSE.
          END IF
          IF (.NOT. is_match) &
             CALL cp_abort(__LOCATION__, &
@@ -856,8 +856,8 @@ CONTAINS
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
             ! work out the pw grid points each proc holds in the two (identical) parallel proc groups
             ! note we only care about the x dir since we assume the y dir is not subdivided
-            ALLOCATE (bounds(0:auxbas_pw_pool%pw_grid%para%group_size - 1, 1:2))
-            DO i = 0, auxbas_pw_pool%pw_grid%para%group_size - 1
+            ALLOCATE (bounds(0:auxbas_pw_pool%pw_grid%para%group%num_pe - 1, 1:2))
+            DO i = 0, auxbas_pw_pool%pw_grid%para%group%num_pe - 1
                bounds(i, 1:2) = auxbas_pw_pool%pw_grid%para%bo(1:2, 1, i, 1)
                bounds(i, 1:2) = bounds(i, 1:2) - auxbas_pw_pool%pw_grid%npts(1)/2 - 1
             END DO
@@ -865,7 +865,7 @@ CONTAINS
             ! first get the number of target procs per group
             ntargets = 0
             offset = -1
-            DO i = 0, auxbas_pw_pool%pw_grid%para%group_size - 1
+            DO i = 0, auxbas_pw_pool%pw_grid%para%group%num_pe - 1
                IF ((bounds(i, 1) .GE. bo_mixed(1, 1) .AND. bounds(i, 1) .LE. bo_mixed(2, 1)) .OR. &
                    (bounds(i, 2) .GE. bo_mixed(1, 1) .AND. bounds(i, 2) .LE. bo_mixed(2, 1))) THEN
                   ntargets = ntargets + 1
@@ -893,8 +893,8 @@ CONTAINS
             ! finally determine which procs will send me grid points
             ! now we need info about y dir also
             DEALLOCATE (bounds)
-            ALLOCATE (bounds(0:pw_pools(1)%pool%pw_grid%para%group_size - 1, 1:4))
-            DO i = 0, pw_pools(1)%pool%pw_grid%para%group_size - 1
+            ALLOCATE (bounds(0:pw_pools(1)%pool%pw_grid%para%group%num_pe - 1, 1:4))
+            DO i = 0, pw_pools(1)%pool%pw_grid%para%group%num_pe - 1
                bounds(i, 1:2) = pw_pools(1)%pool%pw_grid%para%bo(1:2, 1, i, 1)
                bounds(i, 3:4) = pw_pools(1)%pool%pw_grid%para%bo(1:2, 2, i, 1)
                bounds(i, 1:2) = bounds(i, 1:2) - pw_pools(1)%pool%pw_grid%npts(1)/2 - 1
@@ -902,7 +902,7 @@ CONTAINS
             END DO
             ntargets = 0
             offset = -1
-            DO i = 0, pw_pools(1)%pool%pw_grid%para%group_size - 1
+            DO i = 0, pw_pools(1)%pool%pw_grid%para%group%num_pe - 1
                IF ((bo(1, 1) .GE. bounds(i, 1) .AND. bo(1, 1) .LE. bounds(i, 2)) .OR. &
                    (bo(2, 1) .GE. bounds(i, 1) .AND. bo(2, 1) .LE. bounds(i, 2))) THEN
                   ntargets = ntargets + 1

--- a/src/pw/dct.F
+++ b/src/pw/dct.F
@@ -228,9 +228,9 @@ CONTAINS
          blocked = 0
       END IF
 
-      CALL pw_grid_create(dct_pw_grid, pw_grid%para%rs_group, hmat2, &
+      CALL pw_grid_create(dct_pw_grid, pw_grid%para%group, hmat2, &
                           bounds=bounds_new, &
-                          rs_dims=pw_grid%para%rs_dims, &
+                          rs_dims=pw_grid%para%group%num_pe_cart, &
                           blocked=blocked, &
                           bounds_local=bounds_local_new)
 
@@ -320,12 +320,12 @@ CONTAINS
 ! rs_dim1 = 3 -->  src_pos1 = [1  2  3]
 ! rs_dim2 = 4 -->  src_pos2 = [1  2   3  4]
 
-      rs_group = pw_grid%para%rs_group
-      rs_mpo = pw_grid%para%rs_mpo
-      group_size = pw_grid%para%group_size
-      rs_dims = pw_grid%para%rs_dims
+      rs_group = pw_grid%para%group
+      rs_mpo = pw_grid%para%group%mepos
+      group_size = pw_grid%para%group%num_pe
+      rs_dims = pw_grid%para%group%num_pe_cart
 
-      rs_pos = pw_grid%para%rs_pos
+      rs_pos = pw_grid%para%group%mepos_cart
       rs_dim1 = rs_dims(1); rs_dim2 = rs_dims(2)
 
 ! prepare srcs_coord
@@ -434,7 +434,7 @@ CONTAINS
 
       DO k = 1, maxn_sendrecv
 ! convert srcs_coord to pid
-         CALL pw_grid%para%rs_group%rank_cart(ABS(srcs_coord(:, k)) - 1, srcs_expand(k))
+         CALL pw_grid%para%group%rank_cart(ABS(srcs_coord(:, k)) - 1, srcs_expand(k))
 ! find out the flipping status
          IF ((srcs_coord(1, k) .GT. 0) .AND. (srcs_coord(2, k) .GT. 0)) THEN
             flipg_stat(k) = NOT_FLIPPED
@@ -538,9 +538,9 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       pw_grid => pw_in%pw_grid
-      rs_group = pw_grid%para%rs_group
-      rs_mpo = pw_grid%para%my_pos
-      group_size = pw_grid%para%group_size
+      rs_group = pw_grid%para%group
+      rs_mpo = pw_grid%para%group%mepos
+      group_size = pw_grid%para%group%num_pe
 
       bounds_local_new = pw_expanded%pw_grid%bounds_local
 
@@ -719,9 +719,9 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       pw_grid_orig => pw_shrinked%pw_grid
-      rs_group = pw_grid_orig%para%rs_group
-      rs_mpo = pw_grid_orig%para%my_pos
-      group_size = pw_grid_orig%para%group_size
+      rs_group = pw_grid_orig%para%group
+      rs_mpo = pw_grid_orig%para%group%mepos
+      group_size = pw_grid_orig%para%group%num_pe
       bounds_local_xpnd = pw_in%pw_grid%bounds_local
       tag = 1
 
@@ -1054,9 +1054,9 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      rs_group = pw_grid%para%rs_group
-      rs_mpo = pw_grid%para%my_pos
-      group_size = pw_grid%para%group_size
+      rs_group = pw_grid%para%group
+      rs_mpo = pw_grid%para%group%mepos
+      group_size = pw_grid%para%group%num_pe
       bounds = pw_grid%bounds
       bounds_local = pw_grid%bounds_local
 

--- a/src/pw/dct.F
+++ b/src/pw/dct.F
@@ -21,8 +21,7 @@ MODULE dct
                                               mp_request_type,&
                                               mp_waitall
    USE pw_grid_types,                   ONLY: pw_grid_type
-   USE pw_grids,                        ONLY: pw_grid_create,&
-                                              pw_grid_setup
+   USE pw_grids,                        ONLY: pw_grid_create
    USE pw_types,                        ONLY: pw_r3d_rs_type
 #include "../base/base_uses.f90"
 
@@ -214,7 +213,6 @@ CONTAINS
                               dests_shrink, srcs_shrink)
       CALL expansion_bounds(pw_grid, neumann_directions, srcs_expand, flipg_stat, &
                             bounds_shftd, bounds_local_shftd, recv_msgs_bnds, bounds_new, bounds_local_new)
-      CALL pw_grid_create(dct_pw_grid, pw_grid%para%rs_group, local=.FALSE.)
 
       hmat2 = 0.0_dp
       hmat2(1, 1) = scfac(1)*cell_hmat(1, 1)
@@ -230,11 +228,11 @@ CONTAINS
          blocked = 0
       END IF
 
-      CALL pw_grid_setup(hmat2, dct_pw_grid, &
-                         bounds=bounds_new, &
-                         rs_dims=pw_grid%para%rs_dims, &
-                         blocked=blocked, &
-                         bounds_local=bounds_local_new)
+      CALL pw_grid_create(dct_pw_grid, pw_grid%para%rs_group, hmat2, &
+                          bounds=bounds_new, &
+                          rs_dims=pw_grid%para%rs_dims, &
+                          blocked=blocked, &
+                          bounds_local=bounds_local_new)
 
       DEALLOCATE (flipg_stat, dests_expand, srcs_expand, dests_shrink, recv_msgs_bnds)
 

--- a/src/pw/dgs.F
+++ b/src/pw/dgs.F
@@ -22,11 +22,13 @@ MODULE dgs
                                               z_zero
    USE mathlib,                         ONLY: det_3x3,&
                                               inv_3x3
+   USE message_passing,                 ONLY: mp_comm_self,&
+                                              mp_comm_type
    USE pw_grid_info,                    ONLY: pw_find_cutoff
    USE pw_grid_types,                   ONLY: HALFSPACE,&
                                               pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_change,&
-                                              pw_grid_setup
+                                              pw_grid_create
    USE pw_methods,                      ONLY: pw_copy,&
                                               pw_multiply_with,&
                                               pw_zero
@@ -84,45 +86,47 @@ CONTAINS
 !> \param cutoff_radius ...
 !> \param grid_s ...
 !> \param grid_b ...
+!> \param mp_comm ...
 !> \param grid_ref ...
 !> \param rs_dims ...
 !> \param iounit ...
 !> \param fft_usage ...
 ! **************************************************************************************************
    SUBROUTINE dg_pme_grid_setup(b_cell_hmat, npts_s, cutoff_radius, grid_s, grid_b, &
-                                grid_ref, rs_dims, iounit, fft_usage)
+                                mp_comm, grid_ref, rs_dims, iounit, fft_usage)
 
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: b_cell_hmat
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts_s
       REAL(KIND=dp), INTENT(IN)                          :: cutoff_radius
       TYPE(pw_grid_type), POINTER                        :: grid_s, grid_b
+
+      CLASS(mp_comm_type), INTENT(IN) :: mp_comm
       TYPE(pw_grid_type), INTENT(IN), OPTIONAL           :: grid_ref
       INTEGER, DIMENSION(2), INTENT(in), OPTIONAL        :: rs_dims
       INTEGER, INTENT(IN), OPTIONAL                      :: iounit
       LOGICAL, INTENT(IN), OPTIONAL                      :: fft_usage
 
-      INTEGER, DIMENSION(2, 3)                           :: bo
+      INTEGER, DIMENSION(2, 3)                           :: bounds_b, bounds_s
       REAL(KIND=dp)                                      :: cutoff, ecut
       REAL(KIND=dp), DIMENSION(3, 3)                     :: s_cell_hmat, unit_cell_hmat
 
-      CALL dg_find_cutoff(b_cell_hmat, npts_s, cutoff_radius, grid_s, grid_b, cutoff)
+      CALL dg_find_cutoff(b_cell_hmat, npts_s, cutoff_radius, bounds_s, bounds_b, cutoff)
 
       ecut = 0.5_dp*cutoff*cutoff
-      bo = grid_b%bounds
       IF (PRESENT(grid_ref)) THEN
-         CALL pw_grid_setup(b_cell_hmat, grid_b, bounds=bo, cutoff=ecut, spherical=.TRUE., &
-                            ref_grid=grid_ref, rs_dims=rs_dims, iounit=iounit, fft_usage=fft_usage)
+         CALL pw_grid_create(grid_b, mp_comm, b_cell_hmat, bounds=bounds_b, grid_span=HALFSPACE, cutoff=ecut, spherical=.TRUE., &
+                             ref_grid=grid_ref, rs_dims=rs_dims, iounit=iounit, fft_usage=fft_usage)
       ELSE
-         CALL pw_grid_setup(b_cell_hmat, grid_b, bounds=bo, cutoff=ecut, spherical=.TRUE., &
-                            rs_dims=rs_dims, iounit=iounit, fft_usage=fft_usage)
+         CALL pw_grid_create(grid_b, mp_comm, b_cell_hmat, bounds=bounds_b, grid_span=HALFSPACE, cutoff=ecut, spherical=.TRUE., &
+                             rs_dims=rs_dims, iounit=iounit, fft_usage=fft_usage)
       END IF
 
       CALL dg_find_basis(grid_b%npts, b_cell_hmat, unit_cell_hmat)
 
-      CALL dg_set_cell(grid_s%npts, unit_cell_hmat, s_cell_hmat)
+      CALL dg_set_cell(bounds_s(2, :) - bounds_s(1, :) + 1, unit_cell_hmat, s_cell_hmat)
 
-      bo = grid_s%bounds
-      CALL pw_grid_setup(s_cell_hmat, grid_s, bounds=bo, cutoff=ecut, iounit=iounit, fft_usage=fft_usage)
+      CALL pw_grid_create(grid_s, mp_comm_self, s_cell_hmat, bounds=bounds_s, grid_span=HALFSPACE, &
+                          cutoff=ecut, iounit=iounit, fft_usage=fft_usage)
 
    END SUBROUTINE dg_pme_grid_setup
 
@@ -153,20 +157,20 @@ CONTAINS
 !> \param b_cell_hmat ...
 !> \param npts_s ...
 !> \param cutoff_radius ...
-!> \param grid_s ...
-!> \param grid_b ...
+!> \param bounds_s ...
+!> \param bounds_b ...
 !> \param cutoff ...
 ! **************************************************************************************************
-   SUBROUTINE dg_find_cutoff(b_cell_hmat, npts_s, cutoff_radius, grid_s, &
-                             grid_b, cutoff)
+   SUBROUTINE dg_find_cutoff(b_cell_hmat, npts_s, cutoff_radius, &
+                             bounds_s, bounds_b, cutoff)
 
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: b_cell_hmat
       INTEGER, DIMENSION(:), INTENT(IN)                  :: npts_s
       REAL(KIND=dp), INTENT(IN)                          :: cutoff_radius
-      TYPE(pw_grid_type), POINTER                        :: grid_s, grid_b
+      INTEGER, DIMENSION(2, 3), INTENT(OUT)              :: bounds_s, bounds_b
       REAL(KIND=dp), INTENT(OUT)                         :: cutoff
 
-      INTEGER                                            :: nout(3)
+      INTEGER, DIMENSION(3)                              :: nout, npts_b
       REAL(KIND=dp)                                      :: b_cell_deth, cell_lengths(3), dr(3)
       REAL(KIND=dp), DIMENSION(3, 3)                     :: b_cell_h_inv
 
@@ -188,33 +192,30 @@ CONTAINS
       cell_lengths = get_cell_lengths(b_cell_hmat)
 
       CALL dg_get_spacing(nout, cutoff_radius, dr)
-      CALL dg_find_radix(dr, cell_lengths, grid_b%npts)
+      CALL dg_find_radix(dr, cell_lengths, npts_b)
 
 ! In-line code to set grid_b % npts = npts_s if necessary
-      IF (nout(1) > grid_b%npts(1)) THEN
-         grid_b%npts(1) = nout(1)
+      IF (nout(1) > npts_b(1)) THEN
+         npts_b(1) = nout(1)
          dr(1) = cell_lengths(1)/REAL(nout(1), KIND=dp)
       END IF
-      IF (nout(2) > grid_b%npts(2)) THEN
-         grid_b%npts(2) = nout(2)
+      IF (nout(2) > npts_b(2)) THEN
+         npts_b(2) = nout(2)
          dr(2) = cell_lengths(2)/REAL(nout(2), KIND=dp)
       END IF
-      IF (nout(3) > grid_b%npts(3)) THEN
-         grid_b%npts(3) = nout(3)
+      IF (nout(3) > npts_b(3)) THEN
+         npts_b(3) = nout(3)
          dr(3) = cell_lengths(3)/REAL(nout(3), KIND=dp)
       END IF
 
 ! big grid bounds
-      grid_b%bounds(1, :) = -grid_b%npts/2
-      grid_b%bounds(2, :) = +(grid_b%npts - 1)/2
-      grid_b%grid_span = HALFSPACE
+      bounds_b(1, :) = -npts_b/2
+      bounds_b(2, :) = +(npts_b - 1)/2
 ! small grid bounds
-      grid_s%bounds(1, :) = -nout(:)/2
-      grid_s%bounds(2, :) = (+nout(:) - 1)/2
-      grid_s%grid_span = HALFSPACE
-      grid_s%npts = nout
+      bounds_s(1, :) = -nout(:)/2
+      bounds_s(2, :) = (+nout(:) - 1)/2
 
-      cutoff = pw_find_cutoff(grid_b%npts, b_cell_h_inv)
+      cutoff = pw_find_cutoff(npts_b, b_cell_h_inv)
 
    END SUBROUTINE dg_find_cutoff
 

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -68,7 +68,6 @@ MODULE fft_tools
       INTEGER                              :: lg = 0, mg = 0
       INTEGER                              :: nbx = 0, nbz = 0
       INTEGER                              :: nmray = 0, nyzray = 0
-      TYPE(mp_comm_type)                   :: gs_group = mp_comm_type()
       TYPE(mp_cart_type)                   :: rs_group = mp_cart_type()
       INTEGER, DIMENSION(2)                :: g_pos = 0, r_pos = 0, r_dim = 0
       INTEGER                              :: numtask = 0
@@ -485,7 +484,6 @@ CONTAINS
 !> \param n ...
 !> \param cin ...
 !> \param gin ...
-!> \param gs_group ...
 !> \param rs_group ...
 !> \param yzp ...
 !> \param nyzray ...
@@ -494,7 +492,7 @@ CONTAINS
 !> \param status ...
 !> \param debug ...
 ! **************************************************************************************************
-   SUBROUTINE fft3d_ps(fsign, n, cin, gin, gs_group, rs_group, yzp, nyzray, &
+   SUBROUTINE fft3d_ps(fsign, n, cin, gin, rs_group, yzp, nyzray, &
                        bo, scale, status, debug)
 
       INTEGER, INTENT(IN)                                :: fsign
@@ -503,7 +501,6 @@ CONTAINS
          INTENT(INOUT)                                   :: cin
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: gin
-      TYPE(mp_comm_type), INTENT(IN)                     :: gs_group
       TYPE(mp_cart_type), INTENT(IN)                     :: rs_group
       INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
          INTENT(IN)                                      :: yzp
@@ -521,8 +518,7 @@ CONTAINS
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          POINTER                                         :: tbuf
       INTEGER :: g_pos, handle, lg, lmax, mcx2, mcz1, mcz2, mg, mmax, mx1, mx2, my1, mz2, n1, n2, &
-         nmax, numtask, numtask_g, numtask_r, nx, ny, nz, output_unit, r_dim(2), r_pos(2), rp, &
-         sign, stat
+         nmax, numtask, nx, ny, nz, output_unit, r_dim(2), r_pos(2), rp, sign, stat
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: p2p
       LOGICAL                                            :: test
       REAL(KIND=dp)                                      :: norm, sum_data
@@ -538,15 +534,10 @@ CONTAINS
          test = .FALSE.
       END IF
 
-      numtask_g = gs_group%num_pe
-      g_pos = gs_group%mepos
-      numtask_r = rs_group%num_pe
+      g_pos = rs_group%mepos
+      numtask = rs_group%num_pe
       r_dim = rs_group%num_pe_cart
       r_pos = rs_group%mepos_cart
-      IF (numtask_g /= numtask_r) THEN
-         CPABORT("Real space and G space groups are different.")
-      END IF
-      numtask = numtask_r
 
       IF (PRESENT(scale)) THEN
          norm = scale
@@ -572,7 +563,7 @@ CONTAINS
 
       ALLOCATE (p2p(0:numtask - 1))
 
-      CALL gs_group%rank_compare(rs_group, p2p)
+      CALL rs_group%rank_compare(rs_group, p2p)
 
       rp = p2p(g_pos)
       mx1 = bo(2, 1, rp, 1) - bo(1, 1, rp, 1) + 1
@@ -609,7 +600,6 @@ CONTAINS
       fft_scratch_size%nmax = nmax
       fft_scratch_size%nmray = MAXVAL(nyzray)
       fft_scratch_size%nyzray = nyzray(g_pos)
-      fft_scratch_size%gs_group = gs_group
       fft_scratch_size%rs_group = rs_group
       fft_scratch_size%g_pos = g_pos
       fft_scratch_size%r_pos = r_pos
@@ -642,7 +632,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(cin))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A)') "  Two step communication algorithm "
                   WRITE (output_unit, '(A,T60,3I7)') "     Transform Z ", n(3), mx1*my1
@@ -662,7 +652,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(qbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(2) T", sum_data
                END IF
@@ -673,7 +663,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(rbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(3) T", sum_data
                END IF
@@ -688,7 +678,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(pbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(4) TS", sum_data
                END IF
@@ -700,7 +690,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(qbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(5) TS", sum_data
                END IF
@@ -711,7 +701,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(gin))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(6) ", sum_data
                END IF
@@ -722,7 +712,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(gin))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A)') "  Two step communication algorithm "
                   WRITE (output_unit, '(A,T67,2I7)') "     Transform X ", n(1), nyzray(g_pos)
@@ -741,7 +731,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(pbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(2) TS", sum_data
                END IF
@@ -753,7 +743,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(qbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(3) TS", sum_data
                END IF
@@ -768,7 +758,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(rbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(4) T", sum_data
                END IF
@@ -779,7 +769,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(pbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(5) T", sum_data
                END IF
@@ -792,7 +782,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(cin))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(6) ", sum_data
                END IF
@@ -827,7 +817,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(cin))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A)') "     One step communication algorithm "
                   WRITE (output_unit, '(A,T60,3I7)') "     Transform YZ ", n(2), n(3), nx
@@ -842,19 +832,19 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(tbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(2) TS", sum_data
                END IF
             END IF
 
             ! Exchange data ( transpose of matrix ) and sort
-            CALL yz_to_x(tbuf, gs_group, g_pos, p2p, yzp, nyzray, &
+            CALL yz_to_x(tbuf, rs_group, g_pos, p2p, yzp, nyzray, &
                          bo(:, :, :, 2), sbuf, fft_scratch)
 
             IF (test) THEN
                sum_data = ABS(SUM(sbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(3) TS", sum_data
                END IF
@@ -864,7 +854,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(gin))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(4) ", sum_data
                END IF
@@ -875,7 +865,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(gin))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A)') "  One step communication algorithm "
                   WRITE (output_unit, '(A,T67,2I7)') "     Transform X ", n(1), nyzray(g_pos)
@@ -889,19 +879,19 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(sbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(2) TS", sum_data
                END IF
             END IF
 
             ! Exchange data ( transpose of matrix ) and sort
-            CALL x_to_yz(sbuf, gs_group, g_pos, p2p, yzp, nyzray, &
+            CALL x_to_yz(sbuf, rs_group, g_pos, p2p, yzp, nyzray, &
                          bo(:, :, :, 2), tbuf, fft_scratch)
 
             IF (test) THEN
                sum_data = ABS(SUM(tbuf))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(3) TS", sum_data
                END IF
@@ -913,7 +903,7 @@ CONTAINS
 
             IF (test) THEN
                sum_data = ABS(SUM(cin))
-               CALL gs_group%sum(sum_data)
+               CALL rs_group%sum(sum_data)
                IF (g_pos == 0 .AND. output_unit > 0) THEN
                   WRITE (output_unit, '(A,T61,E20.14)') "     Sum of data(4) ", sum_data
                END IF
@@ -1056,7 +1046,6 @@ CONTAINS
       fft_scratch_size%mcx2 = mcx2
       fft_scratch_size%mcz2 = mcz2
       fft_scratch_size%mcy3 = mcy3
-      fft_scratch_size%gs_group = group
       fft_scratch_size%rs_group = group
       fft_scratch_size%g_pos = my_pos
       fft_scratch_size%numtask = DIM(1)*DIM(2)
@@ -1382,7 +1371,8 @@ CONTAINS
 
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
          INTENT(IN)                                      :: sb
-      TYPE(mp_comm_type), INTENT(IN)                     :: group
+
+      CLASS(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, INTENT(IN)                                :: my_pos
       INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)     :: p2p
       INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
@@ -1497,7 +1487,8 @@ CONTAINS
 
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(IN)                                      :: tb
-      TYPE(mp_comm_type), INTENT(IN)                     :: group
+
+      CLASS(mp_comm_type), INTENT(IN)                     :: group
       INTEGER, INTENT(IN)                                :: my_pos
       INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)     :: p2p
       INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:), &
@@ -2923,7 +2914,7 @@ CONTAINS
                CYCLE
             END IF
             IF (PRESENT(fft_sizes)) THEN
-               IF (fft_sizes%gs_group /= fft_scratch_current%fft_scratch%group) THEN
+               IF (fft_sizes%rs_group /= fft_scratch_current%fft_scratch%group) THEN
                   fft_scratch_last => fft_scratch_current
                   fft_scratch_current => fft_scratch_current%fft_scratch_next
                   CYCLE
@@ -2969,7 +2960,7 @@ CONTAINS
                CALL fft_alloc(fft_scratch_new%fft_scratch%a4buf, [n(2), mx2*mz2])
                CALL fft_alloc(fft_scratch_new%fft_scratch%a5buf, [my3*mz3, n(1)])
                CALL fft_alloc(fft_scratch_new%fft_scratch%a6buf, [n(1), my3*mz3])
-               fft_scratch_new%fft_scratch%group = fft_sizes%gs_group
+               fft_scratch_new%fft_scratch%group = fft_sizes%rs_group
 
                dim = fft_sizes%rs_group%num_pe_cart
                pos = fft_sizes%rs_group%mepos_cart
@@ -3022,7 +3013,7 @@ CONTAINS
                mz3 = fft_sizes%mz3
                CALL fft_alloc(fft_scratch_new%fft_scratch%a1buf, [mx1*my1, n(3)])
                CALL fft_alloc(fft_scratch_new%fft_scratch%a2buf, [n(3), mx1*my1])
-               fft_scratch_new%fft_scratch%group = fft_sizes%gs_group
+               fft_scratch_new%fft_scratch%group = fft_sizes%rs_group
                CALL fft_alloc(fft_scratch_new%fft_scratch%a3buf, [mx1*mz1, n(2)])
                CALL fft_alloc(fft_scratch_new%fft_scratch%a4buf, [n(2), mx1*mz1])
                CALL fft_alloc(fft_scratch_new%fft_scratch%a5buf, [my3*mz3, n(1)])
@@ -3076,7 +3067,7 @@ CONTAINS
                CALL fft_alloc(fft_scratch_new%fft_scratch%r1buf, [mmax, lmax])
                CALL fft_alloc(fft_scratch_new%fft_scratch%tbuf, [ny, nz, nx])
 #endif
-               fft_scratch_new%fft_scratch%group = fft_sizes%gs_group
+               fft_scratch_new%fft_scratch%group = fft_sizes%rs_group
                CALL fft_alloc(fft_scratch_new%fft_scratch%r2buf, [lg, mg])
                nm = nmray*mx2
                IF (alltoall_sgl) THEN
@@ -3160,7 +3151,7 @@ CONTAINS
                          fft_scratch_new%fft_scratch%yzcount(0:np - 1))
                ALLOCATE (fft_scratch_new%fft_scratch%xzdispl(0:np - 1), &
                          fft_scratch_new%fft_scratch%yzdispl(0:np - 1))
-               fft_scratch_new%fft_scratch%group = fft_sizes%gs_group
+               fft_scratch_new%fft_scratch%group = fft_sizes%rs_group
 
                dim = fft_sizes%rs_group%num_pe_cart
                pos = fft_sizes%rs_group%mepos_cart
@@ -3375,7 +3366,6 @@ CONTAINS
       equal = equal .AND. fft_size_1%nmray == fft_size_2%nmray
       equal = equal .AND. fft_size_1%nyzray == fft_size_2%nyzray
 
-      equal = equal .AND. fft_size_1%gs_group == fft_size_2%gs_group
       equal = equal .AND. fft_size_1%rs_group == fft_size_2%rs_group
 
       equal = equal .AND. ALL(fft_size_1%g_pos == fft_size_2%g_pos)

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -359,14 +359,13 @@ CONTAINS
 !> \param n ...
 !> \param zin ...
 !> \param zout ...
-!> \param scale ...
 !> \param status ...
 !> \param debug ...
 !> \par History
 !>      none
 !> \author JGH
 ! **************************************************************************************************
-   SUBROUTINE fft3d_s(fsign, n, zin, zout, scale, status, debug)
+   SUBROUTINE fft3d_s(fsign, n, zin, zout, status, debug)
 
       INTEGER, INTENT(IN)                                :: fsign
       INTEGER, DIMENSION(:), INTENT(INOUT)               :: n
@@ -374,7 +373,6 @@ CONTAINS
          INTENT(INOUT)                                   :: zin
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :, :), &
          INTENT(INOUT), OPTIONAL, TARGET                 :: zout
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
       INTEGER, INTENT(OUT), OPTIONAL                     :: status
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
@@ -392,10 +390,12 @@ CONTAINS
       CALL timeset(routineN, handle)
       output_unit = cp_logger_get_default_io_unit()
 
-      IF (PRESENT(scale)) THEN
-         norm = scale
-      ELSE
+      IF (fsign == FWFFT) THEN
+         norm = 1.0_dp/REAL(PRODUCT(n), KIND=dp)
+      ELSE IF (fsign == BWFFT) THEN
          norm = 1.0_dp
+      ELSE
+         CPABORT("Unknown FFT direction!")
       END IF
 
       IF (PRESENT(debug)) THEN
@@ -488,12 +488,11 @@ CONTAINS
 !> \param yzp ...
 !> \param nyzray ...
 !> \param bo ...
-!> \param scale ...
 !> \param status ...
 !> \param debug ...
 ! **************************************************************************************************
    SUBROUTINE fft3d_ps(fsign, n, cin, gin, rs_group, yzp, nyzray, &
-                       bo, scale, status, debug)
+                       bo, status, debug)
 
       INTEGER, INTENT(IN)                                :: fsign
       INTEGER, DIMENSION(:), INTENT(IN)                  :: n
@@ -507,7 +506,6 @@ CONTAINS
       INTEGER, CONTIGUOUS, DIMENSION(0:), INTENT(IN)     :: nyzray
       INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:, :), &
          INTENT(IN)                                      :: bo
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
       INTEGER, INTENT(OUT), OPTIONAL                     :: status
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
@@ -539,10 +537,12 @@ CONTAINS
       r_dim = rs_group%num_pe_cart
       r_pos = rs_group%mepos_cart
 
-      IF (PRESENT(scale)) THEN
-         norm = scale
-      ELSE
+      IF (fsign == FWFFT) THEN
+         norm = 1.0_dp/REAL(PRODUCT(n), KIND=dp)
+      ELSE IF (fsign == BWFFT) THEN
          norm = 1.0_dp
+      ELSE
+         CPABORT("Unknown FFT direction!")
       END IF
 
       sign = fsign
@@ -933,11 +933,10 @@ CONTAINS
 !> \param gin ...
 !> \param group ...
 !> \param bo ...
-!> \param scale ...
 !> \param status ...
 !> \param debug ...
 ! **************************************************************************************************
-   SUBROUTINE fft3d_pb(fsign, n, zin, gin, group, bo, scale, status, debug)
+   SUBROUTINE fft3d_pb(fsign, n, zin, gin, group, bo, status, debug)
 
       INTEGER, INTENT(IN)                                :: fsign
       INTEGER, DIMENSION(3), INTENT(IN)                  :: n
@@ -948,7 +947,6 @@ CONTAINS
       TYPE(mp_cart_type), INTENT(IN)                     :: group
       INTEGER, CONTIGUOUS, DIMENSION(:, :, 0:, :), &
          INTENT(IN)                                      :: bo
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: scale
       INTEGER, INTENT(OUT), OPTIONAL                     :: status
       LOGICAL, INTENT(IN), OPTIONAL                      :: debug
 
@@ -998,10 +996,12 @@ CONTAINS
          test = .FALSE.
       END IF
 
-      IF (PRESENT(scale)) THEN
-         norm = scale
-      ELSE
+      IF (fsign == FWFFT) THEN
+         norm = 1.0_dp/REAL(PRODUCT(n), KIND=dp)
+      ELSE IF (fsign == BWFFT) THEN
          norm = 1.0_dp
+      ELSE
+         CPABORT("Unknown FFT direction!")
       END IF
 
       sign = fsign

--- a/src/pw/ps_wavelet_methods.F
+++ b/src/pw/ps_wavelet_methods.F
@@ -83,9 +83,9 @@ CONTAINS
       hy = pw_grid%dr(2)
       hz = pw_grid%dr(3)
 
-      nproc = PRODUCT(pw_grid%para%rs_dims)
+      nproc = PRODUCT(pw_grid%para%group%num_pe_cart)
 
-      iproc = pw_grid%para%rs_mpo
+      iproc = pw_grid%para%group%mepos
 
       NULLIFY (wavelet%karray, wavelet%rho_z_sliced)
 
@@ -126,8 +126,8 @@ CONTAINS
       REAL(KIND=dp)                                      :: hx, hy, hz
 
       CALL timeset(routineN, handle)
-      nproc = PRODUCT(pw_grid%para%rs_dims)
-      iproc = pw_grid%para%rs_mpo
+      nproc = PRODUCT(pw_grid%para%group%num_pe_cart)
+      iproc = pw_grid%para%group%mepos
       geocode = wavelet%geocode
       nx = pw_grid%npts(1)
       ny = pw_grid%npts(2)
@@ -154,7 +154,7 @@ CONTAINS
       ALLOCATE (wavelet%rho_z_sliced(md1, md3, z_dim))
 
       CALL createKernel(geocode, nx, ny, nz, hx, hy, hz, wavelet%itype_scf, iproc, nproc, wavelet%karray, &
-                        pw_grid%para%rs_group)
+                        pw_grid%para%group)
 
       CALL timestop(handle)
    END SUBROUTINE RS_z_slice_distribution
@@ -186,8 +186,8 @@ CONTAINS
 
       CPASSERT(ASSOCIATED(wavelet))
 
-      nproc = PRODUCT(pw_grid%para%rs_dims)
-      iproc = pw_grid%para%rs_mpo
+      nproc = PRODUCT(pw_grid%para%group%num_pe_cart)
+      iproc = pw_grid%para%group%mepos
       md2 = wavelet%PS_grid(3)
       m2 = pw_grid%npts(3)
       lb(:) = pw_grid%bounds_local(1, :)
@@ -237,10 +237,10 @@ CONTAINS
       IF (should_warn > 0 .AND. iproc == 0) &
          CPWARN("Density non-zero on the edges of the unit cell: wrong results in WAVELET solver")
 
-      DO i = 0, pw_grid%para%rs_dims(1) - 1
-         DO j = 0, pw_grid%para%rs_dims(2) - 1
+      DO i = 0, pw_grid%para%group%num_pe_cart(1) - 1
+         DO j = 0, pw_grid%para%group%num_pe_cart(2) - 1
             cart_pos = (/i, j/)
-            CALL pw_grid%para%rs_group%rank_cart(cart_pos, dest)
+            CALL pw_grid%para%group%rank_cart(cart_pos, dest)
             IF ((ub(1) .GE. lb(1)) .AND. (ub(2) .GE. lb(2))) THEN
                IF (dest*local_z_dim .LE. m2) THEN
                   IF ((dest + 1)*local_z_dim .LE. m2) THEN
@@ -254,8 +254,8 @@ CONTAINS
             ELSE
                scount(dest + 1) = 0
             END IF
-            lox = get_limit(pw_grid%npts(1), pw_grid%para%rs_dims(1), i)
-            loy = get_limit(pw_grid%npts(2), pw_grid%para%rs_dims(2), j)
+            lox = get_limit(pw_grid%npts(1), pw_grid%para%group%num_pe_cart(1), i)
+            loy = get_limit(pw_grid%npts(2), pw_grid%para%group%num_pe_cart(2), j)
             IF ((lox(2) .GE. lox(1)) .AND. (loy(2) .GE. loy(1))) THEN
                IF (iproc*local_z_dim .LE. m2) THEN
                   IF ((iproc + 1)*local_z_dim .LE. m2) THEN
@@ -278,18 +278,18 @@ CONTAINS
          sdispl(i) = sdispl(i - 1) + scount(i - 1)
          rdispl(i) = rdispl(i - 1) + rcount(i - 1)
       END DO
-      CALL pw_grid%para%rs_group%alltoall(sbuf, scount, sdispl, rbuf, rcount, rdispl)
+      CALL pw_grid%para%group%alltoall(sbuf, scount, sdispl, rbuf, rcount, rdispl)
       !!!! and now, how to put the right cubes to the right position!!!!!!
 
       wavelet%rho_z_sliced = 0.0_dp
 
-      DO i = 0, pw_grid%para%rs_dims(1) - 1
-         DO j = 0, pw_grid%para%rs_dims(2) - 1
+      DO i = 0, pw_grid%para%group%num_pe_cart(1) - 1
+         DO j = 0, pw_grid%para%group%num_pe_cart(2) - 1
             cart_pos = (/i, j/)
-            CALL pw_grid%para%rs_group%rank_cart(cart_pos, dest)
+            CALL pw_grid%para%group%rank_cart(cart_pos, dest)
 
-            lox = get_limit(pw_grid%npts(1), pw_grid%para%rs_dims(1), i)
-            loy = get_limit(pw_grid%npts(2), pw_grid%para%rs_dims(2), j)
+            lox = get_limit(pw_grid%npts(1), pw_grid%para%group%num_pe_cart(1), i)
+            loy = get_limit(pw_grid%npts(2), pw_grid%para%group%num_pe_cart(2), j)
             IF (iproc*local_z_dim .LE. m2) THEN
                IF ((iproc + 1)*local_z_dim .LE. m2) THEN
                   loz = local_z_dim
@@ -336,8 +336,8 @@ CONTAINS
 
       CPASSERT(ASSOCIATED(wavelet))
 
-      nproc = PRODUCT(pw_grid%para%rs_dims)
-      iproc = pw_grid%para%rs_mpo
+      nproc = PRODUCT(pw_grid%para%group%num_pe_cart)
+      iproc = pw_grid%para%group%mepos
       md2 = wavelet%PS_grid(3)
       m2 = pw_grid%npts(3)
 
@@ -363,12 +363,12 @@ CONTAINS
          loz = 0
       END IF
 
-      min_x = get_limit(pw_grid%npts(1), pw_grid%para%rs_dims(1), 0)
-      min_y = get_limit(pw_grid%npts(2), pw_grid%para%rs_dims(2), 0)
-      DO i = 0, pw_grid%para%rs_dims(1) - 1
-         DO j = 0, pw_grid%para%rs_dims(2) - 1
+      min_x = get_limit(pw_grid%npts(1), pw_grid%para%group%num_pe_cart(1), 0)
+      min_y = get_limit(pw_grid%npts(2), pw_grid%para%group%num_pe_cart(2), 0)
+      DO i = 0, pw_grid%para%group%num_pe_cart(1) - 1
+         DO j = 0, pw_grid%para%group%num_pe_cart(2) - 1
             cart_pos = (/i, j/)
-            CALL pw_grid%para%rs_group%rank_cart(cart_pos, dest)
+            CALL pw_grid%para%group%rank_cart(cart_pos, dest)
             IF ((ub(1) .GE. lb(1)) .AND. (ub(2) .GE. lb(2))) THEN
                IF (dest*local_z_dim .LE. m2) THEN
                   IF ((dest + 1)*local_z_dim .LE. m2) THEN
@@ -382,8 +382,8 @@ CONTAINS
             ELSE
                rcount(dest + 1) = 0
             END IF
-            lox = get_limit(pw_grid%npts(1), pw_grid%para%rs_dims(1), i)
-            loy = get_limit(pw_grid%npts(2), pw_grid%para%rs_dims(2), j)
+            lox = get_limit(pw_grid%npts(1), pw_grid%para%group%num_pe_cart(1), i)
+            loy = get_limit(pw_grid%npts(2), pw_grid%para%group%num_pe_cart(2), j)
             IF ((lox(2) .GE. lox(1)) .AND. (loy(2) .GE. loy(1))) THEN
                scount(dest + 1) = ABS((lox(2) - lox(1) + 1)*(loy(2) - loy(1) + 1)*loz)
                DO k = lox(1) - min_x(1) + 1, lox(2) - min_x(1) + 1
@@ -405,14 +405,14 @@ CONTAINS
          sdispl(i) = sdispl(i - 1) + scount(i - 1)
          rdispl(i) = rdispl(i - 1) + rcount(i - 1)
       END DO
-      CALL pw_grid%para%rs_group%alltoall(sbuf, scount, sdispl, rbuf, rcount, rdispl)
+      CALL pw_grid%para%group%alltoall(sbuf, scount, sdispl, rbuf, rcount, rdispl)
 
       !!!! and now, how to put the right cubes to the right position!!!!!!
 
-      DO i = 0, pw_grid%para%rs_dims(1) - 1
-         DO j = 0, pw_grid%para%rs_dims(2) - 1
+      DO i = 0, pw_grid%para%group%num_pe_cart(1) - 1
+         DO j = 0, pw_grid%para%group%num_pe_cart(2) - 1
             cart_pos = (/i, j/)
-            CALL pw_grid%para%rs_group%rank_cart(cart_pos, dest)
+            CALL pw_grid%para%group%rank_cart(cart_pos, dest)
             IF (dest*local_z_dim .LE. m2) THEN
                IF ((dest + 1)*local_z_dim .LE. m2) THEN
                   loz = local_z_dim
@@ -454,8 +454,8 @@ CONTAINS
       REAL(KIND=dp)                                      :: hx, hy, hz
 
       CALL timeset(routineN, handle)
-      nproc = PRODUCT(pw_grid%para%rs_dims)
-      iproc = pw_grid%para%rs_mpo
+      nproc = PRODUCT(pw_grid%para%group%num_pe_cart)
+      iproc = pw_grid%para%group%mepos
       geocode = wavelet%geocode
       nx = pw_grid%npts(1)
       ny = pw_grid%npts(2)

--- a/src/pw/ps_wavelet_util.F
+++ b/src/pw/ps_wavelet_util.F
@@ -167,17 +167,17 @@ CONTAINS
          !no powers of hgrid because they are incorporated in the plane wave treatment
          scal = 1._dp/REAL(n1*n2*n3, KIND=dp)
          CALL P_PoissonSolver(n1, n2, n3, nd1, nd2, nd3, md1, md2, md3, nproc, iproc, zf, &
-                              scal, hx, hy, hz, pw_grid%para%rs_group)
+                              scal, hx, hy, hz, pw_grid%para%group)
       ELSE IF (geocode == 'S') THEN
          !only one power of hgrid
          scal = hy/REAL(n1*n2*n3, KIND=dp)
          CALL S_PoissonSolver(n1, n2, n3, nd1, nd2, nd3, md1, md2, md3, nproc, iproc, karray, zf, &
-                              scal, pw_grid%para%rs_group)
+                              scal, pw_grid%para%group)
       ELSE IF (geocode == 'F') THEN
          hgrid = MAX(hx, hy, hz)
          scal = hgrid**3/REAL(n1*n2*n3, KIND=dp)
          CALL F_PoissonSolver(n1, n2, n3, nd1, nd2, nd3, md1, md2, md3, nproc, iproc, karray, zf, &
-                              scal, pw_grid%para%rs_group)
+                              scal, pw_grid%para%group)
          factor = 0.5_dp*hgrid**3
       END IF
 

--- a/src/pw/pw_copy_all.F
+++ b/src/pw/pw_copy_all.F
@@ -58,8 +58,8 @@ CONTAINS
       pg2 => pw2%pw_grid
 
       group = pg1%para%group
-      group_size = pg1%para%group_size
-      me = pg1%para%my_pos
+      group_size = pg1%para%group%num_pe
+      me = pg1%para%group%mepos
       ALLOCATE (ngr(group_size))
       ngr = 0
       ngr(me + 1) = pg1%ngpts_cut_local

--- a/src/pw/pw_gpu.F
+++ b/src/pw/pw_gpu.F
@@ -33,8 +33,7 @@ MODULE pw_gpu
         release_fft_scratch, x_to_yz, xz_to_yz, yz_to_x, yz_to_xz
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: z_zero
-   USE message_passing,                 ONLY: mp_cart_type,&
-                                              mp_comm_type
+   USE message_passing,                 ONLY: mp_cart_type
    USE pw_grid_types,                   ONLY: FULLSPACE
    USE pw_types,                        ONLY: pw_c1d_gs_type,&
                                               pw_r3d_rs_type
@@ -226,8 +225,7 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: grays, pbuf, qbuf, rbuf, sbuf
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER      :: tbuf
       INTEGER                                            :: g_pos, handle, lg, lmax, mg, mmax, mx2, &
-                                                            mz2, n1, n2, ngpts, nmax, numtask, &
-                                                            numtask_g, numtask_r, rp
+                                                            mz2, n1, n2, ngpts, nmax, numtask, rp
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: p2p
       INTEGER, DIMENSION(2)                              :: r_dim, r_pos
       INTEGER, DIMENSION(:), POINTER                     :: n, nloc, nyzray
@@ -235,7 +233,6 @@ CONTAINS
       TYPE(fft_scratch_sizes)                            :: fft_scratch_size
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
       TYPE(mp_cart_type)                                 :: rs_group
-      TYPE(mp_comm_type)                                 :: gs_group
 
       CALL timeset(routineN, handle)
 
@@ -247,20 +244,14 @@ CONTAINS
 
       !..transform
       IF (pw1%pw_grid%para%ray_distribution) THEN
-         gs_group = pw1%pw_grid%para%group
-         rs_group = pw1%pw_grid%para%rs_group
+         rs_group = pw1%pw_grid%para%group
          nyzray => pw1%pw_grid%para%nyzray
          bo => pw1%pw_grid%para%bo
 
-         numtask_g = gs_group%num_pe
-         g_pos = gs_group%mepos
-         numtask_r = rs_group%num_pe
+         g_pos = rs_group%mepos
+         numtask = rs_group%num_pe
          r_dim = rs_group%num_pe_cart
          r_pos = rs_group%mepos_cart
-         IF (numtask_g /= numtask_r) THEN
-            CPABORT("Real space and G space groups are different.")
-         END IF
-         numtask = numtask_r
 
          lg = SIZE(grays, 1)
          mg = SIZE(grays, 2)
@@ -269,7 +260,7 @@ CONTAINS
 
          ALLOCATE (p2p(0:numtask - 1))
 
-         CALL gs_group%rank_compare(rs_group, p2p)
+         CALL rs_group%rank_compare(rs_group, p2p)
 
          rp = p2p(g_pos)
          mx2 = bo(2, 1, rp, 2) - bo(1, 1, rp, 2) + 1
@@ -298,7 +289,6 @@ CONTAINS
          fft_scratch_size%nmax = nmax
          fft_scratch_size%nmray = MAXVAL(nyzray)
          fft_scratch_size%nyzray = nyzray(g_pos)
-         fft_scratch_size%gs_group = gs_group
          fft_scratch_size%rs_group = rs_group
          fft_scratch_size%g_pos = g_pos
          fft_scratch_size%r_pos = r_pos
@@ -359,7 +349,7 @@ CONTAINS
             CALL pw_gpu_cff(pw1, tbuf)
 
             ! Exchange data ( transpose of matrix ) and sort
-            CALL yz_to_x(tbuf, gs_group, g_pos, p2p, pw1%pw_grid%para%yzp, nyzray, &
+            CALL yz_to_x(tbuf, rs_group, g_pos, p2p, pw1%pw_grid%para%yzp, nyzray, &
                          bo(:, :, :, 2), sbuf, fft_scratch)
 
             ! FFT along x
@@ -374,7 +364,7 @@ CONTAINS
 !--------------------------------------------------------------------------
       ELSE
          CPABORT("Not implemented (no ray_distr.) in: pw_gpu_r3dc1d_3d_ps.")
-         !CALL fft3d ( dir, n, pwin, grays, pw1%pw_grid%para%rs_group, &
+         !CALL fft3d ( dir, n, pwin, grays, pw1%pw_grid%para%group, &
          !     pw1%pw_grid%para%bo, scale = scale, debug=test )
       END IF
 
@@ -398,8 +388,7 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: grays, pbuf, qbuf, rbuf, sbuf
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER      :: tbuf
       INTEGER                                            :: g_pos, handle, lg, lmax, mg, mmax, mx2, &
-                                                            mz2, n1, n2, ngpts, nmax, numtask, &
-                                                            numtask_g, numtask_r, rp
+                                                            mz2, n1, n2, ngpts, nmax, numtask, rp
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: p2p
       INTEGER, DIMENSION(2)                              :: r_dim, r_pos
       INTEGER, DIMENSION(:), POINTER                     :: n, nloc, nyzray
@@ -407,7 +396,6 @@ CONTAINS
       TYPE(fft_scratch_sizes)                            :: fft_scratch_size
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
       TYPE(mp_cart_type)                                 :: rs_group
-      TYPE(mp_comm_type)                                 :: gs_group
 
       CALL timeset(routineN, handle)
 
@@ -419,20 +407,14 @@ CONTAINS
 
       !..transform
       IF (pw1%pw_grid%para%ray_distribution) THEN
-         gs_group = pw1%pw_grid%para%group
-         rs_group = pw1%pw_grid%para%rs_group
+         rs_group = pw1%pw_grid%para%group
          nyzray => pw1%pw_grid%para%nyzray
          bo => pw1%pw_grid%para%bo
 
-         numtask_g = gs_group%num_pe
-         g_pos = gs_group%mepos
-         numtask_r = rs_group%num_pe
+         g_pos = rs_group%mepos
+         numtask = rs_group%num_pe
          r_dim = rs_group%num_pe_cart
          r_pos = rs_group%mepos_cart
-         IF (numtask_g /= numtask_r) THEN
-            CPABORT("Real space and G space groups are different.")
-         END IF
-         numtask = numtask_r
 
          lg = SIZE(grays, 1)
          mg = SIZE(grays, 2)
@@ -441,7 +423,7 @@ CONTAINS
 
          ALLOCATE (p2p(0:numtask - 1))
 
-         CALL gs_group%rank_compare(rs_group, p2p)
+         CALL rs_group%rank_compare(rs_group, p2p)
 
          rp = p2p(g_pos)
          mx2 = bo(2, 1, rp, 2) - bo(1, 1, rp, 2) + 1
@@ -470,7 +452,6 @@ CONTAINS
          fft_scratch_size%nmax = nmax
          fft_scratch_size%nmray = MAXVAL(nyzray)
          fft_scratch_size%nyzray = nyzray(g_pos)
-         fft_scratch_size%gs_group = gs_group
          fft_scratch_size%rs_group = rs_group
          fft_scratch_size%g_pos = g_pos
          fft_scratch_size%r_pos = r_pos
@@ -535,7 +516,7 @@ CONTAINS
 
             ! Exchange data ( transpose of matrix ) and sort
             IF (pw1%pw_grid%grid_span /= FULLSPACE) tbuf = z_zero
-            CALL x_to_yz(sbuf, gs_group, g_pos, p2p, pw1%pw_grid%para%yzp, nyzray, &
+            CALL x_to_yz(sbuf, rs_group, g_pos, p2p, pw1%pw_grid%para%yzp, nyzray, &
                          bo(:, :, :, 2), tbuf, fft_scratch)
 
             ! FFT along y and z
@@ -550,7 +531,7 @@ CONTAINS
 !--------------------------------------------------------------------------
       ELSE
          CPABORT("Not implemented (no ray_distr.) in: pw_gpu_c1dr3d_3d_ps.")
-         !CALL fft3d ( dir, n, pwin, grays, pw1%pw_grid%para%rs_group, &
+         !CALL fft3d ( dir, n, pwin, grays, pw1%pw_grid%para%group, &
          !     pw1%pw_grid%para%bo, scale = scale, debug=test )
       END IF
 

--- a/src/pw/pw_gpu.F
+++ b/src/pw/pw_gpu.F
@@ -96,13 +96,11 @@ CONTAINS
 !> \brief perform an fft followed by a gather on the gpu
 !> \param pw1 ...
 !> \param pw2 ...
-!> \param scale ...
 !> \author Benjamin G Levine
 ! **************************************************************************************************
-   SUBROUTINE pw_gpu_r3dc1d_3d(pw1, pw2, scale)
+   SUBROUTINE pw_gpu_r3dc1d_3d(pw1, pw2)
       TYPE(pw_r3d_rs_type), INTENT(IN)                   :: pw1
       TYPE(pw_c1d_gs_type), INTENT(INOUT)                :: pw2
-      REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_r3dc1d_3d'
 
@@ -110,6 +108,7 @@ CONTAINS
       INTEGER                                            :: handle, l1, l2, l3, ngpts
       INTEGER, DIMENSION(:), POINTER                     :: npts
       INTEGER, POINTER                                   :: ptr_ghatmap
+      REAL(KIND=dp)                                      :: scale
       REAL(KIND=dp), POINTER                             :: ptr_pwin
       INTERFACE
          SUBROUTINE pw_gpu_cfffg_c(din, zout, ghatmap, npts, ngpts, scale) BIND(C, name="pw_gpu_cfffg")
@@ -125,6 +124,8 @@ CONTAINS
       END INTERFACE
 
       CALL timeset(routineN, handle)
+
+      scale = 1.0_dp/REAL(pw1%pw_grid%ngpts, KIND=dp)
 
       ngpts = SIZE(pw2%pw_grid%gsq)
       l1 = LBOUND(pw1%array, 1)
@@ -143,7 +144,6 @@ CONTAINS
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
       CALL pw_gpu_cfffg_c(c_loc(ptr_pwin), c_loc(ptr_pwout), c_loc(ptr_ghatmap), npts, ngpts, scale)
 #else
-      MARK_USED(scale)
       CPABORT("Compiled without pw offloading.")
 #endif
 
@@ -154,13 +154,11 @@ CONTAINS
 !> \brief perform an scatter followed by a fft on the gpu
 !> \param pw1 ...
 !> \param pw2 ...
-!> \param scale ...
 !> \author Benjamin G Levine
 ! **************************************************************************************************
-   SUBROUTINE pw_gpu_c1dr3d_3d(pw1, pw2, scale)
+   SUBROUTINE pw_gpu_c1dr3d_3d(pw1, pw2)
       TYPE(pw_c1d_gs_type), INTENT(IN)                   :: pw1
       TYPE(pw_r3d_rs_type), INTENT(INOUT)                :: pw2
-      REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'pw_gpu_c1dr3d_3d'
 
@@ -168,6 +166,7 @@ CONTAINS
       INTEGER                                            :: handle, l1, l2, l3, ngpts, nmaps
       INTEGER, DIMENSION(:), POINTER                     :: npts
       INTEGER, POINTER                                   :: ptr_ghatmap
+      REAL(KIND=dp)                                      :: scale
       REAL(KIND=dp), POINTER                             :: ptr_pwout
       INTERFACE
          SUBROUTINE pw_gpu_sfffc_c(zin, dout, ghatmap, npts, ngpts, nmaps, scale) BIND(C, name="pw_gpu_sfffc")
@@ -182,6 +181,8 @@ CONTAINS
       END INTERFACE
 
       CALL timeset(routineN, handle)
+
+      scale = 1.0_dp
 
       ngpts = SIZE(pw1%pw_grid%gsq)
       l1 = LBOUND(pw2%array, 1)
@@ -201,7 +202,6 @@ CONTAINS
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
       CALL pw_gpu_sfffc_c(c_loc(ptr_pwin), c_loc(ptr_pwout), c_loc(ptr_ghatmap), npts, ngpts, nmaps, scale)
 #else
-      MARK_USED(scale)
       CPABORT("Compiled without pw offloading")
 #endif
 
@@ -212,13 +212,11 @@ CONTAINS
 !> \brief perform an parallel fft followed by a gather on the gpu
 !> \param pw1 ...
 !> \param pw2 ...
-!> \param scale ...
 !> \author Andreas Gloess
 ! **************************************************************************************************
-   SUBROUTINE pw_gpu_r3dc1d_3d_ps(pw1, pw2, scale)
+   SUBROUTINE pw_gpu_r3dc1d_3d_ps(pw1, pw2)
       TYPE(pw_r3d_rs_type), INTENT(IN)                   :: pw1
       TYPE(pw_c1d_gs_type), INTENT(INOUT)                :: pw2
-      REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_gpu_r3dc1d_3d_ps'
 
@@ -230,11 +228,14 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: r_dim, r_pos
       INTEGER, DIMENSION(:), POINTER                     :: n, nloc, nyzray
       INTEGER, DIMENSION(:, :, :, :), POINTER            :: bo
+      REAL(KIND=dp)                                      :: scale
       TYPE(fft_scratch_sizes)                            :: fft_scratch_size
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
       TYPE(mp_cart_type)                                 :: rs_group
 
       CALL timeset(routineN, handle)
+
+      scale = 1.0_dp/REAL(pw1%pw_grid%ngpts, KIND=dp)
 
       ! dimensions
       n => pw1%pw_grid%npts
@@ -364,8 +365,6 @@ CONTAINS
 !--------------------------------------------------------------------------
       ELSE
          CPABORT("Not implemented (no ray_distr.) in: pw_gpu_r3dc1d_3d_ps.")
-         !CALL fft3d ( dir, n, pwin, grays, pw1%pw_grid%para%group, &
-         !     pw1%pw_grid%para%bo, scale = scale, debug=test )
       END IF
 
       CALL timestop(handle)
@@ -375,13 +374,11 @@ CONTAINS
 !> \brief perform an parallel scatter followed by a fft on the gpu
 !> \param pw1 ...
 !> \param pw2 ...
-!> \param scale ...
 !> \author Andreas Gloess
 ! **************************************************************************************************
-   SUBROUTINE pw_gpu_c1dr3d_3d_ps(pw1, pw2, scale)
+   SUBROUTINE pw_gpu_c1dr3d_3d_ps(pw1, pw2)
       TYPE(pw_c1d_gs_type), INTENT(IN)                   :: pw1
       TYPE(pw_r3d_rs_type), INTENT(INOUT)                :: pw2
-      REAL(KIND=dp), INTENT(IN)                          :: scale
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pw_gpu_c1dr3d_3d_ps'
 
@@ -393,11 +390,14 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: r_dim, r_pos
       INTEGER, DIMENSION(:), POINTER                     :: n, nloc, nyzray
       INTEGER, DIMENSION(:, :, :, :), POINTER            :: bo
+      REAL(KIND=dp)                                      :: scale
       TYPE(fft_scratch_sizes)                            :: fft_scratch_size
       TYPE(fft_scratch_type), POINTER                    :: fft_scratch
       TYPE(mp_cart_type)                                 :: rs_group
 
       CALL timeset(routineN, handle)
+
+      scale = 1.0_dp
 
       ! dimensions
       n => pw1%pw_grid%npts
@@ -531,8 +531,6 @@ CONTAINS
 !--------------------------------------------------------------------------
       ELSE
          CPABORT("Not implemented (no ray_distr.) in: pw_gpu_c1dr3d_3d_ps.")
-         !CALL fft3d ( dir, n, pwin, grays, pw1%pw_grid%para%group, &
-         !     pw1%pw_grid%para%bo, scale = scale, debug=test )
       END IF
 
       CALL timestop(handle)

--- a/src/pw/pw_grid_types.F
+++ b/src/pw/pw_grid_types.F
@@ -14,9 +14,7 @@ MODULE pw_grid_types
 
    USE kinds,                           ONLY: dp,&
                                               int_8
-   USE message_passing,                 ONLY: mp_cart_type,&
-                                              mp_comm_null,&
-                                              mp_comm_type
+   USE message_passing,                 ONLY: mp_cart_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -41,18 +39,10 @@ MODULE pw_grid_types
       INTEGER :: mode = PW_MODE_LOCAL ! 0 = local = PW_MODE_LOCAL ; 1 = distributed = PW_MODE_DISTRIBUTED
       LOGICAL :: ray_distribution = .FALSE. ! block or pencil distribution
       LOGICAL :: blocked = .FALSE. ! block or pencil distribution
-      TYPE(mp_comm_type) :: group = mp_comm_null ! MPI group
-      INTEGER :: my_pos = -1! Position within group
-      INTEGER :: group_size = -1! # of Processors in group
-      LOGICAL :: group_head = .FALSE. ! Master process within group
-      INTEGER :: group_head_id = 0 ! Id of group_head
       INTEGER, DIMENSION(:, :, :), ALLOCATABLE :: yzp ! g-space rays (xy,k,pe)
       INTEGER, DIMENSION(:, :), ALLOCATABLE :: yzq ! local inverse pointer of yzp
       INTEGER, DIMENSION(:), ALLOCATABLE :: nyzray ! number of g-space rays (pe)
-      TYPE(mp_cart_type) :: rs_group = mp_cart_type() ! real space group (2-dim cart)
-      INTEGER :: rs_mpo = -1 ! real space group position
-      INTEGER, DIMENSION(2) :: rs_dims = 0 ! real space group dimensions
-      INTEGER, DIMENSION(2) :: rs_pos = -1 ! real space group positions in grid
+      TYPE(mp_cart_type) :: group = mp_cart_type() ! real space group (2-dim cart)
       INTEGER, DIMENSION(:, :, :, :), ALLOCATABLE :: bo ! list of axis distribution
       INTEGER, DIMENSION(:), ALLOCATABLE :: pos_of_x ! what my_pos holds a given x plane....should go: hard-codes to plane distributed
    END TYPE pw_para_type

--- a/src/pw/pw_grids.F
+++ b/src/pw/pw_grids.F
@@ -98,6 +98,8 @@ CONTAINS
       TYPE(pw_grid_type), POINTER                        :: pw_grid
       INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bounds
 
+      INTEGER, DIMENSION(2)                              :: rs_dims
+
       CPASSERT(.NOT. ASSOCIATED(pw_grid))
       ALLOCATE (pw_grid)
       pw_grid%bounds = bounds
@@ -110,7 +112,6 @@ CONTAINS
       pw_grid%ngpts_cut_local = pw_grid%ngpts_local
       pw_grid%grid_span = FULLSPACE
       pw_grid%para%mode = PW_MODE_LOCAL
-      pw_grid%para%rs_dims = 0
       pw_grid%reference = 0
       pw_grid%ref_count = 1
       NULLIFY (pw_grid%g)
@@ -124,13 +125,9 @@ CONTAINS
       pw_grid%id_nr = grid_tag
 
       ! parallel info
-      CALL pw_grid%para%group%from_dup(mp_comm_self)
-      pw_grid%para%group_size = pw_grid%para%group%num_pe
-      pw_grid%para%my_pos = pw_grid%para%group%mepos
-      pw_grid%para%group_head_id = 0
-      pw_grid%para%group_head = &
-         (pw_grid%para%group_head_id == pw_grid%para%my_pos)
-      IF (pw_grid%para%group_size > 1) THEN
+      rs_dims = 1
+      CALL pw_grid%para%group%create(mp_comm_self, 2, rs_dims)
+      IF (pw_grid%para%group%num_pe > 1) THEN
          pw_grid%para%mode = PW_MODE_DISTRIBUTED
       ELSE
          pw_grid%para%mode = PW_MODE_LOCAL
@@ -320,7 +317,6 @@ CONTAINS
       pw_grid%cutoff = 0.0_dp
       pw_grid%grid_span = FULLSPACE
       pw_grid%para%mode = PW_MODE_LOCAL
-      pw_grid%para%rs_dims = 0
       pw_grid%reference = 0
       pw_grid%ref_count = 1
       NULLIFY (pw_grid%g)
@@ -334,13 +330,7 @@ CONTAINS
       pw_grid%id_nr = grid_tag
 
       ! parallel info
-      CALL pw_grid%para%group%from_dup(mp_comm)
-      pw_grid%para%group_size = pw_grid%para%group%num_pe
-      pw_grid%para%my_pos = pw_grid%para%group%mepos
-      pw_grid%para%group_head_id = 0
-      pw_grid%para%group_head = &
-         (pw_grid%para%group_head_id == pw_grid%para%my_pos)
-      IF (pw_grid%para%group_size > 1) THEN
+      IF (mp_comm%num_pe > 1) THEN
          pw_grid%para%mode = PW_MODE_DISTRIBUTED
       ELSE
          pw_grid%para%mode = PW_MODE_LOCAL
@@ -426,7 +416,7 @@ CONTAINS
          CPABORT("BOUNDS, NPTS or CUTOFF have to be specified")
       END IF
 
-      CALL pw_grid_setup_internal(cell_hmat, cell_h_inv, cell_deth, pw_grid, bounds_local=bounds_local, &
+      CALL pw_grid_setup_internal(cell_hmat, cell_h_inv, cell_deth, pw_grid, mp_comm, bounds_local=bounds_local, &
                                   blocked=blocked, ref_grid=ref_grid, rs_dims=rs_dims, iounit=iounit)
 
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
@@ -520,6 +510,7 @@ CONTAINS
 !> \param cell_h_inv ...
 !> \param cell_deth ...
 !> \param pw_grid ...
+!> \param mp_comm ...
 !> \param bounds_local ...
 !> \param blocked ...
 !> \param ref_grid ...
@@ -539,11 +530,13 @@ CONTAINS
 !> \note
 !>      this is the function that should be used in the future
 ! **************************************************************************************************
-   SUBROUTINE pw_grid_setup_internal(cell_hmat, cell_h_inv, cell_deth, pw_grid, bounds_local, &
+   SUBROUTINE pw_grid_setup_internal(cell_hmat, cell_h_inv, cell_deth, pw_grid, mp_comm, bounds_local, &
                                      blocked, ref_grid, rs_dims, iounit)
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: cell_hmat, cell_h_inv
       REAL(KIND=dp), INTENT(IN)                          :: cell_deth
       TYPE(pw_grid_type), INTENT(INOUT)                  :: pw_grid
+
+      CLASS(mp_comm_type), INTENT(IN) :: mp_comm
       INTEGER, DIMENSION(2, 3), INTENT(IN), OPTIONAL     :: bounds_local
       INTEGER, INTENT(in), OPTIONAL                      :: blocked
       TYPE(pw_grid_type), INTENT(in), OPTIONAL           :: ref_grid
@@ -580,7 +573,7 @@ CONTAINS
       ! the indices in yz_mask are from -n/2 .. n/2 shifted by n/2 + 1
       ! these are not mapped indices !
       ALLOCATE (yz_mask(n(2), n(3)))
-      CALL pw_grid_count(cell_h_inv, pw_grid, ecut, yz_mask)
+      CALL pw_grid_count(cell_h_inv, pw_grid, mp_comm, ecut, yz_mask)
 
       ! Check if reference grid is compatible
       IF (PRESENT(ref_grid)) THEN
@@ -590,7 +583,7 @@ CONTAINS
       END IF
 
       ! Distribute grid
-      CALL pw_grid_distribute(pw_grid, yz_mask, bounds_local=bounds_local, ref_grid=ref_grid, blocked=blocked, &
+      CALL pw_grid_distribute(pw_grid, mp_comm, yz_mask, bounds_local=bounds_local, ref_grid=ref_grid, blocked=blocked, &
                               rs_dims=rs_dims)
 
       ! Allocate the grid fields
@@ -714,7 +707,7 @@ CONTAINS
          n(2) = pw_grid%ngpts_local
          CALL pw_grid%para%group%sum(n(1:2))
          n(3) = SUM(pw_grid%para%nyzray)
-         rv(:, 1) = REAL(n, KIND=dp)/REAL(pw_grid%para%group_size, KIND=dp)
+         rv(:, 1) = REAL(n, KIND=dp)/REAL(pw_grid%para%group%num_pe, KIND=dp)
          n(1) = pw_grid%ngpts_cut_local
          n(2) = pw_grid%ngpts_local
          CALL pw_grid%para%group%max(n(1:2))
@@ -726,7 +719,7 @@ CONTAINS
          n(3) = MINVAL(pw_grid%para%nyzray)
          rv(:, 3) = REAL(n, KIND=dp)
 
-         IF (pw_grid%para%group_head .AND. info > 0) THEN
+         IF (info > 0) THEN
             WRITE (info, '(/,A,T71,I10)') &
                " PW_GRID| Information for grid number ", pw_grid%id_nr
             IF (pw_grid%reference > 0) THEN
@@ -734,10 +727,10 @@ CONTAINS
                   " PW_GRID| Number of the reference grid ", pw_grid%reference
             END IF
             WRITE (info, '(A,T60,I10,A)') &
-               " PW_GRID| Grid distributed over ", pw_grid%para%group_size, &
+               " PW_GRID| Grid distributed over ", pw_grid%para%group%num_pe, &
                " processors"
             WRITE (info, '(A,T71,2I5)') &
-               " PW_GRID| Real space group dimensions ", pw_grid%para%rs_dims
+               " PW_GRID| Real space group dimensions ", pw_grid%para%group%num_pe_cart
             IF (pw_grid%para%blocked) THEN
                WRITE (info, '(A,T78,A)') " PW_GRID| the grid is blocked: ", "YES"
             ELSE
@@ -780,6 +773,7 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief Distribute grids in real and Fourier Space to the processors in group
 !> \param pw_grid ...
+!> \param mp_comm ...
 !> \param yz_mask ...
 !> \param bounds_local ...
 !> \param ref_grid ...
@@ -791,9 +785,11 @@ CONTAINS
 !>      JGH (09-Sep-2003) reduce scaling for distribution
 !> \author JGH (22-12-2000)
 ! **************************************************************************************************
-   SUBROUTINE pw_grid_distribute(pw_grid, yz_mask, bounds_local, ref_grid, blocked, rs_dims)
+   SUBROUTINE pw_grid_distribute(pw_grid, mp_comm, yz_mask, bounds_local, ref_grid, blocked, rs_dims)
 
       TYPE(pw_grid_type), INTENT(INOUT)                  :: pw_grid
+
+      CLASS(mp_comm_type), INTENT(IN) :: mp_comm
       INTEGER, DIMENSION(:, :), INTENT(INOUT)            :: yz_mask
       INTEGER, DIMENSION(2, 3), INTENT(IN), OPTIONAL     :: bounds_local
       TYPE(pw_grid_type), INTENT(IN), OPTIONAL           :: ref_grid
@@ -809,6 +805,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: pemap
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: yz_index
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: axis_dist_all
+      INTEGER, DIMENSION(2)                              :: my_rs_dims
       INTEGER, DIMENSION(2, 3)                           :: axis_dist
       LOGICAL                                            :: blocking
 
@@ -820,9 +817,10 @@ CONTAINS
       lbz = pw_grid%bounds(1, 3)
 
       pw_grid%ngpts = PRODUCT(INT(pw_grid%npts, KIND=int_8))
-      CPASSERT(ALL(pw_grid%para%rs_dims == 0))
+
+      my_rs_dims = 0
       IF (PRESENT(rs_dims)) THEN
-         pw_grid%para%rs_dims = rs_dims
+         my_rs_dims = rs_dims
       END IF
 
       IF (PRESENT(blocked)) THEN
@@ -843,13 +841,9 @@ CONTAINS
          pw_grid%ngpts_cut_local = INT(pw_grid%ngpts_cut)
          CPASSERT(pw_grid%ngpts < HUGE(pw_grid%ngpts_local))
          pw_grid%ngpts_local = INT(pw_grid%ngpts)
-         pw_grid%para%rs_dims = 1
-         CALL pw_grid%para%rs_group%create(pw_grid%para%group, 2, &
-                                           pw_grid%para%rs_dims)
-         pw_grid%para%rs_dims = pw_grid%para%rs_group%num_pe_cart
-         pw_grid%para%rs_pos = pw_grid%para%rs_group%mepos_cart
-         CALL pw_grid%para%rs_group%rank_cart(pw_grid%para%rs_pos, pw_grid%para%rs_mpo)
-         pw_grid%para%group_size = 1
+         my_rs_dims = 1
+         CALL pw_grid%para%group%create(mp_comm, 2, my_rs_dims)
+
          ALLOCATE (pw_grid%para%bo(2, 3, 0:0, 3))
          DO i = 1, 3
             pw_grid%para%bo(1, 1:3, 0, i) = 1
@@ -862,7 +856,7 @@ CONTAINS
          nx = pw_grid%npts(1)
          ny = pw_grid%npts(2)
          nz = pw_grid%npts(3)
-         np = pw_grid%para%group_size
+         np = mp_comm%num_pe
 
          ! The user can specify 2 strictly positive indices => specific layout
          !                      1 strictly positive index   => the other is fixed by the number of CPUs
@@ -873,42 +867,42 @@ CONTAINS
          ! if blocking is free:
          !                      1) blocked=.FALSE. for plane distributions
          !                      2) blocked=.TRUE.  for non-plane distributions
-         IF (ANY(pw_grid%para%rs_dims <= 0)) THEN
-            IF (ALL(pw_grid%para%rs_dims <= 0)) THEN
-               pw_grid%para%rs_dims = (/0, 0/)
+         IF (ANY(my_rs_dims <= 0)) THEN
+            IF (ALL(my_rs_dims <= 0)) THEN
+               my_rs_dims = [0, 0]
             ELSE
-               IF (pw_grid%para%rs_dims(1) > 0) THEN
-                  pw_grid%para%rs_dims(2) = np/pw_grid%para%rs_dims(1)
+               IF (my_rs_dims(1) > 0) THEN
+                  my_rs_dims(2) = np/my_rs_dims(1)
                ELSE
-                  pw_grid%para%rs_dims(1) = np/pw_grid%para%rs_dims(2)
+                  my_rs_dims(1) = np/my_rs_dims(2)
                END IF
             END IF
          END IF
          ! reset if the distribution can not be fulfilled
-         IF (PRODUCT(pw_grid%para%rs_dims) .NE. np) pw_grid%para%rs_dims = (/0, 0/)
-         ! reset if the distribution can not be dealt with (/1,np/)
-         IF (ALL(pw_grid%para%rs_dims == (/1, np/))) pw_grid%para%rs_dims = (/0, 0/)
+         IF (PRODUCT(my_rs_dims) .NE. np) my_rs_dims = [0, 0]
+         ! reset if the distribution can not be dealt with [1,np]
+         IF (ALL(my_rs_dims == [1, np])) my_rs_dims = [0, 0]
 
-         ! if (/0,0/) now, we can optimize it ourselves
-         IF (ALL(pw_grid%para%rs_dims == (/0, 0/))) THEN
+         ! if [0,0] now, we can optimize it ourselves
+         IF (ALL(my_rs_dims == [0, 0])) THEN
             ! only small grids have a chance to be 2d distributed
             IF (nx < np) THEN
                ! gives the most square looking distribution
-               CALL mp_dims_create(np, pw_grid%para%rs_dims)
+               CALL mp_dims_create(np, my_rs_dims)
                ! we tend to like the first index being smaller than the second
-               IF (pw_grid%para%rs_dims(1) > pw_grid%para%rs_dims(2)) THEN
-                  itmp = pw_grid%para%rs_dims(1)
-                  pw_grid%para%rs_dims(1) = pw_grid%para%rs_dims(2)
-                  pw_grid%para%rs_dims(2) = itmp
+               IF (my_rs_dims(1) > my_rs_dims(2)) THEN
+                  itmp = my_rs_dims(1)
+                  my_rs_dims(1) = my_rs_dims(2)
+                  my_rs_dims(2) = itmp
                END IF
                ! but should avoid having the first index 1 in all cases
-               IF (pw_grid%para%rs_dims(1) == 1) THEN
-                  itmp = pw_grid%para%rs_dims(1)
-                  pw_grid%para%rs_dims(1) = pw_grid%para%rs_dims(2)
-                  pw_grid%para%rs_dims(2) = itmp
+               IF (my_rs_dims(1) == 1) THEN
+                  itmp = my_rs_dims(1)
+                  my_rs_dims(1) = my_rs_dims(2)
+                  my_rs_dims(2) = itmp
                END IF
             ELSE
-               pw_grid%para%rs_dims = (/np, 1/)
+               my_rs_dims = [np, 1]
             END IF
          END IF
 
@@ -919,7 +913,7 @@ CONTAINS
          CASE (do_pw_grid_blocked_true)
             blocking = .TRUE.
          CASE (do_pw_grid_blocked_free)
-            IF (ALL(pw_grid%para%rs_dims == (/np, 1/))) THEN
+            IF (ALL(my_rs_dims == [np, 1])) THEN
                blocking = .FALSE.
             ELSE
                blocking = .TRUE.
@@ -929,20 +923,16 @@ CONTAINS
          END SELECT
 
          !..create group for real space distribution
-         CALL pw_grid%para%rs_group%create(pw_grid%para%group, 2, &
-                                           pw_grid%para%rs_dims)
-         pw_grid%para%rs_dims = pw_grid%para%rs_group%num_pe_cart
-         pw_grid%para%rs_pos = pw_grid%para%rs_group%mepos_cart
-         CALL pw_grid%para%rs_group%rank_cart(pw_grid%para%rs_pos, pw_grid%para%rs_mpo)
+         CALL pw_grid%para%group%create(mp_comm, 2, my_rs_dims)
 
          IF (PRESENT(bounds_local)) THEN
             pw_grid%bounds_local = bounds_local
          ELSE
-            lo = get_limit(nx, pw_grid%para%rs_dims(1), &
-                           pw_grid%para%rs_pos(1))
+            lo = get_limit(nx, pw_grid%para%group%num_pe_cart(1), &
+                           pw_grid%para%group%mepos_cart(1))
             pw_grid%bounds_local(:, 1) = lo + pw_grid%bounds(1, 1) - 1
-            lo = get_limit(ny, pw_grid%para%rs_dims(2), &
-                           pw_grid%para%rs_pos(2))
+            lo = get_limit(ny, pw_grid%para%group%num_pe_cart(2), &
+                           pw_grid%para%group%mepos_cart(2))
             pw_grid%bounds_local(:, 2) = lo + pw_grid%bounds(1, 2) - 1
             pw_grid%bounds_local(:, 3) = pw_grid%bounds(:, 3)
          END IF
@@ -952,7 +942,7 @@ CONTAINS
 
          !..the third distribution is needed for the second step in the FFT
          ALLOCATE (pw_grid%para%bo(2, 3, 0:np - 1, 3))
-         rsd = pw_grid%para%rs_dims
+         rsd = pw_grid%para%group%num_pe_cart
 
          IF (PRESENT(bounds_local)) THEN
             ! axis_dist tells what portion of 1 .. nx , 1 .. ny , 1 .. nz are in the current process
@@ -960,9 +950,9 @@ CONTAINS
                axis_dist(:, i) = bounds_local(:, i) - pw_grid%bounds(1, i) + 1
             END DO
             ALLOCATE (axis_dist_all(2, 3, np))
-            CALL pw_grid%para%rs_group%allgather(axis_dist, axis_dist_all)
+            CALL pw_grid%para%group%allgather(axis_dist, axis_dist_all)
             DO ip = 0, np - 1
-               CALL pw_grid%para%rs_group%coords(ip, coor)
+               CALL pw_grid%para%group%coords(ip, coor)
                ! distribution xyZ
                pw_grid%para%bo(1:2, 1, ip, 1) = axis_dist_all(1:2, 1, ip + 1)
                pw_grid%para%bo(1:2, 2, ip, 1) = axis_dist_all(1:2, 2, ip + 1)
@@ -982,7 +972,7 @@ CONTAINS
             DEALLOCATE (axis_dist_all)
          ELSE
             DO ip = 0, np - 1
-               CALL pw_grid%para%rs_group%coords(ip, coor)
+               CALL pw_grid%para%group%coords(ip, coor)
                ! distribution xyZ
                pw_grid%para%bo(1:2, 1, ip, 1) = get_limit(nx, rsd(1), coor(1))
                pw_grid%para%bo(1:2, 2, ip, 1) = get_limit(ny, rsd(2), coor(2))
@@ -1035,7 +1025,7 @@ CONTAINS
                yz_mask(lo(1), lo(2)) = 0
                ip = MOD(i - 1, 2*np)
                IF (ip > np - 1) ip = 2*np - ip - 1
-               IF (ip == pw_grid%para%my_pos) THEN
+               IF (ip == pw_grid%para%group%mepos) THEN
                   pw_grid%ngpts_cut_local = pw_grid%ngpts_cut_local + gmax
                END IF
                pw_grid%para%yzq(lo(1), lo(2)) = ip
@@ -1074,7 +1064,7 @@ CONTAINS
                      ns = pw_grid%para%nyzray(ip)
                      pw_grid%para%yzp(1, ns, ip) = j
                      pw_grid%para%yzp(2, ns, ip) = i
-                     IF (ip == pw_grid%para%my_pos) THEN
+                     IF (ip == pw_grid%para%group%mepos) THEN
                         pw_grid%para%yzq(j, i) = ns
                      ELSE
                         pw_grid%para%yzq(j, i) = -1
@@ -1103,7 +1093,7 @@ CONTAINS
                pw_grid%para%nyzray(ip) = n*m
             END DO
 
-            ipl = pw_grid%para%rs_mpo
+            ipl = pw_grid%para%group%mepos
             l = pw_grid%para%bo(2, 1, ipl, 3) - &
                 pw_grid%para%bo(1, 1, ipl, 3) + 1
             m = pw_grid%para%bo(2, 2, ipl, 3) - &
@@ -1133,7 +1123,7 @@ CONTAINS
 
             ALLOCATE (pemap(0:np - 1))
             pemap = 0
-            pemap(pw_grid%para%my_pos) = pw_grid%para%rs_mpo
+            pemap(pw_grid%para%group%mepos) = pw_grid%para%group%mepos
             CALL pw_grid%para%group%sum(pemap)
 
             DO ip = 0, np - 1
@@ -1164,7 +1154,7 @@ CONTAINS
       IF (pw_grid%para%mode .EQ. PW_MODE_DISTRIBUTED) THEN
          ALLOCATE (pw_grid%para%pos_of_x(pw_grid%bounds(1, 1):pw_grid%bounds(2, 1)))
          pw_grid%para%pos_of_x = 0
-         pw_grid%para%pos_of_x(pw_grid%bounds_local(1, 1):pw_grid%bounds_local(2, 1)) = pw_grid%para%my_pos
+         pw_grid%para%pos_of_x(pw_grid%bounds_local(1, 1):pw_grid%bounds_local(2, 1)) = pw_grid%para%group%mepos
          CALL pw_grid%para%group%sum(pw_grid%para%pos_of_x)
       ELSE
          ! this should not be needed
@@ -1203,7 +1193,7 @@ CONTAINS
       mz = SIZE(yz_mask, 2)
 
       ! loop over all processors and all g vectors yz lines on this processor
-      DO ip = 0, ref_grid%para%group_size - 1
+      DO ip = 0, ref_grid%para%group%num_pe - 1
          DO ig = 1, ref_grid%para%nyzray(ip)
             ! go from mapped coordinates to original coordinates
             ! 1, 2, ..., n-1, n -> 0, 1, ..., (n/2)-1, -(n/2), -(n/2)+1, ..., -2, -1
@@ -1235,7 +1225,7 @@ CONTAINS
                yz_mask(y, z) = 0
                pw_grid%para%yzq(y, z) = ip
             END IF
-            IF (ip == pw_grid%para%my_pos) THEN
+            IF (ip == pw_grid%para%group%mepos) THEN
                pw_grid%ngpts_cut_local = pw_grid%ngpts_cut_local + gmax
             END IF
          END DO
@@ -1370,6 +1360,7 @@ CONTAINS
 !> \brief Count total number of g vectors
 !> \param h_inv ...
 !> \param pw_grid ...
+!> \param mp_comm ...
 !> \param cutoff ...
 !> \param yz_mask ...
 !> \par History
@@ -1377,10 +1368,12 @@ CONTAINS
 !> \author apsi
 !>      Christopher Mundy
 ! **************************************************************************************************
-   SUBROUTINE pw_grid_count(h_inv, pw_grid, cutoff, yz_mask)
+   SUBROUTINE pw_grid_count(h_inv, pw_grid, mp_comm, cutoff, yz_mask)
 
       REAL(KIND=dp), DIMENSION(3, 3)                     :: h_inv
       TYPE(pw_grid_type), INTENT(INOUT)                  :: pw_grid
+
+      CLASS(mp_comm_type), INTENT(IN) :: mp_comm
       REAL(KIND=dp), INTENT(IN)                          :: cutoff
       INTEGER, DIMENSION(:, :), INTENT(OUT)              :: yz_mask
 
@@ -1405,7 +1398,7 @@ CONTAINS
             nlim(2) = n_upperlimit
          ELSE IF (pw_grid%para%mode == PW_MODE_DISTRIBUTED) THEN
             n = n_upperlimit - bounds(1, 3) + 1
-            nlim = get_limit(n, pw_grid%para%group_size, pw_grid%para%my_pos)
+            nlim = get_limit(n, mp_comm%num_pe, mp_comm%mepos)
             nlim = nlim + bounds(1, 3) - 1
          ELSE
             CPABORT("para % mode not specified")
@@ -1435,8 +1428,8 @@ CONTAINS
 
       ! number of g-vectors for grid
       IF (pw_grid%para%mode == PW_MODE_DISTRIBUTED) THEN
-         CALL pw_grid%para%group%sum(gpt)
-         CALL pw_grid%para%group%sum(yz_mask)
+         CALL mp_comm%sum(gpt)
+         CALL mp_comm%sum(yz_mask)
       END IF
       pw_grid%ngpts_cut = gpt
 
@@ -1512,7 +1505,7 @@ CONTAINS
          IF (pw_grid%para%ray_distribution) THEN
 
             gpt = 0
-            ip = pw_grid%para%my_pos
+            ip = pw_grid%para%group%mepos
             DO i = 1, pw_grid%para%nyzray(ip)
                n = pw_grid%para%yzp(2, i, ip) + lbz - 1
                m = pw_grid%para%yzp(1, i, ip) + lby - 1
@@ -1540,7 +1533,7 @@ CONTAINS
 
          ELSE
 
-            bol = pw_grid%para%bo(:, :, pw_grid%para%rs_mpo, 3)
+            bol = pw_grid%para%bo(:, :, pw_grid%para%group%mepos, 3)
             gpt = 0
             DO n = bounds(1, 3), bounds(2, 3)
                IF (n < 0) THEN
@@ -1731,7 +1724,7 @@ CONTAINS
 
       IF (pw_grid%para%mode == PW_MODE_DISTRIBUTED) THEN
          ALLOCATE (pw_grid%grays(pw_grid%npts(1), &
-                                 pw_grid%para%nyzray(pw_grid%para%my_pos)))
+                                 pw_grid%para%nyzray(pw_grid%para%group%mepos)))
       END IF
 
       ALLOCATE (pw_grid%mapl%pos(bounds(1, 1):bounds(2, 1)))
@@ -2067,7 +2060,7 @@ CONTAINS
             END DO
          END IF
 
-         ip = pw_grid%para%my_pos
+         ip = pw_grid%para%group%mepos
          is = 0
          DO i = 1, nz
             DO j = 1, ny
@@ -2237,8 +2230,6 @@ CONTAINS
             END IF
             ! also release groups
             CALL pw_grid%para%group%free()
-            IF (PRODUCT(pw_grid%para%rs_dims) /= 0) &
-               CALL pw_grid%para%rs_group%free()
             IF (ALLOCATED(pw_grid%para%pos_of_x)) THEN
                DEALLOCATE (pw_grid%para%pos_of_x)
             END IF

--- a/src/pw/pw_grids.F
+++ b/src/pw/pw_grids.F
@@ -68,7 +68,6 @@ MODULE pw_grids
    PRIVATE
    PUBLIC :: pw_grid_create, pw_grid_retain, pw_grid_release
    PUBLIC :: get_pw_grid_info, pw_grid_compare
-   PUBLIC :: pw_grid_setup
    PUBLIC :: pw_grid_change
 
    INTEGER :: grid_tag = 0
@@ -78,32 +77,37 @@ MODULE pw_grids
    INTEGER, PARAMETER, PUBLIC               :: do_pw_grid_blocked_false = 0, &
                                                do_pw_grid_blocked_true = 1, &
                                                do_pw_grid_blocked_free = 2
+
+   INTERFACE pw_grid_create
+      MODULE PROCEDURE pw_grid_create_local
+      MODULE PROCEDURE pw_grid_create_extended
+   END INTERFACE
+
 CONTAINS
 
 ! **************************************************************************************************
-!> \brief Initialize a PW grid with all defaults
+!> \brief Initialize a PW grid with bounds only (used by some routines)
 !> \param pw_grid ...
-!> \param pe_group ...
-!> \param local ...
+!> \param bounds ...
 !> \par History
 !>      JGH (21-Feb-2003) : initialize pw_grid%reference
 !> \author JGH (7-Feb-2001) & fawzi
 ! **************************************************************************************************
-   SUBROUTINE pw_grid_create(pw_grid, pe_group, local)
+   SUBROUTINE pw_grid_create_local(pw_grid, bounds)
 
       TYPE(pw_grid_type), POINTER                        :: pw_grid
+      INTEGER, DIMENSION(2, 3), INTENT(IN)               :: bounds
 
-      CLASS(mp_comm_type), INTENT(in)                     :: pe_group
-      LOGICAL, INTENT(IN), OPTIONAL                      :: local
-
-      LOGICAL                                            :: my_local
-
-      my_local = .FALSE.
-      IF (PRESENT(local)) my_local = local
       CPASSERT(.NOT. ASSOCIATED(pw_grid))
       ALLOCATE (pw_grid)
-      pw_grid%bounds = 0
-      pw_grid%cutoff = 0.0_dp
+      pw_grid%bounds = bounds
+      pw_grid%bounds_local = bounds
+      pw_grid%npts = bounds(2, :) - bounds(1, :) + 1
+      pw_grid%npts_local = pw_grid%npts
+      pw_grid%ngpts = PRODUCT(INT(pw_grid%npts, KIND=int_8))
+      pw_grid%ngpts_cut = pw_grid%ngpts
+      pw_grid%ngpts_local = PRODUCT(pw_grid%npts)
+      pw_grid%ngpts_cut_local = pw_grid%ngpts_local
       pw_grid%grid_span = FULLSPACE
       pw_grid%para%mode = PW_MODE_LOCAL
       pw_grid%para%rs_dims = 0
@@ -120,19 +124,19 @@ CONTAINS
       pw_grid%id_nr = grid_tag
 
       ! parallel info
-      CALL pw_grid%para%group%from_dup(pe_group)
+      CALL pw_grid%para%group%from_dup(mp_comm_self)
       pw_grid%para%group_size = pw_grid%para%group%num_pe
       pw_grid%para%my_pos = pw_grid%para%group%mepos
       pw_grid%para%group_head_id = 0
       pw_grid%para%group_head = &
          (pw_grid%para%group_head_id == pw_grid%para%my_pos)
-      IF (pw_grid%para%group_size > 1 .AND. (.NOT. my_local)) THEN
+      IF (pw_grid%para%group_size > 1) THEN
          pw_grid%para%mode = PW_MODE_DISTRIBUTED
       ELSE
          pw_grid%para%mode = PW_MODE_LOCAL
       END IF
 
-   END SUBROUTINE pw_grid_create
+   END SUBROUTINE pw_grid_create_local
 
 ! **************************************************************************************************
 !> \brief Check if two pw_grids are equal
@@ -260,8 +264,9 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief sets up a pw_grid
-!> \param cell_hmat ...
 !> \param pw_grid ...
+!> \param mp_comm ...
+!> \param cell_hmat ...
 !> \param grid_span ...
 !> \param cutoff ...
 !> \param bounds ...
@@ -280,12 +285,14 @@ CONTAINS
 !> \note
 !>      this is the function that should be used in the future
 ! **************************************************************************************************
-   SUBROUTINE pw_grid_setup(cell_hmat, pw_grid, grid_span, cutoff, bounds, bounds_local, npts, &
-                            spherical, odd, fft_usage, ncommensurate, icommensurate, blocked, ref_grid, &
-                            rs_dims, iounit)
+   SUBROUTINE pw_grid_create_extended(pw_grid, mp_comm, cell_hmat, grid_span, cutoff, bounds, bounds_local, npts, &
+                                      spherical, odd, fft_usage, ncommensurate, icommensurate, blocked, ref_grid, &
+                                      rs_dims, iounit)
 
+      TYPE(pw_grid_type), POINTER                        :: pw_grid
       REAL(KIND=dp), DIMENSION(3, 3), INTENT(IN)         :: cell_hmat
-      TYPE(pw_grid_type), INTENT(INOUT)                  :: pw_grid
+
+      CLASS(mp_comm_type), INTENT(IN) :: mp_comm
       INTEGER, INTENT(in), OPTIONAL                      :: grid_span
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: cutoff
       INTEGER, DIMENSION(2, 3), INTENT(IN), OPTIONAL     :: bounds, bounds_local
@@ -306,6 +313,38 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3, 3)                     :: cell_h_inv
 
       CALL timeset(routineN, handle)
+
+      CPASSERT(.NOT. ASSOCIATED(pw_grid))
+      ALLOCATE (pw_grid)
+      pw_grid%bounds = 0
+      pw_grid%cutoff = 0.0_dp
+      pw_grid%grid_span = FULLSPACE
+      pw_grid%para%mode = PW_MODE_LOCAL
+      pw_grid%para%rs_dims = 0
+      pw_grid%reference = 0
+      pw_grid%ref_count = 1
+      NULLIFY (pw_grid%g)
+      NULLIFY (pw_grid%gsq)
+      NULLIFY (pw_grid%g_hatmap)
+      NULLIFY (pw_grid%gidx)
+      NULLIFY (pw_grid%grays)
+
+      ! assign a unique tag to this grid
+      grid_tag = grid_tag + 1
+      pw_grid%id_nr = grid_tag
+
+      ! parallel info
+      CALL pw_grid%para%group%from_dup(mp_comm)
+      pw_grid%para%group_size = pw_grid%para%group%num_pe
+      pw_grid%para%my_pos = pw_grid%para%group%mepos
+      pw_grid%para%group_head_id = 0
+      pw_grid%para%group_head = &
+         (pw_grid%para%group_head_id == pw_grid%para%my_pos)
+      IF (pw_grid%para%group_size > 1) THEN
+         pw_grid%para%mode = PW_MODE_DISTRIBUTED
+      ELSE
+         pw_grid%para%mode = PW_MODE_LOCAL
+      END IF
 
       cell_deth = ABS(det_3x3(cell_hmat))
       IF (cell_deth < 1.0E-10_dp) THEN
@@ -396,7 +435,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE pw_grid_setup
+   END SUBROUTINE pw_grid_create_extended
 
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
 ! **************************************************************************************************
@@ -772,7 +811,6 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: axis_dist_all
       INTEGER, DIMENSION(2, 3)                           :: axis_dist
       LOGICAL                                            :: blocking
-      TYPE(mp_comm_type)                                 :: mp_comm_old
 
 !------------------------------------------------------------------------------
 
@@ -806,8 +844,7 @@ CONTAINS
          CPASSERT(pw_grid%ngpts < HUGE(pw_grid%ngpts_local))
          pw_grid%ngpts_local = INT(pw_grid%ngpts)
          pw_grid%para%rs_dims = 1
-         mp_comm_old = mp_comm_self
-         CALL pw_grid%para%rs_group%create(mp_comm_old, 2, &
+         CALL pw_grid%para%rs_group%create(pw_grid%para%group, 2, &
                                            pw_grid%para%rs_dims)
          pw_grid%para%rs_dims = pw_grid%para%rs_group%num_pe_cart
          pw_grid%para%rs_pos = pw_grid%para%rs_group%mepos_cart

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -1351,7 +1351,7 @@ CONTAINS
                                     !..parallel FFT
                                     !
 
-                                    IF (test .AND. pw1%pw_grid%para%group_head .AND. out_unit > 0) THEN
+                                    IF (test .AND. out_unit > 0) THEN
                                        WRITE (out_unit, '(A)') " FFT Protocol "
                                        #:if space=="rs"
                                           WRITE (out_unit, '(A,T76,A)') "  Transform direction ", "FWFFT"
@@ -1365,7 +1365,7 @@ CONTAINS
                                        WRITE (out_unit, '(A,T66,E15.6)') "  scale factor", norm
                                     END IF
 
-                                    my_pos = pw1%pw_grid%para%my_pos
+                                    my_pos = pw1%pw_grid%para%group%mepos
                                     nrays = pw1%pw_grid%para%nyzray(my_pos)
                                     grays => pw1%pw_grid%grays
 
@@ -1377,15 +1377,14 @@ CONTAINS
                                           !..transform
                                           IF (pw1%pw_grid%para%ray_distribution) THEN
                                              CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
-                                                        pw1%pw_grid%para%rs_group, &
                                                         pw1%pw_grid%para%yzp, pw1%pw_grid%para%nyzray, &
                                                         pw1%pw_grid%para%bo, scale=norm, debug=test)
                                           ELSE
-                                             CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%rs_group, &
+                                             CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
                                                         pw1%pw_grid%para%bo, scale=norm, debug=test)
                                           END IF
                                           !..prepare output
-                                          IF (test .AND. pw1%pw_grid%para%group_head .AND. out_unit > 0) &
+                                          IF (test .AND. out_unit > 0) &
                                              WRITE (out_unit, '(A)') "  PW_GATHER : 2d -> 1d "
                                           CALL pw_gather_p_${kind2}$ (pw2, grays)
                                        #:elif kind=="r3d" and kind2=="c1d"
@@ -1404,15 +1403,14 @@ CONTAINS
                                              !..transform
                                              IF (pw1%pw_grid%para%ray_distribution) THEN
                                                 CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
-                                                           pw1%pw_grid%para%rs_group, &
                                                            pw1%pw_grid%para%yzp, pw1%pw_grid%para%nyzray, &
                                                            pw1%pw_grid%para%bo, scale=norm, debug=test)
                                              ELSE
-                                                CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%rs_group, &
+                                                CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
                                                            pw1%pw_grid%para%bo, scale=norm, debug=test)
                                              END IF
                                              !..prepare output
-                                             IF (test .AND. pw1%pw_grid%para%group_head .AND. out_unit > 0) &
+                                             IF (test .AND. out_unit > 0) &
                                                 WRITE (out_unit, '(A)') "  PW_GATHER : 2d -> 1d "
                                              CALL pw_gather_p_${kind2}$ (pw2, grays)
                                              DEALLOCATE (c_in)
@@ -1424,7 +1422,7 @@ CONTAINS
                                     #:else
                                        #:if kind=="c1d" and kind2=="c3d"
                                           !..prepare input
-                                          IF (test .AND. pw1%pw_grid%para%group_head .AND. out_unit > 0) &
+                                          IF (test .AND. out_unit > 0) &
                                              WRITE (out_unit, '(A)') "  PW_SCATTER : 2d -> 1d "
                                           grays = z_zero
                                           CALL pw_scatter_p_${kind}$ (pw1, grays)
@@ -1432,11 +1430,10 @@ CONTAINS
                                           !..transform
                                           IF (pw1%pw_grid%para%ray_distribution) THEN
                                              CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
-                                                        pw1%pw_grid%para%rs_group, &
                                                         pw1%pw_grid%para%yzp, pw1%pw_grid%para%nyzray, &
                                                         pw1%pw_grid%para%bo, scale=norm, debug=test)
                                           ELSE
-                                             CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%rs_group, &
+                                             CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
                                                         pw1%pw_grid%para%bo, scale=norm, debug=test)
                                           END IF
                                           !..prepare output (nothing to do)
@@ -1449,7 +1446,7 @@ CONTAINS
                                           ELSE
 #endif
 !..   prepare input
-                                             IF (test .AND. pw1%pw_grid%para%group_head .AND. out_unit > 0) &
+                                             IF (test .AND. out_unit > 0) &
                                                 WRITE (out_unit, '(A)') "  PW_SCATTER : 2d -> 1d "
                                              grays = z_zero
                                              CALL pw_scatter_p_${kind}$ (pw1, grays)
@@ -1458,15 +1455,14 @@ CONTAINS
                                              !..transform
                                              IF (pw1%pw_grid%para%ray_distribution) THEN
                                                 CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
-                                                           pw1%pw_grid%para%rs_group, &
                                                            pw1%pw_grid%para%yzp, pw1%pw_grid%para%nyzray, &
                                                            pw1%pw_grid%para%bo, scale=norm, debug=test)
                                              ELSE
-                                                CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%rs_group, &
+                                                CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
                                                            pw1%pw_grid%para%bo, scale=norm, debug=test)
                                              END IF
                                              !..prepare output
-                                             IF (test .AND. pw1%pw_grid%para%group_head .AND. out_unit > 0) &
+                                             IF (test .AND. out_unit > 0) &
                                                 WRITE (out_unit, '(A)') "  Real part "
                                              CALL pw_copy_from_array(pw2, c_in)
                                              DEALLOCATE (c_in)
@@ -1477,7 +1473,7 @@ CONTAINS
                                     #:endif
                                  END IF
 
-                                 IF (test .AND. pw1%pw_grid%para%group_head .AND. out_unit > 0) THEN
+                                 IF (test .AND. out_unit > 0) THEN
                                     WRITE (out_unit, '(A)') " End of FFT Protocol "
                                  END IF
 

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -1177,7 +1177,6 @@ CONTAINS
                                  #:endif
                                  INTEGER, DIMENSION(:), POINTER                     :: n
                                  LOGICAL                                            :: test
-                                 REAL(KIND=dp)                                      :: norm
 
                                  CALL timeset(routineN, handle2)
                                  out_unit = cp_logger_get_default_io_unit()
@@ -1203,15 +1202,6 @@ CONTAINS
                                     END IF
                                  END IF
 
-                                 !..prepare input
-                                 #:if space == "rs"
-                                    norm = 1.0_dp/pw1%pw_grid%ngpts
-                                 #:elif space == "gs"
-                                    norm = 1.0_dp
-                                 #:else
-                                    #:stop "Unknown space tag: "+space
-                                 #:endif
-
                                  n => pw1%pw_grid%npts
 
                                  IF (pw1%pw_grid%para%mode == PW_MODE_LOCAL) THEN
@@ -1231,30 +1221,29 @@ CONTAINS
                                           WRITE (out_unit, '(A,T66,A)') "  in space ", "RECIPROCALSPACE"
                                           WRITE (out_unit, '(A,T66,A)') "  out space ", "RECIPROCALSPACE"
                                        #:endif
-                                       WRITE (out_unit, '(A,T66,E15.6)') "  scale factor", norm
                                     END IF
 
                                     #:if space=="rs"
                                        #:if kind==kind2=="c3d"
                                           c_in => pw1%array
                                           c_out => pw2%array
-                                          CALL fft3d(FWFFT, n, c_in, c_out, scale=norm, debug=test)
+                                          CALL fft3d(FWFFT, n, c_in, c_out, debug=test)
                                        #:elif kind=="r3d" and kind2=="c3d"
                                           pw2%array = CMPLX(pw1%array, 0.0_dp, KIND=dp)
                                           c_out => pw2%array
-                                          CALL fft3d(FWFFT, n, c_out, scale=norm, debug=test)
+                                          CALL fft3d(FWFFT, n, c_out, debug=test)
                                        #:elif kind=="c3d" and kind2=="c1d"
                                           c_in => pw1%array
                                           ALLOCATE (c_out(n(1), n(2), n(3)))
                                           ! transform
-                                          CALL fft3d(FWFFT, n, c_in, c_out, scale=norm, debug=test)
+                                          CALL fft3d(FWFFT, n, c_in, c_out, debug=test)
                                           ! gather results
                                           IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  PW_GATHER : 3d -> 1d "
                                           CALL pw_gather_s_${kind2}$_c3d(pw2, c_out)
                                           DEALLOCATE (c_out)
                                        #:elif kind=="r3d" and kind2=="c1d"
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
-                                          CALL pw_gpu_r3dc1d_3d(pw1, pw2, scale=norm)
+                                          CALL pw_gpu_r3dc1d_3d(pw1, pw2)
 #elif defined (__PW_FPGA)
                                           ALLOCATE (c_out(n(1), n(2), n(3)))
                                           ! check if bitstream for the fft size is present
@@ -1266,11 +1255,11 @@ CONTAINS
 #else
                                              CALL pw_fpga_r3dc1d_3d_dp(n, c_out)
 #endif
-                                             CALL zdscal(n(1)*n(2)*n(3), norm, c_out, 1)
+                                             CALL zdscal(n(1)*n(2)*n(3), 1.0_dp/pw1%pw_grid%ngpts, c_out, 1)
                                              CALL pw_gather_s_${kind2}$_c3d(pw2, c_out)
                                           ELSE
                                              CALL pw_copy_to_array(pw1, c_out)
-                                             CALL fft3d(FWFFT, n, c_out, scale=norm, debug=test)
+                                             CALL fft3d(FWFFT, n, c_out, debug=test)
                                              CALL pw_gather_s_${kind2}$_c3d(pw2, c_out)
                                           END IF
                                           DEALLOCATE (c_out)
@@ -1278,7 +1267,7 @@ CONTAINS
                                           ALLOCATE (c_out(n(1), n(2), n(3)))
                                           c_out = 0.0_dp
                                           CALL pw_copy_to_array(pw1, c_out)
-                                          CALL fft3d(FWFFT, n, c_out, scale=norm, debug=test)
+                                          CALL fft3d(FWFFT, n, c_out, debug=test)
                                           CALL pw_gather_s_${kind2}$_c3d(pw2, c_out)
                                           DEALLOCATE (c_out)
 #endif
@@ -1287,11 +1276,11 @@ CONTAINS
                                        #:if kind=="c3d" and kind2=="c3d"
                                           c_in => pw1%array
                                           c_out => pw2%array
-                                          CALL fft3d(BWFFT, n, c_in, c_out, scale=norm, debug=test)
+                                          CALL fft3d(BWFFT, n, c_in, c_out, debug=test)
                                        #:elif kind=="c3d" and kind2=="r3d"
                                           c_in => pw1%array
                                           ALLOCATE (c_out(n(1), n(2), n(3)))
-                                          CALL fft3d(BWFFT, n, c_in, c_out, scale=norm, debug=test)
+                                          CALL fft3d(BWFFT, n, c_in, c_out, debug=test)
                                           ! use real part only
                                           IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  REAL part "
                                           pw2%array = REAL(c_out, KIND=dp)
@@ -1300,10 +1289,10 @@ CONTAINS
                                           c_out => pw2%array
                                           IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  PW_SCATTER : 3d -> 1d "
                                           CALL pw_scatter_s_${kind}$_c3d(pw1, c_out)
-                                          CALL fft3d(BWFFT, n, c_out, scale=norm, debug=test)
+                                          CALL fft3d(BWFFT, n, c_out, debug=test)
                                        #:elif kind=="c1d" and kind2=="r3d"
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
-                                          CALL pw_gpu_c1dr3d_3d(pw1, pw2, scale=norm)
+                                          CALL pw_gpu_c1dr3d_3d(pw1, pw2)
 #elif defined (__PW_FPGA)
                                           ALLOCATE (c_out(n(1), n(2), n(3)))
                                           ! check if bitstream for the fft size is present
@@ -1316,14 +1305,14 @@ CONTAINS
 #else
                                              CALL pw_fpga_c1dr3d_3d_dp(n, c_out)
 #endif
-                                             CALL zdscal(n(1)*n(2)*n(3), norm, c_out, 1)
+                                             CALL zdscal(n(1)*n(2)*n(3), 1.0_dp, c_out, 1)
                                              ! use real part only
                                              CALL pw_copy_from_array(pw2, c_out)
                                           ELSE
                                              IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  PW_SCATTER : 3d -> 1d "
                                              CALL pw_scatter_s_${kind}$_c3d(pw1, c_out)
                                              ! transform
-                                             CALL fft3d(BWFFT, n, c_out, scale=norm, debug=test)
+                                             CALL fft3d(BWFFT, n, c_out, debug=test)
                                              ! use real part only
                                              IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  REAL part "
                                              CALL pw_copy_from_array(pw2, c_out)
@@ -1334,7 +1323,7 @@ CONTAINS
                                           IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  PW_SCATTER : 3d -> 1d "
                                           CALL pw_scatter_s_${kind}$_c3d(pw1, c_out)
                                           ! transform
-                                          CALL fft3d(BWFFT, n, c_out, scale=norm, debug=test)
+                                          CALL fft3d(BWFFT, n, c_out, debug=test)
                                           ! use real part only
                                           IF (test .AND. out_unit > 0) WRITE (out_unit, '(A)') "  REAL part "
                                           CALL pw_copy_from_array(pw2, c_out)
@@ -1362,7 +1351,6 @@ CONTAINS
                                           WRITE (out_unit, '(A,T66,A)') "  in space ", "RECIPROCALSPACE"
                                           WRITE (out_unit, '(A,T66,A)') "  out space ", "RECIPROCALSPACE"
                                        #:endif
-                                       WRITE (out_unit, '(A,T66,E15.6)') "  scale factor", norm
                                     END IF
 
                                     my_pos = pw1%pw_grid%para%group%mepos
@@ -1378,10 +1366,10 @@ CONTAINS
                                           IF (pw1%pw_grid%para%ray_distribution) THEN
                                              CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
                                                         pw1%pw_grid%para%yzp, pw1%pw_grid%para%nyzray, &
-                                                        pw1%pw_grid%para%bo, scale=norm, debug=test)
+                                                        pw1%pw_grid%para%bo, debug=test)
                                           ELSE
                                              CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
-                                                        pw1%pw_grid%para%bo, scale=norm, debug=test)
+                                                        pw1%pw_grid%para%bo, debug=test)
                                           END IF
                                           !..prepare output
                                           IF (test .AND. out_unit > 0) &
@@ -1392,7 +1380,7 @@ CONTAINS
                                           ! (no ray dist. is not efficient in CUDA)
                                           use_pw_gpu = pw1%pw_grid%para%ray_distribution
                                           IF (use_pw_gpu) THEN
-                                             CALL pw_gpu_r3dc1d_3d_ps(pw1, pw2, scale=norm)
+                                             CALL pw_gpu_r3dc1d_3d_ps(pw1, pw2)
                                           ELSE
 #endif
 !..   prepare input
@@ -1404,10 +1392,10 @@ CONTAINS
                                              IF (pw1%pw_grid%para%ray_distribution) THEN
                                                 CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
                                                            pw1%pw_grid%para%yzp, pw1%pw_grid%para%nyzray, &
-                                                           pw1%pw_grid%para%bo, scale=norm, debug=test)
+                                                           pw1%pw_grid%para%bo, debug=test)
                                              ELSE
                                                 CALL fft3d(FWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
-                                                           pw1%pw_grid%para%bo, scale=norm, debug=test)
+                                                           pw1%pw_grid%para%bo, debug=test)
                                              END IF
                                              !..prepare output
                                              IF (test .AND. out_unit > 0) &
@@ -1431,10 +1419,10 @@ CONTAINS
                                           IF (pw1%pw_grid%para%ray_distribution) THEN
                                              CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
                                                         pw1%pw_grid%para%yzp, pw1%pw_grid%para%nyzray, &
-                                                        pw1%pw_grid%para%bo, scale=norm, debug=test)
+                                                        pw1%pw_grid%para%bo, debug=test)
                                           ELSE
                                              CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
-                                                        pw1%pw_grid%para%bo, scale=norm, debug=test)
+                                                        pw1%pw_grid%para%bo, debug=test)
                                           END IF
                                           !..prepare output (nothing to do)
                                        #:elif kind=="c1d" and kind2=="r3d"
@@ -1442,7 +1430,7 @@ CONTAINS
                                           ! (no ray dist. is not efficient in CUDA)
                                           use_pw_gpu = pw1%pw_grid%para%ray_distribution
                                           IF (use_pw_gpu) THEN
-                                             CALL pw_gpu_c1dr3d_3d_ps(pw1, pw2, scale=norm)
+                                             CALL pw_gpu_c1dr3d_3d_ps(pw1, pw2)
                                           ELSE
 #endif
 !..   prepare input
@@ -1456,10 +1444,10 @@ CONTAINS
                                              IF (pw1%pw_grid%para%ray_distribution) THEN
                                                 CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
                                                            pw1%pw_grid%para%yzp, pw1%pw_grid%para%nyzray, &
-                                                           pw1%pw_grid%para%bo, scale=norm, debug=test)
+                                                           pw1%pw_grid%para%bo, debug=test)
                                              ELSE
                                                 CALL fft3d(BWFFT, n, c_in, grays, pw1%pw_grid%para%group, &
-                                                           pw1%pw_grid%para%bo, scale=norm, debug=test)
+                                                           pw1%pw_grid%para%bo, debug=test)
                                              END IF
                                              !..prepare output
                                              IF (test .AND. out_unit > 0) &

--- a/src/pw/pw_spline_utils.F
+++ b/src/pw/pw_spline_utils.F
@@ -1050,7 +1050,7 @@ CONTAINS
          CALL timeset(routineN//"_comm", handle2)
          coarse_slice_size = (coarse_bo(2, 2) - coarse_bo(1, 2) + 1)* &
                              (coarse_bo(2, 3) - coarse_bo(1, 3) + 1)
-         n_procs = coarse_coeffs_pw%pw_grid%para%group_size
+         n_procs = coarse_coeffs_pw%pw_grid%para%group%num_pe
          ALLOCATE (send_size(0:n_procs - 1), send_offset(0:n_procs - 1), &
                    sent_size(0:n_procs - 1), rcv_size(0:n_procs - 1), &
                    rcv_offset(0:n_procs - 1), real_rcv_size(0:n_procs - 1))
@@ -2278,7 +2278,7 @@ CONTAINS
          CALL timeset(routineN//"_comm", handle2)
          coarse_slice_size = (coarse_bo(2, 2) - coarse_bo(1, 2) + 1)* &
                              (coarse_bo(2, 3) - coarse_bo(1, 3) + 1)
-         n_procs = coarse_coeffs_pw%pw_grid%para%group_size
+         n_procs = coarse_coeffs_pw%pw_grid%para%group%num_pe
          ALLOCATE (send_size(0:n_procs - 1), send_offset(0:n_procs - 1), &
                    sent_size(0:n_procs - 1), rcv_size(0:n_procs - 1), &
                    rcv_offset(0:n_procs - 1), pp_lb(0:n_procs - 1), &

--- a/src/pw/realspace_grid_cube.F
+++ b/src/pw/realspace_grid_cube.F
@@ -141,9 +141,9 @@ CONTAINS
 
          ALLOCATE (buf(L3:U3))
 
-         my_rank = pw%pw_grid%para%my_pos
+         my_rank = pw%pw_grid%para%group%mepos
          gid = pw%pw_grid%para%group
-         num_pe = pw%pw_grid%para%group_size
+         num_pe = pw%pw_grid%para%group%num_pe
          tag = 1
 
          rank (1) = unit_nr
@@ -265,8 +265,8 @@ CONTAINS
       END IF
       !get rs grids and parallel environment
       gid = grid%pw_grid%para%group
-      my_rank = grid%pw_grid%para%my_pos
-      num_pe = grid%pw_grid%para%group_size
+      my_rank = grid%pw_grid%para%group%mepos
+      num_pe = grid%pw_grid%para%group%num_pe
       tag = 1
 
       lbounds_local = grid%pw_grid%bounds_local(1, :)
@@ -402,8 +402,8 @@ CONTAINS
 
       !get rs grids and parallel envnment
       gid = grid%pw_grid%para%group
-      my_rank = grid%pw_grid%para%my_pos
-      num_pe = grid%pw_grid%para%group_size
+      my_rank = grid%pw_grid%para%group%mepos
+      num_pe = grid%pw_grid%para%group%num_pe
       tag = 1
 
       DO i = 1, 3
@@ -457,7 +457,7 @@ CONTAINS
          CALL close_file(unit_number=extunit_handle)
       END IF
       ! Sync offset and start parallel read
-      CALL gid%bcast(offset_global, grid%pw_grid%para%group_head_id)
+      CALL gid%bcast(offset_global, grid%pw_grid%para%group%source)
       BOF = offset_global
       CALL extunit%open(groupid=gid, filepath=filename, amode_status=file_amode_rdonly)
       ! Determine byte offsets for each grid z-slice which are local to a process
@@ -655,7 +655,7 @@ CONTAINS
 
       !get rs grids and parallel envnment
       gid = grid%pw_grid%para%group
-      my_rank = grid%pw_grid%para%my_pos
+      my_rank = grid%pw_grid%para%group%mepos
 
       ! Shortcut
       lbounds = grid%pw_grid%bounds(1, :)
@@ -743,7 +743,7 @@ CONTAINS
          END IF
       END IF
       ! Sync offset
-      CALL gid%bcast(BOF, grid%pw_grid%para%group_head_id)
+      CALL gid%bcast(BOF, grid%pw_grid%para%group%source)
       ! Determine byte offsets for each grid z-slice which are local to a process
       ! and convert z-slices to cube format compatible strings
       ALLOCATE (displacements(nslices))
@@ -874,9 +874,9 @@ CONTAINS
       ALLOCATE (buf(L3:U3))
       IF (DOUBLE) ALLOCATE (buf2(L3:U3))
 
-      my_rank = pw%pw_grid%para%my_pos
+      my_rank = pw%pw_grid%para%group%mepos
       gid = pw%pw_grid%para%group
-      num_pe = pw%pw_grid%para%group_size
+      num_pe = pw%pw_grid%para%group%num_pe
       tag = 1
 
       rank (1) = unit_nr

--- a/src/pw/realspace_grid_types.F
+++ b/src/pw/realspace_grid_types.F
@@ -110,7 +110,6 @@ MODULE realspace_grid_types
       ! they are most useful for fully distributed grids, where they reflect the topology of the grid
       TYPE(mp_comm_type) :: group = mp_comm_null
       INTEGER :: my_pos = -1
-      LOGICAL :: group_head = .FALSE.
       INTEGER :: group_size = 0
       INTEGER, DIMENSION(3) :: group_dim = -1
       INTEGER, DIMENSION(3) :: group_coor = -1
@@ -250,14 +249,13 @@ CONTAINS
          desc%distributed = .FALSE.
          desc%group = mp_comm_null
          desc%group_size = 1
-         desc%group_head = .TRUE.
          desc%group_dim = 1
          desc%group_coor = 0
          desc%my_pos = 0
       ELSE
          ! group size of desc grid
          ! global grid dimensions are still the same
-         desc%group_size = pw_grid%para%group_size
+         desc%group_size = pw_grid%para%group%num_pe
          desc%npts = pw_grid%npts
          desc%ngpts = PRODUCT(INT(desc%npts, KIND=int_8))
          desc%lb = pw_grid%bounds(1, :)
@@ -359,7 +357,6 @@ CONTAINS
             END IF
             desc%distributed = .FALSE.
             desc%parallel = .TRUE.
-            desc%group_head = pw_grid%para%group_head
             desc%group_coor(:) = 0
             desc%my_virtual_pos = 0
 
@@ -386,7 +383,6 @@ CONTAINS
             ! we are going parallel on the real space grid
             desc%parallel = .TRUE.
             desc%distributed = .TRUE.
-            desc%group_head = (desc%my_pos == 0)
 
             ! set up global info about the distribution
             ALLOCATE (desc%rank2coord(3, 0:desc%group_size - 1))
@@ -772,8 +768,8 @@ CONTAINS
       INTEGER, DIMENSION(3)                              :: lb, ub
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: recvbuf, sendbuf, swaparray
 
-      ASSOCIATE (np => pw%pw_grid%para%group_size, bo => pw%pw_grid%para%bo(1:2, 1:3, 0:pw%pw_grid%para%group_size - 1, 1), &
-                 pbo => pw%pw_grid%bounds, group => pw%pw_grid%para%rs_group, mepos => pw%pw_grid%para%rs_mpo, &
+      ASSOCIATE (np => pw%pw_grid%para%group%num_pe, bo => pw%pw_grid%para%bo(1:2, 1:3, 0:pw%pw_grid%para%group%num_pe - 1, 1), &
+                 pbo => pw%pw_grid%bounds, group => pw%pw_grid%para%group, mepos => pw%pw_grid%para%group%mepos, &
                  grid => rs%r)
          ALLOCATE (rcount(0:np - 1))
          DO ip = 1, np
@@ -842,8 +838,8 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: recvbuf, sendbuf, swaparray
       TYPE(mp_request_type), DIMENSION(2)                :: req
 
-      ASSOCIATE (np => pw%pw_grid%para%group_size, bo => pw%pw_grid%para%bo(1:2, 1:3, 0:pw%pw_grid%para%group_size - 1, 1), &
-                 pbo => pw%pw_grid%bounds, group => pw%pw_grid%para%rs_group, mepos => pw%pw_grid%para%rs_mpo, &
+      ASSOCIATE (np => pw%pw_grid%para%group%num_pe, bo => pw%pw_grid%para%bo(1:2, 1:3, 0:pw%pw_grid%para%group%num_pe - 1, 1), &
+                 pbo => pw%pw_grid%bounds, group => pw%pw_grid%para%group, mepos => pw%pw_grid%para%group%mepos, &
                  grid => rs%r)
          ALLOCATE (rcount(0:np - 1))
          DO ip = 1, np
@@ -1206,22 +1202,22 @@ CONTAINS
       END DO
 
       ! This is the real redistribution
-      ALLOCATE (bounds(0:pw%pw_grid%para%group_size - 1, 1:4))
+      ALLOCATE (bounds(0:pw%pw_grid%para%group%num_pe - 1, 1:4))
 
       ! work out the pw grid points each proc holds
-      DO i = 0, pw%pw_grid%para%group_size - 1
+      DO i = 0, pw%pw_grid%para%group%num_pe - 1
          bounds(i, 1:2) = pw%pw_grid%para%bo(1:2, 1, i, 1)
          bounds(i, 3:4) = pw%pw_grid%para%bo(1:2, 2, i, 1)
          bounds(i, 1:2) = bounds(i, 1:2) - pw%pw_grid%npts(1)/2 - 1
          bounds(i, 3:4) = bounds(i, 3:4) - pw%pw_grid%npts(2)/2 - 1
       END DO
 
-      ALLOCATE (send_tasks(0:pw%pw_grid%para%group_size - 1, 1:6))
-      ALLOCATE (send_sizes(0:pw%pw_grid%para%group_size - 1))
-      ALLOCATE (send_disps(0:pw%pw_grid%para%group_size - 1))
-      ALLOCATE (recv_tasks(0:pw%pw_grid%para%group_size - 1, 1:6))
-      ALLOCATE (recv_sizes(0:pw%pw_grid%para%group_size - 1))
-      ALLOCATE (recv_disps(0:pw%pw_grid%para%group_size - 1))
+      ALLOCATE (send_tasks(0:pw%pw_grid%para%group%num_pe - 1, 1:6))
+      ALLOCATE (send_sizes(0:pw%pw_grid%para%group%num_pe - 1))
+      ALLOCATE (send_disps(0:pw%pw_grid%para%group%num_pe - 1))
+      ALLOCATE (recv_tasks(0:pw%pw_grid%para%group%num_pe - 1, 1:6))
+      ALLOCATE (recv_sizes(0:pw%pw_grid%para%group%num_pe - 1))
+      ALLOCATE (recv_disps(0:pw%pw_grid%para%group%num_pe - 1))
       send_tasks(:, 1) = 1
       send_tasks(:, 2) = 0
       send_tasks(:, 3) = 1
@@ -1232,7 +1228,7 @@ CONTAINS
       recv_sizes = 0
 
       my_rs_rank = rs%desc%my_pos
-      my_pw_rank = pw%pw_grid%para%rs_mpo
+      my_pw_rank = pw%pw_grid%para%group%mepos
 
       ! find the processors that should hold our data
       ! should be part of the rs grid type
@@ -1284,7 +1280,7 @@ CONTAINS
       ub_recv(:) = ub_send(:)
 !$OMP PARALLEL DO DEFAULT(NONE), &
 !$OMP             SHARED(pw,lb_send,ub_send,bounds,send_tasks,send_sizes)
-      DO j = 0, pw%pw_grid%para%group_size - 1
+      DO j = 0, pw%pw_grid%para%group%num_pe - 1
 
          IF (lb_send(1) .GT. bounds(j, 2)) CYCLE
          IF (ub_send(1) .LT. bounds(j, 1)) CYCLE
@@ -1305,7 +1301,7 @@ CONTAINS
 
       send_disps(0) = 0
       recv_disps(0) = 0
-      DO i = 1, pw%pw_grid%para%group_size - 1
+      DO i = 1, pw%pw_grid%para%group%num_pe - 1
          send_disps(i) = send_disps(i - 1) + send_sizes(i - 1)
          recv_disps(i) = recv_disps(i - 1) + recv_sizes(i - 1)
       END DO
@@ -1465,21 +1461,21 @@ CONTAINS
 
       ! This is the real redistribution
 
-      ALLOCATE (bounds(0:pw%pw_grid%para%group_size - 1, 1:4))
+      ALLOCATE (bounds(0:pw%pw_grid%para%group%num_pe - 1, 1:4))
 
-      DO i = 0, pw%pw_grid%para%group_size - 1
+      DO i = 0, pw%pw_grid%para%group%num_pe - 1
          bounds(i, 1:2) = pw%pw_grid%para%bo(1:2, 1, i, 1)
          bounds(i, 3:4) = pw%pw_grid%para%bo(1:2, 2, i, 1)
          bounds(i, 1:2) = bounds(i, 1:2) - pw%pw_grid%npts(1)/2 - 1
          bounds(i, 3:4) = bounds(i, 3:4) - pw%pw_grid%npts(2)/2 - 1
       END DO
 
-      ALLOCATE (send_tasks(0:pw%pw_grid%para%group_size - 1, 1:6))
-      ALLOCATE (send_sizes(0:pw%pw_grid%para%group_size - 1))
-      ALLOCATE (send_disps(0:pw%pw_grid%para%group_size - 1))
-      ALLOCATE (recv_tasks(0:pw%pw_grid%para%group_size - 1, 1:6))
-      ALLOCATE (recv_sizes(0:pw%pw_grid%para%group_size - 1))
-      ALLOCATE (recv_disps(0:pw%pw_grid%para%group_size - 1))
+      ALLOCATE (send_tasks(0:pw%pw_grid%para%group%num_pe - 1, 1:6))
+      ALLOCATE (send_sizes(0:pw%pw_grid%para%group%num_pe - 1))
+      ALLOCATE (send_disps(0:pw%pw_grid%para%group%num_pe - 1))
+      ALLOCATE (recv_tasks(0:pw%pw_grid%para%group%num_pe - 1, 1:6))
+      ALLOCATE (recv_sizes(0:pw%pw_grid%para%group%num_pe - 1))
+      ALLOCATE (recv_disps(0:pw%pw_grid%para%group%num_pe - 1))
 
       send_tasks = 0
       send_tasks(:, 1) = 1
@@ -1500,7 +1496,7 @@ CONTAINS
       recv_sizes = 0
 
       my_rs_rank = rs%desc%my_pos
-      my_pw_rank = pw%pw_grid%para%rs_mpo
+      my_pw_rank = pw%pw_grid%para%group%mepos
 
       ! find the processors that should hold our data
       ! should be part of the rs grid type
@@ -1513,7 +1509,7 @@ CONTAINS
 !$OMP PARALLEL DO DEFAULT(NONE), &
 !$OMP             PRIVATE(coords,idir,pos,lb_send,ub_send), &
 !$OMP             SHARED(rs,bounds,my_rs_rank,send_tasks,send_sizes,pw)
-      DO i = 0, pw%pw_grid%para%group_size - 1
+      DO i = 0, pw%pw_grid%para%group%num_pe - 1
 
          coords(:) = rs%desc%rank2coord(:, rs%desc%real2virtual(i))
          !calculate the real rs grid points on each processor
@@ -1555,7 +1551,7 @@ CONTAINS
 
 !$OMP PARALLEL DO DEFAULT(NONE), &
 !$OMP             SHARED(pw,lb_send,ub_send,bounds,recv_tasks,recv_sizes)
-      DO j = 0, pw%pw_grid%para%group_size - 1
+      DO j = 0, pw%pw_grid%para%group%num_pe - 1
 
          IF (ub_send(1) .LT. bounds(j, 1)) CYCLE
          IF (lb_send(1) .GT. bounds(j, 2)) CYCLE
@@ -1576,7 +1572,7 @@ CONTAINS
 
       send_disps(0) = 0
       recv_disps(0) = 0
-      DO i = 1, pw%pw_grid%para%group_size - 1
+      DO i = 1, pw%pw_grid%para%group%num_pe - 1
          send_disps(i) = send_disps(i - 1) + send_sizes(i - 1)
          recv_disps(i) = recv_disps(i - 1) + recv_sizes(i - 1)
       END DO

--- a/src/pw_env_methods.F
+++ b/src/pw_env_methods.F
@@ -75,8 +75,7 @@ MODULE pw_env_methods
    USE pw_grids,                        ONLY: do_pw_grid_blocked_false,&
                                               pw_grid_change,&
                                               pw_grid_create,&
-                                              pw_grid_release,&
-                                              pw_grid_setup
+                                              pw_grid_release
    USE pw_poisson_methods,              ONLY: pw_poisson_set
    USE pw_poisson_read_input,           ONLY: pw_poisson_read_parameters
    USE pw_poisson_types,                ONLY: pw_poisson_analytic,&
@@ -381,8 +380,6 @@ CONTAINS
       END IF
 
       DO igrid_level = 1, ngrid_level
-         CALL pw_grid_create(pw_grid, para_env)
-
          cutilev = cutoff(igrid_level)
 
          ! the whole of QS seems to work fine with either blocked/non-blocked distribution in g-space
@@ -405,34 +402,34 @@ CONTAINS
 
          IF (igrid_level == 1) THEN
             IF (ASSOCIATED(old_pw_grid)) THEN
-               CALL pw_grid_setup(my_cell%hmat, pw_grid, grid_span=grid_span, &
-                                  cutoff=cutilev, &
-                                  spherical=spherical, odd=odd, fft_usage=.TRUE., &
-                                  ncommensurate=ncommensurate, icommensurate=igrid_level, &
-                                  blocked=do_pw_grid_blocked_false, &
-                                  ref_grid=old_pw_grid, &
-                                  rs_dims=distribution_layout, &
-                                  iounit=iounit)
+               CALL pw_grid_create(pw_grid, para_env, my_cell%hmat, grid_span=grid_span, &
+                                   cutoff=cutilev, &
+                                   spherical=spherical, odd=odd, fft_usage=.TRUE., &
+                                   ncommensurate=ncommensurate, icommensurate=igrid_level, &
+                                   blocked=do_pw_grid_blocked_false, &
+                                   ref_grid=old_pw_grid, &
+                                   rs_dims=distribution_layout, &
+                                   iounit=iounit)
                old_pw_grid => pw_grid
             ELSE
-               CALL pw_grid_setup(my_cell%hmat, pw_grid, grid_span=grid_span, &
-                                  cutoff=cutilev, &
-                                  spherical=spherical, odd=odd, fft_usage=.TRUE., &
-                                  ncommensurate=ncommensurate, icommensurate=igrid_level, &
-                                  blocked=blocked_id, &
-                                  rs_dims=distribution_layout, &
-                                  iounit=iounit)
+               CALL pw_grid_create(pw_grid, para_env, my_cell%hmat, grid_span=grid_span, &
+                                   cutoff=cutilev, &
+                                   spherical=spherical, odd=odd, fft_usage=.TRUE., &
+                                   ncommensurate=ncommensurate, icommensurate=igrid_level, &
+                                   blocked=blocked_id, &
+                                   rs_dims=distribution_layout, &
+                                   iounit=iounit)
                old_pw_grid => pw_grid
             END IF
          ELSE
-            CALL pw_grid_setup(my_cell%hmat, pw_grid, grid_span=grid_span, &
-                               cutoff=cutilev, &
-                               spherical=spherical, odd=odd, fft_usage=.TRUE., &
-                               ncommensurate=ncommensurate, icommensurate=igrid_level, &
-                               blocked=do_pw_grid_blocked_false, &
-                               ref_grid=old_pw_grid, &
-                               rs_dims=distribution_layout, &
-                               iounit=iounit)
+            CALL pw_grid_create(pw_grid, para_env, my_cell%hmat, grid_span=grid_span, &
+                                cutoff=cutilev, &
+                                spherical=spherical, odd=odd, fft_usage=.TRUE., &
+                                ncommensurate=ncommensurate, icommensurate=igrid_level, &
+                                blocked=do_pw_grid_blocked_false, &
+                                ref_grid=old_pw_grid, &
+                                rs_dims=distribution_layout, &
+                                iounit=iounit)
          END IF
 
          ! init pw_pools
@@ -470,16 +467,15 @@ CONTAINS
       IF (set_vdw_pool) THEN
          CPASSERT(ASSOCIATED(old_pw_grid))
          IF (.NOT. ASSOCIATED(vdw_ref_grid)) vdw_ref_grid => old_pw_grid
-         CALL pw_grid_create(vdw_grid, para_env)
          IF (iounit > 0) WRITE (iounit, "(/,T2,A)") "PW_GRID| Grid for non-local vdW functional"
-         CALL pw_grid_setup(my_cell%hmat, vdw_grid, grid_span=grid_span, &
-                            cutoff=dispersion_env%pw_cutoff, &
-                            spherical=spherical, odd=odd, fft_usage=.TRUE., &
-                            ncommensurate=0, icommensurate=0, &
-                            blocked=do_pw_grid_blocked_false, &
-                            ref_grid=vdw_ref_grid, &
-                            rs_dims=distribution_layout, &
-                            iounit=iounit)
+         CALL pw_grid_create(vdw_grid, para_env, my_cell%hmat, grid_span=grid_span, &
+                             cutoff=dispersion_env%pw_cutoff, &
+                             spherical=spherical, odd=odd, fft_usage=.TRUE., &
+                             ncommensurate=0, icommensurate=0, &
+                             blocked=do_pw_grid_blocked_false, &
+                             ref_grid=vdw_ref_grid, &
+                             rs_dims=distribution_layout, &
+                             iounit=iounit)
          CALL pw_pool_create(pw_env%vdw_pw_pool, pw_grid=vdw_grid)
          CALL pw_grid_release(vdw_grid)
       ELSE
@@ -987,17 +983,14 @@ CONTAINS
                                     extension=".Log")
 
       IF (uf_grid) THEN
-         CALL pw_grid_create(xc_super_ref_pw_grid, para_env)
-         CALL pw_grid_setup(cell_ref%hmat, xc_super_ref_pw_grid, grid_span=grid_span, &
-                            cutoff=4._dp*cutilev, spherical=spherical, odd=.FALSE., fft_usage=.TRUE., &
-                            ncommensurate=my_ncommensurate, icommensurate=1, &
-                            blocked=do_pw_grid_blocked_false, rs_dims=(/para_env%num_pe, 1/), &
-                            iounit=iounit)
+         CALL pw_grid_create(xc_super_ref_pw_grid, para_env, cell_ref%hmat, grid_span=grid_span, &
+                             cutoff=4._dp*cutilev, spherical=spherical, odd=.FALSE., fft_usage=.TRUE., &
+                             ncommensurate=my_ncommensurate, icommensurate=1, &
+                             blocked=do_pw_grid_blocked_false, rs_dims=(/para_env%num_pe, 1/), &
+                             iounit=iounit)
          super_ref_pw_grid => xc_super_ref_pw_grid
       END IF
       IF (mt_s_grid) THEN
-         CALL pw_grid_create(mt_super_ref_pw_grid, para_env)
-
          IF (ASSOCIATED(xc_super_ref_pw_grid)) THEN
             CPABORT("special grid for mt and fine xc grid not compatible")
          ELSE
@@ -1010,10 +1003,10 @@ CONTAINS
 
             ! bug appears for nn==no, also in old versions
             CPASSERT(ALL(nn > no))
-            CALL pw_grid_setup(cell_ref%hmat, mt_super_ref_pw_grid, &
-                               cutoff=my_cutilev, spherical=spherical, fft_usage=.TRUE., &
-                               blocked=do_pw_grid_blocked_false, rs_dims=(/para_env%num_pe, 1/), &
-                               iounit=iounit)
+            CALL pw_grid_create(mt_super_ref_pw_grid, para_env, cell_ref%hmat, &
+                                cutoff=my_cutilev, spherical=spherical, fft_usage=.TRUE., &
+                                blocked=do_pw_grid_blocked_false, rs_dims=(/para_env%num_pe, 1/), &
+                                iounit=iounit)
             super_ref_pw_grid => mt_super_ref_pw_grid
          END IF
       END IF

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -460,7 +460,7 @@ CONTAINS
       END DO
       pos_of_x => grids(auxbas_grid)%pw_grid%para%pos_of_x
       group = grids(auxbas_grid)%pw_grid%para%group
-      me = grids(auxbas_grid)%pw_grid%para%my_pos
+      me = grids(auxbas_grid)%pw_grid%para%group%mepos
       glb = rho%pw_grid%bounds(1, :)
       gub = rho%pw_grid%bounds(2, :)
       IF ((pos_of_x(glb(1)) .EQ. me) .AND. (pos_of_x(gub(1)) .EQ. me)) THEN

--- a/src/qmmm_init.F
+++ b/src/qmmm_init.F
@@ -559,7 +559,6 @@ CONTAINS
                                          pgfs=qmmm_env_qm%pgfs, &
                                          qm_cell_small=qm_cell_small, &
                                          mm_cell=mm_cell, &
-                                         para_env=para_env, &
                                          compatibility=qmmm_env_qm%compatibility, &
                                          qmmm_periodic=qmmm_periodic, &
                                          print_section=print_section, &
@@ -576,7 +575,6 @@ CONTAINS
                                             pgfs=added_charges%pgfs, &
                                             qm_cell_small=qm_cell_small, &
                                             mm_cell=mm_cell, &
-                                            para_env=para_env, &
                                             compatibility=qmmm_env_qm%compatibility, &
                                             qmmm_periodic=qmmm_periodic, &
                                             print_section=print_section, &
@@ -594,7 +592,6 @@ CONTAINS
                                             pgfs=added_shells%pgfs, &
                                             qm_cell_small=qm_cell_small, &
                                             mm_cell=mm_cell, &
-                                            para_env=para_env, &
                                             compatibility=qmmm_env_qm%compatibility, &
                                             qmmm_periodic=qmmm_periodic, &
                                             print_section=print_section, &

--- a/src/qmmm_per_elpot.F
+++ b/src/qmmm_per_elpot.F
@@ -66,7 +66,6 @@ CONTAINS
 !> \param pgfs ...
 !> \param qm_cell_small ...
 !> \param mm_cell ...
-!> \param para_env ...
 !> \param compatibility ...
 !> \param qmmm_periodic ...
 !> \param print_section ...
@@ -79,14 +78,13 @@ CONTAINS
 !> \author Teodoro Laino
 ! **************************************************************************************************
    SUBROUTINE qmmm_per_potential_init(qmmm_coupl_type, per_potentials, potentials, &
-                                      pgfs, qm_cell_small, mm_cell, para_env, compatibility, qmmm_periodic, print_section, &
+                                      pgfs, qm_cell_small, mm_cell, compatibility, qmmm_periodic, print_section, &
                                       eps_mm_rspace, maxchrg, ncp, ncpl)
       INTEGER, INTENT(IN)                                :: qmmm_coupl_type
       TYPE(qmmm_per_pot_p_type), DIMENSION(:), POINTER   :: per_potentials
       TYPE(qmmm_pot_p_type), DIMENSION(:), POINTER       :: potentials
       TYPE(qmmm_gaussian_p_type), DIMENSION(:), POINTER  :: pgfs
       TYPE(cell_type), POINTER                           :: qm_cell_small, mm_cell
-      TYPE(mp_para_env_type), POINTER                    :: para_env
       LOGICAL, INTENT(IN)                                :: compatibility
       TYPE(section_vals_type), POINTER                   :: qmmm_periodic, print_section
       REAL(KIND=dp), INTENT(IN)                          :: eps_mm_rspace, maxchrg
@@ -227,7 +225,7 @@ CONTAINS
          CALL qmmm_per_pot_type_create(per_potentials(K)%Pot, LG=LG, gx=gx, gy=gy, gz=gz, &
                                        Gmax=Gmax, Kmax=Kmax, n_rep_real=n_rep_real, &
                                        Fac=Fac, mm_atom_index=mm_atom_index, &
-                                       mm_cell=mm_cell, para_env=para_env, &
+                                       mm_cell=mm_cell, &
                                        qmmm_per_section=qmmm_periodic, print_section=print_section)
 
          iw = cp_print_key_unit_nr(logger, print_section, "PERIODIC_INFO", &
@@ -267,7 +265,6 @@ CONTAINS
 !> \param Fac ...
 !> \param mm_atom_index ...
 !> \param mm_cell ...
-!> \param para_env ...
 !> \param qmmm_per_section ...
 !> \param print_section ...
 !> \par History
@@ -275,7 +272,7 @@ CONTAINS
 !> \author Teodoro Laino
 ! **************************************************************************************************
    SUBROUTINE qmmm_per_pot_type_create(Pot, LG, gx, gy, gz, GMax, Kmax, n_rep_real, &
-                                       Fac, mm_atom_index, mm_cell, para_env, qmmm_per_section, print_section)
+                                       Fac, mm_atom_index, mm_cell, qmmm_per_section, print_section)
       TYPE(qmmm_per_pot_type), POINTER                   :: Pot
       REAL(KIND=dp), DIMENSION(:), POINTER               :: LG, gx, gy, gz
       REAL(KIND=dp), INTENT(IN)                          :: Gmax
@@ -283,7 +280,6 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: Fac(3)
       INTEGER, DIMENSION(:), POINTER                     :: mm_atom_index
       TYPE(cell_type), POINTER                           :: mm_cell
-      TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(section_vals_type), POINTER                   :: qmmm_per_section, print_section
 
       INTEGER                                            :: npts(3)
@@ -313,7 +309,7 @@ CONTAINS
       grid_print_section => section_vals_get_subs_vals(print_section, "GRID_INFORMATION")
       CALL Setup_Ewald_Spline(pw_grid=Pot%pw_grid, pw_pool=Pot%pw_pool, coeff=Pot%TabLR, &
                               LG=LG, gx=gx, gy=gy, gz=gz, hmat=hmat, npts=npts, param_section=qmmm_per_section, &
-                              tag="qmmm", para_env=para_env, print_section=grid_print_section)
+                              tag="qmmm", print_section=grid_print_section)
 
    END SUBROUTINE qmmm_per_pot_type_create
 

--- a/src/qmmm_pw_grid.F
+++ b/src/qmmm_pw_grid.F
@@ -21,8 +21,7 @@ MODULE qmmm_pw_grid
                                               PW_MODE_DISTRIBUTED,&
                                               PW_MODE_LOCAL,&
                                               pw_grid_type
-   USE pw_grids,                        ONLY: pw_grid_create,&
-                                              pw_grid_release
+   USE pw_grids,                        ONLY: pw_grid_release
    USE pw_pool_types,                   ONLY: pw_pool_create,&
                                               pw_pool_p_type,&
                                               pw_pool_type,&
@@ -124,7 +123,9 @@ CONTAINS
       CPASSERT(.NOT. ASSOCIATED(pw_grid_out))
       pw_mode_loc = pw_grid_in%para%mode
       IF (PRESENT(pw_mode)) pw_mode_loc = pw_mode
-      CALL pw_grid_create(pw_grid_out, pw_grid_in%para%group)
+      ! TODO: introduce pw_grid_create_from_grid
+      ALLOCATE (pw_grid_out)
+      CALL pw_grid_out%para%group%from_dup(pw_grid_in%para%group)
       qmmm_grid_tag = qmmm_grid_tag + 1
       pw_grid_out%id_nr = qmmm_grid_tag
       pw_grid_out%ref_count = 1

--- a/src/qmmm_pw_grid.F
+++ b/src/qmmm_pw_grid.F
@@ -159,22 +159,11 @@ CONTAINS
       pw_grid_out%cutoff = pw_grid_in%cutoff
 
       !para
-      pw_grid_out%para%group_size = pw_grid_out%para%group%num_pe
-      pw_grid_out%para%my_pos = pw_grid_out%para%group%mepos
-      pw_grid_out%para%group_head_id = pw_grid_in%para%group_head_id
-      pw_grid_out%para%group_head = &
-         (pw_grid_out%para%group_head_id == pw_grid_out%para%my_pos)
       pw_grid_out%para%mode = pw_mode_loc
       ALLOCATE (pos_of_x(pw_grid_out%bounds(1, 1):pw_grid_out%bounds(2, 1)))
       pos_of_x(:pw_grid_out%bounds(2, 1) - 1) = pw_grid_in%para%pos_of_x
       pos_of_x(pw_grid_out%bounds(2, 1)) = pos_of_x(pw_grid_out%bounds(2, 1) - 1)
       CALL MOVE_ALLOC(pos_of_x, pw_grid_out%para%pos_of_x)
-      pw_grid_out%para%rs_dims = pw_grid_in%para%rs_dims
-      IF (PRODUCT(pw_grid_in%para%rs_dims) /= 0) THEN
-         CALL pw_grid_out%para%rs_group%from_dup(pw_grid_in%para%rs_group)
-      END IF
-      pw_grid_out%para%rs_pos = pw_grid_in%para%rs_pos
-      pw_grid_out%para%rs_mpo = pw_grid_in%para%rs_mpo
 
       NULLIFY (pw_grid_out%g, pw_grid_out%gsq)
       CPASSERT(pw_grid_in%grid_span == FULLSPACE)

--- a/src/qs_collocate_density.F
+++ b/src/qs_collocate_density.F
@@ -592,8 +592,8 @@ CONTAINS
 
       ALLOCATE (pab(maxco, 1))
       offset = 0
-      my_pos = mgrid_rspace(1)%pw_grid%para%my_pos
-      group_size = mgrid_rspace(1)%pw_grid%para%group_size
+      my_pos = mgrid_rspace(1)%pw_grid%para%group%mepos
+      group_size = mgrid_rspace(1)%pw_grid%para%group%num_pe
 
       DO ikind = 1, SIZE(atomic_kind_set)
 
@@ -2500,8 +2500,8 @@ CONTAINS
 
       offset = 0
       group = mgrid_rspace(1)%pw_grid%para%group
-      my_pos = mgrid_rspace(1)%pw_grid%para%my_pos
-      group_size = mgrid_rspace(1)%pw_grid%para%group_size
+      my_pos = mgrid_rspace(1)%pw_grid%para%group%mepos
+      group_size = mgrid_rspace(1)%pw_grid%para%group%num_pe
       ALLOCATE (where_is_the_point(0:group_size - 1))
 
       DO iatom = 1, natom
@@ -2706,8 +2706,8 @@ CONTAINS
 
       offset = 0
       group = mgrid_rspace(1)%pw_grid%para%group
-      my_pos = mgrid_rspace(1)%pw_grid%para%my_pos
-      group_size = mgrid_rspace(1)%pw_grid%para%group_size
+      my_pos = mgrid_rspace(1)%pw_grid%para%group%mepos
+      group_size = mgrid_rspace(1)%pw_grid%para%group%num_pe
       ALLOCATE (where_is_the_point(0:group_size - 1))
 
       DO iatom = 1, natom

--- a/src/qs_external_density.F
+++ b/src/qs_external_density.F
@@ -115,8 +115,8 @@ CONTAINS
          CALL section_vals_val_get(ext_den_section, "FILE_DENSITY", c_val=filename)
 
          tag = 1
-         ASSOCIATE (gid => rho_ext_r(1)%pw_grid%para%group, my_rank => rho_ext_r(1)%pw_grid%para%my_pos, &
-                    num_pe => rho_ext_r(1)%pw_grid%para%group_size)
+         ASSOCIATE (gid => rho_ext_r(1)%pw_grid%para%group, my_rank => rho_ext_r(1)%pw_grid%para%group%mepos, &
+                    num_pe => rho_ext_r(1)%pw_grid%para%group%num_pe)
 
             IF (dft_control%read_external_density) THEN
 

--- a/src/qs_external_potential.F
+++ b/src/qs_external_potential.F
@@ -412,8 +412,8 @@ CONTAINS
       ! The values of external potential on grid are distributed among the
       ! processes, so first we have to gather them up
       gid = grid%pw_grid%para%group
-      my_rank = grid%pw_grid%para%my_pos
-      num_pe = grid%pw_grid%para%group_size
+      my_rank = grid%pw_grid%para%group%mepos
+      num_pe = grid%pw_grid%para%group%num_pe
       tag = 1
 
       dr = grid%pw_grid%dr

--- a/src/qs_integrate_potential_single.F
+++ b/src/qs_integrate_potential_single.F
@@ -828,8 +828,8 @@ CONTAINS
       eps_rho_rspace = dft_control%qs_control%eps_rho_rspace
 
       offset = 0
-      my_pos = v_rspace%pw_grid%para%my_pos
-      group_size = v_rspace%pw_grid%para%group_size
+      my_pos = v_rspace%pw_grid%para%group%mepos
+      group_size = v_rspace%pw_grid%para%group%num_pe
 
       DO ikind = 1, nkind
 
@@ -1029,8 +1029,8 @@ CONTAINS
       use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
 
       offset = 0
-      my_pos = v_rspace%pw_grid%para%my_pos
-      group_size = v_rspace%pw_grid%para%group_size
+      my_pos = v_rspace%pw_grid%para%group%mepos
+      group_size = v_rspace%pw_grid%para%group%num_pe
 
       DO ikind = 1, nkind
 

--- a/src/tip_scan_methods.F
+++ b/src/tip_scan_methods.F
@@ -23,8 +23,7 @@ MODULE tip_scan_methods
                                               pw_env_type
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_create,&
-                                              pw_grid_release,&
-                                              pw_grid_setup
+                                              pw_grid_release
    USE pw_methods,                      ONLY: pw_axpy,&
                                               pw_multiply_with,&
                                               pw_structure_factor,&
@@ -288,8 +287,7 @@ CONTAINS
       CALL para_env%bcast(dcell)
 
       NULLIFY (pw_grid)
-      CALL pw_grid_create(pw_grid, para_env)
-      CALL pw_grid_setup(dcell, pw_grid, npts=npts)
+      CALL pw_grid_create(pw_grid, para_env, dcell, npts=npts)
       CALL scan_env%tip_pw_r%create(pw_grid)
 !deb
       scaling = 0.1_dp

--- a/src/xc/xc_derivative_set_types.F
+++ b/src/xc/xc_derivative_set_types.F
@@ -17,7 +17,6 @@ MODULE xc_derivative_set_types
                                               cp_sll_xc_deriv_next,&
                                               cp_sll_xc_deriv_type
    USE kinds,                           ONLY: dp
-   USE message_passing,                 ONLY: mp_comm_self
    USE pw_grid_types,                   ONLY: pw_grid_type
    USE pw_grids,                        ONLY: pw_grid_create,&
                                               pw_grid_release
@@ -128,8 +127,7 @@ CONTAINS
       ELSE
          !FM ugly hack, should be replaced by a pool only for 3d arrays
          CPASSERT(PRESENT(local_bounds))
-         CALL pw_grid_create(pw_grid, mp_comm_self)
-         pw_grid%bounds_local = local_bounds
+         CALL pw_grid_create(pw_grid, local_bounds)
          CALL pw_pool_create(derivative_set%pw_pool, pw_grid)
          CALL pw_grid_release(pw_grid)
       END IF


### PR DESCRIPTION
This PR
- removes one the non-cartesian communicator and all components which are mere copies of components of the communicator (positions, process grid).
- pushes normalization factors downstream

This PR was tested on Noctua2 (regtests, 128 H2O with PBE on GPUs vs CPU trunk for correctness)