### PR TITLE
Fixed undefined behavior

### DIFF
--- a/src/dbm/dbm_shard.c
+++ b/src/dbm/dbm_shard.c
@@ -105,15 +105,18 @@ void dbm_shard_copy(dbm_shard_t *shard_a, const dbm_shard_t *shard_b) {
   }
   shard_a->data_size = shard_b->data_size;
 
-  if (shard_a->blocks != NULL) {
+  if (shard_b->nblocks != 0) {
+    assert(shard_a->blocks != NULL && shard_b->blocks != NULL);
     memcpy(shard_a->blocks, shard_b->blocks,
            shard_b->nblocks * sizeof(dbm_block_t));
   }
-  if (shard_a->hashtable != NULL) {
+  if (shard_b->hashtable_size != 0) {
+    assert(shard_a->hashtable != NULL && shard_b->hashtable != NULL);
     memcpy(shard_a->hashtable, shard_b->hashtable,
            shard_b->hashtable_size * sizeof(int));
   }
-  if (shard_a->data != NULL) {
+  if (shard_b->data_size != 0) {
+    assert(shard_a->data != NULL && shard_b->data != NULL);
     memcpy(shard_a->data, shard_b->data, shard_b->data_size * sizeof(double));
   }
 }

--- a/src/grid/cpu/grid_cpu_task_list.c
+++ b/src/grid/cpu/grid_cpu_task_list.c
@@ -498,8 +498,8 @@ static void integrate_one_grid_level(
     bool old_transpose = false;
 
     // Matrix pab and hab are re-used across tasks.
-    double pab[task_list->maxco * task_list->maxco];
-    double hab[task_list->maxco * task_list->maxco];
+    double pab[imax(task_list->maxco * task_list->maxco, 1)];
+    double hab[imax(task_list->maxco * task_list->maxco, 1)];
 
     // Parallelize over blocks to avoid concurred access to hab_blocks.
     const int nthreads = omp_get_num_threads();

--- a/src/grid/ref/grid_ref_task_list.c
+++ b/src/grid/ref/grid_ref_task_list.c
@@ -497,8 +497,8 @@ static void integrate_one_grid_level(
     bool old_transpose = false;
 
     // Matrix pab and hab are re-used across tasks.
-    double pab[task_list->maxco * task_list->maxco];
-    double hab[task_list->maxco * task_list->maxco];
+    double pab[imax(task_list->maxco * task_list->maxco, 1)];
+    double hab[imax(task_list->maxco * task_list->maxco, 1)];
 
     // Parallelize over blocks to avoid concurred access to hab_blocks.
     const int nthreads = omp_get_num_threads();


### PR DESCRIPTION
- Avoid zero-sized allocation (c99/stack/alloca).
- Avoid NULL-pointer for notnull attributed arg.