### PR TITLE
Use podman instead of docker

### DIFF
--- a/tools/docker/Dockerfile.build_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.build_hip_rocm_Mi100 ../../
+# Usage: podman build -f ./Dockerfile.build_hip_rocm_Mi100 ../../
 #
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi50
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.build_hip_rocm_Mi50 ../../
+# Usage: podman build -f ./Dockerfile.build_hip_rocm_Mi50 ../../
 #
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_aiida
+++ b/tools/docker/Dockerfile.test_aiida
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_aiida ../../
+# Usage: podman build -f ./Dockerfile.test_aiida ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_arm64-psmp
+++ b/tools/docker/Dockerfile.test_arm64-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_arm64-psmp ../../
+# Usage: podman build -f ./Dockerfile.test_arm64-psmp ../../
 #
 
 FROM arm64v8/ubuntu:24.04
@@ -30,7 +30,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_asan-psmp
+++ b/tools/docker/Dockerfile.test_asan-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_asan-psmp ../../
+# Usage: podman build -f ./Dockerfile.test_asan-psmp ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_asan-ssmp
+++ b/tools/docker/Dockerfile.test_asan-ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_asan-ssmp ../../
+# Usage: podman build -f ./Dockerfile.test_asan-ssmp ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_ase
+++ b/tools/docker/Dockerfile.test_ase
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_ase ../../
+# Usage: podman build -f ./Dockerfile.test_ase ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_conventions
+++ b/tools/docker/Dockerfile.test_conventions
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_conventions ../../
+# Usage: podman build -f ./Dockerfile.test_conventions ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_coverage-pdbg
+++ b/tools/docker/Dockerfile.test_coverage-pdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_coverage-pdbg ../../
+# Usage: podman build -f ./Dockerfile.test_coverage-pdbg ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_coverage-sdbg
+++ b/tools/docker/Dockerfile.test_coverage-sdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_coverage-sdbg ../../
+# Usage: podman build -f ./Dockerfile.test_coverage-sdbg ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_cuda_A100
+++ b/tools/docker/Dockerfile.test_cuda_A100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_cuda_A100 ../../
+# Usage: podman build -f ./Dockerfile.test_cuda_A100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_cuda_P100
+++ b/tools/docker/Dockerfile.test_cuda_P100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_cuda_P100 ../../
+# Usage: podman build -f ./Dockerfile.test_cuda_P100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_cuda_V100
+++ b/tools/docker/Dockerfile.test_cuda_V100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_cuda_V100 ../../
+# Usage: podman build -f ./Dockerfile.test_cuda_V100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_doxygen
+++ b/tools/docker/Dockerfile.test_doxygen
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_doxygen ../../
+# Usage: podman build -f ./Dockerfile.test_doxygen ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_fedora-psmp
+++ b/tools/docker/Dockerfile.test_fedora-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_fedora-psmp ../../
+# Usage: podman build -f ./Dockerfile.test_fedora-psmp ../../
 #
 
 FROM fedora:41
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_gcc10
+++ b/tools/docker/Dockerfile.test_gcc10
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_gcc10 ../../
+# Usage: podman build -f ./Dockerfile.test_gcc10 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc11
+++ b/tools/docker/Dockerfile.test_gcc11
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_gcc11 ../../
+# Usage: podman build -f ./Dockerfile.test_gcc11 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc12
+++ b/tools/docker/Dockerfile.test_gcc12
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_gcc12 ../../
+# Usage: podman build -f ./Dockerfile.test_gcc12 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc13
+++ b/tools/docker/Dockerfile.test_gcc13
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_gcc13 ../../
+# Usage: podman build -f ./Dockerfile.test_gcc13 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc14
+++ b/tools/docker/Dockerfile.test_gcc14
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_gcc14 ../../
+# Usage: podman build -f ./Dockerfile.test_gcc14 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc8
+++ b/tools/docker/Dockerfile.test_gcc8
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_gcc8 ../../
+# Usage: podman build -f ./Dockerfile.test_gcc8 ../../
 #
 
 FROM ubuntu:20.04
@@ -56,7 +56,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_gcc9
+++ b/tools/docker/Dockerfile.test_gcc9
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_gcc9 ../../
+# Usage: podman build -f ./Dockerfile.test_gcc9 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_generic_pdbg
+++ b/tools/docker/Dockerfile.test_generic_pdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_generic_pdbg ../../
+# Usage: podman build -f ./Dockerfile.test_generic_pdbg ../../
 #
 
 FROM ubuntu:24.04
@@ -29,7 +29,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_generic_psmp ../../
+# Usage: podman build -f ./Dockerfile.test_generic_psmp ../../
 #
 
 FROM ubuntu:24.04
@@ -29,7 +29,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_generic_sdbg
+++ b/tools/docker/Dockerfile.test_generic_sdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_generic_sdbg ../../
+# Usage: podman build -f ./Dockerfile.test_generic_sdbg ../../
 #
 
 FROM ubuntu:24.04
@@ -29,7 +29,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_generic_ssmp
+++ b/tools/docker/Dockerfile.test_generic_ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_generic_ssmp ../../
+# Usage: podman build -f ./Dockerfile.test_generic_ssmp ../../
 #
 
 FROM ubuntu:24.04
@@ -29,7 +29,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_gromacs
+++ b/tools/docker/Dockerfile.test_gromacs
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_gromacs ../../
+# Usage: podman build -f ./Dockerfile.test_gromacs ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_hip_cuda_A100
+++ b/tools/docker/Dockerfile.test_hip_cuda_A100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_hip_cuda_A100 ../../
+# Usage: podman build -f ./Dockerfile.test_hip_cuda_A100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
@@ -125,7 +125,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_hip_cuda_P100
+++ b/tools/docker/Dockerfile.test_hip_cuda_P100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_hip_cuda_P100 ../../
+# Usage: podman build -f ./Dockerfile.test_hip_cuda_P100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
@@ -125,7 +125,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_hip_cuda_V100
+++ b/tools/docker/Dockerfile.test_hip_cuda_V100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_hip_cuda_V100 ../../
+# Usage: podman build -f ./Dockerfile.test_hip_cuda_V100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
@@ -125,7 +125,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_hip_rocm_Mi100 ../../
+# Usage: podman build -f ./Dockerfile.test_hip_rocm_Mi100 ../../
 #
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi50
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_hip_rocm_Mi50 ../../
+# Usage: podman build -f ./Dockerfile.test_hip_rocm_Mi50 ../../
 #
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_i-pi
+++ b/tools/docker/Dockerfile.test_i-pi
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_i-pi ../../
+# Usage: podman build -f ./Dockerfile.test_i-pi ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_intel-psmp
+++ b/tools/docker/Dockerfile.test_intel-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_intel-psmp ../../
+# Usage: podman build -f ./Dockerfile.test_intel-psmp ../../
 #
 
 FROM intel/hpckit:2024.2.1-0-devel-ubuntu22.04
@@ -31,7 +31,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_intel-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_intel-ssmp ../../
+# Usage: podman build -f ./Dockerfile.test_intel-ssmp ../../
 #
 
 FROM intel/hpckit:2024.2.1-0-devel-ubuntu22.04
@@ -31,7 +31,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_manual
+++ b/tools/docker/Dockerfile.test_manual
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_manual ../../
+# Usage: podman build -f ./Dockerfile.test_manual ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_minimal
+++ b/tools/docker/Dockerfile.test_minimal
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_minimal ../../
+# Usage: podman build -f ./Dockerfile.test_minimal ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_misc
+++ b/tools/docker/Dockerfile.test_misc
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_misc ../../
+# Usage: podman build -f ./Dockerfile.test_misc ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_nvhpc
+++ b/tools/docker/Dockerfile.test_nvhpc
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_nvhpc ../../
+# Usage: podman build -f ./Dockerfile.test_nvhpc ../../
 #
 
 FROM ubuntu:22.04

--- a/tools/docker/Dockerfile.test_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_openmpi-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_openmpi-psmp ../../
+# Usage: podman build -f ./Dockerfile.test_openmpi-psmp ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_pdbg ../../
+# Usage: podman build -f ./Dockerfile.test_pdbg ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_performance
+++ b/tools/docker/Dockerfile.test_performance
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_performance ../../
+# Usage: podman build -f ./Dockerfile.test_performance ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_performance_cuda_A100
+++ b/tools/docker/Dockerfile.test_performance_cuda_A100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_performance_cuda_A100 ../../
+# Usage: podman build -f ./Dockerfile.test_performance_cuda_A100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_performance_cuda_P100
+++ b/tools/docker/Dockerfile.test_performance_cuda_P100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_performance_cuda_P100 ../../
+# Usage: podman build -f ./Dockerfile.test_performance_cuda_P100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_performance_cuda_V100
+++ b/tools/docker/Dockerfile.test_performance_cuda_V100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_performance_cuda_V100 ../../
+# Usage: podman build -f ./Dockerfile.test_performance_cuda_V100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
@@ -43,7 +43,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_precommit
+++ b/tools/docker/Dockerfile.test_precommit
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_precommit ../../
+# Usage: podman build -f ./Dockerfile.test_precommit ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_psmp
+++ b/tools/docker/Dockerfile.test_psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_psmp ../../
+# Usage: podman build -f ./Dockerfile.test_psmp ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_sdbg
+++ b/tools/docker/Dockerfile.test_sdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_sdbg ../../
+# Usage: podman build -f ./Dockerfile.test_sdbg ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/Dockerfile.test_spack
+++ b/tools/docker/Dockerfile.test_spack
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_spack ../../
+# Usage: podman build -f ./Dockerfile.test_spack ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_ssmp
+++ b/tools/docker/Dockerfile.test_ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: docker build -f ./Dockerfile.test_ssmp ../../
+# Usage: podman build -f ./Dockerfile.test_ssmp ../../
 #
 
 FROM ubuntu:24.04
@@ -28,7 +28,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -10,11 +10,11 @@ To run a test one simply has to build the image:
 
 ```shell
 ./spack_cache_start.sh
-docker build --network=host --shm-size=1g -f Dockerfile.test_sdbg -t cp2k_test_sdbg ../../
+podman build --network=host --shm-size=1g -f Dockerfile.test_sdbg -t cp2k_test_sdbg ../../
 ```
 
 To retrieve the cached report of an old image simply run it:
 
 ```shell
-docker run cp2k_test_sdbg
+podman run cp2k_test_sdbg
 ```

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -788,7 +788,7 @@ RUN ./install_cp2k_toolchain.sh \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
-# This breaks up the lengthy installation into smaller docker build steps.
+# This breaks up the lengthy installation into smaller build steps.
 COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
 RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
 
@@ -919,7 +919,7 @@ class OutputFile:
         self.content = io.StringIO()
         self.content.write(f"#\n")
         self.content.write(f"# This file was created by generate_dockerfiles.py.\n")
-        self.content.write(f"# Usage: docker build -f ./{filename} ../../\n")
+        self.content.write(f"# Usage: podman build -f ./{filename} ../../\n")
         self.content.write(f"#\n")
 
     def __enter__(self) -> io.StringIO:

--- a/tools/docker/spack_cache_list.sh
+++ b/tools/docker/spack_cache_list.sh
@@ -2,6 +2,6 @@
 
 # author: Ole Schuett
 
-docker exec spack-cache mc ls --recursive --summarize local/spack-cache
+podman exec spack-cache mc ls --recursive --summarize local/spack-cache
 
 #EOF

--- a/tools/docker/spack_cache_remove.sh
+++ b/tools/docker/spack_cache_remove.sh
@@ -2,6 +2,6 @@
 
 # author: Ole Schuett
 
-docker rm spack-cache
+podman rm spack-cache
 
 #EOF

--- a/tools/docker/spack_cache_start.sh
+++ b/tools/docker/spack_cache_start.sh
@@ -2,25 +2,25 @@
 
 # author: Ole Schuett
 
-if docker start spack-cache; then
+if podman start spack-cache; then
   echo "Re-started existing spack cache."
 
 else
   # Start MinIO server.
-  docker run --name spack-cache --detach -p 9000:9000 -p 9001:9001 \
+  podman run --name spack-cache --detach -p 9000:9000 -p 9001:9001 \
     quay.io/minio/minio server /data --console-address ":9001"
 
   sleep 3
-  docker container logs spack-cache
+  podman container logs spack-cache
 
   # Configure localhost.
-  docker exec spack-cache mc alias set local http://localhost:9000 minioadmin minioadmin
+  podman exec spack-cache mc alias set local http://localhost:9000 minioadmin minioadmin
 
   # Create bucket.
-  docker exec spack-cache mc mb local/spack-cache
+  podman exec spack-cache mc mb local/spack-cache
 
   # Make bucket public.
-  docker exec spack-cache mc anonymous set public local/spack-cache
+  podman exec spack-cache mc anonymous set public local/spack-cache
   echo "Started new spack cache."
 fi
 

--- a/tools/docker/spack_cache_stop.sh
+++ b/tools/docker/spack_cache_stop.sh
@@ -2,6 +2,6 @@
 
 # author: Ole Schuett
 
-docker container stop spack-cache
+podman container stop spack-cache
 
 #EOF


### PR DESCRIPTION
Rationale for this proposal: Docker is usually not provided on shared compute clusters, e.g. at HPC centres, because docker runs a daemon with root privileges creating potential security vulnerability. By contrast, podman is daemonless and more lightweight and is built on the same principles as Docker's API.