### PR TITLE
Switch toolchain to new Intel Fortran compiler ifx (ifort -> ifx)

### DIFF
--- a/arch/Linux-intel-x86_64.psmp
+++ b/arch/Linux-intel-x86_64.psmp
@@ -2,7 +2,7 @@
 #
 # CP2K (Intel/MKL x86_64) arch file for Linux clusters
 #
-# Tested with: Intel 22.2 , Intel MPI, Intel MKL,
+# Tested with: Intel 2024.2.0, Intel MPI, Intel MKL,
 #              LIBINT 2.6.0, LIBXC 6.2.2, ELPA 2024.03.001,
 #              PLUMED 2.9.0, SPGLIB 2.3.1, LIBVORI 220621,
 #              GSL 2.7, COSMA 2.6.6, HDF5 1.14.2, SIRIUS 7.5.2,
@@ -13,7 +13,7 @@
 #        Optionally, the Intel compiler version can be specified as argument.
 #        Replace or adapt the "module add" commands below if needed.
 #
-# Last update: 12.06.2024
+# Last update: 21.06.2024
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -78,9 +78,9 @@ SUPERLU_VER    := 6.1.0
 LMAX           := 5
 MAX_CONTR      := 4
 
-CC             := mpiicc
-FC             := mpiifort
-LD             := mpiifort
+CC             := mpiicx
+FC             := mpiifx
+LD             := mpiifx
 AR             := ar -r
 
 ifeq ($(strip $(TARGET_CPU)), native)
@@ -88,7 +88,7 @@ ifeq ($(strip $(TARGET_CPU)), native)
 else
    CFLAGS         := -O2 -fPIC -fp-model precise -funroll-loops -g -mtune=$(TARGET_CPU) -qopenmp -qopenmp-simd -traceback
 endif
-CFLAGS         += -I/opt/intel/oneapi/compiler/latest/opt/compiler/include/intel64 -diag-disable=10448
+#CFLAGS         += -I/opt/intel/oneapi/compiler/latest/opt/compiler/include/intel64
 
 DFLAGS         := -D__parallel
 DFLAGS         += -D__SCALAPACK

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -150,8 +150,6 @@ The --with-PKG options follow the rules:
                           Default = system
   --with-intel            Use the Intel compiler to compile CP2K.
                           Default = system
-  --with-intel-classic    Use the classic Intel compiler to compile CP2K.
-                          Default = no
   --with-cmake            Cmake utilities
                           Default = install
   --with-openmpi          OpenMPI, important if you want a parallel version of CP2K.
@@ -349,7 +347,6 @@ enable_tsan="__FALSE__"
 enable_opencl="__FALSE__"
 enable_cuda="__FALSE__"
 enable_hip="__FALSE__"
-export intel_classic="no"
 export GPUVER="no"
 export MPICH_DEVICE="ch4"
 export TARGET_CPU="native"
@@ -553,9 +550,6 @@ while [ $# -ge 1 ]; do
       if [ "${with_intelmpi}" != "__DONTUSE__" ]; then
         export MPI_MODE=intelmpi
       fi
-      ;;
-    --with-intel-classic*)
-      intel_classic=$(read_with "${1}" "yes")
       ;;
     --with-intel*)
       with_intel=$(read_with "${1}" "__SYSTEM__")

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -127,10 +127,6 @@ fi
 if [ "${with_intel}" == "__DONTUSE__" ]; then
   CFLAGS="$G_CFLAGS -std=c11 -Wall -Wextra -Werror -Wno-vla-parameter -Wno-deprecated-declarations \$(DFLAGS)"
 else
-  CC_arch+=" IF_MPI(-cc=${I_MPI_CC}|)"
-  CXX_arch+=" IF_MPI(-cxx=${I_MPI_CXX}|)"
-  FC_arch+=" IF_MPI(-fc=${I_MPI_FC}|)"
-  LD_arch+=" IF_MPI(-fc=${I_MPI_FC}|)"
   CFLAGS="${G_CFLAGS} -std=c11 -Wall \$(DFLAGS)"
   CXXFLAGS="${G_CFLAGS} -std=c++14 -Wall \$(DFLAGS)"
   FCFLAGS="${FCFLAGS} -diag-disable=8291 -diag-disable=8293 -fpp -fpscomp logicals -free"

--- a/tools/toolchain/scripts/stage0/install_intel.sh
+++ b/tools/toolchain/scripts/stage0/install_intel.sh
@@ -28,15 +28,9 @@ case "${with_intel}" in
     ;;
   __SYSTEM__)
     echo "==================== Finding Intel compiler from system paths ===================="
-    if [ "${intel_classic}" = "yes" ]; then
-      check_command icc "intel" && CC="$(realpath $(command -v icc))" || exit 1
-      check_command icpc "intel" && CXX="$(realpath $(command -v icpc))" || exit 1
-      check_command ifx "intel" && FC="$(realpath $(command -v ifx))" || exit 1
-    else
-      check_command icx "intel" && CC="$(realpath $(command -v icx))" || exit 1
-      check_command icpx "intel" && CXX="$(realpath $(command -v icpx))" || exit 1
-      check_command ifx "intel" && FC="$(realpath $(command -v ifx))" || exit 1
-    fi
+    check_command icx "intel" && CC="$(realpath $(command -v icx))" || exit 1
+    check_command icpx "intel" && CXX="$(realpath $(command -v icpx))" || exit 1
+    check_command ifx "intel" && FC="$(realpath $(command -v ifx))" || exit 1
     F90="${FC}"
     F77="${FC}"
     ;;
@@ -49,15 +43,9 @@ case "${with_intel}" in
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
-    if [ "${intel_classic}" = "yes" ]; then
-      check_command ${pkg_install_dir}/bin/icc "intel" && CC="${pkg_install_dir}/bin/icc" || exit 1
-      check_command ${pkg_install_dir}/bin/icpc "intel" && CXX="${pkg_install_dir}/bin/icpc" || exit 1
-      check_command ${pkg_install_dir}/bin/ifx "intel" && FC="${pkg_install_dir}/bin/ifx" || exit 1
-    else
-      check_command ${pkg_install_dir}/bin/icx "intel" && CC="${pkg_install_dir}/bin/icx" || exit 1
-      check_command ${pkg_install_dir}/bin/icpx "intel" && CXX="${pkg_install_dir}/bin/icpx" || exit 1
-      check_command ${pkg_install_dir}/bin/ifx "intel" && FC="${pkg_install_dir}/bin/ifx" || exit 1
-    fi
+    check_command ${pkg_install_dir}/bin/icx "intel" && CC="${pkg_install_dir}/bin/icx" || exit 1
+    check_command ${pkg_install_dir}/bin/icpx "intel" && CXX="${pkg_install_dir}/bin/icpx" || exit 1
+    check_command ${pkg_install_dir}/bin/ifx "intel" && FC="${pkg_install_dir}/bin/ifx" || exit 1
     F90="${FC}"
     F77="${FC}"
     INTEL_CFLAGS="-I'${pkg_install_dir}/include'"

--- a/tools/toolchain/scripts/stage0/install_intel.sh
+++ b/tools/toolchain/scripts/stage0/install_intel.sh
@@ -31,11 +31,11 @@ case "${with_intel}" in
     if [ "${intel_classic}" = "yes" ]; then
       check_command icc "intel" && CC="$(realpath $(command -v icc))" || exit 1
       check_command icpc "intel" && CXX="$(realpath $(command -v icpc))" || exit 1
-      check_command ifort "intel" && FC="$(realpath $(command -v ifort))" || exit 1
+      check_command ifx "intel" && FC="$(realpath $(command -v ifx))" || exit 1
     else
       check_command icx "intel" && CC="$(realpath $(command -v icx))" || exit 1
       check_command icpx "intel" && CXX="$(realpath $(command -v icpx))" || exit 1
-      check_command ifort "intel" && FC="$(realpath $(command -v ifort))" || exit 1
+      check_command ifx "intel" && FC="$(realpath $(command -v ifx))" || exit 1
     fi
     F90="${FC}"
     F77="${FC}"
@@ -52,11 +52,11 @@ case "${with_intel}" in
     if [ "${intel_classic}" = "yes" ]; then
       check_command ${pkg_install_dir}/bin/icc "intel" && CC="${pkg_install_dir}/bin/icc" || exit 1
       check_command ${pkg_install_dir}/bin/icpc "intel" && CXX="${pkg_install_dir}/bin/icpc" || exit 1
-      check_command ${pkg_install_dir}/bin/ifort "intel" && FC="${pkg_install_dir}/bin/ifort" || exit 1
+      check_command ${pkg_install_dir}/bin/ifx "intel" && FC="${pkg_install_dir}/bin/ifx" || exit 1
     else
       check_command ${pkg_install_dir}/bin/icx "intel" && CC="${pkg_install_dir}/bin/icx" || exit 1
       check_command ${pkg_install_dir}/bin/icpx "intel" && CXX="${pkg_install_dir}/bin/icpx" || exit 1
-      check_command ${pkg_install_dir}/bin/ifort "intel" && FC="${pkg_install_dir}/bin/ifort" || exit 1
+      check_command ${pkg_install_dir}/bin/ifx "intel" && FC="${pkg_install_dir}/bin/ifx" || exit 1
     fi
     F90="${FC}"
     F77="${FC}"

--- a/tools/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_intelmpi.sh
@@ -79,7 +79,7 @@ if [ "${with_intelmpi}" != "__DONTUSE__" ]; then
   else
     I_MPI_CXX="icpx"
     I_MPI_CC="icx"
-    I_MPI_FC="ifort"
+    I_MPI_FC="ifx"
   fi
   INTELMPI_LIBS="-lmpi -lmpicxx"
   echo "I_MPI_CXX is ${I_MPI_CXX}"

--- a/tools/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_intelmpi.sh
@@ -33,7 +33,7 @@ case "${with_intelmpi}" in
     if [ "${with_intel}" != "__DONTUSE__" ]; then
       check_command mpiicc "intelmpi" && MPICC="$(realpath $(command -v mpiicc))" || exit 1
       check_command mpiicpc "intelmpi" && MPICXX="$(realpath $(command -v mpiicpc))" || exit 1
-      check_command mpiifort "intelmpi" && MPIFC="$(realpath $(command -v mpiifort))" || exit 1
+      check_command mpiifx "intelmpi" && MPIFC="$(realpath $(command -v mpiifx))" || exit 1
     else
       echo "The use of Intel MPI is only supported with the Intel compiler"
       exit 1
@@ -59,7 +59,7 @@ case "${with_intelmpi}" in
     if [ "${with_intel}" != "__DONTUSE__" ]; then
       check_command ${pkg_install_dir}/bin/mpiicc "intel" && MPICC="${pkg_install_dir}/bin/mpiicc" || exit 1
       check_command ${pkg_install_dir}/bin/mpiicpc "intel" && MPICXX="${pkg_install_dir}/bin/mpiicpc" || exit 1
-      check_command ${pkg_install_dir}/bin/mpiifort "intel" && MPIFC="${pkg_install_dir}/bin/mpiifort" || exit 1
+      check_command ${pkg_install_dir}/bin/mpiifx "intel" && MPIFC="${pkg_install_dir}/bin/mpiifx" || exit 1
     else
       echo "The use of Intel MPI is only supported with the Intel compiler"
       exit 1
@@ -72,26 +72,11 @@ case "${with_intelmpi}" in
     ;;
 esac
 if [ "${with_intelmpi}" != "__DONTUSE__" ]; then
-  if [ "${intel_classic}" = "yes" ]; then
-    I_MPI_CXX="icpc"
-    I_MPI_CC="icc"
-    I_MPI_FC="ifort"
-  else
-    I_MPI_CXX="icpx"
-    I_MPI_CC="icx"
-    I_MPI_FC="ifx"
-  fi
   INTELMPI_LIBS="-lmpi -lmpicxx"
-  echo "I_MPI_CXX is ${I_MPI_CXX}"
-  echo "I_MPI_CC  is ${I_MPI_CC}"
-  echo "I_MPI_FC  is ${I_MPI_FC}"
   echo "MPICXX    is ${MPICXX}"
   echo "MPICC     is ${MPICC}"
   echo "MPIFC     is ${MPIFC}"
   cat << EOF > "${BUILDDIR}/setup_intelmpi"
-export I_MPI_CXX="${I_MPI_CXX}"
-export I_MPI_CC="${I_MPI_CC}"
-export I_MPI_FC="${I_MPI_FC}"
 export MPI_MODE="${MPI_MODE}"
 export MPIRUN="${MPIRUN}"
 export MPICC="${MPICC}"


### PR DESCRIPTION
This PR serves to reproduce the current problems in compiling CP2K with ifx 2024.1, namely the termination with an internal compiler error in pw_methods.F.