### PR TITLE
Ignore standard build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,16 +92,7 @@ dkms.conf
 # Executables
 
 ### CMake ###
-CMakeLists.txt.user
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-_deps
+build*/
 
 ### CMake Patch ###
 # External projects


### PR DESCRIPTION
Ignore standard CMake `build/` directory (and variations) instead of ignoring specific CMake files.

If CMake files are erroneously created in the source directory, they should appear in `git status` so that it's clear the repository is not in a clean state.