### PR TITLE
Enable Sirius 7.6.1 with toolchain + CMake in CI

### DIFF
--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -152,7 +152,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_MPI=ON \
     -DCP2K_USE_MPI_F08=ON \
     -DCP2K_USE_PLUMED=ON \
-    -DCP2K_USE_SIRIUS=OFF \
+    -DCP2K_USE_SIRIUS=ON \
     -DCP2K_USE_SPGLIB=ON \
     -DCP2K_USE_SPLA=ON \
     -DCP2K_USE_VORI=ON \

--- a/tools/toolchain/scripts/stage8/install_pugixml.sh
+++ b/tools/toolchain/scripts/stage8/install_pugixml.sh
@@ -49,7 +49,7 @@ case "${with_pugixml}" in
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi
-    PUGIXML_ROOT="${pkg_install_dir}"
+    pugixml_ROOT="${pkg_install_dir}"
     PUGIXML_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
@@ -85,14 +85,14 @@ prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 export PUGIXML_LIBS="-lpugixml"
-export PUGIXML_ROOT="${pkg_install_dir}"
+export pugixml_ROOT="${pkg_install_dir}"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_pugixml"
 export PUGIXML_LDFLAGS="${SPLA_LDFLAGS}"
 export PUGIXML_LIBRARY="-lpugixml"
-export PUGIXML_ROOT="$pkg_install_dir"
+export pugixml_ROOT="$pkg_install_dir"
 export PUGIXML_VERSION=${pugixml-ver}
 export CP_LIBS="IF_MPI(${PUGIXML_LIBS}|) \${CP_LIBS}"
 EOF

--- a/tools/toolchain/scripts/stage8/install_sirius.sh
+++ b/tools/toolchain/scripts/stage8/install_sirius.sh
@@ -121,6 +121,8 @@ case "$with_sirius" in
 
       # Patch SIRIUS 7.6.1 for Libxc 7.0.0
       patch -p1 src/potential/xc_functional_base.hpp < ${SCRIPT_DIR}/stage8/sirius_libxc7.patch
+      # Patch SIRIUS 7.6.1 for pugixml (CMake)
+      patch -p1 cmake/sirius_cxxConfig.cmake.in < ${SCRIPT_DIR}/stage8/sirius_1050.patch
 
       rm -Rf build
       mkdir build

--- a/tools/toolchain/scripts/stage8/install_spfft.sh
+++ b/tools/toolchain/scripts/stage8/install_spfft.sh
@@ -141,7 +141,7 @@ case "${with_spfft}" in
       fi
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi
-    SPFFT_ROOT="${pkg_install_dir}"
+    SpFFT_ROOT="${pkg_install_dir}"
     SPFFT_CFLAGS="-I'${pkg_install_dir}/include'"
     SPFFT_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     SPFFT_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath,'${pkg_install_dir}/lib/cuda'"
@@ -179,7 +179,7 @@ prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path CPATH "$pkg_install_dir/include"
 export SPFFT_INCLUDE_DIR="$pkg_install_dir/include"
 export SPFFT_LIBS="-lspfft"
-export SPFFT_ROOT="${pkg_install_dir}"
+export SpFFT_ROOT="${pkg_install_dir}"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
@@ -193,7 +193,7 @@ export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__SPFFT|)"
 export CP_CFLAGS="\${CP_CFLAGS} ${SPFFT_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_CUDA(${SPFFT_CUDA_LDFLAGS}|${SPFFT_LDFLAGS})"
 export SPFFT_LIBRARY="-lspfft"
-export SPFFT_ROOT="${pkg_install_dir}"
+export SpFFT_ROOT="${pkg_install_dir}"
 export SPFFT_INCLUDE_DIR="${pkg_install_dir}/include"
 export CP_LIBS="IF_MPI(${SPFFT_LIBS}|) \${CP_LIBS}"
 EOF

--- a/tools/toolchain/scripts/stage8/sirius_1050.patch
+++ b/tools/toolchain/scripts/stage8/sirius_1050.patch
@@ -1,0 +1,24 @@
+From dfb030e1cc2633d34b22c0a81f9c0b79ea4c54b4 Mon Sep 17 00:00:00 2001
+From: Mathieu Taillefumier <mathieu.taillefumier@free.fr>
+Date: Mon, 20 Jan 2025 16:14:32 +0100
+Subject: [PATCH] Add pugixml to sirius_cxxConfig.cmake.in
+
+---
+ cmake/sirius_cxxConfig.cmake.in | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/cmake/sirius_cxxConfig.cmake.in b/cmake/sirius_cxxConfig.cmake.in
+index 5a2f296ce..cc4612d88 100644
+--- a/cmake/sirius_cxxConfig.cmake.in
++++ b/cmake/sirius_cxxConfig.cmake.in
+@@ -90,6 +90,10 @@ if(NOT TARGET sirius::sirius_cxx)
+     find_package(umpire ${mode})
+   endif()
+ 
++  if(@SIRIUS_USE_PUGIXML@)
++    find_package(pugixml ${mode})
++  endif()
++
+   # Clean-up module path.
+   list(REMOVE_ITEM CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
+ 


### PR DESCRIPTION
The toolchain builds `sirius+pugixml`. A patch is required for this to work with CMake: https://github.com/electronic-structure/SIRIUS/pull/1050.

I tried to update the toolchain to `sirius@7.6.2` to avoid the patches, but I am encountering linking issues that will take me a bit more time to figure out.