### PR TITLE
CMake: introduced default CP2K_SCALAPACK_VENDOR=auto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,9 +180,9 @@ set(CP2K_BLAS_VENDOR
     "auto"
     CACHE STRING "Blas library for computations on host")
 
-set(CP2K_SCALAPACK_VENDOR_LIST "MKL" "SCI" "GENERIC")
+set(CP2K_SCALAPACK_VENDOR_LIST "MKL" "SCI" "GENERIC" "auto")
 set(CP2K_SCALAPACK_VENDOR
-    "GENERIC"
+    "auto"
     CACHE STRING "scalapack vendor/generic backend")
 set_property(CACHE CP2K_SCALAPACK_VENDOR PROPERTY STRINGS
                                                   ${CP2K_SCALAPACK_VENDOR_LIST})

--- a/cmake/modules/FindBlas.cmake
+++ b/cmake/modules/FindBlas.cmake
@@ -125,6 +125,9 @@ else()
   set(CP2K_BLAS_FOUND ON)
 endif()
 
+# cleanup list (regularly contains empty items)
+list(FILTER CP2K_BLAS_LINK_LIBRARIES EXCLUDE REGEX "^$")
+
 # we exclude the CP2K_BLAS_INCLUDE_DIRS from the list of mandatory variables as
 # having the fortran interface is usually enough. C, C++ and others languages
 # might require this information though

--- a/cmake/modules/FindSCALAPACK.cmake
+++ b/cmake/modules/FindSCALAPACK.cmake
@@ -17,7 +17,20 @@ cp2k_set_default_paths(SCALAPACK "SCALAPACK")
 # check if we have mkl as blas library or not and pick the scalapack from mkl
 # distro if found
 if(NOT CP2K_CONFIG_PACKAGE)
-  if(CP2K_SCALAPACK_VENDOR STREQUAL "GENERIC")
+  if(CP2K_SCALAPACK_VENDOR MATCHES "MKL|auto"
+     AND TARGET cp2k::BLAS::MKL::scalapack_link)
+    # we have mkl check for the different mkl target
+    get_target_property(
+      CP2K_SCALAPACK_LINK_LIBRARIES cp2k::BLAS::MKL::scalapack_link
+      INTERFACE_LINK_LIBRARIES)
+    set(CP2K_SCALAPACK_FOUND yes)
+  elseif(CP2K_SCALAPACK_VENDOR MATCHES "SCI|auto"
+         AND TARGET cp2k::BLAS::SCI::scalapack_link)
+    get_target_property(
+      CP2K_SCALAPACK_LINK_LIBRARIES cp2k::BLAS::SCI::scalapack_link
+      INTERFACE_LINK_LIBRARIES)
+    set(CP2K_SCALAPACK_FOUND yes)
+  else() # if(CP2K_SCALAPACK_VENDOR MATCHES "GENERIC|auto")
     if(TARGET cp2k::BLAS::MKL::scalapack_link)
       message(
         WARNING
@@ -26,17 +39,15 @@ if(NOT CP2K_CONFIG_PACKAGE)
           "-----------------------------------------------------------------"
           "\n"
           "You may want to use mkl implementation of scalapack. To do this\n"
-          "add -DCP2K_SCALAPACK_VENDOR=MKL to the cmake command line.      \n")
-    endif()
-
-    if(TARGET cp2k::BLAS::SCI::scalapack_link)
+          "add -DCP2K_SCALAPACK_VENDOR=MKL to the cmake command line.\n")
+    elseif(TARGET cp2k::BLAS::SCI::scalapack_link)
       message(
         WARNING
-          "-----------------------------------------------------------------\n"
-          "-                  FindScalapack warning                        -\n"
-          "-----------------------------------------------------------------\n"
+          "-----------------------------------------------------------------"
+          "-                  FindScalapack warning                        -"
+          "-----------------------------------------------------------------"
           "\n"
-          "You may want to use Cray implementation of scalapack. To do this \n"
+          "You may want to use Cray implementation of scalapack. To do this\n"
           "add -DCP2K_SCALAPACK_VENDOR=SCI to the cmake command line\n\n")
     endif()
 
@@ -62,20 +73,12 @@ if(NOT CP2K_CONFIG_PACKAGE)
     if(NOT CP2K_SCALAPACK_FOUND)
       cp2k_find_libraries(SCALAPACK "scalapack")
     endif()
-
-  elseif(TARGET cp2k::BLAS::MKL::scalapack_link)
-    # we have mkl check for the different mkl target
-    get_target_property(
-      CP2K_SCALAPACK_LINK_LIBRARIES cp2k::BLAS::MKL::scalapack_link
-      INTERFACE_LINK_LIBRARIES)
-    set(CP2K_SCALAPACK_FOUND yes)
-  elseif(TARGET cp2k::BLAS::SCI::scalapack_link)
-    # we have mkl check for the different mkl target
-    get_target_property(
-      CP2K_SCALAPACK_LINK_LIBRARIES cp2k::BLAS::SCI::scalapack_link
-      INTERFACE_LINK_LIBRARIES)
   endif()
 endif()
+
+# cleanup list (regularly contains empty items)
+list(FILTER CP2K_SCALAPACK_LINK_LIBRARIES EXCLUDE REGEX "^$")
+
 # check if found
 find_package_handle_standard_args(SCALAPACK
                                   REQUIRED_VARS CP2K_SCALAPACK_LINK_LIBRARIES)


### PR DESCRIPTION
- Let ScaLAPACK correspond to CP2K_BLAS_VENDOR (auto).
- set(CP2K_SCALAPACK_FOUND yes) for libsci (HPE).

Other
- Link-list regularly contains empty items (BLAS/SCALAPACK).
- Format/cleanup.