### PR TITLE
CMake should not check for libxcf90 since only libxcf03 is used.

### DIFF
--- a/cmake/modules/FindLibXC.cmake
+++ b/cmake/modules/FindLibXC.cmake
@@ -12,25 +12,22 @@ include(cp2k_utils)
 cp2k_set_default_paths(LIBXC "LibXC")
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(CP2K_LIBXC IMPORTED_TARGET GLOBAL libxcf90 libxcf03
+  pkg_check_modules(CP2K_LIBXC IMPORTED_TARGET GLOBAL libxcf03
                     libxc>=${LibXC_FIND_VERSION})
 endif()
 
 if(NOT CP2K_LIBXC_FOUND)
   # Revert pkg_check_modules side effects
   cp2k_set_default_paths(LIBXC "LibXC")
-  foreach(_var xc xcf03 xcf90)
+  foreach(_var xc xcf03)
     string(TOUPPER LIB${_var} _var_up)
     cp2k_find_libraries(${_var_up} ${_var})
   endforeach()
 endif()
 
-if(CP2K_LIBXC_FOUND
-   AND CP2K_LIBXCF90_FOUND
-   AND CP2K_LIBXCF03_FOUND)
+if(CP2K_LIBXC_FOUND AND CP2K_LIBXCF03_FOUND)
   set(CP2K_LIBXC_LINK_LIBRARIES
-      "${CP2K_LIBXCF03_LIBRARIES};${CP2K_LIBXCF90_LIBRARIES};${CP2K_LIBXC_LIBRARIES}"
-  )
+      "${CP2K_LIBXCF03_LIBRARIES};${CP2K_LIBXC_LIBRARIES}")
 endif()
 
 if(NOT CP2K_LIBXC_INCLUDE_DIRS)


### PR DESCRIPTION
Although CP2K is correctly only using the interface provided by libxcf03, for some reason the CMake code tries to find libxcf90 and wants to link it in as well. This makes no sense, since libxcf90 and libxcf03 are different beasts, moreover, libxcf90 has been dropped in libxc 7.0.0.

This patch is necessary to build cp2k against up-to-date releases of Libxc.