### PR TITLE
Add -D__MPI_F08 flag

### DIFF
--- a/arch/Darwin-gnu-arm64.psmp
+++ b/arch/Darwin-gnu-arm64.psmp
@@ -100,6 +100,7 @@ CFLAGS         := -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g 
 
 DFLAGS         := -D__parallel
 DFLAGS         += -D__ACCELERATE
+DFLAGS         += -D__MPI_F08
 DFLAGS         += -D__HAS_IEEE_EXCEPTIONS
 DFLAGS         += -D__MAX_CONTR=$(strip $(MAX_CONTR))
 DFLAGS         += -D__NO_STATM_ACCESS


### PR DESCRIPTION
OpenMPI 5.0.5 does not work with macOS (Darwin-gnu-arm64)