### PR TITLE
WFC-gradients: Do not free HFX buffers by default

### DIFF
--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -462,21 +462,10 @@ CONTAINS
          keyword, __LOCATION__, &
          name="FREE_HFX_BUFFER", &
          description="Free the buffer containing the 4 center integrals used in the Hartree-Fock exchange calculation. "// &
-         "This will be effective only for gradients calculations, since for the energy only "// &
-         "case, the buffers are released by default. (Right now debugging only).", &
+         "Ignored for energy-only calculations. May fail.", &
          usage="FREE_HFX_BUFFER", &
-         default_l_val=.TRUE., &
+         default_l_val=.FALSE., &
          lone_keyword_l_val=.TRUE.)
-      CALL section_add_keyword(section, keyword)
-      CALL keyword_release(keyword)
-
-      CALL keyword_create( &
-         keyword, __LOCATION__, &
-         name="USE_OLD_GRADIENT_CODE", &
-         description="Use the original RI-MP2 gradient code.", &
-         usage="USE_OLD_GRADIENT_CODE  T", &
-         lone_keyword_l_val=.TRUE., &
-         default_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -443,7 +443,6 @@ CONTAINS
       ! Set the CPHF section
       CALL section_vals_val_get(mp2_section, "CANONICAL_GRADIENTS%FREE_HFX_BUFFER", l_val=mp2_env%ri_grad%free_hfx_buffer)
       CALL section_vals_val_get(mp2_section, "CANONICAL_GRADIENTS%EPS_CANONICAL", r_val=mp2_env%ri_grad%eps_canonical)
-      CALL section_vals_val_get(mp2_section, "CANONICAL_GRADIENTS%USE_OLD_GRADIENT_CODE", l_val=mp2_env%ri_grad%use_old_grad)
       CALL section_vals_val_get(mp2_section, "CANONICAL_GRADIENTS%DOT_PRODUCT_BLKSIZE", i_val=mp2_env%ri_grad%dot_blksize)
       CALL section_vals_val_get(mp2_section, "CANONICAL_GRADIENTS%MAX_PARALLEL_COMM", i_val=mp2_env%ri_grad%max_parallel_comm)
       cphf_section => section_vals_get_subs_vals(mp2_section, "CANONICAL_GRADIENTS%CPHF")

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -309,7 +309,6 @@ MODULE mp2_types
       REAL(KIND=dp), DIMENSION(3, 3)                     :: mp2_virial = 0.0_dp
       REAL(dp)                                           :: eps_canonical = 0.0_dp
       LOGICAL                                            :: free_hfx_buffer = .FALSE.
-      LOGICAL                                            :: use_old_grad = .FALSE.
       INTEGER                                            :: dot_blksize = 0
       INTEGER                                            :: max_parallel_comm = 0
    END TYPE grad_util

--- a/src/rpa_rse.F
+++ b/src/rpa_rse.F
@@ -215,8 +215,7 @@ CONTAINS
       CALL exchange_contribution(qs_env, para_env, dimen, mo_coeff, &
                                  hfx_sections, n_rep_hf, &
                                  rho, mat_mu_nu, fm_P_mu_nu, &
-                                 fm_ao, fm_X_mo, fm_ao_mo, &
-                                 mp2_env%ri_grad%free_hfx_buffer)
+                                 fm_ao, fm_X_mo, fm_ao_mo)
 
       ! Calculate DFT exchange-correlation contribution
       CALL xc_contribution(qs_env, fm_ao, fm_ao_mo, fm_XC_mo, mo_coeff, dimen)
@@ -301,13 +300,11 @@ CONTAINS
 !> \param fm_X_ao ...
 !> \param fm_X_mo ...
 !> \param fm_X_ao_mo ...
-!> \param recalc_hfx_integrals ...
 ! **************************************************************************************************
    SUBROUTINE exchange_contribution(qs_env, para_env, dimen, mo_coeff, &
                                     hfx_sections, n_rep_hf, &
                                     rho_work, mat_mu_nu, fm_P_mu_nu, &
-                                    fm_X_ao, fm_X_mo, fm_X_ao_mo, &
-                                    recalc_hfx_integrals)
+                                    fm_X_ao, fm_X_mo, fm_X_ao_mo)
       TYPE(qs_environment_type), INTENT(IN), POINTER     :: qs_env
       TYPE(mp_para_env_type), INTENT(IN), POINTER        :: para_env
       INTEGER, INTENT(IN)                                :: dimen
@@ -321,7 +318,6 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_X_ao
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_X_mo
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_X_ao_mo
-      LOGICAL, INTENT(IN)                                :: recalc_hfx_integrals
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'exchange_contribution'
 
@@ -333,8 +329,6 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      my_recalc_hfx_integrals = recalc_hfx_integrals
-
       CALL qs_rho_get(rho_work, rho_ao=rho_work_ao)
       ns = SIZE(rho_work_ao)
       NULLIFY (P_mu_nu)
@@ -345,6 +339,8 @@ CONTAINS
          CALL dbcsr_copy(P_mu_nu(is)%matrix, rho_work_ao(1)%matrix)
          CALL dbcsr_set(P_mu_nu(is)%matrix, 0.0_dp)
       END DO
+
+      my_recalc_hfx_integrals = .TRUE.
 
       CALL exx_pre_hfx(hfx_sections, qs_env%mp2_env%ri_rpa%x_data, qs_env%mp2_env%ri_rpa%reuse_hfx)
       DO is = 1, ns


### PR DESCRIPTION
This switch is known to lead to segfaults in most cases if turned on. Thus, we turn it off by default. (@abussy FYI)

Fixes #3419