### PR TITLE
Fix macOS arch file for Apple M1

### DIFF
--- a/arch/Darwin-gnu-arm64.psmp
+++ b/arch/Darwin-gnu-arm64.psmp
@@ -3,13 +3,13 @@
 # CP2K Darwin arch file for a parallel arm64 binary
 # (https://www.cp2k.org/howto:compile_on_macos)
 #
-# Tested with: GNU 14.2.0 and OpenMPI 5.0.6 on an Apple M1 (macOS 15.3 Sequoia)
+# Tested with: GNU 14.2.0 and OpenMPI 5.0.7 on an Apple M1 (macOS 15.4.1 Sequoia)
 #
 # Usage: Source this arch file and then run make as instructed.
 #        Ensure the links in /opt/homebrew/bin to the gcc version
 #        and "brew unlink openmpi" (or mpich) if installed.
 #
-# Last update: 12.02.2025
+# Last update: 25.04.2025
 #
 # \
    if [[ "${0}" == "${BASH_SOURCE}" ]]; then \
@@ -23,11 +23,11 @@
    [[ -z "${mpi_implementation}" ]] && mpi_implementation="openmpi"; \
    [[ -z "${target_cpu}" ]] && target_cpu="native"; \
    if $(command -v brew >/dev/null 2>&1); then \
-      brew install cmake; \
       brew install coreutils; \
       brew install fftw; \
       brew install gawk; \
       brew install gcc; \
+      brew install gmp; \
       brew install gsed; \
       brew install gsl; \
       brew install hdf5; \
@@ -45,9 +45,9 @@
       return 1; \
    fi; \
    ./install_cp2k_toolchain.sh --install-all -j${maxtasks} --no-arch-files --target-cpu=${target_cpu} \
-      --with-cmake=$(brew --prefix cmake) --with-elpa=no --with-fftw=$(brew --prefix fftw) --with-gcc=system \
-      --with-gsl=$(brew --prefix gsl) --with-hdf5=$(brew --prefix hdf5) --with-libxc=$(brew --prefix libxc) \
-      --with-ninja=$(brew --prefix ninja) --with-openblas=$(brew --prefix openblas) --with-${mpi_implementation} \
+      --with-elpa=no --with-fftw=$(brew --prefix fftw) --with-gcc=system --with-gsl=$(brew --prefix gsl) \
+      --with-hdf5=$(brew --prefix hdf5) --with-libxc=$(brew --prefix libxc) --with-ninja=$(brew --prefix ninja) \
+      --with-openblas=$(brew --prefix openblas) --with-${mpi_implementation} --with-gmp=$(brew --prefix gmp) \
       --with-libsmeagol --with-libtorch=no --with-deepmd=no; \
    source ./install/setup; \
    cd ../..; \
@@ -196,7 +196,6 @@ endif
 
 ifneq ($(USE_SIRIUS),)
    USE_SIRIUS     := $(strip $(USE_SIRIUS))
-   USE_GSL        := ${GSL_VER}
    LIBVDWXC_INC   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/include
    LIBVDWXC_LIB   := $(INSTALL_PATH)/libvdwxc-$(LIBVDWXC_VER)/lib
    PUGIXML_LIB    := $(INSTALL_PATH)/pugixml-$(PUGIXML_VER)/lib


### PR DESCRIPTION
- Homebrew under macOS 15.4.1 (Sequoia) provides only CMake 4.0.1 which does not build the latest ScaLAPACK version 2.2.2
- CMake 3.31.2 -> 3.31.7