### PR TITLE
Compute DOS with different k-point grid

### DIFF
--- a/src/input_cp2k_kpoints.F
+++ b/src/input_cp2k_kpoints.F
@@ -78,9 +78,9 @@ CONTAINS
                           "- `MACDONALD`"//newline// &
                           "- `GENERAL`"//newline// &
                           newline// &
-                          "For `MONKHORST-PACK` and `MACDONALD` the number of k points in all "// &
-                          "3 dimensions has to be supplied along with the keyword. "// &
-                          "E.g. `MONKHORST-PACK 12 12 8`", &
+                          "For `MONKHORST-PACK` the number of k points in all 3 dimensions has to"// &
+                          " be supplied along with the keyword. For `MACDONALD` also the list of shifts."// &
+                          " E.g. `MONKHORST-PACK 12 12 8`, `MACDONALD 4 4 4 0.25 0.25 0.25`", &
                           usage="SCHEME {KPMETHOD} {integer} {integer} ..", &
                           citations=(/Monkhorst1976, MacDonald1978/), &
                           n_var=-1, type_of_var=char_t)

--- a/src/input_cp2k_print_dft.F
+++ b/src/input_cp2k_print_dft.F
@@ -2166,7 +2166,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE create_dos_section(print_key)
 
-      TYPE(section_type), POINTER                        :: print_key
+      TYPE(section_type), POINTER                        :: print_key, subsection
 
       TYPE(keyword_type), POINTER                        :: keyword
 
@@ -2195,6 +2195,11 @@ CONTAINS
                           default_i_val=4)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
+
+      NULLIFY (subsection)
+      CALL create_kpoints_section(subsection)
+      CALL section_add_subsection(print_key, subsection)
+      CALL section_release(subsection)
 
    END SUBROUTINE create_dos_section
 

--- a/src/input_cp2k_print_dft.F
+++ b/src/input_cp2k_print_dft.F
@@ -118,8 +118,7 @@ MODULE input_cp2k_print_dft
                                   create_ext_vxc_section
    USE input_cp2k_field, ONLY: create_efield_section, &
                                create_per_efield_section
-   USE input_cp2k_kpoints, ONLY: create_kpoint_set_section, &
-                                 create_kpoints_section
+   USE input_cp2k_kpoints, ONLY: create_kpoint_set_section
    USE input_cp2k_loc, ONLY: create_localize_section, &
                              print_wanniers
    USE input_cp2k_ls, ONLY: create_ls_scf_section
@@ -2166,7 +2165,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE create_dos_section(print_key)
 
-      TYPE(section_type), POINTER                        :: print_key, subsection
+      TYPE(section_type), POINTER                        :: print_key
 
       TYPE(keyword_type), POINTER                        :: keyword
 
@@ -2196,10 +2195,13 @@ CONTAINS
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
 
-      NULLIFY (subsection)
-      CALL create_kpoints_section(subsection)
-      CALL section_add_subsection(print_key, subsection)
-      CALL section_release(subsection)
+      CALL keyword_create(keyword, __LOCATION__, name="MP_GRID", &
+                          description="Specify a Monkhorst-Pack grid with which to compute the density of states. "// &
+                          "Works only for a k-point calculation", &
+                          usage="MP_GRID {integer} {integer} {integer}", default_i_vals=(/-1/), &
+                          n_var=3, type_of_var=integer_t)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
 
    END SUBROUTINE create_dos_section
 

--- a/src/qs_dos.F
+++ b/src/qs_dos.F
@@ -21,15 +21,20 @@ MODULE qs_dos
                                               cp_print_key_should_output,&
                                               cp_print_key_unit_nr
    USE input_section_types,             ONLY: section_vals_type,&
-                                              section_vals_val_get
+                                              section_vals_val_get, &
+                                              section_vals_get_subs_vals, &
+                                              section_vals_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
-   USE kpoint_types,                    ONLY: kpoint_type
+   USE kpoint_types,                    ONLY: kpoint_type, kpoint_release
+   USE qs_band_structure,               ONLY: calculate_kp_orbitals
    USE message_passing,                 ONLY: mp_para_env_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
+   USE cell_types,                      ONLY: cell_type
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_type
+   USE string_utilities,                ONLY: uppercase
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -38,7 +43,7 @@ MODULE qs_dos
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_dos'
 
-   PUBLIC :: calculate_dos, calculate_dos_kp
+   PUBLIC :: calculate_dos, calculate_dos_kp, calculate_dos_kp_explicit
 
 ! **************************************************************************************************
 
@@ -345,6 +350,70 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE calculate_dos_kp
+
+   ! at the moment this prints the dos twice
+   SUBROUTINE calculate_dos_kp_explicit(qs_env)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'calculate_dos_kp_explicit'
+
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(section_vals_type), POINTER                   :: dft_section, kpoints_section, input
+      TYPE(cp_logger_type), POINTER                      :: logger
+      INTEGER                                            :: iounit, handle, nval, i
+      LOGICAL                                            :: explicit
+      TYPE(cell_type), POINTER                           :: cell
+      CHARACTER(LEN=default_string_length), &
+         DIMENSION(:), POINTER                           :: tmpstringlist
+      CHARACTER(LEN=default_string_length)               :: kp_scheme
+      INTEGER, DIMENSION(3)                              :: nkp_grid
+
+      ! check whether there is a kpoint set section explicit
+      CALL get_qs_env(qs_env, input=input, cell=cell)
+      kpoints_section => section_vals_get_subs_vals(input, "DFT%PRINT%DOS%KPOINTS")
+      CALL section_vals_get(kpoints_section, explicit=explicit)
+      IF (.NOT. explicit) RETURN
+
+      NULLIFY (logger)
+      logger => cp_get_default_logger()
+      iounit = cp_logger_get_default_io_unit(logger)
+
+      CALL timeset(routineN, handle)
+
+      ! fetch the information from the kpoints subsection in PRINT%DOS
+      CALL section_vals_val_get(kpoints_section, "SCHEME", c_vals=tmpstringlist)
+      nval = SIZE(tmpstringlist)
+      CPASSERT(nval >= 1)
+      kp_scheme = tmpstringlist(1)
+      CALL uppercase(kp_scheme)
+
+      ! SCHEME [Monkhorst-Pack, MacDonald]
+      SELECT CASE (kp_scheme)
+      CASE ("MONKHORST-PACK")
+         CPASSERT(nval >= 4)
+         DO i = 2, 4
+            READ (tmpstringlist(i), *) nkp_grid(i - 1)
+         END DO
+      CASE DEFAULT
+         CPABORT("")
+      END SELECT
+
+      IF (iounit > 0) WRITE (UNIT=iounit, FMT='(/,(T3,A,A,T40,A,3I3,A))') &
+         " Calculate DOS with a ", TRIM(kp_scheme), "grid of ", nkp_grid(:), " kpoints"
+
+      ! calculate orbitals and energies
+      NULLIFY (kpoints)
+      CALL calculate_kp_orbitals(qs_env, kpoints, kp_scheme, 0, nkp_grid)
+
+      ! recompute the dos with the new kpoints set
+      dft_section => section_vals_get_subs_vals(input, "DFT")
+      CALL calculate_dos_kp(kpoints, qs_env, dft_section)
+
+      CALL kpoint_release(kpoints)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE calculate_dos_kp_explicit
 
 END MODULE qs_dos
 

--- a/src/qs_dos.F
+++ b/src/qs_dos.F
@@ -21,20 +21,17 @@ MODULE qs_dos
                                               cp_print_key_should_output,&
                                               cp_print_key_unit_nr
    USE input_section_types,             ONLY: section_vals_type,&
-                                              section_vals_val_get, &
-                                              section_vals_get_subs_vals, &
-                                              section_vals_get
+                                              section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
-   USE kpoint_types,                    ONLY: kpoint_type, kpoint_release
-   USE qs_band_structure,               ONLY: calculate_kp_orbitals
+   USE kpoint_types,                    ONLY: kpoint_release,&
+                                              kpoint_type
    USE message_passing,                 ONLY: mp_para_env_type
+   USE qs_band_structure,               ONLY: calculate_kp_orbitals
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
-   USE cell_types,                      ONLY: cell_type
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_type
-   USE string_utilities,                ONLY: uppercase
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -43,7 +40,7 @@ MODULE qs_dos
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_dos'
 
-   PUBLIC :: calculate_dos, calculate_dos_kp, calculate_dos_kp_explicit
+   PUBLIC :: calculate_dos, calculate_dos_kp
 
 ! **************************************************************************************************
 
@@ -198,7 +195,6 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Compute and write density of states (kpoints)
-!> \param kpoints ...
 !> \param qs_env ...
 !> \param dft_section ...
 !> \date    26.02.2008
@@ -206,9 +202,8 @@ CONTAINS
 !> \author  JGH
 !> \version 1.0
 ! **************************************************************************************************
-   SUBROUTINE calculate_dos_kp(kpoints, qs_env, dft_section)
+   SUBROUTINE calculate_dos_kp(qs_env, dft_section)
 
-      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(section_vals_type), POINTER                   :: dft_section
 
@@ -219,17 +214,19 @@ CONTAINS
       INTEGER                                            :: handle, i, ik, iounit, ispin, iterstep, &
                                                             iv, iw, ndigits, nhist, nmo(2), &
                                                             nmo_kp, nspins
-      LOGICAL                                            :: append, ionode, should_output
+      INTEGER, DIMENSION(:), POINTER                     :: nkp_grid
+      LOGICAL                                            :: append, explicit, ionode, should_output
       REAL(KIND=dp)                                      :: de, e1, e2, emax, emin, eval, wkp
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: ehist, hist, occval
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation_numbers
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
+      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:, :), POINTER        :: mos
       TYPE(mo_set_type), POINTER                         :: mo_set
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
-      NULLIFY (logger)
+      NULLIFY (logger, kpoints)
       logger => cp_get_default_logger()
       ionode = logger%para_env%is_source()
       should_output = BTEST(cp_print_key_should_output(logger%iter_info, dft_section, &
@@ -240,8 +237,29 @@ CONTAINS
       CALL timeset(routineN, handle)
       iterstep = logger%iter_info%iteration(logger%iter_info%n_rlevel)
 
+      ! check whether the user requested a different MP grid for the DOS
+      CALL section_vals_val_get(dft_section, "PRINT%DOS%MP_GRID", i_vals=nkp_grid, explicit=explicit)
+
+      IF (explicit) THEN
+         ! make sure is a valid grid
+         DO i = 1, 3
+            IF (nkp_grid(i) < 1) THEN
+               WRITE (UNIT=iounit, FMT='(T4,A,I3,A,I1)') &
+                  "Invalid kpoint grid for DOS ", nkp_grid(i), " in dimension ", i
+               CPABORT("")
+            END IF
+         END DO
+         ! calculate orbitals and energies
+         CALL calculate_kp_orbitals(qs_env, kpoints, "MONKHORST-PACK", 0, nkp_grid)
+      ELSE
+         ! use the kpoints from the environment
+         CALL get_qs_env(qs_env, kpoints=kpoints)
+      END IF
+
       IF (iounit > 0) WRITE (UNIT=iounit, FMT='(/,(T3,A,T61,I10))') &
          " Calculate DOS at iteration step ", iterstep
+      IF (iounit > 0) WRITE (UNIT=iounit, FMT='((T3,A,3I3,A))') &
+         " Using a", kpoints%nkp_grid(:), ' '//TRIM(kpoints%kp_scheme)//' grid'
 
       CALL section_vals_val_get(dft_section, "PRINT%DOS%DELTA_E", r_val=de)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%APPEND", l_val=append)
@@ -347,73 +365,14 @@ CONTAINS
       CALL cp_print_key_finished_output(iw, logger, dft_section, "PRINT%DOS")
       DEALLOCATE (hist, occval)
 
+      ! destroy the extra k-point set if it was created
+      IF (explicit) THEN
+         CALL kpoint_release(kpoints)
+      END IF
+
       CALL timestop(handle)
 
    END SUBROUTINE calculate_dos_kp
-
-   ! at the moment this prints the dos twice
-   SUBROUTINE calculate_dos_kp_explicit(qs_env)
-      TYPE(qs_environment_type), POINTER                 :: qs_env
-
-      CHARACTER(len=*), PARAMETER                        :: routineN = 'calculate_dos_kp_explicit'
-
-      TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(section_vals_type), POINTER                   :: dft_section, kpoints_section, input
-      TYPE(cp_logger_type), POINTER                      :: logger
-      INTEGER                                            :: iounit, handle, nval, i
-      LOGICAL                                            :: explicit
-      TYPE(cell_type), POINTER                           :: cell
-      CHARACTER(LEN=default_string_length), &
-         DIMENSION(:), POINTER                           :: tmpstringlist
-      CHARACTER(LEN=default_string_length)               :: kp_scheme
-      INTEGER, DIMENSION(3)                              :: nkp_grid
-
-      ! check whether there is a kpoint set section explicit
-      CALL get_qs_env(qs_env, input=input, cell=cell)
-      kpoints_section => section_vals_get_subs_vals(input, "DFT%PRINT%DOS%KPOINTS")
-      CALL section_vals_get(kpoints_section, explicit=explicit)
-      IF (.NOT. explicit) RETURN
-
-      NULLIFY (logger)
-      logger => cp_get_default_logger()
-      iounit = cp_logger_get_default_io_unit(logger)
-
-      CALL timeset(routineN, handle)
-
-      ! fetch the information from the kpoints subsection in PRINT%DOS
-      CALL section_vals_val_get(kpoints_section, "SCHEME", c_vals=tmpstringlist)
-      nval = SIZE(tmpstringlist)
-      CPASSERT(nval >= 1)
-      kp_scheme = tmpstringlist(1)
-      CALL uppercase(kp_scheme)
-
-      ! SCHEME [Monkhorst-Pack, MacDonald]
-      SELECT CASE (kp_scheme)
-      CASE ("MONKHORST-PACK")
-         CPASSERT(nval >= 4)
-         DO i = 2, 4
-            READ (tmpstringlist(i), *) nkp_grid(i - 1)
-         END DO
-      CASE DEFAULT
-         CPABORT("")
-      END SELECT
-
-      IF (iounit > 0) WRITE (UNIT=iounit, FMT='(/,(T3,A,A,T40,A,3I3,A))') &
-         " Calculate DOS with a ", TRIM(kp_scheme), "grid of ", nkp_grid(:), " kpoints"
-
-      ! calculate orbitals and energies
-      NULLIFY (kpoints)
-      CALL calculate_kp_orbitals(qs_env, kpoints, kp_scheme, 0, nkp_grid)
-
-      ! recompute the dos with the new kpoints set
-      dft_section => section_vals_get_subs_vals(input, "DFT")
-      CALL calculate_dos_kp(kpoints, qs_env, dft_section)
-
-      CALL kpoint_release(kpoints)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE calculate_dos_kp_explicit
 
 END MODULE qs_dos
 

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1678,7 +1678,6 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_rmpv, matrix_s
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_deriv
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
       TYPE(molecule_type), POINTER                       :: molecule_set(:)
       TYPE(particle_list_type), POINTER                  :: particles
@@ -1695,6 +1694,8 @@ CONTAINS
       TYPE(scf_control_type), POINTER                    :: scf_control
       TYPE(section_vals_type), POINTER                   :: dft_section, input, sprint_section, &
                                                             trexio_section
+
+! TYPE(kpoint_type), POINTER                         :: kpoints
 
       CALL timeset(routineN, handle)
 
@@ -1751,8 +1752,7 @@ CONTAINS
          IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, "PRINT%DOS") &
                    , cp_p_file)) THEN
             IF (do_kpoints) THEN
-               CALL get_qs_env(qs_env=qs_env, kpoints=kpoints)
-               CALL calculate_dos_kp(kpoints, qs_env, dft_section)
+               CALL calculate_dos_kp(qs_env, dft_section)
             ELSE
                CALL get_qs_env(qs_env, mos=mos)
                CALL calculate_dos(mos, dft_section)

--- a/src/qs_scf_post_scf.F
+++ b/src/qs_scf_post_scf.F
@@ -17,7 +17,6 @@ MODULE qs_scf_post_scf
    USE localization_tb,                 ONLY: wfn_localization_tb
    USE lri_optimize_ri_basis,           ONLY: optimize_lri_basis
    USE qs_band_structure,               ONLY: calculate_band_structure
-   USE qs_dos,                          ONLY: calculate_dos_kp_explicit
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_scf_post_gpw,                 ONLY: scf_post_calculation_gpw
@@ -80,7 +79,6 @@ CONTAINS
          END IF
       END IF
 
-      CALL calculate_dos_kp_explicit(qs_env)
       CALL calculate_band_structure(qs_env)
 
       dft_section => section_vals_get_subs_vals(qs_env%input, "DFT")

--- a/src/qs_scf_post_scf.F
+++ b/src/qs_scf_post_scf.F
@@ -17,6 +17,7 @@ MODULE qs_scf_post_scf
    USE localization_tb,                 ONLY: wfn_localization_tb
    USE lri_optimize_ri_basis,           ONLY: optimize_lri_basis
    USE qs_band_structure,               ONLY: calculate_band_structure
+   USE qs_dos,                          ONLY: calculate_dos_kp_explicit
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_scf_post_gpw,                 ONLY: scf_post_calculation_gpw
@@ -79,6 +80,7 @@ CONTAINS
          END IF
       END IF
 
+      CALL calculate_dos_kp_explicit(qs_env)
       CALL calculate_band_structure(qs_env)
 
       dft_section => section_vals_get_subs_vals(qs_env%input, "DFT")

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -61,7 +61,6 @@ MODULE qs_scf_post_tb
    USE kinds,                           ONLY: default_path_length,&
                                               default_string_length,&
                                               dp
-   USE kpoint_types,                    ONLY: kpoint_type
    USE machine,                         ONLY: m_flush
    USE mathconstants,                   ONLY: twopi
    USE memory_utilities,                ONLY: reallocate
@@ -191,7 +190,6 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks, matrix_p, matrix_s
       TYPE(dbcsr_type), POINTER                          :: mo_coeff_deriv
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(particle_list_type), POINTER                  :: particles
@@ -440,8 +438,7 @@ CONTAINS
          print_key => section_vals_get_subs_vals(print_section, "DOS")
          IF (BTEST(cp_print_key_should_output(logger%iter_info, print_key), cp_p_file)) THEN
             IF (do_kpoints) THEN
-               CALL get_qs_env(qs_env=qs_env, kpoints=kpoints)
-               CALL calculate_dos_kp(kpoints, qs_env, dft_section)
+               CALL calculate_dos_kp(qs_env, dft_section)
             ELSE
                CALL get_qs_env(qs_env, mos=mos)
                CALL calculate_dos(mos, dft_section)


### PR DESCRIPTION
This PR adds support for computing the density of states with a different k-point grid than that used in the SCF. This is common practice for materials simulations, as the DOS requires a finer grid to be properly converged compared to the energy.

The subroutine that computes the DOS is called early on after the SCF from `write_available_results()`. To avoid any major refactoring, duplicating code or double calculation of the dos, I check whether or not to compute the DOS with the new k-point grid at this point. In case a new k-point grid is requested, this triggers additional calculations that break "the assumption" of `write_available_results()`, which is that of only writing what is available right after the SCF and postpone extra calculations to a later stage. However, this does not change the current behavior if this new feature is not used.