### PR TITLE
Fix check for enough MOs after removal of small eigenvalues in MP2

### DIFF
--- a/src/mp2.F
+++ b/src/mp2.F
@@ -367,7 +367,7 @@ CONTAINS
          nmo = nao - ndep
 
          CALL get_mo_set(mo_set=mos(1), nelectron=nelec(1))
-         IF (MAXVAL(nelec) > nmo) THEN
+         IF (MAXVAL(nelec)/(3-nspins) > nmo) THEN
             ! Should not happen as the following MO calculation is the same as during the SCF steps
             CPABORT("Not enough MOs found!")
          END IF


### PR DESCRIPTION
Dear Frederick, 

could you please have a quick look on this? Rémi has found that the CPABORT is triggered here

         CALL get_mo_set(mo_set=mos(1), nelectron=nelec(1))
         **IF (MAXVAL(nelec) > nmo) THEN**
            ! Should not happen as the following MO calculation is the same as during the SCF steps
            **CPABORT("Not enough MOs found!")**
         END IF


when he used a very small basis set for a closed-shell molecule, where N_MO > N_elec / 2 but N_MO < N_elec. Is it correct that for a closed shell molecule, the test should check using N_elec / 2. 

@fstein93 