### PR TITLE
Simplified calling dbcsr_init_lib

### DIFF
--- a/src/f77_interface.F
+++ b/src/f77_interface.F
@@ -114,8 +114,7 @@ MODULE f77_interface
                                               rm_mp_perf_env
    USE nnp_environment,                 ONLY: nnp_init
    USE nnp_environment_types,           ONLY: nnp_type
-   USE offload_api,                     ONLY: offload_get_chosen_device,&
-                                              offload_get_device_count,&
+   USE offload_api,                     ONLY: offload_get_device_count,&
                                               offload_init,&
                                               offload_set_chosen_device
    USE periodic_table,                  ONLY: init_periodic_table
@@ -220,6 +219,8 @@ CONTAINS
       INTEGER, INTENT(out)                               :: ierr
 
       INTEGER                                            :: offload_device_count, unit_nr
+      INTEGER, POINTER                                   :: active_device_id
+      INTEGER, TARGET                                    :: offload_chosen_device
       TYPE(cp_logger_type), POINTER                      :: logger
 
       IF (.NOT. module_initialized) THEN
@@ -275,28 +276,21 @@ CONTAINS
          !   *** init the bibliography ***
          CALL add_all_references()
 
+         NULLIFY (active_device_id)
          offload_device_count = offload_get_device_count()
 
          ! Select active offload device when available.
          IF (offload_device_count > 0) THEN
-            CALL offload_set_chosen_device(MOD(default_para_env%mepos, offload_device_count))
+            offload_chosen_device = MOD(default_para_env%mepos, offload_device_count)
+            CALL offload_set_chosen_device(offload_chosen_device)
+            active_device_id => offload_chosen_device
          END IF
 
          ! Initialize the DBCSR configuration
          ! Attach the time handler hooks to DBCSR
-#if defined __DBCSR_ACC
-         IF (offload_device_count > 0) THEN
-            CALL dbcsr_init_lib(default_para_env%get_handle(), timeset_hook, timestop_hook, &
-                                cp_abort_hook, cp_warn_hook, io_unit=unit_nr, &
-                                accdrv_active_device_id=offload_get_chosen_device())
-         ELSE
-            CALL dbcsr_init_lib(default_para_env%get_handle(), timeset_hook, timestop_hook, &
-                                cp_abort_hook, cp_warn_hook, io_unit=unit_nr)
-         END IF
-#else
          CALL dbcsr_init_lib(default_para_env%get_handle(), timeset_hook, timestop_hook, &
-                             cp_abort_hook, cp_warn_hook, io_unit=unit_nr)
-#endif
+                             cp_abort_hook, cp_warn_hook, io_unit=unit_nr, &
+                             accdrv_active_device_id=active_device_id)
          CALL cp_sirius_init() ! independent of method_name_id == do_sirius
          CALL cp_dlaf_initialize()
          CALL pw_fpga_init()

--- a/src/start/cp2k_runs.F
+++ b/src/start/cp2k_runs.F
@@ -175,6 +175,10 @@ CONTAINS
       INTEGER                                            :: f_env_handle, grid_backend, ierr, &
                                                             iter_level, method_name_id, &
                                                             new_env_id, prog_name_id, run_type_id
+#if defined(__DBCSR_ACC)
+      INTEGER, TARGET                                    :: offload_chosen_device
+#endif
+      INTEGER, POINTER                                   :: active_device_id
       INTEGER(KIND=int_8)                                :: m_memory_max_mpi
       LOGICAL                                            :: echo_input, grid_apply_cutoff, &
                                                             grid_validate, I_was_ionode
@@ -186,20 +190,18 @@ CONTAINS
       TYPE(global_environment_type), POINTER             :: globenv
       TYPE(section_vals_type), POINTER                   :: glob_section, input_file, root_section
 
-      NULLIFY (para_env, f_env, dft_control)
+      NULLIFY (para_env, f_env, dft_control, active_device_id)
       ALLOCATE (para_env)
       para_env = mpi_comm
 
 #if defined(__DBCSR_ACC)
       IF (offload_get_device_count() > 0) THEN
-         CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit, &
-                             accdrv_active_device_id=offload_get_chosen_device())
-      ELSE
-         CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit)
+         offload_chosen_device = offload_get_chosen_device()
+         active_device_id => offload_chosen_device
       END IF
-#else
-      CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit)
 #endif
+      CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit, &
+                          accdrv_active_device_id=active_device_id)
 
       NULLIFY (globenv, force_env)
 
@@ -264,16 +266,8 @@ CONTAINS
       CASE (do_farming) ! TODO: refactor cp2k's startup code
          CALL dbcsr_finalize_lib()
          CALL farming_run(input_declaration, root_section, para_env, initial_variables)
-#if defined(__DBCSR_ACC)
-         IF (offload_get_device_count() > 0) THEN
-            CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit, &
-                                accdrv_active_device_id=offload_get_chosen_device())
-         ELSE
-            CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit)
-         END IF
-#else
-         CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit)
-#endif
+         CALL dbcsr_init_lib(mpi_comm%get_handle(), io_unit=output_unit, &
+                             accdrv_active_device_id=active_device_id)
       CASE (do_opt_basis)
          CALL run_optimize_basis(input_declaration, root_section, para_env)
          globenv%run_type_id = none_run


### PR DESCRIPTION
- Rely on POINTER to optionally initialize accdrv_active_device_id
- Reduces Lines of Code (LOC)
- Complements #3730