### PR TITLE
Enable spglib in ssmp CMake build

### DIFF
--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -191,7 +191,7 @@ elif [[ "${PROFILE}" == "minimal" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCP2K_USE_VORI=OFF \
     -DCP2K_USE_COSMA=OFF \
     -DCP2K_USE_DLAF=OFF \
-    -DCP2K_USE_SPGLIB=OFF \
+    -DCP2K_USE_SPGLIB=ON \
     -DCP2K_USE_LIBTORCH=OFF \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?


### PR DESCRIPTION
It is already enabled in the Spack build. Related to https://github.com/cp2k/cp2k/issues/3416.

https://github.com/cp2k/cp2k/issues/3414 might still be outstanding, but if this is the case the best course of action would be to report the issue and have a fix upstream.