### PR TITLE
FFTW3_LIB: Convert aborts to warnings

### DIFF
--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -147,7 +147,7 @@ CONTAINS
       LOGICAL                                  :: ionode
 
 #if defined ( __FFTW3 )
-      CHARACTER(C_CHAR), DIMENSION(:), ALLOCATABLE :: wisdom_file_name_c
+      CHARACTER(LEN=1, KIND=C_CHAR), DIMENSION(:), ALLOCATABLE :: wisdom_file_name_c
       INTEGER                                  :: file_name_length, i, iunit, istat
       INTEGER(KIND=C_INT)                      :: isuccess
       ! Write out FFTW3 wisdom to file (if we can)
@@ -188,7 +188,7 @@ CONTAINS
       CHARACTER(LEN=*), INTENT(IN)             :: wisdom_file
 
 #if defined ( __FFTW3 )
-      CHARACTER(C_CHAR), DIMENSION(:), ALLOCATABLE :: wisdom_file_name_c
+      CHARACTER(LEN=1, KIND=C_CHAR), DIMENSION(:), ALLOCATABLE :: wisdom_file_name_c
       INTEGER                                  :: file_name_length, i, istat, iunit
       INTEGER(KIND=C_INT)                      :: isuccess
       LOGICAL :: file_exists

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -166,7 +166,8 @@ CONTAINS
             wisdom_file_name_c(file_name_length + 1) = C_NULL_CHAR
             isuccess = fftw_export_wisdom_to_filename(wisdom_file_name_c)
             IF (isuccess == 0) &
-               CALL cp_abort(__LOCATION__, "Error exporting wisdom to file "//TRIM(wisdom_file)//".")
+               CALL cp_warn(__LOCATION__, "Error exporting wisdom to file "//TRIM(wisdom_file)//". "// &
+                            "Wisdom was not exported.")
          END IF
       END IF
 
@@ -240,8 +241,9 @@ CONTAINS
             wisdom_file_name_c(file_name_length + 1) = C_NULL_CHAR
             isuccess = fftw_import_wisdom_from_filename(wisdom_file_name_c)
             IF (isuccess == 0) &
-               CALL cp_abort(__LOCATION__, "Error importing wisdom from file "//TRIM(wisdom_file)//". "// &
-                             "Maybe the file was created with a different configuration than CP2K is run with.")
+               CALL cp_warn(__LOCATION__, "Error importing wisdom from file "//TRIM(wisdom_file)//". "// &
+                            "Maybe the file was created with a different configuration than CP2K is run with. "// &
+                            "CP2K continues without importing wisdom.")
          END IF
       END IF
 


### PR DESCRIPTION
As it turns out, there are issues on reading/writing wisdom files on HPC devices. Thus, this PR downgrades the aborts to warnings. In this way, the user has at least an information on the issue. I extended the message to give a hint to the user.