### PR TITLE
[cmake] Enable hdf5 support in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -841,7 +841,9 @@ if(CP2K_USE_LIBTORCH)
 endif()
 
 if(CP2K_USE_HDF5)
-  message("  - HDF5\n")
+  message("  - HDF5\n" "   - HDF5_VERSION : ${HDF5_VERSION}\n"
+          "   - HDF5_INCLUDE_DIRS : ${HDF5_INCLUDE_DIRS}\n"
+          "   - HDF5_LIBRARIES : ${HDF5_LIBRARIES}\n\n")
 endif()
 
 if(CP2K_USE_FFTW3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ option(
   CP2K_USE_DLAF
   "Use DLA-Future for Cholesky decompositions and the solution of eigenvalue problems"
   OFF)
+option(CP2K_USE_HDF5 "Enable HDF5 support" OFF)
 option(CP2K_USE_LIBXSMM "Use libxsmm for small gemms" OFF)
 option(CP2K_USE_LIBSMEAGOL "Enable libsmeagol support" OFF)
 # option(CP2K_USE_LIBGRPP "Use libgrpp" OFF)
@@ -195,6 +196,7 @@ if(${cp2k_build_options_up} STREQUAL "FULL")
   set(CP2K_USE_ELPA ON)
   set(CP2K_USE_SPGLIB ON)
   set(CP2K_USE_LIBTORCH ON)
+  set(CP2K_USE_HDF5 ON)
   # set(CP@K_USE_LIBGRPP ON)
 endif()
 
@@ -594,6 +596,10 @@ if(CP2K_USE_LIBXC)
   find_package(Libxc 7 REQUIRED CONFIG)
 endif()
 
+if(CP2K_USE_HDF5)
+  find_package(HDF5 REQUIRED COMPONENTS C Fortran)
+endif()
+
 # uncomment this when libgrpp cmake support is complete
 
 # if (CP2K_USE_LIBGRPP) find_package(libgrpp REQUIRED) endif()
@@ -834,6 +840,10 @@ if(CP2K_USE_LIBTORCH)
   message("  - LIBTORCH\n" "    - libraries : ${CP2K_LIBTORCH_LIBRARIES}\n\n")
 endif()
 
+if(CP2K_USE_HDF5)
+  message("  - HDF5\n")
+endif()
+
 if(CP2K_USE_FFTW3)
   message("  - FFTW3\n"
           "    - include directories : ${CP2K_FFTW3_INCLUDE_DIRS}\n"
@@ -939,6 +949,10 @@ endif()
 
 if(NOT CP2K_USE_SPLA)
   message("   - SPLA")
+endif()
+
+if(NOT CP2K_USE_HDF5)
+  message("   - HDF5\n")
 endif()
 
 if(${CP2K_USE_ACCEL} MATCHES "NONE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -841,7 +841,8 @@ if(CP2K_USE_LIBTORCH)
 endif()
 
 if(CP2K_USE_HDF5)
-  message("  - HDF5\n" "   - HDF5_VERSION : ${HDF5_VERSION}\n"
+  message("  - HDF5\n"
+          "   - HDF5_VERSION : ${HDF5_VERSION}\n"
           "   - HDF5_INCLUDE_DIRS : ${HDF5_INCLUDE_DIRS}\n"
           "   - HDF5_LIBRARIES : ${HDF5_LIBRARIES}\n\n")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,26 +321,11 @@ cmake_dependent_option(DBCSR_USE_OPENMP "Enable openmp support in DBCSR" ON
 # ##############################################################################
 
 set(__cp2k_ext "")
-set(__cp2k_cmake_name "")
 
 if(CP2K_USE_MPI)
   set(__cp2k_ext "psmp")
 else()
   set(__cp2k_ext "ssmp")
-endif()
-
-set(__cp2k_cmake_name "local")
-
-if(CP2K_USE_ACCEL MATCHES "CUDA")
-  set(__cp2k_cmake_name "local_cuda")
-endif()
-
-if(CP2K_USE_ACCEL MATCHES "HIP")
-  set(__cp2k_cmake_name "local_hip")
-endif()
-
-if(CP2K_CMAKE_SUFFIX)
-  string(APPEND __cp2k_cmake_name "${CP2K_CMAKE_SUFFIX}")
 endif()
 
 # we can run the src consistency checks without actually searching for any
@@ -841,8 +826,7 @@ if(CP2K_USE_LIBTORCH)
 endif()
 
 if(CP2K_USE_HDF5)
-  message("  - HDF5\n"
-          "   - HDF5_VERSION : ${HDF5_VERSION}\n"
+  message("  - HDF5\n" "   - HDF5_VERSION : ${HDF5_VERSION}\n"
           "   - HDF5_INCLUDE_DIRS : ${HDF5_INCLUDE_DIRS}\n"
           "   - HDF5_LIBRARIES : ${HDF5_LIBRARIES}\n\n")
 endif()

--- a/cmake/cp2kConfig.cmake.in
+++ b/cmake/cp2kConfig.cmake.in
@@ -60,7 +60,7 @@ if(NOT TARGET cp2k::cp2k)
   endif()
 
   if(@CP2K_USE_LIBXC@)
-    find_dependency(LibXC 7 REQUIRED)
+    find_dependency(LibXC 7 REQUIRED CONFIG)
   endif()
 
   if(@CP2K_USE_COSMA@)
@@ -99,6 +99,23 @@ if(NOT TARGET cp2k::cp2k)
     find_dependency(Torch REQUIRED)
   endif()
 
+  if(@CP2K_USE_HDF5@)
+    find_dependency(HDF5 REQUIRED COMPONENTS C Fortran)
+  endif()
+
+  if(@CP2K_USE_DFTD4@)
+    find_dependency(dftd4 REQUIRED)
+  endif()
+
+  if(@CP2K_USE_LIBSMEAGOL@)
+    find_dependency(libsmeagol REQUIRED)
+  endif()
+
+  find_dependency(dbcsr 2.6 REQUIRED)
+
+  if(@CP2K_USE_VORI@)
+    find_dependency(LibVORI REQUIRED)
+  endif()
   include("${CMAKE_CURRENT_LIST_DIR}/cp2kTargets.cmake")
 
   # Clean-up module path.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1636,6 +1636,8 @@ target_link_libraries(
     $<$<BOOL:${CP2K_USE_COSMA}>:cosma::cosma_prefixed_pxgemm>
     $<$<BOOL:${CP2K_USE_COSMA}>:cosma::cosma>
     $<$<BOOL:${CP2K_USE_DLAF}>:DLAF::Fortran>
+    $<$<BOOL:${CP2K_USE_HDF5}>:HDF5::HDF5
+    hdf5::hdf5_fortran>
     DBCSR::dbcsr
     $<$<BOOL:${CP2K_USE_MPI}>:cp2k::SCALAPACK::scalapack>
     cp2k_linalg_libs
@@ -1674,6 +1676,7 @@ target_compile_definitions(
     $<$<BOOL:${CP2K_USE_ELPA}>:__ELPA>
     $<$<BOOL:${CP2K_USE_DLAF}>:__DLAF>
     $<$<BOOL:${CP2K_USE_LIBXC}>:__LIBXC>
+    $<$<BOOL:${CP2K_USE_HDF5}>:__HDF5>
     $<$<OR:$<BOOL:${CP2K_USE_FFTW3_}>,$<BOOL:${CP2K_USE_FFTW3_MKL_}>>:__FFTW3>
     $<$<BOOL:${CP2K_USE_FFTW3_MKL_}>:__FFTW3_MKL>
     $<$<BOOL:${CP2K_USE_LIBINT2}>:__LIBINT>

--- a/tools/docker/Dockerfile.test_gcc10
+++ b/tools/docker/Dockerfile.test_gcc10
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libopenblas-dev \
     libint2-dev \
     libxc-dev \
+    libhdf5-dev \
     libxsmm-dev \
     libspglib-f08-dev \
    && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/Dockerfile.test_gcc11
+++ b/tools/docker/Dockerfile.test_gcc11
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libopenblas-dev \
     libint2-dev \
     libxc-dev \
+    libhdf5-dev \
     libxsmm-dev \
     libspglib-f08-dev \
    && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/Dockerfile.test_gcc12
+++ b/tools/docker/Dockerfile.test_gcc12
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libopenblas-dev \
     libint2-dev \
     libxc-dev \
+    libhdf5-dev \
     libxsmm-dev \
     libspglib-f08-dev \
    && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/Dockerfile.test_gcc13
+++ b/tools/docker/Dockerfile.test_gcc13
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libopenblas-dev \
     libint2-dev \
     libxc-dev \
+    libhdf5-dev \
     libxsmm-dev \
     libspglib-f08-dev \
    && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/Dockerfile.test_gcc14
+++ b/tools/docker/Dockerfile.test_gcc14
@@ -27,6 +27,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libopenblas-dev \
     libint2-dev \
     libxc-dev \
+    libhdf5-dev \
     libxsmm-dev \
     libspglib-f08-dev \
    && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/Dockerfile.test_gcc9
+++ b/tools/docker/Dockerfile.test_gcc9
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libopenblas-dev \
     libint2-dev \
     libxc-dev \
+    libhdf5-dev \
     libxsmm-dev \
     libspglib-f08-dev \
    && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/Dockerfile.test_i386
+++ b/tools/docker/Dockerfile.test_i386
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libopenblas-dev \
     libint2-dev \
     libxc-dev \
+    libhdf5-dev \
      \
     libspglib-f08-dev \
    && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/Dockerfile.test_minimal
+++ b/tools/docker/Dockerfile.test_minimal
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libopenblas-dev \
     libint2-dev \
     libxc-dev \
+    libhdf5-dev \
     libxsmm-dev \
     libspglib-f08-dev \
    && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -466,6 +466,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libopenblas-dev \
     libint2-dev \
     libxc-dev \
+    libhdf5-dev \
     {"libxsmm-dev" if with_libxsmm else ""} \
     libspglib-f08-dev \
    && rm -rf /var/lib/apt/lists/*

--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -72,6 +72,7 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_LIBINT2=ON \
     -DCP2K_USE_LIBXC=ON \
     -DCP2K_USE_FFTW3=ON \
+    -DCP2K_USE_HDF5=ON \
     -DCP2K_USE_SPGLIB=ON \
     -DCP2K_USE_VORI=ON \
     -DCP2K_USE_MPI=ON \

--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -156,6 +156,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_SPGLIB=ON \
     -DCP2K_USE_SPLA=ON \
     -DCP2K_USE_VORI=ON \
+    -DCP2K_USE_HDF5=ON \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -192,6 +193,7 @@ elif [[ "${PROFILE}" == "ubuntu" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCP2K_USE_FFTW3=ON \
     -DCP2K_USE_LIBXSMM=ON \
     -DCP2K_USE_LIBXC=OFF \
+    -DCP2K_USE_HDF5=ON \
     -DCP2K_USE_SPGLIB=OFF \
     -DCP2K_USE_MPI=OFF \
     -DCP2K_USE_MPI_F08=OFF \

--- a/tools/spack/cp2k-dependencies.yaml
+++ b/tools/spack/cp2k-dependencies.yaml
@@ -20,6 +20,8 @@ spack:
     - "spla@1.6.1 +fortran"
     - "dftd4@3.6.0 build_system=cmake"
     - "libsmeagol@1.2"
+    - "hdf5@1.14 +fortran"
+    # - "libsmeagol@1.2"
    # Unfortunately, ScaLAPACK 2.2.1 has not yet been packaged by Spack.
    # https://github.com/Reference-ScaLAPACK/scalapack/tree/v2.2.1
    # which contains https://github.com/Reference-ScaLAPACK/scalapack/pull/26


### PR DESCRIPTION
- Add hdf5 dependency to cmake
- Updated the `cp2kConfig.cmake.in` file with current supported dependencies
- minor cleanup in the `CMakeLists.txt`