### PR TITLE
IFX: use __INTEL_LLVM_COMPILER instead of __MKL

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -104,8 +104,8 @@ Examples are the sequential variant of the Intel MKL, the Cray libsci, the OpenB
 and the reference BLAS/LAPACK packages. If compiling with MKL, users must define `-D__MKL` to ensure
 the code is thread-safe. MKL with multiple OpenMP threads in CP2K requires that CP2K was compiled
 with the Intel compiler. If the `cpp` precompiler is used in a separate precompilation step in
-combination with the Intel Fortran compiler, `-D__INTEL_COMPILER` must be added explicitly (the
-Intel compiler sets `__INTEL_COMPILER` otherwise automatically).
+combination with the Intel Fortran compiler, `-D__INTEL_LLVM_COMPILER` (`-D__INTEL_COMPILER`) must
+be added explicitly (the Intel compiler sets `D__INTEL_LLVM_COMPILER` otherwise automatically).
 
 On the Mac, BLAS and LAPACK may be provided by Apple's Accelerate framework. If using this
 framework, `-D__ACCELERATE` must be defined to account for some interface incompatibilities between

--- a/src/grid/common/grid_common.h
+++ b/src/grid/common/grid_common.h
@@ -10,7 +10,8 @@
 #define GRID_STRINGIFY(SYMBOL) #SYMBOL
 
 // GCC added the simd pragma with version 6.
-#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && __GNUC__ < 6
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) &&                         \
+    !defined(__INTEL_LLVM_COMPILER) && __GNUC__ < 6
 #define GRID_PRAGMA_SIMD(OBJS, N)
 // Intel added the simd pragma with version 19.00.
 #elif defined(__INTEL_COMPILER) && __INTEL_COMPILER < 1900
@@ -22,11 +23,13 @@
 #endif
 
 // GCC added the unroll pragma with version 8 and...
-#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && __GNUC__ < 8
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) &&                         \
+    !defined(__INTEL_LLVM_COMPILER) && __GNUC__ < 8
 #define GRID_PRAGMA_UNROLL(N)
 #define GRID_PRAGMA_UNROLL_UP_TO(N)
 // ...chose a custom syntax.
-#elif defined(__GNUC__) && !defined(__INTEL_COMPILER) && __GNUC__ >= 8
+#elif defined(__GNUC__) && !defined(__INTEL_COMPILER) &&                       \
+    !defined(__INTEL_LLVM_COMPILER) && __GNUC__ >= 8
 #define GRID_PRAGMA_UNROLL(N) _Pragma(GRID_STRINGIFY(GCC unroll N))
 #define GRID_PRAGMA_UNROLL_UP_TO(N) _Pragma(GRID_STRINGIFY(GCC unroll N))
 // Most other compilers support a common syntax.

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -2052,7 +2052,7 @@ CONTAINS
                DO irep = 0, num_integ_group - 1
                   start_point = ranges_info_array(3, irep, comm_exchange%mepos)
                   end_point = ranges_info_array(4, irep, comm_exchange%mepos)
-#if defined(__MKL)
+#if defined(__INTEL_LLVM_COMPILER)
                   Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) = &
                      Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) + &
                      BI_C_rec(1:my_B_size, :, start_point:end_point)

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -247,7 +247,7 @@ CONTAINS
             CALL timeset(routineN, handle)
 
             ! This OMP clause causes an internal compiler error (ICE) with ifx (<=2024.2.1)
-#if defined(__MKL)
+#if defined(__INTEL_LLVM_COMPILER)
             pw%array = ${type2type("0.0_dp", "r3d", kind)}$
 #else
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw)

--- a/tools/precommit/check_file_properties.py
+++ b/tools/precommit/check_file_properties.py
@@ -42,6 +42,7 @@ FLAG_EXCEPTIONS = (
     r"__DATA_DIR",
     r"__FFTW3_UNALIGNED",
     r"__FORCE_USE_FAST_MATH",
+    r"__INTEL_LLVM_COMPILER",
     r"__INTEL_COMPILER",
     r"OFFLOAD_CHECK",
     r"__OFFLOAD_CUDA",


### PR DESCRIPTION
* Note: it is common to use MKL even for non-Intel compiler