### PR TITLE
OMPT: trace OpenMP constructs and check for issues

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1357,7 +1357,7 @@ list(
   xc/xc_xpbe_hole_t_c_lr.F
   xc/xc_xwpbe.F)
 
-list(APPEND CP2K_SRCS_C sockets.c base/machine_cpuid.c)
+list(APPEND CP2K_SRCS_C sockets.c base/machine_cpuid.c base/openmp_trace.c)
 
 set(CP2K_DBM_SRCS_C
     dbm/dbm_distribution.c

--- a/src/base/machine.F
+++ b/src/base/machine.F
@@ -84,7 +84,7 @@ MODULE machine
              m_getcwd, m_getlog, m_getpid, m_procrun, m_abort, &
              m_chdir, m_mov, m_memory, m_memory_details, m_energy, &
              m_cpuinfo, m_cpuid_static, m_cpuid, m_cpuid_name, &
-             m_get_omp_stacksize
+             m_omp_get_stacksize, m_omp_trace_issues
 
    INTERFACE
       ! **********************************************************************************************
@@ -97,6 +97,17 @@ MODULE machine
          IMPORT :: C_INT
          INTEGER(C_INT) :: m_cpuid_static
       END FUNCTION m_cpuid_static
+
+      ! **********************************************************************************************
+      !> \brief Trace OpenMP constructs if ennvironment variable CP2K_OMP_TRACE=1.
+      !> \return Number of OpenMP issues encountered (negative if OMPT disabled).
+      !> \par History
+      !>      11.2024 created [Hans Pabst]
+      ! **********************************************************************************************
+      FUNCTION m_omp_trace_issues() BIND(C, name="openmp_trace_issues")
+         IMPORT :: C_INT
+         INTEGER(C_INT) :: m_omp_trace_issues
+      END FUNCTION m_omp_trace_issues
    END INTERFACE
 
    ! Flushing is enabled by default because without it crash reports can get lost.
@@ -701,7 +712,7 @@ CONTAINS
 !> \brief Retrieve environment variable OMP_STACKSIZE
 !> \param omp_stacksize Value of OMP_STACKSIZE
 ! **************************************************************************************************
-   SUBROUTINE m_get_omp_stacksize(omp_stacksize)
+   SUBROUTINE m_omp_get_stacksize(omp_stacksize)
       CHARACTER(LEN=*), INTENT(OUT)                      :: omp_stacksize
 
       INTEGER                                            :: istat
@@ -711,6 +722,6 @@ CONTAINS
       ! Fall back, if OMP_STACKSIZE is not set
       IF (istat /= 0) omp_stacksize = "default"
 
-   END SUBROUTINE m_get_omp_stacksize
+   END SUBROUTINE m_omp_get_stacksize
 
 END MODULE machine

--- a/src/base/openmp_trace.c
+++ b/src/base/openmp_trace.c
@@ -1,0 +1,125 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2024 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
+/*----------------------------------------------------------------------------*/
+#define OPENMP_TRACE_DISABLED ((unsigned int)-1)
+
+/* routine is exposed in Fortran, hence must be present */
+int openmp_trace_issues(void);
+
+/**
+ * Simple compile-time check if OMPT is available (omp/iomp, not gomp).
+ * __clang__: omp and iomp/icx, __INTEL_COMPILER: iomp/icc
+ * __INTEL_LLVM_COMPILER: already covered by __clang__
+ */
+#if defined(_OPENMP) && (defined(__clang__) || defined(__INTEL_COMPILER))
+
+#include <assert.h>
+#include <omp-tools.h>
+#include <stdlib.h>
+
+#define OPENMP_TRACE_UNUSED(VAR) (void)VAR
+
+#define OPENMP_TRACE_SET_CALLBACK(PREFIX, NAME)                                \
+  if (ompt_set_never ==                                                        \
+      set_callback(ompt_callback_##NAME, (ompt_callback_t)PREFIX##_##NAME)) {  \
+    ++openmp_trace_nissues;                                                    \
+  }
+
+static unsigned int openmp_trace_nissues;
+static unsigned int openmp_trace_nparallel;
+static unsigned int openmp_trace_nmaster;
+
+int openmp_trace_issues(void) { return (int)openmp_trace_nissues; }
+
+static void openmp_trace_parallel_begin(
+    ompt_data_t *encountering_task_data,
+    const ompt_frame_t *encountering_task_frame, ompt_data_t *parallel_data,
+    unsigned int requested_parallelism, int flags, const void *codeptr_ra) {
+  OPENMP_TRACE_UNUSED(encountering_task_data);
+  OPENMP_TRACE_UNUSED(encountering_task_frame);
+  OPENMP_TRACE_UNUSED(parallel_data);
+  OPENMP_TRACE_UNUSED(requested_parallelism);
+  OPENMP_TRACE_UNUSED(flags);
+  OPENMP_TRACE_UNUSED(codeptr_ra);
+  if (0 != openmp_trace_nmaster) {
+    ++openmp_trace_nissues;
+    assert(0);
+  }
+  ++openmp_trace_nparallel;
+}
+
+static void openmp_trace_parallel_end(ompt_data_t *parallel_data,
+                                      ompt_data_t *encountering_task_data,
+                                      int flags, const void *codeptr_ra) {
+  OPENMP_TRACE_UNUSED(parallel_data);
+  OPENMP_TRACE_UNUSED(encountering_task_data);
+  OPENMP_TRACE_UNUSED(flags);
+  OPENMP_TRACE_UNUSED(codeptr_ra);
+  --openmp_trace_nparallel;
+}
+
+static void openmp_trace_master(ompt_scope_endpoint_t endpoint,
+                                ompt_data_t *parallel_data,
+                                ompt_data_t *task_data,
+                                const void *codeptr_ra) {
+  OPENMP_TRACE_UNUSED(parallel_data);
+  OPENMP_TRACE_UNUSED(task_data);
+  OPENMP_TRACE_UNUSED(codeptr_ra);
+  switch (endpoint) {
+  case ompt_scope_begin:
+    ++openmp_trace_nmaster;
+    break;
+  case ompt_scope_end:
+    --openmp_trace_nmaster;
+    break;
+  default:; /* ompt_scope_beginend */
+  }
+}
+
+/* initially, events of interest are registered */
+static int openmp_trace_initialize(ompt_function_lookup_t lookup,
+                                   int initial_device_num,
+                                   ompt_data_t *tool_data) {
+  const ompt_set_callback_t set_callback =
+      (ompt_set_callback_t)lookup("ompt_set_callback");
+  OPENMP_TRACE_UNUSED(initial_device_num);
+  OPENMP_TRACE_UNUSED(tool_data);
+  OPENMP_TRACE_SET_CALLBACK(openmp_trace, parallel_begin);
+  OPENMP_TRACE_SET_CALLBACK(openmp_trace, parallel_end);
+  OPENMP_TRACE_SET_CALLBACK(openmp_trace, master);
+  return 0 == openmp_trace_issues();
+}
+
+/* here tool_data might be freed and analysis concludes */
+static void openmp_trace_finalize(ompt_data_t *tool_data) {
+  OPENMP_TRACE_UNUSED(tool_data);
+}
+
+/* entry point which is automatically called by the OpenMP runtime */
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t openmp_start_tool = {
+      openmp_trace_initialize, openmp_trace_finalize, {0}};
+  const char *const enabled_env = getenv("CP2K_OMP_TRACE");
+  const int enabled = (NULL == enabled_env ? 0 : atoi(enabled_env));
+  ompt_start_tool_result_t *result = NULL;
+  OPENMP_TRACE_UNUSED(omp_version);
+  OPENMP_TRACE_UNUSED(runtime_version);
+  if (0 == enabled) { /* not enabled */
+    openmp_trace_nissues = OPENMP_TRACE_DISABLED;
+    assert(NULL == result);
+  } else { /* trace OpenMP constructs */
+    assert(0 == openmp_trace_nissues);
+    result = &openmp_start_tool;
+  }
+  return result;
+}
+
+#else
+
+int openmp_trace_issues(void) { return OPENMP_TRACE_DISABLED; }
+
+#endif

--- a/src/environment.F
+++ b/src/environment.F
@@ -85,7 +85,7 @@ MODULE environment
    USE local_gemm_api,                  ONLY: local_gemm_set_library
    USE machine,                         ONLY: &
         flush_should_flush, m_cpuid, m_cpuid_name, m_cpuid_static, m_cpuinfo, m_energy, &
-        m_get_omp_stacksize, m_memory_details, m_procrun
+        m_memory_details, m_omp_get_stacksize, m_omp_trace_issues, m_procrun
    USE message_passing,                 ONLY: mp_collect_timings,&
                                               mp_para_env_type
    USE mp_perf_env,                     ONLY: add_mp_perf_env,&
@@ -895,10 +895,16 @@ CONTAINS
             num_threads, &
             start_section_label//"| This output is from process", para_env%mepos
 
-         CALL m_get_omp_stacksize(omp_stacksize)
+         CALL m_omp_get_stacksize(omp_stacksize)
          WRITE (UNIT=output_unit, FMT="(T2,A,T68,A13)") &
-            start_section_label//"| Stack size for threads created by OpenMP (OMP_STACKSIZE)", &
+            start_section_label//"| OpenMP stack size per thread (OMP_STACKSIZE)", &
             ADJUSTR(omp_stacksize)
+
+         IF (0 <= m_omp_trace_issues()) THEN ! only show in header if enabled
+            WRITE (UNIT=output_unit, FMT="(T2,A,T68,A13)") &
+               start_section_label//"| OpenMP issue trace (CP2K_OMP_TRACE)", &
+               "enabled"
+         END IF
 
          CALL m_cpuinfo(model_name)
          WRITE (UNIT=output_unit, FMT="(T2,A,T30,A51)") &
@@ -1318,8 +1324,11 @@ CONTAINS
             CALL close_file(unit_number=unit_exit, file_status="DELETE")
          END IF
 
-         ! Print warning counter
+         ! Print OpenMP issue counter and number of warnings for this workload
          IF (iw > 0) THEN
+            IF (0 <= m_omp_trace_issues()) THEN
+               WRITE (iw, "(T2,A,I0)") "The number of traced issues for OpenMP : ", m_omp_trace_issues()
+            END IF
             WRITE (iw, "(T2,A,I0)") "The number of warnings for this run is : ", warning_counter
             WRITE (iw, *) ""
             WRITE (UNIT=iw, FMT="(T2,A)") REPEAT("-", 79)


### PR DESCRIPTION
- Intel OpenMP implemented an OpenMP 5.0 facility called OMPT for tracing OpenMP constructs.
- Intel OpenMP (libiomp5) is open source (libomp), and LLVM compilers provide necessary bits.
- Effectively, Intel Compiler (icx/icc) works out-of-the box (note: ifx/ifort is no prerequisite).
- GNU compiler shall be possible when linking libomp instead of libgomp. Further, currently
  defined(_OPENMP) && defined(__clang__) can be relaxed or smarter/runtime check).
- Currently only one issue is tracked: if a parallel region is opened inside of a master section.
- The OMPT facility has no runtime impact if not enabled, otherwise the impact shall be low.
- The code can be a starting point to enforce more sophisticated conventions.