### PR TITLE
DBM: adjusted MPI-based memory allocation

### DIFF
--- a/src/dbm/dbm_mpi.c
+++ b/src/dbm/dbm_mpi.c
@@ -479,7 +479,7 @@ void dbm_mpi_alltoallv_double(const double *sendbuf, const int *sendcounts,
  ******************************************************************************/
 void *dbm_mpi_alloc_mem(size_t size) {
   void *result = NULL;
-#if defined(__parallel)
+#if defined(__parallel) && !defined(OPEN_MPI)
   CHECK(MPI_Alloc_mem((MPI_Aint)size, MPI_INFO_NULL, &result));
 #else
   result = malloc(size);
@@ -492,7 +492,7 @@ void *dbm_mpi_alloc_mem(size_t size) {
  * \author Hans Pabst
  ******************************************************************************/
 void dbm_mpi_free_mem(void *mem) {
-#if defined(__parallel)
+#if defined(__parallel) && !defined(OPEN_MPI)
   CHECK(MPI_Free_mem(mem));
 #else
   free(mem);

--- a/tools/precommit/check_file_properties.py
+++ b/tools/precommit/check_file_properties.py
@@ -30,6 +30,7 @@ FLAG_EXCEPTIONS = (
     r"DBM_MEMPOOL_.+",
     r"OPENMP_TRACE_SYMBOL",
     r"OPENCL_DBM_.+",
+    r"OPEN_MPI",
     r"ACC_OPENCL_.+",
     r"FD_DEBUG",
     r"GRID_DO_COLLOCATE",


### PR DESCRIPTION
- Apparently, MPI_Alloc_mem/free are not fully thread-safe.
- Debug shows issue similar to reported elsewhere
- Note: MPI_Alloc_mem was taken out of critical section.