### PR TITLE
Strided writes to abcint in abc_contract_xsmm

### DIFF
--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -249,7 +249,7 @@ CONTAINS
 !> \param ccp_buffer Buffer used for intermediate results (automatically allocated).
 !> \param prefac Prefactor which is finally multiplied into abcint (default: 1.0).
 !> \param pstfac Factor used to consider initial abcint (default: 0.0).
-!> \param dsti Initial index to write abcint.
+!> \param dsti Initial index to write abcint (one-based).
 ! **************************************************************************************************
    SUBROUTINE abc_contract_xsmm(abcint, sabc, sphi_a, sphi_b, sphi_c, ncoa, ncob, ncoc, &
                                 nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer, prefac, pstfac, dsti)
@@ -266,7 +266,7 @@ CONTAINS
 
       REAL(KIND=dp)                                           :: alpha, beta
       INTEGER(KIND=int_8)                                     :: cpp_size, ccp_size
-      INTEGER                                                 :: handle, i
+      INTEGER                                                 :: handle, idx(3), i
       LOGICAL                                                 :: ab_first
 #if defined(__LIBXSMM)
       TYPE(libxsmm_dmmfunction)                               :: xmm1, xmm2
@@ -279,6 +279,9 @@ CONTAINS
 
       beta = 0.0_dp
       IF (PRESENT(pstfac)) beta = pstfac
+
+      idx = 1
+      IF (PRESENT(dsti)) idx = dsti
 
       ! M*N*K FLOPS are used to decide if contracting (AB)C vs A(BC)
       IF ((nsgfa*ncob*(ncoa + nsgfb)) <= (ncoa*nsgfb*(ncob + nsgfa))) THEN
@@ -350,11 +353,9 @@ CONTAINS
 #if defined(__LIBXSMM)
       END IF
 #endif
-      MARK_USED(dsti)
-      DO i = 1, nsgfc ! contractions over c (gemm is not beneficial due to strided destination)
-         CALL dgemv("N", nsgfa*nsgfb, ncoc, alpha, ccp_buffer, nsgfa*nsgfb, sphi_c(:, i), 1, &
-                    beta, abcint(:, :, i), 1) ! [nsgfa*nsgfb,ncoc] x [ncoc,1] -> [nsgfa*nsgfb,1]
-      END DO
+      ! contractions over c: [nsgfa*nsgfb,ncoc] x [ncoc,nsgfc] -> [sgfa*nsgfb,nsgfc]
+      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, alpha, ccp_buffer, nsgfa*nsgfb, &
+                 sphi_c, ncoc, beta, abcint(idx(1):, idx(2):, idx(3):), nsgfa*nsgfb)
 
       CALL timestop(handle)
 

--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -247,22 +247,24 @@ CONTAINS
 !> \param nsgfc ...
 !> \param cpp_buffer Buffer used for intermediate results (automatically allocated).
 !> \param ccp_buffer Buffer used for intermediate results (automatically allocated).
-!> \param prefac Prefactor which is finally multiplied into abcint.
-!> \note tested from version 1.9.0 of libxsmm
+!> \param prefac Prefactor which is finally multiplied into abcint (default: 1.0).
+!> \param pstfac Factor used to consider initial abcint (default: 0.0).
+!> \param dsti Initial index to write abcint.
 ! **************************************************************************************************
    SUBROUTINE abc_contract_xsmm(abcint, sabc, sphi_a, sphi_b, sphi_c, ncoa, ncob, ncoc, &
-                                nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer, prefac)
+                                nsgfa, nsgfb, nsgfc, cpp_buffer, ccp_buffer, prefac, pstfac, dsti)
 
-      REAL(KIND=dp), DIMENSION(*)                 :: abcint
+      REAL(KIND=dp), DIMENSION(:, :, :)           :: abcint
       REAL(KIND=dp), DIMENSION(*), INTENT(IN)     :: sabc
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)  :: sphi_a, sphi_b, sphi_c
       INTEGER, INTENT(IN)                         :: ncoa, ncob, ncoc, nsgfa, nsgfb, nsgfc
       REAL(KIND=dp), DIMENSION(:), ALLOCATABLE    :: cpp_buffer, ccp_buffer
-      REAL(KIND=dp), INTENT(IN), OPTIONAL         :: prefac
+      REAL(KIND=dp), INTENT(IN), OPTIONAL         :: prefac, pstfac
+      INTEGER, DIMENSION(3), INTENT(IN), OPTIONAL :: dsti
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'abc_contract_xsmm'
 
-      REAL(KIND=dp)                                           :: alpha
+      REAL(KIND=dp)                                           :: alpha, beta
       INTEGER(KIND=int_8)                                     :: cpp_size, ccp_size
       INTEGER                                                 :: handle, i
       LOGICAL                                                 :: ab_first
@@ -275,6 +277,9 @@ CONTAINS
       alpha = 1.0_dp
       IF (PRESENT(prefac)) alpha = prefac
 
+      beta = 0.0_dp
+      IF (PRESENT(pstfac)) beta = pstfac
+
       ! M*N*K FLOPS are used to decide if contracting (AB)C vs A(BC)
       IF ((nsgfa*ncob*(ncoa + nsgfb)) <= (ncoa*nsgfb*(ncob + nsgfa))) THEN
          cpp_size = nsgfa*ncob
@@ -283,8 +288,8 @@ CONTAINS
          cpp_size = ncoa*nsgfb
          ab_first = .FALSE.
       END IF
-      ccp_size = nsgfa*nsgfb*ncoc
 
+      ccp_size = nsgfa*nsgfb*ncoc
       IF (.NOT. ALLOCATED(ccp_buffer)) THEN
          ALLOCATE (ccp_buffer(ccp_size))
       ELSE IF (SIZE(ccp_buffer) < ccp_size) THEN
@@ -311,43 +316,45 @@ CONTAINS
 
       IF (libxsmm_available(xmm1) .AND. libxsmm_available(xmm2)) THEN
          IF (ab_first) THEN ! (AB)C
-            DO i = 1, ncoc ! contractions over a and b
+            DO i = 0, ncoc - 1 ! contractions over a and b
                ! [nsgfa,ncoa] x [ncoa,ncob] -> [nsgfa,ncob]
-               CALL libxsmm_dmmcall(xmm1, sphi_a, sabc((i - 1)*ncoa*ncob + 1), cpp_buffer)
+               CALL libxsmm_dmmcall(xmm1, sphi_a, sabc(i*ncoa*ncob + 1), cpp_buffer)
                ! [nsgfa,ncob] x [ncob,nsgfb] -> [nsgfa,nsgfb]
-               CALL libxsmm_dmmcall(xmm2, cpp_buffer, sphi_b, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
+               CALL libxsmm_dmmcall(xmm2, cpp_buffer, sphi_b, ccp_buffer(i*nsgfa*nsgfb + 1))
             END DO
          ELSE ! A(BC)
-            DO i = 1, ncoc ! contractions over a and b
+            DO i = 0, ncoc - 1 ! contractions over a and b
                ! [ncoa,ncob] x [ncob,nsgfb] -> [ncoa,nsgfb]
-               CALL libxsmm_dmmcall(xmm1, sabc((i - 1)*ncoa*ncob + 1), sphi_b, cpp_buffer)
+               CALL libxsmm_dmmcall(xmm1, sabc(i*ncoa*ncob + 1), sphi_b, cpp_buffer)
                ! [nsgfa,ncoa] x [ncoa,nsgfb] -> [nsgfa,nsgfb]
-               CALL libxsmm_dmmcall(xmm2, sphi_a, cpp_buffer, ccp_buffer((i - 1)*nsgfa*nsgfb + 1))
+               CALL libxsmm_dmmcall(xmm2, sphi_a, cpp_buffer, ccp_buffer(i*nsgfa*nsgfb + 1))
             END DO
          END IF
       ELSE
 #endif
          IF (ab_first) THEN ! (AB)C
-            DO i = 1, ncoc ! contractions over a and b
-               CALL dgemm("N", "N", nsgfa, ncob, ncoa, 1.0_dp, sphi_a, nsgfa, sabc((i - 1)*ncoa*ncob + 1), &
-                          ncoa, 0.0_dp, cpp_buffer, nsgfa)
+            DO i = 0, ncoc - 1 ! contractions over a and b
+               CALL dgemm("N", "N", nsgfa, ncob, ncoa, 1.0_dp, sphi_a, nsgfa, sabc(i*ncoa*ncob + 1), &
+                          ncoa, 0.0_dp, cpp_buffer, nsgfa) ! [nsgfa,ncoa] x [ncoa,ncob] -> [nsgfa,ncob]
                CALL dgemm("N", "N", nsgfa, nsgfb, ncob, 1.0_dp, cpp_buffer, nsgfa, sphi_b, ncob, 0.0_dp, &
-                          ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
+                          ccp_buffer(i*nsgfa*nsgfb + 1), nsgfa) ! [nsgfa,ncob] x [ncob,nsgfb] -> [nsgfa,nsgfb]
             END DO
          ELSE ! A(BC)
-            DO i = 1, ncoc ! contractions over a and b
-               CALL dgemm("N", "N", ncoa, nsgfb, ncob, 1.0_dp, sabc((i - 1)*ncoa*ncob + 1), ncoa, sphi_b, &
-                          ncob, 0.0_dp, cpp_buffer, ncoa)
+            DO i = 0, ncoc - 1 ! contractions over a and b
+               CALL dgemm("N", "N", ncoa, nsgfb, ncob, 1.0_dp, sabc(i*ncoa*ncob + 1), ncoa, sphi_b, &
+                          ncob, 0.0_dp, cpp_buffer, ncoa) ! [ncoa,ncob] x [ncob,nsgfb] -> [ncoa,nsgfb]
                CALL dgemm("N", "N", nsgfa, nsgfb, ncoa, 1.0_dp, sphi_a, nsgfa, cpp_buffer, ncoa, 0.0_dp, &
-                          ccp_buffer((i - 1)*nsgfa*nsgfb + 1), nsgfa)
+                          ccp_buffer(i*nsgfa*nsgfb + 1), nsgfa) ! [nsgfa,ncoa] x [ncoa,nsgfb] -> [nsgfa,nsgfb]
             END DO
          END IF
 #if defined(__LIBXSMM)
       END IF
 #endif
-      ! last contraction, over c (larger MM using BLAS)
-      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, alpha, ccp_buffer, nsgfa*nsgfb, sphi_c, ncoc, &
-                 0.0_dp, abcint, nsgfa*nsgfb)
+      MARK_USED(dsti)
+      DO i = 1, nsgfc ! contractions over c (gemm is not beneficial due to strided destination)
+         CALL dgemv("N", nsgfa*nsgfb, ncoc, alpha, ccp_buffer, nsgfa*nsgfb, sphi_c(:, i), 1, &
+                    beta, abcint(:, :, i), 1) ! [nsgfa*nsgfb,ncoc] x [ncoc,1] -> [nsgfa*nsgfb,1]
+      END DO
 
       CALL timestop(handle)
 

--- a/src/aobasis/ai_contraction_sphi.F
+++ b/src/aobasis/ai_contraction_sphi.F
@@ -266,7 +266,7 @@ CONTAINS
 
       REAL(KIND=dp)                                           :: alpha, beta
       INTEGER(KIND=int_8)                                     :: cpp_size, ccp_size
-      INTEGER                                                 :: handle, idx(3), i
+      INTEGER                                                 :: handle, idx(3), i, j
       LOGICAL                                                 :: ab_first
 #if defined(__LIBXSMM)
       TYPE(libxsmm_dmmfunction)                               :: xmm1, xmm2
@@ -353,9 +353,17 @@ CONTAINS
 #if defined(__LIBXSMM)
       END IF
 #endif
-      ! contractions over c: [nsgfa*nsgfb,ncoc] x [ncoc,nsgfc] -> [sgfa*nsgfb,nsgfc]
-      CALL dgemm("N", "N", nsgfa*nsgfb, nsgfc, ncoc, alpha, ccp_buffer, nsgfa*nsgfb, &
-                 sphi_c, ncoc, beta, abcint(idx(1):, idx(2):, idx(3):), nsgfa*nsgfb)
+      ! DGEMM("N", "N", nsgfa*nsgfb, nsgfc, ncoc, alpha, ccp_buffer,
+      !       nsgfa*nsgfb, sphi_c, ncoc, beta, abcint, nsgfa*nsgfb)
+      ! not beneficial due to strided final destination
+      DO j = 0, nsgfc - 1 ! contractions over c
+         ! DGEMV("N", nsgfa*nsgfb, ncoc, alpha, ccp_buffer, nsgfa*nsgfb,
+         !       sphi_c(:, j), 1, beta, abcint(:, :, j), 1)
+         DO i = 0, nsgfb - 1 ! [nsgfa,ncoc] x [ncoc,1] -> [nsgfa,1]
+            CALL dgemv("N", nsgfa, ncoc, alpha, ccp_buffer(i*nsgfa + 1), nsgfa, sphi_c(:, j+1), 1, &
+                       beta, abcint(idx(1), idx(2) + i, idx(3) + j), 1)
+         END DO
+      END DO
 
       CALL timestop(handle)
 

--- a/src/qs_tensors.F
+++ b/src/qs_tensors.F
@@ -1160,12 +1160,10 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_3c_derivatives'
 
-      INTEGER :: block_end_i, block_end_j, block_end_k, block_start_i, block_start_j, &
-         block_start_k, egfi, handle, handle2, i, i_img, i_xyz, iatom, ibasis, ikind, ilist, imax, &
-         iset, j_img, jatom, jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoj, &
-         max_nset, max_nsgfi, maxli, maxlj, maxlk, mepos, natom, nbasis, ncell_RI, ncoi, ncoj, &
-         ncok, nimg, nseti, nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, &
-         unit_id
+      INTEGER :: egfi, handle, handle2, i, i_img, i_xyz, iatom, ibasis, ikind, ilist, imax, iset, &
+         j_img, jatom, jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoj, max_nset, &
+         max_nsgfi, maxli, maxlj, maxlk, mepos, natom, nbasis, ncell_RI, ncoi, ncoj, ncok, nimg, &
+         nseti, nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: img_to_RI_cell_prv
       INTEGER, DIMENSION(2)                              :: bo
       INTEGER, DIMENSION(3)                              :: blk_idx, blk_size, cell_j, cell_k, &
@@ -1186,7 +1184,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: ccp_buffer, cpp_buffer, &
                                                             max_contraction_i, max_contraction_j, &
                                                             max_contraction_k
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: dijk_contr, dummy_block_t
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: dummy_block_t
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: block_t_i, block_t_j, block_t_k, dijk_j, &
                                                             dijk_k, tmp_ijk_i, tmp_ijk_j
       REAL(KIND=dp), DIMENSION(3)                        :: ri, rij, rik, rj, rjk, rk
@@ -1434,9 +1432,8 @@ CONTAINS
 !$OMP          sphi_i,zeti,kind_radius_i,first_sgf_j,lmax_j,lmin_j,npgfj,nsetj,nsgfj,rpgf_j,&
 !$OMP          set_radius_j,sphi_j,zetj,kind_radius_j,first_sgf_k,lmax_k,lmin_k,npgfk,nsetk,nsgfk,&
 !$OMP          rpgf_k,set_radius_k,sphi_k,zetk,kind_radius_k,djk,dij,dik,ncoi,ncoj,ncok,sgfi,sgfj,&
-!$OMP          sgfk,dijk_j,dijk_k,ri,rj,rk,max_contraction_i,max_contraction_j,blk_idx,&
-!$OMP          max_contraction_k,iset,jset,kset,block_t_i,blk_size,dijk_contr,cpp_buffer,ccp_buffer,&
-!$OMP          block_start_j,block_end_j,block_start_k,block_end_k,block_start_i,block_end_i,found,&
+!$OMP          sgfk,dijk_j,dijk_k,ri,rj,rk,max_contraction_i,max_contraction_j,blk_idx,found,&
+!$OMP          max_contraction_k,iset,jset,kset,block_t_i,blk_size,cpp_buffer,ccp_buffer,&
 !$OMP          dummy_block_t,sp,handle2,mepos,bo,block_t_k,der_ext_i,der_ext_j,der_ext_k,tmp_ijk_i,&
 !$OMP          block_k_not_zero,der_k_zero,skip,der_j_zero,block_t_j,block_j_not_zero,tmp_ijk_j,i)
 
@@ -1656,54 +1653,29 @@ CONTAINS
                         END IF
                      END IF
 
-                     ALLOCATE (dijk_contr(nsgfj(jset), nsgfk(kset), nsgfi(iset)))
-
-                     block_start_j = sgfj
-                     block_end_j = sgfj + nsgfj(jset) - 1
-                     block_start_k = sgfk
-                     block_end_k = sgfk + nsgfk(kset) - 1
-                     block_start_i = sgfi
-                     block_end_i = sgfi + nsgfi(iset) - 1
-
                      DO i_xyz = 1, 3
                         IF (der_j_zero(i_xyz)) CYCLE
 
                         block_j_not_zero(i_xyz) = .TRUE.
-                        CALL abc_contract_xsmm(dijk_contr, dijk_j(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                        CALL abc_contract_xsmm(block_t_j(:, :, :, i_xyz), dijk_j(:, :, :, i_xyz), tspj(jset, jkind)%array, &
                                                spk(kset, kkind)%array, spi(iset, ikind)%array, &
                                                ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                               nsgfi(iset), cpp_buffer, ccp_buffer, prefac)
-
-                        block_t_j(block_start_j:block_end_j, &
-                                  block_start_k:block_end_k, &
-                                  block_start_i:block_end_i, i_xyz) = &
-                           block_t_j(block_start_j:block_end_j, &
-                                     block_start_k:block_end_k, &
-                                     block_start_i:block_end_i, i_xyz) + &
-                           dijk_contr(:, :, :)
-
+                                               nsgfi(iset), cpp_buffer, ccp_buffer, prefac, 1.0_dp, &
+                                               [sgfj, sgfk, sgfi])
                      END DO
 
                      DO i_xyz = 1, 3
                         IF (der_k_zero(i_xyz)) CYCLE
 
                         block_k_not_zero(i_xyz) = .TRUE.
-                        CALL abc_contract_xsmm(dijk_contr, dijk_k(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                        CALL abc_contract_xsmm(block_t_k(:, :, :, i_xyz), dijk_k(:, :, :, i_xyz), tspj(jset, jkind)%array, &
                                                spk(kset, kkind)%array, spi(iset, ikind)%array, &
                                                ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                               nsgfi(iset), cpp_buffer, ccp_buffer, prefac)
-
-                        block_t_k(block_start_j:block_end_j, &
-                                  block_start_k:block_end_k, &
-                                  block_start_i:block_end_i, i_xyz) = &
-                           block_t_k(block_start_j:block_end_j, &
-                                     block_start_k:block_end_k, &
-                                     block_start_i:block_end_i, i_xyz) + &
-                           dijk_contr(:, :, :)
-
+                                               nsgfi(iset), cpp_buffer, ccp_buffer, prefac, 1.0_dp, &
+                                               [sgfj, sgfk, sgfi])
                      END DO
 
-                     DEALLOCATE (dijk_j, dijk_k, dijk_contr)
+                     DEALLOCATE (dijk_j, dijk_k)
                   END IF ! number of triples > 0
                END DO
             END DO
@@ -1860,11 +1832,10 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'calc_3c_virial'
 
-      INTEGER :: block_end_i, block_end_j, block_end_k, block_start_i, block_start_j, &
-         block_start_k, egfi, handle, i, i_xyz, iatom, ibasis, ikind, ilist, imax, iset, j_xyz, &
-         jatom, jkind, jset, katom, kkind, kset, m_max, max_ncoj, max_nset, max_nsgfi, maxli, &
-         maxlj, maxlk, mepos, natom, nbasis, ncoi, ncoj, ncok, nseti, nsetj, nsetk, nthread, &
-         op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
+      INTEGER :: egfi, handle, i, i_xyz, iatom, ibasis, ikind, ilist, imax, iset, j_xyz, jatom, &
+         jkind, jset, katom, kkind, kset, m_max, max_ncoj, max_nset, max_nsgfi, maxli, maxlj, &
+         maxlk, mepos, natom, nbasis, ncoi, ncoj, ncok, nseti, nsetj, nsetk, nthread, op_ij, &
+         op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
       INTEGER, DIMENSION(2)                              :: bo
       INTEGER, DIMENSION(3)                              :: blk_size, sp
       INTEGER, DIMENSION(:), POINTER                     :: lmax_i, lmax_j, lmax_k, lmin_i, lmin_j, &
@@ -1882,7 +1853,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: ccp_buffer, cpp_buffer, &
                                                             max_contraction_i, max_contraction_j, &
                                                             max_contraction_k
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: ablock, dijk_contr, tmp_block
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: ablock, tmp_block
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: block_t_i, block_t_j, block_t_k, dijk_j, &
                                                             dijk_k
       REAL(KIND=dp), DIMENSION(3)                        :: ri, rij, rik, rj, rjk, rk, scoord
@@ -2045,8 +2016,7 @@ CONTAINS
 !$OMP          lmax_j,lmin_j,npgfj,nsetj,nsgfj,rpgf_j,set_radius_j,sphi_j,zetj,kind_radius_j,first_sgf_k,&
 !$OMP          lmax_k,lmin_k,npgfk,nsetk,nsgfk,rpgf_k,set_radius_k,sphi_k,zetk,kind_radius_k,djk,dij,dik,&
 !$OMP          ncoi,ncoj,ncok,sgfi,sgfj,sgfk,dijk_j,dijk_k,ri,rj,rk,max_contraction_i,max_contraction_j,&
-!$OMP          tmp_block,max_contraction_k,iset,jset,kset,block_t_i,blk_size,dijk_contr,found,sp,mepos,&
-!$OMP          block_start_j,block_end_j,block_start_k,block_end_k,block_start_i,block_end_i,block_t_k,&
+!$OMP          tmp_block,max_contraction_k,iset,jset,kset,block_t_i,blk_size,found,sp,mepos,block_t_k,&
 !$OMP          bo,der_ext_i,der_ext_j,der_ext_k,ablock,force,scoord,skip,cpp_buffer,ccp_buffer,&
 !$OMP          block_k_not_zero,der_k_zero,der_j_zero,block_t_j,block_j_not_zero)
 
@@ -2195,54 +2165,27 @@ CONTAINS
                         END IF
                      END IF
 
-                     ALLOCATE (dijk_contr(nsgfj(jset), nsgfk(kset), nsgfi(iset)))
-
-                     block_start_j = sgfj
-                     block_end_j = sgfj + nsgfj(jset) - 1
-                     block_start_k = sgfk
-                     block_end_k = sgfk + nsgfk(kset) - 1
-                     block_start_i = sgfi
-                     block_end_i = sgfi + nsgfi(iset) - 1
-
                      DO i_xyz = 1, 3
                         IF (der_j_zero(i_xyz)) CYCLE
 
                         block_j_not_zero(i_xyz) = .TRUE.
-                        CALL abc_contract_xsmm(dijk_contr, dijk_j(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                        CALL abc_contract_xsmm(block_t_j(:, :, :, i_xyz), dijk_j(:, :, :, i_xyz), tspj(jset, jkind)%array, &
                                                spk(kset, kkind)%array, spi(iset, ikind)%array, &
-                                               ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                               nsgfi(iset), cpp_buffer, ccp_buffer)
-
-                        block_t_j(block_start_j:block_end_j, &
-                                  block_start_k:block_end_k, &
-                                  block_start_i:block_end_i, i_xyz) = &
-                           block_t_j(block_start_j:block_end_j, &
-                                     block_start_k:block_end_k, &
-                                     block_start_i:block_end_i, i_xyz) + &
-                           dijk_contr(:, :, :)
-
+                                               ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), nsgfi(iset), &
+                                               cpp_buffer, ccp_buffer, 1.0_dp, 1.0_dp, [sgfj, sgfk, sgfi])
                      END DO
 
                      DO i_xyz = 1, 3
                         IF (der_k_zero(i_xyz)) CYCLE
 
                         block_k_not_zero(i_xyz) = .TRUE.
-                        CALL abc_contract_xsmm(dijk_contr, dijk_k(:, :, :, i_xyz), tspj(jset, jkind)%array, &
+                        CALL abc_contract_xsmm(block_t_k(:, :, :, i_xyz), dijk_k(:, :, :, i_xyz), tspj(jset, jkind)%array, &
                                                spk(kset, kkind)%array, spi(iset, ikind)%array, &
-                                               ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                               nsgfi(iset), cpp_buffer, ccp_buffer)
-
-                        block_t_k(block_start_j:block_end_j, &
-                                  block_start_k:block_end_k, &
-                                  block_start_i:block_end_i, i_xyz) = &
-                           block_t_k(block_start_j:block_end_j, &
-                                     block_start_k:block_end_k, &
-                                     block_start_i:block_end_i, i_xyz) + &
-                           dijk_contr(:, :, :)
-
+                                               ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), nsgfi(iset), &
+                                               cpp_buffer, ccp_buffer, 1.0_dp, 1.0_dp, [sgfj, sgfk, sgfi])
                      END DO
 
-                     DEALLOCATE (dijk_j, dijk_k, dijk_contr)
+                     DEALLOCATE (dijk_j, dijk_k)
                   END IF ! number of triples > 0
                END DO
             END DO
@@ -2355,11 +2298,10 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_3c_integrals'
 
-      INTEGER :: block_end_i, block_end_j, block_end_k, block_start_i, block_start_j, &
-         block_start_k, egfi, handle, handle2, i, iatom, ibasis, ikind, ilist, imax, iset, jatom, &
-         jcell, jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoj, max_nset, max_nsgfi, &
-         maxli, maxlj, maxlk, mepos, natom, nbasis, ncell_RI, ncoi, ncoj, ncok, nimg, nseti, &
-         nsetj, nsetk, nthread, op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
+      INTEGER :: egfi, handle, handle2, i, iatom, ibasis, ikind, ilist, imax, iset, jatom, jcell, &
+         jkind, jset, katom, kcell, kkind, kset, m_max, max_ncoj, max_nset, max_nsgfi, maxli, &
+         maxlj, maxlk, mepos, natom, nbasis, ncell_RI, ncoi, ncoj, ncok, nimg, nseti, nsetj, &
+         nsetk, nthread, op_ij, op_jk, op_pos_prv, sgfi, sgfj, sgfk, unit_id
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: img_to_RI_cell_prv
       INTEGER, DIMENSION(2)                              :: bo
       INTEGER, DIMENSION(3)                              :: blk_idx, blk_size, cell_j, cell_k, &
@@ -2378,8 +2320,7 @@ CONTAINS
                                                             prefac, sijk_ext
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: ccp_buffer, cpp_buffer, &
                                                             max_contraction_j, max_contraction_k
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: block_t, dummy_block_t, sijk, &
-                                                            sijk_contr, tmp_ijk
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: block_t, dummy_block_t, sijk, tmp_ijk
       REAL(KIND=dp), DIMENSION(1, 1, 1)                  :: counter
       REAL(KIND=dp), DIMENSION(3)                        :: ri, rij, rik, rj, rjk, rk
       REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_i, set_radius_j, set_radius_k
@@ -2604,8 +2545,7 @@ CONTAINS
 !$OMP          set_radius_j,sphi_j,zetj,kind_radius_j,first_sgf_k,lmax_k,lmin_k,npgfk,nsetk,nsgfk,&
 !$OMP          rpgf_k,set_radius_k,sphi_k,zetk,kind_radius_k,djk,dij,dik,ncoi,ncoj,ncok,sgfi,sgfj,&
 !$OMP          sgfk,sijk,ri,rj,rk,sijk_ext,block_not_zero,max_contraction_i,max_contraction_j,&
-!$OMP          max_contraction_k,iset,jset,kset,block_t,blk_size,sijk_contr,cpp_buffer,ccp_buffer,&
-!$OMP          block_start_j,block_end_j,block_start_k,block_end_k,block_start_i,block_end_i,found,&
+!$OMP          max_contraction_k,iset,jset,kset,block_t,blk_size,cpp_buffer,ccp_buffer,found,&
 !$OMP          dummy_block_t,sp,handle2,mepos,bo,skip,tmp_ijk,i,blk_idx)
 
       mepos = 0
@@ -2792,32 +2732,15 @@ CONTAINS
                   END IF
 
                   block_not_zero = .TRUE.
-                  ALLOCATE (sijk_contr(nsgfj(jset), nsgfk(kset), nsgfi(iset)))
-                  CALL abc_contract_xsmm(sijk_contr, sijk, tspj(jset, jkind)%array, &
-                                         spk(kset, kkind)%array, spi(iset, ikind)%array, &
-                                         ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
-                                         nsgfi(iset), cpp_buffer, ccp_buffer, prefac)
-                  DEALLOCATE (sijk)
-
                   sgfj = first_sgf_j(1, jset)
                   sgfk = first_sgf_k(1, kset)
 
-                  block_start_j = sgfj
-                  block_end_j = sgfj + nsgfj(jset) - 1
-                  block_start_k = sgfk
-                  block_end_k = sgfk + nsgfk(kset) - 1
-                  block_start_i = sgfi
-                  block_end_i = sgfi + nsgfi(iset) - 1
-
-                  block_t(block_start_j:block_end_j, &
-                          block_start_k:block_end_k, &
-                          block_start_i:block_end_i) = &
-                     block_t(block_start_j:block_end_j, &
-                             block_start_k:block_end_k, &
-                             block_start_i:block_end_i) + &
-                     sijk_contr(:, :, :)
-                  DEALLOCATE (sijk_contr)
-
+                  CALL abc_contract_xsmm(block_t, sijk, tspj(jset, jkind)%array, &
+                                         spk(kset, kkind)%array, spi(iset, ikind)%array, &
+                                         ncoj, ncok, ncoi, nsgfj(jset), nsgfk(kset), &
+                                         nsgfi(iset), cpp_buffer, ccp_buffer, &
+                                         prefac, 1.0_dp, [sgfj, sgfk, sgfi])
+                  DEALLOCATE (sijk)
                END DO
 
             END DO


### PR DESCRIPTION
Currently, "abcint" (INOUT) of `abc_contract_xsmm` is a temporary (work-)array, which is then applied to the desired/actual destination using two strides (three-dimensional array). The goal of this PR is to write the desired destination right-away at the expense of using multiple DGEMV rather than a reasonable-sized DGEMM. The bet is memory ops are overwhelming let alone the intermediate work-array. If this PR proofs beneficial, it enables further benefits like combining `abc_contract_xsmm` and `abc_contract` with the former still requiring pre-transposed `sphi_a`. On top, other inputs to abc_contract may be of temporary/prepared nature rather than using original data; this may also go away if this PR succeeds.