### PR TITLE
Accommodate toolchain for Alps

### DIFF
--- a/tools/toolchain/scripts/stage1/install_mpich.sh
+++ b/tools/toolchain/scripts/stage1/install_mpich.sh
@@ -56,7 +56,7 @@ case "${with_mpich}" in
         MPICC="" \
         FFLAGS="${FCFLAGS} ${compat_flag}" \
         FCFLAGS="${FCFLAGS} ${compat_flag}" \
-        --without-x \
+        --without-x --without-slurm \
         --enable-gl=no \
         --with-device=${MPICH_DEVICE} \
         > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log


### PR DESCRIPTION
* OpenBLAS
  - OpenBLAS detects Alps CPU as NeoverseV2 (LIBCORE), which is suddenly not in the TargetList of OpenBLAS
  - Building and installing OpenBLAS is now more robust relying on the DYNAMIC_ARCH feature.
  - On ARM in particular, "generic" was hard-coded as TARGET=NEHALEM.
  - The USE_THREAD setting is not necessary for CP2K (plain PThread flavor as opposed to OpenMP).
* MPICH/2
  - Apply --without-slurm as it otherwise is likely to meet an incompatible Slurm include file.
  - Previously: compilation error on Alps-like self-hosted SuperMicro system (w/ Ubuntu LTS).