### PR TITLE
DBM: print used in addition to committed memory

### DIFF
--- a/src/dbm/dbm_library.c
+++ b/src/dbm/dbm_library.c
@@ -192,25 +192,27 @@ void dbm_library_print_stats(const int fortran_comm,
   dbm_mpi_max_uint64(&memstats.host_mallocs, 1, comm);
 
   if (0 != memstats.device_mallocs || 0 != memstats.host_mallocs) {
-    print_func(" Memory consumption                           "
-               " Number of allocations  Size [MiB]\n",
+    print_func(" Memory consumption               "
+               " Number of allocations  Used [MiB]  Size [MiB]\n",
                output_unit);
   }
   if (0 < memstats.device_mallocs) {
     dbm_mpi_max_uint64(&memstats.device_size, 1, comm);
     snprintf(buffer, sizeof(buffer),
-             " Device                                        "
-             " %20" PRIuPTR "  %10" PRIuPTR "\n",
+             " Device                            "
+             " %20" PRIuPTR "  %10" PRIuPTR "  %10" PRIuPTR "\n",
              (uintptr_t)memstats.device_mallocs,
+             (uintptr_t)((memstats.device_used + (512U << 10)) >> 20),
              (uintptr_t)((memstats.device_size + (512U << 10)) >> 20));
     print_func(buffer, output_unit);
   }
   if (0 < memstats.host_mallocs) {
     dbm_mpi_max_uint64(&memstats.host_size, 1, comm);
     snprintf(buffer, sizeof(buffer),
-             " Host                                          "
-             " %20" PRIuPTR "  %10" PRIuPTR "\n",
+             " Host                              "
+             " %20" PRIuPTR "  %10" PRIuPTR "  %10" PRIuPTR "\n",
              (uintptr_t)memstats.host_mallocs,
+             (uintptr_t)((memstats.host_used + (512U << 10)) >> 20),
              (uintptr_t)((memstats.host_size + (512U << 10)) >> 20));
     print_func(buffer, output_unit);
   }

--- a/src/dbm/dbm_mempool.h
+++ b/src/dbm/dbm_mempool.h
@@ -38,7 +38,7 @@ void dbm_mempool_host_free(const void *memory);
 void dbm_mempool_device_free(const void *memory);
 
 /*******************************************************************************
- * \brief Internal routine for freeing all memory in the pool (not thread-safe).
+ * \brief Internal routine for freeing all memory in the pool.
  * \author Ole Schuett
  ******************************************************************************/
 void dbm_mempool_clear(void);
@@ -48,14 +48,16 @@ void dbm_mempool_clear(void);
  * \author Hans Pabst
  ******************************************************************************/
 typedef struct dbm_memstats_t {
-  // Memory consumption (maximum).
+  // Memory used out of consumed.
+  uint64_t host_used, device_used;
+  // Memory consumption.
   uint64_t host_size, device_size;
   // Number of allocations.
   uint64_t host_mallocs, device_mallocs;
 } dbm_memstats_t;
 
 /*******************************************************************************
- * \brief Internal routine to query statistics (not thread-safe).
+ * \brief Internal routine to query statistics.
  * \author Hans Pabst
  ******************************************************************************/
 void dbm_mempool_statistics(dbm_memstats_t *memstats);


### PR DESCRIPTION
- No restriction on thread-safety (dbm_mempool_statistics).
- Reduced contention of critical section.
- Introduced "used" memory statistic.