### PR TITLE
Fix occurrence of ghost states with SVDs

### DIFF
--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -2421,6 +2421,13 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create(keyword, __LOCATION__, name="EPS_SVD", &
+                          description="Determines the upper bound of eigenvectors to be removed during the SVD (see DO_SVD).", &
+                          usage="EPS_SVD  1E-5", &
+                          default_r_val=0.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
       CALL keyword_create(keyword, __LOCATION__, name="ERI_BLKSIZE", &
                           description="block sizes for tensors (only used if ERI_METHOD=MME). First value "// &
                           "is the block size for ORB basis, second value is the block size for RI_AUX basis.", &

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -29,9 +29,12 @@ MODULE mp2
    USE cp_dbcsr_api,                    ONLY: dbcsr_get_info,&
                                               dbcsr_p_type
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_triangular_invert
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
+                                              cp_fm_syrk,&
+                                              cp_fm_triangular_invert,&
+                                              cp_fm_upper_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose
-   USE cp_fm_diag,                      ONLY: cp_fm_power
+   USE cp_fm_diag,                      ONLY: choose_eigv_solver
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
@@ -39,6 +42,7 @@ MODULE mp2
                                               cp_fm_get_submatrix,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
+                                              cp_fm_to_fm,&
                                               cp_fm_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type
@@ -78,6 +82,7 @@ MODULE mp2
                                               ri_mp2_laplace,&
                                               ri_mp2_method_gpw,&
                                               ri_rpa_method_gpw
+   USE parallel_gemm_api,               ONLY: parallel_gemm
    USE particle_types,                  ONLY: particle_type
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -121,9 +126,9 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'mp2_main'
 
-      INTEGER :: bin, cholesky_method, dimen, handle, handle2, i, i_thread, iatom, ikind, irep, &
-         ispin, max_nset, my_bin_size, n_rep_hf, n_threads, nao, natom, ndep, nfullcols_total, &
-         nfullrows_total, nkind, nspins, unit_nr
+      INTEGER :: bin, cholesky_method, dimen, handle, handle2, i, i_thread, iatom, ii, ikind, &
+         irep, ispin, max_nset, my_bin_size, n_rep_hf, n_threads, nao, natom, ndep, &
+         nfullcols_total, nfullrows_total, nkind, nmo, nspins, unit_nr
       INTEGER(KIND=int_8)                                :: mem
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of, nelec
       LOGICAL :: calc_ex, do_admm, do_admm_rpa_exx, do_dynamic_load_balancing, do_exx, do_gw, &
@@ -131,6 +136,7 @@ CONTAINS
       REAL(KIND=dp) :: E_admm_from_GW(2), E_ex_from_GW, Emp2, Emp2_AA, Emp2_AA_Cou, Emp2_AA_ex, &
          Emp2_AB, Emp2_AB_Cou, Emp2_AB_ex, Emp2_BB, Emp2_BB_Cou, Emp2_BB_ex, Emp2_Cou, Emp2_ex, &
          Emp2_S, Emp2_T, maxocc, mem_real, t1, t2, t3
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: evals
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: Auto
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: C
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
@@ -138,8 +144,10 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
-      TYPE(cp_fm_type)                                   :: fm_matrix_ks, fm_matrix_s, fm_matrix_work
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff
+      TYPE(cp_fm_type)                                   :: evecs, fm_matrix_ks, fm_matrix_s, &
+                                                            fm_matrix_work
+      TYPE(cp_fm_type), POINTER                          :: fm_matrix_ks_red, fm_matrix_s_red, &
+                                                            fm_work_red, mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks_transl, matrix_s_kp
@@ -169,7 +177,7 @@ CONTAINS
                        "not possible to run MP2")
       END IF
 
-      NULLIFY (virial, dft_control, blacs_env, kpoints)
+      NULLIFY (virial, dft_control, blacs_env, kpoints, fm_matrix_s_red, fm_matrix_ks_red, fm_work_red)
       CALL timeset(routineN, handle)
       logger => cp_get_default_logger()
 
@@ -336,8 +344,74 @@ CONTAINS
 
       CALL cp_fm_struct_release(fm_struct)
 
+      nmo = nao
+      ALLOCATE (nelec(nspins))
       IF (scf_env%cholesky_method == cholesky_off) THEN
-         CALL cp_fm_power(fm_matrix_s, fm_matrix_work, -0.5_dp, scf_control%eps_eigval, ndep)
+         ALLOCATE (evals(nao))
+         evals = 0
+
+         CALL cp_fm_create(evecs, fm_matrix_s%matrix_struct)
+
+         ! Perform an EVD
+         CALL choose_eigv_solver(fm_matrix_s, evecs, evals)
+
+         ! Determine the number of neglectable eigenvalues assuming that the eigenvalues are in ascending order
+         ! (Required by Lapack)
+         ndep = 0
+         DO ii = 1, nao
+            IF (evals(ii) > scf_control%eps_eigval) THEN
+               ndep = ii - 1
+               EXIT
+            END IF
+         END DO
+         nmo = nao - ndep
+
+         CALL get_mo_set(mo_set=mos(1), nelectron=nelec(1))
+         IF (MAXVAL(nelec) > nmo) THEN
+            ! Should not happen as the following MO calculation is the same as during the SCF steps
+            CPABORT("Not enough MOs found!")
+         END IF
+
+         ! Set the eigenvalue of the eigenvectors belonging to the linear subspace to zero
+         evals(1:ndep) = 0.0_dp
+         ! Determine the eigenvalues of the inverse square root
+         evals(ndep + 1:nao) = 1.0_dp/SQRT(evals(ndep + 1:nao))
+
+         IF (ndep > 0) THEN
+            IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T76,I5)') 'Number of removed MOs:', ndep
+            IF (unit_nr > 0) WRITE (unit_nr, '(T3,A,T76,I5)') 'Number of available MOs:', nmo
+
+            ! Create reduced matrices
+            NULLIFY (fm_struct)
+            CALL cp_fm_struct_create(fm_struct, template_fmstruct=fm_matrix_s%matrix_struct, ncol_global=nmo)
+
+            ALLOCATE (fm_matrix_s_red, fm_work_red)
+            CALL cp_fm_create(fm_matrix_s_red, fm_struct)
+            CALL cp_fm_create(fm_work_red, fm_struct)
+            CALL cp_fm_struct_release(fm_struct)
+
+            ALLOCATE (fm_matrix_ks_red)
+            CALL cp_fm_struct_create(fm_struct, template_fmstruct=fm_matrix_s%matrix_struct, &
+                                     nrow_global=nmo, ncol_global=nmo)
+            CALL cp_fm_create(fm_matrix_ks_red, fm_struct)
+            CALL cp_fm_struct_release(fm_struct)
+
+            ! Scale the eigenvalues and copy them to
+            CALL cp_fm_to_fm(evecs, fm_matrix_s_red, nmo, ndep + 1)
+            CALL cp_fm_column_scale(fm_matrix_s_red, evals(ndep + 1:))
+
+            ! Obtain ortho from (P)DGEMM, skip the linear dependent columns
+            CALL parallel_gemm("N", "T", nao, nao, nmo, 1.0_dp, fm_matrix_s_red, evecs, &
+                               0.0_dp, fm_matrix_s, b_first_col=ndep + 1)
+         ELSE
+            ! Take the square roots of the target values to allow application of SYRK
+            evals = SQRT(evals)
+            CALL cp_fm_column_scale(evecs, evals)
+            CALL cp_fm_syrk("U", "N", nao, 1.0_dp, evecs, 1, 1, 0.0_dp, fm_matrix_s)
+            CALL cp_fm_upper_to_full(fm_matrix_s, fm_matrix_work)
+         END IF
+
+         CALL cp_fm_release(evecs)
          cholesky_method = cholesky_off
       ELSE
          ! calculate S^(-1/2) (cholesky decomposition)
@@ -347,7 +421,29 @@ CONTAINS
       END IF
 
       ALLOCATE (mos_mp2(nspins))
-      ALLOCATE (nelec(nspins))
+      DO ispin = 1, nspins
+
+         CALL get_mo_set(mo_set=mos(ispin), maxocc=maxocc, nelectron=nelec(ispin))
+
+         CALL allocate_mo_set(mo_set=mos_mp2(ispin), &
+                              nao=nao, &
+                              nmo=nmo, &
+                              nelectron=nelec(ispin), &
+                              n_el_f=REAL(nelec(ispin), dp), &
+                              maxocc=maxocc, &
+                              flexible_electron_count=dft_control%relax_multiplicity)
+
+         CALL get_mo_set(mos_mp2(ispin), nao=nao)
+         CALL cp_fm_struct_create(fm_struct, nrow_global=nao, &
+                                  ncol_global=nmo, para_env=para_env, &
+                                  context=blacs_env)
+
+         CALL init_mo_set(mos_mp2(ispin), &
+                          fm_struct=fm_struct, &
+                          name="mp2_mos")
+         CALL cp_fm_struct_release(fm_struct)
+      END DO
+
       DO ispin = 1, nspins
 
          ! If ADMM we should make the ks matrix up-to-date
@@ -360,26 +456,6 @@ CONTAINS
          IF (dft_control%do_admm) THEN
             CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, matrix_ks(ispin)%matrix)
          END IF
-
-         CALL get_mo_set(mo_set=mos(ispin), maxocc=maxocc, nelectron=nelec(ispin))
-
-         CALL allocate_mo_set(mo_set=mos_mp2(ispin), &
-                              nao=nao, &
-                              nmo=nao, &
-                              nelectron=nelec(ispin), &
-                              n_el_f=REAL(nelec(ispin), dp), &
-                              maxocc=maxocc, &
-                              flexible_electron_count=dft_control%relax_multiplicity)
-
-         CALL get_mo_set(mos_mp2(ispin), nao=nao)
-         CALL cp_fm_struct_create(fm_struct, nrow_global=nao, &
-                                  ncol_global=nao, para_env=para_env, &
-                                  context=blacs_env)
-
-         CALL init_mo_set(mos_mp2(ispin), &
-                          fm_struct=fm_struct, &
-                          name="mp2_mos")
-         CALL cp_fm_struct_release(fm_struct)
 
          IF (cholesky_method == cholesky_inverse) THEN
 
@@ -395,22 +471,48 @@ CONTAINS
 
          ELSE IF (cholesky_method == cholesky_off) THEN
 
-            CALL eigensolver_symm(matrix_ks_fm=fm_matrix_ks, &
-                                  mo_set=mos_mp2(ispin), &
-                                  ortho=fm_matrix_s, &
-                                  work=fm_matrix_work, &
-                                  do_level_shift=.FALSE., &
-                                  level_shift=0.0_dp, &
-                                  use_jacobi=.FALSE., &
-                                  jacobi_threshold=0.0_dp)
-
+            IF (ASSOCIATED(fm_matrix_s_red)) THEN
+               CALL eigensolver_symm(matrix_ks_fm=fm_matrix_ks, &
+                                     mo_set=mos_mp2(ispin), &
+                                     ortho=fm_matrix_s, &
+                                     work=fm_matrix_work, &
+                                     do_level_shift=.FALSE., &
+                                     level_shift=0.0_dp, &
+                                     use_jacobi=.FALSE., &
+                                     jacobi_threshold=0.0_dp, &
+                                     ortho_red=fm_matrix_s_red, &
+                                     matrix_ks_fm_red=fm_matrix_ks_red, &
+                                     work_red=fm_work_red)
+            ELSE
+               CALL eigensolver_symm(matrix_ks_fm=fm_matrix_ks, &
+                                     mo_set=mos_mp2(ispin), &
+                                     ortho=fm_matrix_s, &
+                                     work=fm_matrix_work, &
+                                     do_level_shift=.FALSE., &
+                                     level_shift=0.0_dp, &
+                                     use_jacobi=.FALSE., &
+                                     jacobi_threshold=0.0_dp)
+            END IF
          END IF
 
+         CALL get_mo_set(mos_mp2(ispin), mo_coeff=mo_coeff)
       END DO
 
       CALL cp_fm_release(fm_matrix_s)
       CALL cp_fm_release(fm_matrix_ks)
       CALL cp_fm_release(fm_matrix_work)
+      IF (ASSOCIATED(fm_matrix_s_red)) THEN
+         CALL cp_fm_release(fm_matrix_s_red)
+         DEALLOCATE (fm_matrix_s_red)
+      END IF
+      IF (ASSOCIATED(fm_matrix_ks_red)) THEN
+         CALL cp_fm_release(fm_matrix_ks_red)
+         DEALLOCATE (fm_matrix_ks_red)
+      END IF
+      IF (ASSOCIATED(fm_work_red)) THEN
+         CALL cp_fm_release(fm_work_red)
+         DEALLOCATE (fm_work_red)
+      END IF
 
       hfx_sections => section_vals_get_subs_vals(input, "DFT%XC%HF")
 

--- a/src/mp2.F
+++ b/src/mp2.F
@@ -32,7 +32,7 @@ MODULE mp2
    USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
                                               cp_fm_syrk,&
                                               cp_fm_triangular_invert,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose
    USE cp_fm_diag,                      ONLY: choose_eigv_solver
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
@@ -408,7 +408,7 @@ CONTAINS
             evals = SQRT(evals)
             CALL cp_fm_column_scale(evecs, evals)
             CALL cp_fm_syrk("U", "N", nao, 1.0_dp, evecs, 1, 1, 0.0_dp, fm_matrix_s)
-            CALL cp_fm_upper_to_full(fm_matrix_s, fm_matrix_work)
+            CALL cp_fm_uplo_to_full(fm_matrix_s, fm_matrix_work)
          END IF
 
          CALL cp_fm_release(evecs)

--- a/src/mp2_gpw.F
+++ b/src/mp2_gpw.F
@@ -139,9 +139,9 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'mp2_gpw_main'
 
-      INTEGER :: blacs_grid_layout, bse_lev_virt, color_sub, dimen, dimen_RI, dimen_RI_red, &
-         eri_method, handle, ispin, local_unit_nr, my_group_L_end, my_group_L_size, &
-         my_group_L_start, nmo, nspins, potential_type, ri_metric_type
+      INTEGER :: blacs_grid_layout, bse_lev_virt, color_sub, dimen_RI, dimen_RI_red, eri_method, &
+         handle, ispin, local_unit_nr, my_group_L_end, my_group_L_size, my_group_L_start, nmo, &
+         nspins, potential_type, ri_metric_type
       INTEGER, ALLOCATABLE, DIMENSION(:) :: ends_array_mc, ends_array_mc_block, gw_corr_lev_occ, &
          gw_corr_lev_virt, homo, starts_array_mc, starts_array_mc_block
       INTEGER, DIMENSION(3)                              :: periodic
@@ -229,14 +229,14 @@ CONTAINS
       ELSE
          CALL get_qs_env(qs_env=qs_env, dft_control=dft_control, mos=mos)
       END IF
-      CALL get_mo_set(mo_set=mos_mp2(1), nao=dimen)
-      ALLOCATE (homo(nspins), Eigenval(dimen, nspins), mo_coeff(nspins))
+      CALL get_mo_set(mo_set=mos_mp2(1), nmo=nmo)
+      ALLOCATE (homo(nspins), Eigenval(nmo, nspins), mo_coeff(nspins))
       DO ispin = 1, nspins
          CALL get_mo_set(mo_set=mos_mp2(ispin), &
-                         eigenvalues=mo_eigenvalues, nmo=nmo, homo=homo(ispin), &
+                         eigenvalues=mo_eigenvalues, homo=homo(ispin), &
                          mo_coeff=mo_coeff_ptr)
          mo_coeff(ispin) = mo_coeff_ptr
-         Eigenval(:, ispin) = mo_eigenvalues(:)
+         Eigenval(:, ispin) = mo_eigenvalues(1:nmo)
       END DO
 
       ! a para_env
@@ -373,7 +373,7 @@ CONTAINS
          ! output the two part of the C matrix (virtual, occupied)
          DO ispin = 1, nspins
 
-            CALL replicate_mat_to_subgroup(para_env, para_env_sub, mo_coeff(ispin), dimen, homo(ispin), mat_munu%matrix, &
+            CALL replicate_mat_to_subgroup(para_env, para_env_sub, mo_coeff(ispin), nmo, homo(ispin), mat_munu%matrix, &
                                            mo_coeff_o(ispin)%matrix, mo_coeff_v(ispin)%matrix, &
                                            mo_coeff_all(ispin)%matrix, mo_coeff_gw(ispin)%matrix, &
                                            my_do_gw, gw_corr_lev_occ(ispin), gw_corr_lev_virt(ispin), do_bse, &

--- a/src/mp2_integrals.F
+++ b/src/mp2_integrals.F
@@ -269,8 +269,9 @@ CONTAINS
                                                             periodic
       LOGICAL                                            :: do_gpw, do_kpoints_from_Gamma, do_svd, &
                                                             memory_info
-      REAL(KIND=dp) :: compression_factor, cutoff_old, eps_pgf_orb, eps_pgf_orb_old, mem_for_abK, &
-         mem_for_iaK, mem_for_ijK, memory_3c, occ, omega_pot, rc_ang, relative_cutoff_old
+      REAL(KIND=dp) :: compression_factor, cutoff_old, eps_pgf_orb, eps_pgf_orb_old, eps_svd, &
+         mem_for_abK, mem_for_iaK, mem_for_ijK, memory_3c, occ, omega_pot, rc_ang, &
+         relative_cutoff_old
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: e_cutoff_old
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: my_Lrows, my_Vrows
       TYPE(cp_eri_mme_param), POINTER                    :: eri_param
@@ -308,6 +309,7 @@ CONTAINS
       eri_method = qs_env%mp2_env%eri_method
       eri_param => qs_env%mp2_env%eri_mme_param
       do_svd = qs_env%mp2_env%do_svd
+      eps_svd = qs_env%mp2_env%eps_svd
       potential_type = qs_env%mp2_env%potential_parameter%potential_type
       ri_metric_type = ri_metric%potential_type
       omega_pot = qs_env%mp2_env%potential_parameter%omega
@@ -364,7 +366,7 @@ CONTAINS
       CALL get_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, mp2_memory, &
                             my_Lrows, my_Vrows, fm_matrix_PQ, ngroup, color_sub, dimen_RI, dimen_RI_red, &
                             kpoints, my_group_L_size, my_group_L_start, my_group_L_end, &
-                            gd_array, calc_PQ_cond_num .AND. .NOT. do_svd, do_svd, &
+                            gd_array, calc_PQ_cond_num .AND. .NOT. do_svd, do_svd, eps_svd, &
                             qs_env%mp2_env%potential_parameter, ri_metric, &
                             fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, &
                             do_im_time, do_kpoints_from_Gamma .OR. do_kpoints_cubic_RPA, qs_env%mp2_env%mp2_gpw%eps_pgf_orb_S, &

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -138,6 +138,7 @@ CONTAINS
 !> \param gd_array ...
 !> \param calc_PQ_cond_num ...
 !> \param do_svd ...
+!> \param eps_svd ...
 !> \param potential ...
 !> \param ri_metric ...
 !> \param fm_matrix_L_kpoints ...
@@ -155,7 +156,7 @@ CONTAINS
    SUBROUTINE get_2c_integrals(qs_env, eri_method, eri_param, para_env, para_env_sub, mp2_memory, &
                                my_Lrows, my_Vrows, fm_matrix_PQ, ngroup, color_sub, dimen_RI, dimen_RI_red, &
                                kpoints, my_group_L_size, my_group_L_start, my_group_L_end, &
-                               gd_array, calc_PQ_cond_num, do_svd, potential, ri_metric, &
+                               gd_array, calc_PQ_cond_num, do_svd, eps_svd, potential, ri_metric, &
                                fm_matrix_L_kpoints, fm_matrix_Minv_L_kpoints, &
                                fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, &
                                do_im_time, do_kpoints, mp2_eps_pgf_orb_S, qs_kind_set, sab_orb_sub, calc_forces, unit_nr)
@@ -175,6 +176,7 @@ CONTAINS
                                                             my_group_L_end
       TYPE(group_dist_d1_type), INTENT(OUT)              :: gd_array
       LOGICAL, INTENT(IN)                                :: calc_PQ_cond_num, do_svd
+      REAL(KIND=dp), INTENT(IN)                          :: eps_svd
       TYPE(libint_potential_type)                        :: potential, ri_metric
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_L_kpoints, &
                                                             fm_matrix_Minv_L_kpoints, &
@@ -216,7 +218,7 @@ CONTAINS
       dimen_RI_red = dimen_RI
 
       IF (compare_potential_types(ri_metric, potential) .AND. .NOT. do_im_time) THEN
-         CALL decomp_mat_L(fm_matrix_L_work, do_svd, num_small_eigen, cond_num, .TRUE., gd_array, ngroup, &
+         CALL decomp_mat_L(fm_matrix_L_work, do_svd, eps_svd, num_small_eigen, cond_num, .TRUE., gd_array, ngroup, &
                            dimen_RI, dimen_RI_red, para_env)
       ELSE
 
@@ -281,14 +283,14 @@ CONTAINS
                CALL cp_fm_create(fm_matrix_V, fm_matrix_L_work%matrix_struct)
                CALL cp_fm_to_fm(fm_matrix_L_work, fm_matrix_V)
 
-               CALL decomp_mat_L(fm_matrix_V, do_svd, num_small_eigen, cond_num, .TRUE., gd_array, ngroup, &
+               CALL decomp_mat_L(fm_matrix_V, do_svd, eps_svd, num_small_eigen, cond_num, .TRUE., gd_array, ngroup, &
                                  dimen_RI, dimen_RI_red, para_env)
             END IF
 
-            CALL decomp_mat_L(fm_matrix_L_work, do_svd, num_small_eigen, cond_num, .FALSE., gd_array, ngroup, &
+            CALL decomp_mat_L(fm_matrix_L_work, do_svd, eps_svd, num_small_eigen, cond_num, .FALSE., gd_array, ngroup, &
                               dimen_RI, dimen_RI_red, para_env)
 
-            CALL decomp_mat_L(fm_matrix_Minv_L_kpoints(1, 1), .FALSE., num_small_eigen, cond_num, .TRUE., &
+            CALL decomp_mat_L(fm_matrix_Minv_L_kpoints(1, 1), .FALSE., 0.0_dp, num_small_eigen, cond_num, .TRUE., &
                               gd_array, ngroup, dimen_RI, dimen_RI_red, para_env)
 
             CALL cp_fm_create(fm_matrix_M_inv_work, fm_matrix_Minv_L_kpoints(1, 1)%matrix_struct)
@@ -359,6 +361,7 @@ CONTAINS
 !> \brief ...
 !> \param fm_matrix_L ...
 !> \param do_svd ...
+!> \param eps_svd ...
 !> \param num_small_eigen ...
 !> \param cond_num ...
 !> \param do_inversion ...
@@ -368,11 +371,12 @@ CONTAINS
 !> \param dimen_RI_red ...
 !> \param para_env ...
 ! **************************************************************************************************
-   SUBROUTINE decomp_mat_L(fm_matrix_L, do_svd, num_small_eigen, cond_num, do_inversion, gd_array, ngroup, &
+   SUBROUTINE decomp_mat_L(fm_matrix_L, do_svd, eps_svd, num_small_eigen, cond_num, do_inversion, gd_array, ngroup, &
                            dimen_RI, dimen_RI_red, para_env)
 
       TYPE(cp_fm_type), INTENT(INOUT)                    :: fm_matrix_L
       LOGICAL, INTENT(IN)                                :: do_svd
+      REAL(KIND=dp), INTENT(IN)                          :: eps_svd
       INTEGER, INTENT(INOUT)                             :: num_small_eigen
       REAL(KIND=dp), INTENT(INOUT)                       :: cond_num
       LOGICAL, INTENT(IN)                                :: do_inversion
@@ -382,7 +386,7 @@ CONTAINS
       TYPE(mp_para_env_type), INTENT(IN)                 :: para_env
 
       IF (do_svd) THEN
-         CALL matrix_root_with_svd(fm_matrix_L, num_small_eigen, cond_num, do_inversion, para_env)
+         CALL matrix_root_with_svd(fm_matrix_L, num_small_eigen, cond_num, eps_svd, do_inversion, para_env)
 
          dimen_RI_red = dimen_RI - num_small_eigen
 
@@ -1071,13 +1075,15 @@ CONTAINS
 !> \param matrix ...
 !> \param num_small_evals ...
 !> \param cond_num ...
+!> \param eps_svd ...
 !> \param do_inversion ...
 !> \param para_env ...
 ! **************************************************************************************************
-   SUBROUTINE matrix_root_with_svd(matrix, num_small_evals, cond_num, do_inversion, para_env)
+   SUBROUTINE matrix_root_with_svd(matrix, num_small_evals, cond_num, eps_svd, do_inversion, para_env)
       TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix
       INTEGER, INTENT(OUT)                               :: num_small_evals
       REAL(KIND=dp), INTENT(OUT)                         :: cond_num
+      REAL(KIND=dp), INTENT(IN)                          :: eps_svd
       LOGICAL, INTENT(IN)                                :: do_inversion
       TYPE(mp_para_env_type), INTENT(IN)                 :: para_env
 
@@ -1106,7 +1112,7 @@ CONTAINS
       ! Determine the number of neglectable eigenvalues assuming that the eigenvalues are in ascending order
       num_small_evals = 0
       DO ii = 1, nrow
-         IF (evals(ii) > 0.0_dp) THEN
+         IF (evals(ii) > eps_svd) THEN
             num_small_evals = ii - 1
             EXIT
          END IF

--- a/src/mp2_setup.F
+++ b/src/mp2_setup.F
@@ -432,6 +432,7 @@ CONTAINS
       CALL section_vals_val_get(mp2_section, "RI%COL_BLOCK", i_val=mp2_env%block_size_col)
       CALL section_vals_val_get(mp2_section, "RI%CALC_COND_NUM", l_val=mp2_env%calc_PQ_cond_num)
       CALL section_vals_val_get(mp2_section, "RI%DO_SVD", l_val=mp2_env%do_svd)
+      CALL section_vals_val_get(mp2_section, "RI%EPS_SVD", r_val=mp2_env%eps_svd)
       CALL section_vals_val_get(mp2_section, "RI%ERI_BLKSIZE", i_vals=mp2_env%eri_blksize)
       CALL section_vals_val_get(mp2_section, "RI%RI_METRIC%POTENTIAL_TYPE", i_val=mp2_env%ri_metric%potential_type)
       CALL section_vals_val_get(mp2_section, "RI%RI_METRIC%OMEGA", r_val=mp2_env%ri_metric%omega)

--- a/src/mp2_types.F
+++ b/src/mp2_types.F
@@ -397,6 +397,7 @@ MODULE mp2_types
       TYPE(cp_eri_mme_param), POINTER                    :: eri_mme_param => NULL()
       INTEGER, DIMENSION(:), POINTER                     :: eri_blksize => NULL()
       LOGICAL                                            :: do_svd = .FALSE.
+      REAL(KIND=dp)                                      :: eps_svd = -1.0_dp
       REAL(KIND=dp)                                      :: eps_range = 0.0_dp
       TYPE(libint_potential_type)                        :: ri_metric = libint_potential_type()
       TYPE(local_gemm_ctxt_type)                         :: local_gemm_ctx = local_gemm_ctxt_type()

--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -291,7 +291,7 @@ CONTAINS
                                                             inv_err, norm, norm_c_inv, res_norm, &
                                                             vol
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: alpha_c, ev
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: a, b, c, c_inv, cpc_h_mix, cpc_s_mix
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: b, c, c_inv, cpc_h_mix, cpc_s_mix
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_c1d_gs_type), DIMENSION(:), POINTER        :: rho_g
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom
@@ -365,17 +365,20 @@ CONTAINS
             mixing_store%ncall_p(ispin) = mixing_store%ncall_p(ispin) - 1
          ELSE
             nb1 = nb + 1
-            ALLOCATE (a(nb1, nb1))
-            a = 0.0_dp
+            IF (ALLOCATED(b)) DEALLOCATE (b)
             ALLOCATE (b(nb1, nb1))
             b = 0.0_dp
+            IF (ALLOCATED(c)) DEALLOCATE (c)
             ALLOCATE (c(nb, nb))
             c = 0.0_dp
+            IF (ALLOCATED(c_inv)) DEALLOCATE (c_inv)
             ALLOCATE (c_inv(nb, nb))
             c_inv = 0.0_dp
+            IF (ALLOCATED(alpha_c)) DEALLOCATE (alpha_c)
             ALLOCATE (alpha_c(nb))
             alpha_c = 0.0_dp
             norm_c_inv = 0.0_dp
+            IF (ALLOCATED(ev)) DEALLOCATE (ev)
             ALLOCATE (ev(nb1))
             ev = 0.0_dp
 
@@ -505,7 +508,6 @@ CONTAINS
          END IF ! nb==1
 
          IF (res_norm > 1.E-14_dp) THEN
-            DEALLOCATE (a)
             DEALLOCATE (b)
             DEALLOCATE (ev)
             DEALLOCATE (c, c_inv, alpha_c)

--- a/src/qs_mixing_utils.F
+++ b/src/qs_mixing_utils.F
@@ -7,7 +7,6 @@
 
 ! **************************************************************************************************
 MODULE qs_mixing_utils
-
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_api,                    ONLY: dbcsr_create,&
                                               dbcsr_p_type,&

--- a/src/qs_mo_occupation.F
+++ b/src/qs_mo_occupation.F
@@ -546,7 +546,8 @@ CONTAINS
          SELECT CASE (smear%method)
          CASE (smear_fermi_dirac)
             IF (.NOT. PRESENT(eval_deriv)) THEN
-               CALL FermiFixed(mo_set%occupation_numbers, mo_set%mu, mo_set%kTS, mo_set%eigenvalues, Nelec, &
+               CALL FermiFixed(mo_set%occupation_numbers(1:mo_set%nmo), mo_set%mu, mo_set%kTS, &
+                               mo_set%eigenvalues(1:mo_set%nmo), Nelec, &
                                smear%electronic_temperature, mo_set%maxocc, xas_estate, occ_estate)
             ELSE
                ! could be a relatively large matrix, but one could get rid of it by never storing it
@@ -555,7 +556,8 @@ CONTAINS
                ! lengthscale could become a parameter, but this is pretty good
                lengthscale = 10*smear%electronic_temperature
 
-               CALL FermiFixedDeriv(dfde, mo_set%occupation_numbers, mo_set%mu, mo_set%kTS, mo_set%eigenvalues, Nelec, &
+               CALL FermiFixedDeriv(dfde, mo_set%occupation_numbers(1:mo_set%nmo), mo_set%mu, &
+                                    mo_set%kTS, mo_set%eigenvalues(1:mo_set%nmo), Nelec, &
                                     smear%electronic_temperature, mo_set%maxocc, lengthscale, xas_estate, occ_estate)
 
                ! deriv of E_{KS}-kT*S wrt to f_i

--- a/src/qs_mo_types.F
+++ b/src/qs_mo_types.F
@@ -238,7 +238,7 @@ CONTAINS
 !> \param fm_struct ...
 !> \param name ...
 !> \par History
-!>      11.2002 rewamped [fawzi]
+!>      11.2002 revamped [fawzi]
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
    SUBROUTINE init_mo_set(mo_set, fm_pool, fm_ref, fm_struct, name)

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -909,17 +909,38 @@ CONTAINS
       ! Release SCF work storage
       CALL cp_fm_release(scf_env%scf_work1)
 
+      IF (ASSOCIATED(scf_env%scf_work1_red)) THEN
+         CALL cp_fm_release(scf_env%scf_work1_red)
+      END IF
       IF (ASSOCIATED(scf_env%scf_work2)) THEN
          CALL cp_fm_release(scf_env%scf_work2)
          DEALLOCATE (scf_env%scf_work2)
+         NULLIFY (scf_env%scf_work2)
+      END IF
+      IF (ASSOCIATED(scf_env%scf_work2_red)) THEN
+         CALL cp_fm_release(scf_env%scf_work2_red)
+         DEALLOCATE (scf_env%scf_work2_red)
+         NULLIFY (scf_env%scf_work2_red)
       END IF
       IF (ASSOCIATED(scf_env%ortho)) THEN
          CALL cp_fm_release(scf_env%ortho)
          DEALLOCATE (scf_env%ortho)
+         NULLIFY (scf_env%ortho)
+      END IF
+      IF (ASSOCIATED(scf_env%ortho_red)) THEN
+         CALL cp_fm_release(scf_env%ortho_red)
+         DEALLOCATE (scf_env%ortho_red)
+         NULLIFY (scf_env%ortho_red)
       END IF
       IF (ASSOCIATED(scf_env%ortho_m1)) THEN
          CALL cp_fm_release(scf_env%ortho_m1)
          DEALLOCATE (scf_env%ortho_m1)
+         NULLIFY (scf_env%ortho_m1)
+      END IF
+      IF (ASSOCIATED(scf_env%ortho_m1_red)) THEN
+         CALL cp_fm_release(scf_env%ortho_m1_red)
+         DEALLOCATE (scf_env%ortho_m1_red)
+         NULLIFY (scf_env%ortho_m1_red)
       END IF
 
       IF (ASSOCIATED(scf_env%ortho_dbcsr)) THEN

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -289,6 +289,20 @@ CONTAINS
          END DO
          ELSE
          DO ispin = 1, nspin
+         IF (ASSOCIATED(scf_env%scf_work1_red) .AND. ASSOCIATED(scf_env%scf_work2_red) &
+             .AND. ASSOCIATED(scf_env%ortho_red)) THEN
+            CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin), &
+                                  mo_set=mos(ispin), &
+                                  ortho=ortho, &
+                                  work=scf_env%scf_work2, &
+                                  do_level_shift=do_level_shift, &
+                                  level_shift=scf_control%level_shift, &
+                                  use_jacobi=use_jacobi, &
+                                  jacobi_threshold=scf_control%diagonalization%jacobi_threshold, &
+                                  matrix_ks_fm_red=scf_env%scf_work1_red(ispin), &
+                                  ortho_red=scf_env%ortho_red, &
+                                  work_red=scf_env%scf_work2_red)
+         ELSE
             CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin), &
                                   mo_set=mos(ispin), &
                                   ortho=ortho, &
@@ -297,6 +311,7 @@ CONTAINS
                                   level_shift=scf_control%level_shift, &
                                   use_jacobi=use_jacobi, &
                                   jacobi_threshold=scf_control%diagonalization%jacobi_threshold)
+         END IF
          END DO
          END IF
 
@@ -1168,7 +1183,6 @@ CONTAINS
          CALL calculate_subspace_eigenvalues(mo_coeff, matrix_ks(ispin)%matrix, &
                                              evals_arg=eigenvalues, &
                                              do_rotation=.TRUE.)
-         !MK WRITE(*,*) routinen//' copy_dbcsr_to_fm'
          CALL copy_fm_to_dbcsr(mos(ispin)%mo_coeff, &
                                mos(ispin)%mo_coeff_b)
          !fm->dbcsr
@@ -1340,6 +1354,7 @@ CONTAINS
                                 eps_diis=scf_control%eps_diis, &
                                 scf_section=scf_section, &
                                 roks=.TRUE.)
+            CPASSERT(scf_env%iter_delta == scf_env%iter_delta)
          ELSE
             CALL qs_diis_b_step(diis_buffer=scf_env%scf_diis_buffer, &
                                 mo_array=mos, &

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -277,6 +277,22 @@ CONTAINS
 
          IF (do_level_shift) THEN
          DO ispin = 1, nspin
+         IF (ASSOCIATED(scf_env%scf_work1_red) .AND. ASSOCIATED(scf_env%scf_work2_red) &
+             .AND. ASSOCIATED(scf_env%ortho_red) .AND. ASSOCIATED(scf_env%ortho_m1_red)) THEN
+            CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin), &
+                                  mo_set=mos(ispin), &
+                                  ortho=ortho, &
+                                  work=scf_env%scf_work2, &
+                                  do_level_shift=do_level_shift, &
+                                  level_shift=scf_control%level_shift, &
+                                  matrix_u_fm=scf_env%ortho_m1, &
+                                  use_jacobi=use_jacobi, &
+                                  jacobi_threshold=scf_control%diagonalization%jacobi_threshold, &
+                                  matrix_ks_fm_red=scf_env%scf_work1_red(ispin), &
+                                  ortho_red=scf_env%ortho_red, &
+                                  work_red=scf_env%scf_work2_red, &
+                                  matrix_u_fm_red=scf_env%ortho_m1_red)
+         ELSE
             CALL eigensolver_symm(matrix_ks_fm=scf_env%scf_work1(ispin), &
                                   mo_set=mos(ispin), &
                                   ortho=ortho, &
@@ -286,6 +302,7 @@ CONTAINS
                                   matrix_u_fm=scf_env%ortho_m1, &
                                   use_jacobi=use_jacobi, &
                                   jacobi_threshold=scf_control%diagonalization%jacobi_threshold)
+         END IF
          END DO
          ELSE
          DO ispin = 1, nspin

--- a/src/qs_scf_initialization.F
+++ b/src/qs_scf_initialization.F
@@ -22,9 +22,9 @@ MODULE qs_scf_initialization
                                               cp_dbcsr_sm_fm_multiply
    USE cp_dbcsr_output,                 ONLY: write_fm_with_basis_info
    USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
-                                              cp_fm_syrk,&
-                                              cp_fm_triangular_invert,&
-                                              cp_fm_upper_to_full
+                                              cp_fm_row_scale,&
+                                              cp_fm_transpose,&
+                                              cp_fm_triangular_invert
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose
    USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
                                               cp_fm_power
@@ -974,71 +974,81 @@ CONTAINS
             ! Determine the eigenvalues of the inverse square root
             evals(ndep + 1:nao) = 1.0_dp/SQRT(evals(ndep + 1:nao))
 
-            IF (ndep > 0) THEN
-               ! Create reduced matrices
-               NULLIFY (fm_struct)
+            ! Create reduced matrices
+            NULLIFY (fm_struct)
+            CALL cp_fm_struct_create(fm_struct, template_fmstruct=scf_env%ortho%matrix_struct, &
+                                     nrow_global=nao, ncol_global=needed_evals)
+
+            ALLOCATE (scf_env%ortho_red, scf_env%scf_work2_red)
+            CALL cp_fm_create(scf_env%ortho_red, fm_struct)
+            CALL cp_fm_create(scf_env%scf_work2_red, fm_struct)
+            CALL cp_fm_struct_release(fm_struct)
+
+            IF (scf_control%level_shift /= 0.0_dp) THEN
                CALL cp_fm_struct_create(fm_struct, template_fmstruct=scf_env%ortho%matrix_struct, &
-                                        nrow_global=nao, ncol_global=needed_evals)
+                                        nrow_global=needed_evals, ncol_global=nao)
 
-               ALLOCATE (scf_env%ortho_red, scf_env%scf_work2_red)
-               CALL cp_fm_create(scf_env%ortho_red, fm_struct)
-               CALL cp_fm_create(scf_env%scf_work2_red, fm_struct)
+               ALLOCATE (scf_env%ortho_m1_red)
+               CALL cp_fm_create(scf_env%ortho_m1_red, fm_struct)
                CALL cp_fm_struct_release(fm_struct)
+            END IF
 
-               ALLOCATE (scf_env%scf_work1_red(SIZE(scf_env%scf_work1)))
-               DO ispin = 1, SIZE(scf_env%scf_work1)
-                  CALL cp_fm_struct_create(fm_struct, template_fmstruct=scf_env%ortho%matrix_struct, &
-                                           nrow_global=needed_evals, ncol_global=needed_evals)
-                  CALL cp_fm_create(scf_env%scf_work1_red(ispin), fm_struct)
-                  CALL cp_fm_struct_release(fm_struct)
-               END DO
+            ALLOCATE (scf_env%scf_work1_red(SIZE(scf_env%scf_work1)))
+            DO ispin = 1, SIZE(scf_env%scf_work1)
+               CALL cp_fm_struct_create(fm_struct, template_fmstruct=scf_env%ortho%matrix_struct, &
+                                        nrow_global=needed_evals, ncol_global=needed_evals)
+               CALL cp_fm_create(scf_env%scf_work1_red(ispin), fm_struct)
+               CALL cp_fm_struct_release(fm_struct)
+            END DO
 
-               ! Scale the eigenvalues and copy them to
-               CALL cp_fm_to_fm(evecs, scf_env%ortho_red, needed_evals, ndep + 1, 1)
-               CALL cp_fm_column_scale(scf_env%ortho_red, evals(ndep + 1:))
+            ! Scale the eigenvalues and copy them to
+            CALL cp_fm_to_fm(evecs, scf_env%ortho_red, needed_evals, ndep + 1, 1)
 
-               ! Copy the linear dependent columns to the mo sets and set their orbital energies
-               ! to a very large value to reduce the probability of occupying them
-               DO ispin = 1, SIZE(mos)
-                  CALL get_mo_set(mos(ispin), nmo=nmo, mo_coeff=mo_coeff, homo=homo, eigenvalues=eigenvalues)
-                  IF (needed_evals < nmo) THEN
-                     IF (needed_evals < homo) THEN
-                        CALL cp_abort(__LOCATION__, &
-                                      "The numerical rank of the overlap matrix is lower than the "// &
-                                      "number of orbitals to be occupied! Check the geometry or increase "// &
-                                      "EPS_DEFAULT or EPS_PGF_ORB!")
-                     END IF
-                     CALL cp_warn(__LOCATION__, &
-                                  "The numerical rank of the overlap matrix is lower than the number of requested MOs! "// &
-                             "Reduce the number of MOs to the number of available MOs. If necessary, request a lower number of "// &
-                                  "MOs or increase EPS_DEFAULT or EPS_PGF_ORB.")
-                     CALL set_mo_set(mos(ispin), nmo=needed_evals)
+            IF (scf_control%level_shift /= 0.0_dp) THEN
+               CALL cp_fm_transpose(scf_env%ortho_red, scf_env%ortho_m1_red)
+            END IF
+
+            CALL cp_fm_column_scale(scf_env%ortho_red, evals(ndep + 1:))
+
+            ! Copy the linear dependent columns to the mo sets and set their orbital energies
+            ! to a very large value to reduce the probability of occupying them
+            DO ispin = 1, SIZE(mos)
+               CALL get_mo_set(mos(ispin), nmo=nmo, mo_coeff=mo_coeff, homo=homo, eigenvalues=eigenvalues)
+               IF (needed_evals < nmo) THEN
+                  IF (needed_evals < homo) THEN
+                     CALL cp_abort(__LOCATION__, &
+                                   "The numerical rank of the overlap matrix is lower than the "// &
+                                   "number of orbitals to be occupied! Check the geometry or increase "// &
+                                   "EPS_DEFAULT or EPS_PGF_ORB!")
                   END IF
-                  ! Copy the last columns to mo_coeff if the container is large enough
-                  CALL cp_fm_to_fm(evecs, mo_coeff, MIN(ndep, MAX(0, nmo - needed_evals)), 1, needed_evals + 1)
-                  ! Set the corresponding eigenvalues to a large value
-                  ! This prevents their occupation but still keeps the information on them
-                  eigenvalues(needed_evals + 1:MIN(nao, nmo)) = 1.0_dp/scf_control%eps_eigval
-               END DO
+                  CALL cp_warn(__LOCATION__, &
+                               "The numerical rank of the overlap matrix is lower than the number of requested MOs! "// &
+                             "Reduce the number of MOs to the number of available MOs. If necessary, request a lower number of "// &
+                               "MOs or increase EPS_DEFAULT or EPS_PGF_ORB.")
+                  CALL set_mo_set(mos(ispin), nmo=needed_evals)
+               END IF
+               ! Copy the last columns to mo_coeff if the container is large enough
+               CALL cp_fm_to_fm(evecs, mo_coeff, MIN(ndep, MAX(0, nmo - needed_evals)), 1, needed_evals + 1)
+               ! Set the corresponding eigenvalues to a large value
+               ! This prevents their occupation but still keeps the information on them
+               eigenvalues(needed_evals + 1:MIN(nao, nmo)) = 1.0_dp/scf_control%eps_eigval
+            END DO
 
-               ! Obtain ortho from (P)DGEMM, skip the linear dependent columns
-               CALL parallel_gemm("N", "T", nao, nao, needed_evals, 1.0_dp, scf_env%ortho_red, evecs, &
-                                  0.0_dp, scf_env%ortho, b_first_col=ndep + 1)
-            ELSE
-               ! Take the square roots of the target values to allow application of SYRK
-               evals = SQRT(evals)
-               CALL cp_fm_column_scale(evecs, evals)
-               CALL cp_fm_syrk("U", "N", nao, 1.0_dp, evecs, 1, 1, 0.0_dp, scf_env%ortho)
-               CALL cp_fm_upper_to_full(scf_env%ortho, scf_env%scf_work2)
+            ! Obtain ortho from (P)DGEMM, skip the linear dependent columns
+            CALL parallel_gemm("N", "T", nao, nao, needed_evals, 1.0_dp, scf_env%ortho_red, evecs, &
+                               0.0_dp, scf_env%ortho, b_first_col=ndep + 1)
+
+            IF (scf_control%level_shift /= 0.0_dp) THEN
+               ! We need SQRT(evals) of the eigenvalues of H, so 1/SQRT(evals) of ortho_red
+               evals(ndep + 1:nao) = 1.0_dp/evals(ndep + 1:nao)
+               CALL cp_fm_row_scale(scf_env%ortho_m1_red, evals(ndep + 1:))
+
+               CALL parallel_gemm("T", "T", nao, nao, needed_evals, 1.0_dp, scf_env%ortho_m1_red, evecs, &
+                                  0.0_dp, scf_env%ortho_m1, b_first_col=ndep + 1)
             END IF
 
             CALL cp_fm_release(evecs)
 
-            IF (scf_control%level_shift /= 0.0_dp) THEN
-               CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, scf_env%ortho_m1)
-               CALL cp_fm_power(scf_env%ortho_m1, scf_env%scf_work2, 0.5_dp, &
-                                scf_control%eps_eigval, ndep)
-            END IF
             s_minus_half_available = .TRUE.
          END IF
 

--- a/src/qs_scf_initialization.F
+++ b/src/qs_scf_initialization.F
@@ -21,9 +21,13 @@ MODULE qs_scf_initialization
                                               cp_dbcsr_m_by_n_from_row_template,&
                                               cp_dbcsr_sm_fm_multiply
    USE cp_dbcsr_output,                 ONLY: write_fm_with_basis_info
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_triangular_invert
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
+                                              cp_fm_syrk,&
+                                              cp_fm_triangular_invert,&
+                                              cp_fm_upper_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose
-   USE cp_fm_diag,                      ONLY: cp_fm_power
+   USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
+                                              cp_fm_power
    USE cp_fm_pool_types,                ONLY: cp_fm_pool_p_type,&
                                               fm_pool_get_el_struct
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
@@ -32,6 +36,7 @@ MODULE qs_scf_initialization
                                               cp_fm_struct_type
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
+                                              cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_to_fm,&
                                               cp_fm_to_fm_triangular,&
@@ -55,6 +60,7 @@ MODULE qs_scf_initialization
    USE kinds,                           ONLY: dp
    USE kpoint_types,                    ONLY: kpoint_type
    USE message_passing,                 ONLY: mp_para_env_type
+   USE parallel_gemm_api,               ONLY: parallel_gemm
    USE pw_types,                        ONLY: pw_c1d_gs_type
    USE qmmm_image_charge,               ONLY: conditional_calc_image_matrix
    USE qs_block_davidson_types,         ONLY: block_davidson_allocate,&
@@ -88,7 +94,8 @@ MODULE qs_scf_initialization
    USE qs_mo_occupation,                ONLY: set_mo_occupation
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               init_mo_set,&
-                                              mo_set_type
+                                              mo_set_type,&
+                                              set_mo_set
    USE qs_outer_scf,                    ONLY: outer_loop_extrapolate,&
                                               outer_loop_switch,&
                                               outer_loop_variables_count
@@ -876,12 +883,18 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'init_scf_run'
 
-      INTEGER                                            :: after, handle, ikind, iw, nao, ndep, &
+      INTEGER                                            :: after, handle, homo, ii, ikind, ispin, &
+                                                            iw, nao, ndep, needed_evals, nmo, &
                                                             output_unit
       LOGICAL                                            :: dft_plus_u_atom, do_kpoints, &
                                                             init_u_ramping_each_scf, omit_headers, &
                                                             s_minus_half_available
       REAL(KIND=dp)                                      :: u_ramping
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: evals
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues
+      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
+      TYPE(cp_fm_type)                                   :: evecs
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -894,7 +907,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (qs_kind_set, matrix_s, dft_control, mos, qs_kind, rho, xas_env)
+      NULLIFY (qs_kind_set, matrix_s, dft_control, mos, qs_kind, rho, xas_env, mo_coeff)
 
       logger => cp_get_default_logger()
 
@@ -936,8 +949,91 @@ CONTAINS
                CALL cp_fm_triangular_invert(scf_env%ortho_m1)
             END IF
          ELSE
-            CALL cp_fm_power(scf_env%ortho, scf_env%scf_work2, -0.5_dp, &
-                             scf_control%eps_eigval, ndep)
+            CALL cp_fm_get_info(scf_env%ortho, ncol_global=nao)
+            ALLOCATE (evals(nao))
+            evals = 0
+
+            CALL cp_fm_create(evecs, scf_env%ortho%matrix_struct)
+
+            ! Perform an EVD
+            CALL choose_eigv_solver(scf_env%ortho, evecs, evals)
+
+            ! Determine the number of neglectable eigenvalues assuming that the eigenvalues are in ascending order
+            ! (Required by Lapack)
+            ndep = 0
+            DO ii = 1, nao
+               IF (evals(ii) > scf_control%eps_eigval) THEN
+                  ndep = ii - 1
+                  EXIT
+               END IF
+            END DO
+            needed_evals = nao - ndep
+
+            ! Set the eigenvalue of the eigenvectors belonging to the linear subspace to zero
+            evals(1:ndep) = 0.0_dp
+            ! Determine the eigenvalues of the inverse square root
+            evals(ndep + 1:nao) = 1.0_dp/SQRT(evals(ndep + 1:nao))
+
+            IF (ndep > 0) THEN
+               ! Create reduced matrices
+               NULLIFY (fm_struct)
+               CALL cp_fm_struct_create(fm_struct, template_fmstruct=scf_env%ortho%matrix_struct, &
+                                        nrow_global=nao, ncol_global=needed_evals)
+
+               ALLOCATE (scf_env%ortho_red, scf_env%scf_work2_red)
+               CALL cp_fm_create(scf_env%ortho_red, fm_struct)
+               CALL cp_fm_create(scf_env%scf_work2_red, fm_struct)
+               CALL cp_fm_struct_release(fm_struct)
+
+               ALLOCATE (scf_env%scf_work1_red(SIZE(scf_env%scf_work1)))
+               DO ispin = 1, SIZE(scf_env%scf_work1)
+                  CALL cp_fm_struct_create(fm_struct, template_fmstruct=scf_env%ortho%matrix_struct, &
+                                           nrow_global=needed_evals, ncol_global=needed_evals)
+                  CALL cp_fm_create(scf_env%scf_work1_red(ispin), fm_struct)
+                  CALL cp_fm_struct_release(fm_struct)
+               END DO
+
+               ! Scale the eigenvalues and copy them to
+               CALL cp_fm_to_fm(evecs, scf_env%ortho_red, needed_evals, ndep + 1, 1)
+               CALL cp_fm_column_scale(scf_env%ortho_red, evals(ndep + 1:))
+
+               ! Copy the linear dependent columns to the mo sets and set their orbital energies
+               ! to a very large value to reduce the probability of occupying them
+               DO ispin = 1, SIZE(mos)
+                  CALL get_mo_set(mos(ispin), nmo=nmo, mo_coeff=mo_coeff, homo=homo, eigenvalues=eigenvalues)
+                  IF (needed_evals < nmo) THEN
+                     IF (needed_evals < homo) THEN
+                        CALL cp_abort(__LOCATION__, &
+                                      "The numerical rank of the overlap matrix is lower than the "// &
+                                      "number of orbitals to be occupied! Check the geometry or increase "// &
+                                      "EPS_DEFAULT or EPS_PGF_ORB!")
+                     END IF
+                     CALL cp_warn(__LOCATION__, &
+                                  "The numerical rank of the overlap matrix is lower than the number of requested MOs! "// &
+                             "Reduce the number of MOs to the number of available MOs. If necessary, request a lower number of "// &
+                                  "MOs or increase EPS_DEFAULT or EPS_PGF_ORB.")
+                     CALL set_mo_set(mos(ispin), nmo=needed_evals)
+                  END IF
+                  ! Copy the last columns to mo_coeff if the container is large enough
+                  CALL cp_fm_to_fm(evecs, mo_coeff, MIN(ndep, MAX(0, nmo - needed_evals)), 1, needed_evals + 1)
+                  ! Set the corresponding eigenvalues to a large value
+                  ! This prevents their occupation but still keeps the information on them
+                  eigenvalues(needed_evals + 1:MIN(nao, nmo)) = 1.0_dp/scf_control%eps_eigval
+               END DO
+
+               ! Obtain ortho from (P)DGEMM, skip the linear dependent columns
+               CALL parallel_gemm("N", "T", nao, nao, needed_evals, 1.0_dp, scf_env%ortho_red, evecs, &
+                                  0.0_dp, scf_env%ortho, b_first_col=ndep + 1)
+            ELSE
+               ! Take the square roots of the target values to allow application of SYRK
+               evals = SQRT(evals)
+               CALL cp_fm_column_scale(evecs, evals)
+               CALL cp_fm_syrk("U", "N", nao, 1.0_dp, evecs, 1, 1, 0.0_dp, scf_env%ortho)
+               CALL cp_fm_upper_to_full(scf_env%ortho, scf_env%scf_work2)
+            END IF
+
+            CALL cp_fm_release(evecs)
+
             IF (scf_control%level_shift /= 0.0_dp) THEN
                CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, scf_env%ortho_m1)
                CALL cp_fm_power(scf_env%ortho_m1, scf_env%scf_work2, 0.5_dp, &

--- a/src/qs_scf_loop_utils.F
+++ b/src/qs_scf_loop_utils.F
@@ -228,7 +228,7 @@ CONTAINS
                                  scf_control, scf_section, &
                                  diis_step)
          END IF
-         ! OT diagonlization
+         ! OT diagonalization
       CASE (ot_diag_method_nr)
          CALL do_ot_diag(scf_env, mos, matrix_ks, matrix_s, &
                          scf_control, scf_section, diis_step)

--- a/src/qs_scf_methods.F
+++ b/src/qs_scf_methods.F
@@ -67,8 +67,6 @@ MODULE qs_scf_methods
              eigensolver_simple, &
              scf_env_density_mixing
 
-   PRIVATE :: correct_mo_eigenvalues, shift_unocc_mos
-
    INTERFACE combine_ks_matrices
       MODULE PROCEDURE combine_ks_matrices_1, &
          combine_ks_matrices_2
@@ -198,7 +196,7 @@ CONTAINS
          CALL cp_fm_cholesky_reduce(matrix_ks_fm, ortho)
 
          IF (do_level_shift) &
-            CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm, mo_coeff=mo_coeff, homo=homo, nmo=nmo, nao=nao, &
+            CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm, mo_coeff=mo_coeff, homo=homo, &
                                  level_shift=level_shift, is_triangular=.TRUE., matrix_u_fm=matrix_u_fm)
 
          CALL choose_eigv_solver(matrix_ks_fm, work, mo_eigenvalues)
@@ -214,7 +212,7 @@ CONTAINS
                                      "SOLVE", pos="LEFT", transa="T")
 
          IF (do_level_shift) &
-            CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm, mo_coeff=mo_coeff, homo=homo, nmo=nmo, nao=nao, &
+            CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm, mo_coeff=mo_coeff, homo=homo, &
                                  level_shift=level_shift, is_triangular=.TRUE., matrix_u_fm=matrix_u_fm)
 
          CALL choose_eigv_solver(matrix_ks_fm, work, mo_eigenvalues)
@@ -232,7 +230,7 @@ CONTAINS
                                         invert_tr=.FALSE., uplo_tr="U", n_rows=nao, n_cols=nao, alpha=1.0_dp)
 
          IF (do_level_shift) &
-            CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm, mo_coeff=mo_coeff, homo=homo, nmo=nmo, nao=nao, &
+            CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm, mo_coeff=mo_coeff, homo=homo, &
                                  level_shift=level_shift, is_triangular=.TRUE., matrix_u_fm=matrix_u_fm)
 
          CALL choose_eigv_solver(matrix_ks_fm, work, mo_eigenvalues)
@@ -324,10 +322,11 @@ CONTAINS
 !> \param ortho_red ...
 !> \param work_red ...
 !> \param matrix_ks_fm_red ...
+!> \param matrix_u_fm_red ...
 ! **************************************************************************************************
    SUBROUTINE eigensolver_symm(matrix_ks_fm, mo_set, ortho, work, do_level_shift, &
                                level_shift, matrix_u_fm, use_jacobi, jacobi_threshold, &
-                               ortho_red, work_red, matrix_ks_fm_red)
+                               ortho_red, work_red, matrix_ks_fm_red, matrix_u_fm_red)
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix_ks_fm
       TYPE(mo_set_type), INTENT(IN)                      :: mo_set
       TYPE(cp_fm_type), INTENT(IN)                       :: ortho, work
@@ -336,7 +335,8 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN), OPTIONAL             :: matrix_u_fm
       LOGICAL, INTENT(IN)                                :: use_jacobi
       REAL(KIND=dp), INTENT(IN)                          :: jacobi_threshold
-      TYPE(cp_fm_type), INTENT(INOUT), OPTIONAL          :: ortho_red, work_red, matrix_ks_fm_red
+      TYPE(cp_fm_type), INTENT(INOUT), OPTIONAL          :: ortho_red, work_red, matrix_ks_fm_red, &
+                                                            matrix_u_fm_red
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'eigensolver_symm'
 
@@ -377,15 +377,11 @@ CONTAINS
             CALL cp_fm_get_info(ortho_red, ncol_global=nao_red)
             CALL cp_fm_symm("L", "U", nao, nao_red, 1.0_dp, matrix_ks_fm, ortho_red, 0.0_dp, work_red)
             CALL parallel_gemm("T", "N", nao_red, nao_red, nao, 1.0_dp, ortho_red, work_red, 0.0_dp, matrix_ks_fm_red)
-         END IF
-         CALL cp_fm_symm("L", "U", nao, nao, 1.0_dp, matrix_ks_fm, ortho, 0.0_dp, work)
-         CALL parallel_gemm("T", "N", nao, nao, nao, 1.0_dp, ortho, work, 0.0_dp, matrix_ks_fm)
 
-         IF (do_level_shift) &
-            CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm, mo_coeff=mo_coeff, homo=homo, nmo=nmo, nao=nao, &
-                                 level_shift=level_shift, is_triangular=.FALSE., matrix_u_fm=matrix_u_fm)
+            IF (do_level_shift) &
+               CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm_red, mo_coeff=mo_coeff, homo=homo, &
+                                    level_shift=level_shift, is_triangular=.FALSE., matrix_u_fm=matrix_u_fm_red)
 
-         IF (PRESENT(work_red) .AND. PRESENT(ortho_red) .AND. PRESENT(matrix_ks_fm_red)) THEN
             CALL cp_fm_create(work_red2, matrix_ks_fm_red%matrix_struct)
             ALLOCATE (eigenvalues(nao_red))
             CALL choose_eigv_solver(matrix_ks_fm_red, work_red2, eigenvalues)
@@ -394,6 +390,9 @@ CONTAINS
                                mo_coeff)
             CALL cp_fm_release(work_red2)
          ELSE
+            IF (do_level_shift) &
+               CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm, mo_coeff=mo_coeff, homo=homo, &
+                                    level_shift=level_shift, is_triangular=.FALSE., matrix_u_fm=matrix_u_fm)
             CALL choose_eigv_solver(matrix_ks_fm, work, mo_eigenvalues)
             CALL parallel_gemm("N", "N", nao, nmo, nao, 1.0_dp, ortho, work, 0.0_dp, &
                                mo_coeff)
@@ -452,7 +451,7 @@ CONTAINS
 
       IF (do_level_shift) THEN
          ! matrix_u_fm is simply an identity matrix, so we omit it here
-         CALL shift_unocc_mos(matrix_ks_fm=matrix_ks, mo_coeff=mo_coeff, homo=homo, nmo=nmo, nao=nao, &
+         CALL shift_unocc_mos(matrix_ks_fm=matrix_ks, mo_coeff=mo_coeff, homo=homo, &
                               level_shift=level_shift, is_triangular=.FALSE.)
       END IF
 
@@ -782,8 +781,6 @@ CONTAINS
 !> \param matrix_ks_fm   transformed Kohn-Sham matrix = U^{-1,T} * KS * U^{-1}
 !> \param mo_coeff       matrix of molecular orbitals (C)
 !> \param homo           number of occupied molecular orbitals
-!> \param nmo            number of molecular orbitals
-!> \param nao            number of atomic orbitals
 !> \param level_shift    amount of shift applying (in a.u.)
 !> \param is_triangular  indicates that matrix_u_fm contains an upper triangular matrix
 !> \param matrix_u_fm    matrix U: S (overlap matrix) = U^T * U;
@@ -791,26 +788,34 @@ CONTAINS
 !> \par History
 !>      03.2016 created [Sergey Chulkov]
 ! **************************************************************************************************
-   SUBROUTINE shift_unocc_mos(matrix_ks_fm, mo_coeff, homo, nmo, nao, &
+   SUBROUTINE shift_unocc_mos(matrix_ks_fm, mo_coeff, homo, &
                               level_shift, is_triangular, matrix_u_fm)
 
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix_ks_fm, mo_coeff
-      INTEGER, INTENT(in)                                :: homo, nmo, nao
+      INTEGER, INTENT(in)                                :: homo
       REAL(kind=dp), INTENT(in)                          :: level_shift
       LOGICAL, INTENT(in)                                :: is_triangular
       TYPE(cp_fm_type), INTENT(IN), OPTIONAL             :: matrix_u_fm
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'shift_unocc_mos'
 
-      INTEGER                                            :: handle
+      INTEGER                                            :: handle, nao, nao_red, nmo
       REAL(kind=dp), ALLOCATABLE, DIMENSION(:)           :: weights
       TYPE(cp_fm_struct_type), POINTER                   :: ao_mo_fmstruct
       TYPE(cp_fm_type)                                   :: u_mo, u_mo_scaled
 
       CALL timeset(routineN, handle)
 
+      IF (PRESENT(matrix_u_fm)) THEN
+         CALL cp_fm_get_info(mo_coeff, ncol_global=nmo)
+         CALL cp_fm_get_info(matrix_u_fm, nrow_global=nao_red, ncol_global=nao)
+      ELSE
+         CALL cp_fm_get_info(mo_coeff, ncol_global=nmo, nrow_global=nao)
+         nao_red = nao
+      END IF
+
       NULLIFY (ao_mo_fmstruct)
-      CALL cp_fm_struct_create(ao_mo_fmstruct, nrow_global=nao, ncol_global=nmo, &
+      CALL cp_fm_struct_create(ao_mo_fmstruct, nrow_global=nao_red, ncol_global=nmo, &
                                para_env=mo_coeff%matrix_struct%para_env, context=mo_coeff%matrix_struct%context)
 
       CALL cp_fm_create(u_mo, ao_mo_fmstruct)
@@ -825,7 +830,7 @@ CONTAINS
             CALL cp_fm_triangular_multiply(matrix_u_fm, u_mo, side="L", transpose_tr=.FALSE., &
                                            invert_tr=.FALSE., uplo_tr="U", n_rows=nao, n_cols=nmo, alpha=1.0_dp)
          ELSE
-            CALL parallel_gemm("N", "N", nao, nmo, nao, 1.0_dp, matrix_u_fm, mo_coeff, 0.0_dp, u_mo)
+            CALL parallel_gemm("N", "N", nao_red, nmo, nao, 1.0_dp, matrix_u_fm, mo_coeff, 0.0_dp, u_mo)
          END IF
       ELSE
          ! assume U is an identity matrix
@@ -846,7 +851,7 @@ CONTAINS
       DEALLOCATE (weights)
 
       ! NewKS = U^{-1,T} * KS * U^{-1} + (U * C) * DELTA * (U * C)^T
-      CALL parallel_gemm("N", "T", nao, nao, nmo, 1.0_dp, u_mo, u_mo_scaled, 1.0_dp, matrix_ks_fm)
+      CALL parallel_gemm("N", "T", nao_red, nao_red, nmo, 1.0_dp, u_mo, u_mo_scaled, 1.0_dp, matrix_ks_fm)
 
       CALL cp_fm_release(u_mo_scaled)
       CALL cp_fm_release(u_mo)

--- a/src/qs_scf_methods.F
+++ b/src/qs_scf_methods.F
@@ -17,7 +17,6 @@
 !>        new subroutine shift_unocc_mos (03.2016, Sergey Chulkov)
 ! **************************************************************************************************
 MODULE qs_scf_methods
-
    USE cp_dbcsr_api,                    ONLY: &
         dbcsr_add, dbcsr_desymmetrize, dbcsr_get_block_p, dbcsr_iterator_blocks_left, &
         dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, &
@@ -322,9 +321,13 @@ CONTAINS
 !> \param matrix_u_fm    matrix U : S (overlap matrix) = U^T * U
 !> \param use_jacobi ...
 !> \param jacobi_threshold ...
+!> \param ortho_red ...
+!> \param work_red ...
+!> \param matrix_ks_fm_red ...
 ! **************************************************************************************************
    SUBROUTINE eigensolver_symm(matrix_ks_fm, mo_set, ortho, work, do_level_shift, &
-                               level_shift, matrix_u_fm, use_jacobi, jacobi_threshold)
+                               level_shift, matrix_u_fm, use_jacobi, jacobi_threshold, &
+                               ortho_red, work_red, matrix_ks_fm_red)
       TYPE(cp_fm_type), INTENT(IN)                       :: matrix_ks_fm
       TYPE(mo_set_type), INTENT(IN)                      :: mo_set
       TYPE(cp_fm_type), INTENT(IN)                       :: ortho, work
@@ -333,11 +336,15 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN), OPTIONAL             :: matrix_u_fm
       LOGICAL, INTENT(IN)                                :: use_jacobi
       REAL(KIND=dp), INTENT(IN)                          :: jacobi_threshold
+      TYPE(cp_fm_type), INTENT(INOUT), OPTIONAL          :: ortho_red, work_red, matrix_ks_fm_red
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'eigensolver_symm'
 
-      INTEGER                                            :: handle, homo, nao, nelectron, nmo
+      INTEGER                                            :: handle, homo, nao, nao_red, nelectron, &
+                                                            nmo
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eigenvalues
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
+      TYPE(cp_fm_type)                                   :: work_red2
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
 
       CALL timeset(routineN, handle)
@@ -366,7 +373,11 @@ CONTAINS
                                  jacobi_threshold, homo + 1)
 
       ELSE ! full S^(-1/2) has been computed
-
+         IF (PRESENT(work_red) .AND. PRESENT(ortho_red) .AND. PRESENT(matrix_ks_fm_red)) THEN
+            CALL cp_fm_get_info(ortho_red, ncol_global=nao_red)
+            CALL cp_fm_symm("L", "U", nao, nao_red, 1.0_dp, matrix_ks_fm, ortho_red, 0.0_dp, work_red)
+            CALL parallel_gemm("T", "N", nao_red, nao_red, nao, 1.0_dp, ortho_red, work_red, 0.0_dp, matrix_ks_fm_red)
+         END IF
          CALL cp_fm_symm("L", "U", nao, nao, 1.0_dp, matrix_ks_fm, ortho, 0.0_dp, work)
          CALL parallel_gemm("T", "N", nao, nao, nao, 1.0_dp, ortho, work, 0.0_dp, matrix_ks_fm)
 
@@ -374,10 +385,19 @@ CONTAINS
             CALL shift_unocc_mos(matrix_ks_fm=matrix_ks_fm, mo_coeff=mo_coeff, homo=homo, nmo=nmo, nao=nao, &
                                  level_shift=level_shift, is_triangular=.FALSE., matrix_u_fm=matrix_u_fm)
 
-         CALL choose_eigv_solver(matrix_ks_fm, work, mo_eigenvalues)
-
-         CALL parallel_gemm("N", "N", nao, nmo, nao, 1.0_dp, ortho, work, 0.0_dp, &
-                            mo_coeff)
+         IF (PRESENT(work_red) .AND. PRESENT(ortho_red) .AND. PRESENT(matrix_ks_fm_red)) THEN
+            CALL cp_fm_create(work_red2, matrix_ks_fm_red%matrix_struct)
+            ALLOCATE (eigenvalues(nao_red))
+            CALL choose_eigv_solver(matrix_ks_fm_red, work_red2, eigenvalues)
+            mo_eigenvalues(1:MIN(nao_red, nmo)) = eigenvalues(1:MIN(nao_red, nmo))
+            CALL parallel_gemm("N", "N", nao, nmo, nao_red, 1.0_dp, ortho_red, work_red2, 0.0_dp, &
+                               mo_coeff)
+            CALL cp_fm_release(work_red2)
+         ELSE
+            CALL choose_eigv_solver(matrix_ks_fm, work, mo_eigenvalues)
+            CALL parallel_gemm("N", "N", nao, nmo, nao, 1.0_dp, ortho, work, 0.0_dp, &
+                               mo_coeff)
+         END IF
 
          IF (do_level_shift) &
             CALL correct_mo_eigenvalues(mo_eigenvalues, homo, nmo, level_shift)

--- a/src/qs_scf_types.F
+++ b/src/qs_scf_types.F
@@ -106,7 +106,7 @@ MODULE qs_scf_types
       TYPE(cp_fm_type), DIMENSION(:), POINTER :: scf_work1 => NULL(), scf_work1_red => NULL()
       TYPE(cp_fm_type), POINTER  :: scf_work2 => NULL(), ortho => NULL(), ortho_m1 => NULL(), &
                                     s_half => NULL(), s_minus_one => NULL(), &
-                                    scf_work2_red => NULL(), ortho_red => NULL()
+                                    scf_work2_red => NULL(), ortho_red => NULL(), ortho_m1_red => NULL()
       TYPE(krylov_space_type), POINTER :: krylov_space => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER :: p_delta => NULL(), p_mix_new => NULL()
       TYPE(dbcsr_type), POINTER :: ortho_dbcsr => NULL(), buf1_dbcsr => NULL(), buf2_dbcsr => NULL()
@@ -170,6 +170,7 @@ CONTAINS
       NULLIFY (scf_env%ortho_red)
       NULLIFY (scf_env%ortho_dbcsr)
       NULLIFY (scf_env%ortho_m1)
+      NULLIFY (scf_env%ortho_m1_red)
       NULLIFY (scf_env%p_mix_new)
       NULLIFY (scf_env%ot_preconditioner)
       NULLIFY (scf_env%qs_ot_env)
@@ -262,6 +263,10 @@ CONTAINS
       IF (ASSOCIATED(scf_env%ortho_m1)) THEN
          CALL cp_fm_release(scf_env%ortho_m1)
          DEALLOCATE (scf_env%ortho_m1)
+      END IF
+      IF (ASSOCIATED(scf_env%ortho_m1_red)) THEN
+         CALL cp_fm_release(scf_env%ortho_m1_red)
+         DEALLOCATE (scf_env%ortho_m1_red)
       END IF
       IF (ASSOCIATED(scf_env%ortho_dbcsr)) THEN
          ! we should not end up here, and give back using the pools

--- a/src/qs_scf_types.F
+++ b/src/qs_scf_types.F
@@ -103,9 +103,10 @@ MODULE qs_scf_types
       COMPLEX(KIND=dp), DIMENSION(:, :, :), POINTER :: cc_buffer => NULL()
       LOGICAL :: print_iter_line = .FALSE., skip_mixing = .FALSE., skip_diis = .FALSE., needs_ortho = .FALSE.
       TYPE(mixing_storage_type), POINTER :: mixing_store => NULL()
-      TYPE(cp_fm_type), DIMENSION(:), POINTER :: scf_work1 => NULL()
+      TYPE(cp_fm_type), DIMENSION(:), POINTER :: scf_work1 => NULL(), scf_work1_red => NULL()
       TYPE(cp_fm_type), POINTER  :: scf_work2 => NULL(), ortho => NULL(), ortho_m1 => NULL(), &
-                                    s_half => NULL(), s_minus_one => NULL()
+                                    s_half => NULL(), s_minus_one => NULL(), &
+                                    scf_work2_red => NULL(), ortho_red => NULL()
       TYPE(krylov_space_type), POINTER :: krylov_space => NULL()
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER :: p_delta => NULL(), p_mix_new => NULL()
       TYPE(dbcsr_type), POINTER :: ortho_dbcsr => NULL(), buf1_dbcsr => NULL(), buf2_dbcsr => NULL()
@@ -163,7 +164,10 @@ CONTAINS
       scf_env%outer_scf%deallocate_jacobian = .TRUE.
       NULLIFY (scf_env%scf_work1)
       NULLIFY (scf_env%scf_work2)
+      NULLIFY (scf_env%scf_work1_red)
+      NULLIFY (scf_env%scf_work2_red)
       NULLIFY (scf_env%ortho)
+      NULLIFY (scf_env%ortho_red)
       NULLIFY (scf_env%ortho_dbcsr)
       NULLIFY (scf_env%ortho_m1)
       NULLIFY (scf_env%p_mix_new)
@@ -236,13 +240,24 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       CALL cp_fm_release(scf_env%scf_work1)
+      IF (ASSOCIATED(scf_env%scf_work1_red)) THEN
+         CALL cp_fm_release(scf_env%scf_work1_red)
+      END IF
       IF (ASSOCIATED(scf_env%scf_work2)) THEN
          CALL cp_fm_release(scf_env%scf_work2)
          DEALLOCATE (scf_env%scf_work2)
       END IF
+      IF (ASSOCIATED(scf_env%scf_work2_red)) THEN
+         CALL cp_fm_release(scf_env%scf_work2_red)
+         DEALLOCATE (scf_env%scf_work2_red)
+      END IF
       IF (ASSOCIATED(scf_env%ortho)) THEN
          CALL cp_fm_release(scf_env%ortho)
          DEALLOCATE (scf_env%ortho)
+      END IF
+      IF (ASSOCIATED(scf_env%ortho_red)) THEN
+         CALL cp_fm_release(scf_env%ortho_red)
+         DEALLOCATE (scf_env%ortho_red)
       END IF
       IF (ASSOCIATED(scf_env%ortho_m1)) THEN
          CALL cp_fm_release(scf_env%ortho_m1)

--- a/src/qs_scf_types.F
+++ b/src/qs_scf_types.F
@@ -243,44 +243,49 @@ CONTAINS
       CALL cp_fm_release(scf_env%scf_work1)
       IF (ASSOCIATED(scf_env%scf_work1_red)) THEN
          CALL cp_fm_release(scf_env%scf_work1_red)
+         DEALLOCATE (scf_env%scf_work1_red)
+         NULLIFY (scf_env%scf_work1_red)
       END IF
       IF (ASSOCIATED(scf_env%scf_work2)) THEN
          CALL cp_fm_release(scf_env%scf_work2)
          DEALLOCATE (scf_env%scf_work2)
+         NULLIFY (scf_env%scf_work2)
       END IF
       IF (ASSOCIATED(scf_env%scf_work2_red)) THEN
          CALL cp_fm_release(scf_env%scf_work2_red)
          DEALLOCATE (scf_env%scf_work2_red)
+         NULLIFY (scf_env%scf_work2_red)
       END IF
       IF (ASSOCIATED(scf_env%ortho)) THEN
          CALL cp_fm_release(scf_env%ortho)
          DEALLOCATE (scf_env%ortho)
+         NULLIFY (scf_env%ortho)
       END IF
       IF (ASSOCIATED(scf_env%ortho_red)) THEN
          CALL cp_fm_release(scf_env%ortho_red)
          DEALLOCATE (scf_env%ortho_red)
+         NULLIFY (scf_env%ortho_red)
       END IF
       IF (ASSOCIATED(scf_env%ortho_m1)) THEN
          CALL cp_fm_release(scf_env%ortho_m1)
          DEALLOCATE (scf_env%ortho_m1)
+         NULLIFY (scf_env%ortho_m1)
       END IF
       IF (ASSOCIATED(scf_env%ortho_m1_red)) THEN
          CALL cp_fm_release(scf_env%ortho_m1_red)
          DEALLOCATE (scf_env%ortho_m1_red)
+         NULLIFY (scf_env%ortho_m1_red)
       END IF
       IF (ASSOCIATED(scf_env%ortho_dbcsr)) THEN
          ! we should not end up here, and give back using the pools
-         CPASSERT(.TRUE.)
          CALL dbcsr_deallocate_matrix(scf_env%ortho_dbcsr)
       END IF
       IF (ASSOCIATED(scf_env%buf1_dbcsr)) THEN
          ! we should not end up here, and give back using the pools
-         CPASSERT(.TRUE.)
          CALL dbcsr_deallocate_matrix(scf_env%buf1_dbcsr)
       END IF
       IF (ASSOCIATED(scf_env%buf2_dbcsr)) THEN
          ! we should not end up here, and give back using the pools
-         CPASSERT(.TRUE.)
          CALL dbcsr_deallocate_matrix(scf_env%buf2_dbcsr)
       END IF
       IF (ASSOCIATED(scf_env%s_half)) THEN
@@ -293,12 +298,10 @@ CONTAINS
       END IF
       IF (ASSOCIATED(scf_env%p_mix_new)) THEN
          ! we should not end up here, and give back using the pools
-         CPASSERT(.TRUE.)
          CALL dbcsr_deallocate_matrix_set(scf_env%p_mix_new)
       END IF
       IF (ASSOCIATED(scf_env%p_delta)) THEN
          ! we should not end up here, and give back using the pools
-         CPASSERT(.TRUE.)
          CALL dbcsr_deallocate_matrix_set(scf_env%p_delta)
       END IF
       IF (ASSOCIATED(scf_env%ot_preconditioner)) THEN

--- a/tests/QS/regtest-gpw-5/TEST_FILES
+++ b/tests/QS/regtest-gpw-5/TEST_FILES
@@ -15,7 +15,7 @@ si8_pulay_reduce.inp                                   1      2e-13            -
 si8_pulay_restore.inp                                  1      2e-13            -31.16058546019718
 si8_pulay_inverse.inp                                  1      2e-13            -31.16058546019690
 si8_pulay_inv_dbcsr.inp                                1      3e-13            -31.16058546019509
-si8_pulay_off.inp                                      1      7e-13            -33.01431207828869
+si8_pulay_off.inp                                      1      7e-13            -31.16058546128284
 #
 si8_pmix_nosmear_mocubes.inp                           1      5e-13            -31.18760296986724
 si8_pulay_mocubes.inp                                  1      5e-13            -31.16058546019718

--- a/tests/QS/regtest-lvlshift/TEST_FILES
+++ b/tests/QS/regtest-lvlshift/TEST_FILES
@@ -11,6 +11,9 @@ c2h2-gpw-inverse.inp                                  52     1.0E-8             
 # METHOD gpw  ; CHOLESKY off
 c2h2-gpw-off.inp                                       1    1.0E-12               -12.47387109223699
 c2h2-gpw-off.inp                                      52     1.0E-8                         0.261219
+# METHOD gpw  ; CHOLESKY off, EPS_EIGVAL 1.0E-1 to check reduction
+c2h2-gpw-off_svd.inp                                   1    1.0E-12               -12.36315070103809
+c2h2-gpw-off_svd.inp                                  52     1.0E-8                         0.299207
 # METHOD gpw  ; CHOLESKY reduce
 c2h2-gpw-reduce.inp                                    1    1.0E-12               -12.47387109223699
 c2h2-gpw-reduce.inp                                   52     1.0E-8                         0.261219

--- a/tests/QS/regtest-lvlshift/c2h2-gpw-off_svd.inp
+++ b/tests/QS/regtest-lvlshift/c2h2-gpw-off_svd.inp
@@ -1,0 +1,61 @@
+&GLOBAL
+  PRINT_LEVEL low
+  PROJECT c2h2-gpw-off_svd
+  RUN_TYPE energy
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT
+    MULTIPLICITY 1
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    &MGRID
+      CUTOFF 200
+    &END MGRID
+    &POISSON
+      PERIODIC none
+      POISSON_SOLVER wavelet
+    &END POISSON
+    &PRINT
+      &MO on
+        EIGENVALUES .true.
+      &END MO
+    &END PRINT
+    &QS
+      METHOD gpw
+    &END QS
+    &SCF
+      CHOLESKY off
+      EPS_EIGVAL 1.0E-1
+      EPS_SCF 1e-6
+      LEVEL_SHIFT 0.2
+      MAX_SCF 30
+      SCF_GUESS atomic
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL pbe
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 8.0 8.0 8.0
+      PERIODIC none
+    &END CELL
+    &COORD
+      C         4.0000007567        4.0000007567        4.6040473631
+      C         4.0000007563        4.0000007563        3.3959518200
+      H         3.9999993927        3.9999993927        5.6739482752
+      H         3.9999993905        3.9999993905        2.3260506143
+    &END COORD
+    &KIND H
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q1
+    &END KIND
+    &KIND C
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q4
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-rtp-5/TEST_FILES
+++ b/tests/QS/regtest-rtp-5/TEST_FILES
@@ -32,8 +32,8 @@ H2O-mom-dens-pulse-1.inp                             1      1e-9           -16.7
 # Periodic system: try with molecule in PBC and smearing
 H2O-periodic-dens-pulse-1.inp                        1      1e-9           -17.17071488628162
 H2O-periodic-dens-pulse-2.inp                        1      1e-9           -17.16724674275025
-si8-smearing-rtp-dens.inp                            1      1e-9           -32.38438017820661
-si8-smearing-rtp-dens-pulse-1.inp                    1      1e-9           -30.86382482362951
+si8-smearing-rtp-dens.inp                            1      1e-9           -31.02203456127943
+si8-smearing-rtp-dens-pulse-1.inp                    1      1e-9           -30.97735046167112
 # Restart using densitry propagation method from GS calculation.
 # Note: A delta kick is required in the input but should not impact the calculation (delta kick + restart from wfn not implemented yet).
 H2O-dens-restart.inp                                 1      1e-9           -17.17842704651846
@@ -41,5 +41,5 @@ H2O-uks-dens-restart.inp                             1      1e-9           -17.1
 H2O-charged-dens-restart.inp                         1      1e-9           -16.81087707009416
 H2O-periodic-dens-restart.inp                        1      1e-9           -17.17819965973394
 # Note: the total energy of si8-smearing-rtp-dens-restart.inp is different from si8-smearing-rtp-dens.inp because of the electronic entropy energy. Using restart, currently, the electronic entropy term is missing. 
-si8-smearing-rtp-dens-restart.inp                    1      1e-9           -32.37909123001641
+si8-smearing-rtp-dens-restart.inp                    1      1e-9           -31.00986183346823
 #EOF


### PR DESCRIPTION
Fixes #3823 . If the Cholesky decomposition is turned off for numerical reasons, CP2K approximates the inverse square roots of the overlap matrix using SVDs. This keeps the null-space during the solution of the eigenvalue problem such that additional eigenvectors with eigenvalue zero are found which are occupied if the Fermi-level $\mu\ge -kT$.
My PR removes the null-space entirely by working in the linear-independent subspace spanned by the eigenvectors outside of the null-space of the overlap matrix. I applied this scheme also to the level-shifting scheme and eigenvalue calculation for MP2. The reference values of the regtests were updated accordingly and are in better agreement with comparable regtests. I reintroduced the EPS_SVD keyword in the MP2 case.
@JWilhelm I tried Tikhonov regularization but found that it does not solve the problem in our case.