### PR TITLE
dbm: use squared epsilon instead of square-root of norm

### DIFF
--- a/src/dbm/dbm_matrix.c
+++ b/src/dbm/dbm_matrix.c
@@ -278,6 +278,7 @@ void dbm_filter(dbm_matrix_t *matrix, const double eps) {
   if (eps == 0.0) {
     return;
   }
+  const double eps2 = eps * eps;
 
 #pragma omp parallel for schedule(dynamic)
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
@@ -293,12 +294,12 @@ void dbm_filter(dbm_matrix_t *matrix, const double eps) {
       const int row_size = matrix->row_sizes[old_blk.row];
       const int col_size = matrix->col_sizes[old_blk.col];
       const int block_size = row_size * col_size;
-      double norm = 0.0; // Compute norm as double, but compare as float.
+      double norm = 0.0;
       for (int i = 0; i < block_size; i++) {
         norm += old_blk_data[i] * old_blk_data[i];
       }
       // For historic reasons zero-sized blocks are never filtered.
-      if (sqrt((float)norm) < eps && block_size > 0) {
+      if (block_size > 0 && norm < eps2) {
         continue; // filter the block
       }
       // Re-create block.

--- a/src/dbm/dbm_multiply_opencl.c
+++ b/src/dbm/dbm_multiply_opencl.c
@@ -70,9 +70,6 @@ void dbm_multiply_gpu_launch_kernel(const offloadStream_t stream,
       offset +=
           (size_t)LIBXSMM_SNPRINTF(params + offset, sizeof(params) - offset,
                                    " -DDBM_MULTIPLY_OPENCL_GEN");
-      if (0 != c_dbcsr_acc_opencl_config.device.intel && 0 != xf) {
-        flags = "-cl-intel-256-GRF-per-thread";
-      }
       wgsize[1] = wgsize[2] = 1;
       wgsize[0] = 16;
       ndims = 3;
@@ -106,9 +103,9 @@ void dbm_multiply_gpu_launch_kernel(const offloadStream_t stream,
           params + offset, sizeof(params) - offset,
           " %s -DSPLIT=%i -DBN=%i -DWG=%i -DSG=%i -DLU=%i",
           0 != gpu ? "-DGPU" : "", split, bn, (int)wgsize[0], (int)wgsize2, lu);
-      if (0 != c_dbcsr_acc_opencl_config.device.intel && 0 < xf) {
-        flags = "-cl-intel-256-GRF-per-thread";
-      }
+    }
+    if (0 != c_dbcsr_acc_opencl_config.device.intel && 0 < xf) {
+      flags = "-cl-intel-256-GRF-per-thread";
     }
     result |= (sizeof(params) > offset ? EXIT_SUCCESS : EXIT_FAILURE);
     result |= c_dbcsr_acc_opencl_kernel(


### PR DESCRIPTION
* OpenCL: account for GEN-kernel (not part of PR).