### PR TITLE
Docker: Migrate psmp test to CMake

### DIFF
--- a/tools/docker/Dockerfile.test_aiida
+++ b/tools/docker/Dockerfile.test_aiida
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-13      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_ase
+++ b/tools/docker/Dockerfile.test_ase
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-13      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_gcc10
+++ b/tools/docker/Dockerfile.test_gcc10
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-10      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_gcc11
+++ b/tools/docker/Dockerfile.test_gcc11
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-11      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_gcc12
+++ b/tools/docker/Dockerfile.test_gcc12
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-12      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_gcc13
+++ b/tools/docker/Dockerfile.test_gcc13
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-13      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_gcc14
+++ b/tools/docker/Dockerfile.test_gcc14
@@ -38,7 +38,7 @@ RUN ln -sf /usr/bin/gcc-14      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_gcc9
+++ b/tools/docker/Dockerfile.test_gcc9
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-9      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_gromacs
+++ b/tools/docker/Dockerfile.test_gromacs
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-13      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_i-pi
+++ b/tools/docker/Dockerfile.test_i-pi
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-13      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_i386
+++ b/tools/docker/Dockerfile.test_i386
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-12      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh ubuntu_i386 ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_minimal
+++ b/tools/docker/Dockerfile.test_minimal
@@ -34,7 +34,7 @@ RUN ln -sf /usr/bin/gcc-13      /usr/local/bin/gcc  && \
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN  ./install_dbcsr.sh
+RUN ./install_dbcsr.sh minimal ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/Dockerfile.test_psmp
+++ b/tools/docker/Dockerfile.test_psmp
@@ -59,25 +59,25 @@ COPY ./tools/toolchain/scripts/arch_base.tmpl \
      ./scripts/
 RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
-# Install CP2K using local.psmp.
+# Install DBCSR
+COPY ./tools/docker/scripts/install_dbcsr.sh ./
+RUN ./install_dbcsr.sh toolchain psmp
+
+# Install CP2K sources.
 WORKDIR /opt/cp2k
-COPY ./Makefile .
 COPY ./src ./src
-COPY ./exts ./exts
-COPY ./tools/build_utils ./tools/build_utils
-RUN /bin/bash -c " \
-    mkdir -p arch && \
-    ln -vs /opt/cp2k-toolchain/install/arch/local.psmp ./arch/"
 COPY ./data ./data
 COPY ./tests ./tests
-COPY ./tools/regtesting ./tools/regtesting
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
-# Run regression tests.
+# Build CP2K with CMake and run regression tests.
 ARG TESTOPTS=""
-COPY ./tools/docker/scripts/test_regtest.sh ./
+COPY ./tools/docker/scripts/build_cp2k_cmake.sh ./tools/docker/scripts/test_regtest_cmake.sh ./
 RUN /bin/bash -o pipefail -c " \
     TESTOPTS='${TESTOPTS}' \
-    ./test_regtest.sh 'local' 'psmp' |& tee report.log && \
+    ./test_regtest_cmake.sh toolchain psmp |& tee report.log && \
     rm -rf regtesting"
 
 # Output the report if the image is old and was therefore pulled from the build cache.

--- a/tools/docker/Dockerfile.test_ssmp
+++ b/tools/docker/Dockerfile.test_ssmp
@@ -61,7 +61,7 @@ RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
 # Install DBCSR
 COPY ./tools/docker/scripts/install_dbcsr.sh ./
-RUN /bin/bash -o pipefail -c "source /opt/cp2k-toolchain/install/setup; ./install_dbcsr.sh"
+RUN ./install_dbcsr.sh toolchain ssmp
 
 # Install CP2K sources.
 WORKDIR /opt/cp2k

--- a/tools/docker/scripts/install_dbcsr.sh
+++ b/tools/docker/scripts/install_dbcsr.sh
@@ -1,5 +1,13 @@
 #!/bin/bash -e
 
+if (($# != 2)); then
+  echo "Usage: install_dbcsr.sh <PROFILE> <VERSION>"
+  exit 1
+fi
+
+PROFILE=$1
+VERSION=$2
+
 DBCSR_ver="2.8.0"
 DBCSR_sha256="d55e4f052f28d1ed0faeaa07557241439243287a184d1fd27f875c8b9ca6bd96"
 
@@ -14,7 +22,21 @@ cd dbcsr-${DBCSR_ver}
 mkdir build
 cd build
 
-if ! cmake -DCMAKE_INSTALL_PREFIX=/opt/dbcsr -DUSE_MPI=OFF -DUSE_OPENMP=ON -DUSE_SMM=blas .. &> cmake.log; then
+if [[ "${PROFILE}" == "toolchain" ]]; then
+  # shellcheck disable=SC1091
+  source /opt/cp2k-toolchain/install/setup
+fi
+
+if [[ "${VERSION}" == "ssmp" ]]; then
+  USE_MPI="OFF"
+elif [[ "${VERSION}" == "psmp" ]]; then
+  USE_MPI="ON"
+else
+  echo "Unknown version: ${VERSION}."
+  exit 1
+fi
+
+if ! cmake -DCMAKE_INSTALL_PREFIX=/opt/dbcsr -DUSE_MPI=${USE_MPI} -DUSE_OPENMP=ON -DUSE_SMM=blas .. &> cmake.log; then
   cat cmake.log
   exit 1
 fi


### PR DESCRIPTION
Lets make psmp our guinea pigs for parallel builds. See also #3416.