### PR TITLE
DBM: hyper-parameters and other improvements

### DIFF
--- a/src/dbm/dbm_distribution.c
+++ b/src/dbm/dbm_distribution.c
@@ -15,6 +15,7 @@
 
 #include "dbm_distribution.h"
 #include "dbm_hyperparams.h"
+#include "dbm_internal.h"
 
 /*******************************************************************************
  * \brief Private routine for creating a new one dimensional distribution.
@@ -69,25 +70,20 @@ static void dbm_dist_1d_free(dbm_dist_1d_t *dist) {
 }
 
 /*******************************************************************************
- * \brief Returns the larger of two given integer (missing from the C standard)
- * \author Ole Schuett
- ******************************************************************************/
-static inline int imax(int x, int y) { return (x > y ? x : y); }
-
-/*******************************************************************************
  * \brief Private routine for finding the optimal number of shard rows.
  * \author Ole Schuett
  ******************************************************************************/
 static int find_best_nrow_shards(const int nshards, const int nrows,
                                  const int ncols) {
-  const double target = (double)imax(nrows, 1) / (double)imax(ncols, 1);
+  const double target = (double)DBM_MAX(nrows, 1) / (double)DBM_MAX(ncols, 1);
   int best_nrow_shards = nshards;
   double best_error = fabs(log(target / (double)nshards));
 
   for (int nrow_shards = 1; nrow_shards <= nshards; nrow_shards++) {
     const int ncol_shards = nshards / nrow_shards;
-    if (nrow_shards * ncol_shards != nshards)
+    if (nrow_shards * ncol_shards != nshards) {
       continue; // Not a factor of nshards.
+    }
     const double ratio = (double)nrow_shards / (double)ncol_shards;
     const double error = fabs(log(target / ratio));
     if (error < best_error) {
@@ -120,7 +116,7 @@ void dbm_distribution_new(dbm_distribution_t **dist_out, const int fortran_comm,
   const int col_dim_remains[2] = {0, 1};
   const dbm_mpi_comm_t col_comm = dbm_mpi_cart_sub(dist->comm, col_dim_remains);
 
-  const int nshards = SHARDS_PER_THREAD * omp_get_max_threads();
+  const int nshards = DBM_SHARDS_PER_THREAD * omp_get_max_threads();
   const int nrow_shards = find_best_nrow_shards(nshards, nrows, ncols);
   const int ncol_shards = nshards / nrow_shards;
 

--- a/src/dbm/dbm_hyperparams.h
+++ b/src/dbm/dbm_hyperparams.h
@@ -8,13 +8,12 @@
 #ifndef DBM_HYPERPARAMS_H
 #define DBM_HYPERPARAMS_H
 
-// TODO: Tune parameters, check if dynamic OpenMP scheduling is really faster?
-
-#define HASHTABLE_FACTOR 3.0
-#define ALLOCATION_FACTOR 1.5
-#define SHARDS_PER_THREAD 1.0
-#define MAX_BATCH_SIZE 30000
-#define BATCH_NUM_BUCKETS 1000
+#define DBM_OMP_SCHEDULE schedule(dynamic, 1)
+#define DBM_HASHTABLE_FACTOR 3.0
+#define DBM_ALLOCATION_FACTOR 1.5
+#define DBM_SHARDS_PER_THREAD 1.0
+#define DBM_MAX_BATCH_SIZE 30000
+#define DBM_BATCH_NUM_BUCKETS 1000
 
 #endif
 

--- a/src/dbm/dbm_internal.h
+++ b/src/dbm/dbm_internal.h
@@ -5,8 +5,13 @@
 /*  SPDX-License-Identifier: BSD-3-Clause                                     */
 /*----------------------------------------------------------------------------*/
 
-#ifndef DBM_MULTIPLY_INTERNAL_H
-#define DBM_MULTIPLY_INTERNAL_H
+#ifndef DBM_INTERNAL_H
+#define DBM_INTERNAL_H
+
+/*******************************************************************************
+ * \brief Returns the larger of two given integer (missing from the C standard)
+ ******************************************************************************/
+#define DBM_MAX(X, Y) ((X) > (Y) ? (X) : (Y))
 
 /*******************************************************************************
  * \brief Internal struct for storing a dbm_block_t plus its norm.

--- a/src/dbm/dbm_matrix.c
+++ b/src/dbm/dbm_matrix.c
@@ -97,7 +97,7 @@ void dbm_copy(dbm_matrix_t *matrix_a, const dbm_matrix_t *matrix_b) {
 
   assert(matrix_a->dist == matrix_b->dist);
 
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix_a); ishard++) {
     dbm_shard_copy(&matrix_a->shards[ishard], &matrix_b->shards[ishard]);
   }
@@ -260,7 +260,7 @@ void dbm_put_block(dbm_matrix_t *matrix, const int row, const int col,
 void dbm_clear(dbm_matrix_t *matrix) {
   assert(omp_get_num_threads() == 1);
 
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
     dbm_shard_t *shard = &matrix->shards[ishard];
     shard->nblocks = 0;
@@ -284,7 +284,7 @@ void dbm_filter(dbm_matrix_t *matrix, const double eps) {
   }
   const double eps2 = eps * eps;
 
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
     dbm_shard_t *shard = &matrix->shards[ishard];
     const int old_nblocks = shard->nblocks;
@@ -350,7 +350,7 @@ void dbm_reserve_blocks(dbm_matrix_t *matrix, const int nblocks,
   }
 #pragma omp barrier
 
-#pragma omp for schedule(dynamic)
+#pragma omp for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
     dbm_shard_t *shard = &matrix->shards[ishard];
     dbm_shard_allocate_promised_blocks(shard);
@@ -371,7 +371,7 @@ void dbm_scale(dbm_matrix_t *matrix, const double alpha) {
     return;
   }
 
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
     dbm_shard_t *shard = &matrix->shards[ishard];
     for (int i = 0; i < shard->data_size; i++) {
@@ -387,7 +387,7 @@ void dbm_scale(dbm_matrix_t *matrix, const double alpha) {
 void dbm_zero(dbm_matrix_t *matrix) {
   assert(omp_get_num_threads() == 1);
 
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
     dbm_shard_t *shard = &matrix->shards[ishard];
     memset(shard->data, 0, shard->data_size * sizeof(double));
@@ -402,7 +402,7 @@ void dbm_add(dbm_matrix_t *matrix_a, const dbm_matrix_t *matrix_b) {
   assert(omp_get_num_threads() == 1);
   assert(matrix_a->dist == matrix_b->dist);
 
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix_b); ishard++) {
     dbm_shard_t *shard_a = &matrix_a->shards[ishard];
     const dbm_shard_t *shard_b = &matrix_b->shards[ishard];
@@ -522,13 +522,13 @@ double dbm_checksum(const dbm_matrix_t *matrix) {
 }
 
 /*******************************************************************************
- * \brief Returns the absolute value of the larges element of the entire matrix.
+ * \brief Returns the largest absolute value of all matrix elements.
  * \author Ole Schuett
  ******************************************************************************/
 double dbm_maxabs(const dbm_matrix_t *matrix) {
   double maxabs = 0.0;
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
-    dbm_shard_t *shard = &matrix->shards[ishard];
+    const dbm_shard_t *shard = &matrix->shards[ishard];
     for (int i = 0; i < shard->data_size; i++) {
       maxabs = fmax(maxabs, fabs(shard->data[i]));
     }

--- a/src/dbm/dbm_mempool.c
+++ b/src/dbm/dbm_mempool.c
@@ -111,7 +111,7 @@ static void *internal_mempool_malloc(const size_t size, const bool on_device) {
     dbm_memchunk_t **indirect = &mempool_available_head, **hit = NULL;
     while (*indirect != NULL) {
       if ((*indirect)->on_device == on_device) {
-        const size_t max_size = (size_t)(ALLOCATION_FACTOR * size /*+ 0.5*/);
+        const size_t max_size = DBM_ALLOCATION_FACTOR * size;
         const size_t hit_size = (*indirect)->size;
         if (NULL == hit) { // Fallback
           hit = indirect;

--- a/src/dbm/dbm_multiply_comm.h
+++ b/src/dbm/dbm_multiply_comm.h
@@ -9,8 +9,8 @@
 #define DBM_MULTIPLY_COMM_H
 
 #include "dbm_distribution.h"
+#include "dbm_internal.h"
 #include "dbm_matrix.h"
-#include "dbm_multiply_internal.h"
 
 #include <stdbool.h>
 

--- a/src/dbm/dbm_multiply_cpu.c
+++ b/src/dbm/dbm_multiply_cpu.c
@@ -81,19 +81,18 @@ void dbm_multiply_cpu_process_batch(const int ntasks, dbm_task_t batch[ntasks],
 #if defined(__LIBXSMM)
 
   // Sort tasks approximately by m,n,k via bucket sort.
-  int buckets[BATCH_NUM_BUCKETS];
-  memset(buckets, 0, BATCH_NUM_BUCKETS * sizeof(int));
+  int buckets[DBM_BATCH_NUM_BUCKETS] = {0};
   for (int itask = 0; itask < ntasks; ++itask) {
-    const int i = hash(batch[itask]) % BATCH_NUM_BUCKETS;
+    const int i = hash(batch[itask]) % DBM_BATCH_NUM_BUCKETS;
     ++buckets[i];
   }
-  for (int i = 1; i < BATCH_NUM_BUCKETS; ++i) {
+  for (int i = 1; i < DBM_BATCH_NUM_BUCKETS; ++i) {
     buckets[i] += buckets[i - 1];
   }
-  assert(buckets[BATCH_NUM_BUCKETS - 1] == ntasks);
+  assert(buckets[DBM_BATCH_NUM_BUCKETS - 1] == ntasks);
   int batch_order[ntasks];
   for (int itask = 0; itask < ntasks; ++itask) {
-    const int i = hash(batch[itask]) % BATCH_NUM_BUCKETS;
+    const int i = hash(batch[itask]) % DBM_BATCH_NUM_BUCKETS;
     --buckets[i];
     batch_order[buckets[i]] = itask;
   }

--- a/src/dbm/dbm_multiply_cpu.h
+++ b/src/dbm/dbm_multiply_cpu.h
@@ -7,7 +7,7 @@
 #ifndef DBM_MULTIPLY_CPU_H
 #define DBM_MULTIPLY_CPU_H
 
-#include "dbm_multiply_internal.h"
+#include "dbm_internal.h"
 #include "dbm_shard.h"
 
 /*******************************************************************************

--- a/src/dbm/dbm_multiply_gpu.c
+++ b/src/dbm/dbm_multiply_gpu.c
@@ -128,7 +128,7 @@ void dbm_multiply_gpu_process_batch(const int ntasks, const dbm_task_t *batch,
   double *old_data_dev = NULL;
   if (shard_c_host->data_promised > shard_c_dev->data_allocated) {
     shard_c_dev->data_allocated =
-        ALLOCATION_FACTOR * shard_c_host->data_promised;
+        DBM_ALLOCATION_FACTOR * shard_c_host->data_promised;
     old_data_dev = shard_c_dev->data;
     shard_c_dev->data =
         dbm_mempool_device_malloc(shard_c_dev->data_allocated * sizeof(double));
@@ -174,7 +174,7 @@ void dbm_multiply_gpu_download_results(dbm_multiply_gpu_context_t *ctx) {
   // Select GPU device.
   offload_activate_chosen_device();
 
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for DBM_OMP_SCHEDULE
   for (int i = 0; i < ctx->nshards; i++) {
     // Grow host buffer if necessary.
     dbm_shard_t *shard_c_host = &ctx->shards_c_host[i];
@@ -198,7 +198,7 @@ void dbm_multiply_gpu_stop(dbm_multiply_gpu_context_t *ctx) {
   offload_activate_chosen_device();
 
   // Wait for completion, then free gpu ressources.
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for DBM_OMP_SCHEDULE
   for (int i = 0; i < ctx->nshards; i++) {
     dbm_shard_gpu_t *shard_c_dev = &ctx->shards_c_dev[i];
     offloadStreamSynchronize(shard_c_dev->stream);

--- a/src/dbm/dbm_multiply_gpu.h
+++ b/src/dbm/dbm_multiply_gpu.h
@@ -11,7 +11,7 @@
 #include "../offload/offload_runtime.h"
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_DBM)
 
-#include "dbm_multiply_internal.h"
+#include "dbm_internal.h"
 #include "dbm_shard.h"
 
 /*******************************************************************************

--- a/src/dbm/dbm_multiply_gpu_kernel.cu
+++ b/src/dbm/dbm_multiply_gpu_kernel.cu
@@ -43,14 +43,6 @@ __device__ static void atomicAddDouble(double *address, double val) {
 }
 
 /*******************************************************************************
- * \brief Returns the larger of two given integer (missing from the C standard)
- * \author Ole Schuett
- ******************************************************************************/
-__device__ constexpr static inline int imax(int x, int y) {
-  return (x > y ? x : y);
-}
-
-/*******************************************************************************
  * \brief Processes a task using tile dimensions give by template parameters.
  * \author Ole Schuett
  ******************************************************************************/
@@ -60,9 +52,9 @@ __device__ static void process_task(const int m, const int n, const int k,
                                     const double *block_b, double *block_c,
                                     double *shared_mem) {
 
-  constexpr int K = NUM_THREADS / imax(M, N);
+  constexpr int K = NUM_THREADS / DBM_MAX(M, N);
 
-  static_assert(K * imax(M, N) == NUM_THREADS, "Wasting threads.");
+  static_assert(K * DBM_MAX(M, N) == NUM_THREADS, "Wasting threads.");
   static_assert(M * N <= NUM_THREADS, "Not enough threads to cover tile.");
 
   double *tile_a = shared_mem;

--- a/src/dbm/dbm_multiply_gpu_kernel.h
+++ b/src/dbm/dbm_multiply_gpu_kernel.h
@@ -11,7 +11,7 @@
 #include "../offload/offload_runtime.h"
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_DBM)
 
-#include "dbm_multiply_internal.h"
+#include "dbm_internal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/dbm/dbm_shard.c
+++ b/src/dbm/dbm_shard.c
@@ -50,8 +50,7 @@ static int next_prime(const int start) {
 static void hashtable_init(dbm_shard_t *shard) {
   // Choosing size as power of two allows to replace modulo with bitwise AND.
   shard->hashtable_size =
-      next_power2(HASHTABLE_FACTOR * shard->nblocks_allocated);
-  shard->hashtable_mask = shard->hashtable_size - 1;
+      next_power2(DBM_HASHTABLE_FACTOR * shard->nblocks_allocated);
   shard->hashtable_prime = next_prime(shard->hashtable_size);
   shard->hashtable = calloc(shard->hashtable_size, sizeof(int));
   assert(shard->hashtable != NULL);
@@ -94,7 +93,6 @@ void dbm_shard_copy(dbm_shard_t *shard_a, const dbm_shard_t *shard_b) {
     assert(shard_a->hashtable != NULL);
   }
   shard_a->hashtable_size = shard_b->hashtable_size;
-  shard_a->hashtable_mask = shard_b->hashtable_mask;
   shard_a->hashtable_prime = shard_b->hashtable_prime;
 
   if (shard_a->data_allocated < shard_b->data_size) {
@@ -142,21 +140,29 @@ static inline unsigned int hash(const unsigned int row,
 }
 
 /*******************************************************************************
+ * \brief Internal routine for masking a slot in the hash-table.
+ * \author Hans Pabst
+ ******************************************************************************/
+static inline int hashtable_mask(const dbm_shard_t *shard) {
+  return shard->hashtable_size - 1;
+}
+
+/*******************************************************************************
  * \brief Private routine for inserting a block into a shard's hashtable.
  * \author Ole Schuett
  ******************************************************************************/
 static void hashtable_insert(dbm_shard_t *shard, const int block_idx) {
   assert(0 <= block_idx && block_idx < shard->nblocks);
   const dbm_block_t *blk = &shard->blocks[block_idx];
-  const int row = blk->row, col = blk->col;
-  int slot = (shard->hashtable_prime * hash(row, col)) & shard->hashtable_mask;
-  while (true) {
-    if (shard->hashtable[slot] == 0) {
-      shard->hashtable[slot] = block_idx + 1; // 1-based because 0 means empty
-      return;
+  const unsigned int h = hash(blk->row, blk->col);
+  int slot = (shard->hashtable_prime * h) & hashtable_mask(shard);
+  for (;; slot = (slot + 1) & hashtable_mask(shard)) { // linear probing
+    for (int i = slot; i < shard->hashtable_size; ++i) {
+      if (shard->hashtable[i] == 0) {        // 0 means empty
+        shard->hashtable[i] = block_idx + 1; // 1-based
+        return;
+      }
     }
-    // linear probing
-    slot = (slot + 1) & shard->hashtable_mask;
   }
 }
 
@@ -166,19 +172,19 @@ static void hashtable_insert(dbm_shard_t *shard, const int block_idx) {
  ******************************************************************************/
 dbm_block_t *dbm_shard_lookup(const dbm_shard_t *shard, const int row,
                               const int col) {
-  int slot = (shard->hashtable_prime * hash(row, col)) & shard->hashtable_mask;
-  while (true) {
-    const int block_idx = shard->hashtable[slot] - 1; // 1-based, 0 means empty.
-    if (block_idx < 0) {
-      return NULL; // block not found
+  int slot = (shard->hashtable_prime * hash(row, col)) & hashtable_mask(shard);
+  for (;; slot = (slot + 1) & hashtable_mask(shard)) { // linear probing
+    for (int i = slot; i < shard->hashtable_size; ++i) {
+      const int block_idx = shard->hashtable[i];
+      if (block_idx == 0) { // 1-based, 0 means empty
+        return NULL;        // block not found
+      }
+      assert(0 < block_idx && block_idx <= shard->nblocks);
+      dbm_block_t *blk = &shard->blocks[block_idx - 1];
+      if (blk->row == row && blk->col == col) {
+        return blk;
+      }
     }
-    assert(0 <= block_idx && block_idx < shard->nblocks);
-    dbm_block_t *blk = &shard->blocks[block_idx];
-    if (blk->row == row && blk->col == col) {
-      return blk;
-    }
-    // linear probing
-    slot = (slot + 1) & shard->hashtable_mask;
   }
 }
 
@@ -190,7 +196,7 @@ dbm_block_t *dbm_shard_promise_new_block(dbm_shard_t *shard, const int row,
                                          const int col, const int block_size) {
   // Grow blocks array if necessary.
   if (shard->nblocks_allocated < shard->nblocks + 1) {
-    shard->nblocks_allocated = ALLOCATION_FACTOR * (shard->nblocks + 1);
+    shard->nblocks_allocated = DBM_ALLOCATION_FACTOR * (shard->nblocks + 1);
     shard->blocks =
         realloc(shard->blocks, shard->nblocks_allocated * sizeof(dbm_block_t));
     assert(shard->blocks != NULL);
@@ -210,7 +216,7 @@ dbm_block_t *dbm_shard_promise_new_block(dbm_shard_t *shard, const int row,
   new_block->col = col;
   new_block->offset = shard->data_promised;
   shard->data_promised += block_size;
-  // The data_size will be increase after the memory is allocated and zeroed.
+  // The data_size will be increased after the memory is allocated and zeroed.
   hashtable_insert(shard, new_block_idx);
   return new_block;
 }
@@ -223,7 +229,7 @@ void dbm_shard_allocate_promised_blocks(dbm_shard_t *shard) {
 
   // Reallocate data array if necessary.
   if (shard->data_promised > shard->data_allocated) {
-    shard->data_allocated = ALLOCATION_FACTOR * shard->data_promised;
+    shard->data_allocated = DBM_ALLOCATION_FACTOR * shard->data_promised;
     shard->data = realloc(shard->data, shard->data_allocated * sizeof(double));
     assert(shard->data != NULL);
   }

--- a/src/dbm/dbm_shard.h
+++ b/src/dbm/dbm_shard.h
@@ -33,7 +33,6 @@ typedef struct {
   dbm_block_t *blocks;
 
   int hashtable_size;  // should be a power of two
-  int hashtable_mask;  // should be hashtable_size - 1, ie. a bit-mask
   int hashtable_prime; // should be a coprime of hashtable_size
   int *hashtable;      // maps row/col to block numbers
 


### PR DESCRIPTION
- Streamlined dbm_mempool_host_malloc vs dbm_mpi_alloc_mem.
  - Leave contended/temporary allocation up to MPI runtime.
- Removed hashtable_mask from internal dbm_shard_t.
- Moved duplicate imax into internal header
  - Made imax a macro for some type-flexibility.
  - Renamed dbm_multiply_internal.h.
- Prefixed hyper-parameters and avoid name clashes.
- Made OpenMP dynamic schedule a hyper-parameter.