### PR TITLE
Try a patched aiida-cp2k version (#3762)

### DIFF
--- a/tools/docker/scripts/test_aiida.sh
+++ b/tools/docker/scripts/test_aiida.sh
@@ -40,7 +40,7 @@ locale-gen ${LANG}
 export CC=gcc
 
 echo -e "\n========== Installing AiiDA-CP2K plugin =========="
-git clone --quiet https://github.com/aiidateam/aiida-cp2k.git /opt/aiida-cp2k/
+git clone --quiet https://github.com/mkrack/aiida-cp2k.git /opt/aiida-cp2k/
 cd /opt/aiida-cp2k/
 pip3 install './[dev]'
 


### PR DESCRIPTION
The restart handling of aiida-cp2k relies on the appearance of certain text strings in the CP2K output file which is fragile. This a follow-up to #3762 to fix [this issue](https://github.com/aiidateam/aiida-cp2k/issues/220).