### PR TITLE
DBM: improvements and optimizations

### DIFF
--- a/src/dbm/Makefile
+++ b/src/dbm/Makefile
@@ -24,26 +24,32 @@ endif
 # Optimization flag derived from OPT flag
 OPTFLAG ?= -O$(patsubst O%,%,$(OPT))
 
-CFLAGS := -g $(OPTFLAG) -march=native -Wall -Wextra -Wcast-qual
+CFLAGS := -fPIC -g $(OPTFLAG) -march=native -Wall -Wextra -Wcast-qual
 
 # Intel Compiler
 ICX := $(shell which icx 2>/dev/null)
 INTEL ?= $(if $(ICX),1,0)
 
+# Build with MPI when MPICC is given
+MPI ?= $(if $(MPICC),1,0)
+
 ifeq ($(INTEL),0)
 MKL_FCRTL := gf
 LIBS += $(if $(OMPRT),-l$(OMPRT),-fopenmp)
-CFLAGS += -fopenmp
+CFLAGS += -fopenmp -Wno-vla-parameter
+CC := $(if $(filter-out 0,$(MPI)),mpicc,gcc)
 else
 MKL_FCRTL := intel
 LIBS += $(if $(OMPRT),-l$(OMPRT),-qopenmp)
 CFLAGS += -qopenmp
-CC := icx
+CC := $(if $(filter-out 0,$(MPI)),mpiicx,icx)
 endif
 
-# Some additional flags when relying on default-CC
-ifeq ($(CC),)
-CFLAGS += -Wno-vla-parameter
+ifneq ($(MPI),0)
+CFLAGS += -D__parallel
+ifneq ($(MPICC),)
+CC := $(MPICC)
+endif
 endif
 
 NVCC := $(shell which nvcc 2>/dev/null)
@@ -91,7 +97,11 @@ endif
 all: dbm_miniapp.x
 
 clean:
-	rm -fv $(ALL_OBJECTS) $(OPENCL_GENKRNL)
+	rm -fv $(ALL_OBJECTS) $(OPENCL_GENKRNL) \
+        dbm_multiply_gpu.o \
+        dbm_multiply_gpu_kernel.o \
+        dbm_multiply_opencl.o \
+        dbm_miniapp.o
 
 realclean: clean
 	rm -fv dbm_miniapp.x
@@ -177,32 +187,18 @@ LIBS += -L${ROCM_PATH}/lib -lamdhip64 -lhipfft -lhipblas -lrocblas
 	cd $(dir $<); $(HIPCC) -c $(HIPFLAGS) $(notdir $<)
 endif
 
-
 # Make LIBXSMM available
 ifneq ($(LIBXSMMROOT),)
 CFLAGS += -D__LIBXSMM -I$(LIBXSMMROOT)/include
-LIBS += \
-        $(LIBXSMMROOT)/lib/libxsmm.a $(LIBXSMMROOT)/lib/libxsmmext.a \
+LIBS += $(LIBXSMMROOT)/lib/libxsmm.a \
+        $(LIBXSMMROOT)/lib/libxsmmext.a \
         -lpthread -lrt
 endif
 
-
-# Build with MPI when mpicc compiler is present.
-ifneq ($(MPICC),)
-%.o: %.c $(OMP_TRACE) $(ALL_HEADERS)
-	cd $(dir $<); $(MPICC) -c -std=c11 $(CFLAGS) -D__parallel $(notdir $<)
-
-dbm_miniapp.x: dbm_miniapp.o $(ALL_OBJECTS)
-	$(MPICC) $(CFLAGS) -o $@ $^ $(LIBS)
-
-
-# Build without MPI otherwise.
-else
 %.o: %.c $(OMP_TRACE) $(ALL_HEADERS)
 	cd $(dir $<); $(CC) -c -std=c11 $(CFLAGS) $(notdir $<)
 
 dbm_miniapp.x: dbm_miniapp.o $(ALL_OBJECTS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
-endif
 #EOF

--- a/src/dbt/tas/dbt_tas_base.F
+++ b/src/dbt/tas/dbt_tas_base.F
@@ -831,7 +831,7 @@ CONTAINS
 !> \return ...
 !> \author Patrick Seewald
 ! **************************************************************************************************
-   FUNCTION dbt_tas_nblkrows_total(matrix) RESULT(nblkrows_total)
+   PURE FUNCTION dbt_tas_nblkrows_total(matrix) RESULT(nblkrows_total)
       TYPE(dbt_tas_type), INTENT(IN)                     :: matrix
       INTEGER(KIND=int_8)                                :: nblkrows_total
 
@@ -844,7 +844,7 @@ CONTAINS
 !> \return ...
 !> \author Patrick Seewald
 ! **************************************************************************************************
-   FUNCTION dbt_tas_nfullrows_total(matrix) RESULT(nfullrows_total)
+   PURE FUNCTION dbt_tas_nfullrows_total(matrix) RESULT(nfullrows_total)
       TYPE(dbt_tas_type), INTENT(IN)                     :: matrix
       INTEGER(KIND=int_8)                                :: nfullrows_total
 
@@ -857,7 +857,7 @@ CONTAINS
 !> \return ...
 !> \author Patrick Seewald
 ! **************************************************************************************************
-   FUNCTION dbt_tas_nblkcols_total(matrix) RESULT(nblkcols_total)
+   PURE FUNCTION dbt_tas_nblkcols_total(matrix) RESULT(nblkcols_total)
       TYPE(dbt_tas_type), INTENT(IN)                     :: matrix
       INTEGER(KIND=int_8)                                :: nblkcols_total
 
@@ -870,7 +870,7 @@ CONTAINS
 !> \return ...
 !> \author Patrick Seewald
 ! **************************************************************************************************
-   FUNCTION dbt_tas_nfullcols_total(matrix) RESULT(nfullcols_total)
+   PURE FUNCTION dbt_tas_nfullcols_total(matrix) RESULT(nfullcols_total)
       TYPE(dbt_tas_type), INTENT(IN)                     :: matrix
       INTEGER(KIND=int_8)                                :: nfullcols_total
 
@@ -1003,11 +1003,11 @@ CONTAINS
          OPTIONAL                                        :: local_rows, local_cols
 
       CLASS(dbt_tas_distribution), ALLOCATABLE, OPTIONAL, &
-         INTENT(OUT)                                                  :: proc_row_dist, proc_col_dist
+         INTENT(OUT)                                                :: proc_row_dist, proc_col_dist
       CLASS(dbt_tas_rowcol_data), ALLOCATABLE, OPTIONAL, &
-         INTENT(OUT)                                                  :: row_blk_size, col_blk_size
+         INTENT(OUT)                                                :: row_blk_size, col_blk_size
       TYPE(dbt_tas_distribution_type), OPTIONAL                     :: distribution
-      CHARACTER(len=*), INTENT(OUT), OPTIONAL                         :: name
+      CHARACTER(len=*), INTENT(OUT), OPTIONAL                       :: name
 
       TYPE(dbt_tas_split_info)                                      :: info
       INTEGER                                                       :: irow, icol


### PR DESCRIPTION
- Avoid stream-synchronization for copy-completion (GPU); at the expense of higher memory consumption (lifetime).
- Implement SMM-threshold (CPU/LIBXSMM/BLAS).

OpenCL backend:
- Adjusted valid range of kernel-parameter (BN).
- Adjusted default value (BN).

Makefile/Miniapp
- Consolidated MPI-compilation-
- Ensure gcc rather than cc.
- Adjusted CFLAGS (-fPIC).
- Fixed clean-target.

Other
- Purified some getter-like functions.