### PR TITLE
sanitizer: fixed more undefined behavior

### DIFF
--- a/src/dbm/dbm_distribution.c
+++ b/src/dbm/dbm_distribution.c
@@ -30,8 +30,10 @@ static void dbm_dist_1d_new(dbm_dist_1d_t *dist, const int length,
   dist->nranks = dbm_mpi_comm_size(comm);
   dist->length = length;
   dist->index2coord = malloc(length * sizeof(int));
-  assert(dist->index2coord != NULL);
-  memcpy(dist->index2coord, coords, length * sizeof(int));
+  assert(dist->index2coord != NULL || length == 0);
+  if (length != 0) {
+    memcpy(dist->index2coord, coords, length * sizeof(int));
+  }
 
   // Check that cart coordinates and ranks are equivalent.
   int cart_dims[1], cart_periods[1], cart_coords[1];
@@ -49,7 +51,7 @@ static void dbm_dist_1d_new(dbm_dist_1d_t *dist, const int length,
 
   // Store local rows/columns.
   dist->local_indicies = malloc(dist->nlocals * sizeof(int));
-  assert(dist->local_indicies != NULL);
+  assert(dist->local_indicies != NULL || dist->nlocals == 0);
   int j = 0;
   for (int i = 0; i < length; i++) {
     if (coords[i] == dist->my_rank) {

--- a/src/dbm/dbm_miniapp.c
+++ b/src/dbm/dbm_miniapp.c
@@ -47,6 +47,7 @@ static dbm_distribution_t *create_dist(const int nrows, const int ncols,
   dbm_mpi_cart_get(comm, 2, cart_dims, cart_periods, cart_coords);
 
   // Create distribution.
+  assert(0 < nrows && 0 < ncols);
   int *row_dist = malloc(nrows * sizeof(int));
   int *col_dist = malloc(ncols * sizeof(int));
   assert(row_dist != NULL && col_dist != NULL);
@@ -76,6 +77,7 @@ create_some_matrix(const int nrows, const int ncols, const int nrows_min,
   dbm_distribution_t *dist = create_dist(nrows, ncols, comm);
 
   // Create matrix.
+  assert(0 < nrows && 0 < ncols);
   int *row_sizes = malloc(nrows * sizeof(int));
   int *col_sizes = malloc(ncols * sizeof(int));
   assert(row_sizes != NULL && col_sizes != NULL);
@@ -131,6 +133,7 @@ static void reserve_all_blocks(dbm_matrix_t *matrix) {
         }
       }
     }
+    assert(0 < nblocks);
     int *reserve_row = malloc(nblocks * sizeof(int));
     int *reserve_col = malloc(nblocks * sizeof(int));
     assert(reserve_row != NULL && reserve_col != NULL);

--- a/src/dbm/dbm_multiply.c
+++ b/src/dbm/dbm_multiply.c
@@ -38,7 +38,7 @@ static float *compute_rows_max_eps(const bool trans, const dbm_matrix_t *matrix,
   const int nrows = (trans) ? matrix->ncols : matrix->nrows;
   int *nblocks_per_row = calloc(nrows, sizeof(int));
   float *row_max_eps = malloc(nrows * sizeof(float));
-  assert(row_max_eps != NULL);
+  assert((nblocks_per_row != NULL && row_max_eps != NULL) || nrows == 0);
 
 #pragma omp parallel
   {

--- a/src/dbm/dbm_multiply_comm.c
+++ b/src/dbm/dbm_multiply_comm.c
@@ -107,8 +107,9 @@ static void create_pack_plans(const bool trans_matrix, const bool trans_dist,
 #pragma omp barrier
 #pragma omp for
     for (int ipack = 0; ipack < npacks; ipack++) {
-      plans_per_pack[ipack] = malloc(nblks_per_pack[ipack] * sizeof(plan_t));
-      assert(plans_per_pack[ipack] != NULL);
+      const int nblks = nblks_per_pack[ipack];
+      plans_per_pack[ipack] = malloc(nblks * sizeof(plan_t));
+      assert(plans_per_pack[ipack] != NULL || nblks == 0);
     }
 
     // 2nd pass: Plan where to send each block.
@@ -268,7 +269,7 @@ static void postprocess_received_blocks(
   memset(nblocks_per_shard, 0, nshards * sizeof(int));
   dbm_pack_block_t *blocks_tmp =
       malloc(nblocks_recv * sizeof(dbm_pack_block_t));
-  assert(blocks_tmp != NULL);
+  assert(blocks_tmp != NULL || nblocks_recv == 0);
 
 #pragma omp parallel
   {
@@ -343,7 +344,7 @@ static dbm_packed_matrix_t pack_matrix(const bool trans_matrix,
   packed.dist_ticks = dist_ticks;
   packed.nsend_packs = nsend_packs;
   packed.send_packs = malloc(nsend_packs * sizeof(dbm_pack_t));
-  assert(packed.send_packs != NULL);
+  assert(packed.send_packs != NULL || nsend_packs == 0);
 
   // Plan all packs.
   plan_t *plans_per_pack[nsend_packs];

--- a/src/dbm/dbm_multiply_gpu.c
+++ b/src/dbm/dbm_multiply_gpu.c
@@ -38,7 +38,7 @@ void dbm_multiply_gpu_start(const int max_batch_size, const int nshards,
 
   // Allocate and upload shards of result matrix C.
   ctx->shards_c_dev = malloc(nshards * sizeof(dbm_shard_gpu_t));
-  assert(ctx->shards_c_dev != NULL);
+  assert(ctx->shards_c_dev != NULL || nshards == 0);
   for (int i = 0; i < nshards; i++) {
     const dbm_shard_t *shard_c_host = &ctx->shards_c_host[i];
     dbm_shard_gpu_t *shard_c_dev = &ctx->shards_c_dev[i];

--- a/src/grid/common/grid_basis_set.c
+++ b/src/grid/common/grid_basis_set.c
@@ -34,28 +34,36 @@ void grid_create_basis_set(const int nset, const int nsgf, const int maxco,
 
   size_t size = nset * sizeof(int);
   basis_set->lmin = malloc(size);
-  assert(basis_set->lmin != NULL);
-  memcpy(basis_set->lmin, lmin, size);
+  assert(basis_set->lmin != NULL || size == 0);
   basis_set->lmax = malloc(size);
-  assert(basis_set->lmax != NULL);
-  memcpy(basis_set->lmax, lmax, size);
+  assert(basis_set->lmax != NULL || size == 0);
   basis_set->npgf = malloc(size);
-  assert(basis_set->npgf != NULL);
-  memcpy(basis_set->npgf, npgf, size);
+  assert(basis_set->npgf != NULL || size == 0);
   basis_set->nsgf_set = malloc(size);
-  assert(basis_set->nsgf_set != NULL);
-  memcpy(basis_set->nsgf_set, nsgf_set, size);
+  assert(basis_set->nsgf_set != NULL || size == 0);
   basis_set->first_sgf = malloc(size);
-  assert(basis_set->first_sgf != NULL);
-  memcpy(basis_set->first_sgf, first_sgf, size);
+  assert(basis_set->first_sgf != NULL || size == 0);
+  if (size != 0) {
+    memcpy(basis_set->lmin, lmin, size);
+    memcpy(basis_set->lmax, lmax, size);
+    memcpy(basis_set->npgf, npgf, size);
+    memcpy(basis_set->nsgf_set, nsgf_set, size);
+    memcpy(basis_set->first_sgf, first_sgf, size);
+  }
+
   size = nsgf * maxco * sizeof(double);
   basis_set->sphi = malloc(size);
-  assert(basis_set->sphi != NULL);
-  memcpy(basis_set->sphi, sphi, size);
+  assert(basis_set->sphi != NULL || size == 0);
+  if (size != 0) {
+    memcpy(basis_set->sphi, sphi, size);
+  }
+
   size = nset * maxpgf * sizeof(double);
   basis_set->zet = malloc(size);
-  assert(basis_set->zet != NULL);
-  memcpy(basis_set->zet, zet, size);
+  assert(basis_set->zet != NULL || size == 0);
+  if (size != 0) {
+    memcpy(basis_set->zet, zet, size);
+  }
 
   *basis_set_out = basis_set;
 }

--- a/src/grid/common/grid_sphere_cache.c
+++ b/src/grid/common/grid_sphere_cache.c
@@ -71,7 +71,7 @@ static void rebuild_cache_entry(const int max_imr, const double drmin,
 
   // Compute required storage size.
   entry->offsets = malloc(max_imr * sizeof(int));
-  assert(entry->offsets != NULL);
+  assert(entry->offsets != NULL || max_imr == 0);
   int nbounds_total = 0;
   for (int imr = 1; imr <= max_imr; imr++) {
     const double radius = imr * drmin;
@@ -82,7 +82,7 @@ static void rebuild_cache_entry(const int max_imr, const double drmin,
 
   // Allocate and fill storage.
   entry->storage = malloc(nbounds_total * sizeof(int));
-  assert(entry->storage != NULL);
+  assert(entry->storage != NULL || nbounds_total == 0);
   for (int imr = 1; imr <= max_imr; imr++) {
     const double radius = imr * drmin;
     const int offset = entry->offsets[imr - 1];

--- a/src/grid/cpu/grid_cpu_task_list.c
+++ b/src/grid/cpu/grid_cpu_task_list.c
@@ -71,27 +71,35 @@ void grid_cpu_create_task_list(
 
   size_t size = nblocks * sizeof(int);
   task_list->block_offsets = malloc(size);
-  assert(task_list->block_offsets != NULL);
-  memcpy(task_list->block_offsets, block_offsets, size);
+  assert(task_list->block_offsets != NULL || size == 0);
+  if (size != 0) {
+    memcpy(task_list->block_offsets, block_offsets, size);
+  }
 
   size = 3 * natoms * sizeof(double);
   task_list->atom_positions = malloc(size);
-  assert(task_list->atom_positions != NULL);
-  memcpy(task_list->atom_positions, atom_positions, size);
+  assert(task_list->atom_positions != NULL || size == 0);
+  if (size != 0) {
+    memcpy(task_list->atom_positions, atom_positions, size);
+  }
 
   size = natoms * sizeof(int);
   task_list->atom_kinds = malloc(size);
-  assert(task_list->atom_kinds != NULL);
-  memcpy(task_list->atom_kinds, atom_kinds, size);
+  assert(task_list->atom_kinds != NULL || size == 0);
+  if (size != 0) {
+    memcpy(task_list->atom_kinds, atom_kinds, size);
+  }
 
   size = nkinds * sizeof(grid_basis_set *);
   task_list->basis_sets = malloc(size);
-  assert(task_list->basis_sets != NULL);
-  memcpy(task_list->basis_sets, basis_sets, size);
+  assert(task_list->basis_sets != NULL || size == 0);
+  if (size != 0) {
+    memcpy(task_list->basis_sets, basis_sets, size);
+  }
 
   size = ntasks * sizeof(grid_cpu_task);
   task_list->tasks = malloc(size);
-  assert(task_list->tasks != NULL);
+  assert(task_list->tasks != NULL || size == 0);
   for (int i = 0; i < ntasks; i++) {
     task_list->tasks[i].level = level_list[i];
     task_list->tasks[i].iatom = iatom_list[i];
@@ -111,7 +119,7 @@ void grid_cpu_create_task_list(
   // Store grid layouts.
   size = nlevels * sizeof(grid_cpu_layout);
   task_list->layouts = malloc(size);
-  assert(task_list->layouts != NULL);
+  assert(task_list->layouts != NULL || size == 0);
   for (int level = 0; level < nlevels; level++) {
     for (int i = 0; i < 3; i++) {
       task_list->layouts[level].npts_global[i] = npts_global[level][i];
@@ -131,9 +139,9 @@ void grid_cpu_create_task_list(
   // Find first and last task for each level and block.
   size = nlevels * nblocks * sizeof(int);
   task_list->first_level_block_task = malloc(size);
-  assert(task_list->first_level_block_task != NULL);
+  assert(task_list->first_level_block_task != NULL || size == 0);
   task_list->last_level_block_task = malloc(size);
-  assert(task_list->last_level_block_task != NULL);
+  assert(task_list->last_level_block_task != NULL || size == 0);
   for (int i = 0; i < nlevels * nblocks; i++) {
     task_list->first_level_block_task[i] = 0;
     task_list->last_level_block_task[i] = -1; // last < first means no tasks
@@ -273,7 +281,7 @@ static void collocate_one_grid_level(
     int old_offset = -1, old_iset = -1, old_jset = -1;
 
     // Matrix pab is re-used across tasks.
-    double pab[task_list->maxco * task_list->maxco];
+    double pab[imax(task_list->maxco * task_list->maxco, 1)];
 
     // Ensure that grid can fit into thread-local storage, reallocate if needed.
     const int npts_local_total = npts_local[0] * npts_local[1] * npts_local[2];
@@ -629,9 +637,12 @@ void grid_cpu_integrate_task_list(
 
   assert(task_list->nlevels == nlevels);
   assert(task_list->natoms == natoms);
+  assert(hab_blocks != NULL);
 
   // Zero result arrays.
-  memset(hab_blocks->host_buffer, 0, hab_blocks->size);
+  if (hab_blocks->size != 0) {
+    memset(hab_blocks->host_buffer, 0, hab_blocks->size);
+  }
   if (forces != NULL) {
     memset(forces, 0, natoms * 3 * sizeof(double));
   }

--- a/src/grid/dgemm/grid_dgemm_collocation_integration.c
+++ b/src/grid/dgemm/grid_dgemm_collocation_integration.c
@@ -19,9 +19,8 @@
 #include "grid_dgemm_utils.h"
 
 struct collocation_integration_ *collocate_create_handle(void) {
-  struct collocation_integration_ *handle = NULL;
-  handle = (struct collocation_integration_ *)malloc(
-      sizeof(struct collocation_integration_));
+  struct collocation_integration_ *handle =
+      malloc(sizeof(struct collocation_integration_));
   assert(handle != NULL);
   memset(handle, 0, sizeof(struct collocation_integration_));
 

--- a/src/grid/ref/grid_ref_task_list.c
+++ b/src/grid/ref/grid_ref_task_list.c
@@ -71,27 +71,35 @@ void grid_ref_create_task_list(
 
   size_t size = nblocks * sizeof(int);
   task_list->block_offsets = malloc(size);
-  assert(task_list->block_offsets != NULL);
-  memcpy(task_list->block_offsets, block_offsets, size);
+  assert(task_list->block_offsets != NULL || size == 0);
+  if (size != 0) {
+    memcpy(task_list->block_offsets, block_offsets, size);
+  }
 
   size = 3 * natoms * sizeof(double);
   task_list->atom_positions = malloc(size);
-  assert(task_list->atom_positions != NULL);
-  memcpy(task_list->atom_positions, atom_positions, size);
+  assert(task_list->atom_positions != NULL || size == 0);
+  if (size != 0) {
+    memcpy(task_list->atom_positions, atom_positions, size);
+  }
 
   size = natoms * sizeof(int);
   task_list->atom_kinds = malloc(size);
-  assert(task_list->atom_kinds != NULL);
-  memcpy(task_list->atom_kinds, atom_kinds, size);
+  assert(task_list->atom_kinds != NULL || size == 0);
+  if (size != 0) {
+    memcpy(task_list->atom_kinds, atom_kinds, size);
+  }
 
   size = nkinds * sizeof(grid_basis_set *);
   task_list->basis_sets = malloc(size);
-  assert(task_list->basis_sets != NULL);
-  memcpy(task_list->basis_sets, basis_sets, size);
+  assert(task_list->basis_sets != NULL || size == 0);
+  if (size != 0) {
+    memcpy(task_list->basis_sets, basis_sets, size);
+  }
 
   size = ntasks * sizeof(grid_ref_task);
   task_list->tasks = malloc(size);
-  assert(task_list->tasks != NULL);
+  assert(task_list->tasks != NULL || size == 0);
   for (int i = 0; i < ntasks; i++) {
     task_list->tasks[i].level = level_list[i];
     task_list->tasks[i].iatom = iatom_list[i];
@@ -111,7 +119,7 @@ void grid_ref_create_task_list(
   // Store grid layouts.
   size = nlevels * sizeof(grid_ref_layout);
   task_list->layouts = malloc(size);
-  assert(task_list->layouts != NULL);
+  assert(task_list->layouts != NULL || size == 0);
   for (int level = 0; level < nlevels; level++) {
     for (int i = 0; i < 3; i++) {
       task_list->layouts[level].npts_global[i] = npts_global[level][i];
@@ -131,9 +139,9 @@ void grid_ref_create_task_list(
   // Find first and last task for each level and block.
   size = nlevels * nblocks * sizeof(int);
   task_list->first_level_block_task = malloc(size);
-  assert(task_list->first_level_block_task != NULL);
+  assert(task_list->first_level_block_task != NULL || size == 0);
   task_list->last_level_block_task = malloc(size);
-  assert(task_list->last_level_block_task != NULL);
+  assert(task_list->last_level_block_task != NULL || size == 0);
   for (int i = 0; i < nlevels * nblocks; i++) {
     task_list->first_level_block_task[i] = 0;
     task_list->last_level_block_task[i] = -1; // last < first means no tasks
@@ -273,7 +281,7 @@ static void collocate_one_grid_level(
     int old_offset = -1, old_iset = -1, old_jset = -1;
 
     // Matrix pab is re-used across tasks.
-    double pab[task_list->maxco * task_list->maxco];
+    double pab[imax(task_list->maxco * task_list->maxco, 1)];
 
     // Ensure that grid can fit into thread-local storage, reallocate if needed.
     const int npts_local_total = npts_local[0] * npts_local[1] * npts_local[2];

--- a/src/hfx_compression_methods.F
+++ b/src/hfx_compression_methods.F
@@ -207,6 +207,8 @@ CONTAINS
       INTEGER                                            :: end_idx, increment_counter, start_idx, &
                                                             stat, tmp_elements, tmp_nints
 
+      CPASSERT(ASSOCIATED(container%current))
+
       start_idx = container%element_counter
       increment_counter = (nbits*CACHE_SIZE + 63)/64
       end_idx = start_idx + increment_counter - 1

--- a/src/motion/rt_propagation.F
+++ b/src/motion/rt_propagation.F
@@ -496,6 +496,7 @@ CONTAINS
 
       NULLIFY (matrix_s, dft_control)
       CALL get_qs_env(qs_env, dft_control=dft_control)
+      CPASSERT(ASSOCIATED(qs_env))
 
       SELECT CASE (rtp_control%initial_wfn)
       CASE (use_scf_wfn)
@@ -536,6 +537,7 @@ CONTAINS
          CALL rt_prop_create(qs_env%rtp, qs_env%mos, qs_env%mpools, dft_control, matrix_s(1)%matrix, &
                              rtp_control%linear_scaling, qs_env%admm_env%mos_aux_fit)
          CALL get_restart_wfn(qs_env)
+         CPASSERT(ASSOCIATED(qs_env))
 
          qs_env%run_rtp = .TRUE.
       END SELECT


### PR DESCRIPTION
- Usually sanitizer can see subsequent exit conditions aka assertions; however, this may not be true to CPASSERT.
- In any case, included CPASSERTs instead of only/implicit assumptions.
- malloc: resolved implementation specific assumption about zero-sized allocation resulting into NULL-pointer.