### PR TITLE
fix: add rpath to GREENX_LDFLAGS

### DIFF
--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -66,7 +66,7 @@ case "$with_greenx" in
       cd ..
     fi
     GREENX_CFLAGS="-I'${pkg_install_dir}/include/modules'"
-    GREENX_LDFLAGS="-L'${pkg_install_dir}/lib'"
+    GREENX_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding GreenX from system paths ===================="


### PR DESCRIPTION
most libraries that are installed by the toolchain have this.