### PR TITLE
Fix charge analysis in case of post-SCF methods

### DIFF
--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -305,7 +305,6 @@ CONTAINS
 
       ! Writes the data that is already available in qs_env
       CALL get_qs_env(qs_env, scf_env=scf_env)
-      CALL write_available_results(qs_env, scf_env)
 
       my_localized_wfn = .FALSE.
       NULLIFY (admm_env, dft_control, pw_env, auxbas_pw_pool, pw_pools, mos, rho, &
@@ -353,6 +352,8 @@ CONTAINS
          ! In MP2 case update the Hartree potential
          CALL update_hartree_with_mp2(rho, qs_env)
       END IF
+
+      CALL write_available_results(qs_env, scf_env)
 
       !    **** the kinetic energy
       IF (cp_print_key_should_output(logger%iter_info, input, &


### PR DESCRIPTION
The currently printed Mulliken and Hirshfeld charge analysis of post-SCF methods prints SCF-based charges. This PR fixes this behavior. See [here](https://groups.google.com/g/cp2k/c/4UQqNSPW4bM/m/QryAk_vVBAAJ?utm_medium=email&utm_source=footer) for the bug report.