### PR TITLE
Fix GW with Cholesky off

### DIFF
--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -2661,8 +2661,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_eps_head_Berry'
 
-      INTEGER :: col, col_end_in_block, col_offset, col_size, handle, i_col, i_row, ikp, nkp, row, &
-         row_offset, row_size, row_start_in_block
+      INTEGER :: col, col_end_in_block, col_offset, col_size, handle, i_col, i_row, ikp, nkp, nmo, &
+         row, row_offset, row_size, row_start_in_block
       REAL(KIND=dp)                                      :: abs_k_square, cell_volume, &
                                                             correct_kpoint(3), cos_square, &
                                                             eigen_diff, relative_kpoint(3), &
@@ -2680,6 +2680,8 @@ CONTAINS
       NULLIFY (data_block)
 
       nkp = kpoints%nkp
+
+      nmo = SIZE(Eigenval)
 
       ALLOCATE (P_head(nkp))
       P_head(:) = 0.0_dp
@@ -2717,9 +2719,9 @@ CONTAINS
                col_end_in_block = col_size
             END IF
 
-            DO i_row = row_start_in_block, row_size
+            DO i_row = row_start_in_block, MIN(row_size, nmo - row_offset + 1)
 
-               DO i_col = 1, col_end_in_block
+               DO i_col = 1, MIN(col_end_in_block, nmo - col_offset + 1)
 
                   eigen_diff = Eigenval(i_col + col_offset - 1) - Eigenval(i_row + row_offset - 1)
 
@@ -2757,9 +2759,9 @@ CONTAINS
                col_end_in_block = col_size
             END IF
 
-            DO i_row = row_start_in_block, row_size
+            DO i_row = row_start_in_block, MIN(row_size, nmo - row_offset + 1)
 
-               DO i_col = 1, col_end_in_block
+               DO i_col = 1, MIN(col_end_in_block, nmo - col_offset + 1)
 
                   eigen_diff = Eigenval(i_col + col_offset - 1) - Eigenval(i_row + row_offset - 1)
 

--- a/src/rpa_gw_sigma_x.F
+++ b/src/rpa_gw_sigma_x.F
@@ -130,6 +130,7 @@ CONTAINS
       REAL(KIND=dp) :: E_GAP_GW, E_HOMO_GW, E_LUMO_GW, eh1, ehfx, eigval_dft, eigval_hf_at_dft, &
          energy_exc, energy_exc1, energy_exc1_aux_fit, energy_exc_aux_fit, energy_total, &
          exx_minus_vxc, hfx_fraction, min_direct_HF_at_DFT_gap, t1, t2, tmp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: matrix_tmp_2_diag
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: Eigenval_kp_HF_at_DFT, vec_Sigma_x
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: Eigenval_kp, vec_Sigma_x_minus_vxc_gw, &
                                                             vec_Sigma_x_minus_vxc_gw_im
@@ -535,6 +536,8 @@ CONTAINS
 
                ALLOCATE (vec_Sigma_x_minus_vxc_gw(nmo, nspins, nkp))
                vec_Sigma_x_minus_vxc_gw = 0.0_dp
+
+               ALLOCATE (matrix_tmp_2_diag(dimen))
             END IF
 
             CALL dbcsr_set(mo_coeff_b, 0.0_dp)
@@ -620,7 +623,8 @@ CONTAINS
                                 matrix_tmp, 0.0_dp, matrix_tmp_2, first_row=homo + 1 - gw_corr_lev_occ, &
                                 last_row=homo + gw_corr_lev_virt)
 
-            CALL dbcsr_get_diag(matrix_tmp_2, vec_Sigma_x_minus_vxc_gw(:, ispin, 1))
+            CALL dbcsr_get_diag(matrix_tmp_2, matrix_tmp_2_diag)
+            vec_Sigma_x_minus_vxc_gw(1:nmo, ispin, 1) = matrix_tmp_2_diag(1:nmo)
 
             CALL dbcsr_set(matrix_tmp, 0.0_dp)
             CALL dbcsr_set(matrix_tmp_2, 0.0_dp)

--- a/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE_cholesky_off.inp
+++ b/tests/QS/regtest-gw-cubic/G0W0_H2O_PBE_cholesky_off.inp
@@ -1,0 +1,102 @@
+&GLOBAL
+  PRINT_LEVEL MEDIUM
+  PROJECT G0W0_H2O_PBE_periodic
+  RUN_TYPE ENERGY
+  &TIMINGS
+    THRESHOLD 0.01
+  &END TIMINGS
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME HFX_BASIS
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    SORT_BASIS EXP
+    &MGRID
+      CUTOFF 100
+      REL_CUTOFF 20
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      POISSON_SOLVER MT
+    &END POISSON
+    &QS
+      EPS_DEFAULT 1.0E-15
+      EPS_PGF_ORB 1.0E-30
+      METHOD GPW
+    &END QS
+    &SCF
+      CHOLESKY OFF
+      EPS_EIGVAL 1.0E-1
+      EPS_SCF 1.0E-4
+      MAX_SCF 100
+      SCF_GUESS ATOMIC
+      &PRINT
+        &RESTART OFF
+        &END RESTART
+      &END PRINT
+    &END SCF
+    &XC
+      &WF_CORRELATION
+        MEMORY 200.
+        NUMBER_PROC 1
+        &LOW_SCALING
+          MEMORY_CUT 1
+        &END LOW_SCALING
+        &RI_RPA
+          RPA_NUM_QUAD_POINTS 10
+          &GW
+            ANALYTIC_CONTINUATION TWO_POLE
+            CORR_MOS_OCC 4
+            CORR_MOS_VIRT 6
+            CROSSING_SEARCH Z_SHOT
+            PERIODIC_CORRECTION
+            RI_SIGMA_X FALSE
+            &PERIODIC_CORRECTION
+              # That value should be chosen much larger !
+              NUM_OMEGA_POINTS 5
+            &END PERIODIC_CORRECTION
+          &END GW
+          &HF
+            FRACTION 1.0000000
+            &SCREENING
+              EPS_SCHWARZ 1.0E-6
+              SCREEN_ON_INITIAL_P FALSE
+            &END SCREENING
+          &END HF
+        &END RI_RPA
+      &END WF_CORRELATION
+      &XC_FUNCTIONAL PBE
+        &PBE
+          SCALE_C 1.0000000
+          SCALE_X 1.0000000
+        &END PBE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom] 7.500 7.500 7.500
+      PERIODIC NONE
+    &END CELL
+    &KIND H
+      BASIS_SET DZVP-GTH
+      BASIS_SET RI_AUX RI_DZVP-GTH
+      BASIS_SET AUX_GW DZVP-GTH
+      POTENTIAL GTH-PBE-q1
+    &END KIND
+    &KIND O
+      BASIS_SET DZVP-GTH
+      BASIS_SET RI_AUX RI_DZVP-GTH
+      BASIS_SET AUX_GW DZVP-GTH
+      POTENTIAL GTH-PBE-q6
+    &END KIND
+    &TOPOLOGY
+      COORD_FILE_FORMAT xyz
+      COORD_FILE_NAME H2O_gas.xyz
+      &CENTER_COORDINATES
+      &END CENTER_COORDINATES
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-gw-cubic/TEST_FILES
+++ b/tests/QS/regtest-gw-cubic/TEST_FILES
@@ -7,6 +7,7 @@ G0W0_H2O_PBE0_30_pts_minimax_regularization.inp       78      1e-04             
 scGW0_and_evGW_H2O_PBE0_trunc_minimax.inp             11      1e-08            -17.108489005370274
 scGW0_H2O_PBE0_trunc_minimax_RI_HFX.inp               11      1e-08            -13.191093644224157
 G0W0_H2O_PBE_periodic.inp                             78      1e-04                         16.475
+G0W0_H2O_PBE_cholesky_off.inp                         78      1e-04                         18.969
 G0W0_OH_PBE.inp                                       79      1e-04                         11.797
 G0W0_OH_PBE_svd.inp                                   79      1e-04                         11.797
 G0W0_OH_PBE_ADMM.inp                                  79      1e-04                         11.490


### PR DESCRIPTION
Follow-up to #3911 
Fixes the issues with the GW method if the SVD is used for the inversion of the overlap matrix. The correlation contributions to the self-energy change compared to the legacy implementation. Add a test to check the respective combination.