### PR TITLE
BSE/RI-RPA: improve abort messages and fix bug for ERI_METHOD OS

### DIFF
--- a/src/bse_full_diag.F
+++ b/src/bse_full_diag.F
@@ -475,7 +475,12 @@ CONTAINS
       ALLOCATE (Exc_ens(homo*virtual))
 
       CALL choose_eigv_solver(fm_C, fm_eigvec_Z, Exc_ens, diag_info)
-      CPASSERT(diag_info == 0)
+
+      IF (diag_info /= 0) THEN
+         CALL cp_abort(__LOCATION__, &
+                       "Diagonalization of C=(A-B)^0.5 (A+B) (A-B)^0.5 failed in BSE")
+      END IF
+
       ! C could have negative eigenvalues, since we do not explicitly check A+B
       ! for positive definiteness (would make another O(N^6) Diagon. necessary)
       ! Instead, we include a check here
@@ -589,7 +594,12 @@ CONTAINS
       ALLOCATE (Exc_ens(homo*virtual))
 
       CALL choose_eigv_solver(fm_A, fm_eigvec, Exc_ens, diag_info)
-      CPASSERT(diag_info == 0)
+
+      IF (diag_info /= 0) THEN
+         CALL cp_abort(__LOCATION__, &
+                       "Diagonalization of A failed in TDA-BSE")
+      END IF
+
       CALL postprocess_bse(Exc_ens, fm_eigvec, mp2_env, qs_env, mo_coeff, &
                            homo, virtual, homo_irred, unit_nr, .TRUE.)
 

--- a/src/bse_util.F
+++ b/src/bse_util.F
@@ -154,7 +154,9 @@ CONTAINS
       ! calculate Trace(Log(Matrix)) as Log(DET(Matrix)) via cholesky decomposition
       CALL cp_fm_cholesky_decompose(matrix=fm_mat_Q_static_bse_gemm, n=dimen_RI, info_out=info_chol)
 
-      CPASSERT(info_chol == 0)
+      IF (info_chol /= 0) THEN
+         CALL cp_abort(__LOCATION__, 'Cholesky decomposition failed for static polarization in BSE')
+      END IF
 
       ! calculate [1+Q(i0)]^-1
       CALL cp_fm_cholesky_invert(fm_mat_Q_static_bse_gemm)
@@ -1542,7 +1544,7 @@ CONTAINS
           mp2_env%bse%num_print_exc > homo*virtual) THEN
          mp2_env%bse%num_print_exc = homo*virtual
          IF (unit_nr > 0) THEN
-            CALL cp_warn(__LOCATION__, &
+            CALL cp_hint(__LOCATION__, &
                          "Keyword NUM_PRINT_EXC is either negative or too large. "// &
                          "Printing all computed excitations.")
          END IF
@@ -1558,7 +1560,7 @@ CONTAINS
          IF (mp2_env%bse%explicit_nto_list) THEN
             IF (mp2_env%bse%num_print_exc_ntos > 0) THEN
                IF (unit_nr > 0) THEN
-                  CALL cp_warn(__LOCATION__, &
+                  CALL cp_hint(__LOCATION__, &
                                "Keywords NUM_PRINT_EXC_NTOS and STATE_LIST are both given in input. "// &
                                "Overriding NUM_PRINT_EXC_NTOS.")
                END IF
@@ -1574,7 +1576,7 @@ CONTAINS
             END DO
             IF (num_state_list_exceptions > 0) THEN
                IF (unit_nr > 0) THEN
-                  CALL cp_warn(__LOCATION__, &
+                  CALL cp_hint(__LOCATION__, &
                                "STATE_LIST contains indices outside the range of included excitation levels. "// &
                                "Ignoring these states.")
                END IF
@@ -1619,7 +1621,7 @@ CONTAINS
       IF (mp2_env%bse%num_print_exc_descr < 0 .OR. &
           mp2_env%bse%num_print_exc_descr > mp2_env%bse%num_print_exc) THEN
          IF (unit_nr > 0) THEN
-            CALL cp_warn(__LOCATION__, &
+            CALL cp_hint(__LOCATION__, &
                          "Keyword NUM_PRINT_EXC_DESCR is either negative or too large. "// &
                          "Printing exciton descriptors up to NUM_PRINT_EXC.")
          END IF

--- a/src/gw_utils.F
+++ b/src/gw_utils.F
@@ -362,7 +362,10 @@ CONTAINS
       DO ikind = 1, n_kind
          CALL get_qs_kind(qs_kind=qs_kind_set(ikind), basis_set=basis_set_a, &
                           basis_type="RI_AUX")
-         CPASSERT(ASSOCIATED(basis_set_a))
+         IF (.NOT. ASSOCIATED(basis_set_a)) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "At least one RI_AUX basis set was not explicitly invoked in &KIND-section.")
+         END IF
       END DO
 
       ALLOCATE (bs_env%i_RI_start_from_atom(n_atom))

--- a/src/mp2_eri.F
+++ b/src/mp2_eri.F
@@ -1320,11 +1320,9 @@ CONTAINS
          ! in the RI basis, there is only a single primitive Gaussian
          kpgf = 1
 
-         IF (lc_max == 0) THEN
-            nc_start = 1
-         ELSE
-            nc_start = ncoset(lc_max - 1) + 1
-         END IF
+         ! ncoset is indexed by -1,..., ,5
+         ! e.g. for pure s: lc_min = lc_max = 0, nc_start = 1
+         nc_start = ncoset(lc_min - 1) + 1
          nc_end = ncoset(lc_max)
 
          CALL coulomb3(la_max, npgfa, zeta(:), rpgfa(:), la_min, &

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -332,8 +332,12 @@ CONTAINS
       END IF
 
       IF (do_bse) THEN
-         CPASSERT(my_do_gw)
-         CPASSERT(.NOT. do_im_time)
+         IF (.NOT. my_do_gw) THEN
+            CALL cp_abort(__LOCATION__, "BSE calculations require prior GW calculations.")
+         END IF
+         IF (do_im_time) THEN
+            CALL cp_abort(__LOCATION__, "BSE calculations are not implemented for low-scaling GW.")
+         END IF
          ! GPW integrals have to be implemented later
          IF (eri_method == do_eri_gpw) THEN
             CALL cp_abort(__LOCATION__, &

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -541,6 +541,15 @@ CONTAINS
              (ri_metric%potential_type == do_potential_coulomb .OR. ri_metric%potential_type == do_potential_long) .OR. &
              eri_method == do_eri_os .AND. ri_metric%potential_type == do_potential_coulomb) THEN
 
+            ! Add a warning for automatically generated RI_AUX basis sets
+            ! Tend to be not sufficiently converged
+            IF (qs_env%mp2_env%ri_aux_auto_generated) THEN
+               CALL cp_warn(__LOCATION__, &
+                            "At least one RI_AUX basis set was not explicitly invoked in &KIND-section. "// &
+                            "Automatically RI-basis sets and ERI_METHOD OS tend to be not converged. "// &
+                            "Consider specifying BASIS_SET RI_AUX explicitly with a sufficiently large basis.")
+            END IF
+
             NULLIFY (mat_munu_local_L)
             ALLOCATE (mat_munu_local_L(my_group_L_size))
             DO LLL = 1, my_group_L_size

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -402,6 +402,7 @@ MODULE mp2_types
       TYPE(local_gemm_ctxt_type)                         :: local_gemm_ctx = local_gemm_ctxt_type()
       REAL(dp)                                           :: e_gap = 0.0_dp, &
                                                             e_range = 0.0_dp
+      LOGICAL                                            :: ri_aux_auto_generated = .FALSE.
    END TYPE mp2_type
 
    TYPE integ_mat_buffer_type

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -88,16 +88,15 @@ MODULE qs_environment
    USE hfx_types,                       ONLY: compare_hfx_sections,&
                                               hfx_create
    USE input_constants,                 ONLY: &
-        dispersion_d2, dispersion_d3, dispersion_d3bj, do_et_ddapc, do_method_am1, do_method_dftb, &
-        do_method_gapw, do_method_gapw_xc, do_method_gpw, do_method_lrigpw, do_method_mndo, &
-        do_method_mndod, do_method_ofgpw, do_method_pdg, do_method_pm3, do_method_pm6, &
-        do_method_pm6fm, do_method_pnnl, do_method_rigpw, do_method_rm1, do_method_xtb, &
-        do_qmmm_gauss, do_qmmm_swave, general_roks, hden_atomic, kg_tnadd_embed_ri, rel_none, &
-        rel_trans_atom, vdw_pairpot_dftd2, vdw_pairpot_dftd3, vdw_pairpot_dftd3bj, &
-        vdw_pairpot_dftd4, wfi_aspc_nr, wfi_linear_ps_method_nr, wfi_linear_wf_method_nr, &
-        wfi_ps_method_nr, wfi_use_guess_method_nr, xc_vdw_fun_none, xc_vdw_fun_nonloc, &
-        xc_vdw_fun_pairpot, xtb_vdw_type_d3, xtb_vdw_type_d4, xtb_vdw_type_none, &
-        do_eri_os, eri_default
+        dispersion_d2, dispersion_d3, dispersion_d3bj, do_eri_os, do_et_ddapc, do_method_am1, &
+        do_method_dftb, do_method_gapw, do_method_gapw_xc, do_method_gpw, do_method_lrigpw, &
+        do_method_mndo, do_method_mndod, do_method_ofgpw, do_method_pdg, do_method_pm3, &
+        do_method_pm6, do_method_pm6fm, do_method_pnnl, do_method_rigpw, do_method_rm1, &
+        do_method_xtb, do_qmmm_gauss, do_qmmm_swave, eri_default, general_roks, hden_atomic, &
+        kg_tnadd_embed_ri, rel_none, rel_trans_atom, vdw_pairpot_dftd2, vdw_pairpot_dftd3, &
+        vdw_pairpot_dftd3bj, vdw_pairpot_dftd4, wfi_aspc_nr, wfi_linear_ps_method_nr, &
+        wfi_linear_wf_method_nr, wfi_ps_method_nr, wfi_use_guess_method_nr, xc_vdw_fun_none, &
+        xc_vdw_fun_nonloc, xc_vdw_fun_pairpot, xtb_vdw_type_d3, xtb_vdw_type_d4, xtb_vdw_type_none
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
@@ -598,7 +597,7 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: n_mo, nelectron_spin
       LOGICAL :: all_potential_present, be_silent, do_kpoints, do_ri_hfx, do_ri_mp2, do_ri_rpa, &
          do_ri_sos_mp2, do_rpa_ri_exx, do_wfc_im_time, e1terms, has_unit_metric, lribas, &
-         mp2_present, orb_gradient, my_eri_method
+         mp2_present, my_eri_method, orb_gradient
       REAL(KIND=dp)                                      :: alpha, ccore, ewald_rcut, fxx, maxocc, &
                                                             rcut, total_zeff_corr, verlet_skin, &
                                                             zeff_correction
@@ -1013,12 +1012,12 @@ CONTAINS
                   ! INTEGRALS method OS for molecules/0D systems doesnt work for default AUX
                   ! eri_default switches to do_eri_os in mp2_gpw.F for 0D systems
                   my_eri_method = qs_env%mp2_env%eri_method == do_eri_os .OR. &
-                                  ( qs_env%mp2_env%eri_method == eri_default .AND. &
-                                  dft_control%qs_control%periodicity == 0) 
+                                  (qs_env%mp2_env%eri_method == eri_default .AND. &
+                                   dft_control%qs_control%periodicity == 0)
                   IF (my_eri_method) THEN
                      CALL cp_abort(__LOCATION__, &
-                                  "Default RI_AUX basis set was invoked, which is not supported for ERI method OS. "//&
-                                  "Please state a RI_AUX basis set in &KIND explicitly.")
+                                   "Default RI_AUX basis set was invoked, which is not supported for ERI method OS. "// &
+                                   "Please state a RI_AUX basis set in &KIND explicitly.")
                   END IF
                   CALL create_ri_aux_basis_set(ri_aux_basis_set, qs_kind, dft_control%auto_basis_ri_aux, basis_sort=sort_basis)
                   CALL add_basis_set_to_container(qs_kind%basis_sets, ri_aux_basis_set, "RI_AUX")

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -1011,6 +1011,9 @@ CONTAINS
                   ! Generate a default basis
                   CALL create_ri_aux_basis_set(ri_aux_basis_set, qs_kind, dft_control%auto_basis_ri_aux, basis_sort=sort_basis)
                   CALL add_basis_set_to_container(qs_kind%basis_sets, ri_aux_basis_set, "RI_AUX")
+                  ! Add a flag, which allows to check if the basis was generated
+                  !  when applying ERI_METHOD OS to mp2, ri-rpa, gw etc
+                  qs_env%mp2_env%ri_aux_auto_generated = .TRUE.
                END IF
             END DO
          END IF

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -88,15 +88,15 @@ MODULE qs_environment
    USE hfx_types,                       ONLY: compare_hfx_sections,&
                                               hfx_create
    USE input_constants,                 ONLY: &
-        dispersion_d2, dispersion_d3, dispersion_d3bj, do_eri_os, do_et_ddapc, do_method_am1, &
-        do_method_dftb, do_method_gapw, do_method_gapw_xc, do_method_gpw, do_method_lrigpw, &
-        do_method_mndo, do_method_mndod, do_method_ofgpw, do_method_pdg, do_method_pm3, &
-        do_method_pm6, do_method_pm6fm, do_method_pnnl, do_method_rigpw, do_method_rm1, &
-        do_method_xtb, do_qmmm_gauss, do_qmmm_swave, eri_default, general_roks, hden_atomic, &
-        kg_tnadd_embed_ri, rel_none, rel_trans_atom, vdw_pairpot_dftd2, vdw_pairpot_dftd3, &
-        vdw_pairpot_dftd3bj, vdw_pairpot_dftd4, wfi_aspc_nr, wfi_linear_ps_method_nr, &
-        wfi_linear_wf_method_nr, wfi_ps_method_nr, wfi_use_guess_method_nr, xc_vdw_fun_none, &
-        xc_vdw_fun_nonloc, xc_vdw_fun_pairpot, xtb_vdw_type_d3, xtb_vdw_type_d4, xtb_vdw_type_none
+        dispersion_d2, dispersion_d3, dispersion_d3bj, do_et_ddapc, do_method_am1, do_method_dftb, &
+        do_method_gapw, do_method_gapw_xc, do_method_gpw, do_method_lrigpw, do_method_mndo, &
+        do_method_mndod, do_method_ofgpw, do_method_pdg, do_method_pm3, do_method_pm6, &
+        do_method_pm6fm, do_method_pnnl, do_method_rigpw, do_method_rm1, do_method_xtb, &
+        do_qmmm_gauss, do_qmmm_swave, general_roks, hden_atomic, kg_tnadd_embed_ri, rel_none, &
+        rel_trans_atom, vdw_pairpot_dftd2, vdw_pairpot_dftd3, vdw_pairpot_dftd3bj, &
+        vdw_pairpot_dftd4, wfi_aspc_nr, wfi_linear_ps_method_nr, wfi_linear_wf_method_nr, &
+        wfi_ps_method_nr, wfi_use_guess_method_nr, xc_vdw_fun_none, xc_vdw_fun_nonloc, &
+        xc_vdw_fun_pairpot, xtb_vdw_type_d3, xtb_vdw_type_d4, xtb_vdw_type_none
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
@@ -597,7 +597,7 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: n_mo, nelectron_spin
       LOGICAL :: all_potential_present, be_silent, do_kpoints, do_ri_hfx, do_ri_mp2, do_ri_rpa, &
          do_ri_sos_mp2, do_rpa_ri_exx, do_wfc_im_time, e1terms, has_unit_metric, lribas, &
-         mp2_present, my_eri_method, orb_gradient
+         mp2_present, orb_gradient
       REAL(KIND=dp)                                      :: alpha, ccore, ewald_rcut, fxx, maxocc, &
                                                             rcut, total_zeff_corr, verlet_skin, &
                                                             zeff_correction
@@ -1009,16 +1009,6 @@ CONTAINS
                IF (.NOT. (ASSOCIATED(ri_aux_basis_set))) THEN
                   ! RI_AUX basis set is not yet loaded
                   ! Generate a default basis
-                  ! INTEGRALS method OS for molecules/0D systems doesnt work for default AUX
-                  ! eri_default switches to do_eri_os in mp2_gpw.F for 0D systems
-                  my_eri_method = qs_env%mp2_env%eri_method == do_eri_os .OR. &
-                                  (qs_env%mp2_env%eri_method == eri_default .AND. &
-                                   dft_control%qs_control%periodicity == 0)
-                  IF (my_eri_method) THEN
-                     CALL cp_abort(__LOCATION__, &
-                                   "Default RI_AUX basis set was invoked, which is not supported for ERI method OS. "// &
-                                   "Please state a RI_AUX basis set in &KIND explicitly.")
-                  END IF
                   CALL create_ri_aux_basis_set(ri_aux_basis_set, qs_kind, dft_control%auto_basis_ri_aux, basis_sort=sort_basis)
                   CALL add_basis_set_to_container(qs_kind%basis_sets, ri_aux_basis_set, "RI_AUX")
                END IF

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -96,7 +96,8 @@ MODULE qs_environment
         rel_trans_atom, vdw_pairpot_dftd2, vdw_pairpot_dftd3, vdw_pairpot_dftd3bj, &
         vdw_pairpot_dftd4, wfi_aspc_nr, wfi_linear_ps_method_nr, wfi_linear_wf_method_nr, &
         wfi_ps_method_nr, wfi_use_guess_method_nr, xc_vdw_fun_none, xc_vdw_fun_nonloc, &
-        xc_vdw_fun_pairpot, xtb_vdw_type_d3, xtb_vdw_type_d4, xtb_vdw_type_none
+        xc_vdw_fun_pairpot, xtb_vdw_type_d3, xtb_vdw_type_d4, xtb_vdw_type_none, &
+        do_eri_os, eri_default
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
@@ -597,7 +598,7 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: n_mo, nelectron_spin
       LOGICAL :: all_potential_present, be_silent, do_kpoints, do_ri_hfx, do_ri_mp2, do_ri_rpa, &
          do_ri_sos_mp2, do_rpa_ri_exx, do_wfc_im_time, e1terms, has_unit_metric, lribas, &
-         mp2_present, orb_gradient
+         mp2_present, orb_gradient, my_eri_method
       REAL(KIND=dp)                                      :: alpha, ccore, ewald_rcut, fxx, maxocc, &
                                                             rcut, total_zeff_corr, verlet_skin, &
                                                             zeff_correction
@@ -1009,6 +1010,16 @@ CONTAINS
                IF (.NOT. (ASSOCIATED(ri_aux_basis_set))) THEN
                   ! RI_AUX basis set is not yet loaded
                   ! Generate a default basis
+                  ! INTEGRALS method OS for molecules/0D systems doesnt work for default AUX
+                  ! eri_default switches to do_eri_os in mp2_gpw.F for 0D systems
+                  my_eri_method = qs_env%mp2_env%eri_method == do_eri_os .OR. &
+                                  ( qs_env%mp2_env%eri_method == eri_default .AND. &
+                                  dft_control%qs_control%periodicity == 0) 
+                  IF (my_eri_method) THEN
+                     CALL cp_abort(__LOCATION__, &
+                                  "Default RI_AUX basis set was invoked, which is not supported for ERI method OS. "//&
+                                  "Please state a RI_AUX basis set in &KIND explicitly.")
+                  END IF
                   CALL create_ri_aux_basis_set(ri_aux_basis_set, qs_kind, dft_control%auto_basis_ri_aux, basis_sort=sort_basis)
                   CALL add_basis_set_to_container(qs_kind%basis_sets, ri_aux_basis_set, "RI_AUX")
                END IF


### PR DESCRIPTION
- BSE: add meaningful abort messages for users
- RI-RPA: [Google group issue](https://groups.google.com/g/cp2k/c/9e8Y55_XW6E) reported a problem, which is related to the [Obara-Saika method](https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/DFT/XC/WF_CORRELATION/INTEGRALS.html) (invoked for 0D systems by default) and the automatically generated RI_AUX basis sets. Here, I just added a graceful abort, which states their incompatability as already written in the [manual](https://manual.cp2k.org/trunk/methods/post_hartree_fock/preliminaries.html#step-5-setup-of-integral-calculation-step).