### PR TITLE
cp_fm_struct - Fix for small matrices

### DIFF
--- a/src/fm/cp_fm_struct.F
+++ b/src/fm/cp_fm_struct.F
@@ -205,7 +205,7 @@ CONTAINS
       IF (.NOT. my_force_block) THEN
          vlen = m_cpuid_vlen()
          nmax_block = (fmstruct%nrow_global + fmstruct%context%num_pe(1) - 1)/ &
-                      (fmstruct%context%num_pe(1))*fmstruct%context%num_pe(1)
+                      (fmstruct%context%num_pe(1))
          IF (1 < vlen) THEN ! flooring not ceiling (OOB)
             fmstruct%nrow_block = fmstruct%nrow_block/vlen*vlen
             nmax_block = nmax_block/vlen*vlen
@@ -213,7 +213,7 @@ CONTAINS
          fmstruct%nrow_block = MAX(MIN(fmstruct%nrow_block, nmax_block), 1)
 
          nmax_block = (fmstruct%ncol_global + fmstruct%context%num_pe(2) - 1)/ &
-                      (fmstruct%context%num_pe(1))*fmstruct%context%num_pe(2)
+                      (fmstruct%context%num_pe(2))
          IF (1 < vlen) THEN ! flooring not ceiling (OOB)
             fmstruct%ncol_block = fmstruct%ncol_block/vlen*vlen
             nmax_block = nmax_block/vlen*vlen


### PR DESCRIPTION
## Introduction

I initially observed that regtests in `QS/regtest-scalable-gw` started to fail on my local machine after commit e7c81ba798 . I recognized that I run the regtests with 4 mpiranks and 1 ompthread, while the CI runs the tests with 2 mpiranks and 2 ompthread. After trying to run the regtests on local machine again with 2x2 (mpiranks x ompthreads), the test succeeded, so I recognized that the distribution of some tasks to the mpiranks probably contains an error.

## Error statement and fix

After consultation with @JWilhelm and @RemiPasquier , we deduced that the determination of the maximum number of rows/columns in a blacs block contains the source of the error - there was a change in this determination in e7c81ba798 which introduced this error. @RemiPasquier mentioned this on the pull request and I am now presenting the solution we arrived at independently. We believe that the maximum number of rows/columns in a blacs block should not be essentially the entire matrix, as this leads to some ranks containing zero local data. The following change restores previous behaviour (while hopefully still allowing for setting the block size to vector length vlen introduced in e7c81ba798)
```
diff --git a/src/fm/cp_fm_struct.F b/src/fm/cp_fm_struct.F
index 4e1cc2238e..ed67078ccd 100644
--- a/src/fm/cp_fm_struct.F
+++ b/src/fm/cp_fm_struct.F
@@ -205,7 +205,7 @@ CONTAINS
       IF (.NOT. my_force_block) THEN
          vlen = m_cpuid_vlen()
          nmax_block = (fmstruct%nrow_global + fmstruct%context%num_pe(1) - 1)/ &
-                      (fmstruct%context%num_pe(1))*fmstruct%context%num_pe(1)
+                      (fmstruct%context%num_pe(1))
          IF (1 < vlen) THEN ! flooring not ceiling (OOB)
             fmstruct%nrow_block = fmstruct%nrow_block/vlen*vlen
             nmax_block = nmax_block/vlen*vlen
@@ -213,7 +213,7 @@ CONTAINS
          fmstruct%nrow_block = MAX(MIN(fmstruct%nrow_block, nmax_block), 1)
 
          nmax_block = (fmstruct%ncol_global + fmstruct%context%num_pe(2) - 1)/ &
-                      (fmstruct%context%num_pe(1))*fmstruct%context%num_pe(2)
+                      (fmstruct%context%num_pe(2))
          IF (1 < vlen) THEN ! flooring not ceiling (OOB)
             fmstruct%ncol_block = fmstruct%ncol_block/vlen*vlen
             nmax_block = nmax_block/vlen*vlen

```

## Error showcase

To show a specific error case, feel free to apply the following patch to current master and run the above mentioned part of the regtests
```
diff --git a/src/gw_large_cell_gamma.F b/src/gw_large_cell_gamma.F
index 1f3dd7d334..ce3a460c01 100644
--- a/src/gw_large_cell_gamma.F
+++ b/src/gw_large_cell_gamma.F
@@ -65,7 +65,8 @@ MODULE gw_large_cell_gamma
                                               int_8
    USE kpoint_coulomb_2c,               ONLY: build_2c_coulomb_matrix_kp
    USE kpoint_types,                    ONLY: kpoint_type
-   USE machine,                         ONLY: m_walltime
+   USE machine,                         ONLY: m_walltime, &
+                                              m_cpuid_vlen
    USE mathconstants,                   ONLY: twopi,&
                                               z_one,&
                                               z_zero
@@ -2290,10 +2291,19 @@ CONTAINS
             ! 2. get S_µν(k_i) from S_µν(k=0)
             CALL cfm_ikp_from_fm_Gamma(cfm_s_ikp, bs_env%fm_s_Gamma, &
                                        ikp, qs_env, bs_env%kpoints_DOS, "ORB")
+            PRINT *, "cpuid_vlen", m_cpuid_vlen()
+            PRINT *, "cart. position", cfm_ks_ikp%matrix_struct%context%mepos(1), &
+                    cfm_ks_ikp%matrix_struct%context%mepos(2), &
+                    "local_data size", &
+                    cfm_ks_ikp%matrix_struct%nrow_locals(cfm_ks_ikp%matrix_struct%context%mepos(1)), &
+                    cfm_ks_ikp%matrix_struct%ncol_locals(cfm_ks_ikp%matrix_struct%context%mepos(2))
 
             ! 3. Diagonalize (Roothaan-Hall): H_KS(k_i)*C(k_i) = S(k_i)*C(k_i)*ϵ(k_i)
             CALL cp_cfm_geeig(cfm_ks_ikp, cfm_s_ikp, cfm_mos_ikp, &
                               bs_env%eigenval_scf(:, ikp, ispin), cfm_work_ikp)
+            PRINT *, cfm_ks_ikp%matrix_struct%context%mepos(1), &
+                    cfm_ks_ikp%matrix_struct%context%mepos(2), &
+                    bs_env%eigenval_scf(:, ikp, ispin)
 
             ! 4. V^xc_µν(k=0) -> V^xc_µν(k_i) -> V^xc_nn(k_i)
             CALL to_ikp_and_mo(V_xc_ikp_n, bs_env%fm_V_xc_Gamma(ispin), &
```

(you can use `cd tests && ./do_regtest.py --mpiranks 4 --ompthreads 1 --workbasedir ../regtesting --restrictdir QS/regtest-scalable-gw` + cp2k architecture and version to run the regtest)

This patch prints the distribution of a complex Hamiltonian matrix used in the GW workflow, and the Hamiltonian eigenvalues. At the current master, the print produces something similar to this for `01_G0W0_periodic_H2O.inp`
```
...
 cpuid_vlen           4
 cart. position           1           1 local_data size           0           0
           1           1  0.64524113528718785       0.92805880329027735       0.77797094839274550       ...
 Sparsity of Σ^c(iτ,k=0): Percentage of skipped atom pairs:                0.0 %
 cpuid_vlen           4
 cart. position           0           0 local_data size          23          23
           0           0 -0.86279915637516102      -0.43417956913078526      -0.29319700876391425      ...
 cpuid_vlen           4
 cart. position           0           1 local_data size          23           0
           0           1  0.64524113528718785       0.92805880329027735       0.77797094839274550       ...
 cpuid_vlen           4
 cart. position           1           0 local_data size           0          23
           1           0  0.64524113528718785       0.92805880329027735       0.77797094839274550       ...
...
```

As you can see, ranks at (0,1), (1,0) and (1,1) have at least one size of local_data zero, i.e. they do not contain any data - all data is stored on the rank (0,0). This leads to an error in `cp_cfm_geeig` - the ranks which have empty local data now contain invalid eigenvalues array, which then propagates to other parts of the code.

## Escaping regtesting

Curiously enough, I suspect that this bug would have been caught by the regtesting if the tests ran with at least one other mpiranks combination other than 2 ranks. By a (un)lucky coincidence, the original code used two different numbers in the flooring procedure of the block size (`(fmstruct%context%num_pe(1))*fmstruct%context%num_pe(2)` instead of `(fmstruct%context%num_pe(2))*fmstruct%context%num_pe(2)`) which in the specific 2 rank case leads to correctly setting the blocks such that both contain approximately equal data. Therefore, in the case of 2 mpiranks, this error was not caught by the regtesting.

Indeed, after rerunning the patch print mentioned above in 2x2 setup, the distributions are reasonable and the eigenvalues are identical on both ranks (again , `01_G0W0_periodic_H2O.inp` calculation)
```
...
 Sparsity of Σ^c(iτ,k=0): Percentage of skipped atom pairs:                0.0 %
 cpuid_vlen           4
 cart. position           0           0 local_data size          15          23
           1           0 -0.86279915637515936      -0.43417956913078576      -0.29319700876391325      ...   
 cpuid_vlen           4
 cart. position           1           0 local_data size           8          23
           0           0 -0.86279915637515936      -0.43417956913078576      -0.29319700876391325      ... 
...
```