### PR TITLE
Enable COSMA, ELPA, libVORI, PLUMED, SIRIUS, SPLA in CMake + Spack CI build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -638,6 +638,12 @@ endif()
 
 if(CP2K_USE_DLAF)
   find_package(DLAFFortran REQUIRED)
+
+  get_target_property(CP2K_DLAF_INCLUDE_DIRS DLAF::DLAF
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(CP2K_DLAF_LINK_LIBRARIES DLAF::dlaf.prop
+                      INTERFACE_LINK_LIBRARIES)
+  message("${CP2K_DLAF_INCLUDE_DIRS} ${CP2K_DLAF_LINK_LIBRARIES}")
 endif()
 
 # FFTW3
@@ -940,6 +946,12 @@ if(CP2K_USE_ELPA)
           "   - libraries           :  ${CP2K_ELPA_LINK_LIBRARIES}\n\n")
 endif()
 
+if(CP2K_USE_DLAF)
+  message(" - DLA-Future\n"
+          "   - include directories : ${CP2K_DLAF_INCLUDE_DIRS}\n"
+          "   - libraries           :  ${CP2K_DLAF_LINK_LIBRARIES}\n\n")
+endif()
+
 if(CP2K_USE_SUPERLU)
   message(" - superlu\n"
           "   - include directories : ${CP2K_SUPERLU_INCLUDE_DIRS}\n"
@@ -986,7 +998,7 @@ if(NOT CP2K_USE_ELPA)
 endif()
 
 if(NOT CP2K_USE_DLAF)
-  message("   - DLAF")
+  message("   - DLA-Future")
 endif()
 
 if(NOT CP2K_USE_PLUMED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,6 +623,11 @@ endif()
 if(CP2K_USE_COSMA)
   find_package(cosma REQUIRED)
 
+  get_target_property(CP2K_COSMA_INCLUDE_DIRS cosma::cosma
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(CP2K_COSMA_LINK_LIBRARIES cosma::cosma
+                      INTERFACE_LINK_LIBRARIES)
+
   # check that cosma::cosma_pxgemm and cosma::cosma_prefixed_pxgemm exist
   if(NOT TARGET cosma::cosma_pxgemm OR NOT TARGET cosma::cosma_prefixed_pxgemm)
     message(
@@ -721,6 +726,11 @@ endif()
 # SIRIUS
 if(CP2K_USE_SIRIUS)
   find_package(sirius REQUIRED)
+
+  get_target_property(CP2K_SIRIUS_INCLUDE_DIRS sirius::sirius
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  get_target_property(CP2K_SIRIUS_LINK_LIBRARIES sirius::sirius_cxx
+                      INTERFACE_LINK_LIBRARIES)
 endif()
 
 if(CP2K_USE_SUPERLU)
@@ -898,8 +908,8 @@ endif()
 if(CP2K_USE_SIRIUS)
   message(
     " - SIRIUS :\n"
-    "   - include directories :  ${SIRIUS_INCLUDE_DIRS}\n"
-    "   - libraries           :  ${SIRIUS_LIBRARIES}\n"
+    "   - include directories :  ${CP2K_SIRIUS_INCLUDE_DIRS}\n"
+    "   - link libraries           :  ${CP2K_SIRIUS_LINK_LIBRARIES}\n"
     "   - dependencies :\n"
     "       - spla\n"
     "       - SpFFT\n"
@@ -915,8 +925,9 @@ if(CP2K_USE_SIRIUS)
 endif()
 
 if(CP2K_USE_COSMA)
-  message(" - COSMA\n" "   - include directories : ${COSMA_INCLUDE_DIRS}\n"
-          "   - libraries           : ${COSMA_LIBRARIES}\n\n")
+  message(" - COSMA\n"
+          "   - include directories : ${CP2K_COSMA_INCLUDE_DIRS}\n"
+          "   - libraries           : ${CP2K_COSMA_LINK_LIBRARIES}\n\n")
 endif()
 
 if(CP2K_USE_QUIP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -726,11 +726,6 @@ endif()
 # SIRIUS
 if(CP2K_USE_SIRIUS)
   find_package(sirius REQUIRED)
-
-  get_target_property(CP2K_SIRIUS_INCLUDE_DIRS sirius::sirius
-                      INTERFACE_INCLUDE_DIRECTORIES)
-  get_target_property(CP2K_SIRIUS_LINK_LIBRARIES sirius::sirius_cxx
-                      INTERFACE_LINK_LIBRARIES)
 endif()
 
 if(CP2K_USE_SUPERLU)
@@ -906,22 +901,7 @@ if(CP2K_USE_DFTD4)
 endif()
 
 if(CP2K_USE_SIRIUS)
-  message(
-    " - SIRIUS :\n"
-    "   - include directories :  ${CP2K_SIRIUS_INCLUDE_DIRS}\n"
-    "   - link libraries           :  ${CP2K_SIRIUS_LINK_LIBRARIES}\n"
-    "   - dependencies :\n"
-    "       - spla\n"
-    "       - SpFFT\n"
-    "       - SPGLIB\n"
-    "       - LibXC\n"
-    "       - fftw3\n"
-    "       - hdf5\n"
-    "       - GSL\n\n")
-
-  if(CP2K_USE_VDWXC)
-    message("     - VDWXC\n")
-  endif()
+  message(" - SIRIUS")
 endif()
 
 if(CP2K_USE_COSMA)

--- a/cmake/modules/FindLibVORI.cmake
+++ b/cmake/modules/FindLibVORI.cmake
@@ -14,7 +14,6 @@ include(cp2k_utils)
 
 cp2k_set_default_paths(LIBVORI "LibVORI")
 cp2k_find_libraries(LIBVORI vori)
-# cp2k_include_dirs(LIBVORI )
 
 if(CP2K_LIBVORI_INCLUDE_DIRS)
   find_package_handle_standard_args(

--- a/tools/docker/Dockerfile.test_spack
+++ b/tools/docker/Dockerfile.test_spack
@@ -42,7 +42,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
 
 # Install a recent developer version of Spack.
 WORKDIR /opt/spack
-ARG SPACK_VERSION=501ee68606405ea2ac26d369a5139d75be88dac8
+ARG SPACK_VERSION=847f560a6eff23f2177f3e8a2c143d309bb06acf
 RUN git init --quiet && \
     git remote add origin https://github.com/spack/spack.git && \
     git fetch --quiet --depth 1 origin ${SPACK_VERSION} --no-tags && \
@@ -54,7 +54,7 @@ RUN spack compiler find
 RUN spack external find --all --not-buildable
 
 # Enable Spack build cache
-ARG SPACK_BUILD_CACHE=develop-2024-12-15
+ARG SPACK_BUILD_CACHE=develop-2025-01-12
 RUN spack mirror add ${SPACK_BUILD_CACHE} https://binaries.spack.io/${SPACK_BUILD_CACHE} && \
     spack mirror add develop https://binaries.spack.io/develop && \
     spack buildcache keys --install --trust --force && \

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -2,10 +2,10 @@
 
 # author: Ole Schuett
 
-from pathlib import Path
-from typing import Any
 import argparse
 import io
+from pathlib import Path
+from typing import Any
 
 
 # ======================================================================================
@@ -841,7 +841,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
 
 # Install a recent developer version of Spack.
 WORKDIR /opt/spack
-ARG SPACK_VERSION=501ee68606405ea2ac26d369a5139d75be88dac8
+ARG SPACK_VERSION=847f560a6eff23f2177f3e8a2c143d309bb06acf
 RUN git init --quiet && \
     git remote add origin https://github.com/spack/spack.git && \
     git fetch --quiet --depth 1 origin ${{SPACK_VERSION}} --no-tags && \
@@ -853,7 +853,7 @@ RUN spack compiler find
 RUN spack external find --all --not-buildable
 
 # Enable Spack build cache
-ARG SPACK_BUILD_CACHE=develop-2024-12-15
+ARG SPACK_BUILD_CACHE=develop-2025-01-12
 RUN spack mirror add ${{SPACK_BUILD_CACHE}} https://binaries.spack.io/${{SPACK_BUILD_CACHE}} && \
     spack mirror add develop https://binaries.spack.io/develop && \
     spack buildcache keys --install --trust --force && \

--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -33,20 +33,25 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_Fortran_FLAGS="-fno-lto" \
     -DCMAKE_INSTALL_PREFIX=/opt/cp2k \
     -Werror=dev \
-    -DCP2K_USE_VORI=ON \
-    -DCP2K_USE_COSMA=ON \
-    -DCP2K_USE_DLAF=ON \
-    -DCP2K_BLAS_VENDOR=OpenBLAS \
-    -DCP2K_USE_SPGLIB=ON \
     -DCP2K_USE_LIBINT2=ON \
     -DCP2K_USE_LIBXC=ON \
-    -DCP2K_USE_LIBXSMM=ON \
-    -DCP2K_USE_PLUMED=ON \
-    -DCP2K_USE_ELPA=ON \
-    -DCP2K_USE_SIRIUS=ON \
-    -DCP2K_USE_LIBTORCH=OFF \
+    -DCP2K_USE_FFTW3=ON \
+    -DCP2K_USE_SPGLIB=ON \
+    -DCP2K_USE_VORI=ON \
     -DCP2K_USE_MPI=ON \
     -DCP2K_USE_MPI_F08=ON \
+    -DCP2K_USE_LIBXSMM=ON \
+    -DCP2K_USE_SUPERLU=OFF \
+    -DCP2K_USE_PLUMED=ON \
+    -DCP2K_USE_SPLA=ON \
+    -DCP2K_USE_METIS=OFF \
+    -DCP2K_USE_ELPA=ON \
+    -DCP2K_USE_COSMA=ON \
+    -DCP2K_USE_SIRIUS=ON \
+    -DCP2K_USE_QUIP=OFF \
+    -DCP2K_USE_PEXSI=OFF \
+    -DCP2K_USE_LIBTORCH=OFF \
+    -DCP2K_USE_DLAF=ON \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
 

--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -33,7 +33,7 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_Fortran_FLAGS="-fno-lto" \
     -DCMAKE_INSTALL_PREFIX=/opt/cp2k \
     -Werror=dev \
-    -DCP2K_USE_VORI=OFF \
+    -DCP2K_USE_VORI=ON \
     -DCP2K_USE_COSMA=ON \
     -DCP2K_USE_DLAF=ON \
     -DCP2K_BLAS_VENDOR=OpenBLAS \
@@ -42,6 +42,8 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_LIBXC=ON \
     -DCP2K_USE_LIBXSMM=ON \
     -DCP2K_USE_PLUMED=ON \
+    -DCP2K_USE_ELPA=ON \
+    -DCP2K_USE_SIRIUS=ON \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_MPI=ON \
     -DCP2K_USE_MPI_F08=ON \

--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -34,13 +34,14 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_INSTALL_PREFIX=/opt/cp2k \
     -Werror=dev \
     -DCP2K_USE_VORI=OFF \
-    -DCP2K_USE_COSMA=OFF \
+    -DCP2K_USE_COSMA=ON \
     -DCP2K_USE_DLAF=ON \
     -DCP2K_BLAS_VENDOR=OpenBLAS \
     -DCP2K_USE_SPGLIB=ON \
     -DCP2K_USE_LIBINT2=ON \
     -DCP2K_USE_LIBXC=ON \
     -DCP2K_USE_LIBXSMM=ON \
+    -DCP2K_USE_PLUMED=ON \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_MPI=ON \
     -DCP2K_USE_MPI_F08=ON \

--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -48,8 +48,8 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_ELPA=ON \
     -DCP2K_USE_COSMA=ON \
     -DCP2K_USE_SIRIUS=ON \
-    -DCP2K_USE_QUIP=OFF \
-    -DCP2K_USE_PEXSI=OFF \
+    -DCP2K_USE_QUIP=OFF \ # Deprecated in #3600
+    -DCP2K_USE_PEXSI=OFF \ # Deprecated in #3600
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_DLAF=ON \
     .. |& tee ./cmake.log
@@ -96,7 +96,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "sdbg" ]]; then
   CMAKE_EXIT_CODE=$?
 
 elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
-  # TODO Fix ELPA, COSMA, SIRIUS, QUIP, PEXSI, and Torch.
+  # TODO Fix ELPA, COSMA, SIRIUS, and Torch.
   # https://github.com/cp2k/cp2k/issues/3416
   cmake \
     -GNinja \
@@ -118,8 +118,8 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_ELPA=OFF \
     -DCP2K_USE_COSMA=OFF \
     -DCP2K_USE_SIRIUS=OFF \
-    -DCP2K_USE_QUIP=OFF \
-    -DCP2K_USE_PEXSI=OFF \
+    -DCP2K_USE_QUIP=OFF \ # Deprecated in #3600
+    -DCP2K_USE_PEXSI=OFF \ # Deprecated in #3600
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_DLAF=OFF \
     .. |& tee ./cmake.log

--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -27,6 +27,7 @@ fi
 
 # TODO: Reconcile PROFILE/VERSION with CP2K_BUILD_OPTIONS in CMakeLists.txt.
 if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
+  # NOTE: pexsi and quip are deprecated in #3600
   cmake \
     -GNinja \
     -DCMAKE_C_FLAGS="-fno-lto" \
@@ -48,8 +49,8 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_ELPA=ON \
     -DCP2K_USE_COSMA=ON \
     -DCP2K_USE_SIRIUS=ON \
-    -DCP2K_USE_QUIP=OFF \ # Deprecated in #3600
-    -DCP2K_USE_PEXSI=OFF \ # Deprecated in #3600
+    -DCP2K_USE_QUIP=OFF \
+    -DCP2K_USE_PEXSI=OFF \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_DLAF=ON \
     .. |& tee ./cmake.log
@@ -98,6 +99,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "sdbg" ]]; then
 elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
   # TODO Fix ELPA, COSMA, SIRIUS, and Torch.
   # https://github.com/cp2k/cp2k/issues/3416
+  # NOTE: pexsi and quip are deprecated in #3600
   cmake \
     -GNinja \
     -DCMAKE_INSTALL_PREFIX=/opt/cp2k \
@@ -118,8 +120,8 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_ELPA=OFF \
     -DCP2K_USE_COSMA=OFF \
     -DCP2K_USE_SIRIUS=OFF \
-    -DCP2K_USE_QUIP=OFF \ # Deprecated in #3600
-    -DCP2K_USE_PEXSI=OFF \ # Deprecated in #3600
+    -DCP2K_USE_QUIP=OFF \
+    -DCP2K_USE_PEXSI=OFF \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_DLAF=OFF \
     .. |& tee ./cmake.log

--- a/tools/spack/cp2k-dependencies.yaml
+++ b/tools/spack/cp2k-dependencies.yaml
@@ -23,16 +23,11 @@ spack:
    # which contains https://github.com/Reference-ScaLAPACK/scalapack/pull/26
 
    # TODO:
-   # - "libvori @220621" # is not recompile with -fPIC
-   #
    # scotch_6.0.0.tar.gz
    # superlu_dist_6.1.0.tar.gz: OK
-   # pexsi_v1.2.0.tar.gz: OK
-   # QUIP-0.9.10.tar.gz
    # hdf5-1.14.2.tar.bz2: OK
    # libvdwxc-0.4.0.tar.gz: OK
    # libtorch-cxx11-abi-shared-with-deps-1.12.1+cpu.zip: OK
-   # SpLA-1.5.5.tar.gz: OK
   view:
     default:
       root: ./spack-env/view

--- a/tools/spack/cp2k-dependencies.yaml
+++ b/tools/spack/cp2k-dependencies.yaml
@@ -17,6 +17,7 @@ spack:
     - "elpa@2024.03.001 +openmp"
     - "sirius @7.6.1 +fortran +pugixml ~apps"
     - "libvori@220621"
+    - "spla@1.6.1 +fortran"
    # Unfortunately, ScaLAPACK 2.2.1 has not yet been packaged by Spack.
    # https://github.com/Reference-ScaLAPACK/scalapack/tree/v2.2.1
    # which contains https://github.com/Reference-ScaLAPACK/scalapack/pull/26

--- a/tools/spack/cp2k-dependencies.yaml
+++ b/tools/spack/cp2k-dependencies.yaml
@@ -14,15 +14,15 @@ spack:
     - "libint@2.9.0 +fortran tune=cp2k-lmax-5"
     - "cosma@2.6.6 +scalapack"
     - "plumed@2.9.2"
+    - "elpa@2024.03.001 +openmp"
+    - "sirius @7.6.1 +fortran +pugixml ~apps"
+    - "libvori@220621"
    # Unfortunately, ScaLAPACK 2.2.1 has not yet been packaged by Spack.
    # https://github.com/Reference-ScaLAPACK/scalapack/tree/v2.2.1
    # which contains https://github.com/Reference-ScaLAPACK/scalapack/pull/26
 
    # TODO:
-   # - "sirius @7.4.3 +fortran +shared +openmp" # build fails
-   # - "plumed @2.9.0 +shared +mpi optional_modules=all" # requires cython
    # - "libvori @220621" # is not recompile with -fPIC
-   # - "elpa @2023.05.001 +openmp"
    #
    # scotch_6.0.0.tar.gz
    # superlu_dist_6.1.0.tar.gz: OK

--- a/tools/spack/cp2k-dependencies.yaml
+++ b/tools/spack/cp2k-dependencies.yaml
@@ -1,16 +1,19 @@
 # This is a Spack Environment file for developing CP2K.
 spack:
   specs:
-    - mpich@4.1.2 device=ch3 netmod=tcp
-    - "openblas @0.3.24 +fortran threads=openmp"
+    - "mpich@4.1.2 device=ch3 netmod=tcp"
+    - "openblas@0.3.24 +fortran threads=openmp"
     - "dbcsr@2.8.0 +openmp +mpi"
-    - "netlib-scalapack @2.2.0"
-    - "libxsmm @1.17"
-    - "fftw @3.3.10 +openmp"
-    - "libxc @6.2.2"
-    - "spglib @2.3.0"
+    - "netlib-scalapack@2.2.0"
+    - "libxsmm@1.17"
+    - "fftw@3.3.10 +openmp"
+    - "libxc@6.2.2"
+    - "spglib@2.3.0"
+    - "dla-future@0.7.3 +scalapack"
     - "dla-future-fortran@0.2.0"
     - "libint@2.9.0 +fortran tune=cp2k-lmax-5"
+    - "cosma@2.6.6 +scalapack"
+    - "plumed@2.9.2"
    # Unfortunately, ScaLAPACK 2.2.1 has not yet been packaged by Spack.
    # https://github.com/Reference-ScaLAPACK/scalapack/tree/v2.2.1
    # which contains https://github.com/Reference-ScaLAPACK/scalapack/pull/26
@@ -19,7 +22,6 @@ spack:
    # - "sirius @7.4.3 +fortran +shared +openmp" # build fails
    # - "plumed @2.9.0 +shared +mpi optional_modules=all" # requires cython
    # - "libvori @220621" # is not recompile with -fPIC
-   # - "cosma @2.6.6"
    # - "elpa @2023.05.001 +openmp"
    #
    # scotch_6.0.0.tar.gz


### PR DESCRIPTION
Enable more optional dependencies on CMake + Spack CI build. This is to ensure CMake works at least with Spack-installed packages. Toolchain-installed packages are being tackled where necessary. (We might soon need to start looking into CMake + toolchain for the `psmp` builds in CI.) 