### PR TITLE
DBM/OpenCL: DBCSR/DBM kernel interoperability

### DIFF
--- a/src/dbm/Makefile
+++ b/src/dbm/Makefile
@@ -45,8 +45,8 @@ CFLAGS += -fopenmp -Wno-vla-parameter
 CC := $(if $(filter-out 0,$(MPI)),mpicc,gcc)
 else
 MKL_FCRTL := intel
-LIBS += $(if $(OMPRT),-l$(OMPRT),-qopenmp)
-CFLAGS += -qopenmp
+LIBS += $(if $(OMPRT),-fopenmp -Wno-recommended-option,-qopenmp)
+CFLAGS += $(if $(OMPRT),-fopenmp -Wno-recommended-option,-qopenmp)
 CC := $(if $(filter-out 0,$(MPI)),mpiicx,icx)
 endif
 
@@ -206,6 +206,6 @@ endif
 	cd $(dir $<); $(CC) -c -std=c11 $(CFLAGS) $(notdir $<)
 
 dbm_miniapp.x: dbm_miniapp.o $(ALL_OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+	$(CC) -o $@ $^ $(LIBS)
 
 #EOF

--- a/src/dbm/dbm_multiply_gpu_kernel.cu
+++ b/src/dbm/dbm_multiply_gpu_kernel.cu
@@ -192,9 +192,8 @@ __global__ static void process_batch_kernel(const double alpha,
  *        All arguments are assumed to be device pointers.
  * \author Ole Schuett
  ******************************************************************************/
-void dbm_multiply_gpu_launch_kernel(const offloadStream_t stream,
-                                    const double alpha, const int ntasks,
-                                    const dbm_task_t *tasks_host,
+void dbm_multiply_gpu_launch_kernel(offloadStream_t stream, double alpha,
+                                    int ntasks, const dbm_task_t *tasks_host,
                                     const dbm_task_t *tasks,
                                     const double *pack_a_data,
                                     const double *pack_b_data,

--- a/src/dbm/dbm_multiply_gpu_kernel.h
+++ b/src/dbm/dbm_multiply_gpu_kernel.h
@@ -22,10 +22,12 @@ extern "C" {
  *        All arguments are assumed to be device pointers.
  * \author Ole Schuett
  ******************************************************************************/
-void dbm_multiply_gpu_launch_kernel(
-    const offloadStream_t stream, const double alpha, const int ntasks,
-    const dbm_task_t *tasks_host, const dbm_task_t *tasks,
-    const double *pack_a_data, const double *pack_b_data, double *shard_c_data);
+void dbm_multiply_gpu_launch_kernel(offloadStream_t stream, double alpha,
+                                    int ntasks, const dbm_task_t *tasks_host,
+                                    const dbm_task_t *tasks,
+                                    const double *pack_a_data,
+                                    const double *pack_b_data,
+                                    double *shard_c_data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Revised parameter format description (support DBCSR-style in kernel).
- DBM_MULTIPLY_SMM=-1: use DBM-kernels for DBCSR.
- DBM_MULTIPLY_SMM=1: use DBCSR-kernels for DBM.

Other:
- Bulk-Lock c_dbcsr_acc_opencl_info_devptr (c_dbcsr_acc_opencl_info_devptr_lock).
- Call dbm_multiply_gpu_launch_info only if necessary.
- Pass stream in non-const fashion.
- Miniapp: drop CFLAGS (linkage).