### PR TITLE
benchmarks should not restart

### DIFF
--- a/benchmarks/QMMM_CBD_PHY/CBD_PHY.inp
+++ b/benchmarks/QMMM_CBD_PHY/CBD_PHY.inp
@@ -31,7 +31,6 @@
     &SCF  ! Parameters controlling the convergence of the scf. This section should not be changed.
       EPS_SCF 1.0E-6
       MAX_SCF 300
-      SCF_GUESS RESTART
       &OT T
         MINIMIZER DIIS
         PRECONDITIONER FULL_ALL

--- a/benchmarks/QMMM_ClC/ClC-19.inp
+++ b/benchmarks/QMMM_ClC/ClC-19.inp
@@ -31,7 +31,6 @@
     &SCF  ! Parameters controlling the convergence of the scf. This section should not be changed.
       EPS_SCF 1.0E-6
       MAX_SCF 300
-      SCF_GUESS RESTART
       &OT T
         MINIMIZER DIIS
         PRECONDITIONER FULL_ALL

--- a/benchmarks/QMMM_ClC/ClC-253.inp
+++ b/benchmarks/QMMM_ClC/ClC-253.inp
@@ -31,7 +31,6 @@
     &SCF  ! Parameters controlling the convergence of the scf. This section should not be changed.
       EPS_SCF 1.0E-6
       MAX_SCF 300
-      SCF_GUESS RESTART
       &OT T
         MINIMIZER DIIS
         PRECONDITIONER FULL_ALL

--- a/benchmarks/QMMM_MQAE/MQAE.inp
+++ b/benchmarks/QMMM_MQAE/MQAE.inp
@@ -31,7 +31,6 @@
     &SCF  ! Parameters controlling the convergence of the scf. This section should not be changed.
       EPS_SCF 1.0E-6
       MAX_SCF 300
-      SCF_GUESS RESTART
       &OT T
         MINIMIZER DIIS
         PRECONDITIONER FULL_ALL

--- a/benchmarks/QMMM_MQAE/MQAE_single_node.inp
+++ b/benchmarks/QMMM_MQAE/MQAE_single_node.inp
@@ -31,7 +31,6 @@
     &SCF  ! Parameters controlling the convergence of the scf. This section should not be changed.
       EPS_SCF 1.0E-5
       MAX_SCF 100
-      SCF_GUESS RESTART
       &OT T
         MINIMIZER DIIS
         PRECONDITIONER FULL_ALL

--- a/benchmarks/QS_LiH_HFX/input_bulk_HFX_3.inp
+++ b/benchmarks/QS_LiH_HFX/input_bulk_HFX_3.inp
@@ -32,7 +32,6 @@
     &SCF
       EPS_SCF 1.0E-6
       MAX_SCF 20
-      SCF_GUESS RESTART
       &OT
         PRECONDITIONER FULL_ALL
       &END OT

--- a/benchmarks/QS_low_scaling_GW/GW.inp
+++ b/benchmarks/QS_low_scaling_GW/GW.inp
@@ -27,7 +27,6 @@
       CHOLESKY OFF
       EPS_SCF 1.0E-6
       MAX_SCF 200
-      SCF_GUESS RESTART
     &END SCF
     &XC
       &WF_CORRELATION


### PR DESCRIPTION
- Removed SCF_GUESS RESTART.
- Default: SCF_GUESS ATOMIC.