### PR TITLE
DBM: statistics for pooled memory

### DIFF
--- a/src/dbm/dbm_mempool.h
+++ b/src/dbm/dbm_mempool.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#include <stdbool.h>
+#include <stdint.h>
 
 /*******************************************************************************
  * \brief Internal routine for allocating host memory from the pool.
@@ -32,10 +32,27 @@ void *dbm_mempool_device_malloc(const size_t size);
 void dbm_mempool_free(void *memory);
 
 /*******************************************************************************
- * \brief Internal routine for freeing all memory in the pool.
+ * \brief Internal routine for freeing all memory in the pool (not thread-safe).
  * \author Ole Schuett
  ******************************************************************************/
 void dbm_mempool_clear(void);
+
+/*******************************************************************************
+ * \brief Internal struct for pool statistics.
+ * \author Hans Pabst
+ ******************************************************************************/
+typedef struct dbm_memstats_t {
+  // Memory consumption (maximum).
+  uint64_t host_size, device_size;
+  // Number of allocations.
+  uint64_t host_mallocs, device_mallocs;
+} dbm_memstats_t;
+
+/*******************************************************************************
+ * \brief Internal routine to query statistics (not thread-safe).
+ * \author Hans Pabst
+ ******************************************************************************/
+void dbm_mempool_statistics(dbm_memstats_t *memstats);
 
 #ifdef __cplusplus
 }

--- a/src/dbm/dbm_mpi.c
+++ b/src/dbm/dbm_mpi.c
@@ -237,10 +237,35 @@ bool dbm_mpi_comms_are_similar(const dbm_mpi_comm_t comm1,
  ******************************************************************************/
 void dbm_mpi_max_int(int *values, const int count, const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  void *recvbuf = dbm_mpi_alloc_mem(count * sizeof(int));
+  int value = 0;
+  void *recvbuf = (0 < count ? dbm_mpi_alloc_mem(count * sizeof(int)) : &value);
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_INT, MPI_MAX, comm));
   memcpy(values, recvbuf, count * sizeof(int));
-  dbm_mpi_free_mem(recvbuf);
+  if (0 < count) {
+    dbm_mpi_free_mem(recvbuf);
+  }
+#else
+  (void)comm; // mark used
+  (void)values;
+  (void)count;
+#endif
+}
+
+/*******************************************************************************
+ * \brief Wrapper around MPI_Allreduce for op MPI_MAX and datatype MPI_UINT64_T.
+ * \author Ole Schuett
+ ******************************************************************************/
+void dbm_mpi_max_uint64(uint64_t *values, const int count,
+                        const dbm_mpi_comm_t comm) {
+#if defined(__parallel)
+  uint64_t value = 0;
+  void *recvbuf =
+      (0 < count ? dbm_mpi_alloc_mem(count * sizeof(uint64_t)) : &value);
+  CHECK(MPI_Allreduce(values, recvbuf, count, MPI_UINT64_T, MPI_MAX, comm));
+  memcpy(values, recvbuf, count * sizeof(uint64_t));
+  if (0 < count) {
+    dbm_mpi_free_mem(recvbuf);
+  }
 #else
   (void)comm; // mark used
   (void)values;
@@ -255,10 +280,14 @@ void dbm_mpi_max_int(int *values, const int count, const dbm_mpi_comm_t comm) {
 void dbm_mpi_max_double(double *values, const int count,
                         const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  void *recvbuf = dbm_mpi_alloc_mem(count * sizeof(double));
+  double value = 0;
+  void *recvbuf =
+      (0 < count ? dbm_mpi_alloc_mem(count * sizeof(double)) : &value);
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_DOUBLE, MPI_MAX, comm));
   memcpy(values, recvbuf, count * sizeof(double));
-  dbm_mpi_free_mem(recvbuf);
+  if (0 < count) {
+    dbm_mpi_free_mem(recvbuf);
+  }
 #else
   (void)comm; // mark used
   (void)values;
@@ -272,10 +301,13 @@ void dbm_mpi_max_double(double *values, const int count,
  ******************************************************************************/
 void dbm_mpi_sum_int(int *values, const int count, const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  void *recvbuf = dbm_mpi_alloc_mem(count * sizeof(int));
+  int value = 0;
+  void *recvbuf = (0 < count ? dbm_mpi_alloc_mem(count * sizeof(int)) : &value);
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_INT, MPI_SUM, comm));
   memcpy(values, recvbuf, count * sizeof(int));
-  dbm_mpi_free_mem(recvbuf);
+  if (0 < count) {
+    dbm_mpi_free_mem(recvbuf);
+  }
 #else
   (void)comm; // mark used
   (void)values;
@@ -290,10 +322,36 @@ void dbm_mpi_sum_int(int *values, const int count, const dbm_mpi_comm_t comm) {
 void dbm_mpi_sum_int64(int64_t *values, const int count,
                        const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  void *recvbuf = dbm_mpi_alloc_mem(count * sizeof(int64_t));
+  int64_t value = 0;
+  void *recvbuf =
+      (0 < count ? dbm_mpi_alloc_mem(count * sizeof(int64_t)) : &value);
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_INT64_T, MPI_SUM, comm));
   memcpy(values, recvbuf, count * sizeof(int64_t));
-  dbm_mpi_free_mem(recvbuf);
+  if (0 < count) {
+    dbm_mpi_free_mem(recvbuf);
+  }
+#else
+  (void)comm; // mark used
+  (void)values;
+  (void)count;
+#endif
+}
+
+/*******************************************************************************
+ * \brief Wrapper around MPI_Allreduce for op MPI_SUM and datatype MPI_UINT64_T.
+ * \author Hans Pabst
+ ******************************************************************************/
+void dbm_mpi_sum_uint64(uint64_t *values, const int count,
+                        const dbm_mpi_comm_t comm) {
+#if defined(__parallel)
+  uint64_t value = 0;
+  void *recvbuf =
+      (0 < count ? dbm_mpi_alloc_mem(count * sizeof(uint64_t)) : &value);
+  CHECK(MPI_Allreduce(values, recvbuf, count, MPI_UINT64_T, MPI_SUM, comm));
+  memcpy(values, recvbuf, count * sizeof(uint64_t));
+  if (0 < count) {
+    dbm_mpi_free_mem(recvbuf);
+  }
 #else
   (void)comm; // mark used
   (void)values;
@@ -308,10 +366,14 @@ void dbm_mpi_sum_int64(int64_t *values, const int count,
 void dbm_mpi_sum_double(double *values, const int count,
                         const dbm_mpi_comm_t comm) {
 #if defined(__parallel)
-  void *recvbuf = dbm_mpi_alloc_mem(count * sizeof(double));
+  double value = 0;
+  void *recvbuf =
+      (0 < count ? dbm_mpi_alloc_mem(count * sizeof(double)) : &value);
   CHECK(MPI_Allreduce(values, recvbuf, count, MPI_DOUBLE, MPI_SUM, comm));
   memcpy(values, recvbuf, count * sizeof(double));
-  dbm_mpi_free_mem(recvbuf);
+  if (0 < count) {
+    dbm_mpi_free_mem(recvbuf);
+  }
 #else
   (void)comm; // mark used
   (void)values;

--- a/src/dbm/dbm_mpi.h
+++ b/src/dbm/dbm_mpi.h
@@ -115,6 +115,13 @@ bool dbm_mpi_comms_are_similar(const dbm_mpi_comm_t comm1,
 void dbm_mpi_max_int(int *values, const int count, const dbm_mpi_comm_t comm);
 
 /*******************************************************************************
+ * \brief Wrapper around MPI_Allreduce for op MPI_MAX and datatype MPI_UINT64_T.
+ * \author Hans Pabst
+ ******************************************************************************/
+void dbm_mpi_max_uint64(uint64_t *values, const int count,
+                        const dbm_mpi_comm_t comm);
+
+/*******************************************************************************
  * \brief Wrapper around MPI_Allreduce for op MPI_MAX and datatype MPI_DOUBLE.
  * \author Ole Schuett
  ******************************************************************************/
@@ -133,6 +140,13 @@ void dbm_mpi_sum_int(int *values, const int count, const dbm_mpi_comm_t comm);
  ******************************************************************************/
 void dbm_mpi_sum_int64(int64_t *values, const int count,
                        const dbm_mpi_comm_t comm);
+
+/*******************************************************************************
+ * \brief Wrapper around MPI_Allreduce for op MPI_SUM and datatype MPI_UINT64_T.
+ * \author Hans Pabst
+ ******************************************************************************/
+void dbm_mpi_sum_uint64(uint64_t *values, const int count,
+                        const dbm_mpi_comm_t comm);
 
 /*******************************************************************************
  * \brief Wrapper around MPI_Allreduce for op MPI_SUM and datatype MPI_DOUBLE.

--- a/src/dbm/dbm_multiply_cpu.h
+++ b/src/dbm/dbm_multiply_cpu.h
@@ -7,8 +7,6 @@
 #ifndef DBM_MULTIPLY_CPU_H
 #define DBM_MULTIPLY_CPU_H
 
-#include <stdbool.h>
-
 #include "dbm_multiply_internal.h"
 #include "dbm_shard.h"
 


### PR DESCRIPTION
- Print number of allocations, and memory consumption.
- MPI: avoid memory allocation for reductions (count=1).
- MPI: dbm_mpi_max_uint64, dbm_mpi_sum_uint64 (unused).
- Stats are based on the max-metric over all ranks.