### PR TITLE
Adjusted tolerance

### DIFF
--- a/tests/QS/regtest-hfx-ri/TEST_FILES
+++ b/tests/QS/regtest-hfx-ri/TEST_FILES
@@ -1,4 +1,4 @@
-H2O-hfx-coulomb.inp                                          1    5.0E-10             -75.96344485612131
+H2O-hfx-coulomb.inp                                          1    6.0E-10             -75.96344483562591
 H2O-hfx-identity.inp                                         1    2.0E-10             -76.00818468795198
 H2O-hfx-periodic-ri-truncated.inp                            1    1.0E-11             -66.82684206238447
 H2O-hybrid-b3lyp.inp                                         1    1.0E-12             -76.15902937273455


### PR DESCRIPTION
- Accounts for e7c81ba and 4939a67 (Dashboard/ssmp/gcc8).