### PR TITLE
Read MOs and external energy derivatives from trexio files

### DIFF
--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -28,9 +28,11 @@ MODULE qs_scf_post_gpw
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_api,                    ONLY: dbcsr_add,&
                                               dbcsr_p_type,&
-                                              dbcsr_type
+                                              dbcsr_type, dbcsr_set,&
+                                              dbcsr_create, dbcsr_release
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
-                                              dbcsr_deallocate_matrix_set
+                                              dbcsr_deallocate_matrix_set, &
+                                              dbcsr_allocate_matrix_set
    USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
    USE cp_ddapc_util,                   ONLY: get_ddapc
    USE cp_fm_diag,                      ONLY: choose_eigv_solver
@@ -1694,7 +1696,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_rmpv, matrix_s
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_rmpv, matrix_s, energy_derivative
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_deriv
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kpoint_type), POINTER                         :: kpoints
@@ -1755,8 +1757,24 @@ CONTAINS
             CALL write_trexio(qs_env, trexio_section)
             ! testing
             ALLOCATE (mos_trexio(dft_control%nspins))
-            CALL read_trexio(qs_env, trexio_section, mos_trexio)
+            ! allocate the energy derivative matrix
+            ! ALLOCATE (energy_derivative(dft_control%nspins))
+
+            NULLIFY (energy_derivative)
+            CALL dbcsr_allocate_matrix_set(energy_derivative, dft_control%nspins)
+            CALL get_qs_env(qs_env, matrix_s=matrix_s)
+            DO ispin = 1, dft_control%nspins
+               ALLOCATE (energy_derivative(ispin)%matrix)
+               CALL dbcsr_create(matrix=energy_derivative(ispin)%matrix, &
+                                 template=matrix_s(ispin)%matrix, name='Energy Derivative')
+               CALL dbcsr_set(energy_derivative(ispin)%matrix, 0.0_dp)
+            END DO
+            CALL read_trexio(qs_env, trexio_section, mos_trexio, energy_derivative)
             DEALLOCATE (mos_trexio)
+            DO ispin = 1, dft_control%nspins
+               CALL dbcsr_release(energy_derivative(ispin)%matrix)
+               DEALLOCATE (energy_derivative(ispin)%matrix)
+            END DO
             !!!
          END IF
          IF (.NOT. do_kpoints) THEN

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -26,12 +26,11 @@ MODULE qs_scf_post_gpw
    USE cp_array_utils,                  ONLY: cp_1d_r_p_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: dft_control_type
-   USE cp_dbcsr_api,                    ONLY: dbcsr_add, &
+   USE cp_dbcsr_api,                    ONLY: dbcsr_add,&
                                               dbcsr_p_type,&
                                               dbcsr_type
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
-                                              dbcsr_deallocate_matrix_set, &
-                                              dbcsr_allocate_matrix_set
+                                              dbcsr_deallocate_matrix_set
    USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
    USE cp_ddapc_util,                   ONLY: get_ddapc
    USE cp_fm_diag,                      ONLY: choose_eigv_solver
@@ -161,7 +160,7 @@ MODULE qs_scf_post_gpw
                                               make_mo_eig
    USE qs_mo_occupation,                ONLY: set_mo_occupation
    USE qs_mo_types,                     ONLY: get_mo_set,&
-                                              mo_set_type, deallocate_mo_set
+                                              mo_set_type
    USE qs_moments,                      ONLY: qs_moment_berry_phase,&
                                               qs_moment_locop
    USE qs_neighbor_list_types,          ONLY: get_iterator_info,&
@@ -194,7 +193,7 @@ MODULE qs_scf_post_gpw
    USE scf_control_types,               ONLY: scf_control_type
    USE stm_images,                      ONLY: th_stm_image
    USE transport,                       ONLY: qs_scf_post_transport
-   USE trexio_utils,                    ONLY: write_trexio, read_trexio
+   USE trexio_utils,                    ONLY: write_trexio
    USE virial_types,                    ONLY: virial_type
    USE voronoi_interface,               ONLY: entry_voronoi_or_bqb
    USE xray_diffraction,                ONLY: calculate_rhotot_elec_gspace,&
@@ -1695,12 +1694,11 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_rmpv, matrix_s, energy_derivative
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_rmpv, matrix_s
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_deriv
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
-      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos_trexio
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1754,22 +1752,6 @@ CONTAINS
          CALL section_vals_get(trexio_section, explicit=explicit)
          IF (explicit) THEN
             CALL write_trexio(qs_env, trexio_section)
-
-            !!!!! Testing read_trexio
-            ALLOCATE (mos_trexio(dft_control%nspins))
-            ! allocate the energy derivative matrix
-            NULLIFY (energy_derivative)
-            CALL dbcsr_allocate_matrix_set(energy_derivative, dft_control%nspins)
-            CALL read_trexio(qs_env, trexio_filename='SiC-TREXIO', mo_set_trexio=mos_trexio, &
-                             energy_derivative=energy_derivative)
-            ! deallocate everything
-            DO ispin = 1, SIZE(mos_trexio)
-               CALL deallocate_mo_set(mos_trexio(ispin))
-            END DO
-            DEALLOCATE (mos_trexio)
-            CALL dbcsr_deallocate_matrix_set(energy_derivative)
-            !!!!!!
-
          END IF
          IF (.NOT. do_kpoints) THEN
             CALL get_qs_env(qs_env, mos=mos, matrix_ks=ks_rmpv)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1760,7 +1760,8 @@ CONTAINS
             ! allocate the energy derivative matrix
             NULLIFY (energy_derivative)
             CALL dbcsr_allocate_matrix_set(energy_derivative, dft_control%nspins)
-            CALL read_trexio(qs_env, trexio_section, mos_trexio, energy_derivative)
+            CALL read_trexio(qs_env, trexio_filename='SiC-TREXIO', mo_set_trexio=mos_trexio, &
+                             energy_derivative=energy_derivative)
             ! deallocate everything
             DO ispin = 1, SIZE(mos_trexio)
                CALL deallocate_mo_set(mos_trexio(ispin))

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -193,7 +193,7 @@ MODULE qs_scf_post_gpw
    USE scf_control_types,               ONLY: scf_control_type
    USE stm_images,                      ONLY: th_stm_image
    USE transport,                       ONLY: qs_scf_post_transport
-   USE trexio_utils,                    ONLY: write_trexio
+   USE trexio_utils,                    ONLY: write_trexio, read_trexio
    USE virial_types,                    ONLY: virial_type
    USE voronoi_interface,               ONLY: entry_voronoi_or_bqb
    USE xray_diffraction,                ONLY: calculate_rhotot_elec_gspace,&
@@ -1699,6 +1699,7 @@ CONTAINS
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
+      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos_trexio
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1752,6 +1753,11 @@ CONTAINS
          CALL section_vals_get(trexio_section, explicit=explicit)
          IF (explicit) THEN
             CALL write_trexio(qs_env, trexio_section)
+            ! testing
+            ALLOCATE (mos_trexio(dft_control%nspins))
+            CALL read_trexio(qs_env, trexio_section, mos_trexio)
+            DEALLOCATE (mos_trexio)
+            !!!
          END IF
          IF (.NOT. do_kpoints) THEN
             CALL get_qs_env(qs_env, mos=mos, matrix_ks=ks_rmpv)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -26,10 +26,9 @@ MODULE qs_scf_post_gpw
    USE cp_array_utils,                  ONLY: cp_1d_r_p_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
    USE cp_control_types,                ONLY: dft_control_type
-   USE cp_dbcsr_api,                    ONLY: dbcsr_add,&
+   USE cp_dbcsr_api,                    ONLY: dbcsr_add, &
                                               dbcsr_p_type,&
-                                              dbcsr_type, dbcsr_set,&
-                                              dbcsr_create, dbcsr_release
+                                              dbcsr_type
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               dbcsr_deallocate_matrix_set, &
                                               dbcsr_allocate_matrix_set
@@ -162,7 +161,7 @@ MODULE qs_scf_post_gpw
                                               make_mo_eig
    USE qs_mo_occupation,                ONLY: set_mo_occupation
    USE qs_mo_types,                     ONLY: get_mo_set,&
-                                              mo_set_type
+                                              mo_set_type, deallocate_mo_set
    USE qs_moments,                      ONLY: qs_moment_berry_phase,&
                                               qs_moment_locop
    USE qs_neighbor_list_types,          ONLY: get_iterator_info,&
@@ -1755,27 +1754,21 @@ CONTAINS
          CALL section_vals_get(trexio_section, explicit=explicit)
          IF (explicit) THEN
             CALL write_trexio(qs_env, trexio_section)
-            ! testing
+
+            !!!!! Testing read_trexio
             ALLOCATE (mos_trexio(dft_control%nspins))
             ! allocate the energy derivative matrix
-            ! ALLOCATE (energy_derivative(dft_control%nspins))
-
             NULLIFY (energy_derivative)
             CALL dbcsr_allocate_matrix_set(energy_derivative, dft_control%nspins)
-            CALL get_qs_env(qs_env, matrix_s=matrix_s)
-            DO ispin = 1, dft_control%nspins
-               ALLOCATE (energy_derivative(ispin)%matrix)
-               CALL dbcsr_create(matrix=energy_derivative(ispin)%matrix, &
-                                 template=matrix_s(ispin)%matrix, name='Energy Derivative')
-               CALL dbcsr_set(energy_derivative(ispin)%matrix, 0.0_dp)
-            END DO
             CALL read_trexio(qs_env, trexio_section, mos_trexio, energy_derivative)
-            DEALLOCATE (mos_trexio)
-            DO ispin = 1, dft_control%nspins
-               CALL dbcsr_release(energy_derivative(ispin)%matrix)
-               DEALLOCATE (energy_derivative(ispin)%matrix)
+            ! deallocate everything
+            DO ispin = 1, SIZE(mos_trexio)
+               CALL deallocate_mo_set(mos_trexio(ispin))
             END DO
-            !!!
+            DEALLOCATE (mos_trexio)
+            CALL dbcsr_deallocate_matrix_set(energy_derivative)
+            !!!!!!
+
          END IF
          IF (.NOT. do_kpoints) THEN
             CALL get_qs_env(qs_env, mos=mos, matrix_ks=ks_rmpv)

--- a/src/trexio.F
+++ b/src/trexio.F
@@ -11,6 +11,9 @@
 !>      05.2024 created [SB]
 !> \author Stefano Battaglia
 ! **************************************************************************************************
+! There could be an issue by including the trexio library in this way, which is that if this
+! file is not compiled before files containing TREXIO import statements, the compiler will complain
+! that it is not able to find the TREXIO module and will fail.
 
 #ifdef __TREXIO
 #include <trexio_f.f90>

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -34,8 +34,8 @@ MODULE trexio_utils
                            dbcsr_iterator_stop, dbcsr_iterator_blocks_left, &
                            dbcsr_reserve_all_blocks, dbcsr_iterator_next_block, &
                            dbcsr_copy, dbcsr_set
-   USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
-   USE cp_output_handling,              ONLY: medium_print_level
+   USE cp_dbcsr_output, ONLY: cp_dbcsr_write_sparse_matrix
+   USE cp_output_handling, ONLY: medium_print_level
    USE external_potential_types, ONLY: sgp_potential_type, get_potential
    USE input_section_types, ONLY: section_vals_type, section_vals_get, &
                                   section_vals_val_get
@@ -986,7 +986,6 @@ CONTAINS
 
    END SUBROUTINE write_trexio
 
-
 ! **************************************************************************************************
 !> \brief Read a trexio file
 !> \param qs_env the qs environment with all the info of the computation
@@ -1027,7 +1026,7 @@ CONTAINS
       REAL(KIND=dp)                                      :: zeff, maxocc
       REAL(KIND=dp), DIMENSION(:), ALLOCATABLE           :: mo_energy, mo_occupation, charge
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: mo_coefficient, mos_sgf, coord, dEdP, temp
-      REAL(KIND=dp), DIMENSION(:,:), POINTER             :: data_block
+      REAL(KIND=dp), DIMENSION(:, :), POINTER             :: data_block
 
       TYPE(cp_logger_type), POINTER                      :: logger => Null()
       TYPE(cp_fm_type), POINTER                          :: mo_coeff_ref, mo_coeff_target
@@ -1065,32 +1064,32 @@ CONTAINS
 
       ! Open the TREXIO file and check that we have the same molecule as in qs_env
       IF (ionode) THEN
-         WRITE(output_unit, "((T2,A,A))") 'TREXIO| Opening file named ', TRIM(filename)
+         WRITE (output_unit, "((T2,A,A))") 'TREXIO| Opening file named ', TRIM(filename)
          f = trexio_open(filename, 'r', TREXIO_HDF5, rc)
          CALL trexio_error(rc)
 
          IF (myprint > medium_print_level) THEN
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading molecule information...'
+            WRITE (output_unit, "((T2,A))") 'TREXIO| Reading molecule information...'
          END IF
          rc = trexio_read_nucleus_num(f, nucleus_num)
          CALL trexio_error(rc)
 
          IF (myprint > medium_print_level) THEN
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear coordinates...'
+            WRITE (output_unit, "((T2,A))") 'TREXIO| Reading nuclear coordinates...'
          END IF
          ALLOCATE (coord(3, nucleus_num))
          rc = trexio_read_nucleus_coord(f, coord)
          CALL trexio_error(rc)
 
          IF (myprint > medium_print_level) THEN
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear labels...'
+            WRITE (output_unit, "((T2,A))") 'TREXIO| Reading nuclear labels...'
          END IF
          ALLOCATE (label(nucleus_num))
          rc = trexio_read_nucleus_label(f, label, 3)
          CALL trexio_error(rc)
 
          IF (myprint > medium_print_level) THEN
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear charges...'
+            WRITE (output_unit, "((T2,A))") 'TREXIO| Reading nuclear charges...'
          END IF
          ALLOCATE (charge(nucleus_num))
          rc = trexio_read_nucleus_charge(f, charge)
@@ -1119,7 +1118,7 @@ CONTAINS
             CPASSERT(charge(iatom) == zeff)
          END DO
 
-         WRITE(output_unit, "((T2,A))") 'TREXIO| Molecule is the same as in qs_env'
+         WRITE (output_unit, "((T2,A))") 'TREXIO| Molecule is the same as in qs_env'
          ! if we get here, we have the same molecule
          DEALLOCATE (coord)
          DEALLOCATE (label)
@@ -1129,7 +1128,7 @@ CONTAINS
       ! check whether we want to read something
       IF (PRESENT(mo_set_trexio)) THEN
          IF (output_unit > 1) THEN
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading molecular orbitals...'
+            WRITE (output_unit, "((T2,A))") 'TREXIO| Reading molecular orbitals...'
          END IF
 
          ! at the moment, we assume that the basis set is the same
@@ -1196,31 +1195,31 @@ CONTAINS
          ! read the MOs info
          IF (ionode) THEN
             IF (myprint > medium_print_level) THEN
-               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO coefficients...'
+               WRITE (output_unit, "((T2,A))") 'TREXIO| Reading MO coefficients...'
             END IF
             rc = trexio_read_mo_coefficient(f, mo_coefficient)
             CALL trexio_error(rc)
 
             IF (myprint > medium_print_level) THEN
-               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO energies...'
+               WRITE (output_unit, "((T2,A))") 'TREXIO| Reading MO energies...'
             END IF
             rc = trexio_read_mo_energy(f, mo_energy)
             CALL trexio_error(rc)
 
             IF (myprint > medium_print_level) THEN
-               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO occupations...'
+               WRITE (output_unit, "((T2,A))") 'TREXIO| Reading MO occupations...'
             END IF
             rc = trexio_read_mo_occupation(f, mo_occupation)
             CALL trexio_error(rc)
 
             IF (myprint > medium_print_level) THEN
-               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO spins...'
+               WRITE (output_unit, "((T2,A))") 'TREXIO| Reading MO spins...'
             END IF
             rc = trexio_read_mo_spin(f, mo_spin)
             CALL trexio_error(rc)
 
             IF (myprint > medium_print_level) THEN
-               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading shell angular momenta...'
+               WRITE (output_unit, "((T2,A))") 'TREXIO| Reading shell angular momenta...'
             END IF
             rc = trexio_read_basis_shell_ang_mom(f, shell_ang_mom)
             CALL trexio_error(rc)
@@ -1242,7 +1241,7 @@ CONTAINS
             nmo = nmo_spin(ispin)
             ! allocate local temp array to read MOs
             ALLOCATE (mos_sgf(nsgf, nmo))
-            mos_sgf(:,:) = 0.0_dp
+            mos_sgf(:, :) = 0.0_dp
 
             ! we need to reorder the MOs according to CP2K convention
             ! from m =  0, +1, -1, +2, -2, ..., +l, -l of TREXIO
@@ -1259,7 +1258,6 @@ CONTAINS
             END DO
             CPASSERT(i == nsgf)
 
-
             IF (nspins == 1) THEN
                maxocc = 2.0_dp
                nelectron = electron_num(1) + electron_num(2)
@@ -1273,7 +1271,7 @@ CONTAINS
             CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff_ref)
             CALL cp_fm_get_info(mo_coeff_ref, context=context, para_env=para_env, nrow_global=nrow_global)
             CALL cp_fm_struct_create(fm_struct_tmp, para_env=para_env, context=context, &
-                                       nrow_global=nrow_global, ncol_global=nmo)
+                                     nrow_global=nrow_global, ncol_global=nmo)
             CALL init_mo_set(mo_set_trexio(ispin), fm_struct=fm_struct_tmp, name="TREXIO MOs")
             CALL cp_fm_struct_release(fm_struct_tmp)
 
@@ -1302,7 +1300,7 @@ CONTAINS
       ! check whether we want to read derivatives
       IF (PRESENT(energy_derivative)) THEN
          IF (output_unit > 1) THEN
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading energy derivatives...'
+            WRITE (output_unit, "((T2,A))") 'TREXIO| Reading energy derivatives...'
          END IF
 
          ! Temporary solution: allocate here the energy derivatives matrix here
@@ -1310,7 +1308,7 @@ CONTAINS
          ! TODO: once available in TREXIO, first read size and then allocate
          ! in the same way done for the MOs
          ALLOCATE (dEdP(nsgf, nsgf))
-         dEdP(:,:) = 0.0_dp
+         dEdP(:, :) = 0.0_dp
 
          ! check if file exists and open it
          IF (ionode) THEN
@@ -1322,22 +1320,22 @@ CONTAINS
 
             ! read the header and check everything is fine
             IF (myprint > medium_print_level) THEN
-               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading header information...'
+               WRITE (output_unit, "((T2,A))") 'TREXIO| Reading header information...'
             END IF
-            READ(unit_dE, *) nrows, ncols
+            READ (unit_dE, *) nrows, ncols
             IF (myprint > medium_print_level) THEN
-               WRITE(output_unit, "((T2,A))") 'TREXIO| Check size of dEdP matrix...'
+               WRITE (output_unit, "((T2,A))") 'TREXIO| Check size of dEdP matrix...'
             END IF
             CPASSERT(nrows == nsgf)
             CPASSERT(ncols == nsgf)
 
             ! read the data
             IF (myprint > medium_print_level) THEN
-               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading dEdP matrix...'
+               WRITE (output_unit, "((T2,A))") 'TREXIO| Reading dEdP matrix...'
             END IF
             ! Read the data matrix
             DO i = 1, nrows
-               READ(unit_dE, *) (dEdP(i,j), j=1, ncols)
+               READ (unit_dE, *) (dEdP(i, j), j=1, ncols)
             END DO
 
             CALL close_file(unit_number=unit_dE)
@@ -1360,17 +1358,17 @@ CONTAINS
          CPASSERT(i == nsgf)
 
          ! Reshuffle
-         ALLOCATE(temp(nsgf, nsgf))
-         temp(:,:) = dEdP(:,:)
+         ALLOCATE (temp(nsgf, nsgf))
+         temp(:, :) = dEdP(:, :)
 
          ! Reorder rows and columns according to trexio_to_cp2k_ang_mom mapping
          DO j = 1, nsgf
             DO i = 1, nsgf
-               dEdP(trexio_to_cp2k_ang_mom(i), trexio_to_cp2k_ang_mom(j)) = temp(i,j)
+               dEdP(trexio_to_cp2k_ang_mom(i), trexio_to_cp2k_ang_mom(j)) = temp(i, j)
             END DO
          END DO
 
-         DEALLOCATE(temp)
+         DEALLOCATE (temp)
 
          CALL get_qs_env(qs_env, matrix_ks=matrix_s)
          DO ispin = 1, nspins
@@ -1387,11 +1385,11 @@ CONTAINS
             !!!!
 
             ! CALL dbcsr_reserve_all_blocks(matrix)
-            CALL dbcsr_iterator_start(iter,energy_derivative(ispin)%matrix)
+            CALL dbcsr_iterator_start(iter, energy_derivative(ispin)%matrix)
             DO WHILE (dbcsr_iterator_blocks_left(iter))
                CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                       row_size=row_size, col_size=col_size, &
-                                       row_offset=row_offset, col_offset=col_offset)
+                                              row_size=row_size, col_size=col_size, &
+                                              row_offset=row_offset, col_offset=col_offset)
 
                ! Copy data from array to block
                DO i = 1, row_size
@@ -1416,7 +1414,7 @@ CONTAINS
 
       ! Close the TREXIO file
       IF (ionode) THEN
-         WRITE(output_unit, "((T2,A,A))") 'TREXIO| Closing file named ', TRIM(filename)
+         WRITE (output_unit, "((T2,A,A))") 'TREXIO| Closing file named ', TRIM(filename)
          rc = trexio_close(f)
          CALL trexio_error(rc)
       END IF
@@ -1429,7 +1427,6 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE read_trexio
-
 
 #ifdef __TREXIO
 ! **************************************************************************************************

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -32,7 +32,8 @@ MODULE trexio_utils
                               cp_logger_type
    USE cp_dbcsr_api, ONLY: dbcsr_p_type, dbcsr_iterator_type, dbcsr_iterator_start, &
                            dbcsr_iterator_stop, dbcsr_iterator_blocks_left, &
-                           dbcsr_reserve_all_blocks, dbcsr_iterator_next_block
+                           dbcsr_reserve_all_blocks, dbcsr_iterator_next_block, &
+                           dbcsr_copy, dbcsr_set
    USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
    USE external_potential_types, ONLY: sgp_potential_type, get_potential
    USE input_section_types, ONLY: section_vals_type, section_vals_get, &
@@ -1015,7 +1016,8 @@ CONTAINS
                                                             save_cartesian, i, j, k, l, m, imo, ishell, &
                                                             nshell, shell_num, nucleus_num, natoms, ikind, &
                                                             iatom, nrow_global, nelectron, nrows, ncols, &
-                                                            row, col, blk_row, blk_col, row_size, col_size
+                                                            row, col, row_size, col_size, &
+                                                            row_offset, col_offset
       INTEGER, DIMENSION(2)                              :: nmo_spin, electron_num
       INTEGER, DIMENSION(:), ALLOCATABLE                 :: mo_spin, shell_ang_mom, trexio_to_cp2k_ang_mom
 
@@ -1028,9 +1030,9 @@ CONTAINS
       TYPE(cp_fm_type), POINTER                          :: mo_coeff_ref, mo_coeff_target
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
       TYPE(cp_blacs_env_type), POINTER                   :: context
-      ! TYPE(cell_type), POINTER                           :: cell => Null()
       TYPE(mp_para_env_type), POINTER                    :: para_env => Null()
       TYPE(dft_control_type), POINTER                    :: dft_control => Null()
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s => Null()
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: kind_set => Null()
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos => Null()
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set => Null()
@@ -1168,10 +1170,6 @@ CONTAINS
          END DO
          CPASSERT(mo_num == SUM(nmo_spin))
 
-            ! ALLOCATE (ao_shell(ao_num))
-            ! rc = trexio_read_ao_shell(f, ao_shell)
-            ! CALL trexio_error(rc)
-
          ALLOCATE (mo_coefficient(ao_num, mo_num))
          ALLOCATE (mo_energy(mo_num))
          ALLOCATE (mo_occupation(mo_num))
@@ -1286,7 +1284,8 @@ CONTAINS
             WRITE(output_unit, "((T2,A))") 'TREXIO| Reading Energy derivatives...'
          END IF
 
-         ! Temporary solution: allocate here the energy derivatives matrix
+         ! Temporary solution: allocate here the energy derivatives matrix here
+         ! assuming that nsgf is the same as the number read from the dEdP file
          ! TODO: once available in TREXIO, first read size and then allocate
          ! in the same way done for the MOs
          ALLOCATE (dEdP(nsgf, nsgf))
@@ -1314,12 +1313,6 @@ CONTAINS
                READ(unit_dE, *) (dEdP(i,j), j=1, ncols)
             END DO
 
-            !!!! DEBUG
-            ! DO i = 1, 5
-            !    WRITE(output_unit,'(*(F12.8))') (dEdP(i,j), j=1, 5)
-            ! END DO
-            !!!!
-
             CALL close_file(unit_number=unit_dE)
          END IF
 
@@ -1339,12 +1332,6 @@ CONTAINS
          END DO
          CPASSERT(i == nsgf)
 
-         !!!! DEBUG
-         ! DO i = 1, nsgf
-         !    WRITE(output_unit, '(*(I4,A,I4))') i, ' → ', trexio_to_cp2k_ang_mom(i)
-         ! END DO
-         !!!!
-
          ! Reshuffle
          ALLOCATE(temp(nsgf, nsgf))
          temp(:,:) = dEdP(:,:)
@@ -1357,42 +1344,43 @@ CONTAINS
          END DO
 
          DEALLOCATE(temp)
-         !!!! DEBUG
-         ! IF (output_unit > 1) THEN
-         !    DO i = 1, 5
-         !       WRITE(output_unit,'(*(F12.8))') (dEdP(i,j), j=1, 5)
-         !    END DO
-         ! END IF
-         !!!!
 
+         CALL get_qs_env(qs_env, matrix_ks=matrix_s)
          DO ispin = 1, nspins
-            ASSOCIATE(matrix => energy_derivative(ispin)%matrix)
-            CALL cp_dbcsr_write_sparse_matrix(matrix, 4, 4, qs_env, para_env, &
-                                              output_unit=output_unit, omit_headers=.false.)
+            ALLOCATE (energy_derivative(ispin)%matrix)
 
-            CALL dbcsr_reserve_all_blocks(matrix)
-            CALL dbcsr_iterator_start(iter, matrix)
+            ! we use the overlap matrix as a template, copying it but removing the sparsity
+            CALL dbcsr_copy(energy_derivative(ispin)%matrix, matrix_s(ispin)%matrix, &
+                            name='Energy Derivative', keep_sparsity=.FALSE.)
+            CALL dbcsr_set(energy_derivative(ispin)%matrix, 0.0_dp)
+
+            !!!! DEBUG
+            ! CALL cp_dbcsr_write_sparse_matrix(energy_derivative(ispin)%matrix, 4, 4, qs_env, para_env, &
+            !                                   output_unit=output_unit, omit_headers=.false.)
+            !!!!
+
+            ! CALL dbcsr_reserve_all_blocks(matrix)
+            CALL dbcsr_iterator_start(iter,energy_derivative(ispin)%matrix)
             DO WHILE (dbcsr_iterator_blocks_left(iter))
                CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
-                                       row_size=row_size, col_size=col_size)
+                                       row_size=row_size, col_size=col_size, &
+                                       row_offset=row_offset, col_offset=col_offset)
 
                ! Copy data from array to block
-               DO blk_col = 1, col_size
-                  DO blk_row = 1, row_size
-                     i = row + blk_row - 1
-                     j = col + blk_col - 1
-                     ! WRITE(output_unit, '(*(A, I4,A,I4))') 'Accessing element', i, ',',j
-                     data_block(blk_row, blk_col) = dEdP(i,j)
+               DO i = 1, row_size
+                  DO j = 1, col_size
+                     data_block(i, j) = dEdP(row_offset + i - 1, col_offset + j - 1)
                   END DO
                END DO
             END DO
             CALL dbcsr_iterator_stop(iter)
-            CALL cp_dbcsr_write_sparse_matrix(matrix, 4, 4, qs_env, para_env, &
-                                              output_unit=output_unit, omit_headers=.false.)
-            END ASSOCIATE
+            !!!! DEBUG
+            ! CALL cp_dbcsr_write_sparse_matrix(energy_derivative(ispin)%matrix, 4, 4, qs_env, para_env, &
+            !                                   output_unit=output_unit, omit_headers=.false.)
+            !!!!
          END DO
 
-      END IF
+      END IF ! finished reading energy derivatives
 
       ! Clean up
       IF (ALLOCATED(shell_ang_mom)) DEALLOCATE (shell_ang_mom)

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -22,7 +22,8 @@ MODULE trexio_utils
    USE cp_dbcsr_operations, ONLY: copy_dbcsr_to_fm
    USE cp_files, ONLY: close_file, file_exists, open_file
    USE cp_fm_types, ONLY: cp_fm_get_info, cp_fm_type, cp_fm_create, cp_fm_set_all, &
-                          cp_fm_get_submatrix, cp_fm_to_fm_submat_general, cp_fm_release
+                          cp_fm_get_submatrix, cp_fm_to_fm_submat_general, cp_fm_release, &
+                          cp_fm_set_element
    USE cp_fm_struct, ONLY: cp_fm_struct_create, &
                            cp_fm_struct_release, &
                            cp_fm_struct_type
@@ -45,27 +46,32 @@ MODULE trexio_utils
                                    qs_environment_type
    USE qs_kind_types, ONLY: get_qs_kind, get_qs_kind_set, &
                             qs_kind_type
-   USE qs_mo_types, ONLY: mo_set_type, get_mo_set
+   USE qs_mo_types, ONLY: mo_set_type, get_mo_set, init_mo_set, allocate_mo_set
 #ifdef __TREXIO
    USE trexio, ONLY: trexio_open, trexio_close, &
                      TREXIO_HDF5, TREXIO_SUCCESS, &
                      trexio_string_of_error, trexio_t, trexio_exit_code, &
                      trexio_write_metadata_code, trexio_write_metadata_code_num, &
-                     trexio_write_nucleus_coord, trexio_write_nucleus_num, &
-                     trexio_write_nucleus_charge, trexio_write_nucleus_label, &
+                     trexio_write_nucleus_coord, trexio_read_nucleus_coord, &
+                     trexio_write_nucleus_num, trexio_read_nucleus_num, &
+                     trexio_write_nucleus_charge, trexio_read_nucleus_charge, &
+                     trexio_write_nucleus_label, trexio_read_nucleus_label, &
                      trexio_write_nucleus_repulsion, &
                      trexio_write_cell_a, trexio_write_cell_b, trexio_write_cell_c, &
                      trexio_write_cell_g_a, trexio_write_cell_g_b, &
                      trexio_write_cell_g_c, trexio_write_cell_two_pi, &
                      trexio_write_pbc_periodic, trexio_write_pbc_k_point_num, &
                      trexio_write_pbc_k_point, trexio_write_pbc_k_point_weight, &
-                     trexio_write_electron_num, trexio_write_electron_up_num, &
-                     trexio_write_electron_dn_num, &
+                     trexio_write_electron_num, trexio_read_electron_num, &
+                     trexio_write_electron_up_num, trexio_read_electron_up_num, &
+                     trexio_write_electron_dn_num, trexio_read_electron_dn_num, &
                      trexio_write_state_num, trexio_write_state_id, &
                      trexio_write_state_energy, &
                      trexio_write_basis_type, trexio_write_basis_prim_num, &
-                     trexio_write_basis_shell_num, trexio_write_basis_nucleus_index, &
-                     trexio_write_basis_shell_ang_mom, trexio_write_basis_shell_factor, &
+                     trexio_write_basis_shell_num, trexio_read_basis_shell_num, &
+                     trexio_write_basis_nucleus_index, &
+                     trexio_write_basis_shell_ang_mom, trexio_read_basis_shell_ang_mom, &
+                     trexio_write_basis_shell_factor, &
                      trexio_write_basis_r_power, trexio_write_basis_shell_index, &
                      trexio_write_basis_exponent, trexio_write_basis_coefficient, &
                      trexio_write_basis_prim_factor, &
@@ -74,10 +80,15 @@ MODULE trexio_utils
                      trexio_write_ecp_nucleus_index, trexio_write_ecp_exponent, &
                      trexio_write_ecp_coefficient, trexio_write_ecp_power, &
                      trexio_write_ao_cartesian, trexio_write_ao_num, &
+                     trexio_read_ao_cartesian, trexio_read_ao_num, &
                      trexio_write_ao_shell, trexio_write_ao_normalization, &
+                     trexio_read_ao_shell, trexio_read_ao_normalization, &
                      trexio_write_mo_num, trexio_write_mo_energy, &
+                     trexio_read_mo_num, trexio_read_mo_energy, &
                      trexio_write_mo_occupation, trexio_write_mo_spin, &
+                     trexio_read_mo_occupation, trexio_read_mo_spin, &
                      trexio_write_mo_class, trexio_write_mo_coefficient, &
+                     trexio_read_mo_class, trexio_read_mo_coefficient, &
                      trexio_write_mo_coefficient_im, trexio_write_mo_k_point, &
                      trexio_write_mo_type
 #endif
@@ -89,7 +100,7 @@ MODULE trexio_utils
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'trexio_utils'
 
-   PUBLIC :: write_trexio
+   PUBLIC :: write_trexio, read_trexio
 
 CONTAINS
 
@@ -968,6 +979,314 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE write_trexio
+
+
+! **************************************************************************************************
+!> \brief Read a trexio file
+!> \param qs_env the qs environment with all the info of the computation
+!> \param trexio_section the section with the trexio info
+! **************************************************************************************************
+   SUBROUTINE read_trexio(qs_env, trexio_section, mo_set_trexio)
+      TYPE(qs_environment_type), INTENT(IN), POINTER                    :: qs_env
+      TYPE(section_vals_type), INTENT(IN), POINTER                      :: trexio_section
+      TYPE(mo_set_type), INTENT(OUT), DIMENSION(:), POINTER, OPTIONAL   :: mo_set_trexio
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'read_trexio'
+
+      INTEGER                                            :: handle
+
+#ifdef __TREXIO
+      INTEGER                                            :: output_unit
+      CHARACTER(len=default_path_length)                 :: filename
+      INTEGER(trexio_t)                                  :: f        ! The TREXIO file handle
+      INTEGER(trexio_exit_code)                          :: rc       ! TREXIO return code
+
+      LOGICAL                                            :: explicit, ionode
+
+      CHARACTER(LEN=2)                                   :: element_symbol
+      CHARACTER(LEN=2), DIMENSION(:), ALLOCATABLE        :: label
+
+      INTEGER                                            :: ao_num, mo_num, nmo, nspins, ispin, nsgf, &
+                                                            save_cartesian, i, j, k, l, m, imo, ishell, &
+                                                            nshell, shell_num, nucleus_num, natoms, ikind, &
+                                                            iatom, nrow_global, nelectron
+      INTEGER, DIMENSION(2)                              :: nmo_spin, electron_num
+      INTEGER, DIMENSION(:), ALLOCATABLE                 :: mo_spin, shell_ang_mom
+
+      REAL(KIND=dp)                                      :: zeff, maxocc
+      REAL(KIND=dp), DIMENSION(:), ALLOCATABLE           :: mo_energy, mo_occupation, charge
+      REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: mo_coefficient, mos_sgf, coord
+
+      TYPE(cp_logger_type), POINTER                      :: logger => Null()
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff_ref, mo_coeff_target
+      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
+      TYPE(cp_blacs_env_type), POINTER                   :: context
+      ! TYPE(cell_type), POINTER                           :: cell => Null()
+      TYPE(mp_para_env_type), POINTER                    :: para_env => Null()
+      TYPE(dft_control_type), POINTER                    :: dft_control => Null()
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: kind_set => Null()
+      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos => Null()
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set => Null()
+#endif
+
+      CALL timeset(routineN, handle)
+
+#ifdef __TREXIO
+      logger => cp_get_default_logger()
+      output_unit = cp_logger_get_default_io_unit(logger)
+
+      CPASSERT(ASSOCIATED(qs_env))
+
+      ! get filename
+      CALL section_vals_val_get(trexio_section, "FILENAME", c_val=filename, explicit=explicit)
+      IF (.NOT. explicit) THEN
+         filename = TRIM(logger%iter_info%project_name)//'-TREXIO.h5'
+      ELSE
+         filename = TRIM(filename)//'.h5'
+      END IF
+
+      CALL get_qs_env(qs_env, para_env=para_env)
+      ionode = para_env%is_source()
+
+      ! fmtstr = "(T2,A,I5,1X,I5,1X,A,1X,A6,  (1X,F  .  ))"
+
+      ! Open the TREXIO file and check that we have the same molecule as in qs_env
+      IF (ionode) THEN
+         WRITE(output_unit, "((T2,A,A))") 'TREXIO| Opening file named ', TRIM(filename)
+         f = trexio_open(filename, 'r', TREXIO_HDF5, rc)
+         CALL trexio_error(rc)
+
+         WRITE(output_unit, "((T2,A))") 'TREXIO| Reading number of nuclei...'
+         rc = trexio_read_nucleus_num(f, nucleus_num)
+         CALL trexio_error(rc)
+
+         WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear coordinates...'
+         ALLOCATE (coord(3, nucleus_num))
+         rc = trexio_read_nucleus_coord(f, coord)
+         CALL trexio_error(rc)
+
+         WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear labels...'
+         ALLOCATE (label(nucleus_num))
+         rc = trexio_read_nucleus_label(f, label, 3)
+         CALL trexio_error(rc)
+
+         WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear charges...'
+         ALLOCATE (charge(nucleus_num))
+         rc = trexio_read_nucleus_charge(f, charge)
+         CALL trexio_error(rc)
+
+         ! get the same info from qs_env
+         CALL get_qs_env(qs_env, particle_set=particle_set, qs_kind_set=kind_set, natom=natoms)
+
+         ! check that we have the same number of atoms
+         CPASSERT(nucleus_num == natoms)
+
+         DO iatom = 1, natoms
+            ! compare the coordinates within a certain tolerance
+            DO i = 1, 3
+               CPASSERT(ABS(coord(i, iatom) - particle_set(iatom)%r(i)) < 1.0E-6_dp)
+            END DO
+
+            ! figure out the element symbol and to which kind_set entry this atomic_kind corresponds to
+            CALL get_atomic_kind(particle_set(iatom)%atomic_kind, element_symbol=element_symbol, kind_number=ikind)
+            ! check that the element symbol is the same
+            CPASSERT(TRIM(element_symbol) == TRIM(label(iatom)))
+
+            ! get the effective nuclear charge for this kind
+            CALL get_qs_kind(kind_set(ikind), zeff=zeff)
+            ! check that the nuclear charge is also the same
+            CPASSERT(charge(iatom) == zeff)
+         END DO
+
+         WRITE(output_unit, "((T2,A))") 'TREXIO| Molecule is the same as in qs_env'
+         ! if we get here, we have the same molecule
+         DEALLOCATE (coord)
+         DEALLOCATE (label)
+         DEALLOCATE (charge)
+      END IF
+
+      ! check whether we want to read something
+      IF (PRESENT(mo_set_trexio)) THEN
+         IF (output_unit > 1) THEN
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MOs information...'
+         END IF
+
+         ! at the moment, we assume that the basis set is the same
+         ! first we read all arrays lengths we need from the trexio file
+         IF (ionode) THEN
+            rc = trexio_read_ao_cartesian(f, save_cartesian)
+            CALL trexio_error(rc)
+
+            rc = trexio_read_ao_num(f, ao_num)
+            CALL trexio_error(rc)
+
+            rc = trexio_read_mo_num(f, mo_num)
+            CALL trexio_error(rc)
+
+            rc = trexio_read_basis_shell_num(f, shell_num)
+            CALL trexio_error(rc)
+
+            rc = trexio_read_electron_up_num(f, electron_num(1))
+            CALL trexio_error(rc)
+
+            rc = trexio_read_electron_dn_num(f, electron_num(2))
+            CALL trexio_error(rc)
+         END IF
+
+         ! broadcast information to all processors and allocate arrays
+         CALL para_env%bcast(save_cartesian, para_env%source)
+         CALL para_env%bcast(ao_num, para_env%source)
+         CALL para_env%bcast(mo_num, para_env%source)
+         CALL para_env%bcast(electron_num, para_env%source)
+         CALL para_env%bcast(shell_num, para_env%source)
+
+         IF (save_cartesian == 1) THEN
+            CPABORT('Reading Cartesian AOs is not yet supported.')
+         END IF
+
+         ! check that the number of AOs and shells is the same
+         CALL get_qs_env(qs_env, qs_kind_set=kind_set)
+         CALL get_qs_kind_set(kind_set, nsgf=nsgf, nshell=nshell)
+         CPASSERT(ao_num == nsgf)
+         CPASSERT(shell_num == nshell)
+
+         ! check that the number of MOs is the same
+         CALL get_qs_env(qs_env, mos=mos, dft_control=dft_control)
+         nspins = dft_control%nspins
+         nmo_spin(:) = 0
+         DO ispin = 1, nspins
+            CALL get_mo_set(mos(ispin), nmo=nmo)
+            nmo_spin(ispin) = nmo
+         END DO
+         CPASSERT(mo_num == SUM(nmo_spin))
+
+            ! ALLOCATE (ao_shell(ao_num))
+            ! rc = trexio_read_ao_shell(f, ao_shell)
+            ! CALL trexio_error(rc)
+
+         ALLOCATE (mo_coefficient(ao_num, mo_num))
+         ALLOCATE (mo_energy(mo_num))
+         ALLOCATE (mo_occupation(mo_num))
+         ALLOCATE (mo_spin(mo_num))
+         ALLOCATE (shell_ang_mom(shell_num))
+
+         mo_coefficient(:, :) = 0.0_dp
+         mo_energy(:) = 0.0_dp
+         mo_occupation(:) = 0.0_dp
+         mo_spin(:) = 0
+         shell_ang_mom(:) = 0
+
+         ! read the MOs info
+         IF (ionode) THEN
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO coefficients...'
+            rc = trexio_read_mo_coefficient(f, mo_coefficient)
+            CALL trexio_error(rc)
+
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO energies...'
+            rc = trexio_read_mo_energy(f, mo_energy)
+            CALL trexio_error(rc)
+
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO occupations...'
+            rc = trexio_read_mo_occupation(f, mo_occupation)
+            CALL trexio_error(rc)
+
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO spins...'
+            rc = trexio_read_mo_spin(f, mo_spin)
+            CALL trexio_error(rc)
+
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading shell angular momenta...'
+            rc = trexio_read_basis_shell_ang_mom(f, shell_ang_mom)
+            CALL trexio_error(rc)
+         END IF
+
+         ! broadcast the data to all processors
+         CALL para_env%bcast(mo_coefficient, para_env%source)
+         CALL para_env%bcast(mo_energy, para_env%source)
+         CALL para_env%bcast(mo_occupation, para_env%source)
+         CALL para_env%bcast(mo_spin, para_env%source)
+         CALL para_env%bcast(shell_ang_mom, para_env%source)
+
+         ! assume nspins and nmo_spin match the ones in the trexio file
+         ! reorder magnetic quantum number
+         DO ispin = 1, nspins
+            ! global MOs index
+            imo = (ispin - 1)*nmo_spin(1)
+            ! get number of MOs for this spin
+            nmo = nmo_spin(ispin)
+            ! allocate local temp array to read MOs
+            ALLOCATE (mos_sgf(nsgf, nmo))
+            mos_sgf(:,:) = 0.0_dp
+
+            ! we need to reorder the MOs according to CP2K convention
+            ! from m =  0, +1, -1, +2, -2, ..., +l, -l of TREXIO
+            !   to m = -l, -l+1, ..., 0, ..., l-1, l   of CP2K
+            i = 0
+            DO ishell = 1, shell_num
+               l = shell_ang_mom(ishell)
+               DO k = 1, 2*l + 1
+                  ! map from running index k: 1...2l+1 to magnetic quantum number m in TREXIO convention
+                  m = (-1)**k*FLOOR(REAL(k, KIND=dp)/2.0_dp)
+                  mos_sgf(i + l + 1 + m, :) = mo_coefficient(i + k, imo + 1:imo + nmo)
+               END DO
+               i = i + 2*l + 1
+            END DO
+            CPASSERT(i == nsgf)
+
+
+            IF (nspins == 1) THEN
+               maxocc = 2.0_dp
+               nelectron = electron_num(1) + electron_num(2)
+            ELSE
+               maxocc = 1.0_dp
+               nelectron = electron_num(ispin)
+            END IF
+            ! the right number of active electrons per spin channel is initialized further down
+            CALL allocate_mo_set(mo_set_trexio(ispin), nsgf, nmo, nelectron, 0.0_dp, maxocc, 0.0_dp)
+
+            CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff_ref)
+            CALL cp_fm_get_info(mo_coeff_ref, context=context, para_env=para_env, nrow_global=nrow_global)
+            CALL cp_fm_struct_create(fm_struct_tmp, para_env=para_env, context=context, &
+                                       nrow_global=nrow_global, ncol_global=nmo)
+            CALL init_mo_set(mo_set_trexio(ispin), fm_struct=fm_struct_tmp, name="TREXIO MOs")
+            CALL cp_fm_struct_release(fm_struct_tmp)
+
+            CALL get_mo_set(mo_set_trexio(ispin), mo_coeff=mo_coeff_target)
+            DO j = 1, nmo
+               ! make sure I copy the right spin channel
+               CPASSERT(mo_spin(j) == ispin - 1)
+               mo_set_trexio(ispin)%eigenvalues(j) = mo_energy(imo + j)
+               mo_set_trexio(ispin)%occupation_numbers(j) = mo_occupation(imo + j)
+               DO i = 1, nsgf
+                  CALL cp_fm_set_element(mo_coeff_target, i, j, mos_sgf(i, j))
+               END DO
+            END DO
+
+            DEALLOCATE (mos_sgf)
+         END DO
+
+         DEALLOCATE (mo_coefficient)
+         DEALLOCATE (mo_energy)
+         DEALLOCATE (mo_occupation)
+         DEALLOCATE (mo_spin)
+         DEALLOCATE (shell_ang_mom)
+
+      END IF ! if MOs should be read
+
+      ! Close the TREXIO file
+      IF (ionode) THEN
+         rc = trexio_close(f)
+         CALL trexio_error(rc)
+      END IF
+
+#else
+      MARK_USED(qs_env)
+      MARK_USED(trexio_section)
+      CPWARN('TREXIO support has not been enabled in this build.')
+#endif
+      CALL timestop(handle)
+
+   END SUBROUTINE read_trexio
+
 
 #ifdef __TREXIO
 ! **************************************************************************************************

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -30,6 +30,10 @@ MODULE trexio_utils
    USE cp_log_handling, ONLY: cp_get_default_logger, &
                               cp_logger_get_default_io_unit, &
                               cp_logger_type
+   USE cp_dbcsr_api, ONLY: dbcsr_p_type, dbcsr_iterator_type, dbcsr_iterator_start, &
+                           dbcsr_iterator_stop, dbcsr_iterator_blocks_left, &
+                           dbcsr_reserve_all_blocks, dbcsr_iterator_next_block
+   USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
    USE external_potential_types, ONLY: sgp_potential_type, get_potential
    USE input_section_types, ONLY: section_vals_type, section_vals_get, &
                                   section_vals_val_get
@@ -986,18 +990,19 @@ CONTAINS
 !> \param qs_env the qs environment with all the info of the computation
 !> \param trexio_section the section with the trexio info
 ! **************************************************************************************************
-   SUBROUTINE read_trexio(qs_env, trexio_section, mo_set_trexio)
+   SUBROUTINE read_trexio(qs_env, trexio_section, mo_set_trexio, energy_derivative)
       TYPE(qs_environment_type), INTENT(IN), POINTER                    :: qs_env
       TYPE(section_vals_type), INTENT(IN), POINTER                      :: trexio_section
       TYPE(mo_set_type), INTENT(OUT), DIMENSION(:), POINTER, OPTIONAL   :: mo_set_trexio
+      TYPE(dbcsr_p_type), INTENT(OUT), DIMENSION(:), POINTER, OPTIONAL  :: energy_derivative
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'read_trexio'
 
       INTEGER                                            :: handle
 
 #ifdef __TREXIO
-      INTEGER                                            :: output_unit
-      CHARACTER(len=default_path_length)                 :: filename
+      INTEGER                                            :: output_unit, unit_dE
+      CHARACTER(len=default_path_length)                 :: filename, filename_dE
       INTEGER(trexio_t)                                  :: f        ! The TREXIO file handle
       INTEGER(trexio_exit_code)                          :: rc       ! TREXIO return code
 
@@ -1009,13 +1014,15 @@ CONTAINS
       INTEGER                                            :: ao_num, mo_num, nmo, nspins, ispin, nsgf, &
                                                             save_cartesian, i, j, k, l, m, imo, ishell, &
                                                             nshell, shell_num, nucleus_num, natoms, ikind, &
-                                                            iatom, nrow_global, nelectron
+                                                            iatom, nrow_global, nelectron, nrows, ncols, &
+                                                            row, col, blk_row, blk_col, row_size, col_size
       INTEGER, DIMENSION(2)                              :: nmo_spin, electron_num
-      INTEGER, DIMENSION(:), ALLOCATABLE                 :: mo_spin, shell_ang_mom
+      INTEGER, DIMENSION(:), ALLOCATABLE                 :: mo_spin, shell_ang_mom, trexio_to_cp2k_ang_mom
 
       REAL(KIND=dp)                                      :: zeff, maxocc
       REAL(KIND=dp), DIMENSION(:), ALLOCATABLE           :: mo_energy, mo_occupation, charge
-      REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: mo_coefficient, mos_sgf, coord
+      REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: mo_coefficient, mos_sgf, coord, dEdP, temp
+      REAL(KIND=dp), DIMENSION(:,:), POINTER             :: data_block
 
       TYPE(cp_logger_type), POINTER                      :: logger => Null()
       TYPE(cp_fm_type), POINTER                          :: mo_coeff_ref, mo_coeff_target
@@ -1027,6 +1034,7 @@ CONTAINS
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: kind_set => Null()
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos => Null()
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set => Null()
+      TYPE(dbcsr_iterator_type)                          :: iter
 #endif
 
       CALL timeset(routineN, handle)
@@ -1041,14 +1049,14 @@ CONTAINS
       CALL section_vals_val_get(trexio_section, "FILENAME", c_val=filename, explicit=explicit)
       IF (.NOT. explicit) THEN
          filename = TRIM(logger%iter_info%project_name)//'-TREXIO.h5'
+         filename_dE = TRIM(logger%iter_info%project_name)//'-TREXIO.dEdP.dat'
       ELSE
          filename = TRIM(filename)//'.h5'
+         filename_dE = TRIM(filename)//'.dEdP.dat'
       END IF
 
       CALL get_qs_env(qs_env, para_env=para_env)
       ionode = para_env%is_source()
-
-      ! fmtstr = "(T2,A,I5,1X,I5,1X,A,1X,A6,  (1X,F  .  ))"
 
       ! Open the TREXIO file and check that we have the same molecule as in qs_env
       IF (ionode) THEN
@@ -1268,9 +1276,128 @@ CONTAINS
          DEALLOCATE (mo_energy)
          DEALLOCATE (mo_occupation)
          DEALLOCATE (mo_spin)
-         DEALLOCATE (shell_ang_mom)
+         ! DEALLOCATE (shell_ang_mom)
 
       END IF ! if MOs should be read
+
+      ! check whether we want to read derivatives
+      IF (PRESENT(energy_derivative)) THEN
+         IF (output_unit > 1) THEN
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading Energy derivatives...'
+         END IF
+
+         ! Temporary solution: allocate here the energy derivatives matrix
+         ! TODO: once available in TREXIO, first read size and then allocate
+         ! in the same way done for the MOs
+         ALLOCATE (dEdP(nsgf, nsgf))
+         dEdP(:,:) = 0.0_dp
+
+         ! check if file exists and open it
+         IF (ionode) THEN
+            IF (file_exists(filename_dE)) THEN
+               CALL open_file(file_name=filename_dE, file_status="OLD", unit_number=unit_dE)
+            ELSE
+               CPABORT("Energy derivatives file "//TRIM(filename_dE)//" not found")
+            END IF
+
+            ! read the header and check everything is fine
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading header information...'
+            READ(unit_dE, *) nrows, ncols
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Check size of dEdP matrix...'
+            CPASSERT(nrows == nsgf)
+            CPASSERT(ncols == nsgf)
+
+            ! read the data
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading dEdP matrix...'
+            ! Read the data matrix
+            DO i = 1, nrows
+               READ(unit_dE, *) (dEdP(i,j), j=1, ncols)
+            END DO
+
+            !!!! DEBUG
+            ! DO i = 1, 5
+            !    WRITE(output_unit,'(*(F12.8))') (dEdP(i,j), j=1, 5)
+            ! END DO
+            !!!!
+
+            CALL close_file(unit_number=unit_dE)
+         END IF
+
+         ! send data to all processes
+         CALL para_env%bcast(dEdP, para_env%source)
+
+         ! AO order map from TREXIO to CP2K
+         ALLOCATE (trexio_to_cp2k_ang_mom(nsgf))
+         i = 0
+         DO ishell = 1, shell_num
+            l = shell_ang_mom(ishell)
+            DO k = 1, 2*l + 1
+               m = (-1)**k*FLOOR(REAL(k, KIND=dp)/2.0_dp)
+               trexio_to_cp2k_ang_mom(i + l + 1 + m) = i + k
+            END DO
+            i = i + 2*l + 1
+         END DO
+         CPASSERT(i == nsgf)
+
+         !!!! DEBUG
+         ! DO i = 1, nsgf
+         !    WRITE(output_unit, '(*(I4,A,I4))') i, ' → ', trexio_to_cp2k_ang_mom(i)
+         ! END DO
+         !!!!
+
+         ! Reshuffle
+         ALLOCATE(temp(nsgf, nsgf))
+         temp(:,:) = dEdP(:,:)
+
+         ! Reorder rows and columns according to trexio_to_cp2k_ang_mom mapping
+         DO j = 1, nsgf
+            DO i = 1, nsgf
+               dEdP(trexio_to_cp2k_ang_mom(i), trexio_to_cp2k_ang_mom(j)) = temp(i,j)
+            END DO
+         END DO
+
+         DEALLOCATE(temp)
+         !!!! DEBUG
+         ! IF (output_unit > 1) THEN
+         !    DO i = 1, 5
+         !       WRITE(output_unit,'(*(F12.8))') (dEdP(i,j), j=1, 5)
+         !    END DO
+         ! END IF
+         !!!!
+
+         DO ispin = 1, nspins
+            ASSOCIATE(matrix => energy_derivative(ispin)%matrix)
+            CALL cp_dbcsr_write_sparse_matrix(matrix, 4, 4, qs_env, para_env, &
+                                              output_unit=output_unit, omit_headers=.false.)
+
+            CALL dbcsr_reserve_all_blocks(matrix)
+            CALL dbcsr_iterator_start(iter, matrix)
+            DO WHILE (dbcsr_iterator_blocks_left(iter))
+               CALL dbcsr_iterator_next_block(iter, row, col, data_block, &
+                                       row_size=row_size, col_size=col_size)
+
+               ! Copy data from array to block
+               DO blk_col = 1, col_size
+                  DO blk_row = 1, row_size
+                     i = row + blk_row - 1
+                     j = col + blk_col - 1
+                     ! WRITE(output_unit, '(*(A, I4,A,I4))') 'Accessing element', i, ',',j
+                     data_block(blk_row, blk_col) = dEdP(i,j)
+                  END DO
+               END DO
+            END DO
+            CALL dbcsr_iterator_stop(iter)
+            CALL cp_dbcsr_write_sparse_matrix(matrix, 4, 4, qs_env, para_env, &
+                                              output_unit=output_unit, omit_headers=.false.)
+            END ASSOCIATE
+         END DO
+
+      END IF
+
+      ! Clean up
+      IF (ALLOCATED(shell_ang_mom)) DEALLOCATE (shell_ang_mom)
+      IF (ALLOCATED(trexio_to_cp2k_ang_mom)) DEALLOCATE (trexio_to_cp2k_ang_mom)
+      IF (ALLOCATED(dEdP)) DEALLOCATE (dEdP)
 
       ! Close the TREXIO file
       IF (ionode) THEN

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -35,6 +35,7 @@ MODULE trexio_utils
                            dbcsr_reserve_all_blocks, dbcsr_iterator_next_block, &
                            dbcsr_copy, dbcsr_set
    USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
+   USE cp_output_handling,              ONLY: medium_print_level
    USE external_potential_types, ONLY: sgp_potential_type, get_potential
    USE input_section_types, ONLY: section_vals_type, section_vals_get, &
                                   section_vals_val_get
@@ -1019,7 +1020,7 @@ CONTAINS
                                                             nshell, shell_num, nucleus_num, natoms, ikind, &
                                                             iatom, nrow_global, nelectron, nrows, ncols, &
                                                             row, col, row_size, col_size, &
-                                                            row_offset, col_offset
+                                                            row_offset, col_offset, myprint
       INTEGER, DIMENSION(2)                              :: nmo_spin, electron_num
       INTEGER, DIMENSION(:), ALLOCATABLE                 :: mo_spin, shell_ang_mom, trexio_to_cp2k_ang_mom
 
@@ -1046,6 +1047,7 @@ CONTAINS
 #ifdef __TREXIO
       logger => cp_get_default_logger()
       output_unit = cp_logger_get_default_io_unit(logger)
+      myprint = logger%iter_info%print_level
 
       CPASSERT(ASSOCIATED(qs_env))
 
@@ -1067,21 +1069,29 @@ CONTAINS
          f = trexio_open(filename, 'r', TREXIO_HDF5, rc)
          CALL trexio_error(rc)
 
-         WRITE(output_unit, "((T2,A))") 'TREXIO| Reading number of nuclei...'
+         IF (myprint > medium_print_level) THEN
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading molecule information...'
+         END IF
          rc = trexio_read_nucleus_num(f, nucleus_num)
          CALL trexio_error(rc)
 
-         WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear coordinates...'
+         IF (myprint > medium_print_level) THEN
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear coordinates...'
+         END IF
          ALLOCATE (coord(3, nucleus_num))
          rc = trexio_read_nucleus_coord(f, coord)
          CALL trexio_error(rc)
 
-         WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear labels...'
+         IF (myprint > medium_print_level) THEN
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear labels...'
+         END IF
          ALLOCATE (label(nucleus_num))
          rc = trexio_read_nucleus_label(f, label, 3)
          CALL trexio_error(rc)
 
-         WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear charges...'
+         IF (myprint > medium_print_level) THEN
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading nuclear charges...'
+         END IF
          ALLOCATE (charge(nucleus_num))
          rc = trexio_read_nucleus_charge(f, charge)
          CALL trexio_error(rc)
@@ -1119,7 +1129,7 @@ CONTAINS
       ! check whether we want to read something
       IF (PRESENT(mo_set_trexio)) THEN
          IF (output_unit > 1) THEN
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MOs information...'
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading molecular orbitals...'
          END IF
 
          ! at the moment, we assume that the basis set is the same
@@ -1185,23 +1195,33 @@ CONTAINS
 
          ! read the MOs info
          IF (ionode) THEN
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO coefficients...'
+            IF (myprint > medium_print_level) THEN
+               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO coefficients...'
+            END IF
             rc = trexio_read_mo_coefficient(f, mo_coefficient)
             CALL trexio_error(rc)
 
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO energies...'
+            IF (myprint > medium_print_level) THEN
+               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO energies...'
+            END IF
             rc = trexio_read_mo_energy(f, mo_energy)
             CALL trexio_error(rc)
 
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO occupations...'
+            IF (myprint > medium_print_level) THEN
+               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO occupations...'
+            END IF
             rc = trexio_read_mo_occupation(f, mo_occupation)
             CALL trexio_error(rc)
 
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO spins...'
+            IF (myprint > medium_print_level) THEN
+               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading MO spins...'
+            END IF
             rc = trexio_read_mo_spin(f, mo_spin)
             CALL trexio_error(rc)
 
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading shell angular momenta...'
+            IF (myprint > medium_print_level) THEN
+               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading shell angular momenta...'
+            END IF
             rc = trexio_read_basis_shell_ang_mom(f, shell_ang_mom)
             CALL trexio_error(rc)
          END IF
@@ -1282,7 +1302,7 @@ CONTAINS
       ! check whether we want to read derivatives
       IF (PRESENT(energy_derivative)) THEN
          IF (output_unit > 1) THEN
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading Energy derivatives...'
+            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading energy derivatives...'
          END IF
 
          ! Temporary solution: allocate here the energy derivatives matrix here
@@ -1301,14 +1321,20 @@ CONTAINS
             END IF
 
             ! read the header and check everything is fine
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading header information...'
+            IF (myprint > medium_print_level) THEN
+               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading header information...'
+            END IF
             READ(unit_dE, *) nrows, ncols
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Check size of dEdP matrix...'
+            IF (myprint > medium_print_level) THEN
+               WRITE(output_unit, "((T2,A))") 'TREXIO| Check size of dEdP matrix...'
+            END IF
             CPASSERT(nrows == nsgf)
             CPASSERT(ncols == nsgf)
 
             ! read the data
-            WRITE(output_unit, "((T2,A))") 'TREXIO| Reading dEdP matrix...'
+            IF (myprint > medium_print_level) THEN
+               WRITE(output_unit, "((T2,A))") 'TREXIO| Reading dEdP matrix...'
+            END IF
             ! Read the data matrix
             DO i = 1, nrows
                READ(unit_dE, *) (dEdP(i,j), j=1, ncols)
@@ -1390,6 +1416,7 @@ CONTAINS
 
       ! Close the TREXIO file
       IF (ionode) THEN
+         WRITE(output_unit, "((T2,A,A))") 'TREXIO| Closing file named ', TRIM(filename)
          rc = trexio_close(f)
          CALL trexio_error(rc)
       END IF

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -989,11 +989,13 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief Read a trexio file
 !> \param qs_env the qs environment with all the info of the computation
-!> \param trexio_section the section with the trexio info
+!> \param trexio_filename the trexio filename without the extension
+!> \param mo_set_trexio the MO set to read from the trexio file
+!> \param energy_derivative the energy derivative to read from the trexio file
 ! **************************************************************************************************
-   SUBROUTINE read_trexio(qs_env, trexio_section, mo_set_trexio, energy_derivative)
+   SUBROUTINE read_trexio(qs_env, trexio_filename, mo_set_trexio, energy_derivative)
       TYPE(qs_environment_type), INTENT(IN), POINTER                    :: qs_env
-      TYPE(section_vals_type), INTENT(IN), POINTER                      :: trexio_section
+      CHARACTER(len=*), INTENT(IN), OPTIONAL                            :: trexio_filename
       TYPE(mo_set_type), INTENT(OUT), DIMENSION(:), POINTER, OPTIONAL   :: mo_set_trexio
       TYPE(dbcsr_p_type), INTENT(OUT), DIMENSION(:), POINTER, OPTIONAL  :: energy_derivative
 
@@ -1007,7 +1009,7 @@ CONTAINS
       INTEGER(trexio_t)                                  :: f        ! The TREXIO file handle
       INTEGER(trexio_exit_code)                          :: rc       ! TREXIO return code
 
-      LOGICAL                                            :: explicit, ionode
+      LOGICAL                                            :: ionode
 
       CHARACTER(LEN=2)                                   :: element_symbol
       CHARACTER(LEN=2), DIMENSION(:), ALLOCATABLE        :: label
@@ -1048,13 +1050,12 @@ CONTAINS
       CPASSERT(ASSOCIATED(qs_env))
 
       ! get filename
-      CALL section_vals_val_get(trexio_section, "FILENAME", c_val=filename, explicit=explicit)
-      IF (.NOT. explicit) THEN
+      IF (.NOT. PRESENT(trexio_filename)) THEN
          filename = TRIM(logger%iter_info%project_name)//'-TREXIO.h5'
          filename_dE = TRIM(logger%iter_info%project_name)//'-TREXIO.dEdP.dat'
       ELSE
-         filename = TRIM(filename)//'.h5'
-         filename_dE = TRIM(filename)//'.dEdP.dat'
+         filename = TRIM(trexio_filename)//'.h5'
+         filename_dE = TRIM(trexio_filename)//'.dEdP.dat'
       END IF
 
       CALL get_qs_env(qs_env, para_env=para_env)


### PR DESCRIPTION
Implement a subroutine to read information from trexio files. At the moment it supports reading MOs and energy derivatives (though from a different text file, waiting that TREXIO supports the right container for this).