### PR TITLE
[dftd3] Improve error messaging when input parameters are missing

### DIFF
--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -988,7 +988,7 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="PARAMETER_FILE_NAME", &
                           description="Name of the parameter file, may include a path (not used for D4)", &
                           usage="PARAMETER_FILE_NAME <FILENAME>", &
-                          default_lc_val="DISPERSION_PARAMETERS")
+                          default_lc_val="dftd3.dat")
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="REFERENCE_FUNCTIONAL", &

--- a/src/qs_dispersion_utils.F
+++ b/src/qs_dispersion_utils.F
@@ -93,7 +93,10 @@ CONTAINS
             IF (.NOT. explicit) THEN
                CALL section_vals_val_get(pp_section, "REFERENCE_FUNCTIONAL", explicit=exfun)
                IF (.NOT. exfun) THEN
-                  CPABORT("D2 vdW REFERENCE_FUNCTIONAL expected (example REFERENCE_FUNCTIONAL PBE). Go to https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3/ for a full list of supported functionals")
+                  CALL cp_abort(__LOCATION__, "D2 vdW REFERENCE_FUNCTIONAL expected a second parameter "// &
+                                "(example REFERENCE_FUNCTIONAL PBE). "// &
+                                "Go to https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3/ "// &
+                                "for a full list of supported functionals")
                END IF
                CALL qs_scaling_dftd2(dispersion_env%scaling, vdw_section)
             ELSE
@@ -124,7 +127,10 @@ CONTAINS
             IF (.NOT. explicit) THEN
                CALL section_vals_val_get(pp_section, "REFERENCE_FUNCTIONAL", explicit=exfun)
                IF (.NOT. exfun) THEN
-                  CPABORT("D3 vdW REFERENCE_FUNCTIONAL expected (example REFERENCE_FUNCTIONAL PBE). Go to https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3/ for a full list of supported functionals")
+                  CALL cp_abort(__LOCATION__, "D3 vdW REFERENCE_FUNCTIONAL expected a second parameter "// &
+                                "(example REFERENCE_FUNCTIONAL PBE). "// &
+                                "Go to https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3/ for a full "// &
+                                "list of supported functionals")
                ELSE
                   CALL section_vals_val_get(vdw_section, &
                                             "PAIR_POTENTIAL%REFERENCE_FUNCTIONAL", &

--- a/src/qs_dispersion_utils.F
+++ b/src/qs_dispersion_utils.F
@@ -92,7 +92,9 @@ CONTAINS
             CALL section_vals_val_get(pp_section, "SCALING", explicit=explicit)
             IF (.NOT. explicit) THEN
                CALL section_vals_val_get(pp_section, "REFERENCE_FUNCTIONAL", explicit=exfun)
-               CPASSERT(exfun)
+               IF (.NOT. exfun) THEN
+                  CPABORT("D2 vdW REFERENCE_FUNCTIONAL expected (example REFERENCE_FUNCTIONAL PBE). Go to https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3/ for a full list of supported functionals")
+               END IF
                CALL qs_scaling_dftd2(dispersion_env%scaling, vdw_section)
             ELSE
                CALL section_vals_val_get(pp_section, "SCALING", r_val=dispersion_env%scaling)
@@ -121,7 +123,13 @@ CONTAINS
             END IF
             IF (.NOT. explicit) THEN
                CALL section_vals_val_get(pp_section, "REFERENCE_FUNCTIONAL", explicit=exfun)
-               CPASSERT(exfun)
+               IF (.NOT. exfun) THEN
+                  CPABORT("D3 vdW REFERENCE_FUNCTIONAL expected (example REFERENCE_FUNCTIONAL PBE). Go to https://www.chemie.uni-bonn.de/grimme/de/software/dft-d3/ for a full list of supported functionals")
+               ELSE
+                  CALL section_vals_val_get(vdw_section, &
+                                            "PAIR_POTENTIAL%REFERENCE_FUNCTIONAL", &
+                                            c_val=dispersion_env%ref_functional)
+               END IF
                IF (dispersion_env%pp_type == vdw_pairpot_dftd3) THEN
                   CALL qs_scaling_dftd3(dispersion_env%s6, dispersion_env%sr6, &
                                         dispersion_env%s8, vdw_section)


### PR DESCRIPTION
The error message returned by cp2k is unclear when these two combination of parameters are present in a input file.

 ```
REFERENCE_FUNCTIONAL
 PARAMETER_FILE_NAME dftd3.dat
```

The error message is also misleading when  "PARAMETER_FILE_NAME" is empty causing confusion. The default value should be dftd3.dat or the error message should be more explicit.