### PR TITLE
Greenx toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ option(CP2K_USE_STATIC_BLAS "Link against static version of BLAS/LAPACK" OFF)
 option(CP2K_USE_GRPP "Enable libgrpp support" ON)
 option(CP2K_USE_TREXIO "Enable trexio support" ON)
 option(CP2K_USE_HDF5 "Enable HDF5 support" ON)
-option(CP2K_USE_GREENX "Enable GreenX support" OFF)
+option(CP2K_USE_GREENX "Enable GreenX support" ON)
 option(BUILD_SHARED_LIBS "Build cp2k shared library" ON)
 option(
   CP2K_USE_FFTW3_WITH_MKL

--- a/cmake/cmake_cp2k.sh
+++ b/cmake/cmake_cp2k.sh
@@ -51,6 +51,7 @@ if [[ "${PROFILE}" == "spack_all" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_SCALAPACK_VENDOR="auto" \
     -DCP2K_USE_DEEPMD=OFF \
+    -DCP2K_USE_GREENX=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -83,6 +84,7 @@ elif [[ "${PROFILE}" == "spack_minimal" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_SPLA=OFF \
     -DCP2K_USE_TREXIO=OFF \
     -DCP2K_USE_VORI=OFF \
+    -DCP2K_USE_GREENX=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -177,6 +179,7 @@ elif [[ "${PROFILE}" == "minimal" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCP2K_USE_SPGLIB=OFF \
     -DCP2K_USE_TREXIO=OFF \
     -DCP2K_USE_VORI=OFF \
+    -DCP2K_USE_GREENX=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -219,6 +222,7 @@ elif [[ "${PROFILE}" == "toolchain_minimal" ]] && [[ "${VERSION}" == "psmp" ]]; 
     -DCP2K_USE_SPLA=OFF \
     -DCP2K_USE_TREXIO=OFF \
     -DCP2K_USE_VORI=OFF \
+    -DCP2K_USE_GREENX=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1485,7 +1485,8 @@ set(CP2K_PROGS_F
     metadyn_tools/graph.F
     motion/dumpdcd.F
     motion/xyz2dcd.F
-    nequip_unittest.F)
+    nequip_unittest.F
+    gx_ac_unittest.F)
 
 if(CP2K_USE_CUDA
    OR CP2K_USE_HIP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1788,7 +1788,8 @@ list(
   "libcp2k_unittest"
   "nequip_unittest"
   "dbt_unittest"
-  "dbt_tas_unittest")
+  "dbt_tas_unittest"
+  "gx_ac_unittest")
 
 add_executable(cp2k-bin start/cp2k.F)
 # for linking
@@ -1802,6 +1803,7 @@ add_executable(libcp2k_unittest start/libcp2k_unittest.c)
 add_executable(nequip_unittest nequip_unittest.F)
 add_executable(dbt_unittest dbt/dbt_unittest.F)
 add_executable(dbt_tas_unittest dbt/tas/dbt_tas_unittest.F)
+add_executable(gx_ac_unittest gx_ac_unittest.F)
 
 set_target_properties(
   cp2k-bin

--- a/src/gx_ac_unittest.F
+++ b/src/gx_ac_unittest.F
@@ -1,0 +1,81 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2025 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief GreenX Analytic continuation unit test
+!> \author Stepan Marek
+! **************************************************************************************************
+PROGRAM gx_ac_unittest
+#include "base/base_uses.f90"
+#if !defined(__GREENX)
+   ! Abort and inform that GreenX was not included in the compilation
+   ! Ideally, this will be avoided in testing by the conditional tests
+   CPABORT("CP2K not compiled with GreenX link - please recompile to access GXAC.")
+#else
+   USE kinds, ONLY: dp
+   USE gx_ac, ONLY: create_thiele_pade, &
+                    evaluate_thiele_pade_at, &
+                    free_params, &
+                    params
+
+
+   ! Create the dataset containing the fitting data
+   ! Two Lorentzian peaks with some overlap
+   COMPLEX(kind=dp), PARAMETER        :: damp_one = (2, 0), &
+                                         damp_two = (4, 0), &
+                                         center_one = (2, 0), &
+                                         center_two = (8, 0), &
+                                         amp_one = (10, 0), &
+                                         amp_two = (10, 0), &
+                                         min_source = (0, 0), &
+                                         min_fit = (0, 0), &
+                                         max_source = (10, 0), &
+                                         max_fit = (10, 0)
+   INTEGER, PARAMETER                 :: n_source = 20, &
+                                         n_fit = 100, &
+                                         n_param = 10
+   INTEGER                            :: i
+   COMPLEX(kind=dp)                   :: d_source, &
+                                         d_fit
+   COMPLEX(kind=dp), DIMENSION(n_source) :: x_source, &
+                                         y_source
+   COMPLEX(kind=dp), DIMENSION(n_fit)    :: x_fit, &
+                                         y_fit
+   TYPE(params)                       :: fit_params
+
+   d_source = (max_source - min_source) / CMPLX(n_source - 1, kind=dp)
+   d_fit = (max_fit - min_fit) / CMPLX(n_fit - 1, kind=dp)
+
+   PRINT '(A12)', "#Source data"
+
+   DO i = 1, n_source
+      x_source(i) = min_source + CMPLX(i-1, 0.0, kind=dp) * d_source
+      y_source(i) = amp_one / (damp_one * damp_one + (x_source(i) - center_one)*(x_source(i) - center_one))
+      y_source(i) = y_source(i) + amp_two/ (damp_two * damp_two + (x_source(i) - center_two) * (x_source(i) - center_two))
+      PRINT '(E20.8E3,E20.8E3)', REAL(x_source(i), kind=dp), REAL(y_source(i), kind=dp)
+   END DO
+
+   PRINT '(A9)', "#Fit data"
+
+   ! Fit points created
+   ! Now do the actual fitting
+   fit_params = create_thiele_pade(n_param, x_source, y_source)
+
+   ! Create the evaluation grid
+   DO i = 1, n_fit
+      x_fit(i) = min_fit + d_fit * CMPLX(i-1, 0, kind=dp)
+   END DO
+
+   y_fit(1:n_fit) = evaluate_thiele_pade_at(fit_params, x_fit)
+
+   DO i=1, n_fit
+      PRINT '(E20.8E3,E20.8E3)', REAL(x_fit(i), kind=dp), REAL(y_fit(i), kind=dp)
+   END DO
+
+   CALL free_params(fit_params)
+#endif
+END PROGRAM gx_ac_unittest

--- a/src/gx_ac_unittest.F
+++ b/src/gx_ac_unittest.F
@@ -22,7 +22,6 @@ PROGRAM gx_ac_unittest
                     free_params, &
                     params
 
-
    ! Create the dataset containing the fitting data
    ! Two Lorentzian peaks with some overlap
    COMPLEX(kind=dp), PARAMETER        :: damp_one = (2, 0), &
@@ -42,20 +41,20 @@ PROGRAM gx_ac_unittest
    COMPLEX(kind=dp)                   :: d_source, &
                                          d_fit
    COMPLEX(kind=dp), DIMENSION(n_source) :: x_source, &
-                                         y_source
+                                            y_source
    COMPLEX(kind=dp), DIMENSION(n_fit)    :: x_fit, &
-                                         y_fit
+                                            y_fit
    TYPE(params)                       :: fit_params
 
-   d_source = (max_source - min_source) / CMPLX(n_source - 1, kind=dp)
-   d_fit = (max_fit - min_fit) / CMPLX(n_fit - 1, kind=dp)
+   d_source = (max_source - min_source)/CMPLX(n_source - 1, kind=dp)
+   d_fit = (max_fit - min_fit)/CMPLX(n_fit - 1, kind=dp)
 
    PRINT '(A12)', "#Source data"
 
    DO i = 1, n_source
-      x_source(i) = min_source + CMPLX(i-1, 0.0, kind=dp) * d_source
-      y_source(i) = amp_one / (damp_one * damp_one + (x_source(i) - center_one)*(x_source(i) - center_one))
-      y_source(i) = y_source(i) + amp_two/ (damp_two * damp_two + (x_source(i) - center_two) * (x_source(i) - center_two))
+      x_source(i) = min_source + CMPLX(i - 1, 0.0, kind=dp)*d_source
+      y_source(i) = amp_one/(damp_one*damp_one + (x_source(i) - center_one)*(x_source(i) - center_one))
+      y_source(i) = y_source(i) + amp_two/(damp_two*damp_two + (x_source(i) - center_two)*(x_source(i) - center_two))
       PRINT '(E20.8E3,E20.8E3)', REAL(x_source(i), kind=dp), REAL(y_source(i), kind=dp)
    END DO
 
@@ -67,12 +66,12 @@ PROGRAM gx_ac_unittest
 
    ! Create the evaluation grid
    DO i = 1, n_fit
-      x_fit(i) = min_fit + d_fit * CMPLX(i-1, 0, kind=dp)
+      x_fit(i) = min_fit + d_fit*CMPLX(i - 1, 0, kind=dp)
    END DO
 
    y_fit(1:n_fit) = evaluate_thiele_pade_at(fit_params, x_fit)
 
-   DO i=1, n_fit
+   DO i = 1, n_fit
       PRINT '(E20.8E3,E20.8E3)', REAL(x_fit(i), kind=dp), REAL(y_fit(i), kind=dp)
    END DO
 

--- a/tests/QS/regtest-gw-kpoints/TEST_FILES.toml
+++ b/tests/QS/regtest-gw-kpoints/TEST_FILES.toml
@@ -1,10 +1,10 @@
-"G0W0_kpoints_in_self_energy.inp"                                  = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=12.866}]
-"G0W0_kpoints_in_self_energy_at_HSE06.inp"                         = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=13.376}]
-"G0W0_kpoints_in_self_energy_RI_overlap.inp"                       = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=12.562}]
-"G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX.inp"      = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=15.536}]
-"G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX_ADMM.inp" = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=15.612}]
-"G0W0_kpoints_in_self_energy_gap_printing.inp"                     = [{matcher="E_G0W0_gap_old", tol=1e-03, ref=18.721}]
-"G0W0_kpoints_in_self_energy_open_shell.inp"                       = [{matcher="E_G0W0_alpha_gap_old", tol=1e-04, ref=14.060},
-                                                                      {matcher="E_G0W0_beta_gap_old", tol=1e-04, ref=27.637}]
-"G0W0_IH_SOC.inp"                                                  = [{matcher="E_G0W0_SOC_gap_old", tol=1e-04, ref=17.2636}]
+"G0W0_kpoints_in_self_energy.inp"                                  = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=12.4044}]
+"G0W0_kpoints_in_self_energy_at_HSE06.inp"                         = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=13.1174}]
+"G0W0_kpoints_in_self_energy_RI_overlap.inp"                       = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=12.1041}]
+"G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX.inp"      = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=15.6799}]
+"G0W0_kpoints_in_self_energy_Sigmax_from_four_center_HFX_ADMM.inp" = [{matcher="E_G0W0_gap_old", tol=1e-04, ref=15.7555}]
+"G0W0_kpoints_in_self_energy_gap_printing.inp"                     = [{matcher="E_G0W0_gap_old", tol=1e-03, ref=18.7767}]
+"G0W0_kpoints_in_self_energy_open_shell.inp"                       = [{matcher="E_G0W0_alpha_gap_old", tol=1e-04, ref=13.9024},
+                                                                      {matcher="E_G0W0_beta_gap_old", tol=1e-04, ref=27.5399}]
+"G0W0_IH_SOC.inp"                                                  = [{matcher="E_G0W0_SOC_gap_old", tol=1e-04, ref=17.2425}]
 #EOF

--- a/tests/QS/regtest-rpa-sigma/TEST_FILES.toml
+++ b/tests/QS/regtest-rpa-sigma/TEST_FILES.toml
@@ -1,7 +1,7 @@
 "RPA_SIGMA_H2O_clenshaw.inp"            = [{matcher="M011", tol=1e-09, ref=-17.192268141449258}]
-"RPA_SIGMA_H2O_minimax.inp"             = [{matcher="M011", tol=1e-09, ref=-17.189840389922761}]
-"RPA_SIGMA_H_minimax.inp"               = [{matcher="M011", tol=1e-09, ref=-0.515037791729464}]
+"RPA_SIGMA_H2O_minimax.inp"             = [{matcher="M011", tol=1e-09, ref=-17.190139749033445}]
+"RPA_SIGMA_H_minimax.inp"               = [{matcher="M011", tol=1e-09, ref=-0.51521647108769}]
 "RPA_SIGMA_H_clenshaw.inp"              = [{matcher="M011", tol=1e-09, ref=-0.515090906944438}]
-"RPA_SIGMA_H2O_minimax_NUM_INTEG_GROUPS.inp" = [{matcher="M011", tol=1e-09, ref=-17.189840389922765}]
+"RPA_SIGMA_H2O_minimax_NUM_INTEG_GROUPS.inp" = [{matcher="M011", tol=1e-09, ref=-17.19013974903345}]
 #EOF
 

--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -4,7 +4,7 @@
 # in case a new directory is added just add it at the top of the list..
 # the order will be regularly checked and modified...
 QS/regtest-double-hybrid-stress-laplace                     libint libxc
-QS/regtest-rpa-sigma                                        libint !greenx
+QS/regtest-rpa-sigma                                        libint greenx
 TMC/regtest_ana_on_the_fly                                  parallel mpiranks>2
 QS/regtest-cusolver                                         cusolvermp
 QS/regtest-dlaf                                             dlaf
@@ -85,7 +85,7 @@ QMMM/SE/regtest
 QS/regtest-nmr-6
 QS/regtest-rpa-cubic-scaling-2                              libint libxc
 Fist/regtest-1-4
-QS/regtest-gw-kpoints                                       libint !greenx
+QS/regtest-gw-kpoints                                       libint greenx
 xTB/regtest-1
 QS/regtest-mp2-grad-1                                       libint libvori
 QS/regtest-nmr-uks-1

--- a/tests/UNIT_TESTS
+++ b/tests/UNIT_TESTS
@@ -8,5 +8,6 @@ libcp2k_unittest
 memory_utilities_unittest
 nequip_unittest                                          libtorch
 parallel_rng_types_unittest
+gx_ac_unittest                                           greenx
 
 #EOF

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -240,6 +240,8 @@ The --with-PKG options follow the rules:
   --with-greenx           Enable GreenX library for Minimax grids and Padé analytic continuation in RT-BSE
                           This package requires CMake, BLAS and LAPACK.
                           Default = no
+  --with-gmp              Enable GMP library, optional dependency of GreenX
+                          Default = no
 
 FURTHER INSTRUCTIONS
 
@@ -277,7 +279,7 @@ mpi_list="mpich openmpi intelmpi"
 math_list="mkl acml openblas"
 lib_list="fftw libint libxc libgrpp libxsmm cosma scalapack elpa dbcsr
           cusolvermp plumed spfft spla gsl spglib hdf5 libvdwxc sirius
-          libvori libtorch deepmd dftd4 pugixml libsmeagol trexio greenx"
+          libvori libtorch deepmd dftd4 pugixml libsmeagol trexio greenx gmp"
 package_list="${tool_list} ${mpi_list} ${math_list} ${lib_list}"
 # ------------------------------------------------------------------------
 
@@ -683,6 +685,9 @@ while [ $# -ge 1 ]; do
       ;;
     --with-greenx*)
       with_greenx=$(read_with "${1}")
+      ;;
+    --with-gmp*)
+      with_gmp=$(read_with "${1}")
       ;;
     --with-dbcsr*)
       with_dbcsr=$(read_with $1)

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -237,6 +237,9 @@ The --with-PKG options follow the rules:
                           Default = install
   --with-trexio           Enable the trexio library (read/write TREXIO files).
                           Default = no
+  --with-greenx           Enable GreenX library for Minimax grids and Padé analytic continuation in RT-BSE
+                          This package requires CMake, BLAS and LAPACK.
+                          Default = no
 
 FURTHER INSTRUCTIONS
 
@@ -274,7 +277,7 @@ mpi_list="mpich openmpi intelmpi"
 math_list="mkl acml openblas"
 lib_list="fftw libint libxc libgrpp libxsmm cosma scalapack elpa dbcsr
           cusolvermp plumed spfft spla gsl spglib hdf5 libvdwxc sirius
-          libvori libtorch deepmd dftd4 pugixml libsmeagol trexio"
+          libvori libtorch deepmd dftd4 pugixml libsmeagol trexio greenx"
 package_list="${tool_list} ${mpi_list} ${math_list} ${lib_list}"
 # ------------------------------------------------------------------------
 
@@ -678,6 +681,9 @@ while [ $# -ge 1 ]; do
     --with-trexio*)
       with_trexio=$(read_with "${1}")
       ;;
+    --with-greenx*)
+      with_greenx=$(read_with "${1}")
+      ;;
     --with-dbcsr*)
       with_dbcsr=$(read_with $1)
       ;;
@@ -820,6 +826,7 @@ if [ "${with_spglib}" = "__INSTALL__" ] ||
   [ "${with_spfft}" = "__INSTALL__" ] ||
   [ "${with_spla}" = "__INSTALL__" ] ||
   [ "${with_ninja}" = "__INSTALL__" ] ||
+  [ "${with_greenx}" = "__INSTALL__" ] ||
   [ "${with_dftd4}" = "__INSTALL__" ]; then
   [ "${with_cmake}" = "__DONTUSE__" ] && with_cmake="__INSTALL__"
 fi

--- a/tools/toolchain/scripts/stage2/install_gmp.sh
+++ b/tools/toolchain/scripts/stage2/install_gmp.sh
@@ -4,16 +4,16 @@
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
 gmp_ver="6.3.0"
-gmp_sha256="a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
-# shellcheck source=/dev/null
+gmp_sha256="e56fd59d76810932a0555aa15a14b61c16bed66110d3c75cc2ac49ddaa9ab24c"
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/common_vars.sh
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/tool_kit.sh
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/signal_trap.sh
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source "${INSTALLDIR}"/toolchain.conf
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_gmp" ] && rm "${BUILDDIR}/setup_gmp"
@@ -32,16 +32,14 @@ case "$with_gmp" in
     if verify_checksums "${install_lock_file}"; then
       echo "gmp-${gmp_ver} is already installed, skipping it."
     else
-      if [ -f gmp-${gmp_ver}.tar.xz ]; then
-        echo "gmp-${gmp_ver}.tar.xz is found"
+      if [ -f gmp-${gmp_ver}.tar.gz ]; then
+        echo "gmp-${gmp_ver}.tar.gz is found"
       else
-        # TODO : Exchange once the gmp is present on the CP2K website
-        #download_pkg_from_cp2k_org "${gmp_sha256}" "gmp-${gmp_ver}.tar.xz"
-        download_pkg_from_urlpath "${gmp_sha256}" "gmp-${gmp_ver}.tar.xz" "https://gmplib.org/download/gmp"
+        download_pkg_from_cp2k_org "${gmp_sha256}" "gmp-${gmp_ver}.tar.gz"
       fi
       echo "Installing from scratch into ${pkg_install_dir}"
       [ -d gmp-${gmp_ver} ] && rm -rf gmp-${gmp_ver}
-      tar -xJf gmp-${gmp_ver}.tar.xz
+      tar -xzf gmp-${gmp_ver}.tar.gz
       cd gmp-${gmp_ver}
       mkdir build
       cd build

--- a/tools/toolchain/scripts/stage2/install_gmp.sh
+++ b/tools/toolchain/scripts/stage2/install_gmp.sh
@@ -1,0 +1,107 @@
+#!/bin/bash -e
+
+[ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
+
+gmp_ver="6.3.0"
+gmp_sha256="a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
+source "${SCRIPT_DIR}"/common_vars.sh
+source "${SCRIPT_DIR}"/tool_kit.sh
+source "${SCRIPT_DIR}"/signal_trap.sh
+source "${INSTALLDIR}"/toolchain.conf
+source "${INSTALLDIR}"/toolchain.env
+
+[ -f "${BUILDDIR}/setup_gmp" ] && rm "${BUILDDIR}/setup_gmp"
+
+GMP_CFLAGS=""
+GMP_LDFLAGS=""
+GMP_LIBS=""
+! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
+cd "${BUILDDIR}"
+
+case "$with_gmp" in
+  __INSTALL__)
+    echo "==================== Installing GMP ===================="
+    pkg_install_dir="${INSTALLDIR}/gmp-${gmp_ver}"
+    install_lock_file="$pkg_install_dir/install_successful"
+    if verify_checksums "${install_lock_file}"; then
+      echo "gmp-${gmp_ver} is already installed, skipping it."
+    else
+      if [ -f gmp-${gmp_ver}.tar.xz ]; then
+        echo "gmp-${gmp_ver}.tar.xz is found"
+      else
+        # TODO : Exchange once the gmp is present on the CP2K website
+        #download_pkg_from_cp2k_org "${gmp_sha256}" "gmp-${gmp_ver}.tar.xz"
+        download_pkg_from_urlpath "${gmp_sha256}" "gmp-${gmp_ver}.tar.xz" "https://gmplib.org/download/gmp"
+      fi
+      echo "Installing from scratch into ${pkg_install_dir}"
+      [ -d gmp-${gmp_ver} ] && rm -rf gmp-${gmp_ver}
+      tar -xJf gmp-${gmp_ver}.tar.xz
+      cd gmp-${gmp_ver}
+      mkdir build
+      cd build
+      # autotools setup, out-of-source build
+      ../configure --prefix="${pkg_install_dir}" \
+        --libdir="${pkg_install_dir}/lib" \
+        --enable-cxx=yes \
+        --includedir="${pkg_install_dir}/include" \
+        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage2/$(basename ${SCRIPT_NAME})"
+      cd ..
+    fi
+    GMP_CFLAGS="-I'${pkg_install_dir}/include'"
+    GMP_LDFLAGS="-L'${pkg_install_dir}/lib'"
+    ;;
+  __SYSTEM__)
+    echo "==================== Finding GMP from system paths ===================="
+    check_lib -lgmp "gmp"
+    check_lib -lgmpxx "gmpxx"
+    add_include_from_paths GMP_CFLAGS "gmp.h" $INCLUDE_PATHS
+    add_lib_from_paths GSL_LDFLAGS "libgmp.*" $LIB_PATHS
+    add_lib_from_paths GSL_LDFLAGS "libgmpxx.*" $LIB_PATHS
+    ;;
+  __DONTUSE__) ;;
+
+  *)
+    echo "==================== Linking GMP to user paths ===================="
+    pkg_install_dir="$with_gmp"
+    check_dir "${pkg_install_dir}/lib"
+    check_dir "${pkg_install_dir}/include"
+    GMP_CFLAGS="-I'${pkg_install_dir}/include'"
+    GMP_LDFLAGS="-L'${pkg_install_dir}/lib'"
+    ;;
+esac
+if [ "$with_gmp" != "__DONTUSE__" ]; then
+  GMP_LIBS=" -lgmp -lgmpxx"
+  cat << EOF > "${BUILDDIR}/setup_gmp"
+export GMP_VER="${gmp_ver}"
+EOF
+  if [ "$with_gmp" != "__SYSTEM__" ]; then
+    cat << EOF >> "${BUILDDIR}/setup_gmp"
+prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
+prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
+prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
+prepend_path CPATH "$pkg_install_dir/include"
+prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+EOF
+  fi
+  # TODO : Is it necessary to have a separate feature for GMP, i.e -D__GMP during compilation?
+  cat << EOF >> "${BUILDDIR}/setup_gmp"
+export GMP_CFLAGS="${GMP_CFLAGS}"
+export GMP_LDFLAGS="${GMP_LDFLAGS}"
+export GMP_LIBS="${GMP_LIBS}"
+export CP_CFLAGS="\${CP_CFLAGS} ${GMP_CFLAGS}"
+export CP_LDFLAGS="\${CP_LDFLAGS} ${GMP_LDFLAGS}"
+export CP_LIBS="${GMP_LIBS} \${CP_LIBS}"
+export GMP_ROOT="${pkg_install_dir}"
+EOF
+    cat "${BUILDDIR}/setup_gmp" >> $SETUPFILE
+fi
+
+load "${BUILDDIR}/setup_gmp"
+write_toolchain_env "${INSTALLDIR}"
+
+cd "${ROOTDIR}"
+report_timing "gmp"

--- a/tools/toolchain/scripts/stage2/install_gmp.sh
+++ b/tools/toolchain/scripts/stage2/install_gmp.sh
@@ -5,10 +5,15 @@ SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
 gmp_ver="6.3.0"
 gmp_sha256="a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}"/common_vars.sh
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}"/tool_kit.sh
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}"/signal_trap.sh
+# shellcheck source=/dev/null
 source "${INSTALLDIR}"/toolchain.conf
+# shellcheck source=/dev/null
 source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_gmp" ] && rm "${BUILDDIR}/setup_gmp"
@@ -18,7 +23,7 @@ GMP_LDFLAGS=""
 GMP_LIBS=""
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
-
+with_gmp=${with_gmp:"__DONTUSE__"}
 case "$with_gmp" in
   __INSTALL__)
     echo "==================== Installing GMP ===================="
@@ -45,10 +50,10 @@ case "$with_gmp" in
         --libdir="${pkg_install_dir}/lib" \
         --enable-cxx=yes \
         --includedir="${pkg_install_dir}/include" \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
-      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage2/$(basename ${SCRIPT_NAME})"
+        > configure.log 2>&1 || tail -n "${LOG_LINES}" configure.log
+      make -j "$(get_nprocs)" > make.log 2>&1 || tail -n "${LOG_LINES}" make.log
+      make install > install.log 2>&1 || tail -n "${LOG_LINES}" install.log
+      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage2/$(basename "${SCRIPT_NAME}")"
       cd ..
     fi
     GMP_CFLAGS="-I'${pkg_install_dir}/include'"
@@ -58,9 +63,9 @@ case "$with_gmp" in
     echo "==================== Finding GMP from system paths ===================="
     check_lib -lgmp "gmp"
     check_lib -lgmpxx "gmpxx"
-    add_include_from_paths GMP_CFLAGS "gmp.h" $INCLUDE_PATHS
-    add_lib_from_paths GSL_LDFLAGS "libgmp.*" $LIB_PATHS
-    add_lib_from_paths GSL_LDFLAGS "libgmpxx.*" $LIB_PATHS
+    add_include_from_paths GMP_CFLAGS "gmp.h" "$INCLUDE_PATHS"
+    add_lib_from_paths GSL_LDFLAGS "libgmp.*" "$LIB_PATHS"
+    add_lib_from_paths GSL_LDFLAGS "libgmpxx.*" "$LIB_PATHS"
     ;;
   __DONTUSE__) ;;
 
@@ -97,7 +102,7 @@ export CP_LDFLAGS="\${CP_LDFLAGS} ${GMP_LDFLAGS}"
 export CP_LIBS="${GMP_LIBS} \${CP_LIBS}"
 export GMP_ROOT="${pkg_install_dir}"
 EOF
-    cat "${BUILDDIR}/setup_gmp" >> $SETUPFILE
+  cat "${BUILDDIR}/setup_gmp" >> "$SETUPFILE"
 fi
 
 load "${BUILDDIR}/setup_gmp"

--- a/tools/toolchain/scripts/stage2/install_stage2.sh
+++ b/tools/toolchain/scripts/stage2/install_stage2.sh
@@ -4,5 +4,6 @@
 # shellcheck disable=all
 
 ./scripts/stage2/install_mathlibs.sh
+./scripts/stage2/install_gmp.sh
 
 #EOF

--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -5,16 +5,15 @@ SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
 greenx_ver="2.1"
 greenx_sha256="2fc1fc2c93b0bab14babc33386f7932192336813cea6db11cd27dbc36b541e41"
-# TODO : Is there a better solution for shellcheck which enables searching of these scripts?
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/common_vars.sh
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/tool_kit.sh
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/signal_trap.sh
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source "${INSTALLDIR}"/toolchain.conf
-# shellcheck source=/dev/null
+# shellcheck disable=SC1091
 source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_greenx" ] && rm "${BUILDDIR}/setup_greenx"

--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -1,0 +1,111 @@
+#!/bin/bash -e
+
+[ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
+SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
+
+greenx_ver="2.1"
+greenx_sha256="2fc1fc2c93b0bab14babc33386f7932192336813cea6db11cd27dbc36b541e41"
+source "${SCRIPT_DIR}"/common_vars.sh
+source "${SCRIPT_DIR}"/tool_kit.sh
+source "${SCRIPT_DIR}"/signal_trap.sh
+source "${INSTALLDIR}"/toolchain.conf
+source "${INSTALLDIR}"/toolchain.env
+
+[ -f "${BUILDDIR}/setup_greenx" ] && rm "${BUILDDIR}/setup_greenx"
+
+GREENX_CFLAGS=""
+GREENX_LDFLAGS=""
+GREENX_LIBS=""
+! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
+cd "${BUILDDIR}"
+
+case "$with_greenx" in
+  __INSTALL__)
+    echo "==================== Installing GreenX ===================="
+    pkg_install_dir="${INSTALLDIR}/greenX-${greenx_ver}"
+    install_lock_file="$pkg_install_dir/install_successful"
+    if verify_checksums "${install_lock_file}"; then
+      echo "greenX-${greenx_ver} is already installed, skipping it."
+    else
+      if [ -f greenX-${greenx_ver}.tar.gz ]; then
+        echo "greenX-${greenx_ver}.tar.gz is found"
+      else
+        download_pkg_from_cp2k_org "${greenx_sha256}" "greenX-${greenx_ver}.tar.gz"
+      fi
+      echo "Installing from scratch into ${pkg_install_dir}"
+      [ -d greenX-${greenx_ver} ] && rm -rf greenX-${greenx_ver}
+      tar -xzf greenX-${greenx_ver}.tar.gz
+      cd greenX-${greenx_ver}
+      mkdir build
+      cd build
+      # CP2K only uses the AC and Minimax components
+      # TODO : Include the gmp optional dependence
+      cmake \
+        -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DAC_COMPONENT=ON \
+        -DMINIMAX_COMPONENT=ON \
+        -DENABLE_GNU_GMP=OFF \
+        -DENABLE_GREENX_CTEST=OFF \
+        .. > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"
+      cd ..
+    fi
+    GREENX_CFLAGS="-I'${pkg_install_dir}/include/modules'"
+    GREENX_LDFLAGS="-L'${pkg_install_dir}/lib'"
+    ;;
+  __SYSTEM__)
+    echo "==================== Finding GreenX from system paths ===================="
+    check_lib -lGXCommon "greenx"
+    check_lib -lgx_ac "greenx"
+    check_lib -lgx_minimax "greenx"
+    # add_include_from_paths LIBXC_CFLAGS "xc.h" $INCLUDE_PATHS
+    # add_lib_from_paths LIBXC_LDFLAGS "libxc.*" $LIB_PATHS
+    ;;
+  __DONTUSE__) ;;
+
+  *)
+    echo "==================== Linking GreenX to user paths ===================="
+    pkg_install_dir="$with_greenx"
+    check_dir "${pkg_install_dir}/lib"
+    check_dir "${pkg_install_dir}/include/modules"
+    GREENX_CFLAGS="-I'${pkg_install_dir}/include/modules'"
+    GREENX_LDFLAGS="-L'${pkg_install_dir}/lib'"
+    ;;
+esac
+# TODO : Solve the pkg-config - pkg-config files are not produced by GreenX, but CMake files are.
+# Will these get correctly propagated to the cmake build? Archfile build should be trivial.
+if [ "$with_greenx" != "__DONTUSE__" ]; then
+  GREENX_LIBS=" -lGXCommon -lgx_ac -lgx_minimax"
+  cat << EOF > "${BUILDDIR}/setup_greenx"
+export GREENX_VER="${greenx_ver}"
+EOF
+  if [ "$with_greenx" != "__SYSTEM__" ]; then
+    cat << EOF >> "${BUILDDIR}/setup_greenx"
+prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
+prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
+prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
+prepend_path CPATH "$pkg_install_dir/include"
+prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+EOF
+  fi
+  cat << EOF >> "${BUILDDIR}/setup_greenx"
+export GREENX_CFLAGS="${GREENX_CFLAGS}"
+export GREENX_LDFLAGS="${GREENX_LDFLAGS}"
+export GREENX_LIBS="${GREENX_LIBS}"
+export CP_DFLAGS="\${CP_DFLAGS} -D__GREENX"
+export CP_CFLAGS="\${CP_CFLAGS} ${GREENX_CFLAGS}"
+export CP_LDFLAGS="\${CP_LDFLAGS} ${GREENX_LDFLAGS}"
+export CP_LIBS="${GREENX_LIBS} \${CP_LIBS}"
+export GREENX_ROOT="${pkg_install_dir}"
+EOF
+    cat "${BUILDDIR}/setup_greenx" >> $SETUPFILE
+fi
+
+load "${BUILDDIR}/setup_greenx"
+write_toolchain_env "${INSTALLDIR}"
+
+cd "${ROOTDIR}"
+report_timing "greenx"

--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -5,10 +5,16 @@ SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
 greenx_ver="2.1"
 greenx_sha256="2fc1fc2c93b0bab14babc33386f7932192336813cea6db11cd27dbc36b541e41"
+# TODO : Is there a better solution for shellcheck which enables searching of these scripts?
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}"/common_vars.sh
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}"/tool_kit.sh
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}"/signal_trap.sh
+# shellcheck source=/dev/null
 source "${INSTALLDIR}"/toolchain.conf
+# shellcheck source=/dev/null
 source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_greenx" ] && rm "${BUILDDIR}/setup_greenx"
@@ -18,7 +24,8 @@ GREENX_LDFLAGS=""
 GREENX_LIBS=""
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
-
+with_greenx=${with_greenx:"__DONTUSE__"}
+with_gmp=${with_greenx:"__DONTUSE__"}
 case "$with_greenx" in
   __INSTALL__)
     echo "==================== Installing GreenX ===================="
@@ -40,10 +47,10 @@ case "$with_greenx" in
       cd build
       # CP2K only uses the AC and Minimax components
       # TODO : Add the stdc++ to libs when libint not used?
-      if [ $with_gmp != "__DONTUSE__" ]; then
-	      gmp_flag=ON
+      if [ "$with_gmp" != "__DONTUSE__" ]; then
+        gmp_flag=ON
       else
-	      gmp_flag=OFF
+        gmp_flag=OFF
       fi
       cmake \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
@@ -52,10 +59,10 @@ case "$with_greenx" in
         -DMINIMAX_COMPONENT=ON \
         -DENABLE_GNU_GMP=$gmp_flag \
         -DENABLE_GREENX_CTEST=OFF \
-        .. > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
-      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"
+        .. > configure.log 2>&1 || tail -n "${LOG_LINES}" configure.log
+      make -j "$(get_nprocs)" > make.log 2>&1 || tail -n "${LOG_LINES}" make.log
+      make install > install.log 2>&1 || tail -n "${LOG_LINES}" install.log
+      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename "${SCRIPT_NAME}")"
       cd ..
     fi
     GREENX_CFLAGS="-I'${pkg_install_dir}/include/modules'"
@@ -106,7 +113,7 @@ export CP_LDFLAGS="\${CP_LDFLAGS} ${GREENX_LDFLAGS}"
 export CP_LIBS="${GREENX_LIBS} \${CP_LIBS}"
 export GREENX_ROOT="${pkg_install_dir}"
 EOF
-    cat "${BUILDDIR}/setup_greenx" >> $SETUPFILE
+  cat "${BUILDDIR}/setup_greenx" >> "$SETUPFILE"
 fi
 
 load "${BUILDDIR}/setup_greenx"

--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -39,13 +39,18 @@ case "$with_greenx" in
       mkdir build
       cd build
       # CP2K only uses the AC and Minimax components
-      # TODO : Include the gmp optional dependence
+      # TODO : Add the stdc++ to libs when libint not used?
+      if [ $with_gmp != "__DONTUSE__" ]; then
+	      gmp_flag=ON
+      else
+	      gmp_flag=OFF
+      fi
       cmake \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DAC_COMPONENT=ON \
         -DMINIMAX_COMPONENT=ON \
-        -DENABLE_GNU_GMP=OFF \
+        -DENABLE_GNU_GMP=$gmp_flag \
         -DENABLE_GREENX_CTEST=OFF \
         .. > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
       make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log

--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -73,8 +73,6 @@ case "$with_greenx" in
     check_lib -lGXCommon "greenx"
     check_lib -lgx_ac "greenx"
     check_lib -lgx_minimax "greenx"
-    # add_include_from_paths LIBXC_CFLAGS "xc.h" $INCLUDE_PATHS
-    # add_lib_from_paths LIBXC_LDFLAGS "libxc.*" $LIB_PATHS
     ;;
   __DONTUSE__) ;;
 
@@ -87,8 +85,6 @@ case "$with_greenx" in
     GREENX_LDFLAGS="-L'${pkg_install_dir}/lib'"
     ;;
 esac
-# TODO : Solve the pkg-config - pkg-config files are not produced by GreenX, but CMake files are.
-# Will these get correctly propagated to the cmake build? Archfile build should be trivial.
 if [ "$with_greenx" != "__DONTUSE__" ]; then
   GREENX_LIBS=" -lGXCommon -lgx_ac -lgx_minimax"
   cat << EOF > "${BUILDDIR}/setup_greenx"

--- a/tools/toolchain/scripts/stage3/install_stage3.sh
+++ b/tools/toolchain/scripts/stage3/install_stage3.sh
@@ -6,6 +6,7 @@
 ./scripts/stage3/install_fftw.sh
 ./scripts/stage3/install_libint.sh
 ./scripts/stage3/install_libxc.sh
+./scripts/stage3/install_greenx.sh
 ./scripts/stage3/install_libgrpp.sh
 
 #EOF


### PR DESCRIPTION
Addition of GreenX library to the toolchain script, following #4078 , which introduced the interface in the CMake script + the Makefile infrastructure. There are several things to be ironed out before I feel comfortable turning this into a full pull request, namely:

 - GreenX has optional dependency on GMP. I have included a GMP install script, but I have seen that at least on archlinux, gmp is required dependency of coreutils - is it necessary to be included in this way/should I check for presence of gmp in a different way?
 - GreenX requires linking to stdc++ (at least when using GMP) - should this be explicitly handled or is this already included somewhere else in the toolchain?
 - shellcheck complains about inaccessible files sourced at the starts of the install scripts - I setup ignore for these warnings, but I am unsure whether this is the correct approach

Furthermore, the test for the use of AC component of GreenX in RTBSE (one of the motivations for inclusion of GreenX as a library) is not yet present. I will work on this, but in the meantime, could maybe someone have a look at the current state of the code and let me know if it looks good?