### PR TITLE
dbt_tas_info: lhs copy-allocation overhead

### DIFF
--- a/src/dbt/tas/dbt_tas_base.F
+++ b/src/dbt/tas/dbt_tas_base.F
@@ -120,10 +120,10 @@ CONTAINS
       CHARACTER(len=*), INTENT(IN)                       :: name
       TYPE(dbt_tas_distribution_type), INTENT(INOUT)     :: dist
 
-      CLASS(dbt_tas_rowcol_data), INTENT(IN)       :: row_blk_size, col_blk_size
+      CLASS(dbt_tas_rowcol_data), INTENT(IN)         :: row_blk_size, col_blk_size
       LOGICAL, INTENT(IN), OPTIONAL                  :: own_dist
 
-      TYPE(dbt_tas_split_info)                     :: info
+      TYPE(dbt_tas_split_info), POINTER              :: info
 
       INTEGER, DIMENSION(:), POINTER, CONTIGUOUS     :: row_blk_size_vec, col_blk_size_vec
       INTEGER                                        :: nrows, ncols, irow, col, icol, row
@@ -145,7 +145,7 @@ CONTAINS
       ALLOCATE (matrix%row_blk_size, source=row_blk_size)
       ALLOCATE (matrix%col_blk_size, source=col_blk_size)
 
-      info = dbt_tas_info(matrix)
+      info => dbt_tas_info(matrix)
 
       SELECT CASE (info%split_rowcol)
       CASE (rowsplit)
@@ -464,11 +464,11 @@ CONTAINS
       INTEGER, INTENT(OUT)                               :: processor
 
       INTEGER, DIMENSION(2)                              :: pcoord
-      TYPE(dbt_tas_split_info)                           :: info
+      TYPE(dbt_tas_split_info), POINTER                  :: info
 
       pcoord(1) = matrix%dist%row_dist%dist(row)
       pcoord(2) = matrix%dist%col_dist%dist(column)
-      info = dbt_tas_info(matrix)
+      info => dbt_tas_info(matrix)
 
       ! workaround for inefficient mpi_cart_rank
       processor = pcoord(1)*info%pdims(2) + pcoord(2)
@@ -751,12 +751,15 @@ CONTAINS
 
       INTEGER                                            :: handle, i
       INTEGER, DIMENSION(SIZE(rows))                     :: columns_group, rows_group
+      TYPE(dbt_tas_split_info), POINTER                  :: info
 
       CALL timeset(routineN, handle)
 
+      info => dbt_tas_info(matrix)
+
       CPASSERT(SIZE(rows) == SIZE(columns))
       DO i = 1, SIZE(rows)
-         CALL dbt_index_global_to_local(dbt_tas_info(matrix), matrix%dist, &
+         CALL dbt_index_global_to_local(info, matrix%dist, &
                                         row=rows(i), row_group=rows_group(i), &
                                         column=columns(i), column_group=columns_group(i))
       END DO
@@ -819,10 +822,10 @@ CONTAINS
 !> \author Patrick Seewald
 ! **************************************************************************************************
    FUNCTION dbt_tas_info(matrix)
-      TYPE(dbt_tas_type), INTENT(IN)                     :: matrix
-      TYPE(dbt_tas_split_info)                           :: dbt_tas_info
+      TYPE(dbt_tas_type), INTENT(IN), TARGET             :: matrix
+      TYPE(dbt_tas_split_info), POINTER                  :: dbt_tas_info
 
-      dbt_tas_info = matrix%dist%info
+      dbt_tas_info => matrix%dist%info
    END FUNCTION
 
 ! **************************************************************************************************

--- a/src/dbt/tas/dbt_tas_split.F
+++ b/src/dbt/tas/dbt_tas_split.F
@@ -677,7 +677,7 @@ CONTAINS
    SUBROUTINE group_to_mrowcol(info, rowcol_dist, igroup, rowcols)
       TYPE(dbt_tas_split_info), INTENT(IN)               :: info
 
-      CLASS(dbt_tas_distribution), INTENT(IN)                   :: rowcol_dist
+      CLASS(dbt_tas_distribution), INTENT(IN)                     :: rowcol_dist
       INTEGER, INTENT(IN)                                         :: igroup
       INTEGER(KIND=int_8), DIMENSION(:), ALLOCATABLE, INTENT(OUT) :: rowcols
       INTEGER, DIMENSION(0:info%pgrid_split_size - 1)             :: nrowcols_group


### PR DESCRIPTION
- Leave it up to the call-side to take dbt_tas_info by-value.
- Adjusted dbt_tas_info to return POINTER.
- Avoid dbt_tas_info in loop.

Standard conforming Fortran compiler behavior comes at high overhead/cost since dbt_tas_split_info is constructed with ALLOCATABLE components, deallocated on assignment to match assigned value, and potentially repeated as in above case (CALL in loop like dummy argument supplied). Now, the user-side can decide whether to take as POINTER or not and to significantly reduce cost of dbt_tas_info. Test case was benchmarks/QS_single_node/RI-HFX_H2O-32.inp.