### PR TITLE
Add regression tester for new Intel ifx compiler

### DIFF
--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -202,6 +202,18 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_hip-rocm-build_rep
 
 # ==============================================================================
 
+[intel-oneapi-hpckit-ssmp]
+sortkey:     1028
+name:        Intel oneAPI HPC Toolkit (ssmp)
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-oneapi-hpckit-ssmp_report.txt
+
+[intel-oneapi-hpckit-psmp]
+sortkey:     1029
+name:        Intel oneAPI HPC Toolkit (psmp)
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-oneapi-hpckit-psmp_report.txt
+
 [intel-ssmp]
 sortkey:     1030
 name:        Intel oneAPI (ssmp)

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.build_hip_rocm_Mi100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.build_hip_rocm_Mi100 ../../
 #
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi50
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.build_hip_rocm_Mi50 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.build_hip_rocm_Mi50 ../../
 #
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete

--- a/tools/docker/Dockerfile.test_aiida
+++ b/tools/docker/Dockerfile.test_aiida
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_aiida ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_aiida ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_arm64-psmp
+++ b/tools/docker/Dockerfile.test_arm64-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_arm64-psmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_arm64-psmp ../../
 #
 
 FROM arm64v8/ubuntu:24.04

--- a/tools/docker/Dockerfile.test_asan-psmp
+++ b/tools/docker/Dockerfile.test_asan-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_asan-psmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_asan-psmp ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_asan-ssmp
+++ b/tools/docker/Dockerfile.test_asan-ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_asan-ssmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_asan-ssmp ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_ase
+++ b/tools/docker/Dockerfile.test_ase
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_ase ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_ase ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_conventions
+++ b/tools/docker/Dockerfile.test_conventions
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_conventions ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_conventions ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_coverage-sdbg
+++ b/tools/docker/Dockerfile.test_coverage-sdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_coverage-sdbg ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_coverage-sdbg ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_cuda_A100
+++ b/tools/docker/Dockerfile.test_cuda_A100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_cuda_A100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_cuda_A100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_cuda_P100
+++ b/tools/docker/Dockerfile.test_cuda_P100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_cuda_P100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_cuda_P100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_cuda_V100
+++ b/tools/docker/Dockerfile.test_cuda_V100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_cuda_V100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_cuda_V100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_doxygen
+++ b/tools/docker/Dockerfile.test_doxygen
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_doxygen ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_doxygen ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_fedora-psmp
+++ b/tools/docker/Dockerfile.test_fedora-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_fedora-psmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_fedora-psmp ../../
 #
 
 FROM fedora:41

--- a/tools/docker/Dockerfile.test_gcc10
+++ b/tools/docker/Dockerfile.test_gcc10
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_gcc10 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_gcc10 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc11
+++ b/tools/docker/Dockerfile.test_gcc11
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_gcc11 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_gcc11 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc12
+++ b/tools/docker/Dockerfile.test_gcc12
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_gcc12 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_gcc12 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc13
+++ b/tools/docker/Dockerfile.test_gcc13
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_gcc13 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_gcc13 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc14
+++ b/tools/docker/Dockerfile.test_gcc14
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_gcc14 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_gcc14 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gcc8
+++ b/tools/docker/Dockerfile.test_gcc8
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_gcc8 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_gcc8 ../../
 #
 
 FROM ubuntu:20.04

--- a/tools/docker/Dockerfile.test_gcc9
+++ b/tools/docker/Dockerfile.test_gcc9
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_gcc9 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_gcc9 ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_generic_pdbg
+++ b/tools/docker/Dockerfile.test_generic_pdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_generic_pdbg ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_generic_pdbg ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_generic_psmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_generic_psmp ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_generic_sdbg
+++ b/tools/docker/Dockerfile.test_generic_sdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_generic_sdbg ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_generic_sdbg ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_generic_ssmp
+++ b/tools/docker/Dockerfile.test_generic_ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_generic_ssmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_generic_ssmp ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_gromacs
+++ b/tools/docker/Dockerfile.test_gromacs
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_gromacs ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_gromacs ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_hip_cuda_A100
+++ b/tools/docker/Dockerfile.test_hip_cuda_A100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_hip_cuda_A100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_hip_cuda_A100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_hip_cuda_P100
+++ b/tools/docker/Dockerfile.test_hip_cuda_P100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_hip_cuda_P100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_hip_cuda_P100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_hip_cuda_V100
+++ b/tools/docker/Dockerfile.test_hip_cuda_V100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_hip_cuda_V100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_hip_cuda_V100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_hip_rocm_Mi100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_hip_rocm_Mi100 ../../
 #
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi50
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_hip_rocm_Mi50 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_hip_rocm_Mi50 ../../
 #
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete

--- a/tools/docker/Dockerfile.test_i-pi
+++ b/tools/docker/Dockerfile.test_i-pi
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_i-pi ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_i-pi ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_intel-oneapi-hpckit-psmp
+++ b/tools/docker/Dockerfile.test_intel-oneapi-hpckit-psmp
@@ -1,14 +1,14 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build --shm-size=1g -f ./Dockerfile.test_coverage-pdbg ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-oneapi-hpckit-psmp ../../
 #
 
-FROM ubuntu:24.04
+FROM intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+RUN ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts
@@ -22,9 +22,13 @@ COPY ./tools/toolchain/scripts/VERSION \
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
-    --mpi-mode=mpich \
     --with-dbcsr=no \
-    --with-gcc=system \
+    --with-ifx=yes \
+    --with-intelmpi \
+    --with-mkl \
+    --with-libsmeagol \
+    --with-libtorch=no \
+    --with-deepmd=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
@@ -64,24 +68,26 @@ COPY ./tools/toolchain/scripts/arch_base.tmpl \
      ./scripts/
 RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
-# Install CP2K using local_coverage.pdbg.
+# Install CP2K using local.psmp.
 WORKDIR /opt/cp2k
-ARG GIT_COMMIT_SHA
 COPY ./Makefile .
 COPY ./src ./src
 COPY ./exts ./exts
 COPY ./tools/build_utils ./tools/build_utils
 RUN /bin/bash -c " \
-    if [ -n "${GIT_COMMIT_SHA}" ] ; then echo "git:\${GIT_COMMIT_SHA::7}" > REVISION; fi && \
     mkdir -p arch && \
-    ln -vs /opt/cp2k-toolchain/install/arch/local_coverage.pdbg ./arch/"
+    ln -vs /opt/cp2k-toolchain/install/arch/local.psmp ./arch/"
 COPY ./data ./data
 COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
-# Run coverage test for pdbg.
-COPY ./tools/docker/scripts/test_coverage.sh .
-RUN ./test_coverage.sh "pdbg" 2>&1 | tee report.log
+# Run regression tests.
+ARG TESTOPTS="--mpiexec mpiexec"
+COPY ./tools/docker/scripts/test_regtest.sh ./
+RUN /bin/bash -o pipefail -c " \
+    TESTOPTS='${TESTOPTS}' \
+    ./test_regtest.sh 'local' 'psmp' |& tee report.log && \
+    rm -rf regtesting"
 
 # Output the report if the image is old and was therefore pulled from the build cache.
 CMD cat $(find ./report.log -mmin +10) | sed '/^Summary:/ s/$/ (cached)/'

--- a/tools/docker/Dockerfile.test_intel-oneapi-hpckit-ssmp
+++ b/tools/docker/Dockerfile.test_intel-oneapi-hpckit-ssmp
@@ -1,14 +1,14 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build --shm-size=1g -f ./Dockerfile.test_coverage-pdbg ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-oneapi-hpckit-ssmp ../../
 #
 
-FROM ubuntu:24.04
+FROM intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+RUN ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts
@@ -22,9 +22,13 @@ COPY ./tools/toolchain/scripts/VERSION \
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
-    --mpi-mode=mpich \
     --with-dbcsr=no \
-    --with-gcc=system \
+    --with-ifx=yes \
+    --with-intelmpi \
+    --with-mkl \
+    --with-libsmeagol \
+    --with-libtorch=no \
+    --with-deepmd=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.
@@ -64,24 +68,26 @@ COPY ./tools/toolchain/scripts/arch_base.tmpl \
      ./scripts/
 RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
-# Install CP2K using local_coverage.pdbg.
+# Install CP2K using local.ssmp.
 WORKDIR /opt/cp2k
-ARG GIT_COMMIT_SHA
 COPY ./Makefile .
 COPY ./src ./src
 COPY ./exts ./exts
 COPY ./tools/build_utils ./tools/build_utils
 RUN /bin/bash -c " \
-    if [ -n "${GIT_COMMIT_SHA}" ] ; then echo "git:\${GIT_COMMIT_SHA::7}" > REVISION; fi && \
     mkdir -p arch && \
-    ln -vs /opt/cp2k-toolchain/install/arch/local_coverage.pdbg ./arch/"
+    ln -vs /opt/cp2k-toolchain/install/arch/local.ssmp ./arch/"
 COPY ./data ./data
 COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
 
-# Run coverage test for pdbg.
-COPY ./tools/docker/scripts/test_coverage.sh .
-RUN ./test_coverage.sh "pdbg" 2>&1 | tee report.log
+# Run regression tests.
+ARG TESTOPTS="--mpiexec mpiexec"
+COPY ./tools/docker/scripts/test_regtest.sh ./
+RUN /bin/bash -o pipefail -c " \
+    TESTOPTS='${TESTOPTS}' \
+    ./test_regtest.sh 'local' 'ssmp' |& tee report.log && \
+    rm -rf regtesting"
 
 # Output the report if the image is old and was therefore pulled from the build cache.
 CMD cat $(find ./report.log -mmin +10) | sed '/^Summary:/ s/$/ (cached)/'

--- a/tools/docker/Dockerfile.test_intel-psmp
+++ b/tools/docker/Dockerfile.test_intel-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_intel-psmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-psmp ../../
 #
 
 FROM intel/hpckit:2024.2.1-0-devel-ubuntu22.04
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --with-dbcsr=no \
+    --with-ifx=no \
     --with-intelmpi \
     --with-mkl \
     --with-libsmeagol \

--- a/tools/docker/Dockerfile.test_intel-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_intel-ssmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-ssmp ../../
 #
 
 FROM intel/hpckit:2024.2.1-0-devel-ubuntu22.04
@@ -23,6 +23,7 @@ COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --with-dbcsr=no \
+    --with-ifx=no \
     --with-intelmpi \
     --with-mkl \
     --with-libsmeagol \

--- a/tools/docker/Dockerfile.test_manual
+++ b/tools/docker/Dockerfile.test_manual
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_manual ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_manual ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_minimal
+++ b/tools/docker/Dockerfile.test_minimal
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_minimal ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_minimal ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_misc
+++ b/tools/docker/Dockerfile.test_misc
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_misc ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_misc ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_nvhpc
+++ b/tools/docker/Dockerfile.test_nvhpc
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_nvhpc ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_nvhpc ../../
 #
 
 FROM ubuntu:22.04

--- a/tools/docker/Dockerfile.test_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_openmpi-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_openmpi-psmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_openmpi-psmp ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_pdbg ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_pdbg ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_performance
+++ b/tools/docker/Dockerfile.test_performance
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_performance ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_performance ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_performance_cuda_A100
+++ b/tools/docker/Dockerfile.test_performance_cuda_A100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_performance_cuda_A100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_performance_cuda_A100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_performance_cuda_P100
+++ b/tools/docker/Dockerfile.test_performance_cuda_P100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_performance_cuda_P100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_performance_cuda_P100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_performance_cuda_V100
+++ b/tools/docker/Dockerfile.test_performance_cuda_V100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_performance_cuda_V100 ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_performance_cuda_V100 ../../
 #
 
 FROM nvidia/cuda:11.8.0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_precommit
+++ b/tools/docker/Dockerfile.test_precommit
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_precommit ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_precommit ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_psmp
+++ b/tools/docker/Dockerfile.test_psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_psmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_psmp ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_sdbg
+++ b/tools/docker/Dockerfile.test_sdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_sdbg ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_sdbg ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_spack
+++ b/tools/docker/Dockerfile.test_spack
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_spack ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_spack ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/Dockerfile.test_ssmp
+++ b/tools/docker/Dockerfile.test_ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build -f ./Dockerfile.test_ssmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_ssmp ../../
 #
 
 FROM ubuntu:24.04

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -228,13 +228,21 @@ nodepools:    pool-t2d-32
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_openmpi-psmp
 
-[intel-psmp]
-display_name: Intel oneAPI (psmp)
+[intel-oneapi-hpckit-ssmp]
+display_name: Intel oneAPI HPC Toolkit (ssmp)
 tags:         weekly
 cpu:          30
 nodepools:    pool-c2-30
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_intel-psmp
+dockerfile:   /tools/docker/Dockerfile.test_intel-oneapi-hpckit-ssmp
+
+[intel-oneapi-hpckit-psmp]
+display_name: Intel oneAPI HPC Toolkit (psmp)
+tags:         weekly
+cpu:          30
+nodepools:    pool-c2-30
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_intel-oneapi-hpckit-psmp
 
 [intel-ssmp]
 display_name: Intel oneAPI (ssmp)
@@ -243,6 +251,14 @@ cpu:          30
 nodepools:    pool-c2-30
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_intel-ssmp
+
+[intel-psmp]
+display_name: Intel oneAPI (psmp)
+tags:         weekly
+cpu:          30
+nodepools:    pool-c2-30
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_intel-psmp
 
 [spack]
 display_name: Spack


### PR DESCRIPTION
Test the latest Intel oneAPI HPC Toolkit version with ssmp and psmp using the new ifx Fortran compiler. The existing Intel tests use still the old ifort compiler.