### PR TITLE
FFTW: Fix import/export wisdom file

### DIFF
--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -157,6 +157,7 @@ CONTAINS
          iunit = get_unit_number()
          OPEN (UNIT=iunit, FILE=wisdom_file, STATUS="UNKNOWN", FORM="FORMATTED", ACTION="WRITE", IOSTAT=istat)
          IF (istat == 0) THEN
+            CLOSE (iunit)
             file_name_length = LEN_TRIM(wisdom_file)
             ALLOCATE (wisdom_file_name_c(file_name_length + 1))
             DO i = 1, file_name_length
@@ -167,7 +168,6 @@ CONTAINS
             isuccess = fftw_export_wisdom_to_filename(wisdom_file_name_c)
             IF (isuccess == 0) &
                CPABORT("Error exporting wisdom to file "//wisdom_file)
-            CLOSE (iunit)
          END IF
       END IF
 
@@ -222,23 +222,17 @@ CONTAINS
       ! all nodes are opening the file here...
       INQUIRE (FILE=wisdom_file, exist=exist)
       IF (exist) THEN
-         iunit = get_unit_number()
-         OPEN (UNIT=iunit, FILE=wisdom_file, STATUS="OLD", FORM="FORMATTED", POSITION="REWIND", &
-               ACTION="READ", IOSTAT=istat)
-         IF (istat == 0) THEN
-            file_name_length = LEN_TRIM(wisdom_file)
-            ALLOCATE (wisdom_file_name_c(file_name_length + 1))
-            DO i = 1, file_name_length
-               wisdom_file_name_c(i) = wisdom_file(i:i)
-            END DO
-            wisdom_file_name_c(file_name_length + 1) = C_NULL_CHAR
-            WRITE (*, *) wisdom_file_name_c
-            isuccess = fftw_import_wisdom_from_filename(wisdom_file_name_c)
-            IF (isuccess == 0) &
-               CPABORT("Error importing wisdom from file "//wisdom_file)
-            ! write(*,*) "FFTW3 import wisdom from file ....",MERGE((/"OK    "/),(/"NOT OK"/),(/isuccess==1/))
-            CLOSE (iunit)
-         END IF
+         file_name_length = LEN_TRIM(wisdom_file)
+         ALLOCATE (wisdom_file_name_c(file_name_length + 1))
+         DO i = 1, file_name_length
+            wisdom_file_name_c(i) = wisdom_file(i:i)
+         END DO
+         wisdom_file_name_c(file_name_length + 1) = C_NULL_CHAR
+         WRITE (*, *) wisdom_file_name_c
+         isuccess = fftw_import_wisdom_from_filename(wisdom_file_name_c)
+         IF (isuccess == 0) &
+            CPABORT("Error importing wisdom from file "//wisdom_file)
+         ! write(*,*) "FFTW3 import wisdom from file ....",MERGE((/"OK    "/),(/"NOT OK"/),(/isuccess==1/))
       END IF
 
 #if defined (__MKL)

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -148,7 +148,8 @@ CONTAINS
       LOGICAL                                  :: ionode
 
 #if defined ( __FFTW3 )
-      INTEGER                                  :: iunit, istat
+      CHARACTER(C_CHAR), DIMENSION(:), ALLOCATABLE :: wisdom_file_name_c
+      INTEGER                                  :: iunit, istat, file_name_length, i
       INTEGER(KIND=C_INT)                      :: isuccess
       ! Write out FFTW3 wisdom to file (if we can)
       ! only the ionode updates the wisdom
@@ -156,7 +157,14 @@ CONTAINS
          iunit = get_unit_number()
          OPEN (UNIT=iunit, FILE=wisdom_file, STATUS="UNKNOWN", FORM="FORMATTED", ACTION="WRITE", IOSTAT=istat)
          IF (istat == 0) THEN
-            isuccess = fftw_export_wisdom_to_filename(wisdom_file//C_NULL_CHAR)
+            file_name_length = LEN_TRIM(wisdom_file)
+            ALLOCATE (wisdom_file_name_c(file_name_length + 1))
+            DO i = 1, file_name_length
+               wisdom_file_name_c(i) = wisdom_file(i:i)
+            END DO
+            wisdom_file_name_c(file_name_length + 1) = C_NULL_CHAR
+            WRITE (*, *) wisdom_file_name_c
+            isuccess = fftw_export_wisdom_to_filename(wisdom_file_name_c)
             IF (isuccess == 0) &
                CPABORT("Error exporting wisdom to file "//wisdom_file)
             CLOSE (iunit)
@@ -180,7 +188,8 @@ CONTAINS
       CHARACTER(LEN=*), INTENT(IN)             :: wisdom_file
 
 #if defined ( __FFTW3 )
-      INTEGER                                  :: istat, iunit
+      CHARACTER(C_CHAR), DIMENSION(:), ALLOCATABLE :: wisdom_file_name_c
+      INTEGER                                  :: istat, iunit, file_name_length, i
       INTEGER(KIND=C_INT) :: isuccess
       LOGICAL                                  :: exist
 
@@ -217,7 +226,14 @@ CONTAINS
          OPEN (UNIT=iunit, FILE=wisdom_file, STATUS="OLD", FORM="FORMATTED", POSITION="REWIND", &
                ACTION="READ", IOSTAT=istat)
          IF (istat == 0) THEN
-            isuccess = fftw_import_wisdom_from_filename(wisdom_file//C_NULL_CHAR)
+            file_name_length = LEN_TRIM(wisdom_file)
+            ALLOCATE (wisdom_file_name_c(file_name_length + 1))
+            DO i = 1, file_name_length
+               wisdom_file_name_c(i) = wisdom_file(i:i)
+            END DO
+            wisdom_file_name_c(file_name_length + 1) = C_NULL_CHAR
+            WRITE (*, *) wisdom_file_name_c
+            isuccess = fftw_import_wisdom_from_filename(wisdom_file_name_c)
             IF (isuccess == 0) &
                CPABORT("Error importing wisdom from file "//wisdom_file)
             ! write(*,*) "FFTW3 import wisdom from file ....",MERGE((/"OK    "/),(/"NOT OK"/),(/isuccess==1/))

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -5,7 +5,6 @@
 !   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
 !--------------------------------------------------------------------------------------------------!
 MODULE fftw3_lib
-
    USE ISO_C_BINDING, ONLY: C_ASSOCIATED, &
                             C_CHAR, &
                             C_DOUBLE, &
@@ -148,7 +147,7 @@ CONTAINS
       LOGICAL                                  :: ionode
 
 #if defined ( __FFTW3 )
-      CHARACTER(C_CHAR), DIMENSION(:), ALLOCATABLE :: wisdom_file_name_c
+      CHARACTER(LEN=:, KIND=C_CHAR), ALLOCATABLE :: wisdom_file_name_c
       INTEGER                                  :: iunit, istat, file_name_length, i
       INTEGER(KIND=C_INT)                      :: isuccess
       ! Write out FFTW3 wisdom to file (if we can)
@@ -157,17 +156,16 @@ CONTAINS
          iunit = get_unit_number()
          OPEN (UNIT=iunit, FILE=wisdom_file, STATUS="UNKNOWN", FORM="FORMATTED", ACTION="WRITE", IOSTAT=istat)
          IF (istat == 0) THEN
-            CLOSE (iunit)
             file_name_length = LEN_TRIM(wisdom_file)
-            ALLOCATE (wisdom_file_name_c(file_name_length + 1))
+            ALLOCATE (CHARACTER(LEN=file_name_length + 1, KIND=C_CHAR) :: wisdom_file_name_c)
             DO i = 1, file_name_length
-               wisdom_file_name_c(i) = wisdom_file(i:i)
+               wisdom_file_name_c(i:i) = wisdom_file(i:i)
             END DO
-            wisdom_file_name_c(file_name_length + 1) = C_NULL_CHAR
-            WRITE (*, *) wisdom_file_name_c
+            wisdom_file_name_c(file_name_length + 1:file_name_length + 1) = C_NULL_CHAR
             isuccess = fftw_export_wisdom_to_filename(wisdom_file_name_c)
             IF (isuccess == 0) &
                CPABORT("Error exporting wisdom to file "//wisdom_file)
+            CLOSE (iunit)
          END IF
       END IF
 
@@ -188,8 +186,8 @@ CONTAINS
       CHARACTER(LEN=*), INTENT(IN)             :: wisdom_file
 
 #if defined ( __FFTW3 )
-      CHARACTER(C_CHAR), DIMENSION(:), ALLOCATABLE :: wisdom_file_name_c
-      INTEGER                                  :: istat, iunit, file_name_length, i
+      CHARACTER(LEN=:, KIND=C_CHAR), ALLOCATABLE :: wisdom_file_name_c
+      INTEGER                                  :: file_name_length, i
       INTEGER(KIND=C_INT) :: isuccess
       LOGICAL                                  :: exist
 
@@ -223,16 +221,14 @@ CONTAINS
       INQUIRE (FILE=wisdom_file, exist=exist)
       IF (exist) THEN
          file_name_length = LEN_TRIM(wisdom_file)
-         ALLOCATE (wisdom_file_name_c(file_name_length + 1))
+         ALLOCATE (CHARACTER(LEN=file_name_length + 1, KIND=C_CHAR) :: wisdom_file_name_c)
          DO i = 1, file_name_length
-            wisdom_file_name_c(i) = wisdom_file(i:i)
+            wisdom_file_name_c(i:i) = wisdom_file(i:i)
          END DO
-         wisdom_file_name_c(file_name_length + 1) = C_NULL_CHAR
-         WRITE (*, *) wisdom_file_name_c
+         wisdom_file_name_c(file_name_length + 1:file_name_length + 1) = C_NULL_CHAR
          isuccess = fftw_import_wisdom_from_filename(wisdom_file_name_c)
          IF (isuccess == 0) &
             CPABORT("Error importing wisdom from file "//wisdom_file)
-         ! write(*,*) "FFTW3 import wisdom from file ....",MERGE((/"OK    "/),(/"NOT OK"/),(/isuccess==1/))
       END IF
 
 #if defined (__MKL)


### PR DESCRIPTION
This PR fixes the incorrect conversion between Fortran- and C-characters which leads to segfaults if CP2K attempts to import/export FFTW wisdom files (see #3491 ). Now, it works, if the wisdom file was created by FFTW3's fftw-wisdom.