### PR TITLE
dbm: params to literals, miniapp command line, minor changes

### DIFF
--- a/src/dbm/Makefile
+++ b/src/dbm/Makefile
@@ -1,7 +1,9 @@
 PROJHOME := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 CP2KHOME := $(abspath $(PROJHOME)/../..)
+OMP_TRACE := $(wildcard $(PROJHOME)/../base/openmp_trace.c)
 ALL_HEADERS := $(shell find . -name "*.h") $(shell find ../offload/ -name "*.h")
-ALL_OBJECTS := ../offload/offload_library.o \
+ALL_OBJECTS :=  $(OMP_TRACE:.c=.o) \
+        ../offload/offload_library.o \
         dbm_distribution.o \
         dbm_library.o \
         dbm_matrix.o \
@@ -22,7 +24,22 @@ endif
 # Optimization flag derived from OPT flag
 OPTFLAG ?= -O$(patsubst O%,%,$(OPT))
 
-CFLAGS := -fopenmp -g $(OPTFLAG) -march=native -Wall -Wextra -Wcast-qual
+CFLAGS := -g $(OPTFLAG) -march=native -Wall -Wextra -Wcast-qual
+
+# Intel Compiler
+ICX := $(shell which icx 2>/dev/null)
+INTEL ?= $(if $(ICX),1,0)
+
+ifeq ($(INTEL),0)
+MKL_FCRTL := gf
+LIBS += $(if $(OMPRT),-l$(OMPRT),-fopenmp)
+CFLAGS += -fopenmp
+else
+MKL_FCRTL := intel
+LIBS += $(if $(OMPRT),-l$(OMPRT),-qopenmp)
+CFLAGS += -qopenmp
+CC := icx
+endif
 
 # Some additional flags when relying on default-CC
 ifeq ($(CC),)
@@ -48,18 +65,20 @@ endif
 ifneq ($(OPENCL),0)
 OPENCL_OFFLOAD := $(firstword $(wildcard $(CP2KHOME)/lib/*/*/exts/dbcsr/libdbcsr.a))
 OPENCL_GENKRNL := $(PROJHOME)/dbm_multiply_opencl.cl.h
+ifneq ($(ICX),)
+LIBS += -lifcoremt -limf
+endif
 endif
 
 # Make foundational runtimes available
-LIBS += -fopenmp -ldl -lstdc++ -lc -lm
+LIBS += -ldl -lstdc++ -lc -lm
 
 
 # Make BLAS/LAPACK available
 ifneq ($(MKLROOT),)
-LIBS += \
-        -L$(MKLROOT)/lib/intel64 \
+LIBS += -L$(MKLROOT)/lib/intel64 \
         -Wl,--start-group \
-        -lmkl_gf_lp64 \
+        -lmkl_$(MKL_FCRTL)_lp64 \
         -lmkl_core \
         -lmkl_sequential \
         -Wl,--end-group
@@ -92,7 +111,7 @@ LIBS += $(OPENCL_OFFLOAD) -lgfortran
 ifneq (Darwin,$(shell uname))
 OPENCL_LIB := $(shell ldconfig -p 2>/dev/null | grep -m1 OpenCL | rev | cut -d' ' -f1 | rev)
 ifeq (,$(OPENCL_LIB))
-OPENCL_LIB := $(wildcard /usr/lib/x86_64-linux-gnu/libOpenCL.so.1)
+OPENCL_LIB := /usr/lib/x86_64-linux-gnu/libOpenCL.so.1
 endif
 ifneq (,$(CUDA_PATH))
 ifeq (,$(wildcard $(OPENCL_INC)))
@@ -106,12 +125,16 @@ else ifneq (,$(wildcard $(OPENCL_ROOT)/include/CL/cl.h))
 ifeq (,$(wildcard $(OPENCL_INC)))
 CFLAGS += -I$(OPENCL_ROOT)/include
 endif
-LIBS += -L$(OPENCL_ROOT)/lib64
-else ifneq (,$(wildcard $(OCL_ROOT)/include/CL/cl.h))
+LIBS += -L$(OPENCL_ROOT)/$(if $(wildcard $(OPENCL_ROOT)/lib64),lib64,lib)
+else ifneq (,$(ICX))
+OPENCL_ROOT := $(abspath $(dir $(ICX))/..)
+ifneq (,$(wildcard $(OPENCL_ROOT)/include/sycl/CL/cl.h))
+LIBS += -L$(OPENCL_ROOT)/$(if $(wildcard $(OPENCL_ROOT)/lib64),lib64,lib)
+LIBS += -L$(OPENCL_ROOT)/compiler/lib/intel64 -lintlc
 ifeq (,$(wildcard $(OPENCL_INC)))
-CFLAGS += -I$(OCL_ROOT)/include
+CFLAGS += -I$(OPENCL_ROOT)/include/sycl
 endif
-LIBS += -L$(OCL_ROOT)/lib64
+endif
 endif
 # OPENCL_INC: directory containing CL/cl.h.
 ifneq (,$(wildcard $(OPENCL_INC)))
@@ -166,7 +189,7 @@ endif
 
 # Build with MPI when mpicc compiler is present.
 ifneq ($(MPICC),)
-%.o: %.c $(ALL_HEADERS)
+%.o: %.c $(OMP_TRACE) $(ALL_HEADERS)
 	cd $(dir $<); $(MPICC) -c -std=c11 $(CFLAGS) -D__parallel $(notdir $<)
 
 dbm_miniapp.x: dbm_miniapp.o $(ALL_OBJECTS)
@@ -175,7 +198,7 @@ dbm_miniapp.x: dbm_miniapp.o $(ALL_OBJECTS)
 
 # Build without MPI otherwise.
 else
-%.o: %.c $(ALL_HEADERS)
+%.o: %.c $(OMP_TRACE) $(ALL_HEADERS)
 	cd $(dir $<); $(CC) -c -std=c11 $(CFLAGS) $(notdir $<)
 
 dbm_miniapp.x: dbm_miniapp.o $(ALL_OBJECTS)

--- a/src/dbm/dbm_hyperparams.h
+++ b/src/dbm/dbm_hyperparams.h
@@ -10,13 +10,13 @@
 
 // TODO: Tune parameters, check if dynamic OpenMP scheduling is really faster?
 
-static const float HASHTABLE_FACTOR = 3.0;
-static const float ALLOCATION_FACTOR = 1.5;
-static const float SHARDS_PER_THREAD = 1.0;
-static const int MAX_BATCH_SIZE = 10000;
-static const int BATCH_NUM_BUCKETS = 1000;
-static const int INITIAL_NBLOCKS_ALLOCATED = 100;
-static const int INITIAL_DATA_ALLOCATED = 1024;
+#define HASHTABLE_FACTOR 3.0
+#define ALLOCATION_FACTOR 1.5
+#define SHARDS_PER_THREAD 1.0
+#define MAX_BATCH_SIZE 10000
+#define BATCH_NUM_BUCKETS 1000
+#define INITIAL_NBLOCKS_ALLOCATED 100
+#define INITIAL_DATA_ALLOCATED 1024
 
 #endif
 

--- a/src/dbm/dbm_miniapp.c
+++ b/src/dbm/dbm_miniapp.c
@@ -274,11 +274,12 @@ int main(int argc, char *argv[]) {
         continue;
       }
       if (0 < mnk[0]) { /* valid MxNxK? */
-        const int extra = (NULL == arg ? 0 : atoi(arg));
-        int nm, nn, nk;
-        if (0 < extra) {
-          nn = nk = 1;
-          nm = extra;
+        int nm = (NULL == arg ? 0 : atoi(arg)), nn, nk;
+        if (0 < nm) {
+          arg = strtok(NULL, delims);
+          nn = (NULL == arg ? 1 : atoi(arg));
+          arg = strtok(NULL, delims);
+          nk = (NULL == arg ? 1 : atoi(arg));
         } else { /* default */
           nm = nn = nk = 128;
         }
@@ -288,7 +289,7 @@ int main(int argc, char *argv[]) {
       } else {
         fprintf(stderr, "ERROR: invalid argument(s)\n");
         result = EXIT_FAILURE;
-        i = argc;
+        i = argc; /* break */
       }
     }
     if (NULL != file) {

--- a/src/dbm/dbm_multiply_cpu.c
+++ b/src/dbm/dbm_multiply_cpu.c
@@ -54,12 +54,14 @@ static inline void dbm_dgemm(const char transa, const char transb, const int m,
  *        http://szudzik.com/ElegantPairing.pdf
  * \author Ole Schuett
  ******************************************************************************/
+#if defined(__LIBXSMM)
 static inline unsigned int hash(const dbm_task_t task) {
   const unsigned int m = task.m, n = task.n, k = task.k;
   const unsigned int mn = (m >= n) ? m * m + m + n : m + n * n;
   const unsigned int mnk = (mn >= k) ? mn * mn + mn + k : mn + k * k;
   return mnk;
 }
+#endif
 
 /*******************************************************************************
  * \brief Internal routine for executing the tasks in given batch on the CPU.


### PR DESCRIPTION
- Changed hyperparams into literal constants (let compiler hard-code).
- Let miniapp parse, e.g., dbm_miniapp.x 4x4x4 128x4096x128.
- Avoid warning about unused function (hash).
- Improved Makefile.