### PR TITLE
D4 dispersion, towards tighter integration with CP2K

### DIFF
--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -993,6 +993,12 @@ CONTAINS
                           type_of_var=char_t)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="D4_REFERENCE_CODE", &
+                          description="Calculate D4 energy using external library.", &
+                          usage="D4_REFERENCE_CODE", default_l_val=.TRUE., &
+                          lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="SCALING", &
                           description="XC Functional dependent scaling parameter, if set to zero CP2K attempts"// &
                           " to guess the xc functional that is in use and sets the associated scaling parameter.", &

--- a/src/qs_dispersion_d3.F
+++ b/src/qs_dispersion_d3.F
@@ -37,6 +37,7 @@ MODULE qs_dispersion_d3
    USE qs_dispersion_types,             ONLY: dftd3_pp,&
                                               qs_atom_dispersion_type,&
                                               qs_dispersion_type
+   USE qs_dispersion_utils,             ONLY: cellhash
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_force_types,                  ONLY: qs_force_type
@@ -878,41 +879,6 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE calculate_dispersion_d3_pairpot
-
-! **************************************************************************************************
-!> \brief ...
-!> \param cell ...
-!> \param ncell ...
-!> \return ...
-! **************************************************************************************************
-   FUNCTION cellhash(cell, ncell) RESULT(hash)
-      INTEGER, DIMENSION(3), INTENT(IN)                  :: cell, ncell
-      INTEGER                                            :: hash
-
-      INTEGER                                            :: ix, iy, iz, nx, ny, nz
-
-      CPASSERT(ALL(ABS(cell) <= ncell))
-
-      ix = cell(1)
-      IF (ix /= 0) THEN
-         ix = 2*ABS(ix) - (1 + SIGN(1, ix))/2
-      END IF
-      iy = cell(2)
-      IF (iy /= 0) THEN
-         iy = 2*ABS(iy) - (1 + SIGN(1, iy))/2
-      END IF
-      iz = cell(3)
-      IF (iz /= 0) THEN
-         iz = 2*ABS(iz) - (1 + SIGN(1, iz))/2
-      END IF
-
-      nx = 2*ncell(1) + 1
-      ny = 2*ncell(2) + 1
-      nz = 2*ncell(3) + 1
-
-      hash = ix*ny*nz + iy*nz + iz + 1
-
-   END FUNCTION cellhash
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/qs_dispersion_d4.F
+++ b/src/qs_dispersion_d4.F
@@ -11,24 +11,48 @@
 ! **************************************************************************************************
 MODULE qs_dispersion_d4
 
-   USE atomic_kind_types, ONLY: get_atomic_kind
+   USE atomic_kind_types, ONLY: atomic_kind_type, &
+                                get_atomic_kind, &
+                                get_atomic_kind_set
    USE cell_types, ONLY: cell_type, &
+                         plane_distance, &
+                         pbc, &
                          get_cell
-#if defined(__DFTD4)
-   USE dftd4, ONLY: d4_model, &
-                    damping_param, &
-                    get_dispersion, &
-                    get_rational_damping, &
-                    new, &
-                    new_d4_model, &
-                    realspace_cutoff, &
-                    structure_type
-#endif
+   USE qs_environment_types, ONLY: get_qs_env, &
+                                   qs_environment_type
+   USE qs_force_types, ONLY: qs_force_type
+   USE qs_kind_types, ONLY: get_qs_kind, &
+                            qs_kind_type, &
+                            set_qs_kind
+   USE qs_neighbor_list_types, ONLY: get_iterator_info, &
+                                     neighbor_list_iterate, &
+                                     neighbor_list_iterator_create, &
+                                     neighbor_list_iterator_p_type, &
+                                     neighbor_list_iterator_release, &
+                                     neighbor_list_set_p_type
+   USE virial_types, ONLY: virial_type
    USE kinds, ONLY: dp
    USE particle_types, ONLY: particle_type
    USE qs_dispersion_types, ONLY: qs_dispersion_type
-   USE qs_force_types, ONLY: qs_force_type
+   USE qs_dispersion_utils, ONLY: cellhash
    USE message_passing, ONLY: mp_para_env_type
+#
+#if defined(__DFTD4)
+!&<
+   USE dftd4,                           ONLY: d4_model, &
+                                              damping_param, &
+                                              get_dispersion, &
+                                              get_rational_damping, &
+                                              new, &
+                                              new_d4_model, &
+                                              realspace_cutoff, &
+                                              structure_type, &
+                                              rational_damping_param, &
+                                              get_coordination_number, &
+                                              get_lattice_points
+   USE dftd4_charge,                    ONLY: get_charges
+!&>
+#endif
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -44,57 +68,65 @@ MODULE qs_dispersion_d4
 CONTAINS
 
 #if defined(__DFTD4)
-   ! **************************************************************************************************
-!> \brief ...
-!> \param dispersion_env ...
-!> \param particle_set ...
-!> \param cell ...
-!> \param para_env ...
-!> \param energy ...
-!> \param force ...
-!> \param atom_of_kind ...
-!> \param virial ...
 ! **************************************************************************************************
-   SUBROUTINE calculate_dispersion_d4_pairpot(dispersion_env, particle_set, cell, para_env, energy, force, atom_of_kind, virial)
-
+!> \brief ...
+!> \param qs_env ...
+!> \param dispersion_env ...
+!> \param evdw ...
+!> \param calculate_forces ...
+!> \param unit_nr ...
+! **************************************************************************************************
+   SUBROUTINE calculate_dispersion_d4_pairpot(qs_env, dispersion_env, evdw, calculate_forces, unit_nr)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_dispersion_type), INTENT(IN), POINTER      :: dispersion_env
-      TYPE(particle_type), DIMENSION(:), INTENT(IN), &
-         POINTER                                         :: particle_set
-      TYPE(cell_type), INTENT(IN), POINTER               :: cell
-      TYPE(mp_para_env_type), POINTER                    :: para_env
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
-      TYPE(qs_force_type), DIMENSION(:), INTENT(INOUT), &
-         OPTIONAL, POINTER                               :: force
-      INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: atom_of_kind
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT), &
-         OPTIONAL                                        :: virial
+      REAL(KIND=dp), INTENT(INOUT)                       :: evdw
+      LOGICAL, INTENT(IN)                                :: calculate_forces
+      INTEGER, INTENT(IN)                                :: unit_nr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_dispersion_d4_pairpot'
+      LOGICAL, PARAMETER                                 :: debug = .FALSE.
 
-      class(damping_param), ALLOCATABLE                  :: param
+      INTEGER                                            :: atoma, handle, i, iatom, ikind, mref, &
+                                                            natom
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind, kind_of
+      INTEGER, DIMENSION(3)                              :: periodic
+      LOGICAL                                            :: grad, use_virial
+      LOGICAL, DIMENSION(3)                              :: lperiod
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: gradient, xyz
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: stress
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
+      TYPE(virial_type), POINTER                         :: virial
+
+      CLASS(damping_param), ALLOCATABLE                  :: param
       TYPE(d4_model)                                     :: disp
       TYPE(structure_type)                               :: mol
       TYPE(realspace_cutoff)                             :: cutoff
+      REAL(dp), ALLOCATABLE :: cn(:), dcndr(:, :, :), dcndL(:, :, :)
+      REAL(dp), ALLOCATABLE :: q(:), dqdr(:, :, :), dqdL(:, :, :)
+      REAL(dp), ALLOCATABLE :: gwvec(:, :), gwdcn(:, :), gwdq(:, :)
+      REAL(dp), ALLOCATABLE :: c6(:, :), dc6dcn(:, :), dc6dq(:, :)
+      REAL(dp), ALLOCATABLE :: dEdcn(:), dEdq(:), energies(:)
+      REAL(dp), ALLOCATABLE :: lattr(:, :)
 
-      INTEGER                                            :: iatom, natom, ind_atom
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: el_num
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: gradient, xyz
-      REAL(KIND=dp), DIMENSION(3, 3)                     :: stress
-      INTEGER                                            :: handle, ikind
-      !REAL(KIND=dp), DIMENSION(3, 3)                    :: h
-      INTEGER, DIMENSION(3)                              :: periodic
-      LOGICAL, DIMENSION(3)                              :: lperiod
+      MARK_USED(unit_nr)
 
       CALL timeset(routineN, handle)
+
+      CALL get_qs_env(qs_env=qs_env, particle_set=particle_set, atomic_kind_set=atomic_kind_set, &
+                      cell=cell, force=force, virial=virial, para_env=para_env)
+      CALL get_atomic_kind_set(atomic_kind_set, atom_of_kind=atom_of_kind, kind_of=kind_of)
+
+      use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
 
       !get information about particles
       natom = SIZE(particle_set)
       ALLOCATE (xyz(3, natom))
-      ALLOCATE (el_num(natom))
       DO iatom = 1, natom
          xyz(:, iatom) = particle_set(iatom)%r(:)
-         CALL get_atomic_kind(particle_set(iatom)%atomic_kind, kind_number=ikind)
-         el_num(iatom) = ikind
       END DO
 
       !get information about cell / lattice
@@ -104,9 +136,18 @@ CONTAINS
       lperiod(3) = periodic(3) == 1
 
       !prepare for the call to the dispersion function
-      CALL new(mol, el_num, xyz, lattice=cell%hmat, periodic=lperiod)
+      CALL new(mol, kind_of, xyz, lattice=cell%hmat, periodic=lperiod)
       CALL new_d4_model(disp, mol)
       CALL get_rational_damping(dispersion_env%ref_functional, param, s9=dispersion_env%s9)
+
+      SELECT TYPE (param)
+      TYPE is (rational_damping_param)
+         dispersion_env%s6 = param%s6
+         dispersion_env%s8 = param%s8
+         dispersion_env%a1 = param%a1
+         dispersion_env%a2 = param%a2
+         dispersion_env%alp = param%alp
+      END SELECT
 
       ! Coordination number cutoff
       cutoff%cn = dispersion_env%rc_cn
@@ -115,80 +156,483 @@ CONTAINS
       ! Three-body interaction cutoff
       cutoff%disp3 = dispersion_env%rc_disp*2._dp
 
-      !> Wrapper to handle the evaluation of dispersion energy and derivatives
-      IF (PRESENT(force)) THEN
-         IF (PRESENT(atom_of_kind)) THEN
-            ALLOCATE (gradient(3, mol%nat))
-            CALL get_dispersion(mol, disp, param, cutoff, energy, gradient, stress)
-            IF (PRESENT(virial)) THEN
-               virial = -1.00_dp*stress
-               IF (para_env%num_pe > 1 .AND. para_env%mepos > 0) virial = 0.00_dp
+      IF (calculate_forces .OR. use_virial .OR. dispersion_env%verbose) THEN
+         grad = .TRUE.
+      ELSE
+         grad = .FALSE.
+      END IF
+
+      IF (dispersion_env%d4_reference_code) THEN
+
+         !> Wrapper to handle the evaluation of dispersion energy and derivatives
+         IF (.NOT. dispersion_env%doabc) THEN
+            CPABORT("Using D4_REFERENCE_CODE enforces calculation of C9 term.")
+         END IF
+         IF (grad) THEN
+            ALLOCATE (gradient(3, natom))
+            CALL get_dispersion(mol, disp, param, cutoff, evdw, gradient, stress)
+            IF (use_virial) THEN
+               virial%pv_virial = virial%pv_virial - stress/para_env%num_pe
             END IF
             DO iatom = 1, natom
-               ikind = el_num(iatom)
-               ind_atom = atom_of_kind(iatom)
-               force(ikind)%dispersion(:, ind_atom) = force(ikind)%dispersion(:, ind_atom) + gradient(:, iatom)
+               ikind = kind_of(iatom)
+               atoma = atom_of_kind(iatom)
+               force(ikind)%dispersion(:, atoma) = &
+                  force(ikind)%dispersion(:, atoma) + gradient(:, iatom)/para_env%num_pe
             END DO
             DEALLOCATE (gradient)
          ELSE
-            CPABORT("missing atom_of_kind")
+            CALL get_dispersion(mol, disp, param, cutoff, evdw)
          END IF
+         !dispersion energy is computed by every MPI process
+         evdw = evdw/para_env%num_pe
+
       ELSE
-         IF (PRESENT(virial)) THEN
-            CPABORT("missing force for virial term")
+
+         mref = MAXVAL(disp%ref)
+
+         IF (grad) ALLOCATE (gradient(3, natom))
+
+         ! Coordination numbers
+         ALLOCATE (cn(natom))
+         IF (grad) ALLOCATE (dcndr(3, natom, natom), dcndL(3, 3, natom))
+         CALL get_lattice_points(mol%periodic, mol%lattice, cutoff%cn, lattr)
+         CALL get_coordination_number(mol, lattr, cutoff%cn, disp%rcov, disp%en, &
+            & cn, dcndr, dcndL)
+
+         ! EEQ charges
+         ALLOCATE (q(natom))
+         IF (grad) ALLOCATE (dqdr(3, natom, natom), dqdL(3, 3, natom))
+         CALL get_charges(mol, q, dqdr, dqdL)
+
+         ! Weights for C6 calculation
+         ALLOCATE (gwvec(mref, natom))
+         IF (grad) ALLOCATE (gwdcn(mref, natom), gwdq(mref, natom))
+         CALL disp%weight_references(mol, cn, q, gwvec, gwdcn, gwdq)
+
+         ! C6 calculation
+         ALLOCATE (c6(mol%nat, mol%nat))
+         IF (grad) ALLOCATE (dc6dcn(natom, natom), dc6dq(natom, natom))
+         CALL disp%get_atomic_c6(mol, gwvec, gwdcn, gwdq, c6, dc6dcn, dc6dq)
+
+         ALLOCATE (energies(natom))
+         energies(:) = 0.0_dp
+         IF (grad) THEN
+            ALLOCATE (dEdcn(natom), dEdq(natom))
+            dEdcn(:) = 0.0_dp
+            dEdq(:) = 0.0_dp
+            gradient(:, :) = 0.0_dp
+            stress(:, :) = 0.0_dp
          END IF
-         CALL get_dispersion(mol, disp, param, cutoff, energy)
+         IF (debug) THEN
+            CALL get_lattice_points(mol%periodic, mol%lattice, cutoff%disp2, lattr)
+            CALL param%get_dispersion2(mol, lattr, cutoff%disp2, disp%r4r2, &
+               & c6, dc6dcn, dc6dq, energies, dEdcn, dEdq, gradient, stress)
+         ELSE
+            CALL dispersion_2b(qs_env, dispersion_env, cutoff%disp2, disp%r4r2, &
+                               c6, dc6dcn, dc6dq, energies, dEdcn, dEdq, &
+                               grad, gradient, stress)
+         END IF
+         IF (grad) THEN
+            DO i = 1, 3
+               gradient(i, :) = gradient(i, :) + MATMUL(dqdr(i, :, :), dEdq(:))
+               stress(i, :) = stress(i, :) + MATMUL(dqdL(i, :, :), dEdq(:))
+            END DO
+         END IF
+
+         IF (dispersion_env%doabc) THEN
+            q(:) = 0.0_dp
+            CALL disp%weight_references(mol, cn, q, gwvec, gwdcn, gwdq)
+            CALL disp%get_atomic_c6(mol, gwvec, gwdcn, gwdq, c6, dc6dcn, dc6dq)
+
+            IF (debug) THEN
+               CALL get_lattice_points(mol%periodic, mol%lattice, cutoff%disp3, lattr)
+               CALL param%get_dispersion3(mol, lattr, cutoff%disp3, disp%r4r2, &
+                  & c6, dc6dcn, dc6dq, energies, dEdcn, dEdq, gradient, stress)
+            ELSE
+               CALL dispersion_3b(qs_env, dispersion_env, cutoff%disp3, disp%r4r2, &
+                                  c6, dc6dcn, dc6dq, energies, dEdcn, dEdq, &
+                                  grad, gradient, stress)
+            END IF
+         END IF
+         IF (grad) THEN
+            DO i = 1, 3
+               gradient(i, :) = gradient(i, :) + MATMUL(dcndr(i, :, :), dEdcn(:))
+               stress(i, :) = stress(i, :) + MATMUL(dcndL(i, :, :), dEdcn(:))
+            END DO
+         END IF
+
+         evdw = SUM(energies)
+         IF (debug) evdw = evdw/para_env%num_pe
+
+         IF (use_virial) THEN
+            IF (debug) THEN
+               virial%pv_virial = virial%pv_virial - stress/para_env%num_pe
+            ELSE
+               virial%pv_virial = virial%pv_virial - stress
+            END IF
+         END IF
+         IF (grad) THEN
+            DO iatom = 1, natom
+               ikind = kind_of(iatom)
+               atoma = atom_of_kind(iatom)
+               force(ikind)%dispersion(:, atoma) = &
+                  force(ikind)%dispersion(:, atoma) + gradient(:, iatom)
+            END DO
+            DEALLOCATE (gradient)
+         END IF
+
       END IF
 
-      !dispersion energy is computed by every MPI process
-      IF (para_env%num_pe > 1 .AND. para_env%mepos > 0) energy = 0.00_dp
-
-      DEALLOCATE (el_num, xyz)
+      DEALLOCATE (xyz)
 
       CALL timestop(handle)
 
    END SUBROUTINE calculate_dispersion_d4_pairpot
 
+! **************************************************************************************************
+
 #else
 
-   ! **************************************************************************************************
-!> \brief ...
-!> \param dispersion_env ...
-!> \param particle_set ...
-!> \param cell ...
-!> \param para_env ...
-!> \param energy ...
-!> \param force ...
-!> \param atom_of_kind ...
-!> \param virial ...
 ! **************************************************************************************************
-   SUBROUTINE calculate_dispersion_d4_pairpot(dispersion_env, particle_set, cell, para_env, energy, force, atom_of_kind, virial)
-
+!> \brief ...
+!> \param qs_env ...
+!> \param dispersion_env ...
+!> \param evdw ...
+!> \param calculate_forces ...
+!> \param unit_nr ...
+! **************************************************************************************************
+   SUBROUTINE calculate_dispersion_d4_pairpot(qs_env, dispersion_env, evdw, calculate_forces, unit_nr)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(qs_dispersion_type), INTENT(IN), POINTER      :: dispersion_env
-      TYPE(particle_type), DIMENSION(:), INTENT(IN), &
-         POINTER                                         :: particle_set
-      TYPE(cell_type), INTENT(IN), POINTER               :: cell
-      TYPE(mp_para_env_type), POINTER                    :: para_env
-      REAL(KIND=dp), INTENT(OUT)                         :: energy
-      TYPE(qs_force_type), DIMENSION(:), INTENT(INOUT), &
-         OPTIONAL, POINTER                               :: force
-      INTEGER, DIMENSION(:), INTENT(IN), OPTIONAL        :: atom_of_kind
-      REAL(KIND=dp), DIMENSION(3, 3), INTENT(OUT), &
-         OPTIONAL                                        :: virial
+      REAL(KIND=dp), INTENT(INOUT)                       :: evdw
+      LOGICAL, INTENT(IN)                                :: calculate_forces
+      INTEGER, INTENT(IN)                                :: unit_nr
 
+      MARK_USED(qs_env)
       MARK_USED(dispersion_env)
-      MARK_USED(particle_set)
-      MARK_USED(cell)
-      MARK_USED(para_env)
-      MARK_USED(energy)
-      MARK_USED(force)
-      MARK_USED(atom_of_kind)
-      MARK_USED(virial)
+      MARK_USED(evdw)
+      MARK_USED(calculate_forces)
+      MARK_USED(unit_nr)
 
-      CPABORT("Build without DFTD4")
+      CPABORT("CP2K build without DFTD4")
 
    END SUBROUTINE calculate_dispersion_d4_pairpot
 
 #endif
+
+! **************************************************************************************************
+!> \brief ...
+!> \param qs_env ...
+!> \param dispersion_env ...
+!> \param cutoff ...
+!> \param r4r2 ...
+!> \param c6 ...
+!> \param dc6dcn ...
+!> \param dc6dq ...
+!> \param energies ...
+!> \param dEdcn ...
+!> \param dEdq ...
+!> \param calculate_forces ...
+!> \param gradient ...
+!> \param stress ...
+! **************************************************************************************************
+   SUBROUTINE dispersion_2b(qs_env, dispersion_env, cutoff, r4r2, &
+                            c6, dc6dcn, dc6dq, energies, dEdcn, dEdq, &
+                            calculate_forces, gradient, stress)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
+      REAL(KIND=dp), INTENT(IN)                          :: cutoff
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r4r2
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: c6, dc6dcn, dc6dq
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: energies, dEdcn, dEdq
+      LOGICAL, INTENT(IN)                                :: calculate_forces
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: gradient, stress
+
+      INTEGER                                            :: iatom, ikind, jatom, jkind, mepos, num_pe
+      REAL(KINd=dp)                                      :: a1, a2, c6ij, d6, d8, dE, dr, dr2, &
+                                                            edisp, fac, gdisp, r0ij, rrij, s6, s8, &
+                                                            t6, t8
+      REAL(KINd=dp), DIMENSION(3)                        :: dG, rij
+      REAL(KINd=dp), DIMENSION(3, 3)                     :: dS
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_vdw
+
+      MARK_USED(qs_env)
+
+      a1 = dispersion_env%a1
+      a2 = dispersion_env%a2
+      s6 = dispersion_env%s6
+      s8 = dispersion_env%s8
+
+      sab_vdw => dispersion_env%sab_vdw
+
+      num_pe = 1
+      CALL neighbor_list_iterator_create(nl_iterator, sab_vdw, nthread=num_pe)
+
+      mepos = 0
+      DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
+         CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=jkind, &
+                                iatom=iatom, jatom=jatom, r=rij)
+         ! vdW potential
+         dr2 = SUM(rij(:)**2)
+         dr = SQRT(dr2)
+         IF (dr <= cutoff .AND. dr > 0.001_dp) THEN
+            rrij = 3._dp*r4r2(ikind)*r4r2(jkind)
+            r0ij = a1*SQRT(rrij) + a2
+            c6ij = c6(jatom, iatom)
+            fac = 1._dp
+            IF (iatom == jatom) fac = 0.5_dp
+            t6 = 1.0_dp/(dr2**3 + r0ij**6)
+            t8 = 1.0_dp/(dr2**4 + r0ij**8)
+
+            edisp = (s6*t6 + s8*rrij*t8)*fac
+            dE = -c6ij*edisp
+            energies(iatom) = energies(iatom) + dE*0.5_dp
+            energies(jatom) = energies(jatom) + dE*0.5_dp
+
+            IF (calculate_forces) THEN
+               d6 = -6.0_dp*dr2**2*t6**2
+               d8 = -8.0_dp*dr2**3*t8**2
+               gdisp = (s6*d6 + s8*rrij*d8)*fac
+               dG(:) = -c6ij*gdisp*rij(:)
+               gradient(:, iatom) = gradient(:, iatom) - dG
+               gradient(:, jatom) = gradient(:, jatom) + dG
+               dS(:, :) = SPREAD(dG, 1, 3)*SPREAD(rij, 2, 3)
+               dEdcn(iatom) = dEdcn(iatom) - dc6dcn(iatom, jatom)*edisp
+               dEdq(iatom) = dEdq(iatom) - dc6dq(iatom, jatom)*edisp
+               dEdcn(jatom) = dEdcn(jatom) - dc6dcn(jatom, iatom)*edisp
+               dEdq(jatom) = dEdq(jatom) - dc6dq(jatom, iatom)*edisp
+               stress(:, :) = stress + dS
+            END IF
+         END IF
+      END DO
+
+      CALL neighbor_list_iterator_release(nl_iterator)
+
+   END SUBROUTINE dispersion_2b
+
+! **************************************************************************************************
+!> \brief ...
+!> \param qs_env ...
+!> \param dispersion_env ...
+!> \param cutoff ...
+!> \param r4r2 ...
+!> \param c6 ...
+!> \param dc6dcn ...
+!> \param dc6dq ...
+!> \param energies ...
+!> \param dEdcn ...
+!> \param dEdq ...
+!> \param calculate_forces ...
+!> \param gradient ...
+!> \param stress ...
+! **************************************************************************************************
+   SUBROUTINE dispersion_3b(qs_env, dispersion_env, cutoff, r4r2, &
+                            c6, dc6dcn, dc6dq, energies, dEdcn, dEdq, &
+                            calculate_forces, gradient, stress)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
+      REAL(KIND=dp), INTENT(IN)                          :: cutoff
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: r4r2
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: c6, dc6dcn, dc6dq
+      REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: energies, dEdcn, dEdq
+      LOGICAL, INTENT(IN)                                :: calculate_forces
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: gradient, stress
+
+      INTEGER                                            :: hashb, hashc, iatom, icx, icy, icz, &
+                                                            ikind, jatom, jkind, katom, kkind, &
+                                                            kstart, mepos, natom, num_pe
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of
+      INTEGER, DIMENSION(3)                              :: cell_b, cell_c, ncell, periodic
+      LOGICAL                                            :: is000
+      REAL(KINd=dp)                                      :: a1, a2, alp, ang, c6ij, c6ik, c6jk, c9, &
+                                                            cutoff2, dang, dE, dfdmp, fac, fac0, &
+                                                            fdmp, r0, r0ij, r0ik, r0jk, r1, r2, &
+                                                            r2ij, r2ik, r2jk, r3, r5, rr, s6, s8, &
+                                                            s9
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: rcpbc
+      REAL(KINd=dp), DIMENSION(3)                        :: dGij, dGik, dGjk, ra, rb, rb0, rc, rc0, &
+                                                            rij, sab_max, vij, vik, vjk
+      REAL(KINd=dp), DIMENSION(3, 3)                     :: dS
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_vdw
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+
+      CALL get_qs_env(qs_env=qs_env, natom=natom, cell=cell, &
+                      atomic_kind_set=atomic_kind_set, particle_set=particle_set)
+
+      ALLOCATE (rcpbc(3, natom))
+      DO iatom = 1, natom
+         rcpbc(:, iatom) = pbc(particle_set(iatom)%r(:), cell)
+      END DO
+      CALL get_atomic_kind_set(atomic_kind_set, kind_of=kind_of)
+
+      a1 = dispersion_env%a1
+      a2 = dispersion_env%a2
+      s6 = dispersion_env%s6
+      s8 = dispersion_env%s8
+      s9 = dispersion_env%s9
+      alp = dispersion_env%alp
+
+      cutoff2 = cutoff**2
+      CALL get_cell(cell=cell, periodic=periodic)
+      sab_max(1) = cutoff/plane_distance(1, 0, 0, cell)
+      sab_max(2) = cutoff/plane_distance(0, 1, 0, cell)
+      sab_max(3) = cutoff/plane_distance(0, 0, 1, cell)
+      ncell(:) = (INT(sab_max(:)) + 1)*periodic(:)
+
+      sab_vdw => dispersion_env%sab_vdw
+
+      num_pe = 1
+      CALL neighbor_list_iterator_create(nl_iterator, sab_vdw, nthread=num_pe)
+
+      mepos = 0
+      DO WHILE (neighbor_list_iterate(nl_iterator, mepos=mepos) == 0)
+         CALL get_iterator_info(nl_iterator, mepos=mepos, ikind=ikind, jkind=jkind, iatom=iatom, jatom=jatom, r=rij)
+
+         r2ij = SUM(rij(:)**2)
+         c6ij = c6(jatom, iatom)
+         r0ij = a1*SQRT(3._dp*r4r2(jkind)*r4r2(ikind)) + a2
+         IF (r2ij <= cutoff2 .AND. r2ij > EPSILON(1._dp)) THEN
+            CALL get_iterator_info(nl_iterator, cell=cell_b)
+            hashb = cellhash(cell_b, ncell)
+            is000 = (ALL(cell_b == 0))
+            rb0(:) = MATMUL(cell%hmat, cell_b)
+            ra(:) = pbc(particle_set(iatom)%r(:), cell)
+            rb(:) = pbc(particle_set(jatom)%r(:), cell) + rb0
+            DO icx = -ncell(1), ncell(1)
+               DO icy = -ncell(2), ncell(2)
+                  DO icz = -ncell(3), ncell(3)
+                     cell_c(1) = icx
+                     cell_c(2) = icy
+                     cell_c(3) = icz
+                     hashc = cellhash(cell_c, ncell)
+                     IF (is000 .AND. (ALL(cell_c == 0))) THEN
+                        ! CASE 1: all atoms in (000), use only ordered triples
+                        kstart = MAX(jatom + 1, iatom + 1)
+                        fac0 = 1.0_dp
+                     ELSE IF (is000) THEN
+                        ! CASE 2: AB in (000), C in other cell
+                        !         This case covers also all instances with BC in same
+                        !         cell not (000)
+                        kstart = 1
+                        fac0 = 1.0_dp
+                     ELSE
+                        ! These are case 2 again, cycle
+                        IF (hashc == hashb) CYCLE
+                        IF (ALL(cell_c == 0)) CYCLE
+                        ! CASE 3: A in (000) and B and C in different cells
+                        kstart = 1
+                        fac0 = 1.0_dp/3.0_dp
+                     END IF
+                     !
+                     rc0 = MATMUL(cell%hmat, cell_c)
+                     !
+                     DO katom = kstart, natom
+                        kkind = kind_of(katom)
+                        c6ik = c6(katom, iatom)
+                        c6jk = c6(katom, jatom)
+                        c9 = -s9*SQRT(ABS(c6ij*c6ik*c6jk))
+                        r0ik = a1*SQRT(3._dp*r4r2(kkind)*r4r2(ikind)) + a2
+                        r0jk = a1*SQRT(3._dp*r4r2(kkind)*r4r2(jkind)) + a2
+                        r0 = r0ij*r0ik*r0jk
+                        rc(:) = rcpbc(:, katom) + rc0(:)
+                        r2jk = SUM((rb - rc)**2)
+                        IF (r2jk >= cutoff2 .OR. r2jk < EPSILON(1._dp)) CYCLE
+                        r2ik = SUM((rc - ra)**2)
+                        IF (r2ik >= cutoff2 .OR. r2ik < EPSILON(1._dp)) CYCLE
+                        r2 = r2ij*r2jk*r2ik
+                        r1 = SQRT(r2)
+                        r3 = r2*r1
+                        r5 = r3*r2
+                        fdmp = 1.0_dp/(1.0_dp + 6.0_dp*(r0/r1)**(alp/3.0_dp))
+                        ang = 0.375_dp*(r2ij + r2jk - r2ik)*(r2ij - r2jk + r2ik)* &
+                              (-r2ij + r2jk + r2ik)/r5 + 1.0_dp/r3
+
+                        ! avoid double counting!
+                        fac = 1._dp
+                        IF (iatom == jatom .OR. iatom == katom .OR. jatom == katom) fac = 0.5_dp
+                        IF (iatom == jatom .AND. iatom == katom) fac = 1._dp/3._dp
+                        fac = fac*fac0
+
+                        rr = ang*fdmp
+                        dE = rr*c9*fac
+                        energies(iatom) = energies(iatom) - dE/3._dp
+                        energies(jatom) = energies(jatom) - dE/3._dp
+                        energies(katom) = energies(katom) - dE/3._dp
+
+                        IF (calculate_forces) THEN
+                           vij = rb - ra
+                           vjk = rc - rb
+                           vik = rc - ra
+
+                           dfdmp = -2.0_dp*alp*(r0/r1)**(alp/3.0_dp)*fdmp**2
+
+                           ! d/drij
+                           dang = -0.375_dp*(r2ij**3 + r2ij**2*(r2jk + r2ik) &
+                                             + r2ij*(3.0_dp*r2jk**2 + 2.0_dp*r2jk*r2ik &
+                                                     + 3.0_dp*r2ik**2) &
+                                             - 5.0_dp*(r2jk - r2ik)**2*(r2jk + r2ik))/r5
+                           dGij(:) = c9*(-dang*fdmp + ang*dfdmp)/r2ij*vij
+
+                           ! d/drik
+                           dang = -0.375_dp*(r2ik**3 + r2ik**2*(r2jk + r2ij) &
+                                             + r2ik*(3.0_dp*r2jk**2 + 2.0_dp*r2jk*r2ij &
+                                                     + 3.0_dp*r2ij**2) &
+                                             - 5.0_dp*(r2jk - r2ij)**2*(r2jk + r2ij))/r5
+                           dGik(:) = c9*(-dang*fdmp + ang*dfdmp)/r2ik*vik
+
+                           ! d/drjk
+                           dang = -0.375_dp*(r2jk**3 + r2jk**2*(r2ik + r2ij) &
+                                             + r2jk*(3.0_dp*r2ik**2 + 2.0_dp*r2ik*r2ij &
+                                                     + 3.0_dp*r2ij**2) &
+                                             - 5.0_dp*(r2ik - r2ij)**2*(r2ik + r2ij))/r5
+                           dGjk(:) = c9*(-dang*fdmp + ang*dfdmp)/r2jk*vjk
+
+                           gradient(:, iatom) = gradient(:, iatom) - dGij - dGik
+                           gradient(:, jatom) = gradient(:, jatom) + dGij - dGjk
+                           gradient(:, katom) = gradient(:, katom) + dGik + dGjk
+
+                           dS(:, :) = SPREAD(dGij, 1, 3)*SPREAD(vij, 2, 3) &
+                                      + SPREAD(dGik, 1, 3)*SPREAD(vik, 2, 3) &
+                                      + SPREAD(dGjk, 1, 3)*SPREAD(vjk, 2, 3)
+
+                           stress(:, :) = stress + dS*fac
+
+                           dEdcn(iatom) = dEdcn(iatom) - dE*0.5_dp &
+                                         & *(dc6dcn(iatom, jatom)/c6ij + dc6dcn(iatom, katom)/c6ik)
+                           dEdcn(jatom) = dEdcn(jatom) - dE*0.5_dp &
+                                         & *(dc6dcn(jatom, iatom)/c6ij + dc6dcn(jatom, katom)/c6jk)
+                           dEdcn(katom) = dEdcn(katom) - dE*0.5_dp &
+                                         & *(dc6dcn(katom, iatom)/c6ik + dc6dcn(katom, jatom)/c6jk)
+
+                           dEdq(iatom) = dEdq(iatom) - dE*0.5_dp &
+                                        & *(dc6dq(iatom, jatom)/c6ij + dc6dq(iatom, katom)/c6ik)
+                           dEdq(jatom) = dEdq(jatom) - dE*0.5_dp &
+                                        & *(dc6dq(jatom, iatom)/c6ij + dc6dq(jatom, katom)/c6jk)
+                           dEdq(katom) = dEdq(katom) - dE*0.5_dp &
+                                        & *(dc6dq(katom, iatom)/c6ik + dc6dq(katom, jatom)/c6jk)
+
+                        END IF
+
+                     END DO
+                  END DO
+               END DO
+            END DO
+         END IF
+      END DO
+
+      CALL neighbor_list_iterator_release(nl_iterator)
+
+      DEALLOCATE (rcpbc)
+
+   END SUBROUTINE dispersion_3b
 
 END MODULE qs_dispersion_d4

--- a/src/qs_dispersion_pairpot.F
+++ b/src/qs_dispersion_pairpot.F
@@ -43,7 +43,6 @@ MODULE qs_dispersion_pairpot
    USE kinds,                           ONLY: default_string_length,&
                                               dp
    USE message_passing,                 ONLY: mp_para_env_type
-   USE particle_types,                  ONLY: particle_type
    USE physcon,                         ONLY: bohr,&
                                               kcalmol,&
                                               kjmol
@@ -354,7 +353,6 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(mp_para_env_type), POINTER                    :: para_env
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_force_type), DIMENSION(:), POINTER         :: force
       TYPE(virial_type), POINTER                         :: virial
 
@@ -440,22 +438,17 @@ CONTAINS
          IF (atstress) THEN
             CPABORT("Atomic stress with DFTD4 not implemented")
          END IF
-         CALL get_qs_env(qs_env=qs_env, particle_set=particle_set, atomic_kind_set=atomic_kind_set, &
-                         cell=cell, force=force, para_env=para_env)
-         use_virial = virial%pv_availability .AND. (.NOT. virial%pv_numer)
-         IF (calculate_forces .OR. debugall) THEN
-            IF (use_virial) THEN
-               CALL calculate_dispersion_d4_pairpot(dispersion_env, particle_set, cell, para_env, &
-                                                    evdw, force=force, atom_of_kind=atom_of_kind, &
-                                                    virial=pv_virial_thread)
-               virial%pv_virial = virial%pv_virial + pv_virial_thread
-            ELSE
-               CALL calculate_dispersion_d4_pairpot(dispersion_env, particle_set, cell, para_env, &
-                                                    evdw, force=force, atom_of_kind=atom_of_kind)
-            END IF
-         ELSE
-            CALL calculate_dispersion_d4_pairpot(dispersion_env, particle_set, cell, para_env, evdw)
+         IF (dispersion_env%lrc) THEN
+            CPABORT("Long range correction with DFTD4 not implemented")
          END IF
+         IF (dispersion_env%srb) THEN
+            CPABORT("Short range bond correction with DFTD4 not implemented")
+         END IF
+         IF (dispersion_env%domol) THEN
+            CPABORT("Molecular approximation with DFTD4 not implemented")
+         END IF
+         !
+         CALL calculate_dispersion_d4_pairpot(qs_env, dispersion_env, evdw, calculate_forces, unit_nr)
       END IF
 
       ! set dispersion energy

--- a/src/qs_dispersion_types.F
+++ b/src/qs_dispersion_types.F
@@ -43,6 +43,10 @@ MODULE qs_dispersion_types
       LOGICAL                                :: verbose = .FALSE. !extended output
       CHARACTER(LEN=default_string_length)  :: parameter_file_name = ""
       CHARACTER(LEN=default_string_length)  :: kernel_file_name = ""
+      !charges
+      LOGICAL                                :: ext_charges = .FALSE.
+      REAL(KIND=dp), DIMENSION(:), POINTER    :: charges => NULL() !charges for D4
+      REAL(KIND=dp), DIMENSION(:), POINTER    :: dcharges => NULL() !derivatives of D4 energy wrt charges
       !DFT-D3 global parameters
       INTEGER                                :: max_elem = -1 !elements parametrized
       INTEGER                                :: maxc = -1 !max coordination number references per element
@@ -51,6 +55,7 @@ MODULE qs_dispersion_types
       REAL(KIND=dp)                          :: s6 = -1.0_dp, s8 = -1.0_dp, sr6 = -1.0_dp !scaling parameters
       REAL(KIND=dp)                          :: a1 = -1.0_dp, a2 = -1.0_dp !BJ scaling parameters
       REAL(KIND=dp)                          :: eps_cn = -1.0_dp
+      LOGICAL                                :: d4_reference_code = .FALSE. !Use D4 calculation from ext. library
       LOGICAL                                :: doabc = .FALSE. !neglect C9 terms
       LOGICAL                                :: c9cnst = .FALSE. !use constant c9 terms
       LOGICAL                                :: lrc = .FALSE. !calculate a long range correction
@@ -173,6 +178,13 @@ CONTAINS
          ! neighborlists
          CALL release_neighbor_list_sets(dispersion_env%sab_vdw)
          CALL release_neighbor_list_sets(dispersion_env%sab_cn)
+         ! charges
+         IF (ASSOCIATED(dispersion_env%charges)) THEN
+            DEALLOCATE (dispersion_env%charges)
+         END IF
+         IF (ASSOCIATED(dispersion_env%dcharges)) THEN
+            DEALLOCATE (dispersion_env%dcharges)
+         END IF
 
          DEALLOCATE (dispersion_env)
 

--- a/src/qs_dispersion_utils.F
+++ b/src/qs_dispersion_utils.F
@@ -43,6 +43,7 @@ MODULE qs_dispersion_utils
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_dispersion_utils'
 
    PUBLIC :: qs_dispersion_env_set, qs_write_dispersion
+   PUBLIC :: cellhash
 
 ! **************************************************************************************************
 CONTAINS
@@ -156,12 +157,23 @@ CONTAINS
          END IF
          IF (dispersion_env%pp_type == vdw_pairpot_dftd4) THEN
             CALL section_vals_val_get(pp_section, "REFERENCE_FUNCTIONAL", explicit=exfun)
-            CPASSERT(exfun)
+            IF (.NOT. exfun) THEN
+               CPABORT("D4 vdW functional needs specification of REFERENCE_FUNCTIONAL")
+            END IF
+            CALL section_vals_val_get(pp_section, "D4_REFERENCE_CODE", &
+                                      l_val=dispersion_env%d4_reference_code)
             CALL section_vals_val_get(vdw_section, "PAIR_POTENTIAL%REFERENCE_FUNCTIONAL", &
                                       c_val=dispersion_env%ref_functional)
             CALL section_vals_val_get(pp_section, "D4_CUTOFF", r_val=dispersion_env%rc_d4)
             CALL section_vals_val_get(pp_section, "D4_CN_CUTOFF", r_val=dispersion_env%rc_cn)
             CALL section_vals_val_get(pp_section, "FACTOR_S9_TERM", r_val=dispersion_env%s9)
+            !C9 term default=T for D4
+            CALL section_vals_val_get(pp_section, "CALCULATE_C9_TERM", explicit=exfun)
+            IF (exfun) THEN
+               CALL section_vals_val_get(pp_section, "CALCULATE_C9_TERM", l_val=dispersion_env%doabc)
+            ELSE
+               dispersion_env%doabc = .TRUE.
+            END IF
          END IF
          CALL section_vals_val_get(pp_section, "R_CUTOFF", r_val=dispersion_env%rc_disp)
          CALL section_vals_val_get(pp_section, "PARAMETER_FILE_NAME", &
@@ -1146,6 +1158,40 @@ CONTAINS
 
    END SUBROUTINE qs_scaling_dftd3bj
 
+! **************************************************************************************************
+!> \brief ...
+!> \param cell ...
+!> \param ncell ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION cellhash(cell, ncell) RESULT(hash)
+      INTEGER, DIMENSION(3), INTENT(IN)                  :: cell, ncell
+      INTEGER                                            :: hash
+
+      INTEGER                                            :: ix, iy, iz, nx, ny, nz
+
+      CPASSERT(ALL(ABS(cell) <= ncell))
+
+      ix = cell(1)
+      IF (ix /= 0) THEN
+         ix = 2*ABS(ix) - (1 + SIGN(1, ix))/2
+      END IF
+      iy = cell(2)
+      IF (iy /= 0) THEN
+         iy = 2*ABS(iy) - (1 + SIGN(1, iy))/2
+      END IF
+      iz = cell(3)
+      IF (iz /= 0) THEN
+         iz = 2*ABS(iz) - (1 + SIGN(1, iz))/2
+      END IF
+
+      nx = 2*ncell(1) + 1
+      ny = 2*ncell(2) + 1
+      nz = 2*ncell(3) + 1
+
+      hash = ix*ny*nz + iy*nz + iz + 1
+
+   END FUNCTION cellhash
 ! **************************************************************************************************
 
 END MODULE qs_dispersion_utils

--- a/src/qs_neighbor_lists.F
+++ b/src/qs_neighbor_lists.F
@@ -49,7 +49,7 @@ MODULE qs_neighbor_lists
    USE input_constants,                 ONLY: &
         dispersion_uff, do_method_lrigpw, do_method_rigpw, do_potential_id, do_potential_short, &
         do_potential_truncated, do_se_IS_slater, vdw_pairpot_dftd3, vdw_pairpot_dftd3bj, &
-        xc_vdw_fun_pairpot
+        vdw_pairpot_dftd4, xc_vdw_fun_pairpot
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
@@ -854,7 +854,11 @@ CONTAINS
       sab_vdw => dispersion_env%sab_vdw
       sab_cn => dispersion_env%sab_cn
       IF (dispersion_env%type == xc_vdw_fun_pairpot .OR. xtb) THEN
-         c_radius(:) = dispersion_env%rc_disp
+         IF (dispersion_env%pp_type == vdw_pairpot_dftd4) THEN
+            c_radius(:) = dispersion_env%rc_d4
+         ELSE
+            c_radius(:) = dispersion_env%rc_disp
+         END IF
          default_present = .TRUE. !include all atoms in vdW (even without basis)
          CALL pair_radius_setup(default_present, default_present, c_radius, c_radius, pair_radius)
          CALL build_neighbor_lists(sab_vdw, particle_set, atom2d, cell, pair_radius, &


### PR DESCRIPTION
First changes to get a tighter integration of the D4 method with CP2K tools.
Default id still to use the standard D4 library.