### PR TITLE
Revert "DBX: Make row/col_blk_size of dbcsr_create CONTIGUOUS"

### DIFF
--- a/src/almo_scf_qs.F
+++ b/src/almo_scf_qs.F
@@ -128,8 +128,8 @@ CONTAINS
       INTEGER                                            :: dimen, handle, hold, iatom, iblock_col, &
                                                             iblock_row, imol, mynode, natoms, &
                                                             nblkrows_tot, nlength, nmols, row
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER :: blk_distr, blk_sizes, block_sizes_new, &
-         col_distr_new, col_sizes_new, distr_new_array, row_distr_new, row_sizes_new
+      INTEGER, DIMENSION(:), POINTER :: blk_distr, blk_sizes, block_sizes_new, col_distr_new, &
+         col_sizes_new, distr_new_array, row_distr_new, row_sizes_new
       LOGICAL                                            :: active, one_dim_is_mo, tr
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: p_new_block
       TYPE(dbcsr_distribution_type)                      :: dist_new, dist_qs

--- a/src/arnoldi/arnoldi_vector.F
+++ b/src/arnoldi/arnoldi_vector.F
@@ -86,7 +86,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_col_vec_from_matrix'
 
       INTEGER                                            :: data_type, handle, npcols
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_dist, row_blk_size, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist
       TYPE(dbcsr_distribution_type)                      :: dist, dist_col_vec
 
@@ -130,7 +130,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_row_vec_from_matrix'
 
       INTEGER                                            :: data_type, handle, nprows
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_dist, row_blk_size, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist
       TYPE(dbcsr_distribution_type)                      :: dist, dist_row_vec
 
@@ -174,7 +174,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_replicated_col_vec_from_matrix'
 
       INTEGER                                            :: data_type, handle, i, npcols
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_dist, row_blk_size, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist
       TYPE(dbcsr_distribution_type)                      :: dist, dist_col_vec
 
@@ -220,7 +220,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_replicated_row_vec_from_matrix'
 
       INTEGER                                            :: data_type, handle, i, nprows
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_dist, row_blk_size, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist
       TYPE(dbcsr_distribution_type)                      :: dist, dist_row_vec
 

--- a/src/common/cp_array_utils.F
+++ b/src/common/cp_array_utils.F
@@ -53,6 +53,8 @@ MODULE cp_array_utils
       #:endfor
    END INTERFACE
 
+!***
+
    #:for nametype1, type1, defaultFormatType1, lessQ in inst_params
 
 ! **************************************************************************************************
@@ -61,9 +63,9 @@ MODULE cp_array_utils
 !>      02.2003 created [fawzi]
 !> \author fawzi
 ! **************************************************************************************************
-      TYPE cp_1d_${nametype1}$_p_type
-         ${type1}$, dimension(:), CONTIGUOUS, POINTER :: array => NULL()
-      END TYPE cp_1d_${nametype1}$_p_type
+      type cp_1d_${nametype1}$_p_type
+         ${type1}$, dimension(:), pointer :: array => NULL()
+      end type cp_1d_${nametype1}$_p_type
 
 ! **************************************************************************************************
 !> \brief represent a pointer to a 2d array
@@ -71,9 +73,9 @@ MODULE cp_array_utils
 !>      02.2003 created [fawzi]
 !> \author fawzi
 ! **************************************************************************************************
-      TYPE cp_2d_${nametype1}$_p_type
-         ${type1}$, dimension(:, :), CONTIGUOUS, POINTER :: array => NULL()
-      END TYPE cp_2d_${nametype1}$_p_type
+      type cp_2d_${nametype1}$_p_type
+         ${type1}$, dimension(:, :), pointer :: array => NULL()
+      end type cp_2d_${nametype1}$_p_type
 
 ! **************************************************************************************************
 !> \brief represent a pointer to a 3d array
@@ -81,9 +83,9 @@ MODULE cp_array_utils
 !>      02.2003 created [fawzi]
 !> \author fawzi
 ! **************************************************************************************************
-      TYPE cp_3d_${nametype1}$_p_type
-         ${type1}$, dimension(:, :, :), CONTIGUOUS, POINTER :: array => NULL()
-      END TYPE cp_3d_${nametype1}$_p_type
+      type cp_3d_${nametype1}$_p_type
+         ${type1}$, dimension(:, :, :), pointer :: array => NULL()
+      end type cp_3d_${nametype1}$_p_type
 
 ! **************************************************************************************************
 !> \brief represent a pointer to a contiguous 1d array
@@ -91,9 +93,9 @@ MODULE cp_array_utils
 !>      02.2003 created [fawzi]
 !> \author fawzi
 ! **************************************************************************************************
-      TYPE cp_1d_${nametype1}$_cp_type
-         ${type1}$, dimension(:), CONTIGUOUS, POINTER :: array => NULL()
-      END TYPE cp_1d_${nametype1}$_cp_type
+      type cp_1d_${nametype1}$_cp_type
+         ${type1}$, dimension(:), contiguous, pointer :: array => NULL()
+      end type cp_1d_${nametype1}$_cp_type
 
 ! **************************************************************************************************
 !> \brief represent a pointer to a contiguous 2d array
@@ -101,9 +103,9 @@ MODULE cp_array_utils
 !>      02.2003 created [fawzi]
 !> \author fawzi
 ! **************************************************************************************************
-      TYPE cp_2d_${nametype1}$_cp_type
-         ${type1}$, dimension(:, :), CONTIGUOUS, POINTER :: array => NULL()
-      END TYPE cp_2d_${nametype1}$_cp_type
+      type cp_2d_${nametype1}$_cp_type
+         ${type1}$, dimension(:, :), contiguous, pointer :: array => NULL()
+      end type cp_2d_${nametype1}$_cp_type
 
 ! **************************************************************************************************
 !> \brief represent a pointer to a contiguous 3d array
@@ -111,9 +113,9 @@ MODULE cp_array_utils
 !>      02.2003 created [fawzi]
 !> \author fawzi
 ! **************************************************************************************************
-      TYPE cp_3d_${nametype1}$_cp_type
-         ${type1}$, dimension(:, :, :), CONTIGUOUS, POINTER :: array => NULL()
-      END TYPE cp_3d_${nametype1}$_cp_type
+      type cp_3d_${nametype1}$_cp_type
+         ${type1}$, dimension(:, :, :), contiguous, pointer :: array => NULL()
+      end type cp_3d_${nametype1}$_cp_type
 
    #:endfor
 

--- a/src/cp_dbcsr_operations.F
+++ b/src/cp_dbcsr_operations.F
@@ -153,7 +153,7 @@ CONTAINS
       INTEGER                                            :: col, handle, ncol_block, ncol_global, &
                                                             nrow_block, nrow_global, row
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_col, first_row, last_col, last_row
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, row_blk_size
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: dbcsr_block, fm_block
       TYPE(dbcsr_distribution_type)                      :: bc_dist
@@ -220,7 +220,7 @@ CONTAINS
       INTEGER                                            :: group_handle, handle, ncol_block, &
                                                             nfullcols_total, nfullrows_total, &
                                                             nrow_block
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, row_blk_size
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       TYPE(dbcsr_distribution_type)                      :: bc_dist, dist
       TYPE(dbcsr_type)                                   :: bc_mat, matrix_nosym
@@ -561,7 +561,7 @@ CONTAINS
       INTEGER                                            :: a_ncol, a_nrow, b_ncol, b_nrow, c_ncol, &
                                                             c_nrow, k_in, k_out, timing_handle, &
                                                             timing_handle_mult
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_blk_size_right_in, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_blk_size_right_in, &
                                                             col_blk_size_right_out, col_dist, &
                                                             row_blk_size, row_dist
       TYPE(dbcsr_type)                                   :: in, out
@@ -705,7 +705,7 @@ CONTAINS
 
       INTEGER                                            :: data_type, k, my_symmetry_mode, nao, &
                                                             npcols, timing_handle
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size_left, col_dist_left, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size_left, col_dist_left, &
                                                             row_blk_size, row_dist
       LOGICAL                                            :: check_product, my_keep_sparsity
       REAL(KIND=dp)                                      :: my_alpha, norm
@@ -881,7 +881,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(IN)                       :: template
 
       INTEGER                                            :: data_type, k_in
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size_right_in, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size_right_in, row_blk_size
       TYPE(dbcsr_distribution_type)                      :: dist_right_in, tmpl_dist
 
       CALL cp_fm_get_info(fm_in, ncol_global=k_in)
@@ -918,7 +918,7 @@ CONTAINS
 
       CHARACTER                                          :: mysym
       INTEGER                                            :: my_data_type, npcols, nprows
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_dist, row_blk_size, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist
       TYPE(dbcsr_distribution_type)                      :: dist_m_n, tmpl_dist
 
@@ -968,7 +968,7 @@ CONTAINS
 
       CHARACTER                                          :: mysym
       INTEGER                                            :: my_data_type, npcols
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_dist, row_blk_size, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist
       TYPE(dbcsr_distribution_type)                      :: dist_m_n, tmpl_dist
 

--- a/src/dbx/cp_dbcsr_api.F
+++ b/src/dbx/cp_dbcsr_api.F
@@ -64,10 +64,9 @@ MODULE cp_dbcsr_api
         dbcsr_type_real_default, dbcsr_type_symmetric, dbcsr_valid_index_prv => dbcsr_valid_index, &
         dbcsr_verify_matrix_prv => dbcsr_verify_matrix, dbcsr_work_create_prv => dbcsr_work_create
    USE dbm_api,                         ONLY: &
-        dbm_add, dbm_checksum, dbm_clear, dbm_copy, dbm_create, dbm_distribution_obj, &
-        dbm_iterator, dbm_redistribute, dbm_scale, dbm_type, dbm_zero
-   USE kinds,                           ONLY: default_string_length,&
-                                              dp,&
+        dbm_add, dbm_checksum, dbm_clear, dbm_copy, dbm_distribution_obj, dbm_iterator, &
+        dbm_redistribute, dbm_scale, dbm_type, dbm_zero
+   USE kinds,                           ONLY: dp,&
                                               int_8
    USE message_passing,                 ONLY: mp_comm_type
 #include "../base/base_uses.f90"
@@ -489,7 +488,7 @@ CONTAINS
       CHARACTER(len=*), INTENT(IN)                       :: name
       TYPE(dbcsr_distribution_type), INTENT(IN)          :: dist
       CHARACTER, INTENT(IN)                              :: matrix_type
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_size, col_blk_size
+      INTEGER, DIMENSION(:), INTENT(INOUT), POINTER      :: row_blk_size, col_blk_size
       INTEGER, INTENT(IN), OPTIONAL                      :: nze, data_type
       LOGICAL, INTENT(IN), OPTIONAL                      :: reuse_arrays, mutable_work
 
@@ -499,12 +498,7 @@ CONTAINS
                                col_blk_size=col_blk_size, nze=nze, data_type=data_type, &
                                reuse_arrays=reuse_arrays, mutable_work=mutable_work)
       ELSE
-         IF (matrix_type /= "N" .OR. PRESENT(nze) .OR. PRESENT(data_type) .OR. &
-             PRESENT(reuse_arrays) .OR. PRESENT(mutable_work)) THEN
-            CPABORT("Not yet implemented for DBM.")
-         END IF
-         CALL dbm_create(matrix%dbm, name=name, dist=dist%dbm, &
-                         row_block_sizes=row_blk_size, col_block_sizes=col_blk_size)
+         CPABORT("Not yet implemented for DBM.")
       END IF
    END SUBROUTINE dbcsr_create_new
 
@@ -531,15 +525,10 @@ CONTAINS
       TYPE(dbcsr_distribution_type), INTENT(IN), &
          OPTIONAL                                        :: dist
       CHARACTER, INTENT(IN), OPTIONAL                    :: matrix_type
-      INTEGER, CONTIGUOUS, DIMENSION(:), OPTIONAL, &
+      INTEGER, DIMENSION(:), INTENT(INOUT), OPTIONAL, &
          POINTER                                         :: row_blk_size, col_blk_size
       INTEGER, INTENT(IN), OPTIONAL                      :: nze, data_type
       LOGICAL, INTENT(IN), OPTIONAL                      :: reuse_arrays, mutable_work
-
-      CHARACTER                                          :: my_matrix_type
-      CHARACTER(len=default_string_length)               :: my_name
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: my_col_blk_size, my_row_blk_size
-      TYPE(dbcsr_distribution_type)                      :: my_dist
 
       IF (USE_DBCSR_BACKEND) THEN
          CALL dbcsr_create_prv(matrix=matrix%dbcsr, name=name, template=template%dbcsr, &
@@ -548,19 +537,7 @@ CONTAINS
                                nze=nze, data_type=data_type, reuse_arrays=reuse_arrays, &
                                mutable_work=mutable_work)
       ELSE
-         CALL dbcsr_get_info(template, name=my_name, matrix_type=my_matrix_type, distribution=my_dist, &
-                             row_blk_size=my_row_blk_size, col_blk_size=my_col_blk_size)
-         IF (PRESENT(name)) my_name = name
-         IF (PRESENT(dist)) my_dist = dist
-         IF (PRESENT(matrix_type)) my_matrix_type = matrix_type
-         IF (PRESENT(row_blk_size)) my_row_blk_size = row_blk_size
-         IF (PRESENT(col_blk_size)) my_col_blk_size = col_blk_size
-         IF (my_matrix_type /= "N" .OR. PRESENT(nze) .OR. PRESENT(data_type) .OR. &
-             PRESENT(reuse_arrays) .OR. PRESENT(mutable_work)) THEN
-            CPABORT("Not yet implemented for DBM.")
-         END IF
-         CALL dbm_create(matrix%dbm, name=my_name, dist=my_dist%dbm, &
-                         row_block_sizes=my_row_blk_size, col_block_sizes=my_col_blk_size)
+         CPABORT("Not yet implemented for DBM.")
       END IF
    END SUBROUTINE dbcsr_create_template
 

--- a/src/dm_ls_scf_qs.F
+++ b/src/dm_ls_scf_qs.F
@@ -107,7 +107,7 @@ CONTAINS
                                                             ls_data_type, natom, nmol
       INTEGER, ALLOCATABLE, DIMENSION(:), TARGET         :: atom_to_cluster, atom_to_cluster_primus, &
                                                             clustered_blk_sizes, primus_of_mol
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: clustered_col_dist, clustered_row_dist, &
+      INTEGER, DIMENSION(:), POINTER                     :: clustered_col_dist, clustered_row_dist, &
                                                             ls_blk_sizes, ls_col_dist, ls_row_dist
       TYPE(dbcsr_distribution_type)                      :: ls_dist, ls_dist_clustered
 
@@ -220,7 +220,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'matrix_qs_to_ls'
 
       INTEGER                                            :: handle
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: pao_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: pao_blk_sizes
       TYPE(dbcsr_type)                                   :: matrix_pao, matrix_tmp
       TYPE(dbcsr_type), POINTER                          :: matrix_trafo
 
@@ -315,7 +315,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'matrix_ls_to_qs'
 
       INTEGER                                            :: handle
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: pao_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: pao_blk_sizes
       LOGICAL                                            :: my_keep_sparsity
       TYPE(dbcsr_type)                                   :: matrix_declustered, matrix_tmp1, &
                                                             matrix_tmp2

--- a/src/ed_analysis.F
+++ b/src/ed_analysis.F
@@ -131,8 +131,8 @@ CONTAINS
       INTEGER                                            :: handle, iatom, ikind, iorb, ispin, jorb, &
                                                             nao, natom, nimages, nkind, no, norb, &
                                                             nref, nspin
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: refbas_blk_sizes
       INTEGER, DIMENSION(2)                              :: nocc
+      INTEGER, DIMENSION(:), POINTER                     :: refbas_blk_sizes
       LOGICAL :: detailed_ener, do_hfx, ewald_correction, explicit, gapw, gapw_xc, &
          ref_orb_canonical, skip_localize, uniform_occupation, uocc
       REAL(KIND=dp)                                      :: ateps, checksum, e1, e2, e_pot, ealpha, &

--- a/src/energy_corrections.F
+++ b/src/energy_corrections.F
@@ -2597,7 +2597,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'mao_create_matrices'
 
       INTEGER                                            :: handle, ispin, nspins
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mao_coef
       TYPE(dbcsr_type)                                   :: cgmat

--- a/src/gw_utils.F
+++ b/src/gw_utils.F
@@ -2904,7 +2904,7 @@ CONTAINS
 
       INTEGER                                            :: handle, img, nimages_scf_desymm
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: sizes_RI
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_bsize, row_bsize
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_V_tr_R
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist

--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -455,8 +455,8 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:) :: dist_AO_1, dist_AO_2, dist_RI, dist_RI_ext, &
          ends_array_mc_block_int, ends_array_mc_int, sizes_AO, sizes_RI, sizes_RI_ext, &
          sizes_RI_ext_split, starts_array_mc_block_int, starts_array_mc_int
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_bsize, row_bsize
       INTEGER, DIMENSION(3)                              :: pcoord, pdims
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       LOGICAL                                            :: converged, do_kpoints_prv
       REAL(dp)                                           :: max_ev, min_ev, occ, RI_range
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
@@ -2492,10 +2492,10 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:) :: atom_of_kind, batch_end, batch_end_RI, batch_ranges, &
          batch_ranges_RI, batch_start, batch_start_RI, dist1, dist2, dist3, idx_to_at_AO, &
          idx_to_at_RI, kind_of
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_bsize, row_bsize
       INTEGER, DIMENSION(2, 1)                           :: ibounds, jbounds, kbounds
       INTEGER, DIMENSION(2, 2)                           :: ijbounds
       INTEGER, DIMENSION(2, 3)                           :: bounds_cpy
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       LOGICAL                                            :: do_resp, resp_only_prv, use_virial_prv
       REAL(dp)                                           :: pref, spin_fac, t1, t2
       REAL(dp), DIMENSION(3, 3)                          :: work_virial
@@ -3135,8 +3135,8 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2, dist_AO_1, dist_AO_2, &
                                                             dist_RI, dummy_end, dummy_start, &
                                                             end_blocks, start_blocks
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_bsize, row_bsize
       INTEGER, DIMENSION(3)                              :: pcoord, pdims
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       REAL(dp)                                           :: compression_factor, memory, occ
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
       TYPE(dbcsr_type), DIMENSION(1, 3)                  :: t_2c_der_metric_prv, t_2c_der_RI_prv
@@ -3622,7 +3622,7 @@ CONTAINS
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       INTEGER                                            :: i_RI, ibasis, nkind, nspins, unit_nr
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_bsize, row_bsize
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       LOGICAL                                            :: mult_by_S, print_density, print_ri_metric
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: density_coeffs, density_coeffs_2
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env

--- a/src/hfx_ri_kp.F
+++ b/src/hfx_ri_kp.F
@@ -2008,9 +2008,9 @@ CONTAINS
          jatom, jblk, jkind, n_dependent, natom, nblks_RI, nimg, nkind
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: present_atoms_i, present_atoms_j
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_dist, col_dist_ext, ri_blk_size_ext, &
-                                                            row_dist, row_dist_ext
       INTEGER, DIMENSION(3)                              :: cell_b, cell_i, cell_j, cell_tot
+      INTEGER, DIMENSION(:), POINTER                     :: col_dist, col_dist_ext, ri_blk_size_ext, &
+                                                            row_dist, row_dist_ext
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell, pgrid
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: do_inverse_prv, found, my_offd, &
@@ -3097,8 +3097,8 @@ CONTAINS
       INTEGER(int_8)                                     :: nze
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes_RI_ext, bsizes_RI_ext_split, &
                                                             dist1, dist2
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_dist, RI_blk_size, row_dist
       INTEGER, DIMENSION(2)                              :: pdims_2d
+      INTEGER, DIMENSION(:), POINTER                     :: col_dist, RI_blk_size, row_dist
       INTEGER, DIMENSION(:, :), POINTER                  :: dbcsr_pgrid
       REAL(dp)                                           :: occ
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist_sub
@@ -3435,8 +3435,8 @@ CONTAINS
       INTEGER(int_8)                                     :: nze
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: bsizes_RI_ext, bsizes_RI_ext_split, &
                                                             dist1, dist2
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_dist, RI_blk_size, row_dist
       INTEGER, DIMENSION(2)                              :: pdims_2d
+      INTEGER, DIMENSION(:), POINTER                     :: col_dist, RI_blk_size, row_dist
       INTEGER, DIMENSION(:, :), POINTER                  :: dbcsr_pgrid
       REAL(dp)                                           :: occ
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist_sub
@@ -4690,8 +4690,8 @@ CONTAINS
       INTEGER(int_8)                                     :: nze
       INTEGER, ALLOCATABLE, DIMENSION(:) :: bsizes_RI_ext, bsizes_RI_ext_split, dist_AO_1, &
          dist_AO_2, dist_RI, dist_RI_ext, dummy_end, dummy_start, end_blocks, start_blocks
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_bsize, row_bsize
       INTEGER, DIMENSION(3)                              :: pcoord, pdims
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       REAL(dp)                                           :: occ
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist
       TYPE(dbcsr_type)                                   :: dbcsr_template

--- a/src/iao_analysis.F
+++ b/src/iao_analysis.F
@@ -1405,7 +1405,7 @@ CONTAINS
                                                             iset, ishell, ispin, l, m, maxl, n, &
                                                             natom, nkind, noce, ns, nset, nsgf, &
                                                             nspin
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: iao_blk_sizes, nshell, oce_blk_sizes, &
+      INTEGER, DIMENSION(:), POINTER                     :: iao_blk_sizes, nshell, oce_blk_sizes, &
                                                             orb_blk_sizes
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgf, last_sgf, lval
       LOGICAL                                            :: found

--- a/src/kg_tnadd_mat.F
+++ b/src/kg_tnadd_mat.F
@@ -104,7 +104,7 @@ CONTAINS
          maxco, maxder, maxl, maxlgto, maxnset, maxpol, maxsgf, mepos, natom, ncoa, ncob, nder, &
          ngau, nkind, npol, nseta, nsetb, nthread, sgfa, sgfb
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_of_kind
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: atom_to_molecule, col_blk_sizes, la_max, &
+      INTEGER, DIMENSION(:), POINTER                     :: atom_to_molecule, col_blk_sizes, la_max, &
                                                             la_min, lb_max, lb_min, npgfa, npgfb, &
                                                             nsgfa, nsgfb, row_blk_sizes
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb

--- a/src/mao_basis.F
+++ b/src/mao_basis.F
@@ -90,7 +90,7 @@ CONTAINS
       INTEGER                                            :: handle, iab, iatom, ikind, iolev, ispin, &
                                                             iw, mao_max_iter, natom, nbas, &
                                                             nimages, nkind, nmao, nspin
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
       LOGICAL                                            :: do_nmao_external, molecule
       REAL(KIND=dp)                                      :: electra(2), eps1, eps_filter, eps_fun, &
                                                             mao_eps_grad

--- a/src/mao_methods.F
+++ b/src/mao_methods.F
@@ -91,7 +91,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: iolevel, iw
 
       INTEGER                                            :: i, iatom, info, jatom, lwork, m, n, nblk
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, mao_blk, row_blk, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, mao_blk, row_blk, &
                                                             row_blk_sizes
       LOGICAL                                            :: found
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: w, work

--- a/src/mao_optimizer.F
+++ b/src/mao_optimizer.F
@@ -61,7 +61,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'mao_optimize'
 
       INTEGER                                            :: handle, i, ispin, iter, nspin
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, mao_sizes_a, mao_sizes_b
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, mao_sizes_a, mao_sizes_b
       LOGICAL                                            :: spin_warning
       REAL(KIND=dp)                                      :: a1, a2, alpha, an, beta, eps_fun, fa1, &
                                                             fa2, fnnew, fnold, fval, grad_norm

--- a/src/mao_wfn_analysis.F
+++ b/src/mao_wfn_analysis.F
@@ -95,7 +95,7 @@ CONTAINS
       CHARACTER(len=2)                                   :: element_symbol, esa, esb, esc
       INTEGER :: fall, handle, ia, iab, iabc, iatom, ib, ic, icol, ikind, irow, ispin, jatom, &
          mao_basis, max_iter, me, na, nab, nabc, natom, nb, nc, nimages, nspin, ssize
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, mao_blk, mao_blk_sizes, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, mao_blk, mao_blk_sizes, &
                                                             orb_blk, row_blk_sizes
       LOGICAL                                            :: analyze_ua, explicit, fo, for, fos, &
                                                             found, neglect_abc, print_basis

--- a/src/minbas_methods.F
+++ b/src/minbas_methods.F
@@ -85,7 +85,7 @@ CONTAINS
       INTEGER                                            :: handle, homo, i, iab, ispin, nao, natom, &
                                                             ndep, nmao, nmo, nmx, np, np1, nspin, &
                                                             nvirt, unit_nr
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
       LOGICAL                                            :: do_minbas, my_full_ortho
       REAL(KIND=dp)                                      :: my_eps_filter
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: dval, dvalo, dvalv, eigval

--- a/src/minbas_wfn_analysis.F
+++ b/src/minbas_wfn_analysis.F
@@ -110,7 +110,7 @@ CONTAINS
       INTEGER                                            :: handle, homo, i, ispin, nao, natom, &
                                                             nimages, nmao, nmo, nspin
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: ecount
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
       LOGICAL                                            :: do_bondorder, explicit, full_ortho, occeq
       REAL(KIND=dp)                                      :: alpha, amax, eps_filter, filter_eps, &
                                                             trace

--- a/src/mp2_gpw.F
+++ b/src/mp2_gpw.F
@@ -1003,7 +1003,7 @@ CONTAINS
 
       CHARACTER                                          :: my_dbcsr_sym_type
       INTEGER                                            :: handle, ikind, natom, nkind
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
       LOGICAL                                            :: my_do_alloc_blocks_from_nbl, &
                                                             my_do_kpoints, my_do_mixed_basis, &
                                                             my_do_ri_aux_basis

--- a/src/mp2_ri_2c.F
+++ b/src/mp2_ri_2c.F
@@ -576,7 +576,7 @@ CONTAINS
                                                             ikp_for_xkp, img, n_real_imag, natom, &
                                                             nimg, nkind, nkp
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: sizes_RI
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_bsize, row_bsize
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: my_do_build_cell_index, my_put_mat_KS_env
       REAL(KIND=dp)                                      :: my_regularization_RI

--- a/src/mscfg_types.F
+++ b/src/mscfg_types.F
@@ -200,9 +200,9 @@ CONTAINS
       INTEGER                                            :: add_blocks_after, dimen, iblock_col, &
                                                             iblock_row, iblock_size, nblocks, &
                                                             nblocks_new, start_index, trailing_size
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER :: blk_distr, blk_sizes, block_sizes_new, &
-         col_distr_new, col_sizes_new, distr_new_array, row_distr_new, row_sizes_new
       INTEGER, DIMENSION(2)                              :: add_blocks_before
+      INTEGER, DIMENSION(:), POINTER :: blk_distr, blk_sizes, block_sizes_new, col_distr_new, &
+         col_sizes_new, distr_new_array, row_distr_new, row_sizes_new
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: data_p, p_new_block
       TYPE(dbcsr_distribution_type)                      :: dist_new, dist_qs
       TYPE(dbcsr_iterator_type)                          :: iter

--- a/src/optbas_opt_utils.F
+++ b/src/optbas_opt_utils.F
@@ -88,7 +88,7 @@ CONTAINS
 
       INTEGER                                            :: handle, ispin, iunit, naux, nmo, norb, &
                                                             nspins
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
       REAL(KIND=dp)                                      :: tmp_energy, trace
       REAL(KIND=dp), DIMENSION(2)                        :: condnum
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env

--- a/src/pao_methods.F
+++ b/src/pao_methods.F
@@ -265,7 +265,7 @@ CONTAINS
 
       INTEGER                                            :: acol, arow, handle, i, iatom, ikind, M, &
                                                             natoms
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_sizes_aux, blk_sizes_pri
+      INTEGER, DIMENSION(:), POINTER                     :: blk_sizes_aux, blk_sizes_pri
       REAL(dp), DIMENSION(:, :), POINTER                 :: block_Y
       TYPE(dbcsr_iterator_type)                          :: iter
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
@@ -372,7 +372,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_build_matrix_X'
 
       INTEGER                                            :: handle, iatom, ikind, natoms
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, row_blk_size
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       CALL timeset(routineN, handle)

--- a/src/pao_optimizer.F
+++ b/src/pao_optimizer.F
@@ -58,7 +58,7 @@ CONTAINS
    SUBROUTINE pao_opt_init_bfgs(pao)
       TYPE(pao_env_type), POINTER                        :: pao
 
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: nparams
+      INTEGER, DIMENSION(:), POINTER                     :: nparams
 
       CALL dbcsr_get_info(pao%matrix_X, row_blk_size=nparams)
 

--- a/src/pao_param_gth.F
+++ b/src/pao_param_gth.F
@@ -61,7 +61,7 @@ CONTAINS
 
       INTEGER                                            :: acol, arow, handle, iatom, idx, ikind, &
                                                             iterm, jatom, maxl, n, natoms
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_sizes_pri, col_blk_size, nterms, &
+      INTEGER, DIMENSION(:), POINTER                     :: blk_sizes_pri, col_blk_size, nterms, &
                                                             row_blk_size
       REAL(dp), DIMENSION(:, :), POINTER                 :: block_V_term, vec_V_terms
       TYPE(dbcsr_iterator_type)                          :: iter
@@ -153,7 +153,7 @@ CONTAINS
    SUBROUTINE pao_param_gth_preconditioner(pao, qs_env, nterms)
       TYPE(pao_env_type), POINTER                        :: pao
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: nterms
+      INTEGER, DIMENSION(:), POINTER                     :: nterms
 
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_param_gth_preconditioner'
 

--- a/src/pao_param_linpot.F
+++ b/src/pao_param_linpot.F
@@ -64,7 +64,7 @@ CONTAINS
 
       INTEGER                                            :: acol, arow, handle, iatom, ikind, N, &
                                                             natoms, nterms
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_sizes_pri, col_blk_size, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_sizes_pri, col_blk_size, row_blk_size
       REAL(dp), DIMENSION(:, :), POINTER                 :: block_V_terms
       REAL(dp), DIMENSION(:, :, :), POINTER              :: V_blocks
       TYPE(dbcsr_iterator_type)                          :: iter
@@ -142,7 +142,7 @@ CONTAINS
 
       INTEGER                                            :: acol, arow, handle, i, iatom, j, k, &
                                                             nterms
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_sizes_nterms
+      INTEGER, DIMENSION(:), POINTER                     :: blk_sizes_nterms
       LOGICAL                                            :: found
       REAL(dp)                                           :: v, w
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: S_evals
@@ -217,7 +217,7 @@ CONTAINS
 
       INTEGER                                            :: acol, arow, handle, i, iatom, j, k, &
                                                             nterms
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_sizes_nterms
+      INTEGER, DIMENSION(:), POINTER                     :: blk_sizes_nterms
       LOGICAL                                            :: found
       REAL(dp)                                           :: eval_capped
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: S_evals

--- a/src/pao_param_methods.F
+++ b/src/pao_param_methods.F
@@ -252,7 +252,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'pao_calc_grad_lnv_wrt_AB'
 
       INTEGER                                            :: handle, nspin
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: pao_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: pao_blk_sizes
       REAL(KIND=dp)                                      :: filter_eps
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s, rho_ao
       TYPE(dbcsr_type) :: matrix_HB, matrix_HPS, matrix_M, matrix_M1, matrix_M1_dc, matrix_M2, &

--- a/src/qs_dftb_matrices.F
+++ b/src/qs_dftb_matrices.F
@@ -874,7 +874,7 @@ CONTAINS
       INTEGER                                            :: i, natom, neighbor_list_id, nkind, nmat, &
                                                             nsgf
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: row_blk_sizes
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -961,7 +961,7 @@ CONTAINS
       INTEGER                                            :: i, img, natom, neighbor_list_id, nkind, &
                                                             nmat, nsgf
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: row_blk_sizes
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set

--- a/src/qs_fb_env_methods.F
+++ b/src/qs_fb_env_methods.F
@@ -140,7 +140,7 @@ CONTAINS
       CHARACTER(len=default_string_length)               :: name
       INTEGER :: filtered_nfullrowsORcols_total, handle, homo_filtered, ispin, lfomo_filtered, &
          my_nmo, nao, ndep, nelectron, nmo, nmo_filtered, nspin, original_nfullrowsORcols_total
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: filtered_rowORcol_block_sizes, &
+      INTEGER, DIMENSION(:), POINTER                     :: filtered_rowORcol_block_sizes, &
                                                             original_rowORcol_block_sizes
       LOGICAL                                            :: collective_com
       REAL(kind=dp) :: diis_error, eps_default, eps_diis, eps_eigval, fermi_level, filter_temp, &

--- a/src/qs_fb_filter_matrix_methods.F
+++ b/src/qs_fb_filter_matrix_methods.F
@@ -117,7 +117,7 @@ CONTAINS
       CHARACTER(LEN=default_string_length)               :: name_string
       INTEGER                                            :: handle, iblkcol, ihalo, ikind, &
                                                             max_nhalos, nblkcols_total, nhalos
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, dummy_halo_atoms, ntfns, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, dummy_halo_atoms, ntfns, &
                                                             row_blk_size
       LOGICAL                                            :: send_data_only
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
@@ -278,7 +278,7 @@ CONTAINS
                                                             natoms_global, natoms_in_halo, &
                                                             nblkcols_total, nblks_recv, nhalos, &
                                                             nmax
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, ntfns, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, ntfns, row_blk_size
       LOGICAL                                            :: check_ok
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
       TYPE(dbcsr_distribution_type)                      :: dbcsr_dist

--- a/src/qs_linres_current.F
+++ b/src/qs_linres_current.F
@@ -189,7 +189,7 @@ CONTAINS
                                                             j, jstate, nao, natom, nmo, nspins, &
                                                             nstates(2), output_unit, unit_nr
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: row_blk_sizes
       LOGICAL                                            :: append_cube, gapw, mpi_io
       REAL(dp)                                           :: dk(3), jrho_tot_G(3, 3), &
                                                             jrho_tot_R(3, 3), maxocc, scale_fac
@@ -2277,7 +2277,7 @@ CONTAINS
       INTEGER :: handle, icenter, idir, idir2, ii, iiB, iii, iiiB, ispin, istate, j, jstate, &
          max_states, nao, natom, nbr_center(2), nmo, nspins, nstate_loc, nstates(2), output_unit
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: row_blk_sizes
       LOGICAL                                            :: chi_pbc, gapw
       REAL(dp)                                           :: chi(3), chi_tmp, contrib, contrib2, &
                                                             dk(3), int_current(3), &
@@ -2702,7 +2702,7 @@ CONTAINS
       INTEGER :: handle, idir, idir2, iiB, iiiB, ispin, jdir, jjdir, kdir, max_states, nao, natom, &
          nbr_center(2), nmo, nspins, nstates(2), output_unit
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: row_blk_sizes
       LOGICAL                                            :: chi_pbc, gapw
       REAL(dp)                                           :: chi(3), contrib, dk(3), int_current(3), &
                                                             maxocc

--- a/src/qs_linres_current_utils.F
+++ b/src/qs_linres_current_utils.F
@@ -137,7 +137,7 @@ CONTAINS
          jcenter, jstate, max_nbr_center, max_states, nao, natom, nbr_center(2), ncubes, nmo, &
          nspins, nstates(2), output_unit
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: list_cubes, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: list_cubes, row_blk_sizes
       INTEGER, DIMENSION(:, :, :), POINTER               :: statetrueindex
       LOGICAL                                            :: append_cube, should_stop
       REAL(dp)                                           :: dk(3), dkl(3), dl(3)
@@ -575,7 +575,7 @@ CONTAINS
          n_rep, nao, natom, nbr_box, ncubes, nmo, nspins, nstate, nstate_list(2), output_unit
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: buff, first_sgf, last_sgf
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: state_list
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: bounds, list, nbox, &
+      INTEGER, DIMENSION(:), POINTER                     :: bounds, list, nbox, &
                                                             selected_states_on_atom_list
       LOGICAL                                            :: force_no_full, gapw, is0, &
                                                             uniform_occupation

--- a/src/qs_linres_issc_utils.F
+++ b/src/qs_linres_issc_utils.F
@@ -783,7 +783,7 @@ CONTAINS
                                                             istat, m, n, n_rep, nao, natom, &
                                                             nspins, output_unit
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: list, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: list, row_blk_sizes
       LOGICAL                                            :: gapw
       TYPE(cp_fm_struct_type), POINTER                   :: tmp_fm_struct
       TYPE(cp_fm_type), POINTER                          :: mo_coeff

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -135,7 +135,7 @@ CONTAINS
                                                             nbr_center(2), nmo, nsgf, nspins, &
                                                             nstates(2), output_unit
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, last_sgf
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: row_blk_sizes
       REAL(dp)                                           :: chk(3), ck(3), ckdk(3), dk(3)
       REAL(dp), DIMENSION(:, :), POINTER                 :: basisfun_center, vecbuf_c0
       TYPE(cell_type), POINTER                           :: cell

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -1510,8 +1510,8 @@ CONTAINS
 
       INTEGER :: handle, i, iatom, ic, icol, ikind, inode, irow, iset, jatom, jkind, jset, ldab, &
          ldsa, ldsb, ldwork, natom, ncoa, ncob, nimg, nkind, nseta, nsetb, sgfa, sgfb
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_sizes
       INTEGER, DIMENSION(3)                              :: icell
+      INTEGER, DIMENSION(:), POINTER                     :: row_blk_sizes
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: found, use_cell_mapping
       REAL(dp), DIMENSION(:, :), POINTER                 :: cblock, cosab, sblock, sinab, work

--- a/src/qs_overlap.F
+++ b/src/qs_overlap.F
@@ -1028,7 +1028,7 @@ CONTAINS
       CHARACTER(LEN=32)                                  :: symmetry_string
       CHARACTER(LEN=default_string_length)               :: mname, name
       INTEGER                                            :: i, maxs, natom
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
       TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -1119,7 +1119,7 @@ CONTAINS
       CHARACTER(LEN=32)                                  :: symmetry_string
       CHARACTER(LEN=default_string_length)               :: mname, name
       INTEGER                                            :: i1, i2, natom
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
       TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set

--- a/src/qs_tddfpt2_fhxc.F
+++ b/src/qs_tddfpt2_fhxc.F
@@ -111,7 +111,7 @@ CONTAINS
       CHARACTER(LEN=default_string_length)               :: basis_type
       INTEGER                                            :: handle, ikind, ispin, ivect, nao, &
                                                             nao_aux, nkind, nspins, nvects
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: blk_sizes
       INTEGER, DIMENSION(maxspins)                       :: nactive
       LOGICAL                                            :: gapw, gapw_xc
       TYPE(admm_type), POINTER                           :: admm_env

--- a/src/qs_tddfpt2_soc.F
+++ b/src/qs_tddfpt2_soc.F
@@ -221,7 +221,7 @@ CONTAINS
                                                             isg, istate, itp, jj, nactive, nao, &
                                                             nex, npcols, nprows, nsg, ntot, ntp
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: evects_sort
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_dist, row_blk_size, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist, row_dist_new
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       LOGICAL                                            :: print_ev, print_some, print_splitting, &

--- a/src/qs_tddfpt2_stda_utils.F
+++ b/src/qs_tddfpt2_stda_utils.F
@@ -170,7 +170,7 @@ CONTAINS
 
       INTEGER                                            :: handle, i, iatom, icol, ikind, imat, &
                                                             irow, jatom, jkind, natom, nmat
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: row_blk_sizes
       LOGICAL                                            :: found
       REAL(KIND=dp)                                      :: dfcut, dgb, dr, eta, fcut, r, rcut, &
                                                             rcuta, rcutb, x

--- a/src/qs_tddfpt2_subgroups.F
+++ b/src/qs_tddfpt2_subgroups.F
@@ -761,7 +761,7 @@ CONTAINS
       CHARACTER                                          :: matrix_type
       CHARACTER(len=default_string_length)               :: matrix_name
       INTEGER                                            :: handle
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_sizes, row_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_sizes, row_blk_sizes
 
       CALL timeset(routineN, handle)
 

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -203,7 +203,7 @@ CONTAINS
 
       INTEGER, DIMENSION(:), INTENT(IN)                  :: gw_corr_lev_occ, gw_corr_lev_virt, homo
       INTEGER, INTENT(IN)                                :: nmo, num_integ_points, unit_nr
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: RI_blk_sizes
+      INTEGER, DIMENSION(:), POINTER                     :: RI_blk_sizes
       LOGICAL, INTENT(IN)                                :: do_ic_model
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:), &

--- a/src/rpa_gw_im_time_util.F
+++ b/src/rpa_gw_im_time_util.F
@@ -135,12 +135,12 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: dist1, dist2, dist3, sizes_AO, &
                                                             sizes_AO_split, sizes_MO, sizes_MO_1, &
                                                             sizes_RI, sizes_RI_split, tmp
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: distp_1, distp_2, sizes_MO_blocked, &
-                                                            sizes_MO_p1, sizes_MO_p2
       INTEGER, DIMENSION(2)                              :: pdims_2d
       INTEGER, DIMENSION(2, 1)                           :: bounds
       INTEGER, DIMENSION(2, 3)                           :: ibounds
       INTEGER, DIMENSION(3)                              :: bounds_3c, pdims
+      INTEGER, DIMENSION(:), POINTER                     :: distp_1, distp_2, sizes_MO_blocked, &
+                                                            sizes_MO_p1, sizes_MO_p2
       LOGICAL                                            :: memory_info, my_do_alpha
       REAL(dp)                                           :: compression_factor, memory_3c, occ
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: norm

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -204,9 +204,9 @@ CONTAINS
                                                             dist_RI, dummy_end, dummy_start, &
                                                             end_blocks, sizes_AO, sizes_RI, &
                                                             start_blocks
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_bsize, row_bsize
       INTEGER, DIMENSION(2)                              :: pdims_t2c
       INTEGER, DIMENSION(3)                              :: nblks_total, pcoord, pdims, pdims_t3c
+      INTEGER, DIMENSION(:), POINTER                     :: col_bsize, row_bsize
       LOGICAL                                            :: do_periodic, use_virial
       REAL(dp)                                           :: compression_factor, eps_pgf_orb, &
                                                             eps_pgf_orb_old, memory, occ

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -1119,7 +1119,7 @@ CONTAINS
       INTEGER(int_8)                                     :: dbcsr_nflop
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: index_to_cell_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cell_to_index_3c
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, prim_blk_sizes, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, prim_blk_sizes, &
                                                             RI_blk_sizes
       LOGICAL :: do_apply_ic_corr_to_gw, do_gw_im_time, do_ic_model, do_kpoints_cubic_RPA, &
          do_periodic, do_print, do_ri_Sigma_x, exit_ev_gw, first_cycle, &

--- a/src/rpa_util.F
+++ b/src/rpa_util.F
@@ -165,7 +165,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:, :), INTENT(OUT) :: index_to_cell_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(OUT)                                     :: cell_to_index_3c
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size
       LOGICAL, INTENT(IN)                                :: do_ic_model, do_kpoints_cubic_RPA, &
                                                             do_kpoints_from_Gamma, do_ri_Sigma_x, &
                                                             my_open_shell
@@ -195,7 +195,7 @@ CONTAINS
       INTEGER                                            :: cell_grid_dm(3), first_ikp_local, &
                                                             handle, i_dim, i_kp, ispin, jquad, &
                                                             nspins_P_omega, periodic(3)
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: row_blk_size
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: wkp_V
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct, fm_struct_sub_kp
@@ -496,7 +496,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'reorder_mat_L'
 
       INTEGER                                            :: handle, ikp, j_size, nblk
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, row_blk_size
       LOGICAL                                            :: do_kpoints, my_allocate_mat_L
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct

--- a/src/xas_methods.F
+++ b/src/xas_methods.F
@@ -607,8 +607,8 @@ CONTAINS
          nsgf_gto, nsgf_sto, nspins, nvirtual, nvirtual2
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: first_sgf, kind_type_tmp, kind_z_tmp, &
                                                             last_sgf
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: bounds, list, lq, nq, row_blk_sizes
       INTEGER, DIMENSION(4, 7)                           :: ne
+      INTEGER, DIMENSION(:), POINTER                     :: bounds, list, lq, nq, row_blk_sizes
       LOGICAL                                            :: ihavethis
       REAL(dp)                                           :: nele, occ_estate, occ_homo, &
                                                             occ_homo_plus, zatom

--- a/src/xas_tdp_atom.F
+++ b/src/xas_tdp_atom.F
@@ -682,7 +682,7 @@ CONTAINS
       INTEGER                                            :: blk, dest, group_handle, handle, iat, &
                                                             ikind, inb, ir, is, jat, jnb, natom, &
                                                             nnb, npcols, nprows, source, tag
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_dist, nsgf, row_dist
+      INTEGER, DIMENSION(:), POINTER                     :: col_dist, nsgf, row_dist
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       LOGICAL                                            :: found_risinv, found_whole
       LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: is_neighbor

--- a/src/xas_tdp_correction.F
+++ b/src/xas_tdp_correction.F
@@ -1069,9 +1069,9 @@ CONTAINS
                                                             nblk_aos, nblk_mos(2), nblk_occ(2), &
                                                             nblk_pqX(3), nblk_ri, nblk_virt(2), &
                                                             nspins
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: ao_blk_size, ao_col_dist, ao_row_dist, &
-                                                            mo_dist_3, ri_blk_size, ri_dist_3
       INTEGER, DIMENSION(3)                              :: pdims
+      INTEGER, DIMENSION(:), POINTER                     :: ao_blk_size, ao_col_dist, ao_row_dist, &
+                                                            mo_dist_3, ri_blk_size, ri_dist_3
       INTEGER, DIMENSION(:, :), POINTER                  :: mat_pgrid
       TYPE(cp_1d_i_p_type), ALLOCATABLE, DIMENSION(:)    :: mo_blk_size, mo_col_dist, mo_row_dist
       TYPE(dbcsr_distribution_type)                      :: mat_dist

--- a/src/xas_tdp_kernel.F
+++ b/src/xas_tdp_kernel.F
@@ -92,7 +92,7 @@ CONTAINS
                                                             iex, lb, natom, nbatch, ndo_mo, &
                                                             ndo_so, nex_atom, nsgfp, ri_atom, &
                                                             source, ub
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size
       LOGICAL                                            :: do_coulomb, do_sc, do_sf, do_sg, do_tp, &
                                                             do_xc, found
       REAL(dp), DIMENSION(:, :), POINTER                 :: PQ
@@ -216,7 +216,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(INOUT)                    :: coul_ker
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: contr1_int
       TYPE(dbcsr_distribution_type), POINTER             :: dist
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size
       TYPE(xas_tdp_env_type), POINTER                    :: xas_tdp_env
       TYPE(xas_tdp_control_type), POINTER                :: xas_tdp_control
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -282,7 +282,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(INOUT)                    :: xc_ker
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: contr1_int_PQ
       TYPE(dbcsr_distribution_type), POINTER             :: dist
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size
       TYPE(donor_state_type), POINTER                    :: donor_state
       TYPE(xas_tdp_env_type), POINTER                    :: xas_tdp_env
       TYPE(xas_tdp_control_type), POINTER                :: xas_tdp_control
@@ -407,7 +407,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(INOUT)                    :: xc_ker
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: contr1_int_PQ
       TYPE(dbcsr_distribution_type), POINTER             :: dist
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size
       TYPE(donor_state_type), POINTER                    :: donor_state
       TYPE(xas_tdp_env_type), POINTER                    :: xas_tdp_env
       TYPE(xas_tdp_control_type), POINTER                :: xas_tdp_control
@@ -495,7 +495,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(INOUT)                    :: sg_xc_ker, tp_xc_ker
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: contr1_int_PQ
       TYPE(dbcsr_distribution_type), POINTER             :: dist
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size
       TYPE(donor_state_type), POINTER                    :: donor_state
       TYPE(xas_tdp_env_type), POINTER                    :: xas_tdp_env
       TYPE(xas_tdp_control_type), POINTER                :: xas_tdp_control
@@ -602,7 +602,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'kernel_exchange'
 
       INTEGER                                            :: handle
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size
       LOGICAL                                            :: do_off_sc
       TYPE(dbcsr_distribution_type), POINTER             :: dist
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: contr1_int
@@ -662,7 +662,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(INOUT)                    :: ondiag_ex_ker
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: contr1_int
       TYPE(dbcsr_distribution_type), POINTER             :: dist
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size
       TYPE(donor_state_type), POINTER                    :: donor_state
       TYPE(xas_tdp_env_type), POINTER                    :: xas_tdp_env
       TYPE(xas_tdp_control_type), POINTER                :: xas_tdp_control
@@ -823,7 +823,7 @@ CONTAINS
       TYPE(dbcsr_type), INTENT(INOUT)                    :: offdiag_ex_ker
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: contr1_int
       TYPE(dbcsr_distribution_type), POINTER             :: dist
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size
       TYPE(donor_state_type), POINTER                    :: donor_state
       TYPE(xas_tdp_env_type), POINTER                    :: xas_tdp_env
       TYPE(xas_tdp_control_type), POINTER                :: xas_tdp_control
@@ -985,7 +985,7 @@ CONTAINS
 
       INTEGER                                            :: handle, i, imo, ispin, katom, kkind, &
                                                             natom, ndo_mo, ndo_so, nkind, nspins
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: ri_blk_size, std_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: ri_blk_size, std_blk_size
       LOGICAL                                            :: do_uks
       REAL(dp), DIMENSION(:, :), POINTER                 :: coeffs
       TYPE(dbcsr_distribution_type)                      :: opt_dbcsr_dist

--- a/src/xas_tdp_utils.F
+++ b/src/xas_tdp_utils.F
@@ -174,7 +174,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'setup_xas_tdp_prob'
 
       INTEGER                                            :: handle
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: submat_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: submat_blk_size
       LOGICAL                                            :: do_coul, do_hfx, do_os, do_sc, do_sf, &
                                                             do_sg, do_tda, do_tp, do_xc
       REAL(dp)                                           :: eps_filter, sx
@@ -1090,7 +1090,7 @@ CONTAINS
 
       INTEGER                                            :: handle, iblk, imo, ispin, jblk, &
                                                             nblk_row, ndo_mo, nspins
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size_q, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size_q, row_blk_size
       LOGICAL                                            :: found_block, my_dosf
       REAL(dp), DIMENSION(:, :), POINTER                 :: work_block
       TYPE(dbcsr_distribution_type), POINTER             :: dist_q
@@ -1178,7 +1178,7 @@ CONTAINS
 
       INTEGER                                            :: handle, iblk, imo, ispin, jblk, &
                                                             nblk_row, ndo_mo, nspins
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size_a, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size_a, row_blk_size
       LOGICAL                                            :: found_block, my_dosf
       REAL(dp), DIMENSION(:, :), POINTER                 :: work_block
       TYPE(dbcsr_distribution_type), POINTER             :: dbcsr_dist, dist_a
@@ -1309,7 +1309,7 @@ CONTAINS
 
       INTEGER                                            :: handle, i, iblk, jblk, nao, nblk_row, &
                                                             ndo_mo, nspins
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: blk_size_g, row_blk_size
+      INTEGER, DIMENSION(:), POINTER                     :: blk_size_g, row_blk_size
       LOGICAL                                            :: found_block, my_do_inv
       REAL(dp), DIMENSION(:, :), POINTER                 :: work_block
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
@@ -1510,7 +1510,7 @@ CONTAINS
       INTEGER                                            :: group, handle, homo, iex, isc, isf, nao, &
                                                             ndo_mo, ndo_so, nex, npcols, nprows, &
                                                             nsc, nsf, ntot, tas(2), tbs(2)
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_dist, row_blk_size, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist, row_dist_new
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       LOGICAL                                            :: do_roks, do_uks
@@ -1947,7 +1947,7 @@ CONTAINS
       INTEGER                                            :: group, handle, iex, isg, itp, nao, &
                                                             ndo_mo, nex, npcols, nprows, nsg, &
                                                             ntot, ntp
-      INTEGER, CONTIGUOUS, DIMENSION(:), POINTER         :: col_blk_size, col_dist, row_blk_size, &
+      INTEGER, DIMENSION(:), POINTER                     :: col_blk_size, col_dist, row_blk_size, &
                                                             row_dist, row_dist_new
       INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
       REAL(dp)                                           :: eps_filter, soc_gst, sqrt2


### PR DESCRIPTION
Reverts cp2k/cp2k#3990

I realized that introducing CONTIGUOUS pointers opens a can of worm because we'd have to keep track of them throughout the code base (and gfortan isn't really helping either).