### PR TITLE
Enable sirius+libvdwxc builds with CMake and improve Spack environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,10 @@ option(
   "disable the dbm accelerated (mostly GPU) backend. It is only effective when general gpu support is enabled."
   ON)
 
+
+cmake_dependent_option(CP2K_USE_LIBVDWXC
+  "Enable libvdwxc support WITH SIRIUS" ON "CP2K_USE_SIRIUS" OFF)
+
 cmake_dependent_option(
   CP2K_USE_UNIFIED_MEMORY "Use CPU/GPU unified memory.
   requires Mi250x or future AMD architectures to be fully functional" OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,9 +143,8 @@ option(
   "disable the dbm accelerated (mostly GPU) backend. It is only effective when general gpu support is enabled."
   ON)
 
-
-cmake_dependent_option(CP2K_USE_LIBVDWXC
-  "Enable libvdwxc support WITH SIRIUS" ON "CP2K_USE_SIRIUS" OFF)
+cmake_dependent_option(CP2K_USE_LIBVDWXC "Enable libvdwxc support WITH SIRIUS"
+                       ON "CP2K_USE_SIRIUS" OFF)
 
 cmake_dependent_option(
   CP2K_USE_UNIFIED_MEMORY "Use CPU/GPU unified memory.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1671,6 +1671,7 @@ target_compile_definitions(
     $<$<BOOL:${CP2K_USE_DFTD4}>:__DFTD4>
     $<$<BOOL:${CP2K_USE_DEEPMD}>:__DEEPMD>
     $<$<BOOL:${CP2K_USE_SIRIUS}>:__SIRIUS>
+    $<$<BOOL:${CP2K_USE_LIBVDWXC}>:__LIBVDWXC>
     $<$<BOOL:${CP2K_USE_SPLA}>:__SPLA>
     $<$<BOOL:${CP2K_USE_SpFFT}>:__SPFFT>
     $<$<BOOL:${CP2K_USE_SPLA_GEMM_OFFLOADING}>:__OFFLOAD_GEMM>

--- a/tools/docker/Dockerfile.test_spack
+++ b/tools/docker/Dockerfile.test_spack
@@ -42,7 +42,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
 
 # Install a recent developer version of Spack.
 WORKDIR /opt/spack
-ARG SPACK_VERSION=develop-2025-02-02
+ARG SPACK_VERSION=40d40ccc525dfa821b5e2998c9e767f08e0065bd
 RUN git init --quiet && \
     git remote add origin https://github.com/spack/spack.git && \
     git fetch --quiet --depth 1 origin ${SPACK_VERSION} --no-tags && \

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -852,7 +852,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
 
 # Install a recent developer version of Spack.
 WORKDIR /opt/spack
-ARG SPACK_VERSION=develop-2025-02-02
+ARG SPACK_VERSION=40d40ccc525dfa821b5e2998c9e767f08e0065bd
 RUN git init --quiet && \
     git remote add origin https://github.com/spack/spack.git && \
     git fetch --quiet --depth 1 origin ${{SPACK_VERSION}} --no-tags && \

--- a/tools/docker/scripts/build_cp2k_cmake.sh
+++ b/tools/docker/scripts/build_cp2k_cmake.sh
@@ -88,6 +88,7 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_ELPA=ON \
     -DCP2K_USE_COSMA=ON \
     -DCP2K_USE_SIRIUS=ON \
+    -DCP2K_USE_LIBVDWXC=ON \
     -DCP2K_USE_GRPP=OFF \
     -DCP2K_USE_TREXIO=ON \
     -DCP2K_USE_LIBTORCH=ON \

--- a/tools/spack/cp2k-dependencies.yaml
+++ b/tools/spack/cp2k-dependencies.yaml
@@ -2,44 +2,89 @@
 spack:
   specs:
     - "mpich@4.1.2"
-    - "openblas@0.3.24 +fortran threads=openmp"
-    - "dbcsr@2.8.0 +openmp +mpi"
-    - "netlib-scalapack@2.2.0"
-    - "libxsmm@1.17"
-    - "fftw@3.3.10 +openmp"
-    - "libxc@7.0.0 +kxc build_system=cmake"
-    - "spglib@2.3.0"
-    - "dla-future@0.7.3 +scalapack"
+    - "openblas@0.3.24"
+    - "netlib-scalapack@2.2.2"
+    - "cosma@2.6.6"
+    - "dbcsr@2.8.0"
+    - "dftd4@3.6.0"
+    - "dla-future@0.7.3"
     - "dla-future-fortran@0.2.0"
-    - "libint@2.9.0 +fortran tune=cp2k-lmax-5"
-    - "cosma@2.6.6 +scalapack"
-    - "plumed@2.9.2"
-    - "elpa@2024.03.001 +openmp"
-    - "sirius @7.6.1 +fortran +pugixml ~apps"
-    - "libvori@220621"
-    - "spla@1.6.1 +fortran"
-    - "trexio@2.5.0 +hdf5 build_system=cmake"
-    - "dftd4@3.6.0 build_system=cmake"
-    - "libsmeagol@1.2"
+    - "elpa@2024.03.001"
+    - "fftw@3.3.10"
     - "hdf5@1.14"
-    - "py-torch@2.5"
+    - "libint@2.9.0"
+    - "libsmeagol@1.2"
+    - "libvori@220621"
+    - "libxc@7.0.0"
+    - "libxsmm@1.17"
+    - "plumed@2.9.2"
     - "python@3.11"
-   # Unfortunately, ScaLAPACK 2.2.1 has not yet been packaged by Spack.
-   # https://github.com/Reference-ScaLAPACK/scalapack/tree/v2.2.1
-   # which contains https://github.com/Reference-ScaLAPACK/scalapack/pull/26
-
-   # TODO:
-   # scotch_6.0.0.tar.gz
-   # superlu_dist_6.1.0.tar.gz: OK
-   # libvdwxc-0.4.0.tar.gz: OK
+    - "py-torch@2.5"
+    - "sirius@7.6.1"
+    - "spglib@2.3.0"
+    - "spla@1.6.1"
+    - "trexio@2.5.0"
   packages:
-    hdf5:
+    all:
+      prefer:
+        - +mpi
+        - ~cuda
+        - ~rocm
+    # MPI, BLAS, LAPACK, ScaLAPACK
+    mpi:
       require:
-        - +fortran
+        - mpich
     mpich:
       require:
         - device=ch3
         - netmod=tcp
+    blas:
+      require:
+        - openblas
+    lapack:
+      require:
+        - openblas
+    scalapack:
+      require:
+        - netlib-scalapack
+    openblas:
+      require:
+        - +fortran
+        - threads=openmp
+    # Dependencies for CP2K
+    cosma:
+      require:
+        - +scalapack
+    dbcsr:
+      require:
+        - +openmp
+    dftd4:
+      require:
+        - build_system=cmake
+    dla-future:
+      require:
+        - +scalapack
+    elpa:
+      require:
+        - +openmp
+    fftw-api:
+      require:
+        - "@3"
+        - fftw
+    fftw:
+      require:
+        - +openmp
+    hdf5:
+      require:
+        - +fortran
+    libint:
+      require:
+        - +fortran
+        - tune=cp2k-lmax-5
+    libxc:
+      require:
+        - +kxc
+        - build_system=cmake
     py-torch:
       require:
         - +custom-protobuf
@@ -47,6 +92,19 @@ spack:
         - ~rocm
         - ~kineto
         - ~distributed
+    sirius:
+      require:
+        - +fortran
+        - +pugixml
+        - ~apps
+        - +vdwxc
+    spla:
+      require:
+        - +fortran
+    trexio:
+      require:
+        - +hdf5
+        - build_system=cmake
   view:
     default:
       root: ./spack-env/view


### PR DESCRIPTION
Enable to use `sirius+libvdwxc` with CMake and enable this in the CMake + Spack configuration.

This PR also improves the definition of the Spack environment: specs only contain the library and the version, while variants are now set under `require:`, to make sure Spack does exactly what we ask for. `blas`, `lapack`, `scalapack`, and `fftw-api` are also required explicitly, to make sure Spack does not potentially pull in libraries from different vendors.