### PR TITLE
Avoid issues pointed out by -fsanitize=undefined

### DIFF
--- a/src/dbx/cp_dbcsr_api.F
+++ b/src/dbx/cp_dbcsr_api.F
@@ -436,11 +436,19 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                      :: reuse_arrays, mutable_work
 
       IF (USE_DBCSR_BACKEND) THEN
-         CALL dbcsr_create_prv(matrix=matrix%dbcsr, name=name, template=template%dbcsr, &
-                               dist=dist%dbcsr, matrix_type=matrix_type, &
-                               row_blk_size=row_blk_size, col_blk_size=col_blk_size, &
-                               nze=0, data_type=dbcsr_type_real_8, reuse_arrays=reuse_arrays, &
-                               mutable_work=mutable_work)
+         IF (PRESENT(dist)) THEN
+            CALL dbcsr_create_prv(matrix=matrix%dbcsr, name=name, template=template%dbcsr, &
+                                  dist=dist%dbcsr, matrix_type=matrix_type, &
+                                  row_blk_size=row_blk_size, col_blk_size=col_blk_size, &
+                                  nze=0, data_type=dbcsr_type_real_8, reuse_arrays=reuse_arrays, &
+                                  mutable_work=mutable_work)
+         ELSE
+            CALL dbcsr_create_prv(matrix=matrix%dbcsr, name=name, template=template%dbcsr, &
+                                  matrix_type=matrix_type, &
+                                  row_blk_size=row_blk_size, col_blk_size=col_blk_size, &
+                                  nze=0, data_type=dbcsr_type_real_8, reuse_arrays=reuse_arrays, &
+                                  mutable_work=mutable_work)
+         END IF
       ELSE
          CPABORT("Not yet implemented for DBM.")
       END IF
@@ -614,8 +622,14 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                      :: reuse_arrays
 
       IF (USE_DBCSR_BACKEND) THEN
-         CALL dbcsr_distribution_new_prv(dist%dbcsr, template%dbcsr, group, pgrid, &
-                                         row_dist, col_dist, reuse_arrays)
+         IF (PRESENT(template)) THEN
+            CALL dbcsr_distribution_new_prv(dist%dbcsr, template%dbcsr, group, pgrid, &
+                                            row_dist, col_dist, reuse_arrays)
+         ELSE
+            CALL dbcsr_distribution_new_prv(dist%dbcsr, group=group, pgrid=pgrid, &
+                                            row_dist=row_dist, col_dist=col_dist, &
+                                            reuse_arrays=reuse_arrays)
+         END IF
       ELSE
          CPABORT("Not yet implemented for DBM.")
       END IF

--- a/src/grid/common/grid_sphere_cache.c
+++ b/src/grid/common/grid_sphere_cache.c
@@ -134,8 +134,10 @@ void grid_sphere_cache_lookup(const double radius, const double dh[3][3],
     const size_t entry_size = sizeof(grid_sphere_cache_entry);
     cache->entries = malloc(cache->size * entry_size);
     assert(cache->entries != NULL);
-    memcpy(cache->entries, old_entries, (cache->size - 1) * entry_size);
-    free(old_entries);
+    if (old_entries != NULL) {
+      memcpy(cache->entries, old_entries, (cache->size - 1) * entry_size);
+      free(old_entries);
+    }
     cache->prev_match = cache->size - 1;
     entry = &cache->entries[cache->size - 1];
     // Initialize new cache entry


### PR DESCRIPTION
- Account for template not being present.
- Account for distribution not being present.
- Avoid passing NULL-pointer to memcpy.