### PR TITLE
Revised CPVERSION_CHECK and related checks

### DIFF
--- a/src/base/base_uses.f90
+++ b/src/base/base_uses.f90
@@ -48,12 +48,13 @@
 #define CPVERSION3(MAJOR, MINOR, UPDATE) (CPVERSION2(MAJOR, MINOR) + (UPDATE))
 #define CPVERSION CPVERSION2
 
-! Usage: CPVERSION_CHECK(9, 5, >, __GNUC__, __GNUC_MINOR__)
 ! On top of CPVERSION macro, test if MAJOR_TEST and MINOR_TEST are defined.
+! Usage:  #if CPVERSION_CHECK(9, 5, >, __GNUC__, __GNUC_MINOR__)
 ! Perform actual comparison according to COMP argument.
-#define CPVERSION_CHECK(MAJOR_BASE, MINOR_BASE, COMP, MAJOR_TEST, MINOR_TEST) ( \
-  (defined(MAJOR_TEST) && defined(MINOR_TEST)) && \
-  (CPVERSION2(MAJOR_BASE, MINOR_BASE) COMP CPVERSION2(MAJOR_TEST, MINOR_TEST)))
+! Note: defined(MAJOR_TEST) and defined(MINOR_TEST) is avoided in macro
+!       definition due to issues handling it in certain compilers.
+#define CPVERSION_CHECK(MAJOR_BASE, MINOR_BASE, COMP, MAJOR_TEST, MINOR_TEST) \
+  (CPVERSION2(MAJOR_BASE, MINOR_BASE) COMP CPVERSION2(MAJOR_TEST, MINOR_TEST))
 
 ! Avoid to default initialize type-components (default c'tor)
 #if CPVERSION_CHECK(9, 5, >, __GNUC__, __GNUC_MINOR__) || defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)

--- a/src/mp2_ri_gpw.F
+++ b/src/mp2_ri_gpw.F
@@ -2052,17 +2052,15 @@ CONTAINS
                DO irep = 0, num_integ_group - 1
                   start_point = ranges_info_array(3, irep, comm_exchange%mepos)
                   end_point = ranges_info_array(4, irep, comm_exchange%mepos)
-#if defined(__INTEL_LLVM_COMPILER)
-                  Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) = &
-                     Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) + &
-                     BI_C_rec(1:my_B_size, :, start_point:end_point)
-#else
+#if !defined(__INTEL_LLVM_COMPILER) || (20250000 <= __INTEL_LLVM_COMPILER)
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) &
 !$OMP                    SHARED(start_point,end_point,my_block_size,&
 !$OMP                           Gamma_P_ia,rec_i,my_B_size,BI_C_rec)
+#endif
                   Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) = &
                      Gamma_P_ia(:, rec_i:rec_i + my_block_size - 1, start_point:end_point) + &
                      BI_C_rec(1:my_B_size, :, start_point:end_point)
+#if !defined(__INTEL_LLVM_COMPILER) || (20250000 <= __INTEL_LLVM_COMPILER)
 !$OMP END PARALLEL WORKSHARE
 #endif
                END DO

--- a/src/pw/pw_methods.F
+++ b/src/pw/pw_methods.F
@@ -246,13 +246,12 @@ CONTAINS
 
             CALL timeset(routineN, handle)
 
-            ! This OMP clause causes an internal compiler error (ICE) with ifx (<=2024.2.1)
-#if defined(__INTEL_LLVM_COMPILER)
-            pw%array = ${type2type("0.0_dp", "r3d", kind)}$
-#else
+#if !defined(__INTEL_LLVM_COMPILER) || (20250000 <= __INTEL_LLVM_COMPILER)
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw)
             pw%array = ${type2type("0.0_dp", "r3d", kind)}$
 !$OMP END PARALLEL WORKSHARE
+#else
+            pw%array = ${type2type("0.0_dp", "r3d", kind)}$
 #endif
 
             CALL timestop(handle)
@@ -953,6 +952,7 @@ CONTAINS
                      IF (.NOT. ASSOCIATED(pw_out%pw_grid, pw1%pw_grid) .OR. .NOT. ASSOCIATED(pw_out%pw_grid, pw2%pw_grid)) &
                         CPABORT("pw_multiply not implemented for non-identical grids!")
 
+#if !defined(__INTEL_LLVM_COMPILER) || (20250000 <= __INTEL_LLVM_COMPILER)
                      IF (my_alpha == 1.0_dp) THEN
 !$OMP PARALLEL WORKSHARE DEFAULT(NONE) SHARED(pw_out, pw1, pw2)
                         pw_out%array = pw_out%array + pw1%array*${type2type("pw2%array", kind2, kind)}$
@@ -962,6 +962,13 @@ CONTAINS
                         pw_out%array = pw_out%array + my_alpha*pw1%array*${type2type("pw2%array", kind2, kind)}$
 !$OMP END PARALLEL WORKSHARE
                      END IF
+#else
+                     IF (my_alpha == 1.0_dp) THEN
+                        pw_out%array = pw_out%array + pw1%array*${type2type("pw2%array", kind2, kind)}$
+                     ELSE
+                        pw_out%array = pw_out%array + my_alpha*pw1%array*${type2type("pw2%array", kind2, kind)}$
+                     END IF
+#endif
 
                      CALL timestop(handle)
 


### PR DESCRIPTION
- Ban using "defined" as part of a macro's definition
- Updated __INTEL_LLVM_COMPILER workarounds