### PR TITLE
Update arch files for the new SIRIUS release 7.6.x

### DIFF
--- a/arch/Darwin-gnu-arm64.psmp
+++ b/arch/Darwin-gnu-arm64.psmp
@@ -9,7 +9,7 @@
 #        Ensure the links in /opt/homebrew/bin to the gcc version
 #        and "brew unlink openmpi" (or mpich) if installed.
 #
-# Last update: 06.09.2024
+# Last update: 12.09.2024
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -185,15 +185,19 @@ endif
 
 ifneq ($(USE_SIRIUS),)
    USE_SIRIUS     := $(strip $(USE_SIRIUS))
+   USE_GSL        := ${GSL_VER}
    LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
    LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
-   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include
+   PUGIXML_LIB    := $(INSTALL_PATH)/pugixml-$(PUGIXML_VER)/lib
+   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include/sirius
    SIRIUS_LIB     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/lib
    CFLAGS         += -I$(LIBVDWXC_INC)
    CFLAGS         += -I$(SIRIUS_INC)
    DFLAGS         += -D__LIBVDWXC
    DFLAGS         += -D__SIRIUS
    LIBS           += $(SIRIUS_LIB)/libsirius.a
+   LIBS           += $(SIRIUS_LIB)/libsirius_cxx.a
+   LIBS           += $(PUGIXML_LIB)/libpugixml.a
    LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
 endif
 

--- a/arch/Eiger-mc-gnu.psmp
+++ b/arch/Eiger-mc-gnu.psmp
@@ -7,7 +7,7 @@
 # Usage: Source this arch file and then run make as instructed.
 #        Replace or adapt the "module load" commands below if needed.
 #
-# Last update: 06.09.2024
+# Last update: 12.09.2024
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -252,20 +252,24 @@ endif
 
 ifneq ($(USE_SIRIUS),)
    USE_SIRIUS     := $(strip $(USE_SIRIUS))
-   USE_GSL        := $(GSL_VER)
+   USE_GSL        := ${GSL_VER}
    LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
    LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
-   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include
+   PUGIXML_LIB    := $(INSTALL_PATH)/pugixml-$(PUGIXML_VER)/lib
+   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include/sirius
    SIRIUS_LIB     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/lib
    CFLAGS         += -I$(LIBVDWXC_INC)
    CFLAGS         += -I$(SIRIUS_INC)
    DFLAGS         += -D__LIBVDWXC
    DFLAGS         += -D__SIRIUS
    ifeq ($(SHARED), yes)
-      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius
+      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius -lsirius_cxx
+      LIBS           += -Wl,-rpath=$(PUGIXML_LIB) -L$(PUGIXML_LIB) -lpugixml
       LIBS           += -Wl,-rpath=$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
    else
       LIBS           += $(SIRIUS_LIB)/libsirius.a
+      LIBS           += $(SIRIUS_LIB)/libsirius_cxx.a
+      LIBS           += $(PUGIXML_LIB)/libpugixml.a
       LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
    endif
 endif

--- a/arch/Eiger-mc-intel.psmp
+++ b/arch/Eiger-mc-intel.psmp
@@ -7,7 +7,7 @@
 # Usage: Source this arch file and then run make as instructed.
 #        Replace or adapt the "module load" commands below if needed.
 #
-# Last update: 06.09.2024
+# Last update: 12.09.2024
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -234,20 +234,24 @@ endif
 
 ifneq ($(USE_SIRIUS),)
    USE_SIRIUS     := $(strip $(USE_SIRIUS))
-   USE_GSL        := $(GSL_VER)
+   USE_GSL        := ${GSL_VER}
    LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
    LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
-   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include
+   PUGIXML_LIB    := $(INSTALL_PATH)/pugixml-$(PUGIXML_VER)/lib
+   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include/sirius
    SIRIUS_LIB     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/lib
    CFLAGS         += -I$(LIBVDWXC_INC)
    CFLAGS         += -I$(SIRIUS_INC)
    DFLAGS         += -D__LIBVDWXC
    DFLAGS         += -D__SIRIUS
    ifeq ($(SHARED), yes)
-      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius
+      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius -lsirius_cxx
+      LIBS           += -Wl,-rpath=$(PUGIXML_LIB) -L$(PUGIXML_LIB) -lpugixml
       LIBS           += -Wl,-rpath=$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
    else
       LIBS           += $(SIRIUS_LIB)/libsirius.a
+      LIBS           += $(SIRIUS_LIB)/libsirius_cxx.a
+      LIBS           += $(PUGIXML_LIB)/libpugixml.a
       LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
    endif
 endif

--- a/arch/Linux-gnu-aarch64.psmp
+++ b/arch/Linux-gnu-aarch64.psmp
@@ -7,7 +7,7 @@
 # Usage: Source this arch file and then run make as instructed.
 #        A full toolchain installation is performed as default.
 #
-# Last update: 06.09.2024
+# Last update: 12.09.2024
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -275,20 +275,24 @@ endif
 
 ifneq ($(USE_SIRIUS),)
    USE_SIRIUS     := $(strip $(USE_SIRIUS))
-   USE_GSL        := $(GSL_VER)
+   USE_GSL        := ${GSL_VER}
    LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
    LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
-   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include
+   PUGIXML_LIB    := $(INSTALL_PATH)/pugixml-$(PUGIXML_VER)/lib
+   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include/sirius
    SIRIUS_LIB     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/lib
    CFLAGS         += -I$(LIBVDWXC_INC)
    CFLAGS         += -I$(SIRIUS_INC)
    DFLAGS         += -D__LIBVDWXC
    DFLAGS         += -D__SIRIUS
    ifeq ($(SHARED), yes)
-      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius
+      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius -lsirius_cxx
+      LIBS           += -Wl,-rpath=$(PUGIXML_LIB) -L$(PUGIXML_LIB) -lpugixml
       LIBS           += -Wl,-rpath=$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
    else
       LIBS           += $(SIRIUS_LIB)/libsirius.a
+      LIBS           += $(SIRIUS_LIB)/libsirius_cxx.a
+      LIBS           += $(PUGIXML_LIB)/libpugixml.a
       LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
    endif
 endif

--- a/arch/Linux-gnu-x86_64.psmp
+++ b/arch/Linux-gnu-x86_64.psmp
@@ -9,7 +9,7 @@
 #        Optionally, GNU compiler and MPI implementation can be specified as arguments.
 #        Replace or adapt the "module add" commands below if needed.
 #
-# Last update: 06.09.2024
+# Last update: 12.09.2024
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -298,17 +298,21 @@ ifneq ($(USE_SIRIUS),)
    USE_GSL        := ${GSL_VER}
    LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
    LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
-   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include
+   PUGIXML_LIB    := $(INSTALL_PATH)/pugixml-$(PUGIXML_VER)/lib
+   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include/sirius
    SIRIUS_LIB     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/lib
    CFLAGS         += -I$(LIBVDWXC_INC)
    CFLAGS         += -I$(SIRIUS_INC)
    DFLAGS         += -D__LIBVDWXC
    DFLAGS         += -D__SIRIUS
    ifeq ($(SHARED), yes)
-      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius
+      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius -lsirius_cxx
+      LIBS           += -Wl,-rpath=$(PUGIXML_LIB) -L$(PUGIXML_LIB) -lpugixml
       LIBS           += -Wl,-rpath=$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
    else
       LIBS           += $(SIRIUS_LIB)/libsirius.a
+      LIBS           += $(SIRIUS_LIB)/libsirius_cxx.a
+      LIBS           += $(PUGIXML_LIB)/libpugixml.a
       LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
    endif
 endif

--- a/arch/Linux-intel-x86_64.psmp
+++ b/arch/Linux-intel-x86_64.psmp
@@ -9,7 +9,7 @@
 #        Optionally, the Intel compiler version can be specified as argument.
 #        Replace or adapt the "module add" commands below if needed.
 #
-# Last update: 06.09.2024
+# Last update: 12.09.2024
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -253,20 +253,24 @@ endif
 
 ifneq ($(USE_SIRIUS),)
    USE_SIRIUS     := $(strip $(USE_SIRIUS))
-   USE_GSL        := $(GSL_VER)
+   USE_GSL        := ${GSL_VER}
    LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
    LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
-   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include
+   PUGIXML_LIB    := $(INSTALL_PATH)/pugixml-$(PUGIXML_VER)/lib
+   SIRIUS_INC     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/include/sirius
    SIRIUS_LIB     := $(INSTALL_PATH)/sirius-$(USE_SIRIUS)/lib
    CFLAGS         += -I$(LIBVDWXC_INC)
    CFLAGS         += -I$(SIRIUS_INC)
    DFLAGS         += -D__LIBVDWXC
    DFLAGS         += -D__SIRIUS
    ifeq ($(SHARED), yes)
-      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius
+      LIBS           += -Wl,-rpath=$(SIRIUS_LIB) -L$(SIRIUS_LIB) -lsirius -lsirius_cxx
+      LIBS           += -Wl,-rpath=$(PUGIXML_LIB) -L$(PUGIXML_LIB) -lpugixml
       LIBS           += -Wl,-rpath=$(LIBVDWXC_LIB) -L$(LIBVDWXC_LIB) -lvdwxc
    else
       LIBS           += $(SIRIUS_LIB)/libsirius.a
+      LIBS           += $(SIRIUS_LIB)/libsirius_cxx.a
+      LIBS           += $(PUGIXML_LIB)/libpugixml.a
       LIBS           += $(LIBVDWXC_LIB)/libvdwxc.a
    endif
 endif

--- a/tools/toolchain/scripts/stage8/install_pugixml.sh
+++ b/tools/toolchain/scripts/stage8/install_pugixml.sh
@@ -76,14 +76,17 @@ case "${with_sirius}" in
 esac
 if [ "$with_pugixml" != "__DONTUSE__" ]; then
   PUGIXML_LIBS="-lpugixml"
+  cat << EOF > "${BUILDDIR}/setup_pugixml"
+export PUGIXML_VER="${pugixml_ver}"
+EOF
   if [ "$with_pugixml" != "__SYSTEM__" ]; then
-    cat << EOF > "${BUILDDIR}/setup_pugixml"
-prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
-prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
+    cat << EOF >> "${BUILDDIR}/setup_pugixml"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 export PUGIXML_LIBS="-lpugixml"
 export PUGIXML_ROOT="${pkg_install_dir}"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_pugixml"

--- a/tools/toolchain/scripts/stage8/install_sirius.sh
+++ b/tools/toolchain/scripts/stage8/install_sirius.sh
@@ -154,6 +154,7 @@ case "$with_sirius" in
       COSTA_DIR="${COSMA_ROOT}/lib/cmake/costa"
       CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${GSL_ROOT}:${SPGLIB_ROOT}:${LIBXC_ROOT}:${SpFFT_DIR}:${SpLA_DIR}:${COSTA_DIR}:${PUGIXML_ROOT}" cmake \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
+        -DCMAKE_INSTALL_LIBDIR="lib" \
         -DCMAKE_CXX_FLAGS_RELEASE="${SIRIUS_OPT}" \
         -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="${SIRIUS_DBG}" \
         -DCMAKE_CXX_COMPILER="${MPICXX}" \
@@ -180,6 +181,7 @@ case "$with_sirius" in
         cd build-cuda
         CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${GSL_ROOT}:${SPGLIB_ROOT}:${LIBXC_ROOT}:${SpFFT_DIR}:${SpLA_DIR}:${COSTA_DIR}" cmake \
           -DCMAKE_INSTALL_PREFIX=${pkg_install_dir}/cuda \
+          -DCMAKE_INSTALL_LIBDIR="lib" \
           -DCMAKE_CXX_FLAGS_RELEASE="${SIRIUS_OPT}" \
           -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="${SIRIUS_DBG}" \
           -DCMAKE_CUDA_FLAGS="-std=c++14 -allow-unsupported-compiler" \


### PR DESCRIPTION
- Add pugixml library
- Add sirius_cxx library
- Define "lib" as library installation folder name for SIRIUS, i.e. suppress "lib64"