### PR TITLE
CMake: Introduce CP2K_USE_EVERYTHING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,21 +114,26 @@ option(CMAKE_POSITION_INDEPENDENT_CODE "Enable position independent code" ON)
 option(CP2K_ENABLE_CONSISTENCY_CHECKS
        "Check that the list of compiled files and files contained in src match"
        OFF)
-option(CP2K_USE_DFTD4 "Enable dispersion corrections with DFTD4" ON)
-option(CP2K_USE_DEEPMD "Enable DeePMD" ON)
-option(CP2K_USE_FFTW3 "Use fftw3 for the calculating fast fourier transforms"
-       ON)
-option(CP2K_USE_MPI "Enable MPI support" ON)
-option(CP2K_USE_LIBINT2 "Enable libint2 support" ON)
-option(CP2K_USE_VORI "Enable libvori support" ON)
-option(CP2K_USE_SPGLIB "Enable spglib support" ON)
-option(CP2K_USE_LIBXC "Enable libxc support" ON)
-option(CP2K_USE_LIBTORCH "Enable libtorch support" ON)
+
+option(CP2K_USE_EVERYTHING
+       "Enable all dependencies. They can be individually turned off again."
+       OFF)
+
+option(CP2K_USE_DFTD4 "Enable DFTD4 support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_DEEPMD "Enable DeePMD" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_FFTW3 "Enable fftw3 support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_MPI "Enable MPI support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_LIBINT2 "Enable libint2 support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_VORI "Enable libvori support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_SPGLIB "Enable spglib support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_LIBXC "Enable libxc support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_LIBTORCH "Enable libtorch support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_GRPP "Enable libgrpp support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_TREXIO "Enable trexio support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_HDF5 "Enable HDF5 support" ${CP2K_USE_EVERYTHING})
+option(CP2K_USE_GREENX "Enable GreenX support" ${CP2K_USE_EVERYTHING})
+
 option(CP2K_USE_STATIC_BLAS "Link against static version of BLAS/LAPACK" OFF)
-option(CP2K_USE_GRPP "Enable libgrpp support" ON)
-option(CP2K_USE_TREXIO "Enable trexio support" ON)
-option(CP2K_USE_HDF5 "Enable HDF5 support" ON)
-option(CP2K_USE_GREENX "Enable GreenX support" ON)
 option(BUILD_SHARED_LIBS "Build cp2k shared library" ON)
 option(
   CP2K_USE_FFTW3_WITH_MKL
@@ -136,27 +141,28 @@ option(
   OFF)
 
 # MPI-enabled options
-cmake_dependent_option(CP2K_USE_COSMA "Enable COSMA support" ON "CP2K_USE_MPI"
-                       OFF)
-cmake_dependent_option(CP2K_USE_DLAF "Enable DLA-Future support" ON
-                       "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_ELPA "Enable ELPA support" ON "CP2K_USE_MPI"
-                       OFF)
-cmake_dependent_option(CP2K_USE_LIBSMEAGOL "Enable libSMEAGOL support" ON
-                       "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_MPI_F08 "Enable MPI Fortran 2008 interface" ON
-                       "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_PLUMED "Enable PLUMED2 support" ON
-                       "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_SIRIUS "Enable SIRIUS support" ON
-                       "CP2K_USE_MPI" OFF)
-cmake_dependent_option(CP2K_USE_SPLA "Enable SPLA support" ON "CP2K_USE_MPI"
-                       OFF)
+cmake_dependent_option(CP2K_USE_COSMA "Enable COSMA support"
+                       ${CP2K_USE_EVERYTHING} "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_DLAF "Enable DLA-Future support"
+                       ${CP2K_USE_EVERYTHING} "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_ELPA "Enable ELPA support"
+                       ${CP2K_USE_EVERYTHING} "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_LIBSMEAGOL "Enable libSMEAGOL support"
+                       ${CP2K_USE_EVERYTHING} "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_MPI_F08 "Enable MPI Fortran 2008 interface"
+                       ${CP2K_USE_EVERYTHING} "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_PLUMED "Enable PLUMED2 support"
+                       ${CP2K_USE_EVERYTHING} "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_SIRIUS "Enable SIRIUS support"
+                       ${CP2K_USE_EVERYTHING} "CP2K_USE_MPI" OFF)
+cmake_dependent_option(CP2K_USE_SPLA "Enable SPLA support"
+                       ${CP2K_USE_EVERYTHING} "CP2K_USE_MPI" OFF)
 
-cmake_dependent_option(CP2K_USE_LIBXSMM "Enable libxsmm support" ON
-                       "NOT CP2K_USE_ACCEL MATCHES \"OPENCL\"" ON)
+cmake_dependent_option(
+  CP2K_USE_LIBXSMM "Enable libxsmm support" ${CP2K_USE_EVERYTHING}
+  "NOT CP2K_USE_ACCEL MATCHES \"OPENCL\"" ON)
 cmake_dependent_option(CP2K_USE_LIBVDWXC "Enable libvdwxc support with SIRIUS"
-                       ON "CP2K_USE_SIRIUS" OFF)
+                       ${CP2K_USE_EVERYTHING} "CP2K_USE_SIRIUS" OFF)
 
 cmake_dependent_option(
   CP2K_DBCSR_USE_CPU_ONLY "Disable the DBCSR accelerated backend" OFF

--- a/cmake/cmake_cp2k.sh
+++ b/cmake/cmake_cp2k.sh
@@ -50,6 +50,7 @@ if [[ "${PROFILE}" == "spack_all" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_SCALAPACK_VENDOR="auto" \
+    -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DEEPMD=OFF \
     -DCP2K_USE_GREENX=OFF \
     -Werror=dev \
@@ -66,25 +67,7 @@ elif [[ "${PROFILE}" == "spack_minimal" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_SCALAPACK_VENDOR="auto" \
-    -DCP2K_USE_COSMA=OFF \
-    -DCP2K_USE_DEEPMD=OFF \
-    -DCP2K_USE_DFTD4=OFF \
-    -DCP2K_USE_DLAF=OFF \
-    -DCP2K_USE_ELPA=OFF \
-    -DCP2K_USE_GRPP=OFF \
-    -DCP2K_USE_HDF5=OFF \
-    -DCP2K_USE_LIBINT2=OFF \
-    -DCP2K_USE_LIBSMEAGOL=OFF \
-    -DCP2K_USE_LIBTORCH=OFF \
-    -DCP2K_USE_LIBXC=OFF \
     -DCP2K_USE_MPI=ON \
-    -DCP2K_USE_PLUMED=OFF \
-    -DCP2K_USE_SIRIUS=OFF \
-    -DCP2K_USE_SPGLIB=OFF \
-    -DCP2K_USE_SPLA=OFF \
-    -DCP2K_USE_TREXIO=OFF \
-    -DCP2K_USE_VORI=OFF \
-    -DCP2K_USE_GREENX=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -96,6 +79,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="auto" \
+    -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_MPI=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
@@ -108,6 +92,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "sdbg" ]]; then
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_DEBUG_MODE=ON \
+    -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_MPI=OFF \
     -Werror=dev \
@@ -122,6 +107,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_SCALAPACK_VENDOR="auto" \
+    -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
@@ -135,6 +121,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "pdbg" ]]; then
     -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_SCALAPACK_VENDOR="auto" \
     -DCP2K_DEBUG_MODE=ON \
+    -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_COSMA=OFF \
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_LIBTORCH=OFF \
@@ -150,6 +137,7 @@ elif [[ "${PROFILE}" == "ubuntu" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="auto" \
+    -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_LIBXC=OFF \
     -DCP2K_USE_MPI=OFF \
@@ -169,18 +157,6 @@ elif [[ "${PROFILE}" == "minimal" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCMAKE_BUILD_TYPE="Release" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="auto" \
-    -DCP2K_USE_DEEPMD=OFF \
-    -DCP2K_USE_DFTD4=OFF \
-    -DCP2K_USE_FFTW3=OFF \
-    -DCP2K_USE_LIBINT2=OFF \
-    -DCP2K_USE_LIBTORCH=OFF \
-    -DCP2K_USE_LIBXC=OFF \
-    -DCP2K_USE_LIBXSMM=OFF \
-    -DCP2K_USE_MPI=OFF \
-    -DCP2K_USE_SPGLIB=OFF \
-    -DCP2K_USE_TREXIO=OFF \
-    -DCP2K_USE_VORI=OFF \
-    -DCP2K_USE_GREENX=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -193,6 +169,7 @@ elif [[ "${PROFILE}" == "toolchain_all" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_SCALAPACK_VENDOR="auto" \
+    -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
@@ -206,24 +183,6 @@ elif [[ "${PROFILE}" == "toolchain_minimal" ]] && [[ "${VERSION}" == "psmp" ]]; 
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_BLAS_VENDOR="auto" \
     -DCP2K_SCALAPACK_VENDOR="auto" \
-    -DCP2K_USE_COSMA=OFF \
-    -DCP2K_USE_DEEPMD=OFF \
-    -DCP2K_USE_DFTD4=OFF \
-    -DCP2K_USE_DLAF=OFF \
-    -DCP2K_USE_ELPA=OFF \
-    -DCP2K_USE_GRPP=OFF \
-    -DCP2K_USE_HDF5=OFF \
-    -DCP2K_USE_LIBINT2=OFF \
-    -DCP2K_USE_LIBSMEAGOL=OFF \
-    -DCP2K_USE_LIBTORCH=OFF \
-    -DCP2K_USE_LIBXC=OFF \
-    -DCP2K_USE_PLUMED=OFF \
-    -DCP2K_USE_SIRIUS=OFF \
-    -DCP2K_USE_SPGLIB=OFF \
-    -DCP2K_USE_SPLA=OFF \
-    -DCP2K_USE_TREXIO=OFF \
-    -DCP2K_USE_VORI=OFF \
-    -DCP2K_USE_GREENX=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?


### PR DESCRIPTION
This is an attempt to address https://github.com/cp2k/cp2k/pull/4063#issuecomment-2733998709 by essentially bringing back the preset to include _everything_.

What do you think?