### PR TITLE
Fix ELPA build with Intel compiler

### DIFF
--- a/arch/Linux-intel-x86_64.psmp
+++ b/arch/Linux-intel-x86_64.psmp
@@ -68,7 +68,7 @@ USE_PLUMED     := 2.9.0
 USE_SIRIUS     := 7.5.2
 USE_SPFFT      := 1.0.6
 USE_SPGLIB     := 2.3.1
-USE_SPLA       := 1.5.5
+USE_SPLA       := 1.6.0
 # Only needed for SIRIUS
 LIBVDWXC_VER   := 0.4.0
 # Only needed for LIBPEXSI
@@ -88,6 +88,7 @@ ifeq ($(strip $(TARGET_CPU)), native)
 else
    CFLAGS         := -O2 -fPIC -fp-model precise -funroll-loops -g -mtune=$(TARGET_CPU) -qopenmp -qopenmp-simd -traceback
 endif
+CFLAGS         += -I/opt/intel/oneapi/compiler/latest/opt/compiler/include/intel64 -diag-disable=10448
 
 DFLAGS         := -D__parallel
 DFLAGS         += -D__SCALAPACK
@@ -107,7 +108,8 @@ ifeq ($(SHARED), yes)
    LDFLAGS        += -Wl,-rpath=$(CP2K_LIB)
    LDFLAGS        += -Wl,-rpath=$(CP2K_LIB)/exts/dbcsr
 else
-   LDFLAGS        := -static-intel -static_mpi
+#  LDFLAGS        := -static-intel -static_mpi
+   LDFLAGS        := -static-intel
 endif
 
 # Settings for regression testing
@@ -129,14 +131,14 @@ endif
 
 ifneq ($(USE_ELPA),)
    USE_ELPA       := $(strip $(USE_ELPA))
-   ELPA_INC       := $(INSTALL_PATH)/elpa-$(USE_ELPA)/cpu/include/elpa_openmp-$(USE_ELPA)
+   ELPA_INC       := $(INSTALL_PATH)/elpa-$(USE_ELPA)/cpu/include/elpa-$(USE_ELPA)
    ELPA_LIB       := $(INSTALL_PATH)/elpa-$(USE_ELPA)/cpu/lib
    CFLAGS         += -I$(ELPA_INC)/elpa -I$(ELPA_INC)/modules
    DFLAGS         += -D__ELPA
    ifeq ($(SHARED), yes)
-      LIBS           += -Wl,-rpath=$(ELPA_LIB) -L$(ELPA_LIB) -lelpa_openmp
+      LIBS           += -Wl,-rpath=$(ELPA_LIB) -L$(ELPA_LIB) -lelpa
    else
-      LIBS           += $(ELPA_LIB)/libelpa_openmp.a
+      LIBS           += $(ELPA_LIB)/libelpa.a
    endif
 endif
 
@@ -367,7 +369,7 @@ FCFLAGS        += -diag-disable=8293
 FCFLAGS        += -fpp
 FCFLAGS        += -fpscomp logicals
 FCFLAGS        += -free
-FCFLAGS        += -std08
+#FCFLAGS        += -std08
 
 LDFLAGS        += $(FCFLAGS)
 LDFLAGS_C      := -nofor-main

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -134,6 +134,9 @@ else
   CFLAGS="${G_CFLAGS} -std=c11 -Wall \$(DFLAGS)"
   CXXFLAGS="${G_CFLAGS} -std=c++14 -Wall \$(DFLAGS)"
   FCFLAGS="${FCFLAGS} -diag-disable=8291 -diag-disable=8293 -fpp -fpscomp logicals -free"
+  # Suppress warnings and add include path to omp_lib.mod explicitly.
+  # No clue why the Intel oneAPI setup script does not include that path (bug?)
+  FCFLAGS="${FCFLAGS} -diag-disable=10448 -I/opt/intel/oneapi/2024.1/opt/compiler/include/intel64"
 fi
 
 # Linker flags

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -50,6 +50,15 @@ case "$with_elpa" in
       fi
       enable_openmp="no"
     fi
+    if [ "${with_intel}" != "__DONTUSE__" ]; then
+      enable_openmp="no"
+      echo "OpenMP disabled for ELPA using the Intel compiler"
+      cflags="$(echo ${CFLAGS} | sed -e 's/[-a-z]*openmp[-a-z]*//g') -I/opt/intel/oneapi/compiler/latest/opt/compiler/include/intel64"
+      fcflags="$(echo ${FCFLAGS} | sed -e 's/[-a-z]*openmp[-a-z]*//g') -I/opt/intel/oneapi/compiler/latest/opt/compiler/include/intel64"
+    else
+      cflags=${CFLAGS}
+      fcflags=${FCFLAGS}
+    fi
 
     if verify_checksums "${install_lock_file}"; then
       echo "elpa-${elpa_ver} is already installed, skipping it."
@@ -113,9 +122,9 @@ case "$with_elpa" in
           CC=${MPICC} \
           CXX=${MPICXX} \
           CPP="cpp -E" \
-          FCFLAGS="${FCFLAGS} ${MATH_CFLAGS} ${SCALAPACK_CFLAGS} -ffree-line-length-none ${AVX_flag} ${FMA_flag} ${SSE4_flag} ${AVX512_flags} -fno-lto" \
-          CFLAGS="${CFLAGS} ${MATH_CFLAGS} ${SCALAPACK_CFLAGS} ${AVX_flag} ${FMA_flag} ${SSE4_flag} ${AVX512_flags} -fno-lto" \
-          CXXFLAGS="${CXXFLAGS} ${MATH_CFLAGS} ${SCALAPACK_CFLAGS} ${AVX_flag} ${FMA_flag} ${SSE4_flag} ${AVX512_flags} -fno-lto" \
+          FCFLAGS="${fcflags} ${MATH_CFLAGS} ${SCALAPACK_CFLAGS} ${AVX_flag} ${FMA_flag} ${SSE4_flag} ${AVX512_flags}" \
+          CFLAGS="${cflags} ${MATH_CFLAGS} ${SCALAPACK_CFLAGS} ${AVX_flag} ${FMA_flag} ${SSE4_flag} ${AVX512_flags}" \
+          CXXFLAGS="${CXXFLAGS} ${MATH_CFLAGS} ${SCALAPACK_CFLAGS} ${AVX_flag} ${FMA_flag} ${SSE4_flag} ${AVX512_flags}" \
           LDFLAGS="-Wl,--allow-multiple-definition -Wl,--enable-new-dtags ${MATH_LDFLAGS} ${SCALAPACK_LDFLAGS} ${cray_ldflags}" \
           LIBS="${SCALAPACK_LIBS} $(resolve_string "${MATH_LIBS}" "MPI")" \
           > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log


### PR DESCRIPTION
- Drop OpenMP for ELPA library build
- Adapt arch file (the Intel compiler does not find omp_lib.mod automatically)