### PR TITLE
GRID: avoid integer overflow

### DIFF
--- a/src/grid/cpu/grid_cpu_task_list.c
+++ b/src/grid/cpu/grid_cpu_task_list.c
@@ -379,10 +379,11 @@ static void collocate_one_grid_level(
       const int actual_group_size = imin(group_size, nthreads - dest_thread);
       // Parallelize summation by dividing grid points across group members.
       const int rank = modulo(ithread, group_size); // position within the group
-      const int lb = (npts_local_total * rank) / actual_group_size;
-      const int ub = (npts_local_total * (rank + 1)) / actual_group_size;
+      const int64_t lb = ((int64_t)npts_local_total * rank) / actual_group_size;
+      const int64_t ub =
+          ((int64_t)npts_local_total * (rank + 1)) / actual_group_size;
       if (src_thread < nthreads) {
-        for (int i = lb; i < ub; i++) {
+        for (int i = (int)lb; i < (int)ub; i++) {
           task_list->threadlocals[dest_thread][i] +=
               task_list->threadlocals[src_thread][i];
         }
@@ -391,9 +392,9 @@ static void collocate_one_grid_level(
     }
 
     // Copy final result from first thread into shared grid.
-    const int lb = (npts_local_total * ithread) / nthreads;
-    const int ub = (npts_local_total * (ithread + 1)) / nthreads;
-    for (int i = lb; i < ub; i++) {
+    const int64_t lb = ((int64_t)npts_local_total * ithread) / nthreads;
+    const int64_t ub = ((int64_t)npts_local_total * (ithread + 1)) / nthreads;
+    for (int i = (int)lb; i < (int)ub; i++) {
       grid->host_buffer[i] = task_list->threadlocals[0][i];
     }
 


### PR DESCRIPTION
- On higher core-count systems, the adjusted expressions can overflow.
- For example (384 threads), the lower bound appeared negative.
- Avoid subsequent OOB access.