### PR TITLE
more explicit upper triangular form

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -113,7 +113,7 @@ Accelerate and reference BLAS/LAPACK.
 
 When building on/for Windows using the Minimalist GNU for Windows (MinGW) environment, you must set
 `-D__MINGW`, `-D__NO_STATM_ACCESS` and `-D__NO_SOCKETS` to avoid undefined references during
-linking, respectively errors while printing the statistics.
+linking, and to respectively avoid errors while printing the statistics.
 
 ### 2e. MPI and ScaLAPACK (optional, required for MPI parallel builds)
 

--- a/src/admm_methods.F
+++ b/src/admm_methods.F
@@ -22,11 +22,10 @@ MODULE admm_methods
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_scale,&
                                               cp_cfm_scale_and_add,&
                                               cp_cfm_scale_and_add_fm,&
-                                              cp_cfm_transpose
+                                              cp_cfm_uplo_to_full
    USE cp_cfm_cholesky,                 ONLY: cp_cfm_cholesky_decompose,&
                                               cp_cfm_cholesky_invert
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
-                                              cp_cfm_get_info,&
                                               cp_cfm_release,&
                                               cp_cfm_to_fm,&
                                               cp_cfm_type,&
@@ -49,7 +48,7 @@ MODULE admm_methods
                                               cp_fm_scale,&
                                               cp_fm_scale_and_add,&
                                               cp_fm_schur_product,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_invert,&
                                               cp_fm_cholesky_reduce,&
@@ -946,7 +945,7 @@ CONTAINS
          CALL dbcsr_deallocate_matrix(matrix_s_tilde)
       END IF
 
-      CALL cp_fm_upper_to_full(admm_env%S_inv, admm_env%work_aux_aux)
+      CALL cp_fm_uplo_to_full(admm_env%S_inv, admm_env%work_aux_aux)
       CALL cp_fm_to_fm(admm_env%S_inv, admm_env%S)
 
       CALL copy_dbcsr_to_fm(matrix_s_mixed(1)%matrix, admm_env%Q)
@@ -955,7 +954,7 @@ CONTAINS
       CALL cp_fm_cholesky_decompose(admm_env%S_inv)
       CALL cp_fm_cholesky_invert(admm_env%S_inv)
       !! Symmetrize the guy
-      CALL cp_fm_upper_to_full(admm_env%S_inv, admm_env%work_aux_aux)
+      CALL cp_fm_uplo_to_full(admm_env%S_inv, admm_env%work_aux_aux)
 
       !! Calculate A=S'^(-1)*Q
       IF (admm_env%block_fit) THEN
@@ -1022,7 +1021,7 @@ CONTAINS
          CALL cp_fm_cholesky_decompose(admm_env%work_nmo_nmo1(ispin))
          CALL cp_fm_cholesky_invert(admm_env%work_nmo_nmo1(ispin))
          !! Symmetrize the guy
-         CALL cp_fm_upper_to_full(admm_env%work_nmo_nmo1(ispin), admm_env%lambda_inv(ispin))
+         CALL cp_fm_uplo_to_full(admm_env%work_nmo_nmo1(ispin), admm_env%lambda_inv(ispin))
          CALL cp_fm_to_fm(admm_env%work_nmo_nmo1(ispin), admm_env%lambda_inv(ispin))
 
          !! ** C_hat = AC
@@ -1217,10 +1216,10 @@ CONTAINS
          pole = Heaviside(admm_env%eigvals_P_to_be_purified(ispin)%eigvals%data(i) - 0.5_dp)
          CALL cp_fm_set_element(admm_env%M_purify(ispin), i, i, pole)
       END DO
-      CALL cp_fm_upper_to_full(admm_env%M_purify(ispin), admm_env%work_aux_aux)
+      CALL cp_fm_uplo_to_full(admm_env%M_purify(ispin), admm_env%work_aux_aux)
 
       CALL copy_dbcsr_to_fm(density_matrix, admm_env%work_aux_aux3)
-      CALL cp_fm_upper_to_full(admm_env%work_aux_aux3, admm_env%work_aux_aux)
+      CALL cp_fm_uplo_to_full(admm_env%work_aux_aux3, admm_env%work_aux_aux)
 
       ! ** S^(-1)*R
       CALL parallel_gemm('N', 'N', nao_aux_fit, nao_aux_fit, nao_aux_fit, &
@@ -1334,10 +1333,10 @@ CONTAINS
                END IF
             END DO
          END DO
-         CALL cp_fm_upper_to_full(admm_env%M_purify(ispin), admm_env%work_aux_aux)
+         CALL cp_fm_uplo_to_full(admm_env%M_purify(ispin), admm_env%work_aux_aux)
 
          CALL copy_dbcsr_to_fm(matrix_ks_aux_fit(ispin)%matrix, admm_env%K(ispin))
-         CALL cp_fm_upper_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
+         CALL cp_fm_uplo_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
 
          !! S^(-1)*R
          CALL parallel_gemm('N', 'N', nao_aux_fit, nao_aux_fit, nao_aux_fit, &
@@ -1443,7 +1442,7 @@ CONTAINS
          CALL cp_fm_cholesky_decompose(admm_env%work_nmo_nmo1(ispin))
          CALL cp_fm_cholesky_invert(admm_env%work_nmo_nmo1(ispin))
          !! Symmetrize the guy
-         CALL cp_fm_upper_to_full(admm_env%work_nmo_nmo1(ispin), admm_env%lambda_inv2(ispin))
+         CALL cp_fm_uplo_to_full(admm_env%work_nmo_nmo1(ispin), admm_env%lambda_inv2(ispin))
          !! Take square
          CALL parallel_gemm('N', 'T', nmo, nmo, nmo, &
                             1.0_dp, admm_env%work_nmo_nmo1(ispin), admm_env%work_nmo_nmo1(ispin), 0.0_dp, &
@@ -1479,7 +1478,7 @@ CONTAINS
                             admm_env%work_aux_aux2)
 
          CALL copy_dbcsr_to_fm(matrix_ks_aux_fit(ispin)%matrix, admm_env%K(ispin))
-         CALL cp_fm_upper_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
+         CALL cp_fm_uplo_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
 
          !! ** S*C_hat*Lambda^{-2}*C_hat^T*H_tilde
          CALL parallel_gemm('N', 'N', nao_aux_fit, nao_aux_fit, nao_aux_fit, &
@@ -1580,7 +1579,7 @@ CONTAINS
       nmo = admm_env%nmo(ispin)
 
       CALL copy_dbcsr_to_fm(matrix_ks_aux_fit(ispin)%matrix, admm_env%K(ispin))
-      CALL cp_fm_upper_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
+      CALL cp_fm_uplo_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
 
       CALL parallel_gemm('N', 'N', nao_aux_fit, nmo, nao_aux_fit, &
                          1.0_dp, admm_env%K(ispin), mo_coeff_aux_fit, 0.0_dp, &
@@ -1626,7 +1625,7 @@ CONTAINS
             END IF
          END DO
       END DO
-      CALL cp_fm_upper_to_full(admm_env%M(ispin), admm_env%work_nmo_nmo1(ispin))
+      CALL cp_fm_uplo_to_full(admm_env%M(ispin), admm_env%work_nmo_nmo1(ispin))
 
       ! *** 2nd term to be added to fm_H
 
@@ -1777,7 +1776,7 @@ CONTAINS
                CALL copy_dbcsr_to_fm(matrix_ks_aux_fit(ispin)%matrix, admm_env%K(ispin))
             END IF
 
-            CALL cp_fm_upper_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
+            CALL cp_fm_uplo_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
 
             !! K*A
             CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, &
@@ -1860,7 +1859,7 @@ CONTAINS
 
                !! T^T*s_aux*T in (27) Merlot (T=A), as calculating A^T*K*A few lines above
                CALL copy_dbcsr_to_fm(matrix_s_aux_fit(1)%matrix, admm_env%work_aux_aux4)
-               CALL cp_fm_upper_to_full(admm_env%work_aux_aux4, admm_env%work_aux_aux5)
+               CALL cp_fm_uplo_to_full(admm_env%work_aux_aux4, admm_env%work_aux_aux5)
 
                ! s_aux*T
                CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, &
@@ -2614,7 +2613,7 @@ CONTAINS
       ELSE
          CALL copy_dbcsr_to_fm(matrix_ks_aux_fit(ispin)%matrix, admm_env%K(ispin))
       END IF
-      CALL cp_fm_upper_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
+      CALL cp_fm_uplo_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
 
       CALL parallel_gemm('N', 'N', nao_aux_fit, nmo, nao_aux_fit, &
                          1.0_dp, admm_env%K(ispin), mo_coeff_aux_fit, 0.0_dp, &
@@ -2660,7 +2659,7 @@ CONTAINS
       nmo = admm_env%nmo(ispin)
 
       CALL copy_dbcsr_to_fm(matrix_ks_aux_fit(ispin)%matrix, admm_env%K(ispin))
-      CALL cp_fm_upper_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
+      CALL cp_fm_uplo_to_full(admm_env%K(ispin), admm_env%work_aux_aux)
 
       CALL get_mo_set(mo_set=mo_set, occupation_numbers=occupation_numbers)
       ALLOCATE (scaling_factor(SIZE(occupation_numbers)))
@@ -3020,7 +3019,7 @@ CONTAINS
                CALL cp_fm_cholesky_decompose(S_inv)
                CALL cp_fm_cholesky_invert(S_inv)
                !! Symmetrize the guy
-               CALL cp_fm_upper_to_full(S_inv, work_aux_aux3)
+               CALL cp_fm_uplo_to_full(S_inv, work_aux_aux3)
 
                !We need to calculate S^-1*K*A*P and S^-1*K*A*P*A^T
                CALL parallel_gemm('N', 'N', nao_aux_fit, nao_aux_fit, nao_aux_fit, 1.0_dp, S_inv, &
@@ -3056,7 +3055,7 @@ CONTAINS
                CALL cp_fm_to_cfm(kp%smat(1, 1), kp%smat(2, 1), cS_inv)
                CALL cp_cfm_cholesky_decompose(cS_inv)
                CALL cp_cfm_cholesky_invert(cS_inv)
-               CALL own_cfm_upper_to_full(cS_inv, cwork_aux_aux)
+               CALL cp_cfm_uplo_to_full(cS_inv, cwork_aux_aux)
 
                !Take the ORB density matrix from the kp_env
                CALL cp_fm_to_cfm(kpoints%kp_env(ikp)%kpoint_env%pmat(1, ispin), &
@@ -3764,7 +3763,7 @@ CONTAINS
       CALL dbcsr_iterator_stop(iter)
 
       CALL copy_dbcsr_to_fm(density_matrix_aux, admm_env%P_to_be_purified(ispin))
-      CALL cp_fm_upper_to_full(admm_env%P_to_be_purified(ispin), admm_env%work_orb_orb2)
+      CALL cp_fm_uplo_to_full(admm_env%P_to_be_purified(ispin), admm_env%work_orb_orb2)
 
       IF (nspins == 1) THEN
          CALL cp_fm_scale(0.5_dp, admm_env%P_to_be_purified(ispin))
@@ -4060,7 +4059,7 @@ CONTAINS
             !Invert S_aux
             CALL cp_fm_cholesky_decompose(rmat_aux_fit)
             CALL cp_fm_cholesky_invert(rmat_aux_fit)
-            CALL cp_fm_upper_to_full(rmat_aux_fit, work_aux_fit)
+            CALL cp_fm_uplo_to_full(rmat_aux_fit, work_aux_fit)
 
             !A = S^-1 * Q
             CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, 1.0_dp, &
@@ -4071,7 +4070,7 @@ CONTAINS
             CALL cp_fm_to_cfm(rmat_aux_fit, imat_aux_fit, cmat_aux_fit)
             CALL cp_cfm_cholesky_decompose(cmat_aux_fit)
             CALL cp_cfm_cholesky_invert(cmat_aux_fit)
-            CALL own_cfm_upper_to_full(cmat_aux_fit, cwork_aux_fit)
+            CALL cp_cfm_uplo_to_full(cmat_aux_fit, cwork_aux_fit)
 
             !A = S^-1 * Q
             CALL cp_fm_to_cfm(rmat_aux_fit_vs_orb, imat_aux_fit_vs_orb, cmat_aux_fit_vs_orb)
@@ -4125,52 +4124,5 @@ CONTAINS
       CALL dbcsr_release(dbcsr_aux_fit_vs_orb(2))
 
    END SUBROUTINE kpoint_calc_admm_matrices
-
-! **************************************************************************************************
-!> \brief ...
-!> \param cfm_mat_Q ...
-!> \param cfm_mat_work ...
-! **************************************************************************************************
-   SUBROUTINE own_cfm_upper_to_full(cfm_mat_Q, cfm_mat_work)
-
-      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mat_Q, cfm_mat_work
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'own_cfm_upper_to_full'
-
-      INTEGER                                            :: handle, i_global, iiB, j_global, jjB, &
-                                                            ncol_local, nrow_local
-      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
-
-      CALL timeset(routineN, handle)
-
-      !TODO: routine cpoied from rpa_gw_kpoints_util.F => put it somewhere centralized?
-
-      ! get info of fm_mat_Q
-      CALL cp_cfm_get_info(matrix=cfm_mat_Q, &
-                           nrow_local=nrow_local, &
-                           ncol_local=ncol_local, &
-                           row_indices=row_indices, &
-                           col_indices=col_indices)
-
-      DO jjB = 1, ncol_local
-         j_global = col_indices(jjB)
-         DO iiB = 1, nrow_local
-            i_global = row_indices(iiB)
-            IF (j_global < i_global) THEN
-               cfm_mat_Q%local_data(iiB, jjB) = z_zero
-            END IF
-            IF (j_global == i_global) THEN
-               cfm_mat_Q%local_data(iiB, jjB) = cfm_mat_Q%local_data(iiB, jjB)/(2.0_dp, 0.0_dp)
-            END IF
-         END DO
-      END DO
-
-      CALL cp_cfm_transpose(cfm_mat_Q, 'C', cfm_mat_work)
-
-      CALL cp_cfm_scale_and_add(z_one, cfm_mat_Q, z_one, cfm_mat_work)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE
 
 END MODULE admm_methods

--- a/src/almo_scf_diis_types.F
+++ b/src/almo_scf_diis_types.F
@@ -388,18 +388,16 @@ CONTAINS
             ! Query the optimal workspace for dsyev
             LWORK = -1
             ALLOCATE (WORK(MAX(1, LWORK)))
-            CALL DSYEV('V', 'L', diis_env%buffer_length + 1, m_b_copy, &
+            CALL dsyev('V', 'L', diis_env%buffer_length + 1, m_b_copy, &
                        diis_env%buffer_length + 1, eigenvalues, WORK, LWORK, INFO)
             LWORK = INT(WORK(1))
             DEALLOCATE (WORK)
 
             ! Allocate the workspace and solve the eigenproblem
             ALLOCATE (WORK(MAX(1, LWORK)))
-            CALL DSYEV('V', 'L', diis_env%buffer_length + 1, m_b_copy, &
+            CALL dsyev('V', 'L', diis_env%buffer_length + 1, m_b_copy, &
                        diis_env%buffer_length + 1, eigenvalues, WORK, LWORK, INFO)
-            IF (INFO .NE. 0) THEN
-               CPABORT("DSYEV failed")
-            END IF
+            IF (INFO .NE. 0) CPABORT("DSYEV failed")
             DEALLOCATE (WORK)
 
             ! use the eigensystem to invert (implicitly) B matrix

--- a/src/almo_scf_methods.F
+++ b/src/almo_scf_methods.F
@@ -53,7 +53,8 @@ MODULE almo_scf_methods
                                               invert_Taylor,&
                                               matrix_sqrt_Newton_Schulz
    USE kinds,                           ONLY: dp
-   USE mathlib,                         ONLY: binomial
+   USE mathlib,                         ONLY: binomial,&
+                                              invmat_symm
    USE message_passing,                 ONLY: mp_comm_type,&
                                               mp_para_env_type
    USE util,                            ONLY: sort
@@ -837,16 +838,14 @@ CONTAINS
                ! Query the optimal workspace for dsyev
                LWORK = -1
                ALLOCATE (WORK(MAX(1, LWORK)))
-               CALL DSYEV('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
+               CALL dsyev('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
                LWORK = INT(WORK(1))
                DEALLOCATE (WORK)
 
                ! Allocate the workspace and solve the eigenproblem
                ALLOCATE (WORK(MAX(1, LWORK)))
-               CALL DSYEV('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
-               IF (INFO .NE. 0) THEN
-                  CPABORT("DSYEV failed")
-               END IF
+               CALL dsyev('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
+               IF (INFO .NE. 0) CPABORT("DSYEV failed")
 
                ! Copy occupied eigenvectors
                IF (almo_scf_env%domain_t(idomain, ispin)%ncols .NE. &
@@ -988,16 +987,14 @@ CONTAINS
                ! Query the optimal workspace for dsyev
                LWORK = -1
                ALLOCATE (WORK(MAX(1, LWORK)))
-               CALL DSYEV('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
+               CALL dsyev('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
                LWORK = INT(WORK(1))
                DEALLOCATE (WORK)
 
                ! Allocate the workspace and solve the eigenproblem
                ALLOCATE (WORK(MAX(1, LWORK)))
-               CALL DSYEV('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
-               IF (INFO .NE. 0) THEN
-                  CPABORT("DSYEV failed")
-               END IF
+               CALL dsyev('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
+               IF (INFO .NE. 0) CPABORT("DSYEV failed")
 
                !!! RZK-warning                                               !!!
                !!! IT IS EXTREMELY IMPORTANT THAT THE DIAGONAL BLOCKS OF THE !!!
@@ -1232,14 +1229,14 @@ CONTAINS
                ! Query the optimal workspace for dsyev
                LWORK = -1
                ALLOCATE (WORK(MAX(1, LWORK)))
-               CALL DSYEV('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, &
+               CALL dsyev('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, &
                           WORK, LWORK, INFO)
                LWORK = INT(WORK(1))
                DEALLOCATE (WORK)
 
                ! Allocate the workspace and solve the eigenproblem
                ALLOCATE (WORK(MAX(1, LWORK)))
-               CALL DSYEV('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
+               CALL dsyev('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
                IF (INFO .NE. 0) THEN
                   IF (unit_nr > 0) THEN
                      WRITE (unit_nr, *) 'BLOCK  = ', iblock_row
@@ -1755,7 +1752,7 @@ CONTAINS
             CALL cp_dbcsr_cholesky_invert(sigma_inv, &
                                           para_env=para_env, &
                                           blacs_env=blacs_env, &
-                                          upper_to_full=.TRUE.)
+                                          uplo_to_full=.TRUE.)
             CALL dbcsr_filter(sigma_inv, eps_filter)
          CASE DEFAULT
             CPABORT("Illegal MO overalp inversion algorithm")
@@ -2701,12 +2698,12 @@ CONTAINS
          unit_nr = -1
       END IF
 
-      !CALL DPOTRF('L', N, Ainv, N, INFO )
+      !CALL dpotrf('L', N, Ainv, N, INFO )
       !IF( INFO.NE.0 ) THEN
       !   CPErrorMessage(cp_failure_level,routineP,"DPOTRF failed")
       !   CPPrecondition(.FALSE.,cp_failure_level,routineP,failure)
       !END IF
-      !CALL DPOTRI('L', N, Ainv, N, INFO )
+      !CALL dpotri('L', N, Ainv, N, INFO )
       !IF( INFO.NE.0 ) THEN
       !   CPErrorMessage(cp_failure_level,routineP,"DPOTRI failed")
       !   CPPrecondition(.FALSE.,cp_failure_level,routineP,failure)
@@ -2724,12 +2721,12 @@ CONTAINS
       ! Query the optimal workspace for dsyev
       LWORK = -1
       ALLOCATE (WORK(MAX(1, LWORK)))
-      CALL DSYEV('V', 'L', N, Asqrtinv, N, eigenvalues, WORK, LWORK, INFO)
+      CALL dsyev('V', 'L', N, Asqrtinv, N, eigenvalues, WORK, LWORK, INFO)
       LWORK = INT(WORK(1))
       DEALLOCATE (WORK)
       ! Allocate the workspace and solve the eigenproblem
       ALLOCATE (WORK(MAX(1, LWORK)))
-      CALL DSYEV('V', 'L', N, Asqrtinv, N, eigenvalues, WORK, LWORK, INFO)
+      CALL dsyev('V', 'L', N, Asqrtinv, N, eigenvalues, WORK, LWORK, INFO)
       IF (INFO .NE. 0) THEN
          IF (unit_nr > 0) WRITE (unit_nr, *) 'DSYEV ERROR MESSAGE: ', INFO
          CPABORT("DSYEV failed")
@@ -2808,7 +2805,7 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pseudo_invert_matrix'
 
-      INTEGER                                            :: handle, ii, INFO, jj, LWORK, range1_eiv, &
+      INTEGER                                            :: handle, INFO, jj, LWORK, range1_eiv, &
                                                             range2_eiv, range3_eiv, unit_nr
       LOGICAL                                            :: use_both, use_ranges_only, use_thr_only
       REAL(KIND=dp)                                      :: my_shift
@@ -2868,23 +2865,7 @@ CONTAINS
 
       SELECT CASE (method)
       CASE (0) ! Inversion via cholesky factorization
-
-         CALL DPOTRF('L', N, Ainv, N, INFO)
-         IF (INFO .NE. 0) THEN
-            CPABORT("DPOTRF failed")
-         END IF
-         CALL DPOTRI('L', N, Ainv, N, INFO)
-         IF (INFO .NE. 0) THEN
-            CPABORT("DPOTRI failed")
-         END IF
-         ! complete the matrix
-         DO ii = 1, N
-            DO jj = ii + 1, N
-               Ainv(ii, jj) = Ainv(jj, ii)
-            END DO
-            !WRITE(*,'(100F13.9)') Ainv(ii,:)
-         END DO
-
+         CALL invmat_symm(Ainv)
       CASE (1)
 
          ! diagonalize first
@@ -2892,19 +2873,19 @@ CONTAINS
          ALLOCATE (temp1(N, N))
          ALLOCATE (temp4(N, N))
          IF (PRESENT(s_inv_half)) THEN
-            CALL DSYMM('L', 'U', N, N, 1.0_dp, s_inv_half, N, A, N, 0.0_dp, temp1, N)
-            CALL DSYMM('R', 'U', N, N, 1.0_dp, s_inv_half, N, temp1, N, 0.0_dp, Ainv, N)
+            CALL dsymm('L', 'U', N, N, 1.0_dp, s_inv_half, N, A, N, 0.0_dp, temp1, N)
+            CALL dsymm('R', 'U', N, N, 1.0_dp, s_inv_half, N, temp1, N, 0.0_dp, Ainv, N)
          END IF
          ! Query the optimal workspace for dsyev
          LWORK = -1
          ALLOCATE (WORK(MAX(1, LWORK)))
-         CALL DSYEV('V', 'L', N, Ainv, N, eigenvalues, WORK, LWORK, INFO)
+         CALL dsyev('V', 'L', N, Ainv, N, eigenvalues, WORK, LWORK, INFO)
 
          LWORK = INT(WORK(1))
          DEALLOCATE (WORK)
          ! Allocate the workspace and solve the eigenproblem
          ALLOCATE (WORK(MAX(1, LWORK)))
-         CALL DSYEV('V', 'L', N, Ainv, N, eigenvalues, WORK, LWORK, INFO)
+         CALL dsyev('V', 'L', N, Ainv, N, eigenvalues, WORK, LWORK, INFO)
 
          IF (INFO .NE. 0) THEN
             IF (unit_nr > 0) WRITE (unit_nr, *) 'EIGENSYSTEM ERROR MESSAGE: ', INFO
@@ -2973,20 +2954,20 @@ CONTAINS
          !WRITE(*,*) ' EIV RANGES: ', range1_eiv, range2_eiv, range3_eiv
          IF (PRESENT(bad_modes_projector_down)) THEN
             IF (PRESENT(s_half)) THEN
-               CALL DSYMM('L', 'U', N, N, 1.0_dp, s_half, N, temp2, N, 0.0_dp, Ainv, N)
-               CALL DSYMM('R', 'U', N, N, 1.0_dp, s_half, N, temp3, N, 0.0_dp, temp4, N)
-               CALL DGEMM('N', 'N', N, N, N, 1.0_dp, Ainv, N, temp4, N, 0.0_dp, bad_modes_projector_down, N)
+               CALL dsymm('L', 'U', N, N, 1.0_dp, s_half, N, temp2, N, 0.0_dp, Ainv, N)
+               CALL dsymm('R', 'U', N, N, 1.0_dp, s_half, N, temp3, N, 0.0_dp, temp4, N)
+               CALL dgemm('N', 'N', N, N, N, 1.0_dp, Ainv, N, temp4, N, 0.0_dp, bad_modes_projector_down, N)
             ELSE
-               CALL DGEMM('N', 'N', N, N, N, 1.0_dp, temp2, N, temp3, N, 0.0_dp, bad_modes_projector_down, N)
+               CALL dgemm('N', 'N', N, N, N, 1.0_dp, temp2, N, temp3, N, 0.0_dp, bad_modes_projector_down, N)
             END IF
          END IF
 
          IF (PRESENT(s_inv_half)) THEN
-            CALL DSYMM('L', 'U', N, N, 1.0_dp, s_inv_half, N, temp2, N, 0.0_dp, temp4, N)
-            CALL DSYMM('R', 'U', N, N, 1.0_dp, s_inv_half, N, temp1, N, 0.0_dp, temp2, N)
-            CALL DGEMM('N', 'N', N, N, N, 1.0_dp, temp4, N, temp2, N, 0.0_dp, Ainv, N)
+            CALL dsymm('L', 'U', N, N, 1.0_dp, s_inv_half, N, temp2, N, 0.0_dp, temp4, N)
+            CALL dsymm('R', 'U', N, N, 1.0_dp, s_inv_half, N, temp1, N, 0.0_dp, temp2, N)
+            CALL dgemm('N', 'N', N, N, N, 1.0_dp, temp4, N, temp2, N, 0.0_dp, Ainv, N)
          ELSE
-            CALL DGEMM('N', 'N', N, N, N, 1.0_dp, temp2, N, temp1, N, 0.0_dp, Ainv, N)
+            CALL dgemm('N', 'N', N, N, N, 1.0_dp, temp2, N, temp1, N, 0.0_dp, Ainv, N)
          END IF
          DEALLOCATE (temp1, temp2, temp4)
          IF (PRESENT(bad_modes_projector_down)) DEALLOCATE (temp3)
@@ -3030,7 +3011,6 @@ CONTAINS
 !>       2012.04 created [Rustam Z. Khaliullin]
 !> \author Rustam Z. Khaliullin
 ! **************************************************************************************************
-
    SUBROUTINE pseudo_matrix_power(A, Apow, power, N, range1, range1_thr, shift)
 
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: A
@@ -3091,14 +3071,13 @@ CONTAINS
       ! Query the optimal workspace for dsyev
       LWORK = -1
       ALLOCATE (WORK(MAX(1, LWORK)))
-      CALL DSYEV('V', 'L', N, Apow, N, eigenvalues, WORK, LWORK, INFO)
+      CALL dsyev('V', 'L', N, Apow, N, eigenvalues, WORK, LWORK, INFO)
 
       LWORK = INT(WORK(1))
       DEALLOCATE (WORK)
       ! Allocate the workspace and solve the eigenproblem
       ALLOCATE (WORK(MAX(1, LWORK)))
-
-      CALL DSYEV('V', 'L', N, Apow, N, eigenvalues, WORK, LWORK, INFO)
+      CALL dsyev('V', 'L', N, Apow, N, eigenvalues, WORK, LWORK, INFO)
 
       IF (INFO .NE. 0) THEN
          IF (unit_nr > 0) WRITE (unit_nr, *) 'EIGENSYSTEM ERROR MESSAGE: ', INFO

--- a/src/almo_scf_optimizer.F
+++ b/src/almo_scf_optimizer.F
@@ -7131,7 +7131,7 @@ CONTAINS
             CALL cp_dbcsr_cholesky_invert(m_prec_out, &
                                           para_env=para_env, &
                                           blacs_env=blacs_env, &
-                                          upper_to_full=.TRUE.)
+                                          uplo_to_full=.TRUE.)
          END IF !skip_inversion
 
          CALL dbcsr_filter(m_prec_out, eps_filter)
@@ -7191,7 +7191,7 @@ CONTAINS
       !!!CALL cp_dbcsr_cholesky_invert(prec_vv,&
       !!!        para_env=almo_scf_env%para_env,&
       !!!        blacs_env=almo_scf_env%blacs_env,&
-      !!!        upper_to_full=.TRUE.)
+      !!!        uplo_to_full=.TRUE.)
       !!!CALL dbcsr_filter(prec_vv,&
       !!!        almo_scf_env%eps_filter)
       !!!
@@ -7243,7 +7243,7 @@ CONTAINS
       !CALL cp_dbcsr_cholesky_invert(prec_oo_inv,&
       !        para_env=almo_scf_env%para_env,&
       !        blacs_env=almo_scf_env%blacs_env,&
-      !        upper_to_full=.TRUE.)
+      !        uplo_to_full=.TRUE.)
 
       CALL dbcsr_release(m_tmp_nn_1)
       CALL dbcsr_release(m_tmp_no_3)
@@ -8755,7 +8755,7 @@ CONTAINS
 !S-1.G CALL dbcsr_cholesky_invert(m_prec_out,&
 !S-1.G         para_env=para_env,&
 !S-1.G         blacs_env=blacs_env,&
-!S-1.G         upper_to_full=.TRUE.)
+!S-1.G         uplo_to_full=.TRUE.)
 !S-1.G CALL dbcsr_multiply("N","N",1.0_dp,&
 !S-1.G         m_prec_out,&
 !S-1.G         matrix_grad,&
@@ -8829,12 +8829,12 @@ CONTAINS
       ! Query the optimal workspace for dsyev
       LWORK = -1
       ALLOCATE (WORK(MAX(1, LWORK)))
-      CALL DSYEV('V', 'L', H_size, Hinv, H_size, eigenvalues, WORK, LWORK, INFO)
+      CALL dsyev('V', 'L', H_size, Hinv, H_size, eigenvalues, WORK, LWORK, INFO)
       LWORK = INT(WORK(1))
       DEALLOCATE (WORK)
       ! Allocate the workspace and solve the eigenproblem
       ALLOCATE (WORK(MAX(1, LWORK)))
-      CALL DSYEV('V', 'L', H_size, Hinv, H_size, eigenvalues, WORK, LWORK, INFO)
+      CALL dsyev('V', 'L', H_size, Hinv, H_size, eigenvalues, WORK, LWORK, INFO)
       IF (INFO .NE. 0) THEN
          WRITE (unit_nr, *) 'DSYEV ERROR MESSAGE: ', INFO
          CPABORT("DSYEV failed")
@@ -8905,12 +8905,12 @@ CONTAINS
 
 !!!!    Hinv=H
 !!!!    INFO=0
-!!!!    CALL DPOTRF('L', H_size, Hinv, H_size, INFO )
+!!!!    CALL dpotrf('L', H_size, Hinv, H_size, INFO )
 !!!!    IF( INFO.NE.0 ) THEN
 !!!!       WRITE(*,*) 'DPOTRF ERROR MESSAGE: ', INFO
 !!!!       CPABORT("DPOTRF failed")
 !!!!    END IF
-!!!!    CALL DPOTRI('L', H_size, Hinv, H_size, INFO )
+!!!!    CALL dpotri('L', H_size, Hinv, H_size, INFO )
 !!!!    IF( INFO.NE.0 ) THEN
 !!!!       WRITE(*,*) 'DPOTRI ERROR MESSAGE: ', INFO
 !!!!       CPABORT("DPOTRI failed")
@@ -9328,7 +9328,7 @@ CONTAINS
          CALL cp_dbcsr_cholesky_invert(m_s_inv, &
                                        para_env=almo_scf_env%para_env, &
                                        blacs_env=almo_scf_env%blacs_env, &
-                                       upper_to_full=.TRUE.)
+                                       uplo_to_full=.TRUE.)
          CALL dbcsr_filter(m_s_inv, almo_scf_env%eps_filter)
 
       END IF ! s_inv
@@ -9789,7 +9789,7 @@ CONTAINS
                         CALL cp_dbcsr_cholesky_invert(m_model_hessian_inv(ispin), &
                                                       para_env=almo_scf_env%para_env, &
                                                       blacs_env=almo_scf_env%blacs_env, &
-                                                      upper_to_full=.TRUE.)
+                                                      uplo_to_full=.TRUE.)
                         CALL dbcsr_filter(m_model_hessian_inv(ispin), &
                                           almo_scf_env%eps_filter)
                      END DO

--- a/src/aobasis/aux_basis_set.F
+++ b/src/aobasis/aux_basis_set.F
@@ -117,13 +117,14 @@ CONTAINS
                   zb = (2.0_dp*zet(j, iset))**(0.25_dp*(2*l + 3))
                   zetab = zet(i, iset) + zet(j, iset)
                   so(i, j) = za*zb/zetab**(l + 1.5_dp)
-                  so(j, i) = so(i, j)
+                  IF (i .NE. j) so(j, i) = so(i, j)
                END DO
             END DO
             info = 0
-            CALL dpotrf("U", nx, so, nx, info)
+            ! upper triangular form used below
+            CALL dpotrf('U', nx, so, nx, info)
             CPASSERT(info == 0)
-            CALL dtrtri("U", "N", nx, so, nx, info)
+            CALL dtrtri('U', "N", nx, so, nx, info)
             CPASSERT(info == 0)
             DO i = ns + 1, ns + nl(l, iset)
                DO j = 1, i - ns

--- a/src/atom_utils.F
+++ b/src/atom_utils.F
@@ -1442,11 +1442,11 @@ CONTAINS
 
       ! First Bessel transform
       work_inp(:nc) = density(:nc)*wr(:nc)
-      CALL DSYMV('U', nc, 1.0_dp, kernel, nc, work_inp, 1, 0.0_dp, work_out, 1)
+      CALL dsymv('U', nc, 1.0_dp, kernel, nc, work_inp, 1, 0.0_dp, work_out, 1)
 
       ! Second Bessel transform
       work_inp(:nc) = work_out(:nc)*EXP(-r(:nc)**2)/r(:nc)**2*wr(:nc)
-      CALL DSYMV('U', nc, 1.0_dp, kernel, nc, work_inp, 1, 0.0_dp, work_out, 1)
+      CALL dsymv('U', nc, 1.0_dp, kernel, nc, work_inp, 1, 0.0_dp, work_out, 1)
 
       cpot(:nc) = work_out(:nc)*(2.0_dp*REAL(nu, dp) + 1.0_dp)*4.0_dp/pi*omega
 

--- a/src/auto_basis.F
+++ b/src/auto_basis.F
@@ -620,7 +620,7 @@ CONTAINS
       !Solve for tab
       tx(1:nfit, 1:nfun) = fx(1:nfit, 1:nfun)
       x2(1:nfit, 1:nfit) = xx(1:nfit, 1:nfit)
-      CALL DPOSV("U", nfit, nfun, x2, nfit, tx, nfit, info)
+      CALL dposv("U", nfit, nfun, x2, nfit, tx, nfit, info)
       IF (info == 0) THEN
          ! value t*xx*t
          xij = 0.0_dp

--- a/src/bse_iterative.F
+++ b/src/bse_iterative.F
@@ -954,13 +954,13 @@ CONTAINS
       !MG to do: Check for symmetry of ZAZ!
       ALLOCATE (WORK(1))
       WORK = 0.0_dp
-      CALL DSYEV("V", "U", num_Z_vectors, ZAZ, num_Z_vectors, Subspace_full_eigenval, WORK, -1, ZAZ_diag_info)
+      CALL dsyev("V", "U", num_Z_vectors, ZAZ, num_Z_vectors, Subspace_full_eigenval, WORK, -1, ZAZ_diag_info)
       LWORK = INT(WORK(1))
       DEALLOCATE (WORK)
       ALLOCATE (WORK(LWORK))
       WORK = 0.0_dp
       !MG to check: Usage of symmetric routine okay? (Correct LWORK?)
-      CALL DSYEV("V", "U", num_Z_vectors, ZAZ, num_Z_vectors, Subspace_full_eigenval, WORK, LWORK, ZAZ_diag_info)
+      CALL dsyev("V", "U", num_Z_vectors, ZAZ, num_Z_vectors, Subspace_full_eigenval, WORK, LWORK, ZAZ_diag_info)
 
       IF (ZAZ_diag_info /= 0) THEN
          CPABORT("ZAZ could not be diagonalized successfully.")
@@ -1185,13 +1185,13 @@ CONTAINS
          !MG to do: Check for symmetry of ZAZ!
          ALLOCATE (WORK(1))
          WORK = 0.0_dp
-         CALL DSYEV("N", "U", homo*virtual, A_full_reshaped, homo*virtual, Full_exc_spectrum, WORK, -1, diag_info)
+         CALL dsyev("N", "U", homo*virtual, A_full_reshaped, homo*virtual, Full_exc_spectrum, WORK, -1, diag_info)
          LWORK = INT(WORK(1))
          DEALLOCATE (WORK)
          ALLOCATE (WORK(LWORK))
          WORK = 0.0_dp
          !MG to check: Usage of symmetric routine okay? (Correct LWORK?)
-         CALL DSYEV("N", "U", homo*virtual, A_full_reshaped, homo*virtual, Full_exc_spectrum, WORK, LWORK, diag_info)
+         CALL dsyev("N", "U", homo*virtual, A_full_reshaped, homo*virtual, Full_exc_spectrum, WORK, LWORK, diag_info)
 
          DEALLOCATE (WORK)
 

--- a/src/bse_util.F
+++ b/src/bse_util.F
@@ -25,7 +25,7 @@ MODULE bse_util
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
    USE cp_fm_basic_linalg,              ONLY: cp_fm_trace,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_invert
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
@@ -160,7 +160,7 @@ CONTAINS
       CALL cp_fm_cholesky_invert(fm_mat_Q_static_bse_gemm)
 
       ! symmetrize the result
-      CALL cp_fm_upper_to_full(fm_mat_Q_static_bse_gemm, fm_work)
+      CALL cp_fm_uplo_to_full(fm_mat_Q_static_bse_gemm, fm_work)
 
       CALL parallel_gemm(transa="N", transb="N", m=dimen_RI, n=homo**2, k=dimen_RI, alpha=1.0_dp, &
                          matrix_a=fm_mat_Q_static_bse_gemm, matrix_b=fm_mat_S_ij_bse, beta=0.0_dp, &

--- a/src/common/eigenvalueproblems.F
+++ b/src/common/eigenvalueproblems.F
@@ -40,35 +40,22 @@ CONTAINS
 !> \brief ...
 !> \param matrix ...
 !> \param mysize ...
-!> \param storageform ...
+!> \param uplo ...
 !> \param eigenvalues ...
 !> \param eigenvectors ...
 ! **************************************************************************************************
-   SUBROUTINE diagonalise_ssyev(matrix, mysize, storageform, eigenvalues, &
+   SUBROUTINE diagonalise_ssyev(matrix, mysize, uplo, eigenvalues, &
                                 eigenvectors)
 
       REAL(KIND=dp), INTENT(IN)                          :: matrix(:, :)
       INTEGER, INTENT(IN)                                :: mysize
-      CHARACTER(LEN=*), INTENT(IN)                       :: storageform
+      CHARACTER(LEN=1), INTENT(IN)                       :: uplo
       REAL(KIND=dp), INTENT(OUT)                         :: eigenvalues(:), eigenvectors(:, :)
 
       CHARACTER, PARAMETER                               :: jobz = "V"
 
-      CHARACTER                                          :: uplo
       INTEGER                                            :: info, lda, lwork
       REAL(KIND=dp)                                      :: work(3*mysize - 1)
-
-      IF (storageform(1:5) == "Lower" .OR. &
-          storageform(1:5) == "LOWER" .OR. &
-          storageform(1:5) == "lower") THEN
-         uplo = "L"
-      ELSE IF (storageform(1:5) == "Upper" .OR. &
-               storageform(1:5) == "upper" .OR. &
-               storageform(1:5) == "UPPER") THEN
-         uplo = "U"
-      ELSE
-         CPABORT("Unknown form of storage")
-      END IF
 
       lda = SIZE(matrix, 1)
       lwork = 3*mysize - 1
@@ -87,37 +74,24 @@ CONTAINS
 !> \brief ...
 !> \param matrix ...
 !> \param mysize ...
-!> \param storageform ...
+!> \param uplo ...
 !> \param eigenvalues ...
 !> \param eigenvectors ...
 ! **************************************************************************************************
-   SUBROUTINE diagonalise_chpev(matrix, mysize, storageform, eigenvalues, &
+   SUBROUTINE diagonalise_chpev(matrix, mysize, uplo, eigenvalues, &
                                 eigenvectors)
 
       COMPLEX(KIND=dp), INTENT(INOUT)                    :: matrix(:)
       INTEGER, INTENT(IN)                                :: mysize
-      CHARACTER(LEN=*), INTENT(IN)                       :: storageform
+      CHARACTER(LEN=1), INTENT(IN)                       :: uplo
       REAL(KIND=dp), INTENT(OUT)                         :: eigenvalues(:)
       COMPLEX(KIND=dp), INTENT(OUT)                      :: eigenvectors(:, :)
 
       CHARACTER, PARAMETER                               :: jobz = "V"
 
-      CHARACTER                                          :: uplo
       INTEGER                                            :: info
       COMPLEX(KIND=dp)                                   :: work(2*mysize - 1)
       REAL(KIND=dp)                                      :: rwork(3*mysize - 2)
-
-      IF (storageform(1:5) == "Lower" .OR. &
-          storageform(1:5) == "LOWER" .OR. &
-          storageform(1:5) == "lower") THEN
-         uplo = "L"
-      ELSE IF (storageform(1:5) == "Upper" .OR. &
-               storageform(1:5) == "upper" .OR. &
-               storageform(1:5) == "UPPER") THEN
-         uplo = "U"
-      ELSE
-         CPABORT("Unknown form of storage")
-      END IF
 
       CALL zhpev(jobz, uplo, mysize, matrix, eigenvalues, &
                  eigenvectors, mysize, work, rwork, info)

--- a/src/common/mathlib.F
+++ b/src/common/mathlib.F
@@ -564,54 +564,48 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief returns inverse of real symmetric, positive definite matrix
 !> \param a matrix
-!> \param cholesky_triangle if cholesky decomposition of a was already done
-!>        using dpotrf, indicating if the upper or lower triangle of a is
-!>        stored. If not given, cholesky decomposition of a will be done
-!>        before inversion.
+!> \param potrf if cholesky decomposition of a was already done using dpotrf.
+!>        If not given, cholesky decomposition of a will be done before inversion.
+!> \param uplo indicating if the upper or lower triangle of a is stored.
 !> \author Dorothea Golze [02.2015]
 ! **************************************************************************************************
-   SUBROUTINE invmat_symm(a, cholesky_triangle)
+   SUBROUTINE invmat_symm(a, potrf, uplo)
       REAL(KIND=dp), INTENT(INOUT)                       :: a(:, :)
-      CHARACTER(LEN=1), INTENT(IN), OPTIONAL             :: cholesky_triangle
+      LOGICAL, INTENT(IN), OPTIONAL                      :: potrf
+      CHARACTER(LEN=1), INTENT(IN), OPTIONAL             :: uplo
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'invmat_symm'
 
-      CHARACTER(LEN=1)                                   :: my_triangle
-      INTEGER                                            :: handle, i, info, n
+      CHARACTER(LEN=1)                                   :: myuplo
+      INTEGER                                            :: handle, info, n
+      LOGICAL                                            :: do_potrf
 
       CALL timeset(routineN, handle)
+
+      do_potrf = .TRUE.
+      IF (PRESENT(potrf)) do_potrf = potrf
+
+      myuplo = 'U'
+      IF (PRESENT(uplo)) myuplo = uplo
 
       n = SIZE(a, 1)
       info = 0
 
-      IF (PRESENT(cholesky_triangle)) THEN
-         my_triangle = cholesky_triangle
-      ELSE
-         my_triangle = "U"
-      END IF
-
       ! do cholesky decomposition
-      IF (.NOT. PRESENT(cholesky_triangle)) THEN
-         CALL dpotrf(my_triangle, n, a, n, info)
-         IF (info /= 0) THEN
-            CPABORT("DPOTRF failed")
-         END IF
+      IF (do_potrf) THEN
+         CALL dpotrf(myuplo, n, a, n, info)
+         IF (info /= 0) CPABORT("DPOTRF failed")
       END IF
 
       ! do inversion using the cholesky decomposition
-      CALL dpotri(my_triangle, n, a, n, info)
-      IF (info /= 0) THEN
-         CPABORT("Matrix inversion failed")
-      END IF
+      CALL dpotri(myuplo, n, a, n, info)
+      IF (info /= 0) CPABORT("Matrix inversion failed")
 
-      IF (my_triangle == "U") THEN
-         DO i = 1, n - 1
-            a(i + 1:n, i) = a(i, i + 1:n)
-         END DO
+      ! complete the matrix
+      IF ((myuplo == "U") .OR. (myuplo == "u")) THEN
+         CALL symmetrize_matrix(a, "upper_to_lower")
       ELSE
-         DO i = 1, n - 1
-            a(i, i + 1:n) = a(i + 1:n, i)
-         END DO
+         CALL symmetrize_matrix(a, "lower_to_upper")
       END IF
 
       CALL timestop(handle)
@@ -1761,7 +1755,7 @@ CONTAINS
       lrwork = -1
       liwork = -1
 
-      CALL ZHEEVD('V', 'U', n, eigenvectors, n, eigenvalues, work, lwork, rwork, lrwork, iwork, liwork, info)
+      CALL zheevd('V', 'U', n, eigenvectors, n, eigenvalues, work, lwork, rwork, lrwork, iwork, liwork, info)
 
       lwork = CEILING(REAL(work(1), KIND=dp))
       lrwork = CEILING(REAL(rwork(1), KIND=dp))
@@ -1771,7 +1765,7 @@ CONTAINS
       ALLOCATE (iwork(liwork), rwork(lrwork), work(lwork))
 
       ! diagonalization proper
-      CALL ZHEEVD('V', 'U', n, eigenvectors, n, eigenvalues, work, lwork, rwork, lrwork, iwork, liwork, info)
+      CALL zheevd('V', 'U', n, eigenvectors, n, eigenvalues, work, lwork, rwork, lrwork, iwork, liwork, info)
 
       DEALLOCATE (iwork, rwork, work)
       IF (info /= 0) &

--- a/src/cp_dbcsr_cholesky.F
+++ b/src/cp_dbcsr_cholesky.F
@@ -23,7 +23,7 @@ MODULE cp_dbcsr_cholesky
    USE cp_fm_basic_linalg,              ONLY: cp_fm_cholesky_restore,&
                                               cp_fm_potrf,&
                                               cp_fm_potri,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
@@ -54,7 +54,7 @@ CONTAINS
 !> \param blacs_env ...
 !> \par History
 !>      05.2002 created [JVdV]
-!>      12.2002 updated, added n optional parm [fawzi]
+!>      12.2002 updated, added n optional argument [fawzi]
 !> \author Joost
 ! **************************************************************************************************
    SUBROUTINE cp_dbcsr_cholesky_decompose(matrix, n, para_env, blacs_env)
@@ -105,17 +105,17 @@ CONTAINS
 !> \param n size of the matrix to invert (defaults to the min(size(matrix)))
 !> \param para_env ...
 !> \param blacs_env ...
-!> \param upper_to_full ...
+!> \param uplo_to_full ...
 !> \par History
 !>      05.2002 created [JVdV]
 !> \author Joost VandeVondele
 ! **************************************************************************************************
-   SUBROUTINE cp_dbcsr_cholesky_invert(matrix, n, para_env, blacs_env, upper_to_full)
+   SUBROUTINE cp_dbcsr_cholesky_invert(matrix, n, para_env, blacs_env, uplo_to_full)
       TYPE(dbcsr_type)                                   :: matrix
       INTEGER, INTENT(in), OPTIONAL                      :: n
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
-      LOGICAL, INTENT(IN)                                :: upper_to_full
+      LOGICAL, INTENT(IN)                                :: uplo_to_full
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_dbcsr_cholesky_invert'
 
@@ -145,9 +145,9 @@ CONTAINS
 
       CALL cp_fm_potri(fm_matrix, my_n)
 
-      IF (upper_to_full) THEN
+      IF (uplo_to_full) THEN
          CALL cp_fm_create(fm_matrix_tmp, fm_matrix%matrix_struct, name="fm_matrix_tmp")
-         CALL cp_fm_upper_to_full(fm_matrix, fm_matrix_tmp)
+         CALL cp_fm_uplo_to_full(fm_matrix, fm_matrix_tmp)
          CALL cp_fm_release(fm_matrix_tmp)
       END IF
 

--- a/src/cp_dbcsr_diag.F
+++ b/src/cp_dbcsr_diag.F
@@ -67,7 +67,7 @@ CONTAINS
 
       ! Computes all eigenvalues and vectors of a real symmetric matrix
       ! should be quite a bit faster than syevx for that case
-      ! especially in parallel with thightly clustered evals
+      ! especially in parallel with tightly clustered evals
       ! needs more workspace in the worst case, but much better distributed
 
       TYPE(dbcsr_type)                                   :: matrix, eigenvectors

--- a/src/cp_dbcsr_operations.F
+++ b/src/cp_dbcsr_operations.F
@@ -466,7 +466,7 @@ CONTAINS
 !>
 ! **************************************************************************************************
    SUBROUTINE dbcsr_multiply_local(matrix_a, vec_b, vec_c, ncol, alpha)
-      TYPE(dbcsr_type), INTENT(IN)                    :: matrix_a
+      TYPE(dbcsr_type), INTENT(IN)                       :: matrix_a
       REAL(dp), DIMENSION(:, :), INTENT(IN)              :: vec_b
       REAL(dp), DIMENSION(:, :), INTENT(INOUT)           :: vec_c
       INTEGER, INTENT(in), OPTIONAL                      :: ncol
@@ -479,7 +479,7 @@ CONTAINS
       LOGICAL                                            :: has_symm
       REAL(dp)                                           :: my_alpha, my_alpha2
       REAL(dp), DIMENSION(:, :), POINTER                 :: data_d
-      TYPE(dbcsr_iterator_type)                            :: iter
+      TYPE(dbcsr_iterator_type)                          :: iter
 
       CALL timeset(routineN, timing_handle)
 
@@ -559,8 +559,8 @@ CONTAINS
 !>
 ! **************************************************************************************************
    SUBROUTINE cp_dbcsr_sm_fm_multiply(matrix, fm_in, fm_out, ncol, alpha, beta)
-      TYPE(dbcsr_type), INTENT(IN)                    :: matrix
-      TYPE(cp_fm_type), INTENT(IN)                          :: fm_in, fm_out
+      TYPE(dbcsr_type), INTENT(IN)                       :: matrix
+      TYPE(cp_fm_type), INTENT(IN)                       :: fm_in, fm_out
       INTEGER, INTENT(IN)                                :: ncol
       REAL(dp), INTENT(IN), OPTIONAL                     :: alpha, beta
 
@@ -575,7 +575,7 @@ CONTAINS
                                                             row_dist, col_dist, col_blk_size
       TYPE(dbcsr_type)                                   :: in, out
       REAL(dp)                                           :: my_alpha, my_beta
-      TYPE(dbcsr_distribution_type)                       :: dist, dist_right_in, product_dist
+      TYPE(dbcsr_distribution_type)                      :: dist, dist_right_in, product_dist
 
       CALL timeset(routineN, timing_handle)
 

--- a/src/ct_methods.F
+++ b/src/ct_methods.F
@@ -301,7 +301,7 @@ CONTAINS
             CALL cp_dbcsr_cholesky_invert(u_pp, &
                                           para_env=cts_env%para_env, &
                                           blacs_env=cts_env%blacs_env, &
-                                          upper_to_full=.TRUE.)
+                                          uplo_to_full=.TRUE.)
             !CALL dbcsr_scale(u_pp,-1.0_dp)
 
             CALL dbcsr_create(u_qq, template=matrix_qq, &
@@ -315,7 +315,7 @@ CONTAINS
             CALL cp_dbcsr_cholesky_invert(u_qq, &
                                           para_env=cts_env%para_env, &
                                           blacs_env=cts_env%blacs_env, &
-                                          upper_to_full=.TRUE.)
+                                          uplo_to_full=.TRUE.)
 
             ! transform all riccati matrices (left-right preconditioner)
             CALL dbcsr_create(tmp1, template=matrix_qq, &
@@ -1532,16 +1532,14 @@ CONTAINS
             ! Query the optimal workspace for dsyev
             LWORK = -1
             ALLOCATE (WORK(MAX(1, LWORK)))
-            CALL DSYEV('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
+            CALL dsyev('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
             LWORK = INT(WORK(1))
             DEALLOCATE (WORK)
 
             ! Allocate the workspace and solve the eigenproblem
             ALLOCATE (WORK(MAX(1, LWORK)))
-            CALL DSYEV('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
-            IF (INFO .NE. 0) THEN
-               CPABORT("DSYEV failed")
-            END IF
+            CALL dsyev('V', 'L', iblock_size, data_copy, iblock_size, eigenvalues, WORK, LWORK, INFO)
+            IF (INFO .NE. 0) CPABORT("DSYEV failed")
 
             ! copy eigenvectors into a cp_dbcsr matrix
             NULLIFY (p_new_block)

--- a/src/dkh_main.F
+++ b/src/dkh_main.F
@@ -12,7 +12,7 @@ MODULE dkh_main
                                               cp_fm_syrk,&
                                               cp_fm_transpose,&
                                               cp_fm_triangular_multiply,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_reduce
    USE cp_fm_diag,                      ONLY: cp_fm_syevd
@@ -197,7 +197,7 @@ CONTAINS
       !-----------------------------------------------------------------------
 
       CALL cp_fm_cholesky_reduce(matrix_v, matrix_sinv)
-      CALL cp_fm_upper_to_full(matrix_v, matrix_aux)
+      CALL cp_fm_uplo_to_full(matrix_v, matrix_aux)
       CALL parallel_gemm("T", "N", n, n, n, 1.0_dp, matrix_eig, matrix_v, 0.0_dp, matrix_aux)
       CALL parallel_gemm("N", "N", n, n, n, 1.0_dp, matrix_aux, matrix_eig, 0.0_dp, matrix_v)
 
@@ -206,7 +206,7 @@ CONTAINS
       !-----------------------------------------------------------------------
 
       CALL cp_fm_cholesky_reduce(matrix_pVp, matrix_sinv)
-      CALL cp_fm_upper_to_full(matrix_pVp, matrix_aux)
+      CALL cp_fm_uplo_to_full(matrix_pVp, matrix_aux)
       CALL parallel_gemm("T", "N", n, n, n, 1.0_dp, matrix_eig, matrix_pVp, 0.0_dp, matrix_aux)
       CALL parallel_gemm("N", "N", n, n, n, 1.0_dp, matrix_aux, matrix_eig, 0.0_dp, matrix_pVp)
 
@@ -275,7 +275,7 @@ CONTAINS
       !-----------------------------------------------------------------------
 
       CALL cp_fm_scale_and_add(1.0_dp, matrix_ev1, 1.0_dp, matrix_ev2)
-      CALL cp_fm_upper_to_full(matrix_ev1, matrix_aux)
+      CALL cp_fm_uplo_to_full(matrix_ev1, matrix_aux)
       CALL cp_fm_to_fm(matrix_ev1, matrix_v)
       IF (dkh_order .GE. 3) THEN
          CALL cp_fm_scale_and_add(1.0_dp, matrix_v, 1.0_dp, matrix_ev3)
@@ -427,7 +427,7 @@ CONTAINS
       END DO
 
       CALL cp_fm_syrk('U', 'N', 1, 1.0_dp, vec_a, 1, 1, 0.0_dp, matrix_aux)
-      CALL cp_fm_upper_to_full(matrix_aux, matrix_aux2)
+      CALL cp_fm_uplo_to_full(matrix_aux, matrix_aux2)
       CALL cp_fm_schur_product(matrix_v, matrix_aux, matrix_pe1p)
 
       DO i = 1, nrow_local
@@ -435,7 +435,7 @@ CONTAINS
       END DO
 
       CALL cp_fm_syrk('U', 'N', 1, 1.0_dp, vec_a, 1, 1, 0.0_dp, matrix_aux)
-      CALL cp_fm_upper_to_full(matrix_aux, matrix_aux2)
+      CALL cp_fm_uplo_to_full(matrix_aux, matrix_aux2)
       CALL cp_fm_schur_product(matrix_pvp, matrix_aux, matrix_aux2)
 
       CALL cp_fm_scale_and_add(4.0_dp, matrix_pe1p, 1.0_dp, matrix_aux2)
@@ -1058,7 +1058,7 @@ CONTAINS
       END DO
 
       CALL cp_fm_syrk('U', 'N', 1, 1.0_dp, vec_a, 1, 1, 0.0_dp, matrix_aux)
-      CALL cp_fm_upper_to_full(matrix_aux, matrix_axa)
+      CALL cp_fm_uplo_to_full(matrix_aux, matrix_axa)
       CALL cp_fm_schur_product(matrix_x, matrix_aux, matrix_axa)
 
       !     DO i=1,n
@@ -1121,7 +1121,7 @@ CONTAINS
       END DO
 
       CALL cp_fm_syrk('U', 'N', 1, 1.0_dp, vec_a, 1, 1, 0.0_dp, matrix_aux)
-      CALL cp_fm_upper_to_full(matrix_aux, matrix_axa)
+      CALL cp_fm_uplo_to_full(matrix_aux, matrix_axa)
       CALL cp_fm_schur_product(matrix_x, matrix_aux, matrix_axa)
 
       CALL cp_fm_release(vec_a)

--- a/src/efield_utils.F
+++ b/src/efield_utils.F
@@ -239,7 +239,6 @@ CONTAINS
 
          END DO
          IF (dft_control%apply_efield_field) energy%efield_core = efield_ener
-!          energy%efield_core = efield_ener
       END IF
       CALL timestop(handle)
    END SUBROUTINE calculate_ecore_efield

--- a/src/emd/rt_delta_pulse.F
+++ b/src/emd/rt_delta_pulse.F
@@ -36,7 +36,7 @@ MODULE rt_delta_pulse
                                               dbcsr_deallocate_matrix_set
    USE cp_fm_basic_linalg,              ONLY: cp_fm_scale_and_add,&
                                               cp_fm_triangular_multiply,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_invert,&
                                               cp_fm_cholesky_reduce,&
@@ -467,7 +467,7 @@ CONTAINS
       CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, S_inv_fm)
       CALL cp_fm_cholesky_decompose(S_inv_fm)
       CALL cp_fm_cholesky_invert(S_inv_fm)
-      CALL cp_fm_upper_to_full(S_inv_fm, tmp)
+      CALL cp_fm_uplo_to_full(S_inv_fm, tmp)
       CALL cp_fm_release(tmp)
 
       DO i = 1, SIZE(mos)

--- a/src/emd/rt_propagation_methods.F
+++ b/src/emd/rt_propagation_methods.F
@@ -510,7 +510,7 @@ CONTAINS
          CALL cp_dbcsr_cholesky_decompose(S_inv, para_env=rtp%ao_ao_fmstruct%para_env, &
                                           blacs_env=rtp%ao_ao_fmstruct%context)
          CALL cp_dbcsr_cholesky_invert(S_inv, para_env=rtp%ao_ao_fmstruct%para_env, &
-                                       blacs_env=rtp%ao_ao_fmstruct%context, upper_to_full=.TRUE.)
+                                       blacs_env=rtp%ao_ao_fmstruct%context, uplo_to_full=.TRUE.)
       END IF
 
       CALL timestop(handle)

--- a/src/emd/rt_propagator_init.F
+++ b/src/emd/rt_propagator_init.F
@@ -22,7 +22,7 @@ MODULE rt_propagator_init
                                               cp_dbcsr_plus_fm_fm_t
    USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
                                               cp_fm_scale,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_diag,                      ONLY: cp_fm_syevd
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
@@ -252,7 +252,7 @@ CONTAINS
 
       ALLOCATE (eigval_H(ndim))
       CALL copy_dbcsr_to_fm(s_mat(1)%matrix, tmp)
-      CALL cp_fm_upper_to_full(tmp, eigvec_H)
+      CALL cp_fm_uplo_to_full(tmp, eigvec_H)
 
       CALL cp_fm_syevd(tmp, eigvec_H, eigval_H)
 
@@ -272,7 +272,7 @@ CONTAINS
       DO ispin = 1, SIZE(matrix_ks)
 
          CALL copy_dbcsr_to_fm(matrix_ks(ispin)%matrix, H_fm)
-         CALL cp_fm_upper_to_full(H_fm, tmp_mat_H)
+         CALL cp_fm_uplo_to_full(H_fm, tmp_mat_H)
          CALL cp_fm_scale(t, H_fm)
 
          CALL parallel_gemm("N", "N", ndim, ndim, ndim, one, H_fm, S_minus_half, zero, &

--- a/src/environment.F
+++ b/src/environment.F
@@ -351,7 +351,7 @@ CONTAINS
       TYPE(global_environment_type), POINTER             :: globenv
 
       CHARACTER(LEN=3*default_string_length)             :: message
-      CHARACTER(len=default_string_length)               :: c_val
+      CHARACTER(LEN=default_string_length)               :: c_val
       INTEGER                                            :: i, iw
       TYPE(cp_logger_type), POINTER                      :: logger
 
@@ -506,9 +506,9 @@ CONTAINS
 
       CHARACTER(LEN=6), PARAMETER                        :: start_section_label = "GLOBAL"
 
-      CHARACTER(len=13)                                  :: omp_stacksize, tracing_string
-      CHARACTER(len=6)                                   :: print_level_string
-      CHARACTER(len=default_path_length)                 :: basis_set_file_name, coord_file_name, &
+      CHARACTER(LEN=13)                                  :: omp_stacksize, tracing_string
+      CHARACTER(LEN=6)                                   :: print_level_string
+      CHARACTER(LEN=default_path_length)                 :: basis_set_file_name, coord_file_name, &
                                                             mm_potential_file_name, &
                                                             potential_file_name
       CHARACTER(LEN=default_string_length)               :: env_num, model_name, project_name
@@ -1104,7 +1104,7 @@ CONTAINS
    SUBROUTINE fm_setup(glob_section)
       TYPE(section_vals_type), POINTER                   :: glob_section
 
-      INTEGER                                            :: multiplication_type, ncb, nrb
+      INTEGER                                            :: mm_type, ncb, nrb
       LOGICAL                                            :: force_me
       TYPE(section_vals_type), POINTER                   :: fm_section
 
@@ -1113,13 +1113,10 @@ CONTAINS
       CALL section_vals_val_get(fm_section, "NROW_BLOCKS", i_val=nrb)
       CALL section_vals_val_get(fm_section, "NCOL_BLOCKS", i_val=ncb)
       CALL section_vals_val_get(fm_section, "FORCE_BLOCK_SIZE", l_val=force_me)
-
       CALL cp_fm_struct_config(nrow_block=nrb, ncol_block=ncb, force_block=force_me)
 
-      CALL section_vals_val_get(fm_section, "TYPE_OF_MATRIX_MULTIPLICATION", &
-                                i_val=multiplication_type)
-
-      CALL cp_fm_setup(multiplication_type)
+      CALL section_vals_val_get(fm_section, "TYPE_OF_MATRIX_MULTIPLICATION", i_val=mm_type)
+      CALL cp_fm_setup(mm_type)
 
    END SUBROUTINE fm_setup
 
@@ -1172,7 +1169,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp2k_get_walltime(section, keyword_name, walltime)
       TYPE(section_vals_type), POINTER                   :: section
-      CHARACTER(len=*), INTENT(in)                       :: keyword_name
+      CHARACTER(LEN=*), INTENT(in)                       :: keyword_name
       REAL(KIND=dp), INTENT(out)                         :: walltime
 
       CHARACTER(LEN=1)                                   :: c1, c2

--- a/src/fm/cp_cfm_basic_linalg.F
+++ b/src/fm/cp_cfm_basic_linalg.F
@@ -53,7 +53,7 @@ MODULE cp_cfm_basic_linalg
              cp_cfm_rot_rows, &
              cp_cfm_rot_cols, &
              cp_cfm_det, & ! determinant of a complex matrix with correct sign
-             cp_cfm_upper_to_full
+             cp_cfm_uplo_to_full
 
    REAL(kind=dp), EXTERNAL :: zlange, pzlange
 
@@ -455,7 +455,7 @@ CONTAINS
 !>    The original content of the matrix is destroyed.
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_lu_decompose(matrix_a, determinant)
-      TYPE(cp_cfm_type), INTENT(IN)                   :: matrix_a
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix_a
       COMPLEX(kind=dp), INTENT(out)                      :: determinant
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_lu_decompose'
@@ -528,7 +528,7 @@ CONTAINS
       DEALLOCATE (ipivot)
 
       CALL timestop(handle)
-   END SUBROUTINE
+   END SUBROUTINE cp_cfm_lu_decompose
 
 ! **************************************************************************************************
 !> \brief Performs one of the matrix-matrix operations:
@@ -565,7 +565,7 @@ CONTAINS
       COMPLEX(kind=dp), INTENT(in)                       :: alpha
       TYPE(cp_cfm_type), INTENT(IN)                      :: matrix_a, matrix_b
       COMPLEX(kind=dp), INTENT(in)                       :: beta
-      TYPE(cp_cfm_type), INTENT(IN)                   :: matrix_c
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix_c
       INTEGER, INTENT(in), OPTIONAL                      :: a_first_col, a_first_row, b_first_col, &
                                                             b_first_row, c_first_col, c_first_row
 
@@ -642,7 +642,7 @@ CONTAINS
 !> \author Joost VandeVondele
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_column_scale(matrix_a, scaling)
-      TYPE(cp_cfm_type), INTENT(IN)                   :: matrix_a
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix_a
       COMPLEX(kind=dp), DIMENSION(:), INTENT(in)         :: scaling
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_column_scale'
@@ -741,7 +741,7 @@ CONTAINS
 !> \author Florian Schiffmann
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_solve(matrix_a, general_a, determinant)
-      TYPE(cp_cfm_type), INTENT(IN)                   :: matrix_a, general_a
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix_a, general_a
       COMPLEX(kind=dp), OPTIONAL                         :: determinant
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_solve'
@@ -833,7 +833,7 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_lu_invert(matrix, info_out)
-      TYPE(cp_cfm_type), INTENT(IN)                   :: matrix
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix
       INTEGER, INTENT(out), OPTIONAL                     :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_lu_invert'
@@ -1070,7 +1070,7 @@ CONTAINS
 !> \author MI
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_triangular_invert(matrix_a, uplo, info_out)
-      TYPE(cp_cfm_type), INTENT(IN)         :: matrix_a
+      TYPE(cp_cfm_type), INTENT(IN)            :: matrix_a
       CHARACTER, INTENT(in), OPTIONAL          :: uplo
       INTEGER, INTENT(out), OPTIONAL           :: info_out
 
@@ -1079,7 +1079,7 @@ CONTAINS
       CHARACTER                                :: unit_diag, my_uplo
       INTEGER                                  :: handle, info, ncol_global
       COMPLEX(kind=dp), DIMENSION(:, :), &
-         POINTER                                :: a
+         POINTER                               :: a
 #if defined(__parallel)
       INTEGER, DIMENSION(9)                    :: desca
 #endif
@@ -1122,7 +1122,7 @@ CONTAINS
    SUBROUTINE cp_cfm_transpose(matrix, trans, matrixt)
       TYPE(cp_cfm_type), INTENT(IN)                      :: matrix
       CHARACTER, INTENT(in)                              :: trans
-      TYPE(cp_cfm_type), INTENT(IN)                   :: matrixt
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrixt
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_transpose'
 
@@ -1348,17 +1348,20 @@ CONTAINS
 !> \brief ...
 !> \param matrix ...
 !> \param workspace ...
+!> \param uplo triangular format; defaults to 'U'
 !> \par History
 !>      12.2024 Added optional workspace as input [Rocco Meli]
 !> \author Jan Wilhelm
 ! **************************************************************************************************
-   SUBROUTINE cp_cfm_upper_to_full(matrix, workspace)
+   SUBROUTINE cp_cfm_uplo_to_full(matrix, workspace, uplo)
 
       TYPE(cp_cfm_type), INTENT(IN)                      :: matrix
-      TYPE(cp_cfm_type), OPTIONAL                        :: workspace
+      TYPE(cp_cfm_type), INTENT(IN), OPTIONAL            :: workspace
+      CHARACTER, INTENT(IN), OPTIONAL                    :: uplo
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_cfm_upper_to_full'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_cfm_uplo_to_full'
 
+      CHARACTER                                          :: myuplo
       INTEGER                                            :: handle, i_global, iiB, j_global, jjB, &
                                                             ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
@@ -1372,6 +1375,9 @@ CONTAINS
          work = workspace
       END IF
 
+      myuplo = 'U'
+      IF (PRESENT(uplo)) myuplo = uplo
+
       ! get info of fm_mat_Q
       CALL cp_cfm_get_info(matrix=matrix, &
                            nrow_local=nrow_local, &
@@ -1383,10 +1389,9 @@ CONTAINS
          j_global = col_indices(jjB)
          DO iiB = 1, nrow_local
             i_global = row_indices(iiB)
-            IF (j_global < i_global) THEN
+            IF (MERGE(j_global < i_global, j_global > i_global, (myuplo == "U") .OR. (myuplo == "u"))) THEN
                matrix%local_data(iiB, jjB) = z_zero
-            END IF
-            IF (j_global == i_global) THEN
+            ELSE IF (j_global == i_global) THEN
                matrix%local_data(iiB, jjB) = matrix%local_data(iiB, jjB)/(2.0_dp, 0.0_dp)
             END IF
          END DO
@@ -1402,6 +1407,6 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE cp_cfm_upper_to_full
+   END SUBROUTINE cp_cfm_uplo_to_full
 
 END MODULE cp_cfm_basic_linalg

--- a/src/fm/cp_cfm_cholesky.F
+++ b/src/fm/cp_cfm_cholesky.F
@@ -48,7 +48,7 @@ CONTAINS
 !> \author Joost
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_cholesky_decompose(matrix, n, info_out)
-      TYPE(cp_cfm_type), INTENT(IN)                   :: matrix
+      TYPE(cp_cfm_type), INTENT(IN)                      :: matrix
       INTEGER, INTENT(in), OPTIONAL                      :: n
       INTEGER, INTENT(out), OPTIONAL                     :: info_out
 
@@ -91,7 +91,7 @@ CONTAINS
       ELSE
          IF (info /= 0) &
             CALL cp_abort(__LOCATION__, &
-                          "Cholesky decompose failed: matrix is not positive definite  or ill-conditioned")
+                          "Cholesky decompose failed: matrix is not positive definite or ill-conditioned")
       END IF
 
       CALL timestop(handle)
@@ -109,12 +109,12 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    SUBROUTINE cp_cfm_cholesky_invert(matrix, n, info_out)
-      TYPE(cp_cfm_type), INTENT(IN)           :: matrix
+      TYPE(cp_cfm_type), INTENT(IN)              :: matrix
       INTEGER, INTENT(in), OPTIONAL              :: n
       INTEGER, INTENT(out), OPTIONAL             :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_cholesky_invert'
-      COMPLEX(kind=dp), DIMENSION(:, :), POINTER  :: aa
+      COMPLEX(kind=dp), DIMENSION(:, :), POINTER :: aa
       INTEGER                                    :: info, handle
       INTEGER                                    :: my_n
 #if defined(__parallel)

--- a/src/fm/cp_cfm_diag.F
+++ b/src/fm/cp_cfm_diag.F
@@ -159,7 +159,7 @@ CONTAINS
       CALL ieee_set_halting_mode(IEEE_ALL, halt)
 #endif
 #else
-      CALL ZHEEVD('V', 'U', n, m(1, 1), SIZE(m, 1), eigenvalues(1), &
+      CALL zheevd('V', 'U', n, m(1, 1), SIZE(m, 1), eigenvalues(1), &
                   work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
       eigenvectors%local_data = matrix%local_data
 #endif

--- a/src/fm/cp_cfm_dlaf_api.F
+++ b/src/fm/cp_cfm_dlaf_api.F
@@ -7,7 +7,7 @@
 
 MODULE cp_cfm_dlaf_api
 
-   USE cp_cfm_basic_linalg, ONLY: cp_cfm_upper_to_full
+   USE cp_cfm_basic_linalg, ONLY: cp_cfm_uplo_to_full
    USE cp_cfm_types, ONLY: cp_cfm_type
 #if defined(__DLAF)
    USE dlaf_fortran, ONLY: dlaf_pzheevd, &
@@ -167,7 +167,7 @@ CONTAINS
 #if defined(__DLAF)
       ! DLAF needs the lower triangular part
       ! Use eigenvectors matrix as workspace
-      CALL cp_cfm_upper_to_full(matrix, eigenvectors)
+      CALL cp_cfm_uplo_to_full(matrix, eigenvectors)
 
       n = matrix%matrix_struct%nrow_global
 
@@ -236,8 +236,8 @@ CONTAINS
 #if defined(__DLAF)
       ! DLAF needs the lower triangular part
       ! Use eigenvectors matrix as workspace
-      CALL cp_cfm_upper_to_full(amatrix, eigenvectors)
-      CALL cp_cfm_upper_to_full(bmatrix, eigenvectors)
+      CALL cp_cfm_uplo_to_full(amatrix, eigenvectors)
+      CALL cp_cfm_uplo_to_full(bmatrix, eigenvectors)
 
       n = amatrix%matrix_struct%nrow_global
 

--- a/src/fm/cp_fm_basic_linalg.F
+++ b/src/fm/cp_fm_basic_linalg.F
@@ -47,7 +47,7 @@ MODULE cp_fm_basic_linalg
              cp_fm_norm, & ! different norms of A
              cp_fm_schur_product, & ! schur product
              cp_fm_transpose, & ! transpose a matrix
-             cp_fm_upper_to_full, & ! symmetrise an upper symmetric matrix
+             cp_fm_uplo_to_full, & ! symmetrise a triangular matrix
              cp_fm_syrk, & ! rank k update
              cp_fm_triangular_multiply, & ! triangular matrix multiply / solve
              cp_fm_symm, & ! multiply a symmetric with a non-symmetric matrix
@@ -167,7 +167,7 @@ CONTAINS
 
       REAL(KIND=dp), INTENT(IN)                          :: alpha
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix_a
-      REAL(KIND=dp), INTENT(in), OPTIONAL                :: beta
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: beta
       TYPE(cp_fm_type), INTENT(IN), OPTIONAL             :: matrix_b
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_scale_and_add'
@@ -215,7 +215,7 @@ CONTAINS
       END IF
       IF (my_beta .NE. 0.0_dp) THEN
          IF (matrix_a%matrix_struct%context /= matrix_b%matrix_struct%context) &
-            CPABORT("matrixes must be in the same blacs context")
+            CPABORT("Matrices must be in the same blacs context")
 
          IF (cp_fm_struct_equivalent(matrix_a%matrix_struct, &
                                      matrix_b%matrix_struct)) THEN
@@ -228,7 +228,7 @@ CONTAINS
                size_b = SIZE(b, 1)*SIZE(b, 2)
             END IF
             IF (size_a /= size_b) &
-               CPABORT("Matrixes must have same locale sizes")
+               CPABORT("Matrices must have same local sizes")
 
             IF (matrix_a%use_sp .AND. matrix_b%use_sp) THEN
                CALL saxpy(size_a, REAL(my_beta, sp), b_sp, 1, a_sp, 1)
@@ -309,8 +309,11 @@ CONTAINS
                    bb, &
                    1, 1, &
                    descb)
+#elif defined(__MKL)
+      CALL mkl_domatadd('C', trans, 'N', nrow_global, ncol_global, &
+                        alpha, aa, nrow_global, beta, b, nrow_global, bb, nrow_global)
 #else
-      ! dgeadd is not a standard BLAS function, although is implemented
+      ! dgeadd is not a standard BLAS function, although it is implemented
       ! in some libraries like OpenBLAS, so not going to use it here
       SELECT CASE (trans)
       CASE ('T')
@@ -350,7 +353,7 @@ CONTAINS
 !>      - Use cp_fm_get_diag instead of n times cp_fm_get_element (A. Bussy)
 ! **************************************************************************************************
    SUBROUTINE cp_fm_lu_decompose(matrix_a, almost_determinant, correct_sign)
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix_a
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_a
       REAL(KIND=dp), INTENT(OUT)               :: almost_determinant
       LOGICAL, INTENT(IN), OPTIONAL            :: correct_sign
 
@@ -409,7 +412,7 @@ CONTAINS
       DEALLOCATE (ipivot)
       almost_determinant = determinant ! notice that the sign is random
       CALL timestop(handle)
-   END SUBROUTINE
+   END SUBROUTINE cp_fm_lu_decompose
 
 ! **************************************************************************************************
 !> \brief computes matrix_c = beta * matrix_c + alpha * ( matrix_a  ** transa ) * ( matrix_b ** transb )
@@ -443,7 +446,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                :: alpha
       TYPE(cp_fm_type), INTENT(IN)             :: matrix_a, matrix_b
       REAL(KIND=dp), INTENT(IN)                :: beta
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix_c
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_c
       INTEGER, INTENT(IN), OPTIONAL            :: a_first_col, a_first_row, &
                                                   b_first_col, b_first_row, &
                                                   c_first_col, c_first_row
@@ -557,7 +560,7 @@ CONTAINS
 !>      where matrix_a is symmetric
 !> \param side : 'L' -> matrix_a is on the left 'R' -> matrix_a is on the right
 !>      alpha,beta :: can be 0.0_dp and 1.0_dp
-!> \param uplo ...
+!> \param uplo triangular format
 !> \param m ...
 !> \param n ...
 !> \param alpha ...
@@ -568,18 +571,18 @@ CONTAINS
 !> \author Matthias Krack
 !> \note
 !>      matrix_c should have no overlap with matrix_a, matrix_b
-!>      all matrices in QS are upper triangular, so uplo should be 'U' always
+!>      all matrices in QS are triangular according to uplo
 !>      matrix_a is always an m x m matrix
-!>      it is typically slower to do cp_fm_symm than cp_fm_gemm (especially in parallel easily 50 percent !)
+!>      typically slower than cp_fm_gemm (especially in parallel easily 50 percent)
 ! **************************************************************************************************
    SUBROUTINE cp_fm_symm(side, uplo, m, n, alpha, matrix_a, matrix_b, beta, matrix_c)
 
       CHARACTER(LEN=1), INTENT(IN)             :: side, uplo
       INTEGER, INTENT(IN)                      :: m, n
       REAL(KIND=dp), INTENT(IN)                :: alpha
-      TYPE(cp_fm_type), INTENT(IN)                :: matrix_a, matrix_b
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_a, matrix_b
       REAL(KIND=dp), INTENT(IN)                :: beta
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix_c
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_c
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_symm'
 
@@ -668,8 +671,6 @@ CONTAINS
 !> \param beta ...
 !> \param matrix_c ...
 !> \author Matthias Krack
-!> \note
-!>      In QS uplo should 'U' (upper part updated)
 ! **************************************************************************************************
    SUBROUTINE cp_fm_syrk(uplo, trans, k, alpha, matrix_a, ia, ja, beta, matrix_c)
       CHARACTER(LEN=1), INTENT(IN)             :: uplo, trans
@@ -678,7 +679,7 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)             :: matrix_a
       INTEGER, INTENT(IN)                      :: ia, ja
       REAL(KIND=dp), INTENT(IN)                :: beta
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix_c
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_c
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_syrk'
 
@@ -852,9 +853,9 @@ CONTAINS
 ! **************************************************************************************************
    #:for longname, shortname, appendix in types
       SUBROUTINE cp_fm_trace_a1b0t1_${shortname}$ (matrix_a, matrix_b, trace)
-         TYPE(${longname}$), DIMENSION(:), INTENT(in)       :: matrix_a
+         TYPE(${longname}$), DIMENSION(:), INTENT(IN)       :: matrix_a
          TYPE(cp_fm_type), INTENT(IN)                       :: matrix_b
-         REAL(kind=dp), DIMENSION(:), INTENT(out)           :: trace
+         REAL(kind=dp), DIMENSION(:), INTENT(OUT)           :: trace
 
          CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b0t1_${shortname}$'
 
@@ -929,9 +930,9 @@ CONTAINS
    #:for longname1, shortname1, appendix1 in types
       #:for longname2, shortname2, appendix2 in types
          SUBROUTINE cp_fm_trace_a1b1t1_${shortname1}$${shortname2}$ (matrix_a, matrix_b, trace, accurate)
-            TYPE(${longname1}$), DIMENSION(:), INTENT(in)       :: matrix_a
-            TYPE(${longname2}$), DIMENSION(:), INTENT(in)       :: matrix_b
-            REAL(kind=dp), DIMENSION(:), INTENT(out)           :: trace
+            TYPE(${longname1}$), DIMENSION(:), INTENT(IN)      :: matrix_a
+            TYPE(${longname2}$), DIMENSION(:), INTENT(IN)      :: matrix_b
+            REAL(kind=dp), DIMENSION(:), INTENT(OUT)           :: trace
             LOGICAL, INTENT(IN), OPTIONAL                      :: accurate
 
             CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_trace_a1b1t1_${shortname1}$${shortname2}$'
@@ -1003,9 +1004,9 @@ CONTAINS
    #:for longname1, shortname1, appendix1 in types
       #:for longname2, shortname2, appendix2 in types
          SUBROUTINE cp_fm_contracted_trace_a2b2t2_${shortname1}$${shortname2}$ (matrix_a, matrix_b, trace, accurate)
-            TYPE(${longname1}$), DIMENSION(:, :), INTENT(in)       :: matrix_a
-            TYPE(${longname2}$), DIMENSION(:, :), INTENT(in)       :: matrix_b
-            REAL(kind=dp), DIMENSION(:, :), INTENT(out)        :: trace
+            TYPE(${longname1}$), DIMENSION(:, :), INTENT(IN)   :: matrix_a
+            TYPE(${longname2}$), DIMENSION(:, :), INTENT(IN)   :: matrix_b
+            REAL(kind=dp), DIMENSION(:, :), INTENT(OUT)        :: trace
             LOGICAL, INTENT(IN), OPTIONAL                      :: accurate
 
             CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_contracted_trace_a2b2t2_${shortname1}$${shortname2}$'
@@ -1122,12 +1123,12 @@ CONTAINS
                                         transpose_tr, invert_tr, uplo_tr, unit_diag_tr, n_rows, n_cols, &
                                         alpha)
       TYPE(cp_fm_type), INTENT(IN)                       :: triangular_matrix, matrix_b
-      CHARACTER, INTENT(in), OPTIONAL                    :: side
-      LOGICAL, INTENT(in), OPTIONAL                      :: transpose_tr, invert_tr
-      CHARACTER, INTENT(in), OPTIONAL                    :: uplo_tr
-      LOGICAL, INTENT(in), OPTIONAL                      :: unit_diag_tr
-      INTEGER, INTENT(in), OPTIONAL                      :: n_rows, n_cols
-      REAL(KIND=dp), INTENT(in), OPTIONAL                :: alpha
+      CHARACTER, INTENT(IN), OPTIONAL                    :: side
+      LOGICAL, INTENT(IN), OPTIONAL                      :: transpose_tr, invert_tr
+      CHARACTER, INTENT(IN), OPTIONAL                    :: uplo_tr
+      LOGICAL, INTENT(IN), OPTIONAL                      :: unit_diag_tr
+      INTEGER, INTENT(IN), OPTIONAL                      :: n_rows, n_cols
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: alpha
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_triangular_multiply'
 
@@ -1236,10 +1237,10 @@ CONTAINS
 !> \param matrix ...
 !> \param matrixt ...
 !> \note
-!>      all matrix elements are transposed (see cp_fm_upper_to_half to symmetrise a matrix)
+!>      all matrix elements are transposed (see cp_fm_uplo_to_full to symmetrise a matrix)
 ! **************************************************************************************************
    SUBROUTINE cp_fm_transpose(matrix, matrixt)
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix, matrixt
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix, matrixt
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_transpose'
 
@@ -1280,24 +1281,27 @@ CONTAINS
    END SUBROUTINE cp_fm_transpose
 
 ! **************************************************************************************************
-!> \brief given an upper triangular matrix computes the corresponding full matrix
-!> \param matrix the upper triangular matrix as input, the full matrix as output
+!> \brief given a triangular matrix according to uplo, computes the corresponding full matrix
+!> \param matrix the triangular matrix as input, the full matrix as output
 !> \param work a matrix of the same size as matrix
+!> \param uplo triangular format; defaults to 'U'
 !> \author Matthias Krack
 !> \note
-!>       the lower triangular part is irrelevant
+!>       the opposite triangular part is irrelevant
 ! **************************************************************************************************
-   SUBROUTINE cp_fm_upper_to_full(matrix, work)
+   SUBROUTINE cp_fm_uplo_to_full(matrix, work, uplo)
 
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix, work
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix, work
+      CHARACTER, INTENT(IN), OPTIONAL          :: uplo
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_upper_to_full'
+      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_uplo_to_full'
 
+      CHARACTER                                :: myuplo
       INTEGER                                  :: handle, icol_global, irow_global, &
                                                   mypcol, myprow, ncol_global, &
                                                   npcol, nprow, nrow_global
-      REAL(KIND=dp), DIMENSION(:, :), POINTER   :: a
-      REAL(KIND=sp), DIMENSION(:, :), POINTER   :: a_sp
+      REAL(KIND=dp), DIMENSION(:, :), POINTER  :: a
+      REAL(KIND=sp), DIMENSION(:, :), POINTER  :: a_sp
       TYPE(cp_blacs_env_type), POINTER         :: context
 
 #if defined(__parallel)
@@ -1305,9 +1309,12 @@ CONTAINS
                                                   ncol_block, ncol_local, &
                                                   nrow_block, nrow_local
       INTEGER, DIMENSION(9)                    :: desca, descc
-      REAL(KIND=dp), DIMENSION(:, :), POINTER   :: c
-      REAL(KIND=sp), DIMENSION(:, :), POINTER   :: c_sp
+      REAL(KIND=dp), DIMENSION(:, :), POINTER  :: c
+      REAL(KIND=sp), DIMENSION(:, :), POINTER  :: c_sp
 #endif
+
+      myuplo = 'U'
+      IF (PRESENT(uplo)) myuplo = uplo
 
       nrow_global = matrix%matrix_struct%nrow_global
       ncol_global = matrix%matrix_struct%ncol_global
@@ -1344,7 +1351,7 @@ CONTAINS
          icol_global = matrix%matrix_struct%col_indices(icol_local)
          DO irow_local = 1, nrow_local
             irow_global = matrix%matrix_struct%row_indices(irow_local)
-            IF (irow_global > icol_global) THEN
+            IF (MERGE(irow_global > icol_global, irow_global < icol_global, (myuplo == "U") .OR. (myuplo == "u"))) THEN
                IF (matrix%use_sp) THEN
                   c_sp(irow_local, icol_local) = 0.0_sp
                ELSE
@@ -1380,7 +1387,9 @@ CONTAINS
 
       a => matrix%local_data
       a_sp => matrix%local_data_sp
-      DO irow_global = 1, nrow_global
+
+      IF ((myuplo == "U") .OR. (myuplo == "u")) THEN
+         DO irow_global = 1, nrow_global
          DO icol_global = irow_global + 1, ncol_global
             IF (matrix%use_sp) THEN
                a_sp(icol_global, irow_global) = a_sp(irow_global, icol_global)
@@ -1388,12 +1397,23 @@ CONTAINS
                a(icol_global, irow_global) = a(irow_global, icol_global)
             END IF
          END DO
-      END DO
+         END DO
+      ELSE
+         DO icol_global = 1, ncol_global
+         DO irow_global = icol_global + 1, nrow_global
+            IF (matrix%use_sp) THEN
+               a_sp(irow_global, icol_global) = a_sp(icol_global, irow_global)
+            ELSE
+               a(irow_global, icol_global) = a(icol_global, irow_global)
+            END IF
+         END DO
+         END DO
+      END IF
 
 #endif
       CALL timestop(handle)
 
-   END SUBROUTINE cp_fm_upper_to_full
+   END SUBROUTINE cp_fm_uplo_to_full
 
 ! **************************************************************************************************
 !> \brief scales column i of matrix a with scaling(i)
@@ -1408,8 +1428,8 @@ CONTAINS
 !>      where every vector has a different prefactor
 ! **************************************************************************************************
    SUBROUTINE cp_fm_column_scale(matrixa, scaling)
-      TYPE(cp_fm_type), INTENT(IN)          :: matrixa
-      REAL(KIND=dp), DIMENSION(:), INTENT(in)  :: scaling
+      TYPE(cp_fm_type), INTENT(IN)             :: matrixa
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)  :: scaling
 
       INTEGER                                  :: k, mypcol, myprow, n, ncol_global, &
                                                   npcol, nprow
@@ -1471,8 +1491,8 @@ CONTAINS
 !> \note
 ! **************************************************************************************************
    SUBROUTINE cp_fm_row_scale(matrixa, scaling)
-      TYPE(cp_fm_type), INTENT(IN)          :: matrixa
-      REAL(KIND=dp), DIMENSION(:), INTENT(in)  :: scaling
+      TYPE(cp_fm_type), INTENT(IN)             :: matrixa
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)  :: scaling
 
       INTEGER                                  :: n, m, nrow_global, nrow_local, ncol_local
       INTEGER, DIMENSION(:), POINTER           :: row_indices
@@ -1524,6 +1544,7 @@ CONTAINS
       END IF
 #endif
    END SUBROUTINE cp_fm_row_scale
+
 ! **************************************************************************************************
 !> \brief Inverts a cp_fm_type matrix, optionally returning the determinant of the input matrix
 !> \param matrix_a the matrix to invert
@@ -1542,7 +1563,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_invert(matrix_a, matrix_inverse, det_a, eps_svd, eigval)
 
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix_a, matrix_inverse
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_a, matrix_inverse
       REAL(KIND=dp), INTENT(OUT), OPTIONAL     :: det_a
       REAL(KIND=dp), INTENT(IN), OPTIONAL      :: eps_svd
       REAL(KIND=dp), DIMENSION(:), POINTER, &
@@ -1552,10 +1573,10 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)       :: ipivot
       REAL(KIND=dp)                            :: determinant, my_eps_svd
       REAL(KIND=dp), DIMENSION(:, :), POINTER  :: a
-      TYPE(cp_fm_type)                :: matrix_lu
+      TYPE(cp_fm_type)                         :: matrix_lu
 
 #if defined(__parallel)
-      TYPE(cp_fm_type)                :: u, vt, sigma, inv_sigma_ut
+      TYPE(cp_fm_type)                         :: u, vt, sigma, inv_sigma_ut
       TYPE(mp_comm_type) :: group
       INTEGER                                  :: i, info, liwork, lwork, exponent_of_minus_one
       INTEGER, DIMENSION(9)                    :: desca
@@ -1715,12 +1736,12 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief inverts a triangular matrix
 !> \param matrix_a ...
-!> \param uplo_tr ...
+!> \param uplo_tr triangular format; defaults to 'U'
 !> \author MI
 ! **************************************************************************************************
    SUBROUTINE cp_fm_triangular_invert(matrix_a, uplo_tr)
 
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix_a
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_a
       CHARACTER, INTENT(IN), OPTIONAL          :: uplo_tr
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_triangular_invert'
@@ -1743,7 +1764,6 @@ CONTAINS
       a => matrix_a%local_data
 
 #if defined(__parallel)
-
       desca(:) = matrix_a%matrix_struct%descriptor(:)
 
       CALL pdtrtri(uplo, unit_diag, ncol_global, a(1, 1), 1, 1, desca, info)
@@ -1757,7 +1777,7 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief  performs a QR factorization of the input rectangular matrix A or of a submatrix of A
-!>         the computed upper triangular matrix R is in output in the submatrix sub(A) of size NxN
+!>         the computed triangular matrix R is in output of the submatrix sub(A) of size NxN
 !>         M and M give the dimension of the submatrix that has to be factorized (MxN) with M>N
 !> \param matrix_a ...
 !> \param matrix_r ...
@@ -1767,13 +1787,15 @@ CONTAINS
 !> \param first_col ...
 !> \author MI
 ! **************************************************************************************************
-   SUBROUTINE cp_fm_qr_factorization(matrix_a, matrix_r, nrow_fact, ncol_fact, first_row, first_col)
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix_a, matrix_r
+   SUBROUTINE cp_fm_qr_factorization(matrix_a, matrix_r, nrow_fact, ncol_fact, first_row, first_col, uplo)
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_a, matrix_r
       INTEGER, INTENT(IN), OPTIONAL            :: nrow_fact, ncol_fact, &
                                                   first_row, first_col
+      CHARACTER, INTENT(IN), OPTIONAL          :: uplo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_qr_factorization'
 
+      CHARACTER                                :: myuplo
       INTEGER                                  :: handle, i, icol, info, irow, &
                                                   j, lda, lwork, ncol, &
                                                   ndim, nrow
@@ -1785,6 +1807,9 @@ CONTAINS
 #endif
 
       CALL timeset(routineN, handle)
+
+      myuplo = 'U'
+      IF (PRESENT(uplo)) myuplo = uplo
 
       ncol = matrix_a%matrix_struct%ncol_global
       nrow = matrix_a%matrix_struct%nrow_global
@@ -1801,7 +1826,6 @@ CONTAINS
 
       CPASSERT(nrow >= ncol)
       ndim = SIZE(a, 2)
-!    ALLOCATE(ipiv(ndim))
       ALLOCATE (tau(ndim))
 
 #if defined(__parallel)
@@ -1829,11 +1853,19 @@ CONTAINS
 
       ALLOCATE (r_mat(ncol, ncol))
       CALL cp_fm_get_submatrix(matrix_a, r_mat, 1, 1, ncol, ncol)
-      DO i = 1, ncol
+      IF ((myuplo == "U") .OR. (myuplo == "u")) THEN
+         DO i = 1, ncol
          DO j = i + 1, ncol
             r_mat(j, i) = 0.0_dp
          END DO
-      END DO
+         END DO
+      ELSE
+         DO j = 1, ncol
+         DO i = j + 1, ncol
+            r_mat(i, j) = 0.0_dp
+         END DO
+         END DO
+      END IF
       CALL cp_fm_set_submatrix(matrix_r, r_mat, 1, 1, ncol, ncol)
 
       DEALLOCATE (tau, work, r_mat)
@@ -1844,13 +1876,12 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief computes the the solution to A*b=A_general using lu decomposition
-!>        pay attention, both matrices are overwritten, a_general contais the result
-!> \param matrix_a ...
-!> \param general_a ...
+!> \param matrix_a input matrix; will be overwritten
+!> \param general_a contains the result
 !> \author Florian Schiffmann
 ! **************************************************************************************************
    SUBROUTINE cp_fm_solve(matrix_a, general_a)
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix_a, general_a
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix_a, general_a
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_solve'
 
@@ -1978,7 +2009,7 @@ CONTAINS
 !> \author Lianheng Tong
 ! **************************************************************************************************
    SUBROUTINE cp_fm_lu_invert(matrix, info_out)
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix
       INTEGER, INTENT(OUT), OPTIONAL           :: info_out
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_lu_invert'
@@ -2251,7 +2282,7 @@ CONTAINS
 !> \brief compute a QR factorization with column pivoting of a M-by-N distributed matrix
 !>        sub( A ) = A(IA:IA+M-1,JA:JA+N-1)
 !> \param matrix   : input M-by-N distributed matrix sub( A ) which is to be factored
-!> \param tau      :  scalar factors TAU of the elementary reflectors. TAU is tied to the distributed matrix A
+!> \param tau      : scalar factors TAU of the elementary reflectors. TAU is tied to the distributed matrix A
 !> \param nrow ...
 !> \param ncol ...
 !> \param first_row ...
@@ -2610,11 +2641,14 @@ CONTAINS
 !> \brief Cholesky decomposition
 !> \param fm_matrix ...
 !> \param n ...
+!> \param uplo triangular format; defaults to 'U'
 ! **************************************************************************************************
-   SUBROUTINE cp_fm_potrf(fm_matrix, n)
+   SUBROUTINE cp_fm_potrf(fm_matrix, n, uplo)
       TYPE(cp_fm_type)                         :: fm_matrix
-      INTEGER, INTENT(in)                      :: n
+      INTEGER, INTENT(IN)                      :: n
+      CHARACTER, INTENT(IN), OPTIONAL          :: uplo
 
+      CHARACTER                                :: myuplo
       INTEGER                                  :: info
       REAL(KIND=dp), DIMENSION(:, :), POINTER  :: a
       REAL(KIND=sp), DIMENSION(:, :), POINTER  :: a_sp
@@ -2622,57 +2656,66 @@ CONTAINS
       INTEGER, DIMENSION(9)                    :: desca
 #endif
 
+      myuplo = 'U'
+      IF (PRESENT(uplo)) myuplo = uplo
+
       a => fm_matrix%local_data
       a_sp => fm_matrix%local_data_sp
 #if defined(__parallel)
       desca(:) = fm_matrix%matrix_struct%descriptor(:)
       IF (fm_matrix%use_sp) THEN
-         CALL pspotrf('U', n, a_sp(1, 1), 1, 1, desca, info)
+         CALL pspotrf(myuplo, n, a_sp(1, 1), 1, 1, desca, info)
       ELSE
-         CALL pdpotrf('U', n, a(1, 1), 1, 1, desca, info)
+         CALL pdpotrf(myuplo, n, a(1, 1), 1, 1, desca, info)
       END IF
 #else
       IF (fm_matrix%use_sp) THEN
-         CALL spotrf('U', n, a_sp(1, 1), SIZE(a_sp, 1), info)
+         CALL spotrf(myuplo, n, a_sp(1, 1), SIZE(a_sp, 1), info)
       ELSE
-         CALL dpotrf('U', n, a(1, 1), SIZE(a, 1), info)
+         CALL dpotrf(myuplo, n, a(1, 1), SIZE(a, 1), info)
       END IF
 #endif
       IF (info /= 0) &
-         CPABORT("Cholesky decomposition failed. Matrix ill conditioned ?")
+         CPABORT("Cholesky decomposition failed. Matrix ill-conditioned?")
 
    END SUBROUTINE cp_fm_potrf
 
 ! **************************************************************************************************
 !> \brief Invert trianguar matrix
-!> \param fm_matrix the matrix to invert (must be an upper triangular matrix)
+!> \param fm_matrix the matrix to invert (triangular matrix according to uplo)
 !> \param n size of the matrix to invert
+!> \param uplo triangular format; defaults to 'U'
 ! **************************************************************************************************
-   SUBROUTINE cp_fm_potri(fm_matrix, n)
-      TYPE(cp_fm_type)                          :: fm_matrix
-      INTEGER, INTENT(in)                       :: n
+   SUBROUTINE cp_fm_potri(fm_matrix, n, uplo)
+      TYPE(cp_fm_type)                         :: fm_matrix
+      INTEGER, INTENT(IN)                      :: n
+      CHARACTER, INTENT(IN), OPTIONAL          :: uplo
 
-      REAL(KIND=dp), DIMENSION(:, :), POINTER   :: a
-      REAL(KIND=sp), DIMENSION(:, :), POINTER   :: a_sp
-      INTEGER                                   :: info
+      CHARACTER                                :: myuplo
+      REAL(KIND=dp), DIMENSION(:, :), POINTER  :: a
+      REAL(KIND=sp), DIMENSION(:, :), POINTER  :: a_sp
+      INTEGER                                  :: info
 #if defined(__parallel)
-      INTEGER, DIMENSION(9)                     :: desca
+      INTEGER, DIMENSION(9)                    :: desca
 #endif
+
+      myuplo = 'U'
+      IF (PRESENT(uplo)) myuplo = uplo
 
       a => fm_matrix%local_data
       a_sp => fm_matrix%local_data_sp
 #if defined(__parallel)
       desca(:) = fm_matrix%matrix_struct%descriptor(:)
       IF (fm_matrix%use_sp) THEN
-         CALL pspotri('U', n, a_sp(1, 1), 1, 1, desca, info)
+         CALL pspotri(myuplo, n, a_sp(1, 1), 1, 1, desca, info)
       ELSE
-         CALL pdpotri('U', n, a(1, 1), 1, 1, desca, info)
+         CALL pdpotri(myuplo, n, a(1, 1), 1, 1, desca, info)
       END IF
 #else
       IF (fm_matrix%use_sp) THEN
-         CALL spotri('U', n, a_sp(1, 1), SIZE(a_sp, 1), info)
+         CALL spotri(myuplo, n, a_sp(1, 1), SIZE(a_sp, 1), info)
       ELSE
-         CALL dpotri('U', n, a(1, 1), SIZE(a, 1), info)
+         CALL dpotri(myuplo, n, a(1, 1), SIZE(a, 1), info)
       END IF
 #endif
       CPASSERT(info == 0)

--- a/src/fm/cp_fm_cholesky.F
+++ b/src/fm/cp_fm_cholesky.F
@@ -47,7 +47,7 @@ CONTAINS
 !> \author Joost
 ! **************************************************************************************************
    SUBROUTINE cp_fm_cholesky_decompose(matrix, n, info_out)
-      TYPE(cp_fm_type), INTENT(IN)          :: matrix
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix
       INTEGER, INTENT(in), OPTIONAL            :: n
       INTEGER, INTENT(out), OPTIONAL           :: info_out
 

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -24,7 +24,7 @@ MODULE cp_fm_diag
                                  cp_fm_syrk, &
                                  cp_fm_triangular_invert, &
                                  cp_fm_triangular_multiply, &
-                                 cp_fm_upper_to_full
+                                 cp_fm_uplo_to_full
    USE cp_fm_cholesky, ONLY: cp_fm_cholesky_decompose
    USE cp_fm_diag_utils, ONLY: cp_fm_redistribute_end, &
                                cp_fm_redistribute_start
@@ -432,7 +432,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_syevd(matrix, eigenvectors, eigenvalues, info)
 
-      TYPE(cp_fm_type), INTENT(IN)  :: matrix, eigenvectors
+      TYPE(cp_fm_type), INTENT(IN)             :: matrix, eigenvectors
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT) :: eigenvalues
       INTEGER, INTENT(OUT), OPTIONAL           :: info
 
@@ -1167,7 +1167,7 @@ CONTAINS
 
 #endif
       CALL cp_fm_syrk("U", "N", ncol_global, 1.0_dp, work, 1, 1, 0.0_dp, matrix)
-      CALL cp_fm_upper_to_full(matrix, work)
+      CALL cp_fm_uplo_to_full(matrix, work)
 
       ! Print some warnings/notes
       IF (matrix%matrix_struct%para_env%is_source() .AND. my_verbose) THEN

--- a/src/fm/cp_fm_dlaf_api.F
+++ b/src/fm/cp_fm_dlaf_api.F
@@ -7,7 +7,7 @@
 
 MODULE cp_fm_dlaf_api
 
-   USE cp_fm_basic_linalg, ONLY: cp_fm_upper_to_full
+   USE cp_fm_basic_linalg, ONLY: cp_fm_uplo_to_full
    USE cp_fm_types, ONLY: cp_fm_type
    USE kinds, ONLY: dp
 #include "../base/base_uses.f90"
@@ -174,7 +174,7 @@ CONTAINS
 #if defined(__DLAF)
       ! DLAF needs the lower triangular part
       ! Use eigenvectors matrix as workspace
-      CALL cp_fm_upper_to_full(matrix, eigenvectors)
+      CALL cp_fm_uplo_to_full(matrix, eigenvectors)
 
       n = matrix%matrix_struct%nrow_global
 
@@ -281,8 +281,8 @@ CONTAINS
 #if defined(__DLAF)
       ! DLAF needs the lower triangular part
       ! Use eigenvectors matrix as workspace
-      CALL cp_fm_upper_to_full(a_matrix, eigenvectors)
-      CALL cp_fm_upper_to_full(b_matrix, eigenvectors)
+      CALL cp_fm_uplo_to_full(a_matrix, eigenvectors)
+      CALL cp_fm_uplo_to_full(b_matrix, eigenvectors)
 
       n = a_matrix%matrix_struct%nrow_global
 

--- a/src/fm/cp_fm_elpa.F
+++ b/src/fm/cp_fm_elpa.F
@@ -18,7 +18,7 @@ MODULE cp_fm_elpa
                       MACHINE_X86_AVX, &
                       MACHINE_X86_AVX2
    USE cp_blacs_env, ONLY: cp_blacs_env_type
-   USE cp_fm_basic_linalg, ONLY: cp_fm_upper_to_full
+   USE cp_fm_basic_linalg, ONLY: cp_fm_uplo_to_full
    USE cp_fm_diag_utils, ONLY: cp_fm_redistribute_start, &
                                cp_fm_redistribute_end, &
                                cp_fm_redistribute_info
@@ -363,7 +363,7 @@ CONTAINS
       mypcol = context%mepos(2)
 
       ! elpa needs the full matrix
-      CALL cp_fm_upper_to_full(matrix, eigenvectors)
+      CALL cp_fm_uplo_to_full(matrix, eigenvectors)
 
       CALL cp_fm_struct_get(matrix%matrix_struct, &
                             local_leading_dimension=n_rows, &
@@ -403,7 +403,7 @@ CONTAINS
          CALL cp_fm_create(matrix=matrix_noqr, matrix_struct=matrix%matrix_struct)
          CALL cp_fm_to_fm(matrix, matrix_noqr)
          CALL cp_fm_create(matrix=eigenvectors_noqr, matrix_struct=eigenvectors%matrix_struct)
-         CALL cp_fm_upper_to_full(matrix_noqr, eigenvectors_noqr)
+         CALL cp_fm_uplo_to_full(matrix_noqr, eigenvectors_noqr)
       END IF
 
       IF (io_unit > 0 .AND. elpa_should_print) THEN

--- a/src/fm/cp_fm_types.F
+++ b/src/fm/cp_fm_types.F
@@ -42,7 +42,7 @@ MODULE cp_fm_types
    LOGICAL, PARAMETER          :: debug_this_module = .TRUE.
    INTEGER, PARAMETER :: src_tag = 3, dest_tag = 5, send_tag = 7, recv_tag = 11
 
-   INTEGER, PRIVATE :: mm_type = 1
+   INTEGER, PRIVATE :: cp_fm_mm_type = 1
 
    PUBLIC :: cp_fm_type, &
              cp_fm_p_type, copy_info_type
@@ -163,10 +163,10 @@ CONTAINS
    SUBROUTINE cp_fm_create(matrix, matrix_struct, name, use_sp)
       TYPE(cp_fm_type), INTENT(OUT)                      :: matrix
       TYPE(cp_fm_struct_type), INTENT(IN), TARGET        :: matrix_struct
-      CHARACTER(len=*), INTENT(in), OPTIONAL             :: name
+      CHARACTER(LEN=*), INTENT(in), OPTIONAL             :: name
       LOGICAL, INTENT(in), OPTIONAL                      :: use_sp
 
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_create'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'cp_fm_create'
 
       INTEGER                                            :: handle, ncol_local, npcol, nprow, &
                                                             nrow_local
@@ -445,7 +445,7 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       INTEGER, INTENT(IN), OPTIONAL                      :: ncol, start_col
 
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_init_random'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'cp_fm_init_random'
 
       INTEGER :: handle, icol_global, icol_local, irow_local, my_ncol, my_start_col, ncol_global, &
          ncol_local, nrow_global, nrow_local
@@ -530,7 +530,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: alpha
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: beta
 
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_set_all'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'cp_fm_set_all'
 
       INTEGER                                            :: handle, i, n
 
@@ -896,7 +896,7 @@ CONTAINS
       INTEGER, INTENT(in), OPTIONAL                      :: start_row, start_col, n_rows, n_cols
       LOGICAL, INTENT(in), OPTIONAL                      :: transpose
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_get_submatrix'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_get_submatrix'
 
       INTEGER                                            :: handle, i, i0, j, j0, ncol, ncol_global, &
                                                             ncol_local, nrow, nrow_global, &
@@ -1058,7 +1058,7 @@ CONTAINS
       REAL(KIND=dp), INTENT(OUT)                         :: a_max
       INTEGER, INTENT(OUT), OPTIONAL                     :: ir_max, ic_max
 
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_maxabsval'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'cp_fm_maxabsval'
 
       INTEGER                                            :: handle, i, ic_max_local, ir_max_local, &
                                                             j, mepos, ncol_local, nrow_local, &
@@ -1159,7 +1159,7 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       REAL(KIND=dp), INTENT(OUT)                         :: a_max
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_maxabsrownorm'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_maxabsrownorm'
 
       INTEGER                                            :: handle, i, j, ncol_local, nrow_global, &
                                                             nrow_local
@@ -1200,7 +1200,7 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: norm_array
 
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_vectorsnorm'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'cp_fm_vectorsnorm'
 
       INTEGER                                            :: handle, i, j, ncol_global, ncol_local, &
                                                             nrow_local
@@ -1246,7 +1246,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: sum_array
       CHARACTER(LEN=1), INTENT(IN), OPTIONAL             :: dir
 
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_fm_vectorssum'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'cp_fm_vectorssum'
 
       INTEGER                                            :: handle, i, j, ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
@@ -1421,11 +1421,12 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE cp_fm_to_fm_triangular(msource, mtarget, uplo)
 
-      TYPE(cp_fm_type), INTENT(IN)          :: msource, mtarget
-      CHARACTER(LEN=*), INTENT(IN)             :: uplo
+      TYPE(cp_fm_type), INTENT(IN)             :: msource, mtarget
+      CHARACTER(LEN=1), OPTIONAL, INTENT(IN)   :: uplo
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_to_fm_triangular'
 
+      CHARACTER(LEN=1)                         :: myuplo
       INTEGER                                  :: handle, ncol, nrow
       REAL(KIND=dp), DIMENSION(:, :), POINTER  :: a, b
 #if defined(__parallel)
@@ -1433,6 +1434,9 @@ CONTAINS
 #endif
 
       CALL timeset(routineN, handle)
+
+      myuplo = 'U'
+      IF (PRESENT(uplo)) myuplo = uplo
 
       nrow = msource%matrix_struct%nrow_global
       ncol = msource%matrix_struct%ncol_global
@@ -1443,9 +1447,9 @@ CONTAINS
 #if defined(__parallel)
       desca(:) = msource%matrix_struct%descriptor(:)
       descb(:) = mtarget%matrix_struct%descriptor(:)
-      CALL pdlacpy(uplo, nrow, ncol, a(1, 1), 1, 1, desca, b(1, 1), 1, 1, descb)
+      CALL pdlacpy(myuplo, nrow, ncol, a(1, 1), 1, 1, desca, b(1, 1), 1, 1, descb)
 #else
-      CALL dlacpy(uplo, nrow, ncol, a(1, 1), nrow, b(1, 1), nrow)
+      CALL dlacpy(myuplo, nrow, ncol, a(1, 1), nrow, b(1, 1), nrow)
 #endif
 
       CALL timestop(handle)
@@ -2142,7 +2146,7 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)             :: fm
       INTEGER, INTENT(IN)                      :: unit
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_write_unformatted'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_write_unformatted'
 
       INTEGER                                  :: handle, j, max_block, &
                                                   ncol_global, nrow_global
@@ -2247,7 +2251,7 @@ CONTAINS
       INTEGER, INTENT(IN)                      :: unit
       CHARACTER(LEN=*), INTENT(IN), OPTIONAL   :: header, value_format
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_write_formatted'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_write_formatted'
 
       CHARACTER(LEN=21)                        :: my_value_format
       INTEGER                                  :: handle, i, j, max_block, &
@@ -2373,7 +2377,7 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(INOUT)          :: fm
       INTEGER, INTENT(IN)                      :: unit
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'cp_fm_read_unformatted'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'cp_fm_read_unformatted'
 
       INTEGER                                  :: handle, j, max_block, &
                                                   ncol_global, nrow_global
@@ -2423,12 +2427,12 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param mult_type ...
+!> \param mm_type ...
 ! **************************************************************************************************
-   SUBROUTINE cp_fm_setup(mult_type)
-      INTEGER, INTENT(IN)                                :: mult_type
+   SUBROUTINE cp_fm_setup(mm_type)
+      INTEGER, INTENT(IN)                                :: mm_type
 
-      mm_type = mult_type
+      cp_fm_mm_type = mm_type
    END SUBROUTINE cp_fm_setup
 
 ! **************************************************************************************************
@@ -2438,7 +2442,7 @@ CONTAINS
    FUNCTION cp_fm_get_mm_type() RESULT(res)
       INTEGER                                            :: res
 
-      res = mm_type
+      res = cp_fm_mm_type
    END FUNCTION
 
 ! **************************************************************************************************

--- a/src/gw_large_cell_gamma.F
+++ b/src/gw_large_cell_gamma.F
@@ -16,7 +16,7 @@ MODULE gw_large_cell_gamma
                                               get_cell,&
                                               pbc
    USE constants_operator,              ONLY: operator_coulomb
-   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_upper_to_full
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_uplo_to_full
    USE cp_cfm_cholesky,                 ONLY: cp_cfm_cholesky_decompose,&
                                               cp_cfm_cholesky_invert
    USE cp_cfm_diag,                     ONLY: cp_cfm_geeig
@@ -894,7 +894,7 @@ CONTAINS
          ! successful Cholesky decomposition
          CALL cp_cfm_cholesky_invert(cfm_M_inv_ikp)
          ! symmetrize the result
-         CALL cp_cfm_upper_to_full(cfm_M_inv_ikp)
+         CALL cp_cfm_uplo_to_full(cfm_M_inv_ikp)
       ELSE
          ! Cholesky decomposition not successful: use expensive diagonalization
          CALL cp_cfm_power(cfm_work, threshold=bs_env%eps_eigval_mat_RI, exponent=-1.0_dp)
@@ -1434,7 +1434,7 @@ CONTAINS
 
       ! 2. b) Inversion of ε(iω_j,k) using its Cholesky decomposition
       CALL cp_cfm_cholesky_invert(cfm_eps_ikp_freq_j)
-      CALL cp_cfm_upper_to_full(cfm_eps_ikp_freq_j)
+      CALL cp_cfm_uplo_to_full(cfm_eps_ikp_freq_j)
 
       ! 2. c) ε^-1(iω_j,k)-Id
       CALL cfm_add_on_diag(cfm_eps_ikp_freq_j, -z_one)

--- a/src/gw_utils.F
+++ b/src/gw_utils.F
@@ -3010,7 +3010,7 @@ CONTAINS
       lrwork = -1
       liwork = -1
 
-      CALL ZHEEVD('V', 'U', n, A(1, 1), n, eigenvalues(1), &
+      CALL zheevd('V', 'U', n, A(1, 1), n, eigenvalues(1), &
                   work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
       lwork = INT(REAL(work(1), dp))
       lrwork = INT(REAL(rwork(1), dp))
@@ -3024,7 +3024,7 @@ CONTAINS
       ALLOCATE (work(lwork))
       work(:) = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
 
-      CALL ZHEEVD('V', 'U', n, A(1, 1), n, eigenvalues(1), &
+      CALL zheevd('V', 'U', n, A(1, 1), n, eigenvalues(1), &
                   work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
 
       eigenvectors(:, :) = A(:, :)

--- a/src/hfx_communication.F
+++ b/src/hfx_communication.F
@@ -103,7 +103,7 @@ CONTAINS
       CALL dbcsr_iterator_start(iter, rho, shared=.FALSE.)
       DO WHILE (dbcsr_iterator_blocks_left(iter))
          CALL dbcsr_iterator_next_block(iter, iatom, jatom, sparse_block, blk)
-         ! the resulting vector will eb only the upper triangle.
+         ! the resulting vector will be only the upper triangle.
          ! in case of antisymmetry take care to change signs if a lower block gets copied
          symmfac = 1.0_dp
          IF (antisymmetric .AND. iatom > jatom) symmfac = -1.0_dp

--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -234,7 +234,7 @@ CONTAINS
          CASE (hfx_ri_do_2c_cholesky)
             CALL dbcsr_copy(t_2c_op_RI_inv(1), t_2c_op_RI(1))
             CALL cp_dbcsr_cholesky_decompose(t_2c_op_RI_inv(1), para_env=para_env, blacs_env=blacs_env)
-            CALL cp_dbcsr_cholesky_invert(t_2c_op_RI_inv(1), para_env=para_env, blacs_env=blacs_env, upper_to_full=.TRUE.)
+            CALL cp_dbcsr_cholesky_invert(t_2c_op_RI_inv(1), para_env=para_env, blacs_env=blacs_env, uplo_to_full=.TRUE.)
          CASE (hfx_ri_do_2c_diag)
             CALL dbcsr_copy(t_2c_op_RI_inv(1), t_2c_op_RI(1))
             CALL cp_dbcsr_power(t_2c_op_RI_inv(1), -1.0_dp, ri_data%eps_eigval, n_dependent, &
@@ -818,7 +818,7 @@ CONTAINS
       CASE (hfx_ri_do_2c_cholesky)
          CALL dbcsr_copy(t_2c_int_mat(1), t_2c_op_RI(1))
          CALL cp_dbcsr_cholesky_decompose(t_2c_int_mat(1), para_env=para_env, blacs_env=blacs_env)
-         CALL cp_dbcsr_cholesky_invert(t_2c_int_mat(1), para_env=para_env, blacs_env=blacs_env, upper_to_full=.TRUE.)
+         CALL cp_dbcsr_cholesky_invert(t_2c_int_mat(1), para_env=para_env, blacs_env=blacs_env, uplo_to_full=.TRUE.)
       CASE (hfx_ri_do_2c_diag)
          CALL dbcsr_copy(t_2c_int_mat(1), t_2c_op_RI(1))
          CALL cp_dbcsr_power(t_2c_int_mat(1), -1.0_dp, ri_data%eps_eigval, n_dependent, &
@@ -3853,7 +3853,7 @@ CONTAINS
       CASE (hfx_ri_do_2c_cholesky)
          CALL dbcsr_copy(ri_2c_inv, ri_2c_ints)
          CALL cp_dbcsr_cholesky_decompose(ri_2c_inv, para_env=para_env, blacs_env=blacs_env)
-         CALL cp_dbcsr_cholesky_invert(ri_2c_inv, para_env=para_env, blacs_env=blacs_env, upper_to_full=.TRUE.)
+         CALL cp_dbcsr_cholesky_invert(ri_2c_inv, para_env=para_env, blacs_env=blacs_env, uplo_to_full=.TRUE.)
       CASE (hfx_ri_do_2c_diag)
          CALL dbcsr_copy(ri_2c_inv, ri_2c_ints)
          CALL cp_dbcsr_power(ri_2c_inv, -1.0_dp, ri_data%eps_eigval, n_dependent, &

--- a/src/hfx_ri_kp.F
+++ b/src/hfx_ri_kp.F
@@ -2253,7 +2253,7 @@ CONTAINS
                CALL dbcsr_copy(work_tight_inv, work_tight)
                CALL cp_dbcsr_cholesky_decompose(work_tight_inv, para_env=para_env, blacs_env=blacs_env)
                CALL cp_dbcsr_cholesky_invert(work_tight_inv, para_env=para_env, blacs_env=blacs_env, &
-                                             upper_to_full=.TRUE.)
+                                             uplo_to_full=.TRUE.)
             CASE (hfx_ri_do_2c_diag)
                CALL dbcsr_copy(work_tight_inv, work_tight)
                CALL cp_dbcsr_power(work_tight_inv, -1.0_dp, ri_data%eps_eigval, n_dependent, &

--- a/src/lri_environment_methods.F
+++ b/src/lri_environment_methods.F
@@ -1040,7 +1040,7 @@ CONTAINS
             IF (LOG(1._dp/rcond) > lri_env%cond_max) THEN
                CALL get_pseudo_inverse_svd(s, sinv, rskip)
             ELSE
-               CALL invmat_symm(sinv, "U")
+               CALL invmat_symm(sinv, potrf=.FALSE.)
             END IF
          ELSE
             CALL get_pseudo_inverse_svd(s, sinv, rskip)

--- a/src/lri_optimize_ri_basis.F
+++ b/src/lri_optimize_ri_basis.F
@@ -882,12 +882,12 @@ CONTAINS
          work = 0.0_dp
          lwork = -1
          ! get lwork
-         CALL DSYTRD('U', nn, smat, nn, diag, off_diag, tau, work, lwork, info)
+         CALL dsytrd('U', nn, smat, nn, diag, off_diag, tau, work, lwork, info)
          lwork = INT(work(1))
          CALL reallocate(work, 1, lwork)
          ! get the eigenvalues
-         CALL DSYTRD('U', nn, smat, nn, diag, off_diag, tau, work, lwork, info)
-         CALL DSTERF(nn, diag, off_diag, info)
+         CALL dsytrd('U', nn, smat, nn, diag, off_diag, tau, work, lwork, info)
+         CALL dsterf(nn, diag, off_diag, info)
 
          lrii%cond_num = MAXVAL(ABS(diag))/MINVAL(ABS(diag))
 

--- a/src/motion/integrator.F
+++ b/src/motion/integrator.F
@@ -2346,7 +2346,7 @@ CONTAINS
          !
 
          CALL diagonalise(matrix=npt(:, :)%v, mysize=3, &
-                          storageform="UPPER", eigenvalues=tmp%e_val, eigenvectors=tmp%u)
+                          uplo="U", eigenvalues=tmp%e_val, eigenvectors=tmp%u)
 
          tmp%arg_r(:) = 0.5_dp*tmp%e_val(:)*dt* &
                         0.5_dp*tmp%e_val(:)*dt

--- a/src/motion/pint_piglet.F
+++ b/src/motion/pint_piglet.F
@@ -716,7 +716,7 @@ CONTAINS
       A(:, :) = SST(:, :)
 
       !first call to figure out how big work array needs to be
-      CALL DSYEV('V', & ! Compute eigenvalues and eigenvectors
+      CALL dsyev('V', & ! Compute eigenvalues and eigenvectors
                  'U', & ! Store upper triagonal matrix
                  n, & ! order of matrix A to calculate the eigenvalues/vectors from
                  A, & ! Matrix to calculate the eigenvalues/vectors from
@@ -730,7 +730,7 @@ CONTAINS
       ALLOCATE (work(lwork))
       work(:) = 0.0_dp
 
-      CALL DSYEV('V', & ! Compute eigenvalues and eigenvectors
+      CALL dsyev('V', & ! Compute eigenvalues and eigenvectors
                  'U', & ! Store upper triagonal matrix
                  n, & ! order of matrix A to calculate the eigenvalues/vectors from
                  A, & ! Matrix to calculate the eigenvalues/vectors from
@@ -753,7 +753,7 @@ CONTAINS
       tmpmatrix(:, :) = 0.0_dp
       ! Transform matrix back
       !tmpmatrix = A*S
-      CALL DGEMM('N', & ! A-matrix is not transposed
+      CALL dgemm('N', & ! A-matrix is not transposed
                  'N', & ! S-matrix is not transposed
                  n, & ! number of rows of A-matrix
                  n, & ! number of columns of S-matrix
@@ -767,7 +767,7 @@ CONTAINS
                  tmpmatrix, & ! result matrix: tmpmatrix
                  n) ! leading dimension of tmpmatrix
       !S = tmpmatrix*TRANSPOSE(A) = A*S*TRANSPOSE(A)
-      CALL DGEMM('N', & ! tmpmatrix not transposed
+      CALL dgemm('N', & ! tmpmatrix not transposed
                  'T', & ! A-matrix is transposed
                  n, & ! number of rows of tmpmatrix
                  n, & ! number of columns of A-matrix

--- a/src/mp2_cphf.F
+++ b/src/mp2_cphf.F
@@ -32,7 +32,7 @@ MODULE mp2_cphf
                                               cp_dbcsr_plus_fm_fm_t,&
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_upper_to_full
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_uplo_to_full
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_p_type,&
                                               cp_fm_struct_release,&
@@ -418,7 +418,7 @@ CONTAINS
          ! transpose P_MO matrix (easy way to symmetrize)
          CALL cp_fm_set_all(fm_back, 0.0_dp)
          ! P_mo now is ready
-         CALL cp_fm_upper_to_full(matrix=P_mo(ispin), work=fm_back)
+         CALL cp_fm_uplo_to_full(matrix=P_mo(ispin), work=fm_back)
       END DO
       CALL cp_fm_release(P_ia)
 
@@ -640,7 +640,7 @@ CONTAINS
          CALL cp_fm_set_all(fm_ao, 0.0_dp)
          CALL copy_dbcsr_to_fm(matrix=p_env%kpp1(ispin)%matrix, fm=fm_ao)
          CALL cp_fm_set_all(fm_back, 0.0_dp)
-         CALL cp_fm_upper_to_full(fm_ao, fm_back)
+         CALL cp_fm_uplo_to_full(fm_ao, fm_back)
 
          ASSOCIATE (mat_out => fm_mo_out(ispin))
 

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -1699,16 +1699,17 @@ CONTAINS
 
       CALL cp_fm_triangular_invert(matrix_a=fm_matrix_L, uplo_tr='U')
 
-      ! clean the lower part of the L^{-1} matrix (just to not have surprises afterwards)
+      ! clear the lower part of the L^{-1} matrix (just to have no surprises afterwards)
       CALL cp_fm_get_info(matrix=fm_matrix_L, &
                           nrow_local=nrow_local, &
                           ncol_local=ncol_local, &
                           row_indices=row_indices, &
                           col_indices=col_indices)
-      DO iiB = 1, nrow_local
-         i_global = row_indices(iiB)
-         DO jjB = 1, ncol_local
-            j_global = col_indices(jjB)
+      ! assume upper triangular format
+      DO jjB = 1, ncol_local
+         j_global = col_indices(jjB)
+         DO iiB = 1, nrow_local
+            i_global = row_indices(iiB)
             IF (j_global < i_global) fm_matrix_L%local_data(iiB, jjB) = 0.0_dp
          END DO
       END DO

--- a/src/optbas_fenv_manipulation.F
+++ b/src/optbas_fenv_manipulation.F
@@ -16,7 +16,7 @@ MODULE optbas_fenv_manipulation
                                               dbcsr_p_type,&
                                               dbcsr_type
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_upper_to_full
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_invert
    USE cp_fm_pool_types,                ONLY: cp_fm_pool_p_type
@@ -243,10 +243,10 @@ CONTAINS
       CALL cp_fm_create(matrix_s_inv, matrix_struct=fm_struct_tmp)
       CALL cp_fm_create(work1, matrix_struct=fm_struct_tmp)
       CALL copy_dbcsr_to_fm(matrix_s, matrix_s_inv)
-      CALL cp_fm_upper_to_full(matrix_s_inv, work1)
+      CALL cp_fm_uplo_to_full(matrix_s_inv, work1)
       CALL cp_fm_cholesky_decompose(matrix_s_inv)
       CALL cp_fm_cholesky_invert(matrix_s_inv)
-      CALL cp_fm_upper_to_full(matrix_s_inv, work1)
+      CALL cp_fm_uplo_to_full(matrix_s_inv, work1)
       CALL cp_fm_struct_release(fm_struct_tmp)
       CALL cp_fm_release(work1)
 

--- a/src/pao_ml_gaussprocess.F
+++ b/src/pao_ml_gaussprocess.F
@@ -100,7 +100,7 @@ CONTAINS
       ! calculate weights
       ALLOCATE (weights(npoints))
       weights(:) = cov(:)
-      CALL DPOTRS("U", npoints, 1, training_matrix%GP, npoints, weights, npoints, info)
+      CALL dpotrs("U", npoints, 1, training_matrix%GP, npoints, weights, npoints, info)
       CPASSERT(info == 0)
 
       ! calculate predicted output
@@ -150,7 +150,7 @@ CONTAINS
       ! calculate derivative of covariances
       ALLOCATE (cov_deriv(npoints))
       cov_deriv(:) = weights_deriv(:)
-      CALL DPOTRS("U", npoints, 1, training_matrix%GP, npoints, cov_deriv, npoints, info)
+      CALL dpotrs("U", npoints, 1, training_matrix%GP, npoints, cov_deriv, npoints, info)
       CPASSERT(info == 0)
 
       ! calculate derivative of kernel

--- a/src/pao_param_exp.F
+++ b/src/pao_param_exp.F
@@ -406,7 +406,7 @@ CONTAINS
       lrwork = -1
       liwork = -1
 
-      CALL ZHEEVD('V', 'U', n, A(1, 1), n, eigenvalues(1), &
+      CALL zheevd('V', 'U', n, A(1, 1), n, eigenvalues(1), &
                   work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
       lwork = INT(REAL(work(1), dp))
       lrwork = INT(REAL(rwork(1), dp))
@@ -420,7 +420,7 @@ CONTAINS
       ALLOCATE (work(lwork))
       work(:) = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
 
-      CALL ZHEEVD('V', 'U', n, A(1, 1), n, eigenvalues(1), &
+      CALL zheevd('V', 'U', n, A(1, 1), n, eigenvalues(1), &
                   work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
 
       eigenvectors = A

--- a/src/preconditioner_makes.F
+++ b/src/preconditioner_makes.F
@@ -30,7 +30,7 @@ MODULE preconditioner_makes
    USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
                                               cp_fm_triangular_invert,&
                                               cp_fm_triangular_multiply,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_reduce,&
                                               cp_fm_cholesky_restore
@@ -251,7 +251,7 @@ CONTAINS
       CASE (cholesky_inverse)
 ! if cho inverse
          CALL cp_fm_triangular_invert(fm_s)
-         CALL cp_fm_upper_to_full(fm_h, fm)
+         CALL cp_fm_uplo_to_full(fm_h, fm)
 
          CALL cp_fm_triangular_multiply(fm_s, fm_h, side="R", transpose_tr=.FALSE., &
                                         invert_tr=.FALSE., uplo_tr="U", n_rows=n, n_cols=n, alpha=1.0_dp)
@@ -465,7 +465,7 @@ CONTAINS
       preconditioner_env%energy_gap = MAX(energy_gap, error_estimate*fudge_factor)
       CALL copy_dbcsr_to_fm(matrix_h, matrix_tmp)
       matrix_pre => preconditioner_env%fm
-      CALL cp_fm_upper_to_full(matrix_tmp, matrix_pre)
+      CALL cp_fm_uplo_to_full(matrix_tmp, matrix_pre)
       ! tmp = H ( 1 - PS )
       CALL parallel_gemm('N', 'T', n, n, k, -1.0_dp, matrix_hc0, matrix_sc0, 1.0_dp, matrix_tmp)
 
@@ -617,7 +617,7 @@ CONTAINS
 
       matrix_pre => preconditioner_env%fm
       CALL copy_dbcsr_to_fm(matrix_h, matrix_tmp)
-      CALL cp_fm_upper_to_full(matrix_tmp, matrix_pre)
+      CALL cp_fm_uplo_to_full(matrix_tmp, matrix_pre)
       ! tmp = H ( 1 - PS )
       CALL parallel_gemm('N', 'T', n, n, k, -1.0_dp, matrix_hc0, matrix_sc0, 1.0_dp, matrix_tmp)
 

--- a/src/preconditioner_solvers.F
+++ b/src/preconditioner_solvers.F
@@ -26,7 +26,7 @@ MODULE preconditioner_solvers
         dbcsr_p_type, dbcsr_release, dbcsr_type, dbcsr_type_no_symmetry, dbcsr_type_real_8
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               copy_fm_to_dbcsr
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_upper_to_full
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_invert
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
@@ -157,7 +157,7 @@ CONTAINS
       END IF
       CALL cp_fm_cholesky_invert(fm)
 
-      CALL cp_fm_upper_to_full(fm, fm_work)
+      CALL cp_fm_uplo_to_full(fm, fm_work)
       CALL cp_fm_release(fm_work)
 
       CALL timestop(handle)

--- a/src/qmmm_image_charge.F
+++ b/src/qmmm_image_charge.F
@@ -39,6 +39,7 @@ MODULE qmmm_image_charge
    USE kinds,                           ONLY: default_path_length,&
                                               dp
    USE mathconstants,                   ONLY: pi
+   USE mathlib,                         ONLY: invmat_symm
    USE memory_utilities,                ONLY: reallocate
    USE message_passing,                 ONLY: mp_para_env_type
    USE pw_env_types,                    ONLY: pw_env_get,&
@@ -182,8 +183,8 @@ CONTAINS
       pot_const(:) = -pot_const(:) + V0*SQRT((pi/eta)**3)
 
       !solve linear system of equations T*coeff=-pot_const
-      !LU factorization of T  by DGETRF done in calculate_image_matrix
-      CALL DGETRS('N', natom, 1, qs_env%image_matrix, natom, qs_env%ipiv, &
+      !LU factorization of T by DGETRF done in calculate_image_matrix
+      CALL dgetrs('N', natom, 1, qs_env%image_matrix, natom, qs_env%ipiv, &
                   pot_const, natom, info)
       CPASSERT(info == 0)
 
@@ -616,7 +617,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_image_matrix'
 
-      INTEGER                                            :: handle, j, k, natom, output_unit, stat
+      INTEGER                                            :: handle, natom, output_unit, stat
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(section_vals_type), POINTER                   :: input
 
@@ -664,20 +665,12 @@ CONTAINS
 
       IF (qmmm_env%image_charge_pot%coeff_iterative) THEN
          !inversion --> preconditioner matrix for CG
-         CALL DPOTRF('L', natom, qs_env%image_matrix, natom, stat)
-         CPASSERT(stat == 0)
-         CALL DPOTRI('L', natom, qs_env%image_matrix, natom, stat)
-         CPASSERT(stat == 0)
-         DO j = 1, natom
-            DO k = j + 1, natom
-               qs_env%image_matrix(j, k) = qs_env%image_matrix(k, j)
-            END DO
-         END DO
+         CALL invmat_symm(qs_env%image_matrix)
          CALL write_image_matrix(qs_env%image_matrix, qs_env)
       ELSE
          !pivoting prior to DGETRS (Gaussian elimination)
          IF (PRESENT(ipiv)) THEN
-            CALL DGETRF(natom, natom, image_matrix, natom, ipiv, stat)
+            CALL dgetrf(natom, natom, image_matrix, natom, ipiv, stat)
             CPASSERT(stat == 0)
          END IF
       END IF

--- a/src/qs_density_matrices.F
+++ b/src/qs_density_matrices.F
@@ -27,7 +27,7 @@ MODULE qs_density_matrices
                                               cp_fm_scale_and_add,&
                                               cp_fm_symm,&
                                               cp_fm_transpose,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
@@ -332,7 +332,7 @@ CONTAINS
       CALL cp_fm_struct_release(fm_struct)
       CALL copy_dbcsr_to_fm(matrix_ks, ks)
       CALL copy_dbcsr_to_fm(matrix_p, p)
-      CALL cp_fm_upper_to_full(p, work)
+      CALL cp_fm_uplo_to_full(p, work)
       CALL cp_fm_symm("L", "U", nao, nao, 1.0_dp, ks, p, 0.0_dp, work)
       CALL parallel_gemm("T", "N", nao, nao, nao, 1.0_dp, p, work, 0.0_dp, ks)
       CALL dbcsr_set(matrix_w, 0.0_dp)

--- a/src/qs_electric_field_gradient.F
+++ b/src/qs_electric_field_gradient.F
@@ -319,7 +319,7 @@ CONTAINS
 
          DO iat = 1, natomkind
             iatom = atom_list(iat)
-            CALL diagonalise(efg_tensor(:, :, iatom), 3, "UPPER", &
+            CALL diagonalise(efg_tensor(:, :, iatom), 3, "U", &
                              eigenvalues, eigenvectors)
             CALL efgsort(eigenvalues, efg_diagval(:, iatom))
          END DO

--- a/src/qs_fb_env_methods.F
+++ b/src/qs_fb_env_methods.F
@@ -27,7 +27,7 @@ MODULE qs_fb_env_methods
                                               cp_fm_symm,&
                                               cp_fm_triangular_invert,&
                                               cp_fm_triangular_multiply,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_reduce,&
                                               cp_fm_cholesky_restore
@@ -652,7 +652,7 @@ CONTAINS
                CALL choose_eigv_solver(fm_KS, fm_work, mo_eigenvalues)
                CALL cp_fm_cholesky_restore(fm_work, nmo, fm_ortho, mo_coeff, "SOLVE")
             CASE (cholesky_restore)
-               CALL cp_fm_upper_to_full(fm_KS, fm_work)
+               CALL cp_fm_uplo_to_full(fm_KS, fm_work)
                CALL cp_fm_cholesky_restore(fm_KS, nao, fm_ortho, fm_work, "SOLVE", &
                                            pos="RIGHT")
                CALL cp_fm_cholesky_restore(fm_work, nao, fm_ortho, fm_KS, "SOLVE", &
@@ -661,7 +661,7 @@ CONTAINS
                CALL cp_fm_cholesky_restore(fm_work, nmo, fm_ortho, mo_coeff, "SOLVE")
             CASE (cholesky_inverse)
                CALL cp_fm_triangular_invert(fm_ortho)
-               CALL cp_fm_upper_to_full(fm_KS, fm_work)
+               CALL cp_fm_uplo_to_full(fm_KS, fm_work)
                CALL cp_fm_triangular_multiply(fm_ortho, &
                                               fm_KS, &
                                               side="R", &

--- a/src/qs_fb_filter_matrix_methods.F
+++ b/src/qs_fb_filter_matrix_methods.F
@@ -1297,18 +1297,10 @@ CONTAINS
       CALL timeset("fb_atomic_filter_dsygv", handle_dsygv)
 
       info = 0
-      CALL dsygv(1, &
-                 'V', &
-                 'U', &
-                 mat_dim, &
-                 eigenvectors, &
-                 mat_dim, &
-                 atomic_S_copy, &
-                 mat_dim, &
-                 eigenvalues, &
-                 work, &
-                 -1, &
-                 info)
+      CALL dsygv(1, 'V', 'U', &
+                 mat_dim, eigenvectors, mat_dim, &
+                 atomic_S_copy, mat_dim, eigenvalues, &
+                 work, -1, info)
       work_array_size = NINT(work(1))
       ! now allocate work array
       DEALLOCATE (work)
@@ -1318,18 +1310,10 @@ CONTAINS
       atomic_S_copy(:, :) = atomic_S(:, :)
       eigenvectors(:, :) = atomic_H(:, :)
       info = 0
-      CALL dsygv(1, &
-                 'V', &
-                 'U', &
-                 mat_dim, &
-                 eigenvectors, &
-                 mat_dim, &
-                 atomic_S_copy, &
-                 mat_dim, &
-                 eigenvalues, &
-                 work, &
-                 work_array_size, &
-                 info)
+      CALL dsygv(1, 'V', 'U', &
+                 mat_dim, eigenvectors, mat_dim, &
+                 atomic_S_copy, mat_dim, eigenvalues, &
+                 work, work_array_size, info)
       ! check if diagonalisation is successful
       IF (info .NE. 0) THEN
          WRITE (*, *) "DSYGV ERROR MESSAGE: ", info

--- a/src/qs_ot.F
+++ b/src/qs_ot.F
@@ -1127,7 +1127,7 @@ CONTAINS
                                           para_env=qs_ot_env%para_env, blacs_env=qs_ot_env%blacs_env)
          CALL cp_dbcsr_cholesky_invert(qs_ot_env%matrix_os, &
                                        para_env=qs_ot_env%para_env, blacs_env=qs_ot_env%blacs_env, &
-                                       upper_to_full=.TRUE.)
+                                       uplo_to_full=.TRUE.)
          qs_ot_env%os_valid = .TRUE.
       END IF
       CALL dbcsr_multiply('T', 'N', rone, matrix_target, matrix_gx, &

--- a/src/qs_ot_eigensolver.F
+++ b/src/qs_ot_eigensolver.F
@@ -182,7 +182,7 @@ CONTAINS
                                              para_env=qs_ot_env(1)%para_env, blacs_env=qs_ot_env(1)%blacs_env)
             CALL cp_dbcsr_cholesky_invert(matrix_os_ortho, &
                                           para_env=qs_ot_env(1)%para_env, blacs_env=qs_ot_env(1)%blacs_env, &
-                                          upper_to_full=.TRUE.)
+                                          uplo_to_full=.TRUE.)
 
             CALL dbcsr_multiply('T', 'N', rone, matrix_s_ortho, matrix_c, &
                                 rzero, matrix_buf1_ortho)

--- a/src/qs_scf_block_davidson.F
+++ b/src/qs_scf_block_davidson.F
@@ -31,7 +31,7 @@ MODULE qs_scf_block_davidson
                                               cp_fm_symm,&
                                               cp_fm_transpose,&
                                               cp_fm_triangular_invert,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_restore
    USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
@@ -242,7 +242,7 @@ CONTAINS
             CALL cp_fm_create(s_fm, fm_struct_tmp, name="matrix_tmp")
             !copy matrix_h in h_fm
             CALL copy_dbcsr_to_fm(matrix_h, h_fm)
-            CALL cp_fm_upper_to_full(h_fm, s_fm)
+            CALL cp_fm_uplo_to_full(h_fm, s_fm)
 
             !copy matrix_s in s_fm
 !        CALL cp_fm_set_all(s_fm,0.0_dp)

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -35,7 +35,7 @@ MODULE qs_scf_diagonalization
                                               cp_dbcsr_sm_fm_multiply,&
                                               dbcsr_allocate_matrix_set
    USE cp_fm_basic_linalg,              ONLY: cp_fm_symm,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_reduce,&
                                               cp_fm_cholesky_restore
    USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
@@ -1307,7 +1307,7 @@ CONTAINS
             ! Q = S*C
             mo2ao => mob
 !MK     CALL copy_sm_to_fm(matrix_s(1)%matrix,work)
-!MK     CALL cp_fm_symm("L","U",nao,nao,1.0_dp,work,moa,0.0_dp,mo2ao)
+!MK     CALL cp_fm_symm("L", "U",nao, nao, 1.0_dp, work, moa, 0.0_dp, mo2ao)
             CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, moa, mo2ao, nao)
          END IF
 
@@ -1394,13 +1394,13 @@ CONTAINS
          CASE (cholesky_reduce)
             CALL cp_fm_cholesky_reduce(ksa, ortho)
          CASE (cholesky_restore)
-            CALL cp_fm_upper_to_full(ksa, work)
+            CALL cp_fm_uplo_to_full(ksa, work)
             CALL cp_fm_cholesky_restore(ksa, nao, ortho, work, &
                                         "SOLVE", pos="RIGHT")
             CALL cp_fm_cholesky_restore(work, nao, ortho, ksa, &
                                         "SOLVE", pos="LEFT", transa="T")
          CASE (cholesky_inverse)
-            CALL cp_fm_upper_to_full(ksa, work)
+            CALL cp_fm_uplo_to_full(ksa, work)
             CALL cp_fm_cholesky_restore(ksa, nao, ortho, work, &
                                         "MULTIPLY", pos="RIGHT")
             CALL cp_fm_cholesky_restore(work, nao, ortho, ksa, &
@@ -1534,7 +1534,7 @@ CONTAINS
       DO ispin = 1, SIZE(matrix_ks)
 
          ks => scf_env%scf_work1(ispin)
-         CALL cp_fm_upper_to_full(ks, work)
+         CALL cp_fm_uplo_to_full(ks, work)
 
          CALL get_mo_set(mo_set=mos(ispin), &
                          nao=nao, &
@@ -1549,7 +1549,7 @@ CONTAINS
          SELECT CASE (scf_env%cholesky_method)
          CASE (cholesky_reduce)
             CALL cp_fm_cholesky_reduce(ks, ortho)
-            CALL cp_fm_upper_to_full(ks, work)
+            CALL cp_fm_uplo_to_full(ks, work)
             CALL cp_fm_cholesky_restore(mo_coeff, nmo, ortho, c0, "MULTIPLY")
          CASE (cholesky_restore)
             CALL cp_fm_cholesky_restore(ks, nao, ortho, work, &

--- a/src/qs_scf_methods.F
+++ b/src/qs_scf_methods.F
@@ -27,7 +27,7 @@ MODULE qs_scf_methods
    USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
                                               cp_fm_symm,&
                                               cp_fm_triangular_multiply,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_reduce,&
                                               cp_fm_cholesky_restore
    USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
@@ -208,7 +208,7 @@ CONTAINS
             CALL correct_mo_eigenvalues(mo_eigenvalues, homo, nmo, level_shift)
 
       CASE (cholesky_restore)
-         CALL cp_fm_upper_to_full(matrix_ks_fm, work)
+         CALL cp_fm_uplo_to_full(matrix_ks_fm, work)
          CALL cp_fm_cholesky_restore(matrix_ks_fm, nao, ortho, work, &
                                      "SOLVE", pos="RIGHT")
          CALL cp_fm_cholesky_restore(work, nao, ortho, matrix_ks_fm, &
@@ -225,7 +225,7 @@ CONTAINS
             CALL correct_mo_eigenvalues(mo_eigenvalues, homo, nmo, level_shift)
 
       CASE (cholesky_inverse)
-         CALL cp_fm_upper_to_full(matrix_ks_fm, work)
+         CALL cp_fm_uplo_to_full(matrix_ks_fm, work)
 
          CALL cp_fm_triangular_multiply(ortho, matrix_ks_fm, side="R", transpose_tr=.FALSE., &
                                         invert_tr=.FALSE., uplo_tr="U", n_rows=nao, n_cols=nao, alpha=1.0_dp)

--- a/src/qs_tddfpt2_soc.F
+++ b/src/qs_tddfpt2_soc.F
@@ -28,7 +28,7 @@ MODULE qs_tddfpt2_soc
                                               cp_dbcsr_sm_fm_multiply
    USE cp_fm_basic_linalg,              ONLY: cp_fm_scale,&
                                               cp_fm_transpose,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
@@ -1796,7 +1796,7 @@ CONTAINS
                                  t_firstcol=1 + nsg + 2*ntp + 1)
 
          ! Symmetrize the matrix (only upper triangle built)
-         CALL cp_fm_upper_to_full(amew_op(i), work_fm)
+         CALL cp_fm_uplo_to_full(amew_op(i), work_fm)
 
       END DO !i
 

--- a/src/rpa_grad.F
+++ b/src/rpa_grad.F
@@ -16,7 +16,7 @@ MODULE rpa_grad
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_fm_basic_linalg,              ONLY: cp_fm_geadd,&
                                               cp_fm_scale_and_add,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_invert
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_get,&
@@ -771,7 +771,7 @@ CONTAINS
          ! calculate [1+Q(iw')]^-1
          CALL cp_fm_cholesky_invert(fm_mat_Q(1))
          ! symmetrize the result, fm_work_PQ is only a work matrix
-         CALL cp_fm_upper_to_full(fm_mat_Q(1), fm_work_PQ)
+         CALL cp_fm_uplo_to_full(fm_mat_Q(1), fm_work_PQ)
 
          CALL cp_fm_release(fm_work_PQ)
 

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -46,7 +46,7 @@ MODULE rpa_gw
    USE cp_files,                        ONLY: close_file,&
                                               open_file
    USE cp_fm_basic_linalg,              ONLY: cp_fm_scale_and_add,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_invert
    USE cp_fm_diag,                      ONLY: cp_fm_syevd
@@ -853,7 +853,7 @@ CONTAINS
          ! calculate [1+Q(iw')]^-1
          CALL cp_fm_cholesky_invert(fm_mat_Q)
          ! symmetrize the result, fm_mat_R_gw is only temporary work matrix
-         CALL cp_fm_upper_to_full(fm_mat_Q, fm_mat_R_gw)
+         CALL cp_fm_uplo_to_full(fm_mat_Q, fm_mat_R_gw)
 
          ! periodic correction for GW (paper Phys. Rev. B 95, 235123 (2017))
          IF (do_periodic) THEN
@@ -981,7 +981,7 @@ CONTAINS
       CALL cp_fm_cholesky_invert(fm_mat_Q)
 
       ! symmetrize the result
-      CALL cp_fm_upper_to_full(fm_mat_Q, fm_mat_work)
+      CALL cp_fm_uplo_to_full(fm_mat_Q, fm_mat_work)
 
       ! subtract 1 from the diagonal to get rid of exchange self-energy
 !$OMP           PARALLEL DO DEFAULT(NONE) PRIVATE(jjB,iiB,i_global,j_global) &
@@ -3035,7 +3035,7 @@ CONTAINS
          CALL cp_fm_cholesky_decompose(fm_mat_s_aux_aux_inv)
          CALL cp_fm_cholesky_invert(fm_mat_s_aux_aux_inv)
          ! Symmetrize the guy
-         CALL cp_fm_upper_to_full(fm_mat_s_aux_aux_inv, fm_mat_work_aux_aux)
+         CALL cp_fm_uplo_to_full(fm_mat_s_aux_aux_inv, fm_mat_work_aux_aux)
 
          CALL copy_fm_to_dbcsr(fm_mat_s_aux_aux_inv, matrix_s_inv_aux_aux, keep_sparsity=.FALSE.)
 

--- a/src/rpa_gw_kpoints_util.F
+++ b/src/rpa_gw_kpoints_util.F
@@ -17,7 +17,7 @@ MODULE rpa_gw_kpoints_util
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_cfm_basic_linalg,             ONLY: cp_cfm_column_scale,&
                                               cp_cfm_scale_and_add_fm,&
-                                              cp_cfm_upper_to_full
+                                              cp_cfm_uplo_to_full
    USE cp_cfm_cholesky,                 ONLY: cp_cfm_cholesky_decompose,&
                                               cp_cfm_cholesky_invert
    USE cp_cfm_diag,                     ONLY: cp_cfm_geeig,&
@@ -1063,7 +1063,7 @@ CONTAINS
       CALL cp_cfm_cholesky_invert(cfm_mat_Q)
 
       ! symmetrize the result
-      CALL cp_cfm_upper_to_full(cfm_mat_Q)
+      CALL cp_cfm_uplo_to_full(cfm_mat_Q)
 
       ! subtract exchange part by subtracing identity matrix from epsilon
       CALL cp_cfm_get_info(matrix=cfm_mat_Q, &

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -491,7 +491,7 @@ CONTAINS
 
       CALL dbcsr_copy(dbcsr_work, t_2c_int_tmp(1))
       CALL cp_dbcsr_cholesky_decompose(dbcsr_work, para_env=para_env, blacs_env=blacs_env)
-      CALL cp_dbcsr_cholesky_invert(dbcsr_work, para_env=para_env, blacs_env=blacs_env, upper_to_full=.TRUE.)
+      CALL cp_dbcsr_cholesky_invert(dbcsr_work, para_env=para_env, blacs_env=blacs_env, uplo_to_full=.TRUE.)
 
       CALL dbt_create(dbcsr_work, t_2c_tmp)
       CALL dbt_copy_matrix_to_tensor(dbcsr_work, t_2c_tmp)
@@ -558,7 +558,7 @@ CONTAINS
       CALL dbcsr_create(force_data%inv_ovlp, template=matrix_s(1)%matrix)
       CALL dbcsr_copy(force_data%inv_ovlp, matrix_s(1)%matrix)
       CALL cp_dbcsr_cholesky_decompose(force_data%inv_ovlp, para_env=para_env, blacs_env=blacs_env)
-      CALL cp_dbcsr_cholesky_invert(force_data%inv_ovlp, para_env=para_env, blacs_env=blacs_env, upper_to_full=.TRUE.)
+      CALL cp_dbcsr_cholesky_invert(force_data%inv_ovlp, para_env=para_env, blacs_env=blacs_env, uplo_to_full=.TRUE.)
 
       DO i_xyz = 1, 3
          CALL dbt_create(t_2c_der_tmp(1, i_xyz), t_2c_tmp)
@@ -1423,7 +1423,7 @@ CONTAINS
          CALL dbcsr_add_on_diag(dbcsr_work_symm, 1.0_dp)
 
          CALL cp_dbcsr_cholesky_decompose(dbcsr_work_symm, para_env=para_env, blacs_env=blacs_env)
-         CALL cp_dbcsr_cholesky_invert(dbcsr_work_symm, para_env=para_env, blacs_env=blacs_env, upper_to_full=.TRUE.)
+         CALL cp_dbcsr_cholesky_invert(dbcsr_work_symm, para_env=para_env, blacs_env=blacs_env, uplo_to_full=.TRUE.)
 
          CALL dbcsr_add_on_diag(dbcsr_work_symm, -1.0_dp)
 

--- a/src/rtp_admm_methods.F
+++ b/src/rtp_admm_methods.F
@@ -24,7 +24,7 @@ MODULE rtp_admm_methods
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               copy_fm_to_dbcsr,&
                                               cp_dbcsr_plus_fm_fm_t
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_upper_to_full
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose,&
                                               cp_fm_cholesky_invert
    USE cp_fm_types,                     ONLY: cp_fm_get_info,&
@@ -339,7 +339,7 @@ CONTAINS
 
       IF (geometry_did_change) THEN
          CALL copy_dbcsr_to_fm(matrix_s_aux_fit(1)%matrix, admm_env%S_inv)
-         CALL cp_fm_upper_to_full(admm_env%S_inv, admm_env%work_aux_aux)
+         CALL cp_fm_uplo_to_full(admm_env%S_inv, admm_env%work_aux_aux)
          CALL cp_fm_to_fm(admm_env%S_inv, admm_env%S)
 
          CALL copy_dbcsr_to_fm(matrix_s_mixed(1)%matrix, admm_env%Q)
@@ -348,7 +348,7 @@ CONTAINS
          CALL cp_fm_cholesky_decompose(admm_env%S_inv)
          CALL cp_fm_cholesky_invert(admm_env%S_inv)
          !! Symmetrize the guy
-         CALL cp_fm_upper_to_full(admm_env%S_inv, admm_env%work_aux_aux)
+         CALL cp_fm_uplo_to_full(admm_env%S_inv, admm_env%work_aux_aux)
          !! Calculate A=S'^(-1)*P
          CALL parallel_gemm('N', 'N', nao_aux_fit, nao_orb, nao_aux_fit, &
                             1.0_dp, admm_env%S_inv, admm_env%Q, 0.0_dp, &

--- a/src/s_square_methods.F
+++ b/src/s_square_methods.F
@@ -168,7 +168,7 @@ CONTAINS
          END IF
       CASE DEFAULT
          ! We should never get here
-         CPABORT("Alpha, beta, what else ?")
+         CPABORT("Alpha, beta, what else?")
       END SELECT
 
       CALL timestop(handle)

--- a/src/swarm/glbopt_history.F
+++ b/src/swarm/glbopt_history.F
@@ -135,10 +135,9 @@ CONTAINS
             matrix(j, i) = t
          END DO
       END DO
-      !TODO: call dsyv through cp2k wrappers
-      !TODO: do we need to store lower triangle of matrix?
       ALLOCATE (res(N))
-      CALL DSYEV('N', 'U', N, matrix, N, res, work, N**2, info)
+      ! matrix values are garbage on exit because of jobz='N'
+      CALL dsyev('N', 'U', N, matrix, N, res, work, N**2, info)
       IF (info /= 0) CPABORT("goedecker_fingerprint: DSYEV failed")
    END SUBROUTINE goedecker_fingerprint
 

--- a/src/xas_tdp_atom.F
+++ b/src/xas_tdp_atom.F
@@ -833,7 +833,7 @@ CONTAINS
 
       ELSE
          CALL cp_dbcsr_cholesky_decompose(ri_sinv, para_env=para_env, blacs_env=blacs_env)
-         CALL cp_dbcsr_cholesky_invert(ri_sinv, para_env=para_env, blacs_env=blacs_env, upper_to_full=.TRUE.)
+         CALL cp_dbcsr_cholesky_invert(ri_sinv, para_env=para_env, blacs_env=blacs_env, uplo_to_full=.TRUE.)
          CALL dbcsr_filter(ri_sinv, 1.E-10_dp) !make sure ri_sinv is sparse coming out of fm routines
       END IF
       CALL dbcsr_replicate_all(ri_sinv)

--- a/src/xas_tdp_utils.F
+++ b/src/xas_tdp_utils.F
@@ -37,7 +37,7 @@ MODULE xas_tdp_utils
    USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
                                               cp_fm_scale,&
                                               cp_fm_transpose,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
                                               cp_fm_geeig
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
@@ -1379,7 +1379,7 @@ CONTAINS
          CALL get_qs_env(qs_env, para_env=para_env, blacs_env=blacs_env)
          CALL dbcsr_copy(matrix_sinv, matrix_s(1)%matrix)
          CALL cp_dbcsr_cholesky_decompose(matrix_sinv, para_env=para_env, blacs_env=blacs_env)
-         CALL cp_dbcsr_cholesky_invert(matrix_sinv, para_env=para_env, blacs_env=blacs_env, upper_to_full=.TRUE.)
+         CALL cp_dbcsr_cholesky_invert(matrix_sinv, para_env=para_env, blacs_env=blacs_env, uplo_to_full=.TRUE.)
 
 !     Fill the matrices G^-1 by looping over the block of S^-1 and putting them on the diagonal
          CALL dbcsr_iterator_start(iter, matrix_sinv)
@@ -2547,7 +2547,7 @@ CONTAINS
                                  s_firstrow=1, s_firstcol=1, t_firstrow=1 + nsc + 1, t_firstcol=1 + nsc + 1)
 
          !Symmetry => only upper diag explicitly built
-         CALL cp_fm_upper_to_full(amew_op(i), work_fm)
+         CALL cp_fm_uplo_to_full(amew_op(i), work_fm)
 
       END DO !i
 
@@ -2750,7 +2750,7 @@ CONTAINS
                                  t_firstcol=1 + nsg + 2*ntp + 1)
 
          ! Symmetrize the matrix (only upper triangle built)
-         CALL cp_fm_upper_to_full(amew_op(i), work_fm)
+         CALL cp_fm_uplo_to_full(amew_op(i), work_fm)
 
       END DO !i
 


### PR DESCRIPTION
- Use invmat_symm if complete matrix desired.
- Renamed upper_to_full to uplo_to_full.
- Call invmat_symm instead of POTRx.
- Removed own_cfm_upper_to_full.