### PR TITLE
Re-init FFT scratch in case of PW env changes.

### DIFF
--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -136,6 +136,7 @@ MODULE fft_tools
    PRIVATE
    PUBLIC :: init_fft, fft3d, finalize_fft
    PUBLIC :: fft_alloc, fft_dealloc
+   PUBLIC :: init_fft_scratch_pool
    PUBLIC :: fft_radix_operations, fft_fw1d
    PUBLIC :: FWFFT, BWFFT
    PUBLIC :: FFT_RADIX_CLOSEST, FFT_RADIX_NEXT
@@ -2948,6 +2949,7 @@ CONTAINS
             CASE DEFAULT
                CPABORT("")
             CASE (100) ! fft3d_pb: full cube distribution
+               CPASSERT(PRESENT(fft_sizes))
                mx1 = fft_sizes%mx1
                my1 = fft_sizes%my1
                mx2 = fft_sizes%mx2
@@ -3006,6 +3008,7 @@ CONTAINS
                                         fft_scratch_new%fft_scratch%a2buf, fft_scratch_new%fft_scratch%a1buf, fft_plan_style)
 
             CASE (101) ! fft3d_pb: full cube distribution (dim 1)
+               CPASSERT(PRESENT(fft_sizes))
                mx1 = fft_sizes%mx1
                my1 = fft_sizes%my1
                mz1 = fft_sizes%mz1
@@ -3043,6 +3046,7 @@ CONTAINS
                                         fft_scratch_new%fft_scratch%a3buf, fft_scratch_new%fft_scratch%a1buf, fft_plan_style)
 
             CASE (200) ! fft3d_ps: plane distribution
+               CPASSERT(PRESENT(fft_sizes))
                nx = fft_sizes%nx
                ny = fft_sizes%ny
                nz = fft_sizes%nz
@@ -3092,6 +3096,7 @@ CONTAINS
                                         fft_scratch_new%fft_scratch%r1buf, fft_scratch_new%fft_scratch%tbuf, fft_plan_style)
 
             CASE (300) ! fft3d_ps: block distribution
+               CPASSERT(PRESENT(fft_sizes))
                mx1 = fft_sizes%mx1
                mx2 = fft_sizes%mx2
                my1 = fft_sizes%my1

--- a/src/pw_env_methods.F
+++ b/src/pw_env_methods.F
@@ -43,6 +43,7 @@ MODULE pw_env_methods
                                               derivative_cd5,&
                                               derivative_cd7,&
                                               rho_dependent
+   USE fft_tools,                       ONLY: init_fft_scratch_pool
    USE gaussian_gridlevels,             ONLY: destroy_gaussian_gridlevel,&
                                               gaussian_gridlevel,&
                                               init_gaussian_gridlevel
@@ -248,6 +249,9 @@ CONTAINS
          DEALLOCATE (pw_env%cube_info)
       END IF
       NULLIFY (pw_env%pw_pools, pw_env%cube_info)
+
+      ! remove fft scratch pool, as it depends on pw_env mpi group handles
+      CALL init_fft_scratch_pool()
 
       !
       !


### PR DESCRIPTION
For methods that have to re-initialize the PW environment  (change of computational cell), it might happen, that the FFT scratches get out of sync on different processors. If this happens for a blocked FFT, jobs will hang in a synchronization (mp_cart_create).
Solution: re-initialize the FFT scratches when PW env is changed.