### PR TITLE
DBM: call offload_activate_chosen_device for offloadMallocHost/offloadFreeHost

### DIFF
--- a/src/dbm/Makefile
+++ b/src/dbm/Makefile
@@ -57,13 +57,17 @@ CC := $(MPICC)
 endif
 endif
 
+ifeq ($(filter-out 0,$(OPENCL)),)
 NVCC := $(shell which nvcc 2>/dev/null)
 NVARCH := sm_70
 NVFLAGS := -g $(OPTFLAG) -lineinfo -arch $(NVARCH) -Wno-deprecated-gpu-targets -Xcompiler "$(CFLAGS)" -D__OFFLOAD_CUDA
 
 HIPCC := $(shell which hipcc 2>/dev/null)
 HIPARCH := gfx90a
+ROCM_PATH_ENV := $(shell echo "$${ROCM_PATH}")
+ROCM_PATH := $(if $(ROCM_PATH_ENV),$(ROCM_PATH_ENV),/opt/rocm)
 HIPFLAGS := -fPIE -g $(OPTFLAG) --offload-arch=$(HIPARCH) -Wall -Wextra -Werror -I${ROCM_PATH}/include -D__OFFLOAD_HIP -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_AMD__
+endif
 
 # prefer NVCC or HIPCC over OpenCL
 ifneq ($(NVCC)$(HIPCC),)
@@ -144,11 +148,12 @@ endif
 LIBS += -L$(OPENCL_ROOT)/$(if $(wildcard $(OPENCL_ROOT)/lib64),lib64,lib)
 else ifneq (,$(ICX))
 OPENCL_ROOT := $(abspath $(dir $(ICX))/..)
-ifneq (,$(wildcard $(OPENCL_ROOT)/include/sycl/CL/cl.h))
+CLINC := $(wildcard $(OPENCL_ROOT)/include/sycl/CL/cl.h $(OPENCL_ROOT)/include/CL/cl.h)
+ifneq (,$(CLINC))
 LIBS += -L$(OPENCL_ROOT)/$(if $(wildcard $(OPENCL_ROOT)/lib64),lib64,lib)
 LIBS += -L$(OPENCL_ROOT)/compiler/lib/intel64 -lintlc
 ifeq (,$(wildcard $(OPENCL_INC)))
-CFLAGS += -I$(OPENCL_ROOT)/include/sycl
+CFLAGS += -I$(abspath $(dir $(firstword $(CLINC)))/..)
 endif
 endif
 endif

--- a/src/dbm/dbm_mempool.c
+++ b/src/dbm/dbm_mempool.c
@@ -78,6 +78,7 @@ static void *actual_malloc(size_t size, bool on_device) {
       offloadMalloc(&memory, size);
     } else {
 #if DBM_ALLOC_OFFLOAD
+      offload_activate_chosen_device();
       offloadMallocHost(&memory, size);
 #else
       memory = dbm_mpi_alloc_mem(size);
@@ -115,6 +116,7 @@ static void actual_free(const void *memory, bool on_device) {
       offloadFree(mem);
     } else {
 #if DBM_ALLOC_OFFLOAD
+      offload_activate_chosen_device();
       offloadFreeHost(mem);
 #else
       dbm_mpi_free_mem(mem);


### PR DESCRIPTION
- Fixes potential issues with mapping (unified) memory.
- Miniapp: improved finding ROCM_PATH.