### PR TITLE
Toolchain: Build HIP with -std=c++14

### DIFF
--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -233,7 +233,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       HIP_FLAGS+="-fPIE -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx906 -O3 --std=c++11 -Wall -Wextra \$(DFLAGS)"
       LIBS+=" IF_HIP(-lamdhip64 -lhipfft -lhipblas -lrocblas IF_DEBUG(-lroctx64 -lroctracer64|)|)"
       DFLAGS+=" IF_HIP(-D__HIP_PLATFORM_AMD__ -D__OFFLOAD_HIP IF_DEBUG(-D__OFFLOAD_PROFILING|)|)  -D__DBCSR_ACC"
-      CXXFLAGS+=" -fopenmp -Wall -Wextra"
+      CXXFLAGS+=" -std=c++14 -fopenmp -Wall -Wextra"
       ;;
     Mi100)
       check_lib -lamdhip64 "hip"
@@ -249,7 +249,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       HIP_FLAGS+="-fPIE -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx908 -O3 --std=c++11 -Wall -Wextra \$(DFLAGS)"
       LIBS+=" IF_HIP(-lamdhip64 -lhipfft -lhipblas -lrocblas IF_DEBUG(-lroctx64 -lroctracer64|)|)"
       DFLAGS+=" IF_HIP(-D__HIP_PLATFORM_AMD__ -D__OFFLOAD_HIP IF_DEBUG(-D__OFFLOAD_PROFILING|)|) -D__DBCSR_ACC"
-      CXXFLAGS+=" -fopenmp -Wall -Wextra"
+      CXXFLAGS+=" -std=c++14 -fopenmp -Wall -Wextra"
       ;;
     Mi250)
       check_lib -lamdhip64 "hip"
@@ -265,7 +265,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       HIP_FLAGS+="-fPIE -D__HIP_PLATFORM_AMD__ -g --offload-arch=gfx90a -munsafe-fp-atomics -O3 --std=c++11 -Wall -Wextra \$(DFLAGS)"
       LIBS+=" IF_HIP(-lamdhip64 -lhipfft -lhipblas -lrocblas IF_DEBUG(-lroctx64 -lroctracer64|)|)"
       DFLAGS+=" IF_HIP(-D__HIP_PLATFORM_AMD__ -D__OFFLOAD_HIP IF_DEBUG(-D__OFFLOAD_PROFILING|)|) -D__DBCSR_ACC"
-      CXXFLAGS+=" -fopenmp -Wall -Wextra"
+      CXXFLAGS+=" -std=c++14 -fopenmp -Wall -Wextra"
       ;;
     *)
       check_command nvcc "cuda"
@@ -280,7 +280,7 @@ if [ "${ENABLE_HIP}" = __TRUE__ ] && [ "${GPUVER}" != no ]; then
       HIP_INCLUDES+=" -I${CUDA_PATH:-${CUDA_HOME:-/CUDA_HOME-notset}}/include"
       # GCC issues lots of warnings for hip/nvidia_detail/hip_runtime_api.h
       CFLAGS+=" -Wno-error ${CUDA_CFLAGS}"
-      CXXFLAGS+=" -Wno-error ${CUDA_CFLAGS}"
+      CXXFLAGS+=" -std=c++14 -Wno-error ${CUDA_CFLAGS}"
       # Set LD-flags
       # Multiple definition because of hip/include/hip/nvidia_detail/nvidia_hiprtc.h
       LDFLAGS+=" -Wl,--allow-multiple-definition"


### PR DESCRIPTION
Follow up to #4241, which added `-std=c17` because because GCC 15 applies `-std=gnu23` by default.

Unfortunately, when compiling for HIP the GCC 11 gets stuck on:

```
/usr/bin/mpicxx -c -D__HIP -DARCH_NUMBER=60 \
-std=c++14 -O2 -fPIC -fno-omit-frame-pointer -fopenmp -g -mtune=native \
-std=c++17 -D__LIBXSMM -D__parallel -D__FFTW3 -D__LIBINT -D__LIBXC -D__LIBGRPP -D__parallel -D__COSMA -D__ELPA -D__GSL -D__HDF5 -D__LIBVDWXC -D__SPGLIB -D__LIBVORI -D__SPFFT -D__OFFLOAD_GEMM -D__SPLA -D__SIRIUS -D__HIP_PLATFORM_NVIDIA__ -D__HIP_PLATFORM_NVCC__ -D__OFFLOAD_HIP -D__DBCSR_ACC -Wno-deprecated-declarations -Wno-error -I/opt/rocm-4.5.2/include -I/usr/local/cuda/include -Wno-error=unused-parameter -I'/opt/cp2k/exts/dbcsr/src' /opt/cp2k/exts/dbcsr/src/acc/libsmm_acc/libsmm_acc.cpp
```
