### PR TITLE
Add DeePMD support in CMake and enable it in CMake + toolchain CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -927,7 +927,7 @@ if(NOT CP2K_USE_DFTD4)
   message("   - DFTD4")
 endif()
 
-if(NOT CP2K_USE_DFTD4)
+if(NOT CP2K_USE_DEEPMD)
   message("   - DeePMD")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ option(CP2K_ENABLE_CONSISTENCY_CHECKS
 option(CP2K_DEBUG_MODE "Enable several additional options for debugging cp2k."
        OFF)
 option(CP2K_USE_DFTD4 "Enable dispersion coorections DFTD4" OFF)
+option(CP2K_USE_DEEPMD "Enable DeePMD" OFF)
 option(CP2K_USE_SIRIUS "Enable plane wave dft calculations with sirius" OFF)
 option(CP2K_USE_FFTW3 "Use fftw3 for the calculating fast fourier transforms"
        ON)
@@ -698,6 +699,10 @@ if(CP2K_USE_DFTD4)
                       INTERFACE_INCLUDE_DIRECTORIES)
 endif()
 
+if(CP2K_USE_DEEPMD)
+  find_package(DeePMD REQUIRED CONFIG)
+endif()
+
 # SIRIUS
 if(CP2K_USE_SIRIUS)
   find_package(sirius REQUIRED)
@@ -864,6 +869,10 @@ if(CP2K_USE_DFTD4)
   )
 endif()
 
+if(CP2K_USE_DEEPMD)
+  message(" - DeePMD\n\n")
+endif()
+
 if(CP2K_USE_LIBSMEAGOL)
   message(" - LIBSMEAGOL :\n"
           "   - include directories :  ${CP2K_LIBSMEAGOL_INCLUDE_DIRS}\n"
@@ -916,6 +925,10 @@ endif()
 
 if(NOT CP2K_USE_DFTD4)
   message("   - DFTD4")
+endif()
+
+if(NOT CP2K_USE_DFTD4)
+  message("   - DeePMD")
 endif()
 
 if(NOT CP2K_USE_SIRIUS)

--- a/cmake/cp2kConfig.cmake.in
+++ b/cmake/cp2kConfig.cmake.in
@@ -107,6 +107,10 @@ if(NOT TARGET cp2k::cp2k)
     find_dependency(dftd4 REQUIRED)
   endif()
 
+  if(@CP2K_USE_DEEPMD@)
+    find_dependency(DeepMD REQUIRED)
+  endif()
+
   if(@CP2K_USE_LIBSMEAGOL@)
     find_dependency(libsmeagol REQUIRED)
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1620,7 +1620,8 @@ target_link_libraries(
   cp2k_link_libs
   INTERFACE
     $<$<BOOL:${CP2K_USE_DFTD4}>:dftd4::dftd4>
-    $<$<BOOL:${CP2K_USE_DFTD4}>:DeePMD::deepmd DeePMD::deepmd_c>
+    $<$<BOOL:${CP2K_USE_DFTD4}>:DeePMD::deepmd
+    DeePMD::deepmd_c>
     $<$<BOOL:${CP2K_USE_SIRIUS}>:sirius::sirius>
     $<$<BOOL:${CP2K_USE_VORI}>:cp2k::VORI::vori>
     $<$<BOOL:${CP2K_USE_SPGLIB}>:Spglib::symspg>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1620,6 +1620,7 @@ target_link_libraries(
   cp2k_link_libs
   INTERFACE
     $<$<BOOL:${CP2K_USE_DFTD4}>:dftd4::dftd4>
+    $<$<BOOL:${CP2K_USE_DFTD4}>:DeePMD::deepmd DeePMD::deepmd_c>
     $<$<BOOL:${CP2K_USE_SIRIUS}>:sirius::sirius>
     $<$<BOOL:${CP2K_USE_VORI}>:cp2k::VORI::vori>
     $<$<BOOL:${CP2K_USE_SPGLIB}>:Spglib::symspg>
@@ -1669,6 +1670,7 @@ target_compile_definitions(
     $<$<BOOL:${CP2K_USE_SPGLIB}>:__SPGLIB>
     $<$<BOOL:${CP2K_USE_LIBSMEAGOL}>:__SMEAGOL>
     $<$<BOOL:${CP2K_USE_DFTD4}>:__DFTD4>
+    $<$<BOOL:${CP2K_USE_DEEPMD}>:__DEEPMD>
     $<$<BOOL:${CP2K_USE_SIRIUS}>:__SIRIUS>
     $<$<BOOL:${CP2K_USE_SPLA}>:__SPLA>
     $<$<BOOL:${CP2K_USE_SpFFT}>:__SPFFT>

--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -97,6 +97,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCP2K_BLAS_VENDOR=OpenBLAS \
     -DCP2K_USE_COSMA=OFF \
+    -DCP2K_USE_DEEPMD=ON \
     -DCP2K_USE_DFTD4=ON \
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_FFTW3=ON \
@@ -133,14 +134,13 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "sdbg" ]]; then
   CMAKE_EXIT_CODE=$?
 
 elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
-  # TODO Fix SIRIUS.
-  # https://github.com/cp2k/cp2k/issues/3416
   cmake \
     -GNinja \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCP2K_BLAS_VENDOR=OpenBLAS \
     -DCP2K_USE_COSMA=ON \
+    -DCP2K_USE_DEEPMD=ON \
     -DCP2K_USE_DFTD4=ON \
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_ELPA=ON \

--- a/tools/toolchain/scripts/stage6/deepmd-kit_4577.patch
+++ b/tools/toolchain/scripts/stage6/deepmd-kit_4577.patch
@@ -1,0 +1,13 @@
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index ca798604..32f3a855 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -446,7 +446,7 @@ if(BUILD_CPP_IF
+   set(version_file "${generated_dir}/${CMAKE_PROJECT_NAME}ConfigVersion.cmake")
+   write_basic_package_version_file(
+     ${version_file}
+-    VERSION $<IF:${GIT_SUMM}?${GIT_SUMM}:"0.0.0">
++    VERSION $<IF:${GIT_SUMM}?${GIT_SUMM}:0.0.0>
+     COMPATIBILITY AnyNewerVersion)
+   install(
+     EXPORT ${targets_export_name}

--- a/tools/toolchain/scripts/stage6/install_deepmd.sh
+++ b/tools/toolchain/scripts/stage6/install_deepmd.sh
@@ -45,6 +45,10 @@ case "$with_deepmd" in
       cd deepmd-kit-${deepmd_ver}/source
       # Workaround for https://github.com/deepmodeling/deepmd-kit/issues/4569
       sed -i /CXX_STANDARD/d CMakeLists.txt
+
+      # PR 4577: https://github.com/deepmodeling/deepmd-kit/pull/4577
+      patch -p2 CMakeLists.txt < ${SCRIPT_DIR}/stage6/deepmd-kit_4577.patch
+
       mkdir build
       cd build
       cmake \
@@ -90,6 +94,7 @@ EOF
 prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
+prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF
     cat "${BUILDDIR}/setup_deepmd" >> $SETUPFILE
   fi


### PR DESCRIPTION
Mathieu is working on the Spack package, so CMake + Spack CI will come in a separate PR.

The patch is needed to fix a warning, so that we can keep `-Werror=dev`.