### PR TITLE
Remove CMake build presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ option(CMAKE_POSITION_INDEPENDENT_CODE "Enable position independent code" ON)
 option(CP2K_ENABLE_CONSISTENCY_CHECKS
        "Check that the list of compiled files and files contained in src match"
        OFF)
-option(CP2K_USE_DFTD4 "Enable dispersion coorections DFTD4" ON)
+option(CP2K_USE_DFTD4 "Enable dispersion corrections with DFTD4" ON)
 option(CP2K_USE_DEEPMD "Enable DeePMD" ON)
 option(CP2K_USE_FFTW3 "Use fftw3 for the calculating fast fourier transforms"
        ON)
@@ -117,6 +117,7 @@ option(
   "MKL has its own compatible implementation of the fftw library. This option, when ON, will use the separate and original fftw library."
   OFF)
 
+# MPI-enabled options
 cmake_dependent_option(CP2K_USE_COSMA "Enable COSMA support" ON "CP2K_USE_MPI"
                        OFF)
 cmake_dependent_option(CP2K_USE_DLAF "Enable DLA-Future support" ON
@@ -125,8 +126,6 @@ cmake_dependent_option(CP2K_USE_ELPA "Enable ELPA support" ON "CP2K_USE_MPI"
                        OFF)
 cmake_dependent_option(CP2K_USE_LIBSMEAGOL "Enable libSMEAGOL support" ON
                        "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_LIBXSMM "Enable libxsmm support" ON
-                       "NOT CP2K_USE_ACCEL MATCHES \"OPENCL\"" ON)
 cmake_dependent_option(CP2K_USE_MPI_F08 "Enable MPI Fortran 2008 interface" ON
                        "CP2K_USE_MPI" OFF)
 cmake_dependent_option(CP2K_USE_PLUMED "Enable PLUMED2 support" ON
@@ -136,6 +135,8 @@ cmake_dependent_option(CP2K_USE_SIRIUS "Enable SIRIUS support" ON
 cmake_dependent_option(CP2K_USE_SPLA "Enable SPLA support" ON "CP2K_USE_MPI"
                        OFF)
 
+cmake_dependent_option(CP2K_USE_LIBXSMM "Enable libxsmm support" ON
+                       "NOT CP2K_USE_ACCEL MATCHES \"OPENCL\"" ON)
 cmake_dependent_option(CP2K_USE_LIBVDWXC "Enable libvdwxc support with SIRIUS"
                        ON "CP2K_USE_SIRIUS" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,76 +191,9 @@ if(NOT ${CP2K_SCALAPACK_VENDOR} IN_LIST CP2K_SCALAPACK_VENDOR_LIST)
   message(FATAL_ERROR "Invalid scalapack vendor backend")
 endif()
 
-set(CP2K_BUILD_OPTIONS_LIST "CUSTOM" "DEFAULT" "MINIMAL" "FULL" "SERIAL")
-
-set(CP2K_BUILD_OPTIONS
-    "CUSTOM"
-    CACHE
-      STRING
-      "Build cp2k with a predefined set of dependencies. The default setting is full user control"
-)
-set_property(CACHE CP2K_BUILD_OPTIONS PROPERTY STRINGS
-                                               ${CP2K_BUILD_OPTIONS_LIST})
-
 set(CP2K_DATA_DIR
     "default"
     CACHE STRING "Set the location for cp2k data")
-
-string(TOUPPER ${CP2K_BUILD_OPTIONS} cp2k_build_options_up)
-
-if(NOT ${cp2k_build_options_up} IN_LIST CP2K_BUILD_OPTIONS_LIST)
-  message(FATAL_ERROR "Invalid value for cp2k build options")
-endif()
-
-if(${cp2k_build_options_up} STREQUAL "MINIMAL")
-  set(CP2K_USE_FFTW3 ON)
-  set(CP2K_USE_MPI ON)
-endif()
-
-if(${cp2k_build_options_up} STREQUAL "FULL")
-  set(CP2K_USE_FFTW3 ON)
-  set(CP2K_USE_MPI ON)
-  set(CP2K_USE_DFTD4 ON)
-  set(CP2K_USE_SIRIUS ON)
-  set(CP2K_USE_LIBXSMM ON)
-  set(CP2K_USE_VORI ON)
-  set(CP2K_USE_COSMA ON)
-  set(CP2K_USE_SPLA ON)
-  set(CP2K_USE_LIBXC ON)
-  set(CP2K_USE_LIBINT2 ON)
-  set(CP2K_USE_ELPA ON)
-  set(CP2K_USE_SPGLIB ON)
-  set(CP2K_USE_LIBTORCH ON)
-  set(CP2K_USE_HDF5 ON)
-  set(CP2K_USE_LIBGRPP ON)
-  set(CP2K_USE_TREXIO ON)
-endif()
-
-if(${cp2k_build_options_up} STREQUAL "SERIAL")
-  set(CP2K_USE_FFTW3 ON)
-  set(CP2K_USE_MPI OFF)
-  set(CP2K_USE_SIRIUS ON)
-  set(CP2K_USE_LIBXSMM ON)
-  set(CP2K_USE_VORI ON)
-  set(CP2K_USE_COSMA ON)
-  set(CP2K_USE_SPLA ON)
-  set(CP2K_USE_LIBXC ON)
-  set(CP2K_USE_LIBINT2 ON)
-  set(CP2K_USE_ELPA ON)
-  set(CP2K_USE_SPGLIB ON)
-  set(CP2K_USE_LIBTORCH ON)
-endif()
-
-if(${cp2k_build_options_up} STREQUAL "DEFAULT")
-  set(CP2K_USE_FFTW3 ON)
-  set(CP2K_USE_MPI ON)
-  set(CP2K_USE_SIRIUS ON)
-  set(CP2K_USE_COSMA ON)
-  set(CP2K_USE_LIBXSMM ON)
-  set(CP2K_USE_LIBXC ON)
-  set(CP2K_USE_LIBINT2 ON)
-  set(CP2K_USE_SPGLIB ON)
-endif()
 
 # ##############################################################################
 # gpu related options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,41 +97,37 @@ option(CMAKE_POSITION_INDEPENDENT_CODE "Enable position independent code" ON)
 option(CP2K_ENABLE_CONSISTENCY_CHECKS
        "Check that the list of compiled files and files contained in src match"
        OFF)
-option(CP2K_USE_DFTD4 "Enable dispersion coorections DFTD4" OFF)
-option(CP2K_USE_DEEPMD "Enable DeePMD" OFF)
-option(CP2K_USE_SIRIUS "Enable plane wave dft calculations with sirius" OFF)
+option(CP2K_USE_DFTD4 "Enable dispersion coorections DFTD4" ON)
+option(CP2K_USE_DEEPMD "Enable DeePMD" ON)
 option(CP2K_USE_FFTW3 "Use fftw3 for the calculating fast fourier transforms"
        ON)
 option(CP2K_USE_MPI "Enable MPI support" ON)
-option(CP2K_USE_ELPA "Enable elpa support" OFF)
-option(CP2K_USE_COSMA "COSMA is a drop in replacement of scalapack dgemm" OFF)
-option(CP2K_USE_LIBINT2 "Enable libint2 support" OFF)
-option(CP2K_USE_PLUMED "Enable plumed2 support" OFF)
-option(CP2K_USE_VORI "Enable libvori support" OFF)
-option(CP2K_USE_SPGLIB "Enable spglib support" OFF)
-option(CP2K_USE_LIBXC "Enable libxc support" OFF)
-option(CP2K_USE_LIBTORCH "Enable libtorch support" OFF)
+option(CP2K_USE_LIBINT2 "Enable libint2 support" ON)
+option(CP2K_USE_VORI "Enable libvori support" ON)
+option(CP2K_USE_SPGLIB "Enable spglib support" ON)
+option(CP2K_USE_LIBXC "Enable libxc support" ON)
+option(CP2K_USE_LIBTORCH "Enable libtorch support" ON)
 option(CP2K_USE_STATIC_BLAS "Link against static version of BLAS/LAPACK" OFF)
-option(CP2K_USE_SPLA
-       "Use SPLA offloading gemm feature to the GPU if it is beneficial. " OFF)
-option(
-  CP2K_USE_DLAF
-  "Use DLA-Future for Cholesky decompositions and the solution of eigenvalue problems"
-  OFF)
-option(CP2K_USE_GRPP "Enable libgrpp support" OFF)
-option(CP2K_USE_TREXIO "Enable trexio support" OFF)
-option(CP2K_USE_HDF5 "Enable HDF5 support" OFF)
-option(CP2K_USE_LIBSMEAGOL "Enable libsmeagol support" OFF)
+option(CP2K_USE_GRPP "Enable libgrpp support" ON)
+option(CP2K_USE_TREXIO "Enable trexio support" ON)
+option(CP2K_USE_HDF5 "Enable HDF5 support" ON)
 option(BUILD_SHARED_LIBS "Build cp2k shared library" ON)
 option(
   CP2K_USE_FFTW3_WITH_MKL
   "MKL has its own compatible implementation of the fftw library. This option, when ON, will use the separate and original fftw library."
   OFF)
 
-cmake_dependent_option(CP2K_USE_LIBXSMM "Use libxsmm for small gemms" OFF
-                       "NOT CP2K_USE_ACCEL MATCHES \"OPENCL\"" ON)
+cmake_dependent_option(CP2K_USE_COSMA "Enable COSMA support" ON "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_DLAF "Enable DLA-Future support" ON "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_ELPA "Enable ELPA support" ON "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_LIBSMEAGOL "Enable libSMEAGOL support" ON "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_LIBXSMM "Enable libxsmm support" ON "NOT CP2K_USE_ACCEL MATCHES \"OPENCL\"" ON)
+cmake_dependent_option(CP2K_USE_MPI_F08 "Enable MPI Fortran 2008 interface" ON "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_PLUMED "Enable PLUMED2 support" ON "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_SIRIUS "Enable SIRIUS support" ON "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_SPLA "Enable SPLA support" ON "CP2K_USE_MPI" OFF)
 
-cmake_dependent_option(CP2K_USE_LIBVDWXC "Enable libvdwxc support WITH SIRIUS"
+cmake_dependent_option(CP2K_USE_LIBVDWXC "Enable libvdwxc support with SIRIUS"
                        ON "CP2K_USE_SIRIUS" OFF)
 
 cmake_dependent_option(
@@ -155,13 +151,11 @@ cmake_dependent_option(
   "CP2K_USE_ACCEL MATCHES \"HIP\"" OFF)
 
 cmake_dependent_option(CP2K_ENABLE_ELPA_OPENMP_SUPPORT
-                       "Enable elpa openmp support" ON "CP2K_USE_ELPA" OFF)
+                       "Enable ELPA OpenMP support" ON "CP2K_USE_ELPA" OFF)
 cmake_dependent_option(CP2K_ENABLE_FFTW3_OPENMP_SUPPORT
-                       "Enable FFTW openmp support" ON "CP2K_USE_FFTW3" OFF)
+                       "Enable FFTW OpenMP support" ON "CP2K_USE_FFTW3" OFF)
 cmake_dependent_option(CP2K_ENABLE_FFTW3_THREADS_SUPPORT
-                       "Enable FFTW THREADS support" OFF "CP2K_USE_FFTW3" OFF)
-cmake_dependent_option(CP2K_USE_MPI_F08 "Enable MPI Fortran 2008 interface" OFF
-                       "CP2K_USE_MPI" OFF)
+                       "Enable FFTW threads support" OFF "CP2K_USE_FFTW3" OFF)
 
 cmake_dependent_option(
   CP2K_USE_CUSOLVER_MP
@@ -344,24 +338,6 @@ Intel MPI compiler wrappers. Check the INSTALL.md for more information.")
         "RMA with ${MPI_Fortran_LIBRARY_VERSION_STRING} is not supported due to issues with its implementation."
         " Please use a newer version of OpenMPI or switch to MPICH if you plan on using MPI-RMA."
     )
-  endif()
-else()
-  if(CP2K_USE_SIRIUS
-     OR CP2K_USE_COSMA
-     OR CP2K_USE_SPLA
-     OR CP2K_USE_ELPA
-     OR CP2K_USE_PLUMED)
-    message(
-      WARNING
-        "SIRIUS, COSMA, SPLA, and ELPA require MPI support.\n"
-        "Either set -DCP2K_USE_MPI to ON or turn the following dependencies off\n\n"
-        "List of dependencies with mpi support\n")
-    foreach(__libs sirius COSMA SPLA ELPA PLUMED)
-      if(CP2K_USE_${__libs})
-        message(WARNING " - ${__libs}")
-      endif()
-    endforeach()
-    message(FATAL_ERROR " -- ")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,15 +117,24 @@ option(
   "MKL has its own compatible implementation of the fftw library. This option, when ON, will use the separate and original fftw library."
   OFF)
 
-cmake_dependent_option(CP2K_USE_COSMA "Enable COSMA support" ON "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_DLAF "Enable DLA-Future support" ON "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_ELPA "Enable ELPA support" ON "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_LIBSMEAGOL "Enable libSMEAGOL support" ON "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_LIBXSMM "Enable libxsmm support" ON "NOT CP2K_USE_ACCEL MATCHES \"OPENCL\"" ON)
-cmake_dependent_option(CP2K_USE_MPI_F08 "Enable MPI Fortran 2008 interface" ON "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_PLUMED "Enable PLUMED2 support" ON "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_SIRIUS "Enable SIRIUS support" ON "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_SPLA "Enable SPLA support" ON "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_COSMA "Enable COSMA support" ON "CP2K_USE_MPI"
+                       OFF)
+cmake_dependent_option(CP2K_USE_DLAF "Enable DLA-Future support" ON
+                       "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_ELPA "Enable ELPA support" ON "CP2K_USE_MPI"
+                       OFF)
+cmake_dependent_option(CP2K_USE_LIBSMEAGOL "Enable libSMEAGOL support" ON
+                       "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_LIBXSMM "Enable libxsmm support" ON
+                       "NOT CP2K_USE_ACCEL MATCHES \"OPENCL\"" ON)
+cmake_dependent_option(CP2K_USE_MPI_F08 "Enable MPI Fortran 2008 interface" ON
+                       "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_PLUMED "Enable PLUMED2 support" ON
+                       "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_SIRIUS "Enable SIRIUS support" ON
+                       "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_SPLA "Enable SPLA support" ON "CP2K_USE_MPI"
+                       OFF)
 
 cmake_dependent_option(CP2K_USE_LIBVDWXC "Enable libvdwxc support with SIRIUS"
                        ON "CP2K_USE_SIRIUS" OFF)

--- a/cmake/cmake_cp2k.sh
+++ b/cmake/cmake_cp2k.sh
@@ -37,6 +37,7 @@ cd build || return 1
 # TODO: Reconcile PROFILE/VERSION with CP2K_BUILD_OPTIONS in CMakeLists.txt
 if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
   # PyTorch's TorchConfig.cmake is buried in the Python site-packages directory
+  # TODO: DeepMD-kit is not available in the Spack environment (yet)
   export Torch_DIR="/opt/spack/var/spack/environments/myenv/spack-env/view/lib/python3.11/site-packages/torch/share/cmake/Torch"
   cmake \
     -GNinja \
@@ -46,27 +47,7 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="OpenBLAS" \
     -DCP2K_SCALAPACK_VENDOR="GENERIC" \
-    -DCP2K_USE_LIBINT2=ON \
-    -DCP2K_USE_LIBXC=ON \
-    -DCP2K_USE_FFTW3=ON \
-    -DCP2K_USE_HDF5=ON \
-    -DCP2K_USE_SPGLIB=ON \
-    -DCP2K_USE_VORI=ON \
-    -DCP2K_USE_MPI=ON \
-    -DCP2K_USE_MPI_F08=ON \
-    -DCP2K_USE_LIBXSMM=ON \
-    -DCP2K_USE_PLUMED=ON \
-    -DCP2K_USE_SPLA=ON \
-    -DCP2K_USE_ELPA=ON \
-    -DCP2K_USE_COSMA=ON \
-    -DCP2K_USE_SIRIUS=ON \
-    -DCP2K_USE_LIBVDWXC=ON \
-    -DCP2K_USE_GRPP=ON \
-    -DCP2K_USE_TREXIO=ON \
-    -DCP2K_USE_LIBTORCH=ON \
-    -DCP2K_USE_DLAF=ON \
-    -DCP2K_USE_DFTD4=ON \
-    -DCP2K_USE_LIBSMEAGOL=ON \
+    -DCP2K_USE_DEEPMD=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -78,22 +59,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR=OpenBLAS \
-    -DCP2K_USE_COSMA=OFF \
-    -DCP2K_USE_DEEPMD=ON \
-    -DCP2K_USE_DFTD4=ON \
-    -DCP2K_USE_DLAF=OFF \
-    -DCP2K_USE_FFTW3=ON \
-    -DCP2K_USE_GRPP=ON \
-    -DCP2K_USE_HDF5=ON \
-    -DCP2K_USE_LIBINT2=ON \
-    -DCP2K_USE_LIBTORCH=ON \
-    -DCP2K_USE_LIBXC=ON \
-    -DCP2K_USE_LIBXSMM=ON \
     -DCP2K_USE_MPI=OFF \
-    -DCP2K_USE_MPI_F08=OFF \
-    -DCP2K_USE_SPGLIB=ON \
-    -DCP2K_USE_TREXIO=ON \
-    -DCP2K_USE_VORI=ON \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -105,16 +71,8 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "sdbg" ]]; then
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR=OpenBLAS \
     -DCP2K_DEBUG_MODE=ON \
-    -DCP2K_USE_COSMA=OFF \
-    -DCP2K_USE_DLAF=OFF \
-    -DCP2K_USE_FFTW3=ON \
-    -DCP2K_USE_LIBINT2=ON \
     -DCP2K_USE_LIBTORCH=OFF \
-    -DCP2K_USE_LIBXC=ON \
     -DCP2K_USE_MPI=OFF \
-    -DCP2K_USE_MPI_F08=OFF \
-    -DCP2K_USE_SPGLIB=ON \
-    -DCP2K_USE_VORI=ON \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -126,27 +84,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR=OpenBLAS \
-    -DCP2K_USE_COSMA=ON \
-    -DCP2K_USE_DEEPMD=ON \
-    -DCP2K_USE_DFTD4=ON \
     -DCP2K_USE_DLAF=OFF \
-    -DCP2K_USE_ELPA=ON \
-    -DCP2K_USE_FFTW3=ON \
-    -DCP2K_USE_GRPP=ON \
-    -DCP2K_USE_HDF5=ON \
-    -DCP2K_USE_LIBINT2=ON \
-    -DCP2K_USE_LIBSMEAGOL=ON \
-    -DCP2K_USE_LIBTORCH=ON \
-    -DCP2K_USE_LIBXC=ON \
-    -DCP2K_USE_LIBXSMM=ON \
-    -DCP2K_USE_MPI=ON \
-    -DCP2K_USE_MPI_F08=ON \
-    -DCP2K_USE_PLUMED=ON \
-    -DCP2K_USE_SIRIUS=ON \
-    -DCP2K_USE_SPGLIB=ON \
-    -DCP2K_USE_SPLA=ON \
-    -DCP2K_USE_TREXIO=ON \
-    -DCP2K_USE_VORI=ON \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -160,14 +98,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "pdbg" ]]; then
     -DCP2K_DEBUG_MODE=ON \
     -DCP2K_USE_COSMA=OFF \
     -DCP2K_USE_DLAF=OFF \
-    -DCP2K_USE_FFTW3=ON \
-    -DCP2K_USE_LIBINT2=ON \
     -DCP2K_USE_LIBTORCH=OFF \
-    -DCP2K_USE_LIBXC=ON \
-    -DCP2K_USE_MPI=ON \
-    -DCP2K_USE_MPI_F08=ON \
-    -DCP2K_USE_SPGLIB=ON \
-    -DCP2K_USE_VORI=ON \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -180,16 +111,9 @@ elif [[ "${PROFILE}" == "ubuntu" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR=OpenBLAS \
-    -DCP2K_USE_COSMA=OFF \
-    -DCP2K_USE_DLAF=OFF \
-    -DCP2K_USE_FFTW3=ON \
-    -DCP2K_USE_LIBINT2=ON \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_LIBXC=OFF \
-    -DCP2K_USE_LIBXSMM=ON \
-    -DCP2K_USE_HDF5=ON \
     -DCP2K_USE_MPI=OFF \
-    -DCP2K_USE_MPI_F08=OFF \
     -DCP2K_USE_SPGLIB=OFF \
     -DCP2K_USE_VORI=OFF \
     -Werror=dev \
@@ -202,15 +126,12 @@ elif [[ "${PROFILE}" == "minimal" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCMAKE_BUILD_TYPE="Release" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR=OpenBLAS \
-    -DCP2K_USE_COSMA=OFF \
-    -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_FFTW3=OFF \
     -DCP2K_USE_LIBINT2=OFF \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_LIBXC=OFF \
     -DCP2K_USE_LIBXSMM=OFF \
     -DCP2K_USE_MPI=OFF \
-    -DCP2K_USE_MPI_F08=OFF \
     -DCP2K_USE_SPGLIB=OFF \
     -DCP2K_USE_VORI=OFF \
     -Werror=dev \
@@ -229,16 +150,12 @@ elif [[ "${PROFILE}" == "minimal" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_DFTD4=OFF \
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_ELPA=OFF \
-    -DCP2K_USE_FFTW3=ON \
     -DCP2K_USE_GRPP=OFF \
     -DCP2K_USE_HDF5=OFF \
     -DCP2K_USE_LIBINT2=OFF \
     -DCP2K_USE_LIBSMEAGOL=OFF \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_LIBXC=OFF \
-    -DCP2K_USE_LIBXSMM=ON \
-    -DCP2K_USE_MPI=ON \
-    -DCP2K_USE_MPI_F08=ON \
     -DCP2K_USE_PLUMED=OFF \
     -DCP2K_USE_SIRIUS=OFF \
     -DCP2K_USE_SPGLIB=OFF \


### PR DESCRIPTION
I'm starting to look at ways to simplify, cleanup, and consolidate the CMake build system. This PR removes the `CP2K_BUILD_OPTIONS` presets because they are not particularly useful and rather arbitrary. It's better to be explicit about the different dependencies one wants to build CP2K with.