### PR TITLE
Fix typos in usage strings

### DIFF
--- a/src/input_cp2k_almo.F
+++ b/src/input_cp2k_almo.F
@@ -688,7 +688,7 @@ CONTAINS
                              description="Maximum number of iterations in the outer loop. "// &
                              "Use the outer loop to update the preconditioner and reset the conjugator. "// &
                              "This can speed up convergence significantly.", &
-                             usage="MAX_ITER 10", default_i_val=0)
+                             usage="MAX_ITER_OUTER_LOOP 10", default_i_val=0)
          CALL section_add_keyword(section, keyword)
          CALL keyword_release(keyword)
 

--- a/src/input_cp2k_as.F
+++ b/src/input_cp2k_as.F
@@ -283,7 +283,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="BLIST", &
                           description="List of beta orbitals to be printed. -1 defaults to all values", &
-                          usage="ALIST {1 2 3 ...}", n_var=-1, default_i_vals=(/-1/), &
+                          usage="BLIST {1 2 3 ...}", n_var=-1, default_i_vals=(/-1/), &
                           lone_keyword_i_val=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_atom.F
+++ b/src/input_cp2k_atom.F
@@ -338,20 +338,20 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="NUM_GTO_CORE", &
                           description="Number of Gaussian type functions for s, p, d, ... "// &
                           "for the main body of the basis", &
-                          usage="NUM_GTO 6 ", n_var=1, type_of_var=integer_t, &
+                          usage="NUM_GTO_CORE 6 ", n_var=1, type_of_var=integer_t, &
                           default_i_val=-1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="NUM_GTO_EXTENDED", &
                           description="Number of Gaussian type functions for s, p, d, ... "// &
                           "for the extension set", &
-                          usage="NUM_GTO 4 ", n_var=1, type_of_var=integer_t, &
+                          usage="NUM_GTO_EXTENDED 4 ", n_var=1, type_of_var=integer_t, &
                           default_i_val=-1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="NUM_GTO_POLARIZATION", &
                           description="Number of Gaussian type functions for the polarization set", &
-                          usage="NUM_GTO 4 ", n_var=1, type_of_var=integer_t, &
+                          usage="NUM_GTO_POLARIZATION 4 ", n_var=1, type_of_var=integer_t, &
                           default_i_val=-1)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_colvar.F
+++ b/src/input_cp2k_colvar.F
@@ -460,7 +460,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="LAMBDA", &
                           description="Specify the lambda parameter at the exponent of the conditioned distance function.", &
-                          usage="R0 {real}", default_r_val=3.0_dp, &
+                          usage="LAMBDA {real}", default_r_val=3.0_dp, &
                           unit_str="bohr", n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -856,7 +856,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="COMPONENT", &
                           description="Define the component of the position vector which will be used "// &
                           "as a colvar.", &
-                          usage="AXIS (XYZ | X | Y | Z | XY| XZ | YZ)", &
+                          usage="COMPONENT (XYZ | X | Y | Z | XY| XZ | YZ)", &
                           enum_c_vals=s2a("XYZ", "X", "Y", "Z", "XY", "XZ", "YZ"), &
                           enum_i_vals=(/do_clv_xyz, do_clv_x, do_clv_y, do_clv_z, do_clv_xy, do_clv_xz, do_clv_yz/), &
                           default_i_val=do_clv_xyz)
@@ -915,7 +915,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="COMPONENT_A", &
                           description="Define the component of the position vector which will be used "// &
                           "as a colvar for atom A.", &
-                          usage="AXIS (XYZ | X | Y | Z | XY| XZ | YZ)", &
+                          usage="COMPONENT_A (XYZ | X | Y | Z | XY| XZ | YZ)", &
                           enum_c_vals=s2a("XYZ", "X", "Y", "Z", "XY", "XZ", "YZ"), &
                           enum_i_vals=(/do_clv_xyz, do_clv_x, do_clv_y, do_clv_z, do_clv_xy, do_clv_xz, do_clv_yz/), &
                           default_i_val=do_clv_xyz)
@@ -925,7 +925,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="COMPONENT_B", &
                           description="Define the component of the position vector which will be used "// &
                           "as a colvar for atom B.", &
-                          usage="AXIS (XYZ | X | Y | Z | XY| XZ | YZ)", &
+                          usage="COMPONENT_B (XYZ | X | Y | Z | XY| XZ | YZ)", &
                           enum_c_vals=s2a("XYZ", "X", "Y", "Z", "XY", "XZ", "YZ"), &
                           enum_i_vals=(/do_clv_xyz, do_clv_x, do_clv_y, do_clv_z, do_clv_xy, do_clv_xz, do_clv_yz/), &
                           default_i_val=do_clv_xyz)
@@ -1527,7 +1527,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="OXYGENS_WATER", &
                           description="Specifies indexes of atoms building the coordination variable."// &
                           " Oxygens of the water molecules. ", &
-                          usage="OXYGENS {integer} {integer} ..", repeats=.TRUE., &
+                          usage="OXYGENS_WATER {integer} {integer} ..", repeats=.TRUE., &
                           n_var=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1535,7 +1535,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="OXYGENS_ACID", &
                           description="Specifies indexes of atoms building the coordination variable."// &
                           " Oxygens of the carboxyl groups.", &
-                          usage="OXYGENS {integer} {integer} ..", repeats=.TRUE., &
+                          usage="OXYGENS_ACID {integer} {integer} ..", repeats=.TRUE., &
                           n_var=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1654,7 +1654,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="OXYGENS_WATER", &
                           description="Specifies indexes of atoms building the coordination variable."// &
                           " Oxygens of the water molecules. ", &
-                          usage="OXYGENS {integer} {integer} ..", repeats=.TRUE., &
+                          usage="OXYGENS_WATER {integer} {integer} ..", repeats=.TRUE., &
                           n_var=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1662,7 +1662,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="OXYGENS_ACID", &
                           description="Specifies indexes of atoms building the coordination variable."// &
                           " Oxygens of the carboxyl groups.", &
-                          usage="OXYGENS {integer} {integer} ..", repeats=.TRUE., &
+                          usage="OXYGENS_ACID {integer} {integer} ..", repeats=.TRUE., &
                           n_var=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1835,7 +1835,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="ALIGN_FRAMES", &
                           description="Whether the reference frames should be aligned to minimize the RMSD", &
-                          usage="ALIGN_FRAME", &
+                          usage="ALIGN_FRAMES", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1958,7 +1958,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="ALIGN_FRAMES", &
                           description="Whether the reference frames should be aligned to minimize the RMSD", &
-                          usage="ALIGN_FRAME", &
+                          usage="ALIGN_FRAMES", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -2047,7 +2047,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="GRID_SPACING", &
                           description="Distance between two gridpoints for the grid on the COLVAR", &
-                          usage="STEP_SIZE {real}", repeats=.TRUE., &
+                          usage="GRID_SPACING {real}", repeats=.TRUE., &
                           type_of_var=real_t, default_r_val=0.01_dp)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
@@ -2099,7 +2099,7 @@ CONTAINS
                           description="Specifies the name of the variable that parametrises the FUNCTION "// &
                           "defining how COLVARS should be combined. The matching follows the same order of the "// &
                           "COLVARS definition in the input file.", &
-                          usage="VARIABLE CV1 CV2 CV3", type_of_var=char_t, n_var=-1, repeats=.FALSE.)
+                          usage="VARIABLES CV1 CV2 CV3", type_of_var=char_t, n_var=-1, repeats=.FALSE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_constraints.F
+++ b/src/input_cp2k_constraints.F
@@ -518,7 +518,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="ATOM_TYPE", &
                           description="Defines the atoms' type forming a bond with an hydrogen. If not specified"// &
                           " the default bond value of the first molecule is used as constraint target", &
-                          usage="ATOMS <CHARACTER>", &
+                          usage="ATOM_TYPE <CHARACTER>", &
                           n_var=-1, type_of_var=char_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -567,7 +567,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="WEIGHT_TYPE", &
                           description="Defines the weight used to define the center of the sphere"// &
                           " (if ATOM_LIST is provided)", &
-                          usage="WEIGHT (UNIT|MASS)", &
+                          usage="WEIGHT_TYPE (UNIT|MASS)", &
                           enum_c_vals=(/"UNIT", "MASS"/), &
                           enum_i_vals=(/weight_type_unit, weight_type_mass/), &
                           default_i_val=weight_type_unit)

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -214,7 +214,7 @@ CONTAINS
                                         "Method based on Mulliken gross orbital populations (GOP)"), &
                           n_var=1, &
                           default_i_val=plus_u_mulliken, &
-                          usage="METHOD Lowdin")
+                          usage="PLUS_U_METHOD Lowdin")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -710,7 +710,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="BLOCK_LIST", &
                           description="Specifies a list of atoms.", &
-                          usage="LIST {integer} {integer} .. {integer}", &
+                          usage="BLOCK_LIST {integer} {integer} .. {integer}", &
                           n_var=-1, type_of_var=integer_t, repeats=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -784,7 +784,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="CONDITION_NUMBER", &
                           description="Prints information regarding the condition numbers of the A matrix (to be inverted)", &
-                          usage="ANALYTICAL_GTERM <LOGICAL>", &
+                          usage="CONDITION_NUMBER <LOGICAL>", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_ec.F
+++ b/src/input_cp2k_ec.F
@@ -316,7 +316,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="S_INVERSION", &
                           description="Method used to compute the inverse of S.", &
-                          usage="S_PRECONDITIONER MOLECULAR", &
+                          usage="S_INVERSION MOLECULAR", &
                           default_i_val=ls_s_inversion_sign_sqrt, &
                           enum_c_vals=s2a("SIGN_SQRT", "HOTELLING"), &
                           enum_desc=s2a("Using the inverse sqrt as obtained from sign function iterations.", &
@@ -525,7 +525,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="S_INVERSION", &
                           description="Method used to compute the inverse of S.", &
-                          usage="S_PRECONDITIONER MOLECULAR", &
+                          usage="S_INVERSION MOLECULAR", &
                           default_i_val=ls_s_inversion_sign_sqrt, &
                           enum_c_vals=s2a("SIGN_SQRT", "HOTELLING"), &
                           enum_desc=s2a("Using the inverse sqrt as obtained from sign function iterations.", &

--- a/src/input_cp2k_external.F
+++ b/src/input_cp2k_external.F
@@ -197,7 +197,7 @@ CONTAINS
                           "one grid. The number of points in each direction, and the spacing must "// &
                           "be previously defined choosing the plane waves cut-off in section MGRID "// &
                           "keyword CUTOFF, and the cube dimension in section SUBSYS / CELL / keyword ABC", &
-                          usage="DENSITY_FILE_NAME <FILENAME>", &
+                          usage="FILE_DENSITY <FILENAME>", &
                           type_of_var=char_t, default_c_val="RHO_O.dat", n_var=-1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -208,7 +208,7 @@ CONTAINS
                           "the values depending, restarting from the previous calculation with the smaller "// &
                           "value. To choose the progressive values of LAMBDA look at the convergence of the "// &
                           "eigenvalues.", &
-                          usage="DX <REAL>", default_r_val=10.0_dp)
+                          usage="LAMBDA <REAL>", default_r_val=10.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_field.F
+++ b/src/input_cp2k_field.F
@@ -73,7 +73,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="POLARISATION", &
                           description="Polarisation vector of electric field", &
-                          usage="POLARISIATION  0.0 0.0 1.0", &
+                          usage="POLARISATION  0.0 0.0 1.0", &
                           repeats=.FALSE., n_var=3, &
                           type_of_var=real_t, default_r_vals=(/0.0_dp, 0.0_dp, 1.0_dp/))
       CALL section_add_keyword(section, keyword)

--- a/src/input_cp2k_field.F
+++ b/src/input_cp2k_field.F
@@ -293,14 +293,14 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="START_STEP_OUT", &
                           description="Step when the field starts to vanish ", &
-                          usage="START_STEP 0", &
+                          usage="START_STEP_OUT 0", &
                           default_i_val=0)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="END_STEP_OUT", &
                           description="Step when the field disappears", &
-                          usage="END_TIME 2", &
+                          usage="END_STEP_OUT 2", &
                           default_i_val=-1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -332,7 +332,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="TIMESTEP", &
                           description="The time step between the entries in the list with the electric field.", &
-                          usage="TIME_STEP 1", &
+                          usage="TIMESTEP 1", &
                           unit_str="fs", &
                           default_r_val=1.0_dp)
       CALL section_add_keyword(section, keyword)

--- a/src/input_cp2k_free_energy.F
+++ b/src/input_cp2k_free_energy.F
@@ -687,7 +687,7 @@ CONTAINS
       CALL keyword_create( &
          keyword, __LOCATION__, name="TYPE", &
          description="Specify the type of wall", &
-         usage=" TYPE (REFLECTIVE|QUADRATIC|QUARTIC|GAUSSIAN|NONE)", &
+         usage="TYPE (REFLECTIVE|QUADRATIC|QUARTIC|GAUSSIAN|NONE)", &
          enum_c_vals=s2a("REFLECTIVE", "QUADRATIC", "QUARTIC", "GAUSSIAN", "NONE"), &
          enum_desc=s2a("Reflective wall. Colvar velocity is inverted when the colvar is beyond the wall position.", &
                        "Applies a quadratic potential at the wall position.", &
@@ -713,7 +713,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="DIRECTION", &
                           description="Specify the direction of the wall.", &
-                          usage=" TYPE (WALL_PLUS|WALL_MINUS)", &
+                          usage="DIRECTION (WALL_PLUS|WALL_MINUS)", &
                           enum_c_vals=s2a("WALL_PLUS", "WALL_MINUS"), &
                           enum_desc=s2a("Wall extends from the position towards larger values of COLVAR", &
                                         "Wall extends from the position towards smaller values of COLVAR"), &
@@ -730,7 +730,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="DIRECTION", &
                           description="Specify the direction of the wall.", &
-                          usage=" TYPE (WALL_PLUS|WALL_MINUS)", &
+                          usage="DIRECTION (WALL_PLUS|WALL_MINUS)", &
                           enum_c_vals=s2a("WALL_PLUS", "WALL_MINUS"), &
                           enum_desc=s2a("Wall extends from the position towards larger values of COLVAR", &
                                         "Wall extends from the position towards smaller values of COLVAR"), &
@@ -755,7 +755,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="DIRECTION", &
                           description="Specify the direction of the wall.", &
-                          usage=" TYPE (WALL_PLUS|WALL_MINUS)", &
+                          usage="DIRECTION (WALL_PLUS|WALL_MINUS)", &
                           enum_c_vals=s2a("WALL_PLUS", "WALL_MINUS"), &
                           enum_desc=s2a("Wall extends from the position towards larger values of COLVAR", &
                                         "Wall extends from the position towards smaller values of COLVAR"), &
@@ -780,7 +780,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="WW", &
                           description="Specify the height of the gaussian: WW*e^(-((CV-POS)/sigma)^2)", &
-                          usage="K <REAL>", unit_str='hartree', &
+                          usage="WW <REAL>", unit_str='hartree', &
                           type_of_var=real_t)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_global.F
+++ b/src/input_cp2k_global.F
@@ -199,7 +199,7 @@ CONTAINS
                           "when the number of MPI processes is varied. If the print key PRINT_ELPA is "// &
                           "active the validity of the eigenvalues is checked against values calculated without "// &
                           "ELPA QR.", &
-                          usage="ELPA_QR", &
+                          usage="ELPA_QR_UNSAFE", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_hfx.F
+++ b/src/input_cp2k_hfx.F
@@ -601,7 +601,7 @@ CONTAINS
                           "Default is POTENTIAL_TYPE from INTERACTION_POTENTIAL. "// &
                           "The standard "// &
                           "Coulomb operator cannot be used in periodic systems.", &
-                          usage="OPERATOR {string}", &
+                          usage="RI_METRIC {string}", &
                           repeats=.FALSE., &
                           variants=(/"KP_RI_METRIC"/), &
                           default_i_val=0, &

--- a/src/input_cp2k_loc.F
+++ b/src/input_cp2k_loc.F
@@ -251,7 +251,7 @@ CONTAINS
                           "This keyword has to be present if unoccupied states should be localized. "// &
                           "This keyword can be repeated several times "// &
                           "(useful if you have to specify many indexes).", &
-                          usage="LIST 1 2", &
+                          usage="LIST_UNOCCUPIED 1 2", &
                           n_var=-1, type_of_var=integer_t, repeats=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -280,7 +280,7 @@ CONTAINS
          description="Select the orbitals to be localized within the given energy range."// &
          " This type of selection cannot be added on top of the selection through a LIST. It reads to reals that are"// &
          " lower and higher boundaries of the energy range.", &
-         usage=" ENERGY_RANGE lower_bound {real}, higher_bound {real}", &
+         usage="ENERGY_RANGE lower_bound {real}, higher_bound {real}", &
          repeats=.FALSE., &
          n_var=2, default_r_vals=(/0._dp, 0._dp/), unit_str='eV', &
          type_of_var=real_t)
@@ -315,7 +315,7 @@ CONTAINS
                                        print_level=debug_print_level + 1, filename="__STD_OUT__")
       CALL keyword_create(keyword, __LOCATION__, name="ORDER", &
                           description="Maximum order of mulitpoles to be calculated.", &
-                          usage=" ORDER {integer}", default_i_val=2, type_of_var=integer_t)
+                          usage="ORDER {integer}", default_i_val=2, type_of_var=integer_t)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       !

--- a/src/input_cp2k_ls.F
+++ b/src/input_cp2k_ls.F
@@ -275,7 +275,7 @@ CONTAINS
          keyword, __LOCATION__, name="RESTART_WRITE", &
          description="Write the density matrix at the end of the SCF (currently requires EXTRAPOLATION_ORDER>0). "// &
          "Files might be rather large.", &
-         usage="RESTART_READ", default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+         usage="RESTART_WRITE", default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -287,7 +287,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="S_INVERSION", &
                           description="Method used to compute the inverse of S.", &
-                          usage="S_PRECONDITIONER MOLECULAR", &
+                          usage="S_INVERSION MOLECULAR", &
                           default_i_val=ls_s_inversion_sign_sqrt, &
                           enum_c_vals=s2a("SIGN_SQRT", "HOTELLING"), &
                           enum_desc=s2a("Using the inverse sqrt as obtained from sign function iterations.", &
@@ -432,7 +432,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="LINE_SEARCH", &
                           description="Line serch type used in the curvy_setp optimization.", &
-                          usage="LINE Search 3POINT", default_i_val=ls_scf_line_search_3point, &
+                          usage="LINE_SEARCH 3POINT", default_i_val=ls_scf_line_search_3point, &
                           enum_c_vals=s2a("3POINT", "3POINT_2D"), &
                           enum_desc=s2a("Performs a three point line search", &
                                         "Only for spin unrestricted calcualtions. Separate step sizes for alpha and beta spin"// &
@@ -473,7 +473,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="MIN_FILTER", &
                           description="Lowest EPS_FILTER in dynamic filtering. Given as multiple of EPS_FILTER:"// &
                           " EPS_FILTER_MIN=EPS_FILTER*MIN_FILTER", &
-                          usage="FILTER_FACTOR 1.0", default_r_val=1.0_dp)
+                          usage="MIN_FILTER 1.0", default_r_val=1.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_mixed.F
+++ b/src/input_cp2k_mixed.F
@@ -222,7 +222,7 @@ CONTAINS
                           "nonorthogonal diabatic CDFT Hamiltonian. The energies and expansion coefficients "// &
                           "of the CDFT-CI states are outputted. Keyword COUPLING must be active "// &
                           "to use this feature.", &
-                          usage="LOWDIN", type_of_var=logical_t, &
+                          usage="CI", type_of_var=logical_t, &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_mm.F
+++ b/src/input_cp2k_mm.F
@@ -292,7 +292,7 @@ CONTAINS
                           description="Do not abort when critical force-field parameters "// &
                           "are missing. CP2K will run as if the terms containing the "// &
                           "missing parameters are zero.", &
-                          usage="IGNORE_MISSING_BOND_PARAMS T", default_l_val=.FALSE., &
+                          usage="IGNORE_MISSING_CRITICAL_PARAMS .TRUE.", default_l_val=.FALSE., &
                           lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1515,7 +1515,7 @@ CONTAINS
                           description="Units of coordinates in the NEQUIP model.pth file. "// &
                           "The units of positions, energies and forces must be self-consistent: "// &
                           "e.g. coordinates in Angstrom, energies in eV, forces in eV/Angstrom. ", &
-                          usage="UNIT angstrom", default_c_val="angstrom")
+                          usage="UNIT_COORDS angstrom", default_c_val="angstrom")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1523,7 +1523,7 @@ CONTAINS
                           description="Units of energy in the NEQUIP model.pth file. "// &
                           "The units of positions, energies and forces must be self-consistent: "// &
                           "e.g. coordinates in Angstrom, energies in eV, forces in eV/Angstrom. ", &
-                          usage="UNIT hartree", default_c_val="eV")
+                          usage="UNIT_ENERGY hartree", default_c_val="eV")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1531,7 +1531,7 @@ CONTAINS
                           description="Units of the forces in the NEQUIP model.pth file. "// &
                           "The units of positions, energies and forces must be self-consistent: "// &
                           "e.g. coordinates in Angstrom, energies in eV, forces in eV/Angstrom. ", &
-                          usage="UNIT hartree/bohr", default_c_val="eV/Angstrom")
+                          usage="UNIT_FORCES hartree/bohr", default_c_val="eV/Angstrom")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1539,7 +1539,7 @@ CONTAINS
                           description="Units of the cell vectors in the NEQUIP model.pth file. "// &
                           "The units of positions, energies and forces must be self-consistent: "// &
                           "e.g. coordinates in Angstrom, energies in eV, forces in eV/Angstrom. ", &
-                          usage="UNIT angstrom", default_c_val="angstrom")
+                          usage="UNIT_CELL angstrom", default_c_val="angstrom")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1587,7 +1587,7 @@ CONTAINS
                           description="Units of coordinates in the ALLEGRO model.pth file. "// &
                           "The units of positions, energies and forces must be self-consistent: "// &
                           "e.g. coordinates in Angstrom, energies in eV, forces in eV/Angstrom. ", &
-                          usage="UNIT angstrom", default_c_val="angstrom")
+                          usage="UNIT_COORDS angstrom", default_c_val="angstrom")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1595,7 +1595,7 @@ CONTAINS
                           description="Units of energy in the ALLEGRO model.pth file. "// &
                           "The units of positions, energies and forces must be self-consistent: "// &
                           "e.g. coordinates in Angstrom, energies in eV, forces in eV/Angstrom. ", &
-                          usage="UNIT hartree", default_c_val="eV")
+                          usage="UNIT_ENERGY hartree", default_c_val="eV")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1603,7 +1603,7 @@ CONTAINS
                           description="Units of the forces in the ALLEGRO model.pth file. "// &
                           "The units of positions, energies and forces must be self-consistent: "// &
                           "e.g. coordinates in Angstrom, energies in eV, forces in eV/Angstrom. ", &
-                          usage="UNIT hartree/bohr", default_c_val="eV/Angstrom")
+                          usage="UNIT_FORCES hartree/bohr", default_c_val="eV/Angstrom")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1611,7 +1611,7 @@ CONTAINS
                           description="Units of the cell vectors in the ALLEGRO model.pth file. "// &
                           "The units of positions, energies and forces must be self-consistent: "// &
                           "e.g. coordinates in Angstrom, energies in eV, forces in eV/Angstrom. ", &
-                          usage="UNIT angstrom", default_c_val="angstrom")
+                          usage="UNIT_CELL angstrom", default_c_val="angstrom")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1955,7 +1955,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="MAP_ATOMS", &
                           description="Defines the kinds for which internally is defined the BMHFT nonbond potential"// &
                           " at the moment only Na and Cl.", &
-                          usage="ATOMS {KIND1} {KIND2}", type_of_var=char_t, &
+                          usage="MAP_ATOMS {KIND1} {KIND2}", type_of_var=char_t, &
                           n_var=2)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -2043,7 +2043,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="MAP_ATOMS", &
                           description="Defines the kinds for which internally is defined the BMHFTD nonbond potential"// &
                           " at the moment no species included.", &
-                          usage="ATOMS {KIND1} {KIND2}", type_of_var=char_t, &
+                          usage="MAP_ATOMS {KIND1} {KIND2}", type_of_var=char_t, &
                           n_var=2)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -2192,7 +2192,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="POLY2", &
                           description="Coefficients of the polynomial used in the third range "// &
                           "This keyword can be repeated several times.", &
-                          usage="POLY1 C1 C2 C3 ..", &
+                          usage="POLY2 C1 C2 C3 ..", &
                           n_var=-1, unit_str="K_e", type_of_var=real_t, repeats=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -2542,7 +2542,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="F", &
                           description="Defines the F parameter of Siepmann potential", &
-                          usage="B {real}", type_of_var=real_t, &
+                          usage="F {real}", type_of_var=real_t, &
                           default_r_val=13.3_dp, n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -2598,7 +2598,7 @@ CONTAINS
                           " the formation of such ions. The T3 term (dipole term)"// &
                           " is then switched off for evaluating the interaction"// &
                           " between the O^2- ion and the metal.", &
-                          usage="ALLOW_O2-_FORMATION TRUE", &
+                          usage="ALLOW_O_FORMATION .TRUE.", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_motion_print.F
+++ b/src/input_cp2k_motion_print.F
@@ -331,7 +331,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="PRINT_ATOM_KIND", &
                           description="Write the atom kind given in the subsys section instead of the element symbol. "// &
                           "Only valid for the XMOL format.", &
-                          usage="PRINT_ELEMENT_NAME logical", &
+                          usage="PRINT_ATOM_KIND logical", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -1744,7 +1744,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="PRINT_IC_LIST", &
                           description="If true, the image charge correction values are printed in a list, "// &
                           "such that it can be used as input for a subsequent evGW calculation.", &
-                          usage="PRINT_IC_LIST", &
+                          usage="PRINT_IC_LIST .TRUE.", &
                           default_l_val=.FALSE., &
                           lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)

--- a/src/input_cp2k_mp2.F
+++ b/src/input_cp2k_mp2.F
@@ -427,7 +427,7 @@ CONTAINS
          description="Number of groups for the integration in the Laplace method. Each groups processes "// &
          "the same amount of quadrature points. It must be a divisor of the number of quadrature points and "// &
          "NUM_INTEG_GROUPS*GROUP_SIZE must be a divisor of the total number of processes. The default (-1) is automatic.", &
-         usage="SIZE_INTEG_GROUP 2", &
+         usage="NUM_INTEG_GROUPS 2", &
          default_i_val=-1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -554,7 +554,7 @@ CONTAINS
                           "the same amount of quadrature points. It must be a divisor of the number of quadrature points and "// &
                           "NUM_INTEG_GROUPS*GROUP_SIZE must be a divisor of the total number of processes. "// &
                           "The default (-1) is automatic.", &
-                          usage="SIZE_INTEG_GROUP 2", &
+                          usage="NUM_INTEG_GROUPS 2", &
                           default_i_val=-1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -724,7 +724,7 @@ CONTAINS
                           "Updates of Kohn-Sham orbitals (for example qsGW) are not implemented. "// &
                           "For details which type of eigenvalue self-consistency might be good, "// &
                           "please consult Golze, Dvorak, Rinke, Front. Chem. 2019.", &
-                          usage="GW_SELF_CONSISTENCY evGW0", &
+                          usage="SELF_CONSISTENCY evGW0", &
                           enum_c_vals=s2a("G0W0", "evGW0", "evGW"), &
                           enum_i_vals=(/G0W0, evGW0, evGW/), &
                           enum_desc=s2a("Use DFT eigenvalues; not update.", &
@@ -842,7 +842,7 @@ CONTAINS
                           "If the G0W0 HOMO-LUMO gap differs by less than the "// &
                           "target accuracy during the iteration, the eigenvalue "// &
                           "self-consistency cycle stops. Unit: Hartree.", &
-                          usage="EPS_EV_SC_ITER 0.00005", &
+                          usage="EPS_ITER 0.00005", &
                           default_r_val=cp_unit_to_cp2k(value=0.00136_dp, unit_str="eV"), &
                           unit_str="eV")
 
@@ -882,7 +882,7 @@ CONTAINS
                           description="If true, print the self-energy for all levels for real energy "// &
                           "together with the straight line to see the quasiparticle energy as intersection. "// &
                           "In addition, prints the self-energy for imaginary frequencies together with the Pade fit.", &
-                          usage="SELF_ENERGY", &
+                          usage="PRINT_SELF_ENERGY", &
                           default_l_val=.FALSE., &
                           lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
@@ -982,7 +982,7 @@ CONTAINS
                           description="Specify number of k-points for the k-point grid of the self-energy. Internally, a "// &
                           "Monkhorst-Pack grid is used. A dense k-point grid may be necessary to compute an accurate density "// &
                           "of state from GW. Large self-energy k-meshes do not cost much more computation time.", &
-                          usage="KPOINTS  nx  ny  nz", repeats=.TRUE., &
+                          usage="KPOINTS_SELF_ENERGY  nx  ny  nz", repeats=.TRUE., &
                           n_var=3, type_of_var=integer_t, default_i_vals=(/0, 0, 0/))
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1261,7 +1261,7 @@ CONTAINS
                           "in case a diffused basis is used for GW to converge the HOMO-LUMO gap. In this case, "// &
                           "numerical problems may occur due to diffuse functions in the basis. This keyword only works if "// &
                           "AUX_GW <basis set>  is specified in the kind section for every atom kind.", &
-                          usage="AUX_BAS_GW TRUE", &
+                          usage="DO_AUX_BAS_GW TRUE", &
                           default_l_val=.FALSE., &
                           lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
@@ -1709,7 +1709,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="NUM_DAVIDSON_ITER", &
                           description="Maximum number of iterations for determining the transition energies.", &
-                          usage="MAX_ITER 100", &
+                          usage="NUM_DAVIDSON_ITER 100", &
                           default_i_val=100)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1744,7 +1744,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="PRINT_IC_LIST", &
                           description="If true, the image charge correction values are printed in a list, "// &
                           "such that it can be used as input for a subsequent evGW calculation.", &
-                          usage="PRINT_IC_VALUES", &
+                          usage="PRINT_IC_LIST", &
                           default_l_val=.FALSE., &
                           lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
@@ -1911,7 +1911,7 @@ CONTAINS
          name="EPS_EIGVAL_S_GAMMA", &
          description="Parameter to reduce the expansion coefficients in RI for periodic GW. Removes all "// &
          "eigenvectors and eigenvalues of M_PQ(k=0) that are smaller than EPS_EIGVAL_S. ", &
-         usage="EPS_EIGVAL_S 1.0E-3", &
+         usage="EPS_EIGVAL_S_GAMMA 1.0E-3", &
          default_r_val=0.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -2169,7 +2169,7 @@ CONTAINS
                           description="Use a Polak-Ribiere update of the search vector in CG instead of the Fletcher "// &
                           "Reeves update. Improves the convergence with modified step sizes. "// &
                           "Ignored with other methods than CG.", &
-                          usage="ENFORCE_DECREASE T", &
+                          usage="DO_POLAK_RIBIERE T", &
                           lone_keyword_l_val=.TRUE., &
                           default_l_val=.FALSE.)
       CALL section_add_keyword(section, keyword)
@@ -2204,7 +2204,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="EPS_CONV", &
                           description="Target accuracy for Z-vector euation solution.", &
-                          usage="EPS 1.e-6", default_r_val=1.e-6_dp)
+                          usage="EPS_CONV 1.e-6", default_r_val=1.e-6_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -2333,7 +2333,7 @@ CONTAINS
          name="SCALE_COULOMB", &
          description="Scaling factor of (truncated) Coulomb potential in mixed (truncated) Coulomb/Longrange potential. "// &
          "Only valid when mixed potential is requested.", &
-         usage="OMEGA 0.5", type_of_var=real_t, &
+         usage="SCALE_COULOMB 0.5", type_of_var=real_t, &
          default_r_val=1.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -2343,7 +2343,7 @@ CONTAINS
          name="SCALE_LONGRANGE", &
          description="Scaling factor of longrange Coulomb potential in mixed (truncated) Coulomb/Longrange potential. "// &
          "Only valid when mixed potential is requested.", &
-         usage="OMEGA 0.5", type_of_var=real_t, &
+         usage="SCALE_LONGRANGE 0.5", type_of_var=real_t, &
          default_r_val=1.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_opt.F
+++ b/src/input_cp2k_opt.F
@@ -181,14 +181,14 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="SPIN_DENS_CONV_MAX", &
                           description="Convergence criterion for "// &
                           "the maximum electron density difference.", &
-                          usage="DENS_CONV_MAX 0.01", default_r_val=0.01_dp)
+                          usage="SPIN_DENS_CONV_MAX 0.01", default_r_val=0.01_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="SPIN_DENS_CONV_INT", &
                           description="Convergence criterion for "// &
                           "the integrated electron density difference.", &
-                          usage="DENS_CONV_INT 0.1", default_r_val=0.1_dp)
+                          usage="SPIN_DENS_CONV_INT 0.1", default_r_val=0.1_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -234,7 +234,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="VW_SMOOTH_CUT_RANGE", &
                           description="Smooth cutoff range for von Weizsacker potential in "// &
                           "the FAB optimization procedure.", &
-                          usage="VW_CUTOFF 1.0", default_r_val=1.0_dp)
+                          usage="VW_SMOOTH_CUT_RANGE 1.0", default_r_val=1.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -242,7 +242,7 @@ CONTAINS
                           description="Specifies the guess of the embedding  "// &
                           "potential. For optimization in finite basis (not grid optimization) "// &
                           "in is a constant part to be added to the one in finite basis. ", &
-                          usage="DEGREES_OF_FREEDOM ALL", &
+                          usage="POT_GUESS NONE", &
                           enum_c_vals=s2a("NONE", "DIFF", "Fermi_Amaldi", "RESP"), &
                           enum_desc=s2a("Initial guess is zero grid.", &
                                         "Initial density difference. A euristic but working approach.", &
@@ -358,14 +358,14 @@ CONTAINS
                           description="Convergence criterion for "// &
                           "the maximum element of the beta-spin density "// &
                           "matrix difference.", &
-                          usage="DM_CONV_MAX 0.01", default_r_val=0.01_dp)
+                          usage="BETA_DM_CONV_MAX 0.01", default_r_val=0.01_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="BETA_DM_CONV_INT", &
                           description="Convergence criterion for "// &
                           "the total beta-spin density matrix difference.", &
-                          usage="DM_CONV_INT 0.1", default_r_val=0.1_dp)
+                          usage="BETA_DM_CONV_INT 0.1", default_r_val=0.1_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_poisson.F
+++ b/src/input_cp2k_poisson.F
@@ -475,7 +475,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="aint_precond", &
                           description="the approximate inverse to use to get the starting point"// &
                           " for the linear solver of the spline3 methods", &
-                          usage="kind spline3", &
+                          usage="aint_precond copy", &
                           default_i_val=precond_spl3_aint, &
                           enum_c_vals=s2a("copy", "spl3_nopbc_aint1", "spl3_nopbc_precond1", &
                                           "spl3_nopbc_aint2", "spl3_nopbc_precond2", "spl3_nopbc_precond3"), &
@@ -487,7 +487,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="precond", &
                           description="The preconditioner used"// &
                           " for the linear solver of the spline3 methods", &
-                          usage="kind spline3", &
+                          usage="precond copy", &
                           default_i_val=precond_spl3_3, &
                           enum_c_vals=s2a("copy", "spl3_nopbc_aint1", "spl3_nopbc_precond1", &
                                           "spl3_nopbc_aint2", "spl3_nopbc_precond2", "spl3_nopbc_precond3"), &
@@ -821,7 +821,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="base_radii", &
                           description="The base radius of the annulus.", &
-                          usage="base_radius <r1(real)> <r2(real)>", unit_str="angstrom", &
+                          usage="base_radii <r1(real)> <r2(real)>", unit_str="angstrom", &
                           n_var=2, type_of_var=real_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_print_dft.F
+++ b/src/input_cp2k_print_dft.F
@@ -1055,7 +1055,7 @@ CONTAINS
                           name="VEL_REPRS", &
                           description="Calculate expectation values of the el. multipole moments in their velocity "// &
                           "representation during RTP. Implemented up to el. quadrupole moment.", &
-                          usage="VEL_REPS yes", &
+                          usage="VEL_REPRS yes", &
                           repeats=.FALSE., &
                           n_var=1, &
                           default_l_val=.FALSE., &
@@ -1343,7 +1343,7 @@ CONTAINS
                           description="Indexes of the atoms minimal basis to be printed as cube files "// &
                           "This keyword can be repeated several times "// &
                           "(useful if you have to specify many indexes).", &
-                          usage="CUBES_LIST 1 2", &
+                          usage="ATOM_LIST 1 2", &
                           n_var=-1, type_of_var=integer_t, repeats=.TRUE.)
       CALL section_add_keyword(sub_print_key, keyword)
       CALL keyword_release(keyword)
@@ -1655,7 +1655,7 @@ CONTAINS
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="PRINT_CUBES", &
                           description="Print the energy windows to cube files", &
-                          usage="DENSITY_PROPAGATION .TRUE.", &
+                          usage="PRINT_CUBES .TRUE.", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
@@ -2480,7 +2480,7 @@ CONTAINS
                           description="Specifies the MO according to "// &
                           "the marks set in MOLECULAR_STATES. The value corresponds to the repetition "// &
                           "of MARK_STATES in MOLECULAR_STATES", &
-                          usage="ORIG_MARKED_STATE 1", type_of_var=integer_t, default_i_val=0)
+                          usage="RESULT_MARKED_STATE 1", type_of_var=integer_t, default_i_val=0)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
 
@@ -2699,7 +2699,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="aint_precond", &
                           description="the approximate inverse to use to get the starting point"// &
                           " for the linear solver of the spline3 methods", &
-                          usage="kind spline3", &
+                          usage="aint_precond copy", &
                           default_i_val=precond_spl3_aint, &
                           enum_c_vals=s2a("copy", "spl3_nopbc_aint1", "spl3_nopbc_precond1", &
                                           "spl3_nopbc_aint2", "spl3_nopbc_precond2", "spl3_nopbc_precond3"), &
@@ -2711,7 +2711,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="precond", &
                           description="The preconditioner used"// &
                           " for the linear solver of the spline3 methods", &
-                          usage="kind spline3", &
+                          usage="precond copy", &
                           default_i_val=precond_spl3_3, &
                           enum_c_vals=s2a("copy", "spl3_nopbc_aint1", "spl3_nopbc_precond1", &
                                           "spl3_nopbc_aint2", "spl3_nopbc_precond2", "spl3_nopbc_precond3"), &

--- a/src/input_cp2k_projection_rtp.F
+++ b/src/input_cp2k_projection_rtp.F
@@ -100,7 +100,7 @@ CONTAINS
                           "Use this keyword if REFERENCE_TYPE=SCF. "// &
                           "Set to -1 to project on all the MO available. "// &
                           "One file will be generated per index defined.", &
-                          usage="MO_REF_INDEX 1 2", &
+                          usage="REF_MO_INDEX 1 2", &
                           default_i_vals=(/1/), &
                           n_var=-1, type_of_var=integer_t, repeats=.FALSE.)
       CALL section_add_keyword(section, keyword)
@@ -140,7 +140,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="TD_MO_INDEX", &
                           description="Indexes of the time dependent MOs to project on the reference MOs. "// &
                           "Set to -1 to project on all the TD MOs.", &
-                          usage="MO_TD_INDEX 1 2", &
+                          usage="TD_MO_INDEX 1 2", &
                           default_i_vals=(/1/), &
                           n_var=-1, type_of_var=integer_t, repeats=.FALSE.)
       CALL section_add_keyword(section, keyword)
@@ -149,7 +149,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="TD_MO_SPIN", &
                           description="Spin of the TD MOs to consider. 1 for ALPHA spin, 2 for BETA spin. "// &
                           "If the TD calculation is spin independent this key is not used.", &
-                          usage="MO_TD_SPIN 1", &
+                          usage="TD_MO_SPIN 1", &
                           default_i_val=1, &
                           n_var=1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)

--- a/src/input_cp2k_properties_dft.F
+++ b/src/input_cp2k_properties_dft.F
@@ -189,7 +189,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="EPS_FILTER", &
                           description="Filter threshold for response density matrix.", &
-                          usage="EPS 1.e-8", default_r_val=def_eps_filter)
+                          usage="EPS_FILTER 1.e-8", default_r_val=def_eps_filter)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -358,7 +358,7 @@ CONTAINS
 
          CALL keyword_create(keyword, __LOCATION__, name="LIST_OF_ATOMS", &
                              description="Specifies a list of atoms.", &
-                             usage="LIST {integer} {integer} .. {integer}", repeats=.TRUE., &
+                             usage="LIST_OF_ATOMS {integer} {integer} .. {integer}", repeats=.TRUE., &
                              n_var=-1, type_of_var=integer_t)
          CALL section_add_keyword(section, keyword)
          CALL keyword_release(keyword)
@@ -468,7 +468,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="LIST_OF_ATOMS", &
                           description="Specifies a list of atoms.", &
-                          usage="LIST {integer} {integer} .. {integer}", repeats=.TRUE., &
+                          usage="LIST_OF_ATOMS {integer} {integer} .. {integer}", repeats=.TRUE., &
                           n_var=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -520,7 +520,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="MAGNETIC_ORIGIN_REFERENCE", &
                           description="User-defined reference point of the magnetic dipole operator.", &
-                          usage="REFERENCE_POINT x y z", &
+                          usage="MAGNETIC_ORIGIN_REFERENCE x y z", &
                           repeats=.FALSE., n_var=3, type_of_var=real_t, unit_str='bohr')
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -543,7 +543,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="SPATIAL_ORIGIN_REFERENCE", &
                           description="User-defined reference point of the velocity gauge factor/spatial origin.", &
-                          usage="REFERENCE_POINT x y z", &
+                          usage="SPATIAL_ORIGIN_REFERENCE x y z", &
                           repeats=.FALSE., n_var=3, type_of_var=real_t, unit_str='bohr')
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -893,7 +893,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="ATOMS_LIST", &
                           description="list of atoms for which the shift is printed into a file ", &
-                          usage="LIST_ATOMS 1 2", n_var=-1, &
+                          usage="ATOMS_LIST 1 2", n_var=-1, &
                           type_of_var=integer_t, repeats=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
@@ -992,7 +992,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="ATOMS_LIST", &
                           description="list of atoms for which the indirect spin-spin is printed into a file ", &
-                          usage="LIST_ATOMS 1 2", n_var=-1, &
+                          usage="ATOMS_LIST 1 2", n_var=-1, &
                           type_of_var=integer_t, repeats=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
@@ -2176,7 +2176,7 @@ CONTAINS
          "Automatic choice of the k-point mesh for negative "// &
          "values, i.e. KPOINTS_W -1 -1 -1. "// &
          "K-point extrapolation of W is automatically switched on.", &
-         usage="KPOINTS N_x  N_y  N_z", &
+         usage="KPOINTS_W N_x  N_y  N_z", &
          n_var=3, type_of_var=integer_t, default_i_vals=(/-1, -1, -1/))
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_qmmm.F
+++ b/src/input_cp2k_qmmm.F
@@ -204,7 +204,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="CENTER_GRID", &
                           description="This keyword specifies whether the QM system is centered in units of the grid spacing.", &
-                          usage="grid_center LOGICAL", &
+                          usage="CENTER_GRID LOGICAL", &
                           default_l_val=.FALSE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -302,7 +302,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="CORR_RADIUS", &
                           description="Specifies the correction radius of the atomic kinds"// &
                           " The correction radius is connected to the use of the compatibility keyword.", &
-                          usage="RADIUS real", n_var=1, type_of_var=real_t, unit_str="angstrom")
+                          usage="CORR_RADIUS real", n_var=1, type_of_var=real_t, unit_str="angstrom")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -970,7 +970,7 @@ CONTAINS
          keyword, __LOCATION__, name="CORR_RADIUS", &
          description="Overwrite the specification of the correction radius only for the MM atom involved in the link. "// &
          "Default is to use the same correction radius as for the specified type.", &
-         usage="RADIUS real", n_var=1, type_of_var=real_t, unit_str="angstrom")
+         usage="CORR_RADIUS real", n_var=1, type_of_var=real_t, unit_str="angstrom")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1006,7 +1006,7 @@ CONTAINS
                           " This keyword affects only the QM/MM potential, it doesn't affect the electrostatic in"// &
                           " the classical part of the code."// &
                           " Default 1.0 i.e. no charge rescaling of the MM atom of the QM/MM link bond.", &
-                          usage="SCALE_FACTOR real", n_var=1, type_of_var=real_t, &
+                          usage="QMMM_SCALE_FACTOR real", n_var=1, type_of_var=real_t, &
                           default_r_val=CHARGE_SCALE_FACTOR)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1019,7 +1019,7 @@ CONTAINS
                           " This keyword modifies the MM charge in FIST. The modified charge will be used then also"// &
                           " for the generation of the QM/MM potential. "// &
                           "Default 1.0 i.e. no charge rescaling of the MM atom of the QM/MM link bond.", &
-                          usage="SCALE_FACTOR real", n_var=1, type_of_var=real_t, &
+                          usage="FIST_SCALE_FACTOR real", n_var=1, type_of_var=real_t, &
                           default_r_val=CHARGE_SCALE_FACTOR)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1058,7 +1058,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="CORR_RADIUS", &
                           description="Specifies the correction radius used for the QM/MM electrostatic coupling after movement", &
-                          usage="RADIUS real", n_var=1, type_of_var=real_t, unit_str="angstrom", default_r_val=0.0_dp)
+                          usage="CORR_RADIUS real", n_var=1, type_of_var=real_t, unit_str="angstrom", default_r_val=0.0_dp)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
 
@@ -1102,7 +1102,7 @@ CONTAINS
       CALL keyword_create( &
          keyword, __LOCATION__, name="CORR_RADIUS", &
          description="Specifies the correction radius used for the QM/MM electrostatic coupling for the added source", &
-         usage="RADIUS real", n_var=1, unit_str="angstrom", &
+         usage="CORR_RADIUS real", n_var=1, unit_str="angstrom", &
          default_r_val=cp_unit_to_cp2k(RADIUS_QMMM_DEFAULT, "angstrom"))
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
@@ -1155,7 +1155,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="aint_precond", &
                           description="the approximate inverse to use to get the starting point"// &
                           " for the linear solver of the spline3 methods", &
-                          usage="kind spline3", &
+                          usage="aint_precond copy", &
                           default_i_val=precond_spl3_aint, &
                           enum_c_vals=s2a("copy", "spl3_nopbc_aint1", "spl3_nopbc_precond1", &
                                           "spl3_nopbc_aint2", "spl3_nopbc_precond2", "spl3_nopbc_precond3"), &
@@ -1167,7 +1167,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="precond", &
                           description="The preconditioner used"// &
                           " for the linear solver of the spline3 methods", &
-                          usage="kind spline3", &
+                          usage="precond copy", &
                           default_i_val=precond_spl3_3, &
                           enum_c_vals=s2a("copy", "spl3_nopbc_aint1", "spl3_nopbc_precond1", &
                                           "spl3_nopbc_aint2", "spl3_nopbc_precond2", "spl3_nopbc_precond3"), &

--- a/src/input_cp2k_resp.F
+++ b/src/input_cp2k_resp.F
@@ -382,7 +382,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="RMAX_KIND", &
                           description="Specifies the maximum distance a fit point is away from an atom "// &
                           "of a given kind", &
-                          usage="RMAX 2.5 Br", repeats=.TRUE., &
+                          usage="RMAX_KIND 2.5 Br", repeats=.TRUE., &
                           n_var=-1, type_of_var=char_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -390,7 +390,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="RMIN_KIND", &
                           description="Specifies the minimum distance a fit point is away from an atom "// &
                           "of a given kind", &
-                          usage="RMIN 2.1 Br", repeats=.TRUE., &
+                          usage="RMIN_KIND 2.1 Br", repeats=.TRUE., &
                           n_var=-1, type_of_var=char_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_scf.F
+++ b/src/input_cp2k_scf.F
@@ -1444,7 +1444,7 @@ CONTAINS
                           description="Name of the reference spin density cube file for fragment A."// &
                           " May include a path. The reference spin density needs to be outputted"// &
                           " on the same grid as the full system (same cutoff and cell, output stride 1).", &
-                          usage="FRAGMENT_A_FILE_NAME <FILENAME>", &
+                          usage="FRAGMENT_A_SPIN_FILE <FILENAME>", &
                           default_lc_val="fragment_a_spin.cube")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1454,7 +1454,7 @@ CONTAINS
                           description="Name of the reference spin density cube file for fragment B."// &
                           " May include a path. The reference spin density needs to be outputted"// &
                           " on the same grid as the full system (same cutoff and cell, output stride 1).", &
-                          usage="FRAGMENT_B_FILE_NAME <FILENAME>", &
+                          usage="FRAGMENT_B_SPIN_FILE <FILENAME>", &
                           default_lc_val="fragment_b_spin.cube")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1697,7 +1697,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="USE_BOHR", &
                           description="Convert the Gaussian radius from angstrom to bohr. This results in a larger "// &
                           "Gaussian than without unit conversion.", &
-                          usage="CAVITY_USE_BOHR TRUE", &
+                          usage="USE_BOHR .TRUE.", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_smeagol.F
+++ b/src/input_cp2k_smeagol.F
@@ -114,7 +114,7 @@ CONTAINS
       ! use a list of atomic indices (AM.SpeciesBS) instead of list of atomic kind labels (AM.SpeciesBS)
       CALL keyword_create(keyword, __LOCATION__, name="AM.AtomListBS", &
                           description="Specifies a list of atoms to include.", &
-                          usage="AM.SpeciesBS {integer} {integer} .. {integer}", repeats=.FALSE., &
+                          usage="AM.AtomListBS {integer} {integer} .. {integer}", repeats=.FALSE., &
                           n_var=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_subsys.F
+++ b/src/input_cp2k_subsys.F
@@ -724,7 +724,7 @@ CONTAINS
                           description="Specify the units of measurement for the velocities "// &
                           "(currently works only for the path integral code). "// &
                           "All available CP2K units can be used.", &
-                          usage="UNIT angstrom*au_t^-1", &
+                          usage="PINT_UNIT angstrom*au_t^-1", &
                           default_c_val="bohr*au_t^-1")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1111,7 +1111,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="ELEC_CONF", &
                           description="Specifies the electronic configuration used in construction the "// &
                           "atomic initial guess (see the pseudo potential file for the default values).", &
-                          usage="ELEC_COND n_elec(s)  n_elec(p)  n_elec(d)  ... ", &
+                          usage="ELEC_CONF n_elec(s)  n_elec(p)  n_elec(d)  ... ", &
                           n_var=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -1224,7 +1224,7 @@ CONTAINS
                           description="the radius which defines the atomic region where "// &
                           "the hard compensation density is confined. "// &
                           "should be less than HARD_EXP_RADIUS (GAPW) (Bohr, default equals HARD_EXP_RADIUS)", &
-                          usage="RHO_EXP_RADIUS 0.9", type_of_var=real_t, n_var=1)
+                          usage="RHO0_EXP_RADIUS 0.9", type_of_var=real_t, n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_tb.F
+++ b/src/input_cp2k_tb.F
@@ -343,7 +343,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="D2_EXP_PRE", &
                           description="Exp prefactor for damping for the D2 dispersion method,", &
-                          usage="EXP_PRE 2.0", default_r_val=2.0_dp)
+                          usage="D2_EXP_PRE 2.0", default_r_val=2.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_thermostats.F
+++ b/src/input_cp2k_thermostats.F
@@ -85,7 +85,7 @@ CONTAINS
       IF (.NOT. my_coupled_thermostat) THEN
          CALL keyword_create(keyword, __LOCATION__, name="TYPE", &
                              description="Specify the thermostat used for the constant temperature ensembles.", &
-                             usage="thermostat NOSE", &
+                             usage="TYPE NOSE", &
                              default_i_val=do_thermo_nose, &
                              enum_c_vals=s2a("NOSE"), &
                              enum_i_vals=(/do_thermo_nose/), &
@@ -158,7 +158,7 @@ CONTAINS
       IF (.NOT. my_coupled_thermostat) THEN
          CALL keyword_create(keyword, __LOCATION__, name="TYPE", &
                              description="Specify the thermostat used for the constant temperature ensembles.", &
-                             usage="thermostat NOSE", &
+                             usage="TYPE NOSE", &
                              default_i_val=do_thermo_nose, &
                              enum_c_vals=s2a("NOSE"), &
                              enum_i_vals=(/do_thermo_nose/), &
@@ -233,7 +233,7 @@ CONTAINS
       IF (.NOT. my_coupled_thermostat) THEN
          CALL keyword_create(keyword, __LOCATION__, name="TYPE", &
                              description="Specify the thermostat used for the constant temperature ensembles.", &
-                             usage="thermostat NOSE", &
+                             usage="TYPE NOSE", &
                              default_i_val=do_thermo_nose, &
                              enum_c_vals=s2a("NOSE", "CSVR", "GLE", "AD_LANGEVIN"), &
                              enum_i_vals=(/do_thermo_nose, &
@@ -261,7 +261,7 @@ CONTAINS
       ELSE
          CALL keyword_create(keyword, __LOCATION__, name="TYPE", &
                              description="Specify the thermostat used for the constant temperature ensembles.", &
-                             usage="thermostat NOSE", &
+                             usage="TYPE NOSE", &
                              default_i_val=do_thermo_same_as_part, &
                              enum_c_vals=s2a("SAME_AS_PARTICLE", "NOSE", "CSVR"), &
                              enum_i_vals=(/do_thermo_same_as_part, do_thermo_nose, do_thermo_csvr/), &

--- a/src/input_cp2k_voronoi.F
+++ b/src/input_cp2k_voronoi.F
@@ -115,7 +115,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="REFINEMENT_FACTOR", &
                           description="Sets the refinement factor for the Voronoi integration.", &
-                          usage="REFINEMENT 2", n_var=1, default_i_val=1, type_of_var=integer_t)
+                          usage="REFINEMENT_FACTOR 2", n_var=1, default_i_val=1, type_of_var=integer_t)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_xas.F
+++ b/src/input_cp2k_xas.F
@@ -448,7 +448,7 @@ CONTAINS
                           "By default, takes the value of QS%EPS_PGF_ORB. Useful if "// &
                           "the former value is tiny due to possible ground state HFX "// &
                           "contributions.", &
-                          usage="EPS_PGS_XAS {real}", &
+                          usage="EPS_PGF_XAS {real}", &
                           type_of_var=real_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -1309,7 +1309,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="DENSITY_SMOOTH_CUTOFF_RANGE", &
                           description="Parameter for the smoothing procedure in xc calculation", &
-                          usage="gradient_cutoff {real}", default_r_val=0.0_dp)
+                          usage="DENSITY_SMOOTH_CUTOFF_RANGE {real}", default_r_val=0.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -1089,7 +1089,7 @@ CONTAINS
                           description="Parameters for the short-range bond correction to the DFT-D3 model. "// &
                           "s*(za*zb)^t1*EXP(-g*dr*r0ab^t2), parameters: s, g, t1, t2 "// &
                           "Defaults: s=0.08, g=10.0, t1=0.5, t2=-1.0 ", &
-                          usage="SHORT_RANGE_CORRECTION_PARAMETRS", default_r_vals=(/0.08_dp, 10.0_dp, 0.5_dp, -1.0_dp/), &
+                          usage="SHORT_RANGE_CORRECTION_PARAMETERS", default_r_vals=(/0.08_dp, 10.0_dp, 0.5_dp, -1.0_dp/), &
                           n_var=4, type_of_var=real_t)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -760,7 +760,7 @@ CONTAINS
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="K_RHO", &
                           description="Value of the K_rho parameter (default = 0.42).", &
-                          usage="ALPHA 0.42", default_r_val=0.42_dp)
+                          usage="K_RHO 0.42", default_r_val=0.42_dp)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL section_add_subsection(section, subsection)
@@ -844,7 +844,7 @@ CONTAINS
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="C_CAA", &
                           description="B97 C parameters for opposite spin correlation.", &
-                          usage="C_CAB <REAL> <REAL> <REAL>", &
+                          usage="C_CAA <REAL> <REAL> <REAL>", &
                           default_r_vals=(/0.17_dp, 2.35_dp, -2.55_dp/), &
                           type_of_var=real_t, n_var=3)
       CALL section_add_keyword(section, keyword)

--- a/src/input_optimize_basis.F
+++ b/src/input_optimize_basis.F
@@ -124,7 +124,7 @@ CONTAINS
          "The first entry corresponds to the original basis sets. Every further value is assigned to the combinations "// &
          "in the order given for BASIS_COMBINATIONS.", &
          repeats=.TRUE., &
-         usage="CONTITION_WEIGHT REAL ", default_r_val=1.0_dp)
+         usage="CONDITION_WEIGHT REAL ", default_r_val=1.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -177,7 +177,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="BASIS_SET", &
                           description="The name of the basis set for the kind. Has to be specified in BASIS_TEMPLATE_FILE.", &
-                          usage="H", default_c_val="DEFAULT")
+                          usage="BASIS_SET H", default_c_val="DEFAULT")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -268,7 +268,7 @@ CONTAINS
                           description="Specifies the reference basis ID which is used as template to create the new set. "// &
                           "The original basis has ID 0. All following sets are counted in order as specified in the Input."// &
                           " The descriptors always assume the structure of the input basis set.", &
-                          repeats=.FALSE., usage="REFERNCE_SET INTEGER", default_i_val=0)
+                          repeats=.FALSE., usage="REFERENCE_SET INTEGER", default_i_val=0)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/motion/input_cp2k_md.F
+++ b/src/motion/input_cp2k_md.F
@@ -857,7 +857,7 @@ CONTAINS
                           description="Maximum accepted temperature deviation"// &
                           " from the expected value, for the fast motion."// &
                           " If 0, no rescaling is performed", &
-                          usage="temp_tol 0.0", default_r_val=0.0_dp, unit_str='K')
+                          usage="temp_tol_fast 0.0", default_r_val=0.0_dp, unit_str='K')
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -865,7 +865,7 @@ CONTAINS
                           description="Maximum accepted temperature deviation"// &
                           " from the expected value, for the slow motion."// &
                           " If 0, no rescaling is performed", &
-                          usage="temp_tol 0.0", default_r_val=0.0_dp, unit_str='K')
+                          usage="temp_tol_slow 0.0", default_r_val=0.0_dp, unit_str='K')
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/start/input_cp2k.F
+++ b/src/start/input_cp2k.F
@@ -718,7 +718,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="MAX_JOBS_PER_GROUP", &
                           variants=(/"MAX_JOBS"/), &
                           description="maximum number of jobs executed per group", &
-                          usage="max_step 4", default_i_val=65535)
+                          usage="MAX_JOBS_PER_GROUP 4", default_i_val=65535)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/start/input_cp2k.F
+++ b/src/start/input_cp2k.F
@@ -237,7 +237,7 @@ CONTAINS
                           "Klimes, Kresse, JCTC 10, 2498 (2014), Eq. 30. Printed is the L1-error (=minimax "// &
                           "error for a given range and a given number of grid points. The input parameter is "// &
                           "the given number of different Rc values.", &
-                          usage="MINIMAX 1000", default_i_val=0)
+                          usage="LEAST_SQ_FT 1000", default_i_val=0)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -966,17 +966,17 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="K", &
                           description="Dimension 1 of C", &
-                          usage="A 1024", default_i_val=256)
+                          usage="K 1024", default_i_val=256)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="M", &
                           description="Inner dimension M   ", &
-                          usage="A 1024", default_i_val=256)
+                          usage="M 1024", default_i_val=256)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="N", &
                           description="Dimension 2 of C", &
-                          usage="A 1024", default_i_val=256)
+                          usage="N 1024", default_i_val=256)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -988,7 +988,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="NCOL_BLOCK", &
                           description="block_size for cols", &
-                          usage="nrow_block 64", default_i_val=32)
+                          usage="NCOL_BLOCK 64", default_i_val=32)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1132,17 +1132,17 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="M", &
                           description="Dimension 1 of C", &
-                          usage="A 1024", default_i_val=256)
+                          usage="M 1024", default_i_val=256)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="N", &
                           description="Dimension 2 of C", &
-                          usage="A 1024", default_i_val=256)
+                          usage="N 1024", default_i_val=256)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="K", &
                           description="Inner dimension M   ", &
-                          usage="A 1024", default_i_val=256)
+                          usage="K 1024", default_i_val=256)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1212,13 +1212,13 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="BSPARSITY", &
                           description="Sparsity of B matrix", &
-                          usage="ASPARSITY 80", default_r_val=0.0_dp)
+                          usage="BSPARSITY 80", default_r_val=0.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="CSPARSITY", &
                           description="Sparsity of C matrix", &
-                          usage="ASPARSITY 90", default_r_val=0.0_dp)
+                          usage="CSPARSITY 90", default_r_val=0.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1272,17 +1272,17 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="M", &
                           description="Dimension 1 of C", &
-                          usage="A 1024", default_i_val=256)
+                          usage="M 1024", default_i_val=256)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="N", &
                           description="Dimension 2 of C", &
-                          usage="A 1024", default_i_val=256)
+                          usage="N 1024", default_i_val=256)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="K", &
                           description="Inner dimension M   ", &
-                          usage="A 1024", default_i_val=256)
+                          usage="K 1024", default_i_val=256)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
@@ -1330,13 +1330,13 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="BSPARSITY", &
                           description="Sparsity of B matrix", &
-                          usage="ASPARSITY 80", default_r_val=0.0_dp)
+                          usage="BSPARSITY 80", default_r_val=0.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="CSPARSITY", &
                           description="Sparsity of C matrix", &
-                          usage="ASPARSITY 90", default_r_val=0.0_dp)
+                          usage="CSPARSITY 90", default_r_val=0.0_dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/start/input_cp2k_motion.F
+++ b/src/start/input_cp2k_motion.F
@@ -242,7 +242,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="ENSEMBLE", &
                           description="Specify the type of simulation", &
-                          usage="PROGRAM (TRADITIONAL|GEMC_NVT|GEMC_NPT|VIRIAL)", &
+                          usage="ENSEMBLE (TRADITIONAL|GEMC_NVT|GEMC_NPT|VIRIAL)", &
                           enum_c_vals=s2a("TRADITIONAL", "GEMC_NVT", "GEMC_NPT", "VIRIAL"), &
                           enum_i_vals=(/do_mc_traditional, do_mc_gemc_nvt, do_mc_gemc_npt, do_mc_virial/), &
                           default_i_val=do_mc_traditional)
@@ -1122,7 +1122,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="METHOD", &
                           description="Specify which kind of method to use for locating transition states", &
                           citations=(/Henkelman1999/), &
-                          usage="TYPE (DIMER)", &
+                          usage="METHOD (DIMER)", &
                           enum_c_vals=s2a("DIMER"), &
                           enum_desc=s2a("Uses the dimer method to optimize transition states."), &
                           enum_i_vals=(/default_dimer_method_id/), &
@@ -1152,7 +1152,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="ANGLE_TOLERANCE", &
                           description="This keyword sets the value of the tolerance angle for the line search"// &
                           " performed to optimize the orientation of the dimer.", &
-                          usage="ANGLE_TOL {real}", unit_str='rad', &
+                          usage="ANGLE_TOLERANCE {real}", unit_str='rad', &
                           default_r_val=cp_unit_to_cp2k(5.0_dp, "deg"))
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
@@ -1331,7 +1331,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="FLETCHER_REEVES", &
                           description="Uses FLETCHER-REEVES instead of POLAK-RIBIERE when using Conjugate Gradients", &
-                          usage="FLETCHER-REEVES", &
+                          usage="FLETCHER_REEVES", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -2584,7 +2584,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="MIN_CYCLE_LENGTHS_WDG", &
                           description="Density of winding paths "// &
                           "not shorter than the given length", &
-                          repeats=.FALSE., usage="<INT> <INT> .. <INT>", &
+                          repeats=.FALSE., usage="MIN_CYCLE_LENGTHS_WDG <INT> <INT> .. <INT>", &
                           type_of_var=integer_t, n_var=-1)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
@@ -2592,7 +2592,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="MIN_CYCLE_LENGTHS_NON", &
                           description="Density of non-winding paths "// &
                           "not shorter than the given length", &
-                          repeats=.FALSE., usage="<INT> <INT> .. <INT>", &
+                          repeats=.FALSE., usage="MIN_CYCLE_LENGTHS_NON <INT> <INT> .. <INT>", &
                           type_of_var=integer_t, n_var=-1)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
@@ -2600,7 +2600,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="MIN_CYCLE_LENGTHS_ALL", &
                           description="Density of all paths "// &
                           "not shorter than the given length", &
-                          repeats=.FALSE., usage="<INT> <INT> .. <INT>", &
+                          repeats=.FALSE., usage="MIN_CYCLE_LENGTHS_ALL <INT> <INT> .. <INT>", &
                           type_of_var=integer_t, n_var=-1)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
@@ -2675,37 +2675,37 @@ CONTAINS
                           n_keywords=7, n_subsections=0, repeats=.FALSE.)
       CALL keyword_create(keyword, __LOCATION__, name="PROJECTED_AREA", &
                           description="Projected area vector for all environments", &
-                          repeats=.TRUE., usage="<REAL> <REAL> .. <REAL>", &
+                          repeats=.TRUE., usage="PROJECTED_AREA <REAL> <REAL> .. <REAL>", &
                           type_of_var=real_t, n_var=-1)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="PROJECTED_AREA_2", &
                           description="Projected area vector squared for all environments", &
-                          repeats=.TRUE., usage="<REAL> <REAL> .. <REAL>", &
+                          repeats=.TRUE., usage="PROJECTED_AREA_2 <REAL> <REAL> .. <REAL>", &
                           type_of_var=real_t, n_var=-1)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="WINDING_NUMBER_2", &
                           description="Winding number vector squared for all environments", &
-                          repeats=.TRUE., usage="<REAL> <REAL> .. <REAL>", &
+                          repeats=.TRUE., usage="WINDING_NUMBER_2 <REAL> <REAL> .. <REAL>", &
                           type_of_var=real_t, n_var=-1)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="MOMENT_OF_INERTIA", &
                           description="Moment of inertia vector for all environments", &
-                          repeats=.TRUE., usage="<REAL> <REAL> .. <REAL>", &
+                          repeats=.TRUE., usage="MOMENT_OF_INERTIA <REAL> <REAL> .. <REAL>", &
                           type_of_var=real_t, n_var=-1)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="RDF", &
                           description="Radial distributions averaged over all environments", &
-                          repeats=.TRUE., usage="<REAL> <REAL> .. <REAL>", &
+                          repeats=.TRUE., usage="RDF <REAL> <REAL> .. <REAL>", &
                           type_of_var=real_t, n_var=-1)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="RHO", &
                           description="Spatial distributions averaged over all environments", &
-                          repeats=.TRUE., usage="<REAL> <REAL> .. <REAL>", &
+                          repeats=.TRUE., usage="RHO <REAL> <REAL> .. <REAL>", &
                           type_of_var=real_t, n_var=-1)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)

--- a/src/tmc/input_cp2k_tmc.F
+++ b/src/tmc/input_cp2k_tmc.F
@@ -90,7 +90,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, &
                           name="GROUP_ANLYSIS_NR", &
                           description="amount of groups (cores) for analysing the configurations", &
-                          usage="GROUP_ANALYSIS_NR {INTEGER}", &
+                          usage="GROUP_ANLYSIS_NR {INTEGER}", &
                           default_i_val=1, lone_keyword_i_val=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -107,7 +107,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, &
                           name="RND_DETERMINISTIC", &
                           description="the initialisation number for the random number generator", &
-                          usage="RND_INIT {INTEGER}", &
+                          usage="RND_DETERMINISTIC {INTEGER}", &
                           default_i_val=-1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -124,7 +124,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, &
                           name="NR_TEMPERATURE", &
                           description="the number of different temperature for parallel tempering", &
-                          usage="NR_TEMP {INTEGER}", &
+                          usage="NR_TEMPERATURE {INTEGER}", &
                           default_i_val=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -250,7 +250,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, &
                           name="RESTART_IN", &
                           description="if existing use the last restart file", &
-                          usage="RESTART or RSTART {FILENAME}", &
+                          usage="RESTART_IN {FILENAME}", &
                           default_c_val="", lone_keyword_c_val=tmc_default_unspecified_name)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -263,7 +263,7 @@ CONTAINS
                           "If the value is 0, no restart file is written at all. "// &
                           "The frequency specifies is related "// &
                           "to the calculated Markov chain elements", &
-                          usage="RESTART or RESTART {INTEGER}", &
+                          usage="RESTART_OUT {INTEGER}", &
                           default_i_val=-1, lone_keyword_i_val=-9)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -535,7 +535,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, &
                           name="NR_TEMPERATURE", &
                           description="the number of different temperature for parallel tempering", &
-                          usage="NR_TEMP {INTEGER}", &
+                          usage="NR_TEMPERATURE {INTEGER}", &
                           default_i_val=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
@@ -632,7 +632,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="PREFIX_ANA_FILES", &
                           description="specifies a prefix for all analysis files.", &
-                          usage="ANA_FILES_PREFIX {prefix}", &
+                          usage="PREFIX_ANA_FILES {prefix}", &
                           default_c_val="")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)


### PR DESCRIPTION
As per #3986, fixed all the typos in usage string in manuals according to their keyword names.

Only one problem, the keyword CP2K_INPUT.MOTION.TMC.GROUP_ANLYSIS_NR itself is misspelled (should be CP2K_INPUT.MOTION.TMC.GROUP_ANALYSIS_NR) and might need additional fixing. I changed the usage string according to the misspelled version of the keyword.
