### PR TITLE
Smearing with fixed magnetic moment for k-points

### DIFF
--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -961,7 +961,7 @@ CONTAINS
                CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                             smear%electronic_temperature, 2.0_dp)
             ELSE IF (smear%fixed_mag_mom > 0.0_dp) THEN
-               CPABORT("kpoints: Smearing with fixed magnetic moments not (yet) supported")
+               ! CPABORT("kpoints: Smearing with fixed magnetic moments not (yet) supported")
                nel = REAL(ne_a, KIND=dp)
                CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                             smear%electronic_temperature, 1.0_dp)

--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -961,7 +961,6 @@ CONTAINS
                CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                             smear%electronic_temperature, 2.0_dp)
             ELSE IF (smear%fixed_mag_mom > 0.0_dp) THEN
-               ! CPABORT("kpoints: Smearing with fixed magnetic moments not (yet) supported")
                nel = REAL(ne_a, KIND=dp)
                CALL Fermikp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                             smear%electronic_temperature, 1.0_dp)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1817,7 +1817,7 @@ CONTAINS
          IF (output_unit > 0) WRITE (UNIT=output_unit, FMT='(/,(T3,A,T61,F20.10))') &
             "Integrated spin density: ", total_spin_dens
          total_abs_spin_dens = pw_integrate_function(wf_r, oprt="ABS")
-         IF (output_unit > 0) WRITE (UNIT=output_unit, FMT='(/,(T3,A,T61,F20.10))') &
+         IF (output_unit > 0) WRITE (UNIT=output_unit, FMT='((T3,A,T61,F20.10))') &
             "Integrated absolute spin density: ", total_abs_spin_dens
          CALL auxbas_pw_pool%give_back_pw(wf_r)
          !

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1668,7 +1668,7 @@ CONTAINS
       INTEGER                                            :: handle, homo, ispin, nmo, output_unit
       LOGICAL                                            :: all_equal, do_kpoints, explicit
       REAL(KIND=dp)                                      :: maxocc, s_square, s_square_ideal, &
-                                                            total_abs_spin_dens
+                                                            total_abs_spin_dens, total_spin_dens
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues, occupation_numbers
       TYPE(admm_type), POINTER                           :: admm_env
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
@@ -1813,9 +1813,12 @@ CONTAINS
          CALL auxbas_pw_pool%create_pw(wf_r)
          CALL pw_copy(rho_r(1), wf_r)
          CALL pw_axpy(rho_r(2), wf_r, alpha=-1._dp)
+         total_spin_dens = pw_integrate_function(wf_r)
+         IF (output_unit > 0) WRITE (UNIT=output_unit, FMT='(/,(T3,A,T61,F20.10))') &
+            "Integrated spin density: ", total_spin_dens
          total_abs_spin_dens = pw_integrate_function(wf_r, oprt="ABS")
          IF (output_unit > 0) WRITE (UNIT=output_unit, FMT='(/,(T3,A,T61,F20.10))') &
-            "Integrated absolute spin density  : ", total_abs_spin_dens
+            "Integrated absolute spin density: ", total_abs_spin_dens
          CALL auxbas_pw_pool%give_back_pw(wf_r)
          !
          ! XXX Fix Me XXX

--- a/src/scf_control_types.F
+++ b/src/scf_control_types.F
@@ -621,9 +621,8 @@ CONTAINS
                   WRITE (UNIT=output_unit, FMT="(T25,A,T71,ES10.2)") &
                      "Electronic temperature [a.u.]:", scf_control%smear%electronic_temperature, &
                      "Accuracy threshold:", scf_control%smear%eps_fermi_dirac
-                  IF (scf_control%smear%fixed_mag_mom > 0.0_dp) WRITE (UNIT=output_unit, FMT="(T25,A,F10.5)") &
-                     "Spin channel alpha and spin channel beta are smeared independently, keeping"// &
-                     " fixed difference in number of electrons equal to ", scf_control%smear%fixed_mag_mom
+                  IF (scf_control%smear%fixed_mag_mom > 0.0_dp) WRITE (UNIT=output_unit, FMT="(T25,A,T61,F20.1)") &
+                     "Fixed magnetic moment set to:", scf_control%smear%fixed_mag_mom
                CASE (smear_energy_window)
                   WRITE (UNIT=output_unit, FMT="(T25,A,T71,F10.6)") &
                      "Smear window [a.u.]:       ", scf_control%smear%window_size

--- a/tests/QS/regtest-kp-3/TEST_FILES.toml
+++ b/tests/QS/regtest-kp-3/TEST_FILES.toml
@@ -5,6 +5,7 @@
 #      for details see cp2k/tools/do_regtest
 "cc1.inp"                               = [{matcher="E_total", tol=1.0E-12, ref=-45.38964266770495}]
 "bn1.inp"                               = [{matcher="M094", tol=1.0E-14, ref=27}]
+"ch1.inp"                               = [{matcher="E_total", tol=1.0E-12, ref=-12.18193777586973}]
 #cc2.inp                   1 1.0E-12 -45.38989062944852
 #cc3.inp                   1 1.0E-12 -45.38990176407365
 #cc4.inp                   1 1.0E-12 -45.38975726647867

--- a/tests/QS/regtest-kp-3/ch1.inp
+++ b/tests/QS/regtest-kp-3/ch1.inp
@@ -1,0 +1,86 @@
+&GLOBAL
+  PRINT_LEVEL medium
+  PROJECT graphene
+  RUN_TYPE energy
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD quickstep
+  STRESS_TENSOR analytical
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+    CHARGE 0
+    MULTIPLICITY 2
+    POTENTIAL_FILE_NAME POTENTIAL_UZH
+    UKS true
+    &KPOINTS
+      SCHEME monkhorst-pack 3 3 1
+    &END KPOINTS
+    &MGRID
+      CUTOFF 200
+    &END MGRID
+    &POISSON
+      PERIODIC xyz
+      POISSON_SOLVER periodic
+    &END POISSON
+    &QS
+      EPS_DEFAULT 1.0e-8
+      EXTRAPOLATION use_guess
+      METHOD gpw
+    &END QS
+    &SCF
+      ADDED_MOS 4
+      EPS_SCF 1.0e-6
+      IGNORE_CONVERGENCE_FAILURE true
+      MAX_SCF 1
+      SCF_GUESS atomic
+      &PRINT
+        &RESTART off
+        &END RESTART
+      &END PRINT
+      &SMEAR on
+        ELECTRONIC_TEMPERATURE 100
+        FIXED_MAGNETIC_MOMENT 1
+        METHOD fermi_dirac
+      &END SMEAR
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL pbe
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC [angstrom] 2.4612 2.4612 10.
+      ALPHA_BETA_GAMMA 90. 90. 120.
+      PERIODIC xyz
+      SYMMETRY hexagonal_gamma_120
+    &END CELL
+    &COORD
+      scaled
+      C  1./3.  2./3.  0.
+      C  2./3.  1./3.  0.
+      H  1./3.  2./3.  0.1
+    &END COORD
+    &KIND C
+      BASIS_SET ccgrb-d-q4
+      POTENTIAL gth-gga-q4
+    &END KIND
+    &KIND H
+      BASIS_SET ccgrb-d-q1
+      POTENTIAL gth-gga-q1
+      &BS
+        &ALPHA
+          L 0
+          N 1
+          NEL 1
+        &END ALPHA
+        &BETA
+          L 0
+          N 1
+          NEL -1
+        &END BETA
+      &END BS
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL


### PR DESCRIPTION
This PR enables the use of the `FIXED_MAGNETIC_MOMENT` option in combination with a k-point calculation.
It also changes the printout in the SCF parameters section of the output, as it was badly formatted. From:
```
Smear method:                                   FERMI_DIRAC
Electronic temperature [K]:                           300.0
Electronic temperature [a.u.]:                     9.50E-04
Accuracy threshold:                                1.00E-10
Spin channel alpha and spin channel beta are smeared independently, keeping fixed difference in number of electrons equal to    1.00000  
```
to
```
Smear method:                                   FERMI_DIRAC
Electronic temperature [K]:                           300.0
Electronic temperature [a.u.]:                     9.50E-04
Accuracy threshold:                                1.00E-10
Fixed magnetic moment set to:                           1.0  
```

At last, it also adds the calculation of the integrated spin density after the SCF is done in case of spin-polarized calculations. While this information is in principle visible in the Mulliken analysis, the `integrated absolute spin density` output alone is at time source of confusion, see [here](https://groups.google.com/g/cp2k/c/dFUIwOAfmWM/m/u1TR7bbNBAAJ).
Now, at the end of the SCF both the spin density and the absolute spin density are printed one after the other, providing more insight overall, e.g.:
```
Integrated spin density:                                          1.0000014640
Integrated absolute spin density:                                 5.4025472785
```