### PR TITLE
Use new external DLA-Future Fortran interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -912,7 +912,6 @@ if(CP2K_USE_ELPA)
           "   - libraries           :  ${CP2K_ELPA_LINK_LIBRARIES}\n\n")
 endif()
 
-
 if(CP2K_USE_SUPERLU)
   message(" - superlu\n"
           "   - include directories : ${CP2K_SUPERLU_INCLUDE_DIRS}\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,7 +632,7 @@ if(CP2K_USE_VORI)
 endif()
 
 if(CP2K_USE_DLAF)
-  find_package(DLAF REQUIRED)
+  find_package(DLAFFortran REQUIRED)
 endif()
 
 # FFTW3
@@ -912,14 +912,6 @@ if(CP2K_USE_ELPA)
           "   - libraries           :  ${CP2K_ELPA_LINK_LIBRARIES}\n\n")
 endif()
 
-if(CP2K_USE_DLAF)
-  get_target_property(CP2K_DLAF_INCLUDE_DIRS DLAF::DLAF
-                      INTERFACE_INCLUDE_DIRECTORIES)
-  get_target_property(CP2K_DLAF_LINK_LIBRARIES DLAF::DLAF
-                      INTERFACE_LINK_LIBRARIES)
-  message(" - DLAF\n" "   - include directories : ${CP2K_DLAF_INCLUDE_DIRS}\n"
-          "   - libraries           :  ${CP2K_DLAF_LINK_LIBRARIES}\n\n")
-endif()
 
 if(CP2K_USE_SUPERLU)
   message(" - superlu\n"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1568,6 +1568,7 @@ target_link_libraries(
     $<$<BOOL:${CP2K_USE_TORCH}>:${TORCH_LIBRARIES}>
     $<$<BOOL:${CP2K_USE_COSMA}>:cosma::cosma_prefixed_pxgemm>
     $<$<BOOL:${CP2K_USE_COSMA}>:cosma::cosma>
+    $<$<BOOL:${CP2K_USE_DLAF}>:dlafort>
     $<$<BOOL:${CP2K_USE_DLAF}>:DLAF::DLAF>
     DBCSR::dbcsr
     $<$<BOOL:${CP2K_USE_MPI}>:cp2k::SCALAPACK::scalapack>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1568,8 +1568,7 @@ target_link_libraries(
     $<$<BOOL:${CP2K_USE_TORCH}>:${TORCH_LIBRARIES}>
     $<$<BOOL:${CP2K_USE_COSMA}>:cosma::cosma_prefixed_pxgemm>
     $<$<BOOL:${CP2K_USE_COSMA}>:cosma::cosma>
-    $<$<BOOL:${CP2K_USE_DLAF}>:dlafort>
-    $<$<BOOL:${CP2K_USE_DLAF}>:DLAF::DLAF>
+    $<$<BOOL:${CP2K_USE_DLAF}>:DLAF::Fortran>
     DBCSR::dbcsr
     $<$<BOOL:${CP2K_USE_MPI}>:cp2k::SCALAPACK::scalapack>
     cp2k_linalg_libs

--- a/src/fm/cp_dlaf_utils_api.F
+++ b/src/fm/cp_dlaf_utils_api.F
@@ -6,12 +6,6 @@
 !--------------------------------------------------------------------------------------------------!
 
 MODULE cp_dlaf_utils_api
-   USE ISO_C_BINDING,                   ONLY: C_CHAR,&
-                                              C_INT,&
-                                              C_LOC,&
-                                              C_NULL_CHAR,&
-                                              C_PTR
-                                       
    USE dlaf_fortran,                    ONLY: dlaf_create_grid_from_blacs,&
                                               dlaf_finalize,&
                                               dlaf_free_grid,&
@@ -37,6 +31,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_dlaf_initialize()
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_dlaf_initialize'
+
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
@@ -54,6 +49,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_dlaf_finalize()
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_dlaf_finalize'
+
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
@@ -74,6 +70,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: blacs_context
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_dlaf_create_grid'
+
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
@@ -97,6 +94,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: blacs_context
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_dlaf_free_grid'
+
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)

--- a/src/fm/cp_dlaf_utils_api.F
+++ b/src/fm/cp_dlaf_utils_api.F
@@ -12,7 +12,7 @@ MODULE cp_dlaf_utils_api
                                               C_NULL_CHAR,&
                                               C_PTR
                                        
-   USE dlafort,                        ONLY: dlaf_create_grid,&
+   USE dlaf_fortran,                    ONLY: dlaf_create_grid_from_blacs,&
                                               dlaf_finalize,&
                                               dlaf_free_grid,&
                                               dlaf_initialize
@@ -78,7 +78,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 #if defined(__DLAF)
-      CALL dlaf_create_grid(blacs_context)
+      CALL dlaf_create_grid_from_blacs(blacs_context)
 #else
       MARK_USED(blacs_context)
       CPABORT("CP2K compiled without the DLA-Future library.")

--- a/src/fm/cp_dlaf_utils_api.F
+++ b/src/fm/cp_dlaf_utils_api.F
@@ -11,6 +11,11 @@ MODULE cp_dlaf_utils_api
                                               C_LOC,&
                                               C_NULL_CHAR,&
                                               C_PTR
+                                       
+   USE dlafort,                        ONLY: dlaf_create_grid,&
+                                              dlaf_finalize,&
+                                              dlaf_free_grid,&
+                                              dlaf_initialize
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -32,44 +37,12 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_dlaf_initialize()
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_dlaf_initialize'
-      INTEGER, PARAMETER                                 :: dlaf_argc = 1, pika_argc = 1
-
-      CHARACTER(len=5, kind=C_CHAR), ALLOCATABLE, TARGET :: dlaf_argv(:), pika_argv(:)
       INTEGER                                            :: handle
-      TYPE(C_PTR), ALLOCATABLE, DIMENSION(:)             :: dlaf_argv_ptr, pika_argv_ptr
-      INTERFACE
-         SUBROUTINE dlaf_init(pika_argc, pika_argv, dlaf_argc, dlaf_argv) BIND(C, name='dlaf_initialize')
-            IMPORT :: C_PTR, C_INT
-            TYPE(c_ptr), DIMENSION(*) :: pika_argv
-            TYPE(c_ptr), DIMENSION(*) :: dlaf_argv
-            INTEGER(kind=c_int), value :: pika_argc
-            INTEGER(kind=c_int), value :: dlaf_argc
-         END SUBROUTINE dlaf_init
-      END INTERFACE
 
       CALL timeset(routineN, handle)
-
 #if defined(__DLAF)
-      ALLOCATE (pika_argv(pika_argc))
-      pika_argv(1) = "dlaf"//C_NULL_CHAR
-      ALLOCATE (dlaf_argv(dlaf_argc))
-      dlaf_argv(1) = "dlaf"//C_NULL_CHAR
-
-      ALLOCATE (pika_argv_ptr(pika_argc))
-      pika_argv_ptr(1) = c_loc(pika_argv(1))
-      ALLOCATE (dlaf_argv_ptr(dlaf_argc))
-      dlaf_argv_ptr(1) = c_loc(dlaf_argv(1))
-
-      CALL dlaf_init(pika_argc, pika_argv_ptr, dlaf_argc, dlaf_argv_ptr)
-#else
-      MARK_USED(pika_argv)
-      MARK_USED(pika_argv_ptr)
-      MARK_USED(pika_argc)
-      MARK_USED(dlaf_argv)
-      MARK_USED(dlaf_argv_ptr)
-      MARK_USED(dlaf_argc)
+      CALL dlaf_initialize()
 #endif
-
       CALL timestop(handle)
    END SUBROUTINE cp_dlaf_initialize
 
@@ -81,20 +54,12 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_dlaf_finalize()
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_dlaf_finalize'
-
       INTEGER                                            :: handle
-      INTERFACE
-         SUBROUTINE dlaf_finalize_aux() &
-            BIND(C, name='dlaf_finalize')
-         END SUBROUTINE dlaf_finalize_aux
-      END INTERFACE
 
       CALL timeset(routineN, handle)
-
 #if defined(__DLAF)
-      CALL dlaf_finalize_aux()
+      CALL dlaf_finalize()
 #endif
-
       CALL timestop(handle)
    END SUBROUTINE cp_dlaf_finalize
 
@@ -109,25 +74,15 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: blacs_context
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_dlaf_create_grid'
-
       INTEGER                                            :: handle
-      INTERFACE
-         SUBROUTINE dlaf_create_grid(blacs_contxt) &
-            BIND(C, name='dlaf_create_grid_from_blacs')
-            IMPORT :: C_INT
-            INTEGER(KIND=C_INT), VALUE :: blacs_contxt
-         END SUBROUTINE
-      END INTERFACE
 
       CALL timeset(routineN, handle)
-
 #if defined(__DLAF)
       CALL dlaf_create_grid(blacs_context)
 #else
       MARK_USED(blacs_context)
       CPABORT("CP2K compiled without the DLA-Future library.")
 #endif
-
       CALL timestop(handle)
    END SUBROUTINE cp_dlaf_create_grid
 
@@ -142,25 +97,15 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: blacs_context
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_dlaf_free_grid'
-
       INTEGER                                            :: handle
-      INTERFACE
-         SUBROUTINE dlaf_free_grid(blacs_contxt) &
-            BIND(C, name='dlaf_free_grid')
-            IMPORT :: C_INT
-            INTEGER(KIND=C_INT), VALUE :: blacs_contxt
-         END SUBROUTINE
-      END INTERFACE
 
       CALL timeset(routineN, handle)
-
 #if defined(__DLAF)
       CALL dlaf_free_grid(blacs_context)
 #else
       MARK_USED(blacs_context)
       CPABORT("CP2K compiled without the DLA-Future library.")
 #endif
-
       CALL timestop(handle)
    END SUBROUTINE cp_dlaf_free_grid
 

--- a/src/fm/cp_dlaf_utils_api.F
+++ b/src/fm/cp_dlaf_utils_api.F
@@ -6,11 +6,15 @@
 !--------------------------------------------------------------------------------------------------!
 
 MODULE cp_dlaf_utils_api
-   USE dlaf_fortran,                    ONLY: dlaf_create_grid_from_blacs,&
-                                              dlaf_finalize,&
-                                              dlaf_free_grid,&
-                                              dlaf_initialize
+
 #include "../base/base_uses.f90"
+
+#if defined(__DLAF)
+   USE dlaf_fortran, ONLY: dlaf_create_grid_from_blacs, &
+                           dlaf_finalize, &
+                           dlaf_free_grid, &
+                           dlaf_initialize
+#endif
 
    IMPLICIT NONE
 

--- a/src/fm/cp_fm_dlaf_api.F
+++ b/src/fm/cp_fm_dlaf_api.F
@@ -7,18 +7,12 @@
 
 MODULE cp_fm_dlaf_api
 
-   USE ISO_C_BINDING,                   ONLY: C_CHAR,&
-                                              C_DOUBLE,&
-                                              C_INT,&
-                                              C_LOC,&
-                                              C_PTR,&
-                                              C_SIGNED_CHAR
    USE cp_fm_basic_linalg,              ONLY: cp_fm_upper_to_full
    USE cp_fm_types,                     ONLY: cp_fm_type
-   USE kinds,                           ONLY: dp
    USE dlaf_fortran,                    ONLY: dlaf_pdpotrf,&
-                                              dlaf_pspotrf, &
-                                              dlaf_pdsyevd
+                                              dlaf_pdsyevd,&
+                                              dlaf_pspotrf
+   USE kinds,                           ONLY: dp
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -54,6 +48,7 @@ CONTAINS
       INTEGER, TARGET                                    :: info
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_pdpotrf_dlaf'
+
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
@@ -94,6 +89,7 @@ CONTAINS
       INTEGER, TARGET                                    :: info
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_pspotrf_dlaf'
+
       INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
@@ -160,26 +156,21 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix, eigenvectors
       REAL(kind=dp), DIMENSION(:), INTENT(OUT), TARGET   :: eigenvalues
 
+      CHARACTER(len=*), PARAMETER :: dlaf_name = 'pdsyevd_dlaf', routineN = 'cp_fm_diag_dlaf_base'
       CHARACTER, PARAMETER                               :: uplo = 'L'
-      INTEGER                                            :: n
+
+      CHARACTER(LEN=100)                                 :: message
+      INTEGER                                            :: dlaf_handle, handle, n
       INTEGER, DIMENSION(9)                              :: desca, descz
       INTEGER, TARGET                                    :: info
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: a, z
-      
-      CHARACTER(LEN=100)                                 :: message
-      
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_diag_dlaf_base'
-      INTEGER                                            :: handle
-      INTEGER                                            :: dlaf_handle
-      CHARACTER(len=*), PARAMETER                        :: dlaf_name = 'pdsyevd_dlaf'
-      
+
       CALL timeset(routineN, handle)
 
 #if defined(__DLAF)
       ! DLAF needs the lower triangular part
       ! Use eigenvectors matrix as workspace
       CALL cp_fm_upper_to_full(matrix, eigenvectors)
-
 
       n = matrix%matrix_struct%nrow_global
 

--- a/src/fm/cp_fm_dlaf_api.F
+++ b/src/fm/cp_fm_dlaf_api.F
@@ -16,7 +16,7 @@ MODULE cp_fm_dlaf_api
    USE cp_fm_basic_linalg,              ONLY: cp_fm_upper_to_full
    USE cp_fm_types,                     ONLY: cp_fm_type
    USE kinds,                           ONLY: dp
-   USE dlafort,                        ONLY: dlaf_pdpotrf,&
+   USE dlaf_fortran,                    ONLY: dlaf_pdpotrf,&
                                               dlaf_pspotrf, &
                                               dlaf_pdsyevd
 #include "../base/base_uses.f90"

--- a/src/fm/cp_fm_dlaf_api.F
+++ b/src/fm/cp_fm_dlaf_api.F
@@ -16,6 +16,9 @@ MODULE cp_fm_dlaf_api
    USE cp_fm_basic_linalg,              ONLY: cp_fm_upper_to_full
    USE cp_fm_types,                     ONLY: cp_fm_type
    USE kinds,                           ONLY: dp
+   USE dlafort,                        ONLY: dlaf_pdpotrf,&
+                                              dlaf_pspotrf, &
+                                              dlaf_pdsyevd
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -51,24 +54,11 @@ CONTAINS
       INTEGER, TARGET                                    :: info
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_pdpotrf_dlaf'
-
       INTEGER                                            :: handle
-      INTERFACE
-         SUBROUTINE pdpotrf_dlaf(uplo, n, a, ia, ja, desca, info) &
-            BIND(C, name='dlaf_pdpotrf')
-            IMPORT :: C_PTR, C_INT, C_DOUBLE, C_SIGNED_CHAR
-            INTEGER(KIND=C_SIGNED_CHAR), VALUE :: uplo
-            INTEGER(KIND=C_INT), VALUE      ::        ia, ja, n
-            TYPE(C_PTR), VALUE ::       info
-            INTEGER(kind=C_INT), DIMENSION(*)         :: desca
-            TYPE(C_PTR), VALUE ::              a
-         END SUBROUTINE pdpotrf_dlaf
-      END INTERFACE
 
       CALL timeset(routineN, handle)
-
 #if defined(__DLAF)
-      CALL pdpotrf_dlaf(IACHAR(uplo, C_SIGNED_CHAR), n, C_LOC(a(1, 1)), ia, ja, desca, C_LOC(info))
+      CALL dlaf_pdpotrf(uplo, n, a, ia, ja, desca, info)
 #else
       MARK_USED(uplo)
       MARK_USED(n)
@@ -104,24 +94,12 @@ CONTAINS
       INTEGER, TARGET                                    :: info
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_pspotrf_dlaf'
-
       INTEGER                                            :: handle
-      INTERFACE
-         SUBROUTINE pspotrf_dlaf(uplo, n, a, ia, ja, desca, info) &
-            BIND(C, name='dlaf_pspotrf')
-            IMPORT :: C_PTR, C_INT, C_DOUBLE, C_SIGNED_CHAR
-            INTEGER(KIND=C_SIGNED_CHAR), VALUE :: uplo
-            INTEGER(KIND=C_INT), VALUE      ::        ia, ja, n
-            TYPE(C_PTR), VALUE    ::       info
-            INTEGER(kind=C_INT), DIMENSION(*)         :: desca
-            TYPE(C_PTR), VALUE   ::              a
-         END SUBROUTINE pspotrf_dlaf
-      END INTERFACE
 
       CALL timeset(routineN, handle)
 
 #if defined(__DLAF)
-      CALL pspotrf_dlaf(IACHAR(uplo, C_SIGNED_CHAR), n, C_LOC(a(1, 1)), ia, ja, desca, C_LOC(info))
+      CALL dlaf_pspotrf(uplo, n, a, ia, ja, desca, info)
 #else
       MARK_USED(uplo)
       MARK_USED(n)
@@ -182,28 +160,19 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix, eigenvectors
       REAL(kind=dp), DIMENSION(:), INTENT(OUT), TARGET   :: eigenvalues
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_diag_dlaf_base'
       CHARACTER, PARAMETER                               :: uplo = 'L'
-      CHARACTER(LEN=100)                                 :: message
-      INTEGER                                            :: dlaf_handle, handle, n
+      INTEGER                                            :: n
       INTEGER, DIMENSION(9)                              :: desca, descz
       INTEGER, TARGET                                    :: info
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: a, z
-      INTERFACE
-         SUBROUTINE pdsyevd_dlaf(uplo, n, a, ia, ja, desca, w, z, iz, jz, descz, info) &
-            BIND(C, name='dlaf_pdsyevd')
-
-            IMPORT :: C_INT, C_DOUBLE, C_CHAR, C_PTR, C_SIGNED_CHAR
-
-            INTEGER(kind=C_SIGNED_CHAR), VALUE :: uplo
-            INTEGER(kind=C_INT), VALUE :: n, ia, ja, iz, jz
-            TYPE(C_PTR), VALUE :: a, w, z
-            INTEGER(kind=C_INT), DIMENSION(9) :: desca, descz
-            TYPE(C_PTR), VALUE :: info
-         END SUBROUTINE pdsyevd_dlaf
-      END INTERFACE
+      
+      CHARACTER(LEN=100)                                 :: message
+      
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_diag_dlaf_base'
+      INTEGER                                            :: handle
+      INTEGER                                            :: dlaf_handle
       CHARACTER(len=*), PARAMETER                        :: dlaf_name = 'pdsyevd_dlaf'
-
+      
       CALL timeset(routineN, handle)
 
 #if defined(__DLAF)
@@ -211,7 +180,6 @@ CONTAINS
       ! Use eigenvectors matrix as workspace
       CALL cp_fm_upper_to_full(matrix, eigenvectors)
 
-      CALL timeset(dlaf_name, dlaf_handle)
 
       n = matrix%matrix_struct%nrow_global
 
@@ -222,15 +190,9 @@ CONTAINS
       descz(:) = eigenvectors%matrix_struct%descriptor(:)
 
       info = -1
+      CALL timeset(dlaf_name, dlaf_handle)
 
-      CALL pdsyevd_dlaf( &
-         uplo=IACHAR(uplo, C_SIGNED_CHAR), &
-         n=n, &
-         a=C_LOC(a(1, 1)), ia=1, ja=1, desca=desca, &
-         w=C_LOC(eigenvalues(1)), &
-         z=C_LOC(z(1, 1)), iz=1, jz=1, descz=descz, &
-         info=C_LOC(info) &
-         )
+      CALL dlaf_pdsyevd(uplo, n, a, 1, 1, desca, eigenvalues, z, 1, 1, descz, info)
 
       CALL timestop(dlaf_handle)
 

--- a/src/fm/cp_fm_dlaf_api.F
+++ b/src/fm/cp_fm_dlaf_api.F
@@ -7,13 +7,16 @@
 
 MODULE cp_fm_dlaf_api
 
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_upper_to_full
-   USE cp_fm_types,                     ONLY: cp_fm_type
-   USE dlaf_fortran,                    ONLY: dlaf_pdpotrf,&
-                                              dlaf_pdsyevd,&
-                                              dlaf_pspotrf
-   USE kinds,                           ONLY: dp
+   USE cp_fm_basic_linalg, ONLY: cp_fm_upper_to_full
+   USE cp_fm_types, ONLY: cp_fm_type
+   USE kinds, ONLY: dp
 #include "../base/base_uses.f90"
+
+#if defined(__DLAF)
+   USE dlaf_fortran, ONLY: dlaf_pdpotrf, &
+                           dlaf_pdsyevd, &
+                           dlaf_pspotrf
+#endif
 
    IMPLICIT NONE
 

--- a/tools/docker/Dockerfile.test_cmake
+++ b/tools/docker/Dockerfile.test_cmake
@@ -44,7 +44,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
 WORKDIR /opt/spack
 RUN git init --quiet && \
     git remote add origin https://github.com/spack/spack.git && \
-    git fetch --quiet --depth 1 origin tag develop-2024-05-05 --no-tags && \
+    git fetch --quiet --depth 1 origin tag develop-2024-05-26 --no-tags && \
     git checkout --quiet FETCH_HEAD
 ENV PATH="/opt/spack/bin:${PATH}"
 

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -836,7 +836,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
 WORKDIR /opt/spack
 RUN git init --quiet && \
     git remote add origin https://github.com/spack/spack.git && \
-    git fetch --quiet --depth 1 origin tag develop-2024-05-05 --no-tags && \
+    git fetch --quiet --depth 1 origin tag develop-2024-05-26 --no-tags && \
     git checkout --quiet FETCH_HEAD
 ENV PATH="/opt/spack/bin:${{PATH}}"
 

--- a/tools/spack/cp2k-dependencies.yaml
+++ b/tools/spack/cp2k-dependencies.yaml
@@ -10,7 +10,7 @@ spack:
     - "fftw @3.3.10 +openmp"
     - "libxc @6.2.2"
     - "spglib @2.3.0"
-    - "dla-future@0.4.0 +scalapack"
+    - "dla-future-fortran@0.1.0"
    # Unfortunately, ScaLAPACK 2.2.1 has not yet been packaged by Spack.
    # https://github.com/Reference-ScaLAPACK/scalapack/tree/v2.2.1
    # which contains https://github.com/Reference-ScaLAPACK/scalapack/pull/26


### PR DESCRIPTION
The Fortran interface to DLA-Future is now provided by a standalone package [DLA-Future-Fortran](https://github.com/eth-cscs/DLA-Future-Fortran), so that it can be re-used by other Fortran applications and extended beyond the needs of CP2K.

This PR introduces the use of DLA-Future-Fortran. `dla-future-fortran@0.1.0` is available in Spack, and the Spack tag in the Docker container has been updated.