### PR TITLE
Update Spack commit in CI to enable dbcsr@2.8.0

### DIFF
--- a/tools/docker/Dockerfile.test_cmake
+++ b/tools/docker/Dockerfile.test_cmake
@@ -42,9 +42,10 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
 
 # Install a recent developer version of Spack.
 WORKDIR /opt/spack
+ARG SPACK_VERSION=501ee68606405ea2ac26d369a5139d75be88dac8
 RUN git init --quiet && \
     git remote add origin https://github.com/spack/spack.git && \
-    git fetch --quiet --depth 1 origin v0.23.0 --no-tags && \
+    git fetch --quiet --depth 1 origin ${SPACK_VERSION} --no-tags && \
     git checkout --quiet FETCH_HEAD
 ENV PATH="/opt/spack/bin:${PATH}"
 

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -840,9 +840,10 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
 
 # Install a recent developer version of Spack.
 WORKDIR /opt/spack
+ARG SPACK_VERSION=501ee68606405ea2ac26d369a5139d75be88dac8
 RUN git init --quiet && \
     git remote add origin https://github.com/spack/spack.git && \
-    git fetch --quiet --depth 1 origin v0.23.0 --no-tags && \
+    git fetch --quiet --depth 1 origin ${{SPACK_VERSION}} --no-tags && \
     git checkout --quiet FETCH_HEAD
 ENV PATH="/opt/spack/bin:${{PATH}}"
 


### PR DESCRIPTION
Close #3805. Tested locally. The CMake CI action needs to be manually triggered.