### PR TITLE
CMake: resolve inconsistencies with DBCSR

### DIFF
--- a/cmake/cmake_cp2k.sh
+++ b/cmake/cmake_cp2k.sh
@@ -35,6 +35,7 @@ mkdir build
 cd build || return 1
 
 # TODO: Reconcile PROFILE/VERSION with CP2K_BUILD_OPTIONS in CMakeLists.txt
+#
 if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
   # PyTorch's TorchConfig.cmake is buried in the Python site-packages directory
   # TODO: DeepMD-kit is not available in the Spack environment (yet)
@@ -45,8 +46,8 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_C_FLAGS="-fno-lto" \
     -DCMAKE_Fortran_FLAGS="-fno-lto" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCP2K_BLAS_VENDOR="OpenBLAS" \
-    -DCP2K_SCALAPACK_VENDOR="GENERIC" \
+    -DCP2K_BLAS_VENDOR="auto" \
+    -DCP2K_SCALAPACK_VENDOR="auto" \
     -DCP2K_USE_DEEPMD=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
@@ -60,8 +61,8 @@ elif [[ "${PROFILE}" == "spack_minimal" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_Fortran_FLAGS="-fno-lto" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCP2K_BLAS_VENDOR=OpenBLAS \
-    -DCP2K_SCALAPACK_VENDOR="GENERIC" \
+    -DCP2K_BLAS_VENDOR="auto" \
+    -DCP2K_SCALAPACK_VENDOR="auto" \
     -DCP2K_USE_COSMA=OFF \
     -DCP2K_USE_DEEPMD=OFF \
     -DCP2K_USE_DFTD4=OFF \
@@ -90,7 +91,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCMAKE_BUILD_TYPE="Release" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCP2K_BLAS_VENDOR=OpenBLAS \
+    -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_USE_MPI=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
@@ -101,7 +102,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "sdbg" ]]; then
     -GNinja \
     -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCP2K_BLAS_VENDOR=OpenBLAS \
+    -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_DEBUG_MODE=ON \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_MPI=OFF \
@@ -115,7 +116,8 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_BUILD_TYPE="Release" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCP2K_BLAS_VENDOR=OpenBLAS \
+    -DCP2K_BLAS_VENDOR="auto" \
+    -DCP2K_SCALAPACK_VENDOR="auto" \
     -DCP2K_USE_DLAF=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
@@ -126,7 +128,8 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "pdbg" ]]; then
     -GNinja \
     -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCP2K_BLAS_VENDOR=OpenBLAS \
+    -DCP2K_BLAS_VENDOR="auto" \
+    -DCP2K_SCALAPACK_VENDOR="auto" \
     -DCP2K_DEBUG_MODE=ON \
     -DCP2K_USE_COSMA=OFF \
     -DCP2K_USE_DLAF=OFF \
@@ -142,7 +145,7 @@ elif [[ "${PROFILE}" == "ubuntu" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -GNinja \
     -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCP2K_BLAS_VENDOR=OpenBLAS \
+    -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_LIBXC=OFF \
     -DCP2K_USE_MPI=OFF \
@@ -182,7 +185,8 @@ elif [[ "${PROFILE}" == "toolchain_all" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_BUILD_TYPE="Release" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCP2K_BLAS_VENDOR=OpenBLAS \
+    -DCP2K_BLAS_VENDOR="auto" \
+    -DCP2K_SCALAPACK_VENDOR="auto" \
     -DCP2K_USE_DLAF=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
@@ -194,7 +198,8 @@ elif [[ "${PROFILE}" == "toolchain_minimal" ]] && [[ "${VERSION}" == "psmp" ]]; 
     -DCMAKE_BUILD_TYPE="Release" \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
-    -DCP2K_BLAS_VENDOR=OpenBLAS \
+    -DCP2K_BLAS_VENDOR="auto" \
+    -DCP2K_SCALAPACK_VENDOR="auto" \
     -DCP2K_USE_COSMA=OFF \
     -DCP2K_USE_DEEPMD=OFF \
     -DCP2K_USE_DFTD4=OFF \

--- a/tools/docker/scripts/install_dbcsr.sh
+++ b/tools/docker/scripts/install_dbcsr.sh
@@ -45,7 +45,7 @@ else
   exit 1
 fi
 
-if ! cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" -DCMAKE_INSTALL_LIBDIR=lib -DUSE_MPI=${USE_MPI} -DUSE_OPENMP=ON -DUSE_SMM=blas .. &> cmake.log; then
+if ! cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" -DCMAKE_INSTALL_LIBDIR=lib -DUSE_MPI=${USE_MPI} -DUSE_OPENMP=ON .. &> cmake.log; then
   cat cmake.log
   exit 1
 fi


### PR DESCRIPTION
- Ensure CP2K_SCALAPACK_VENDOR for PSMP builds.
- Ensure CP2K_BLAS_VENDOR for all builds.
- Rely on "auto" for both BLAS and SCALAPACK;
   it is favorable to test CMake setup to picks the
   right components from environment.
- Tested environment is given by Toolchain.
- Avoid USE_SMM=blas for DBCSR for current release,
  it's "blas" with next release changing to "auto".
- This resolves inconsistencies between DBCSR's
  USE_SMM and CP2K_BLAS_VENDOR.