### PR TITLE
refactored wfn_mix input reference

### DIFF
--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -2899,21 +2899,21 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="OVERWRITE_MOS", &
                         description="If set to True, the active molecular orbitals in memory will be replaced by the mixed wfn "// &
                         "at the end of the wfn mixing procedure. For instance, you can then use this new set of MOs to perform "// &
-                          "RTP or EMD directly. Not that in the case of an RTP run with INITIAL_WFN=RESTART_WFN, this keyword "// &
-                          "is not used: the mixed wfn is used to start the time-dependent run. "// &
-                          "Default value is False.", &
+                     "RTP or EMD directly. Note that in the case of an RTP run with INITIAL_WFN=RESTART_WFN, the OVERWRITE_MOS "// &
+                          "keyword is not used.", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL section_create(subsection, __LOCATION__, name="UPDATE", &
-                          description="update a result MO with with a linear combination of of original MOs."// &
-                          " This section can be repeated to build arbitrary linear combinations using repeatedly y=a*y+b*x.", &
+                          description="Update a result MO with with a linear combination of original MOs."// &
+                          " This section can be repeated to build arbitrary linear combinations using repeatedly y=a*y+b*x.\n "// &
+                          "RESULT is (y), RESULT_SCALE is (a), ORIG is (x), ORIG_SCALE is (b)", &
                           n_keywords=1, n_subsections=0, repeats=.TRUE.)
 
       CALL keyword_create(keyword, __LOCATION__, name="RESULT_MO_INDEX", &
                           description="Index of the MO (y) to be modified. Counting down in energy: "// &
-                          "set to 1 for the HOMO, to 3 for the HOMO-3.", &
+                          "set to 1 for the highest MO, to 3 for the highest MO-2.", &
                           usage="RESULT_MO_INDEX 1", type_of_var=integer_t, default_i_val=0)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
@@ -2923,6 +2923,14 @@ CONTAINS
                           "the marks set in MOLECULAR_STATES. The value corresponds to the repetition "// &
                           "of MARK_STATES in MOLECULAR_STATES", &
                           usage="ORIG_MARKED_STATE 1", type_of_var=integer_t, default_i_val=0)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="REVERSE_MO_INDEX", &
+                          description="Reverses the index order of the OCCUPIED and EXTERNAL MOs. With this keyword "// &
+                          "ORIG_MO_INDEX/RESULT_MO_INDEX 1 point to the lowest energy MO (instead of the highest) "// &
+                          "and counts up in energy. The VIRTUAL MOs indexing is unchanged.", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
 
@@ -2944,11 +2952,11 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="ORIG_MO_INDEX", &
                           description="Index of the original MO (x). "// &
                           "If ORIG_TYPE is OCCUPIED, it counts down in energy: set to 1 to point to "// &
-                          "the HOMO and to 3 for the HOMO-3. "// &
+                          "the highest MO and to 3 for the highest MO-2. "// &
                           "If ORIG_TYPE is VIRTUAL, it counts up in energy: set to 1 to point to "// &
-                          "the LUMO and to 3 for the LUMO+3. "// &
+                          "the lowest virtual MO and to 3 for the lowest MO+2. "// &
                           "If ORIG_TYPE is EXTERNAL, it counts down in energy for the external "// &
-                          "set of MOs: set to 1 to point to the HOMO and to 3 for the HOMO-3. "// &
+                          "set of MOs: set to 1 to point to the highest MO and to 3 for the highest MO-2. "// &
                           "Do not set to zero or negative values.", &
                           usage="ORIG_MO_INDEX 1", type_of_var=integer_t, default_i_val=0)
       CALL section_add_keyword(subsection, keyword)
@@ -2972,21 +2980,21 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="ORIG_SCALE", &
-                          description="Scaling factor of the result variable (b).", &
+                          description="Scaling factor of the original variable (b).", &
                           usage="ORIG_SCALE 0.0", type_of_var=real_t)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="ORIG_TYPE", &
-                          description="Type of the orgine MO. Note that using VIRTUAL along with an RTP run with "// &
-                          "INITIAL_WFN=RESTART_WFN will probably crash since no virtual state "// &
-                          "will be available.", &
+                          description="Type of the original MO. Note that if ADDED_MOS was used in the "// &
+                          "SCF construction of the MO matrix, these extra MOs are also treated as OCCUPIED. ", &
                           enum_c_vals=s2a("OCCUPIED", "VIRTUAL", 'EXTERNAL'), &
                           usage="ORIG_TYPE OCCUPIED", &
                           default_i_val=wfn_mix_orig_occ, &
-                          enum_desc=s2a("The original MO is in the MOs matrix itself.", &
-                                        "The original MO is not in the MOs matrix but in the 'unoccupied' one. "// &
-                                        "The SCF cycle shall provide it.", &
+                          enum_desc=s2a("The original MO is the result of the SCF procedure. This can also contain "// &
+                                        "unoccupied MOs if the SCF%ADDED_MOS keyword was used.", &
+                                        "The original MO is taken from the result of additional MOs calculated a "// &
+                                        "posteriori of the SCF by request of the user. E.g. by specifying print%mo_cubes%nlumo. ", &
                                         "The orginal MO is from an external .wfn file. Use the keyword "// &
                                         "ORIG_EXT_FILE_NAME to define its name."), &
                           enum_i_vals=(/wfn_mix_orig_occ, wfn_mix_orig_virtual, wfn_mix_orig_external/))

--- a/src/qs_scf_wfn_mix.F
+++ b/src/qs_scf_wfn_mix.F
@@ -92,7 +92,7 @@ CONTAINS
       INTEGER :: handle, i_rep, ispin, mark_ind, mark_number, n_rep, orig_mo_index, &
          orig_spin_index, orig_type, restart_unit, result_mo_index, result_spin_index
       LOGICAL                                            :: explicit, is_file, my_for_rtp, &
-                                                            overwrite_mos
+                                                            overwrite_mos, reverse_mo_index
       REAL(KIND=dp)                                      :: orig_scale, orthonormality, result_scale
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_vector
       TYPE(cp_fm_type)                                   :: matrix_x, matrix_y
@@ -142,7 +142,7 @@ CONTAINS
             CALL section_vals_val_get(update_section, "RESULT_MO_INDEX", i_rep_section=i_rep, i_val=result_mo_index)
             CALL section_vals_val_get(update_section, "RESULT_MARKED_STATE", i_rep_section=i_rep, i_val=mark_number)
             CALL section_vals_val_get(update_section, "RESULT_SPIN_INDEX", i_rep_section=i_rep, i_val=result_spin_index)
-            ! result_scale is the 'b' coefficient
+            ! result_scale is the 'a' coefficient
             CALL section_vals_val_get(update_section, "RESULT_SCALE", i_rep_section=i_rep, r_val=result_scale)
 
             mark_ind = 1
@@ -154,7 +154,7 @@ CONTAINS
             CALL section_vals_val_get(update_section, "ORIG_MO_INDEX", i_rep_section=i_rep, i_val=orig_mo_index)
             CALL section_vals_val_get(update_section, "ORIG_MARKED_STATE", i_rep_section=i_rep, i_val=mark_number)
             CALL section_vals_val_get(update_section, "ORIG_SPIN_INDEX", i_rep_section=i_rep, i_val=orig_spin_index)
-            ! orig_scal is the 'a' coefficient
+            ! orig_scal is the 'b' coefficient
             CALL section_vals_val_get(update_section, "ORIG_SCALE", i_rep_section=i_rep, r_val=orig_scale)
 
             IF (orig_type == wfn_mix_orig_virtual) mark_ind = 2
@@ -162,12 +162,18 @@ CONTAINS
 
             CALL section_vals_val_get(wfn_mix_section, "OVERWRITE_MOS", l_val=overwrite_mos)
 
+            CALL section_vals_val_get(update_section, "REVERSE_MO_INDEX", l_val=reverse_mo_index)
+
             ! First get a copy of the proper orig
             ! Origin is in the MO matrix
             IF (orig_type == wfn_mix_orig_occ) THEN
-               CALL cp_fm_to_fm(mos(orig_spin_index)%mo_coeff, matrix_x, 1, &
-                                mos(orig_spin_index)%nmo - orig_mo_index + 1, 1)
-
+               IF (reverse_mo_index) THEN
+                  CALL cp_fm_to_fm(mos(orig_spin_index)%mo_coeff, matrix_x, 1, &
+                                   orig_mo_index, 1)
+               ELSE
+                  CALL cp_fm_to_fm(mos(orig_spin_index)%mo_coeff, matrix_x, 1, &
+                                   mos(orig_spin_index)%nmo - orig_mo_index + 1, 1)
+               END IF
                ! Orgin is in the virtual matrix
             ELSE IF (orig_type == wfn_mix_orig_virtual) THEN
                IF (.NOT. ASSOCIATED(unoccupied_orbs)) &
@@ -207,9 +213,13 @@ CONTAINS
                                          rst_unit=restart_unit)
                IF (para_env%is_source()) CALL close_file(unit_number=restart_unit)
 
-               CALL cp_fm_to_fm(mos_orig_ext(orig_spin_index)%mo_coeff, matrix_x, 1, &
-                                mos_orig_ext(orig_spin_index)%nmo - orig_mo_index + 1, 1)
-
+               IF (reverse_mo_index) THEN
+                  CALL cp_fm_to_fm(mos_orig_ext(orig_spin_index)%mo_coeff, matrix_x, 1, &
+                                   orig_mo_index, 1)
+               ELSE
+                  CALL cp_fm_to_fm(mos_orig_ext(orig_spin_index)%mo_coeff, matrix_x, 1, &
+                                   mos_orig_ext(orig_spin_index)%nmo - orig_mo_index + 1, 1)
+               END IF
                DO ispin = 1, SIZE(mos_orig_ext)
                   CALL deallocate_mo_set(mos_orig_ext(ispin))
                END DO
@@ -217,14 +227,25 @@ CONTAINS
             END IF
 
             ! Second, get a copy of the target
-            CALL cp_fm_to_fm(mos_new(result_spin_index)%mo_coeff, matrix_y, &
-                             1, mos_new(result_spin_index)%nmo - result_mo_index + 1, 1)
+            IF (reverse_mo_index) THEN
+               CALL cp_fm_to_fm(mos_new(result_spin_index)%mo_coeff, matrix_y, &
+                                1, result_mo_index, 1)
+            ELSE
+               CALL cp_fm_to_fm(mos_new(result_spin_index)%mo_coeff, matrix_y, &
+                                1, mos_new(result_spin_index)%nmo - result_mo_index + 1, 1)
+            END IF
 
             ! Third, perform the mix
             CALL cp_fm_scale_and_add(result_scale, matrix_y, orig_scale, matrix_x)
+
             ! and copy back in the result mos
-            CALL cp_fm_to_fm(matrix_y, mos_new(result_spin_index)%mo_coeff, &
-                             1, 1, mos_new(result_spin_index)%nmo - result_mo_index + 1)
+            IF (reverse_mo_index) THEN
+               CALL cp_fm_to_fm(matrix_y, mos_new(result_spin_index)%mo_coeff, &
+                                1, 1, result_mo_index)
+            ELSE
+               CALL cp_fm_to_fm(matrix_y, mos_new(result_spin_index)%mo_coeff, &
+                                1, 1, mos_new(result_spin_index)%nmo - result_mo_index + 1)
+            END IF
          END DO
 
          CALL cp_fm_release(matrix_x)


### PR DESCRIPTION
Updates the WFN_MIX input reference description and adds a keyword to allow reversing the MO indexing. This simplifies the input section when mixing low energy states and when the number of MOs in the wavefunction are modified by user request.