### PR TITLE
build: patch to support libxc 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,7 +613,7 @@ if(CP2K_USE_ELPA)
 endif()
 
 if(CP2K_USE_LIBXC)
-  find_package(LibXC 6 REQUIRED EXACT)
+  find_package(LibXC 7 REQUIRED)
 endif()
 
 # uncomment this when libgrpp cmake support is complete

--- a/cmake/cp2kConfig.cmake.in
+++ b/cmake/cp2kConfig.cmake.in
@@ -60,7 +60,7 @@ if(NOT TARGET cp2k::cp2k)
   endif()
 
   if(@CP2K_USE_LIBXC@)
-    find_dependency(LibXC 6 REQUIRED EXACT)
+    find_dependency(LibXC 7 REQUIRED)
   endif()
 
   if(@CP2K_USE_COSMA@)

--- a/cmake/modules/FindLibXC.cmake
+++ b/cmake/modules/FindLibXC.cmake
@@ -13,11 +13,7 @@ cp2k_set_default_paths(LIBXC "LibXC")
 
 if(PKG_CONFIG_FOUND)
   # For LibXC >= 7, the Fortran interface is only libxcf03
-  pkg_check_modules(CP2K_LIBXC
-    IMPORTED_TARGET GLOBAL
-    libxcf03
-    libxc>=7
-  )
+  pkg_check_modules(CP2K_LIBXC IMPORTED_TARGET GLOBAL libxcf03 libxc>=7)
 endif()
 
 if(NOT CP2K_LIBXC_FOUND)
@@ -32,8 +28,7 @@ endif()
 if(CP2K_LIBXC_FOUND)
   # Require both libxc + libxcf03 for LibXC 7
   set(CP2K_LIBXC_LINK_LIBRARIES
-    "${CP2K_LIBXCF03_LIBRARIES};${CP2K_LIBXC_LIBRARIES}"
-  )
+      "${CP2K_LIBXCF03_LIBRARIES};${CP2K_LIBXC_LIBRARIES}")
 endif()
 
 if(NOT CP2K_LIBXC_INCLUDE_DIRS)

--- a/cmake/modules/FindLibXC.cmake
+++ b/cmake/modules/FindLibXC.cmake
@@ -12,8 +12,12 @@ include(cp2k_utils)
 cp2k_set_default_paths(LIBXC "LibXC")
 
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(CP2K_LIBXC IMPORTED_TARGET GLOBAL libxcf03
-                    libxc>=${LibXC_FIND_VERSION})
+  # For LibXC >= 7, the Fortran interface is only libxcf03
+  pkg_check_modules(CP2K_LIBXC
+    IMPORTED_TARGET GLOBAL
+    libxcf03
+    libxc>=7
+  )
 endif()
 
 if(NOT CP2K_LIBXC_FOUND)
@@ -25,9 +29,11 @@ if(NOT CP2K_LIBXC_FOUND)
   endforeach()
 endif()
 
-if(CP2K_LIBXC_FOUND AND CP2K_LIBXCF03_FOUND)
+if(CP2K_LIBXC_FOUND)
+  # Require both libxc + libxcf03 for LibXC 7
   set(CP2K_LIBXC_LINK_LIBRARIES
-      "${CP2K_LIBXCF03_LIBRARIES};${CP2K_LIBXC_LIBRARIES}")
+    "${CP2K_LIBXCF03_LIBRARIES};${CP2K_LIBXC_LIBRARIES}"
+  )
 endif()
 
 if(NOT CP2K_LIBXC_INCLUDE_DIRS)


### PR DESCRIPTION
libxc 7 only has `libxcf03`, so removing all refs for `libxcf90` (was thinking to also support libxc 6, but keep running into some linkage issue)

fixes #3724

relates to https://github.com/Homebrew/homebrew-core/pull/202462