### PR TITLE
Various improvements for the calculations forces and stress on AMD GPUs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,10 +541,13 @@ if(CP2K_USE_ACCEL MATCHES "CUDA")
 elseif(CP2K_USE_ACCEL MATCHES "HIP")
   enable_language(HIP)
   # Find hip
+
   find_package(hipfft REQUIRED IMPORTED CONFIG)
   find_package(hipblas REQUIRED IMPORTED CONFIG)
 
-  set(CMAKE_HIP_ARCHITECTURES gfx801 gfx900 gfx90a)
+  if(CMAKE_HIP_PLATFORM MATCHES "nvidia")
+    find_package(CUDAToolkit)
+  endif()
   if(NOT CMAKE_BUILD_TYPE)
     set(HIP_RELEASE_OPTIONS "-O3 --std=c++11")
   elseif(${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1509,10 +1509,15 @@ endif()
 
 if(CP2K_USE_HIP)
   add_library(cp2k_hip_libs INTERFACE)
-  target_link_libraries(cp2k_hip_libs INTERFACE hip::hipfft roc::hipblas
-                                                hip::host)
+  target_link_libraries(
+    cp2k_hip_libs
+    INTERFACE hip::hipfft roc::hipblas hip::host
+              $<$<STREQUAL:"${CMAKE_HIP_PLATFORM}","nvidia">:CUDA::toolkit
+              CUDA::cudart CUDA::cuda_driver>)
+  # if (CMAKE_HIP_PLATFORM MATCHES "nvidia") include_directories("
+  # -I$ENV{ROCM_PATH}/include") include_directories("
+  # -I${CUDAToolkit_INCLUDE_DIRS}") endif()
 endif()
-
 add_library(cp2k_linalg_libs INTERFACE)
 target_link_libraries(
   cp2k_linalg_libs
@@ -1529,13 +1534,21 @@ target_link_libraries(
             OpenMP::OpenMP_C
             OpenMP::OpenMP_CXX)
 
+if(CMAKE_HIP_PLATFORM MATCHES "amd")
+  set(CP2K_GPU_PLATFORM_DFLAGS "__HIP_PLATFORM_AMD__")
+else()
+  set(CP2K_HIP_INCLUDES "${CP2K_HIP_PATH}/include")
+  message("Info: ${CP2K_HIP_INCLUDES}")
+  set(CP2K_GPU_PLATFORM_DFLAGS "__HIP_PLATFORM_NVIDIA__")
+endif()
 set(CP2K_GPU_DFLAGS
-    $<$<BOOL:${CP2K_USE_HIP}>:__HIP_PLATFORM_AMD__
-    __OFFLOAD_HIP>
-    $<$<COMPILE_LANGUAGE:HIP>:__HIP_PLATFORM_AMD__
-    __OFFLOAD_HIP>
+    $<$<BOOL:${CP2K_USE_UNIFIED_MEMORY}>:__OFFLOAD_UNIFIED_MEMORY>
     $<$<BOOL:${CP2K_USE_CUDA}>:__OFFLOAD_CUDA>
-    $<$<COMPILE_LANGUAGE:CUDA>:__OFFLOAD_CUDA>)
+    $<$<COMPILE_LANGUAGE:CUDA>:__OFFLOAD_CUDA>
+    $<$<BOOL:${CP2K_USE_HIP}>:__OFFLOAD_HIP
+    ${CP2K_GPU_PLATFORM_DFLAGS}>
+    $<$<COMPILE_LANGUAGE:HIP>:__OFFLOAD_HIP
+    ${CP2K_GPU_PLATFORM_DFLAGS}>)
 
 # ##############################################################################
 # set properties for the cp2k target.
@@ -1583,6 +1596,8 @@ endif()
 
 include_directories(
   ${CMAKE_MPI_INCLUDE_DIRECTORIES}
+  $<$<BOOL:${CUDAToolkit_FOUND}>:${CUDAToolkit_INCLUDE_DIRS}>
+  $<$<BOOL:${CP2K_USE_HIP}>:${CMAKE_HIP_INCLUDE_DIRECTORIES}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/base>
@@ -1665,16 +1680,10 @@ target_compile_definitions(
     $<$<BOOL:${CP2K_USE_LIBTORCH}>:__LIBTORCH>
     $<$<BOOL:${CP2K_USE_COSMA}>:__COSMA>
     $<$<BOOL:${CP2K_USE_LIBXSMM}>:__LIBXSMM>
-    $<$<STREQUAL:${CP2K_BLAS_VENDOR},MKL>:__MKL>
-    $<$<STREQUAL:${CP2K_BLAS_VENDOR},Apple>:__ACCELERATE>
+    $<$<STREQUAL:"${CP2K_BLAS_VENDOR}","MKL">:__MKL>
+    $<$<STREQUAL:"${CP2K_BLAS_VENDOR}","Apple">:__ACCELERATE>
     $<$<BOOL:${CP2K_USE_CUSOLVER_MP}>:__CUSOLVERMP>
-    $<$<BOOL:${CP2K_USE_CUDA}>:__OFFLOAD_CUDA>
-    $<$<COMPILE_LANGUAGE:CUDA>:__OFFLOAD_CUDA>
-    $<$<BOOL:${CP2K_USE_HIP}>:__HIP_PLATFORM_AMD__
-    __OFFLOAD_HIP>
-    $<$<BOOL:${CP2K_USE_UNIFIED_MEMORY}>:__OFFLOAD_UNIFIED_MEMORY>
-    $<$<COMPILE_LANGUAGE:HIP>:__HIP_PLATFORM_AMD__
-    __OFFLOAD_HIP>)
+    ${CP2K_GPU_DFLAGS})
 
 if(CP2K_USE_CUDA OR CP2K_USE_HIP)
   # these checks are only relevant when the debug mode is on
@@ -1755,7 +1764,7 @@ add_executable(dbm_miniapp dbm/dbm_miniapp.c ${CP2K_DBM_SRCS_C}
                            ${CP2K_DBM_SRCS_GPU} ${CP2K_OFFLOAD_SRCS_C})
 target_compile_definitions(
   dbm_miniapp PRIVATE $<$<BOOL:${CP2K_USE_LIBXSMM}>:__LIBXSMM>
-                      $<$<STREQUAL:${CP2K_BLAS_VENDOR},"MKL">:__MKL>)
+                      $<$<STREQUAL:"${CP2K_BLAS_VENDOR}","MKL">:__MKL>)
 
 if(CP2K_DISABLE_DBM_GPU)
   target_compile_definitions(dbm_miniapp PRIVATE __NO_OFFLOAD_DBM)
@@ -1773,7 +1782,7 @@ foreach(__app grid_miniapp grid_unittest)
     ${CP2K_OFFLOAD_SRCS_C})
   target_compile_definitions(
     ${__app} PRIVATE $<$<BOOL:${CP2K_USE_LIBXSMM}>:__LIBXSMM>
-                     $<$<STREQUAL:${CP2K_BLAS_VENDOR},"MKL">:__MKL>)
+                     $<$<STREQUAL:"${CP2K_BLAS_VENDOR}","MKL">:__MKL>)
 
   if(CP2K_DISABLE_GRID_GPU)
     target_compile_definitions(${__app} PUBLIC __NO_OFFLOAD_GRID)

--- a/src/grid/hip/grid_hip_context.cu
+++ b/src/grid/hip/grid_hip_context.cu
@@ -414,15 +414,17 @@ extern "C" void grid_hip_collocate_task_list(const void *ptr,
     ctx->grid_[level].zero(ctx->level_streams[level]);
   }
 
-  ctx->pab_block_.associate(pab_blocks->host_buffer, pab_blocks->device_buffer,
-                            pab_blocks->size / sizeof(double));
-
   int lp_diff = -1;
 
   ctx->synchronize(ctx->main_stream);
 
   for (int level = 0; level < ctx->nlevels; level++) {
     ctx->collocate_one_grid_level(level, func, &lp_diff);
+  }
+
+  // download result from device to host.
+  for (int level = 0; level < ctx->nlevels; level++) {
+    ctx->grid_[level].copy_to_host(ctx->level_streams[level]);
   }
 
   // update counters while we wait for kernels to finish. It is not thread safe
@@ -444,11 +446,6 @@ extern "C" void grid_hip_collocate_task_list(const void *ptr,
         }
       }
     }
-  }
-
-  // download result from device to host.
-  for (int level = 0; level < ctx->nlevels; level++) {
-    ctx->grid_[level].copy_to_host(ctx->level_streams[level]);
   }
 
   // need to wait for all streams to finish
@@ -475,8 +472,6 @@ extern "C" void grid_hip_integrate_task_list(
   ctx->verify_checksum();
   // Select GPU device.
   ctx->set_device();
-
-  // ctx->coef_dev_.zero(ctx->level_streams[0]);
 
   for (int level = 0; level < ctx->nlevels; level++) {
     if (ctx->number_of_tasks_per_level_[level]) {
@@ -517,7 +512,6 @@ extern "C" void grid_hip_integrate_task_list(
 
   // we can actually treat the full task list without bothering about the level
   // at that stage. This can be taken care of inside the kernel.
-
   for (int level = 0; level < ctx->nlevels; level++) {
     // launch kernel, but only after grid has arrived
     ctx->integrate_one_grid_level(level, &lp_diff);
@@ -544,7 +538,6 @@ extern "C" void grid_hip_integrate_task_list(
     if (ctx->number_of_tasks_per_level_[level])
       ctx->synchronize(ctx->level_streams[level]);
   }
-
   // computing the hab coefficients does not depend on the number of grids so we
   // can run these calculations on the main stream
   ctx->compute_hab_coefficients();

--- a/src/grid/hip/grid_hip_context.h
+++ b/src/grid/hip/grid_hip_context.h
@@ -24,6 +24,7 @@ extern "C" {
 
 #include "../../offload/offload_library.h"
 #include "../../offload/offload_runtime.h"
+
 namespace rocm_backend {
 // a little helper class in the same spirit than std::vector. it must exist
 // somewhere. Maybe possible to get the same thing with std::vector and

--- a/src/grid/hip/grid_hip_integrate.cu
+++ b/src/grid/hip/grid_hip_integrate.cu
@@ -117,77 +117,85 @@ __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
     __syncthreads();
     cxyz_to_cab(task, smem_alpha, coef_, smem_cab);
     __syncthreads();
-
-    for (int i = tid / 8; i < task.nsgf_setb; i += 8) {
-      for (int j = tid % 8; j < task.nsgf_seta; j += 8) {
-        T res = 0.0;
-
-        T block_val1 = 0.0;
+    for (int jco = task.first_cosetb; jco < task.ncosetb; jco++) {
+      const auto &b = coset_inv[jco];
+      for (int ico = task.first_coseta; ico < task.ncoseta; ico++) {
+        const auto &a = coset_inv[ico];
+        const T hab = get_hab<COMPUTE_TAU, T>(a, b, task.zeta, task.zetb,
+                                              task.n1, smem_cab);
+        __shared__ T shared_forces_a[3];
+        __shared__ T shared_forces_b[3];
+        __shared__ T shared_virial[9];
 
         if (CALCULATE_FORCES) {
-          if (task.block_transposed) {
-            block_val1 =
-                task.pab_block[j * task.nsgfb + i] * task.off_diag_twice;
-          } else {
-            block_val1 =
-                task.pab_block[i * task.nsgfa + j] * task.off_diag_twice;
+          if (tid < 3) {
+            shared_forces_a[tid] = get_force_a<COMPUTE_TAU, T>(
+                a, b, tid, task.zeta, task.zetb, task.n1, smem_cab);
+            shared_forces_b[tid] = get_force_b<COMPUTE_TAU, T>(
+                a, b, tid, task.zeta, task.zetb, task.rab, task.n1, smem_cab);
+          }
+          if ((tid < 9) && (dev_.ptr_dev[5] != nullptr)) {
+            shared_virial[tid] =
+                get_virial_a<COMPUTE_TAU, T>(a, b, tid / 3, tid % 3, task.zeta,
+                                             task.zetb, task.n1, smem_cab) +
+                get_virial_b<COMPUTE_TAU, T>(a, b, tid / 3, tid % 3, task.zeta,
+                                             task.zetb, task.rab, task.n1,
+                                             smem_cab);
           }
         }
-
-        for (int jco = task.first_cosetb; jco < task.ncosetb; jco++) {
-          const auto &b = coset_inv[jco];
-          T block_val = 0.0;
+        __syncthreads();
+        for (int i = tid / 8; i < task.nsgf_setb; i += 8) {
           const T sphib = task.sphib[i * task.maxcob + jco];
-          for (int ico = task.first_coseta; ico < task.ncoseta; ico++) {
-            const auto &a = coset_inv[ico];
-            const T hab = get_hab<COMPUTE_TAU, T>(a, b, task.zeta, task.zetb,
-                                                  task.n1, smem_cab);
-            const T sphia = task.sphia[j * task.maxcoa + ico];
-            block_val += hab * sphia * sphib;
+          for (int j = tid % 8; j < task.nsgf_seta; j += 8) {
+            const T sphia_times_sphib =
+                task.sphia[j * task.maxcoa + ico] * sphib;
+            // T block_val = hab * sphia_times_sphib;
 
             if (CALCULATE_FORCES) {
+              T block_val1 = 0.0;
+              if (task.block_transposed) {
+                block_val1 =
+                    task.pab_block[j * task.nsgfb + i] * task.off_diag_twice;
+              } else {
+                block_val1 =
+                    task.pab_block[i * task.nsgfa + j] * task.off_diag_twice;
+              }
               for (int k = 0; k < 3; k++) {
-                fa[k] += block_val1 * sphia * sphib *
-                         get_force_a<COMPUTE_TAU, T>(
-                             a, b, k, task.zeta, task.zetb, task.n1, smem_cab);
-                fb[k] +=
-                    block_val1 * sphia * sphib *
-                    get_force_b<COMPUTE_TAU, T>(a, b, k, task.zeta, task.zetb,
-                                                task.rab, task.n1, smem_cab);
+                fa[k] += block_val1 * sphia_times_sphib * shared_forces_a[k];
+                // get_force_a<COMPUTE_TAU, T>(
+                //     a, b, k, task.zeta, task.zetb, task.n1, smem_cab);
+                fb[k] += block_val1 * sphia_times_sphib * shared_forces_b[k];
+                // get_force_b<COMPUTE_TAU, T>(a, b, k, task.zeta, task.zetb,
+                //                             task.rab, task.n1, smem_cab);
               }
               if (dev_.ptr_dev[5] != nullptr) {
                 for (int k = 0; k < 3; k++) {
                   for (int l = 0; l < 3; l++) {
-                    virial[3 * k + l] +=
-                        (get_virial_a<COMPUTE_TAU, T>(a, b, k, l, task.zeta,
-                                                      task.zetb, task.n1,
-                                                      smem_cab) +
-                         get_virial_b<COMPUTE_TAU, T>(a, b, k, l, task.zeta,
-                                                      task.zetb, task.rab,
-                                                      task.n1, smem_cab)) *
-                        block_val1 * sphia * sphib;
+                    virial[3 * k + l] += shared_virial[3 * k + l] * block_val1 *
+                                         sphia_times_sphib;
                   }
                 }
               }
             }
+            // we can use shuffle_down if it exists for T
+
+            // these atomic operations are not needed since the blocks are
+            // updated by one single block thread. However the grid_miniapp will
+            // fail if not there.
+            if (task.block_transposed) {
+              task.hab_block[j * task.nsgfb + i] += hab * sphia_times_sphib;
+              //              atomicAdd(task.hab_block + j * task.nsgfb + i, hab
+              //              *  sphia_times_sphib);
+            } else {
+              task.hab_block[i * task.nsgfa + j] += hab * sphia_times_sphib;
+              // atomicAdd(task.hab_block + i * task.nsgfa + j, hab *
+              // sphia_times_sphib);
+            }
           }
-
-          res += block_val;
         }
-
-        // we can use shuffle_down if it exists for T
-
-        // these atomic operations are not needed since the blocks are updated
-        // by one single block thread. However the grid_miniapp will fail if not
-        // there.
-        if (task.block_transposed) {
-          atomicAdd(task.hab_block + j * task.nsgfb + i, res);
-        } else {
-          atomicAdd(task.hab_block + i * task.nsgfa + j, res);
-        }
+        __syncthreads();
       }
     }
-    __syncthreads();
   }
 
   if (CALCULATE_FORCES) {
@@ -555,11 +563,17 @@ __launch_bounds__(64) void integrate_kernel(const kernel_params dev_) {
             for (int ic = 0; (ic < lbatch) && ((ic + ico) < length); ic++) {
               auto &co = coset_inv[ic + ico];
               T tmp = 1.0;
-              for (int po = 0; po < co.l[2]; po++)
+              for (int po = 0; po < (co.l[2] >> 1); po++)
+                tmp *= r3z2;
+              if (co.l[2] & 0x1)
                 tmp *= r3.z;
-              for (int po = 0; po < co.l[1]; po++)
+              for (int po = 0; po < (co.l[1] >> 1); po++)
+                tmp *= r3y2;
+              if (co.l[1] & 0x1)
                 tmp *= r3.y;
-              for (int po = 0; po < co.l[0]; po++)
+              for (int po = 0; po < (co.l[0] >> 1); po++)
+                tmp *= r3x2;
+              if (co.l[0] & 0x1)
                 tmp *= r3.x;
               accumulator[ic][tid] += tmp * grid_value;
             }


### PR DESCRIPTION
Fix for issue https://github.com/cp2k/cp2k/issues/3925 

- HIP backend can be compiled on nvidia GPU with cmake (modulo a PR fixing rocm)
- Up to a factor 20 improvement in the calculations of forces and stress
- Remove atomic operations in the calculations of the operator coefficients
- up to 30 % improvemnt in collocate routine