### PR TITLE
Add asserts after malloc and realloc in DBM and grid code

### DIFF
--- a/src/dbm/dbm_distribution.c
+++ b/src/dbm/dbm_distribution.c
@@ -29,6 +29,7 @@ static void dbm_dist_1d_new(dbm_dist_1d_t *dist, const int length,
   dist->nranks = dbm_mpi_comm_size(comm);
   dist->length = length;
   dist->index2coord = malloc(length * sizeof(int));
+  assert(dist->index2coord != NULL);
   memcpy(dist->index2coord, coords, length * sizeof(int));
 
   // Check that cart coordinates and ranks are equivalent.
@@ -47,6 +48,7 @@ static void dbm_dist_1d_new(dbm_dist_1d_t *dist, const int length,
 
   // Store local rows/columns.
   dist->local_indicies = malloc(dist->nlocals * sizeof(int));
+  assert(dist->local_indicies != NULL);
   int j = 0;
   for (int i = 0; i < length; i++) {
     if (coords[i] == dist->my_rank) {

--- a/src/dbm/dbm_library.c
+++ b/src/dbm/dbm_library.c
@@ -41,6 +41,7 @@ void dbm_library_init(void) {
 
   max_threads = omp_get_max_threads();
   per_thread_counters = malloc(max_threads * sizeof(int64_t *));
+  assert(per_thread_counters != NULL);
 
   // Using parallel regions to ensure memory is allocated near a thread's core.
 #pragma omp parallel default(none) shared(per_thread_counters)                 \
@@ -49,6 +50,7 @@ void dbm_library_init(void) {
     const int ithread = omp_get_thread_num();
     const size_t counters_size = DBM_NUM_COUNTERS * sizeof(int64_t);
     per_thread_counters[ithread] = malloc(counters_size);
+    assert(per_thread_counters[ithread] != NULL);
     memset(per_thread_counters[ithread], 0, counters_size);
   }
 

--- a/src/dbm/dbm_matrix.c
+++ b/src/dbm/dbm_matrix.c
@@ -34,6 +34,7 @@ void dbm_create(dbm_matrix_t **matrix_out, dbm_distribution_t *dist,
 
   size_t size = (strlen(name) + 1) * sizeof(char);
   matrix->name = malloc(size);
+  assert(matrix->name != NULL);
   memcpy(matrix->name, name, size);
 
   matrix->nrows = nrows;
@@ -41,13 +42,16 @@ void dbm_create(dbm_matrix_t **matrix_out, dbm_distribution_t *dist,
 
   size = nrows * sizeof(int);
   matrix->row_sizes = malloc(size);
+  assert(matrix->row_sizes != NULL);
   memcpy(matrix->row_sizes, row_sizes, size);
 
   size = ncols * sizeof(int);
   matrix->col_sizes = malloc(size);
+  assert(matrix->col_sizes != NULL);
   memcpy(matrix->col_sizes, col_sizes, size);
 
   matrix->shards = malloc(dbm_get_num_shards(matrix) * sizeof(dbm_shard_t));
+  assert(matrix->shards != NULL);
 #pragma omp parallel for
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
     dbm_shard_init(&matrix->shards[ishard]);
@@ -427,6 +431,7 @@ void dbm_iterator_start(dbm_iterator_t **iter_out, const dbm_matrix_t *matrix) {
   assert(omp_get_num_threads() == omp_get_max_threads() &&
          "Please call dbm_iterator_start within an OpenMP parallel region.");
   dbm_iterator_t *iter = malloc(sizeof(dbm_iterator_t));
+  assert(iter != NULL);
   iter->matrix = matrix;
   iter->next_block = 0;
   iter->next_shard = omp_get_thread_num();

--- a/src/dbm/dbm_mempool.c
+++ b/src/dbm/dbm_mempool.c
@@ -115,6 +115,7 @@ static void *internal_mempool_malloc(const size_t size, const bool on_device) {
     // If no chunk was found, allocate a new one.
     if (chunk == NULL) {
       chunk = malloc(sizeof(dbm_memchunk_t));
+      assert(chunk != NULL);
       chunk->on_device = on_device;
       chunk->size = 0;
       chunk->mem = NULL;

--- a/src/dbm/dbm_miniapp.c
+++ b/src/dbm/dbm_miniapp.c
@@ -50,6 +50,7 @@ static dbm_matrix_t *create_some_matrix(const int nrows, const int ncols,
   // Create distribution.
   int *row_dist = malloc(nrows * sizeof(int));
   int *col_dist = malloc(ncols * sizeof(int));
+  assert(row_dist != NULL && col_dist != NULL);
   for (int i = 0; i < nrows; i++) {
     row_dist[i] = i % cart_dims[0];
   }
@@ -65,6 +66,7 @@ static dbm_matrix_t *create_some_matrix(const int nrows, const int ncols,
   // Create matrix.
   int *row_sizes = malloc(nrows * sizeof(int));
   int *col_sizes = malloc(ncols * sizeof(int));
+  assert(row_sizes != NULL && col_sizes != NULL);
   for (int i = 0; i < nrows; i++) {
     row_sizes[i] = row_size;
   }
@@ -103,6 +105,7 @@ static void reserve_all_blocks(dbm_matrix_t *matrix) {
     }
     int *reserve_row = malloc(nblocks * sizeof(int));
     int *reserve_col = malloc(nblocks * sizeof(int));
+    assert(reserve_row != NULL && reserve_col != NULL);
     int iblock = 0;
 #pragma omp for collapse(2)
     for (int row = 0; row < nrows; row++) {

--- a/src/dbm/dbm_multiply.c
+++ b/src/dbm/dbm_multiply.c
@@ -47,6 +47,7 @@ static float *compute_rows_max_eps(const bool trans, const dbm_matrix_t *matrix,
   const int nrows = (trans) ? matrix->ncols : matrix->nrows;
   int *nblocks_per_row = calloc(nrows, sizeof(int));
   float *row_max_eps = malloc(nrows * sizeof(float));
+  assert(row_max_eps != NULL);
 
 #pragma omp parallel
   {

--- a/src/dbm/dbm_multiply_comm.c
+++ b/src/dbm/dbm_multiply_comm.c
@@ -114,6 +114,7 @@ static void create_pack_plans(const bool trans_matrix, const bool trans_dist,
 #pragma omp for
     for (int ipack = 0; ipack < npacks; ipack++) {
       plans_per_pack[ipack] = malloc(nblks_per_pack[ipack] * sizeof(plan_t));
+      assert(plans_per_pack[ipack] != NULL);
     }
 
     // 2nd pass: Plan where to send each block.
@@ -272,6 +273,7 @@ static void postprocess_received_blocks(
   memset(nblocks_per_shard, 0, nshards * sizeof(int));
   dbm_pack_block_t *blocks_tmp =
       malloc(nblocks_recv * sizeof(dbm_pack_block_t));
+  assert(blocks_tmp != NULL);
 
 #pragma omp parallel
   {
@@ -346,6 +348,7 @@ static dbm_packed_matrix_t pack_matrix(const bool trans_matrix,
   packed.dist_ticks = dist_ticks;
   packed.nsend_packs = nsend_packs;
   packed.send_packs = malloc(nsend_packs * sizeof(dbm_pack_t));
+  assert(packed.send_packs != NULL);
 
   // Plan all packs.
   plan_t *plans_per_pack[nsend_packs];
@@ -524,6 +527,7 @@ dbm_comm_iterator_t *dbm_comm_iterator_start(const bool transa,
                                              const dbm_matrix_t *matrix_c) {
 
   dbm_comm_iterator_t *iter = malloc(sizeof(dbm_comm_iterator_t));
+  assert(iter != NULL);
   iter->dist = matrix_c->dist;
 
   // During each communication tick we'll fetch a pack_a and pack_b.

--- a/src/dbm/dbm_multiply_gpu.c
+++ b/src/dbm/dbm_multiply_gpu.c
@@ -38,6 +38,7 @@ void dbm_multiply_gpu_start(const int max_batch_size, const int nshards,
 
   // Allocate and upload shards of result matrix C.
   ctx->shards_c_dev = malloc(nshards * sizeof(dbm_shard_gpu_t));
+  assert(ctx->shards_c_dev != NULL);
   for (int i = 0; i < nshards; i++) {
     const dbm_shard_t *shard_c_host = &ctx->shards_c_host[i];
     dbm_shard_gpu_t *shard_c_dev = &ctx->shards_c_dev[i];

--- a/src/dbm/dbm_shard.c
+++ b/src/dbm/dbm_shard.c
@@ -54,6 +54,7 @@ static void hashtable_init(dbm_shard_t *shard) {
   shard->hashtable_mask = shard->hashtable_size - 1;
   shard->hashtable_prime = next_prime(shard->hashtable_size);
   shard->hashtable = calloc(shard->hashtable_size, sizeof(int));
+  assert(shard->hashtable != NULL);
 }
 
 /*******************************************************************************
@@ -64,11 +65,13 @@ void dbm_shard_init(dbm_shard_t *shard) {
   shard->nblocks = 0;
   shard->nblocks_allocated = INITIAL_NBLOCKS_ALLOCATED;
   shard->blocks = malloc(shard->nblocks_allocated * sizeof(dbm_block_t));
+  assert(shard->blocks != NULL);
   hashtable_init(shard);
   shard->data_size = 0;
   shard->data_promised = 0;
   shard->data_allocated = INITIAL_DATA_ALLOCATED;
   shard->data = malloc(shard->data_allocated * sizeof(double));
+  assert(shard->data != NULL);
 
   omp_init_lock(&shard->lock);
 }
@@ -82,6 +85,7 @@ void dbm_shard_copy(dbm_shard_t *shard_a, const dbm_shard_t *shard_b) {
   shard_a->nblocks = shard_b->nblocks;
   shard_a->nblocks_allocated = shard_b->nblocks_allocated;
   shard_a->blocks = malloc(shard_b->nblocks_allocated * sizeof(dbm_block_t));
+  assert(shard_a->blocks != NULL);
   memcpy(shard_a->blocks, shard_b->blocks,
          shard_b->nblocks * sizeof(dbm_block_t));
 
@@ -90,12 +94,14 @@ void dbm_shard_copy(dbm_shard_t *shard_a, const dbm_shard_t *shard_b) {
   shard_a->hashtable_mask = shard_b->hashtable_mask;
   shard_a->hashtable_prime = shard_b->hashtable_prime;
   shard_a->hashtable = malloc(shard_b->hashtable_size * sizeof(int));
+  assert(shard_a->hashtable != NULL);
   memcpy(shard_a->hashtable, shard_b->hashtable,
          shard_b->hashtable_size * sizeof(int));
 
   free(shard_a->data);
   shard_a->data_allocated = shard_b->data_allocated;
   shard_a->data = malloc(shard_b->data_allocated * sizeof(double));
+  assert(shard_a->data != NULL);
   shard_a->data_size = shard_b->data_size;
   memcpy(shard_a->data, shard_b->data, shard_b->data_size * sizeof(double));
 }
@@ -173,8 +179,9 @@ dbm_block_t *dbm_shard_promise_new_block(dbm_shard_t *shard, const int row,
   // Grow blocks array if necessary.
   if (shard->nblocks_allocated < shard->nblocks + 1) {
     shard->nblocks_allocated = ALLOCATION_FACTOR * (shard->nblocks + 1);
-    shard->blocks = (dbm_block_t *)realloc(
-        shard->blocks, shard->nblocks_allocated * sizeof(dbm_block_t));
+    shard->blocks =
+        realloc(shard->blocks, shard->nblocks_allocated * sizeof(dbm_block_t));
+    assert(shard->blocks != NULL);
 
     // rebuild hashtable
     free(shard->hashtable);
@@ -205,8 +212,8 @@ void dbm_shard_allocate_promised_blocks(dbm_shard_t *shard) {
   // Reallocate data array if necessary.
   if (shard->data_promised > shard->data_allocated) {
     shard->data_allocated = ALLOCATION_FACTOR * shard->data_promised;
-    shard->data =
-        (double *)realloc(shard->data, shard->data_allocated * sizeof(double));
+    shard->data = realloc(shard->data, shard->data_allocated * sizeof(double));
+    assert(shard->data != NULL);
   }
 
   // Zero new blocks.

--- a/src/grid/common/grid_basis_set.c
+++ b/src/grid/common/grid_basis_set.c
@@ -5,6 +5,7 @@
 /*  SPDX-License-Identifier: BSD-3-Clause                                     */
 /*----------------------------------------------------------------------------*/
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -24,6 +25,7 @@ void grid_create_basis_set(const int nset, const int nsgf, const int maxco,
                            grid_basis_set **basis_set_out) {
 
   grid_basis_set *basis_set = malloc(sizeof(grid_basis_set));
+  assert(basis_set != NULL);
 
   basis_set->nset = nset;
   basis_set->nsgf = nsgf;
@@ -32,20 +34,27 @@ void grid_create_basis_set(const int nset, const int nsgf, const int maxco,
 
   size_t size = nset * sizeof(int);
   basis_set->lmin = malloc(size);
+  assert(basis_set->lmin != NULL);
   memcpy(basis_set->lmin, lmin, size);
   basis_set->lmax = malloc(size);
+  assert(basis_set->lmax != NULL);
   memcpy(basis_set->lmax, lmax, size);
   basis_set->npgf = malloc(size);
+  assert(basis_set->npgf != NULL);
   memcpy(basis_set->npgf, npgf, size);
   basis_set->nsgf_set = malloc(size);
+  assert(basis_set->nsgf_set != NULL);
   memcpy(basis_set->nsgf_set, nsgf_set, size);
   basis_set->first_sgf = malloc(size);
+  assert(basis_set->first_sgf != NULL);
   memcpy(basis_set->first_sgf, first_sgf, size);
   size = nsgf * maxco * sizeof(double);
   basis_set->sphi = malloc(size);
+  assert(basis_set->sphi != NULL);
   memcpy(basis_set->sphi, sphi, size);
   size = nset * maxpgf * sizeof(double);
   basis_set->zet = malloc(size);
+  assert(basis_set->zet != NULL);
   memcpy(basis_set->zet, zet, size);
 
   *basis_set_out = basis_set;

--- a/src/grid/common/grid_library.c
+++ b/src/grid/common/grid_library.c
@@ -63,6 +63,7 @@ void grid_library_init(void) {
 
   max_threads = omp_get_max_threads();
   per_thread_globals = malloc(max_threads * sizeof(grid_library_globals *));
+  assert(per_thread_globals != NULL);
 
 // Using parallel regions to ensure memory is allocated near a thread's core.
 #pragma omp parallel default(none) shared(per_thread_globals)                  \
@@ -70,6 +71,7 @@ void grid_library_init(void) {
   {
     const int ithread = omp_get_thread_num();
     per_thread_globals[ithread] = malloc(sizeof(grid_library_globals));
+    assert(per_thread_globals[ithread] != NULL);
     memset(per_thread_globals[ithread], 0, sizeof(grid_library_globals));
   }
 

--- a/src/grid/common/grid_sphere_cache.c
+++ b/src/grid/common/grid_sphere_cache.c
@@ -71,6 +71,7 @@ static void rebuild_cache_entry(const int max_imr, const double drmin,
 
   // Compute required storage size.
   entry->offsets = malloc(max_imr * sizeof(int));
+  assert(entry->offsets != NULL);
   int nbounds_total = 0;
   for (int imr = 1; imr <= max_imr; imr++) {
     const double radius = imr * drmin;
@@ -81,6 +82,7 @@ static void rebuild_cache_entry(const int max_imr, const double drmin,
 
   // Allocate and fill storage.
   entry->storage = malloc(nbounds_total * sizeof(int));
+  assert(entry->storage != NULL);
   for (int imr = 1; imr <= max_imr; imr++) {
     const double radius = imr * drmin;
     const int offset = entry->offsets[imr - 1];
@@ -102,7 +104,7 @@ void grid_sphere_cache_lookup(const double radius, const double dh[3][3],
 
   // Find or create cache entry for given grid.
   const double dr0 = dh[0][0], dr1 = dh[1][1], dr2 = dh[2][2];
-  grid_sphere_cache_entry *entry = 0;
+  grid_sphere_cache_entry *entry = NULL;
   bool found = false;
 
   // Fast path: check prev match.
@@ -131,6 +133,7 @@ void grid_sphere_cache_lookup(const double radius, const double dh[3][3],
     grid_sphere_cache_entry *old_entries = cache->entries;
     const size_t entry_size = sizeof(grid_sphere_cache_entry);
     cache->entries = malloc(cache->size * entry_size);
+    assert(cache->entries != NULL);
     memcpy(cache->entries, old_entries, (cache->size - 1) * entry_size);
     free(old_entries);
     cache->prev_match = cache->size - 1;

--- a/src/grid/cpu/grid_cpu_collocate.c
+++ b/src/grid/cpu/grid_cpu_collocate.c
@@ -201,6 +201,7 @@ void grid_cpu_collocate_pgf_product(
   if (DUMP_TASKS) {
     const size_t sizeof_grid = sizeof(double) * npts_local_total;
     grid_before = malloc(sizeof_grid);
+    assert(grid_before != NULL);
     memcpy(grid_before, grid, sizeof_grid);
     memset(grid, 0, sizeof_grid);
   }

--- a/src/grid/cpu/grid_cpu_task_list.c
+++ b/src/grid/cpu/grid_cpu_task_list.c
@@ -60,6 +60,7 @@ void grid_cpu_create_task_list(
   }
 
   grid_cpu_task_list *task_list = malloc(sizeof(grid_cpu_task_list));
+  assert(task_list != NULL);
 
   task_list->orthorhombic = orthorhombic;
   task_list->ntasks = ntasks;
@@ -70,22 +71,27 @@ void grid_cpu_create_task_list(
 
   size_t size = nblocks * sizeof(int);
   task_list->block_offsets = malloc(size);
+  assert(task_list->block_offsets != NULL);
   memcpy(task_list->block_offsets, block_offsets, size);
 
   size = 3 * natoms * sizeof(double);
   task_list->atom_positions = malloc(size);
+  assert(task_list->atom_positions != NULL);
   memcpy(task_list->atom_positions, atom_positions, size);
 
   size = natoms * sizeof(int);
   task_list->atom_kinds = malloc(size);
+  assert(task_list->atom_kinds != NULL);
   memcpy(task_list->atom_kinds, atom_kinds, size);
 
   size = nkinds * sizeof(grid_basis_set *);
   task_list->basis_sets = malloc(size);
+  assert(task_list->basis_sets != NULL);
   memcpy(task_list->basis_sets, basis_sets, size);
 
   size = ntasks * sizeof(grid_cpu_task);
   task_list->tasks = malloc(size);
+  assert(task_list->tasks != NULL);
   for (int i = 0; i < ntasks; i++) {
     task_list->tasks[i].level = level_list[i];
     task_list->tasks[i].iatom = iatom_list[i];
@@ -105,6 +111,7 @@ void grid_cpu_create_task_list(
   // Store grid layouts.
   size = nlevels * sizeof(grid_cpu_layout);
   task_list->layouts = malloc(size);
+  assert(task_list->layouts != NULL);
   for (int level = 0; level < nlevels; level++) {
     for (int i = 0; i < 3; i++) {
       task_list->layouts[level].npts_global[i] = npts_global[level][i];
@@ -124,7 +131,9 @@ void grid_cpu_create_task_list(
   // Find first and last task for each level and block.
   size = nlevels * nblocks * sizeof(int);
   task_list->first_level_block_task = malloc(size);
+  assert(task_list->first_level_block_task != NULL);
   task_list->last_level_block_task = malloc(size);
+  assert(task_list->last_level_block_task != NULL);
   for (int i = 0; i < nlevels * nblocks; i++) {
     task_list->first_level_block_task[i] = 0;
     task_list->last_level_block_task[i] = -1; // last < first means no tasks
@@ -148,9 +157,11 @@ void grid_cpu_create_task_list(
   // Initialize thread-local storage.
   size = omp_get_max_threads() * sizeof(double *);
   task_list->threadlocals = malloc(size);
+  assert(task_list->threadlocals != NULL);
   memset(task_list->threadlocals, 0, size);
   size = omp_get_max_threads() * sizeof(size_t);
   task_list->threadlocal_sizes = malloc(size);
+  assert(task_list->threadlocal_sizes != NULL);
   memset(task_list->threadlocal_sizes, 0, size);
 
   *task_list_out = task_list;
@@ -272,6 +283,7 @@ static void collocate_one_grid_level(
         free(task_list->threadlocals[ithread]);
       }
       task_list->threadlocals[ithread] = malloc(grid_size);
+      assert(task_list->threadlocals[ithread] != NULL);
       task_list->threadlocal_sizes[ithread] = grid_size;
     }
 

--- a/src/grid/dgemm/grid_dgemm_collocation_integration.c
+++ b/src/grid/dgemm/grid_dgemm_collocation_integration.c
@@ -5,6 +5,7 @@
 /*  SPDX-License-Identifier: BSD-3-Clause                                     */
 /*----------------------------------------------------------------------------*/
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,10 +22,7 @@ struct collocation_integration_ *collocate_create_handle(void) {
   struct collocation_integration_ *handle = NULL;
   handle = (struct collocation_integration_ *)malloc(
       sizeof(struct collocation_integration_));
-
-  if (handle == NULL) {
-    abort();
-  }
+  assert(handle != NULL);
   memset(handle, 0, sizeof(struct collocation_integration_));
 
   handle->alpha.alloc_size_ = 8192;
@@ -39,6 +37,7 @@ struct collocation_integration_ *collocate_create_handle(void) {
   handle->pol_alloc_size = realloc_tensor(&handle->pol);
 
   handle->scratch = malloc(32768 * sizeof(double));
+  assert(handle->scratch != NULL);
   handle->scratch_alloc_size = 32768;
   handle->T_alloc_size = 8192;
   handle->W_alloc_size = 2048;
@@ -46,11 +45,14 @@ struct collocation_integration_ *collocate_create_handle(void) {
   handle->blockDim[1] = 5;
   handle->blockDim[2] = 5;
   handle->device_id = (int *)malloc(sizeof(double) * 12);
+  assert(handle->device_id != NULL);
   handle->number_of_devices = 1;
 
   /* to suppress when we remove the spherical cutoff */
   handle->map = (int **)malloc(3 * sizeof(int *));
+  assert(handle->map != NULL);
   handle->map[0] = (int *)malloc(sizeof(int) * 512 * 3);
+  assert(handle->map[0] != NULL);
   handle->map[1] = handle->map[0] + 512;
   handle->map[2] = handle->map[1] + 512;
   handle->cmax = 512 * 3;
@@ -105,8 +107,7 @@ void initialize_W_and_T(collocation_integration *const handler,
     if (handler->scratch)
       free(handler->scratch);
     handler->scratch = malloc(sizeof(double) * handler->scratch_alloc_size);
-    if (handler->scratch == NULL)
-      abort();
+    assert(handler->scratch != NULL);
   }
 }
 
@@ -135,8 +136,7 @@ void initialize_W_and_T_integrate(collocation_integration *const handler,
     if (handler->scratch)
       free(handler->scratch);
     handler->scratch = malloc(sizeof(double) * handler->scratch_alloc_size);
-    if (handler->scratch == NULL)
-      abort();
+    assert(handler->scratch != NULL);
   }
 }
 

--- a/src/grid/dgemm/grid_dgemm_context.c
+++ b/src/grid/dgemm/grid_dgemm_context.c
@@ -92,6 +92,7 @@ void update_atoms_position(const int natoms,
           realloc(data->atom_positions, 3 * natoms * sizeof(double));
     }
   }
+  assert(data->atom_positions != NULL);
 
   data->natoms = natoms;
 
@@ -119,6 +120,7 @@ void update_atoms_kinds(const int natoms, const int *atoms_kinds,
       data->atom_kinds = realloc(data->atom_kinds, natoms * sizeof(int));
     }
   }
+  assert(data->atom_kinds != NULL);
   // data->natoms is initialized before calling this function
   if (data->natoms)
     memcpy(data->atom_kinds, atoms_kinds, sizeof(int) * natoms);
@@ -142,6 +144,7 @@ void update_block_offsets(const int nblocks, const int *const block_offsets,
       data->block_offsets = realloc(data->block_offsets, sizeof(int) * nblocks);
     }
   }
+  assert(data->block_offsets != NULL);
 
   data->nblocks = nblocks;
   data->nblocks_total = imax(data->nblocks_total, nblocks);
@@ -159,6 +162,7 @@ void update_basis_set(const int nkinds, const grid_basis_set **const basis_sets,
           realloc(data->basis_sets, nkinds * sizeof(grid_basis_set *));
     }
   }
+  assert(data->basis_sets != NULL);
   data->nkinds = nkinds;
   data->nkinds_total = imax(data->nkinds_total, nkinds);
   memcpy(data->basis_sets, basis_sets, nkinds * sizeof(grid_basis_set *));
@@ -193,9 +197,11 @@ void update_task_lists(const int nlevels, const int ntasks,
     if (ctx->nlevels_total < nlevels) {
       /* save the address of the full task list. NULL when completly empty */
       ctx->tasks = realloc(ctx->tasks, nlevels * sizeof(_task *));
+      assert(ctx->tasks != NULL);
     }
     if (ctx->ntasks_total < ntasks) {
       ctx->tasks[0] = realloc(ctx->tasks[0], ntasks * sizeof(_task));
+      assert(ctx->tasks[0] != NULL);
     }
   }
 
@@ -344,6 +350,7 @@ void update_grid(const int nlevels, grid_context *ctx) {
       ctx->grid = realloc(ctx->grid, sizeof(tensor) * nlevels);
     }
   }
+  assert(ctx->grid != NULL);
 
   ctx->nlevels_total = imax(ctx->nlevels_total, nlevels);
   ctx->nlevels = nlevels;
@@ -447,10 +454,12 @@ void initialize_grid_context_on_gpu(void *ptr, const int number_of_devices,
 
   ctx->number_of_devices = number_of_devices;
   ctx->queue_length = 8192;
-  if (ctx->device_id == NULL)
+  if (ctx->device_id == NULL) {
     ctx->device_id = malloc(sizeof(int) * number_of_devices);
-  else
+  } else {
     ctx->device_id = realloc(ctx->device_id, sizeof(int) * number_of_devices);
+  }
+  assert(ctx->device_id != NULL);
 
   memcpy(ctx->device_id, device_id, sizeof(int) * number_of_devices);
 }

--- a/src/grid/dgemm/grid_dgemm_integrate.c
+++ b/src/grid/dgemm/grid_dgemm_integrate.c
@@ -1074,6 +1074,7 @@ void grid_dgemm_integrate_task_list(
 
   if (ctx->scratch == NULL)
     ctx->scratch = malloc(hab_blocks->size * max_threads);
+  assert(ctx->scratch != NULL);
 
   // #pragma omp parallel for
   for (int level = 0; level < ctx->nlevels; level++) {

--- a/src/grid/dgemm/grid_dgemm_tensor_local.c
+++ b/src/grid/dgemm/grid_dgemm_tensor_local.c
@@ -10,7 +10,7 @@
 #include "grid_dgemm_utils.h"
 
 size_t realloc_tensor(tensor *t) {
-  assert(t);
+  assert(t != NULL);
 
   if (t->alloc_size_ == 0) {
     /* there is a mistake somewhere. We can not have t->old_alloc_size_ != 0 and
@@ -29,8 +29,7 @@ size_t realloc_tensor(tensor *t) {
 
   if (t->data == NULL) {
     t->data = malloc(sizeof(double) * t->alloc_size_);
-    if (!t->data)
-      abort();
+    assert(t->data != NULL);
     t->old_alloc_size_ = t->alloc_size_;
   }
 
@@ -38,13 +37,10 @@ size_t realloc_tensor(tensor *t) {
 }
 
 void alloc_tensor(tensor *t) {
-  if (t == NULL) {
-    abort();
-  }
+  assert(t != NULL);
 
   t->data = malloc(sizeof(double) * t->alloc_size_);
-  if (!t->data)
-    abort();
+  assert(t->data != NULL);
   t->old_alloc_size_ = t->alloc_size_;
 }
 

--- a/src/grid/grid_task_list.c
+++ b/src/grid/grid_task_list.c
@@ -43,6 +43,7 @@ void grid_create_task_list(
 
   if (*task_list_out == NULL) {
     task_list = malloc(sizeof(grid_task_list));
+    assert(task_list != NULL);
     memset(task_list, 0, sizeof(grid_task_list));
 
     // Resolve AUTO to a concrete backend.
@@ -68,6 +69,7 @@ void grid_create_task_list(
   task_list->nlevels = nlevels;
   size_t size = nlevels * 3 * sizeof(int);
   task_list->npts_local = malloc(size);
+  assert(task_list->npts_local != NULL);
   memcpy(task_list->npts_local, npts_local, size);
 
   // Always create reference backend because it might be needed for validation.

--- a/src/grid/ref/grid_ref_task_list.c
+++ b/src/grid/ref/grid_ref_task_list.c
@@ -60,6 +60,7 @@ void grid_ref_create_task_list(
   }
 
   grid_ref_task_list *task_list = malloc(sizeof(grid_ref_task_list));
+  assert(task_list != NULL);
 
   task_list->orthorhombic = orthorhombic;
   task_list->ntasks = ntasks;
@@ -70,22 +71,27 @@ void grid_ref_create_task_list(
 
   size_t size = nblocks * sizeof(int);
   task_list->block_offsets = malloc(size);
+  assert(task_list->block_offsets != NULL);
   memcpy(task_list->block_offsets, block_offsets, size);
 
   size = 3 * natoms * sizeof(double);
   task_list->atom_positions = malloc(size);
+  assert(task_list->atom_positions != NULL);
   memcpy(task_list->atom_positions, atom_positions, size);
 
   size = natoms * sizeof(int);
   task_list->atom_kinds = malloc(size);
+  assert(task_list->atom_kinds != NULL);
   memcpy(task_list->atom_kinds, atom_kinds, size);
 
   size = nkinds * sizeof(grid_basis_set *);
   task_list->basis_sets = malloc(size);
+  assert(task_list->basis_sets != NULL);
   memcpy(task_list->basis_sets, basis_sets, size);
 
   size = ntasks * sizeof(grid_ref_task);
   task_list->tasks = malloc(size);
+  assert(task_list->tasks != NULL);
   for (int i = 0; i < ntasks; i++) {
     task_list->tasks[i].level = level_list[i];
     task_list->tasks[i].iatom = iatom_list[i];
@@ -105,6 +111,7 @@ void grid_ref_create_task_list(
   // Store grid layouts.
   size = nlevels * sizeof(grid_ref_layout);
   task_list->layouts = malloc(size);
+  assert(task_list->layouts != NULL);
   for (int level = 0; level < nlevels; level++) {
     for (int i = 0; i < 3; i++) {
       task_list->layouts[level].npts_global[i] = npts_global[level][i];
@@ -124,7 +131,9 @@ void grid_ref_create_task_list(
   // Find first and last task for each level and block.
   size = nlevels * nblocks * sizeof(int);
   task_list->first_level_block_task = malloc(size);
+  assert(task_list->first_level_block_task != NULL);
   task_list->last_level_block_task = malloc(size);
+  assert(task_list->last_level_block_task != NULL);
   for (int i = 0; i < nlevels * nblocks; i++) {
     task_list->first_level_block_task[i] = 0;
     task_list->last_level_block_task[i] = -1; // last < first means no tasks
@@ -148,9 +157,11 @@ void grid_ref_create_task_list(
   // Initialize thread-local storage.
   size = omp_get_max_threads() * sizeof(double *);
   task_list->threadlocals = malloc(size);
+  assert(task_list->threadlocals != NULL);
   memset(task_list->threadlocals, 0, size);
   size = omp_get_max_threads() * sizeof(size_t);
   task_list->threadlocal_sizes = malloc(size);
+  assert(task_list->threadlocal_sizes != NULL);
   memset(task_list->threadlocal_sizes, 0, size);
 
   *task_list_out = task_list;
@@ -272,6 +283,7 @@ static void collocate_one_grid_level(
         free(task_list->threadlocals[ithread]);
       }
       task_list->threadlocals[ithread] = malloc(grid_size);
+      assert(task_list->threadlocals[ithread] != NULL);
       task_list->threadlocal_sizes[ithread] = grid_size;
     }
 


### PR DESCRIPTION
This will cleanly catch any out-of-memory errors instead of leading to  confusing seg-faults down the line.