### PR TITLE
DBM: more accurate matrix checksum

### DIFF
--- a/src/dbm/dbm_internal.h
+++ b/src/dbm/dbm_internal.h
@@ -9,7 +9,7 @@
 #define DBM_INTERNAL_H
 
 /*******************************************************************************
- * \brief Returns the larger of two given integer (missing from the C standard)
+ * \brief Returns the larger of two given integers (missing from the C standard)
  * \author Ole Schuett
  ******************************************************************************/
 static inline int imax(int x, int y) { return (x > y ? x : y); }

--- a/src/offload/offload_runtime.h
+++ b/src/offload/offload_runtime.h
@@ -22,10 +22,12 @@
 
 #if defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP) ||                       \
     defined(__OFFLOAD_OPENCL)
-#define __OFFLOAD
-
 #include <stdio.h>
 #include <stdlib.h>
+
+#if !defined(__OFFLOAD)
+#define __OFFLOAD
+#endif
 
 #if defined(__OFFLOAD_CUDA)
 #include <cuda_runtime.h>


### PR DESCRIPTION
- Miniapp: fixed conditional compilation (#4052).
- Calculate checksum more accurately.
  - Miniapp: expected value uses uint64_t.
  - Kahan's summation is needed.
- OpenCL
  - Revised SLM-variant of DBM-kernel.
  - Adjusted internal parameters
  - Make use of NDEBUG.
- Cleanup offload/offload_library.h.