### PR TITLE
build(docker): use cache mounts for apt and dnf

### DIFF
--- a/ci/docker/build_cp2k_spack.Dockerfile
+++ b/ci/docker/build_cp2k_spack.Dockerfile
@@ -53,14 +53,18 @@ RUN /bin/bash -c -o pipefail " \
 # Stage 2b: Install CP2K
 FROM ${BASE_IMAGE} AS install_cp2k
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install required packages
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     g++ \
     gcc \
     gfortran \
     hwloc \
     libhwloc-dev \
-    python3 && rm -rf /var/lib/apt/lists/*
+    python3
 
 # Import build arguments from base image
 COPY --from=build_cp2k /CP2K_VERSION /

--- a/ci/docker/build_deps_spack.Dockerfile
+++ b/ci/docker/build_deps_spack.Dockerfile
@@ -11,8 +11,12 @@ ARG BASE_IMAGE="ubuntu:24.04"
 
 FROM ${BASE_IMAGE} AS build_deps
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install packages required to build the CP2K dependencies with Spack
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     bzip2 \
     ca-certificates \
     cmake \
@@ -38,7 +42,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     wget \
     xxd \
     xz-utils \
-    zstd && rm -rf /var/lib/apt/lists/*
+    zstd
 
 # Create dummy xpmem library for the MPICH build. At runtime the
 # container engine will inject the xpmem library from the host system

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi100
@@ -5,13 +5,16 @@
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install some Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     hipblas                                                           \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Setup HIP environment.
 ENV ROCM_PATH /opt/rocm
@@ -23,7 +26,13 @@ RUN hipconfig
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi50
@@ -5,13 +5,16 @@
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install some Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     hipblas                                                           \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Setup HIP environment.
 ENV ROCM_PATH /opt/rocm
@@ -23,7 +26,13 @@ RUN hipconfig
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_aiida
+++ b/tools/docker/Dockerfile.test_aiida
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_arm64-psmp
+++ b/tools/docker/Dockerfile.test_arm64-psmp
@@ -8,7 +8,13 @@ FROM arm64v8/ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh arm64v8/ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh arm64v8/ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_asan-psmp
+++ b/tools/docker/Dockerfile.test_asan-psmp
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_ase
+++ b/tools/docker/Dockerfile.test_ase
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_conventions
+++ b/tools/docker/Dockerfile.test_conventions
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_coverage
+++ b/tools/docker/Dockerfile.test_coverage
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_cuda_A100
+++ b/tools/docker/Dockerfile.test_cuda_A100
@@ -13,17 +13,26 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
 # See also https://github.com/cp2k/cp2k/pull/2337
 ENV CUDA_CACHE_DISABLE 1
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_cuda_P100
+++ b/tools/docker/Dockerfile.test_cuda_P100
@@ -13,17 +13,26 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
 # See also https://github.com/cp2k/cp2k/pull/2337
 ENV CUDA_CACHE_DISABLE 1
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_cuda_V100
+++ b/tools/docker/Dockerfile.test_cuda_V100
@@ -13,17 +13,26 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
 # See also https://github.com/cp2k/cp2k/pull/2337
 ENV CUDA_CACHE_DISABLE 1
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_fedora-psmp
+++ b/tools/docker/Dockerfile.test_fedora-psmp
@@ -8,7 +8,13 @@ FROM fedora:41
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh fedora:41
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh fedora:41
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_gcc10
+++ b/tools/docker/Dockerfile.test_gcc10
@@ -5,8 +5,13 @@
 
 FROM ubuntu:24.04
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
 # Install Ubuntu packages.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get update -qq && apt-get install -qq --no-install-recommends \
     cmake \
     less \
@@ -25,8 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libxc-dev \
     libhdf5-dev \
     libxsmm-dev \
-    libspglib-f08-dev \
-   && rm -rf /var/lib/apt/lists/*
+    libspglib-f08-dev
 
 # Create links in /usr/local/bin to overrule links in /usr/bin.
 RUN ln -sf /usr/bin/gcc-10      /usr/local/bin/gcc  && \

--- a/tools/docker/Dockerfile.test_gcc11
+++ b/tools/docker/Dockerfile.test_gcc11
@@ -5,8 +5,13 @@
 
 FROM ubuntu:24.04
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
 # Install Ubuntu packages.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get update -qq && apt-get install -qq --no-install-recommends \
     cmake \
     less \
@@ -25,8 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libxc-dev \
     libhdf5-dev \
     libxsmm-dev \
-    libspglib-f08-dev \
-   && rm -rf /var/lib/apt/lists/*
+    libspglib-f08-dev
 
 # Create links in /usr/local/bin to overrule links in /usr/bin.
 RUN ln -sf /usr/bin/gcc-11      /usr/local/bin/gcc  && \

--- a/tools/docker/Dockerfile.test_gcc12
+++ b/tools/docker/Dockerfile.test_gcc12
@@ -5,8 +5,13 @@
 
 FROM ubuntu:24.04
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
 # Install Ubuntu packages.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get update -qq && apt-get install -qq --no-install-recommends \
     cmake \
     less \
@@ -25,8 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libxc-dev \
     libhdf5-dev \
     libxsmm-dev \
-    libspglib-f08-dev \
-   && rm -rf /var/lib/apt/lists/*
+    libspglib-f08-dev
 
 # Create links in /usr/local/bin to overrule links in /usr/bin.
 RUN ln -sf /usr/bin/gcc-12      /usr/local/bin/gcc  && \

--- a/tools/docker/Dockerfile.test_gcc13
+++ b/tools/docker/Dockerfile.test_gcc13
@@ -5,8 +5,13 @@
 
 FROM ubuntu:24.04
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
 # Install Ubuntu packages.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get update -qq && apt-get install -qq --no-install-recommends \
     cmake \
     less \
@@ -25,8 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libxc-dev \
     libhdf5-dev \
     libxsmm-dev \
-    libspglib-f08-dev \
-   && rm -rf /var/lib/apt/lists/*
+    libspglib-f08-dev
 
 # Create links in /usr/local/bin to overrule links in /usr/bin.
 RUN ln -sf /usr/bin/gcc-13      /usr/local/bin/gcc  && \

--- a/tools/docker/Dockerfile.test_gcc14
+++ b/tools/docker/Dockerfile.test_gcc14
@@ -5,12 +5,20 @@
 
 FROM ubuntu:24.04
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
 # Add Ubuntu universe repository.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends software-properties-common
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && \
+    apt-get install -qq --no-install-recommends software-properties-common
 RUN add-apt-repository universe
 
 # Install Ubuntu packages.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get update -qq && apt-get install -qq --no-install-recommends \
     cmake \
     less \
@@ -29,8 +37,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libxc-dev \
     libhdf5-dev \
     libxsmm-dev \
-    libspglib-f08-dev \
-   && rm -rf /var/lib/apt/lists/*
+    libspglib-f08-dev
 
 # Create links in /usr/local/bin to overrule links in /usr/bin.
 RUN ln -sf /usr/bin/gcc-14      /usr/local/bin/gcc  && \

--- a/tools/docker/Dockerfile.test_gcc8
+++ b/tools/docker/Dockerfile.test_gcc8
@@ -5,8 +5,12 @@
 
 FROM ubuntu:20.04
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install Ubuntu packages.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get update -qq && apt-get install -qq --no-install-recommends \
     cmake \
     gcc-8 \
@@ -15,8 +19,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libfftw3-dev \
     libopenblas-dev \
     libgsl-dev \
-    libhdf5-dev \
-   && rm -rf /var/lib/apt/lists/*
+    libhdf5-dev
 
 # Create links in /usr/local/bin to overrule links in /usr/bin.
 RUN ln -sf /usr/bin/gcc-8      /usr/local/bin/gcc  && \
@@ -26,7 +29,13 @@ RUN ln -sf /usr/bin/gcc-8      /usr/local/bin/gcc  && \
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_gcc9
+++ b/tools/docker/Dockerfile.test_gcc9
@@ -5,8 +5,13 @@
 
 FROM ubuntu:24.04
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
 # Install Ubuntu packages.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get update -qq && apt-get install -qq --no-install-recommends \
     cmake \
     less \
@@ -25,8 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libxc-dev \
     libhdf5-dev \
     libxsmm-dev \
-    libspglib-f08-dev \
-   && rm -rf /var/lib/apt/lists/*
+    libspglib-f08-dev
 
 # Create links in /usr/local/bin to overrule links in /usr/bin.
 RUN ln -sf /usr/bin/gcc-9      /usr/local/bin/gcc  && \

--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_gromacs
+++ b/tools/docker/Dockerfile.test_gromacs
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_hip_cuda_A100
+++ b/tools/docker/Dockerfile.test_hip_cuda_A100
@@ -17,7 +17,11 @@ ENV HIPAMD_DIR /opt/hipamd-rocm-4.5.2
 # See also https://github.com/cp2k/cp2k/pull/2337
 ENV CUDA_CACHE_DISABLE 1
 
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get update -qq && apt-get install -qq --no-install-recommends \
     ca-certificates \
     build-essential \
@@ -27,8 +31,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     mpich \
     libmpich-dev \
     wget \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
+    libssl-dev
 
 # Install HIP from source because the hip-nvcc package drags in 10GB of unnecessary dependencies.
 WORKDIR /opt
@@ -105,7 +108,13 @@ RUN hipconfig
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_hip_cuda_P100
+++ b/tools/docker/Dockerfile.test_hip_cuda_P100
@@ -17,7 +17,11 @@ ENV HIPAMD_DIR /opt/hipamd-rocm-4.5.2
 # See also https://github.com/cp2k/cp2k/pull/2337
 ENV CUDA_CACHE_DISABLE 1
 
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get update -qq && apt-get install -qq --no-install-recommends \
     ca-certificates \
     build-essential \
@@ -27,8 +31,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     mpich \
     libmpich-dev \
     wget \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
+    libssl-dev
 
 # Install HIP from source because the hip-nvcc package drags in 10GB of unnecessary dependencies.
 WORKDIR /opt
@@ -105,7 +108,13 @@ RUN hipconfig
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_hip_cuda_V100
+++ b/tools/docker/Dockerfile.test_hip_cuda_V100
@@ -17,7 +17,11 @@ ENV HIPAMD_DIR /opt/hipamd-rocm-4.5.2
 # See also https://github.com/cp2k/cp2k/pull/2337
 ENV CUDA_CACHE_DISABLE 1
 
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get update -qq && apt-get install -qq --no-install-recommends \
     ca-certificates \
     build-essential \
@@ -27,8 +31,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     mpich \
     libmpich-dev \
     wget \
-    libssl-dev \
-    && rm -rf /var/lib/apt/lists/*
+    libssl-dev
 
 # Install HIP from source because the hip-nvcc package drags in 10GB of unnecessary dependencies.
 WORKDIR /opt
@@ -105,7 +108,13 @@ RUN hipconfig
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi100
@@ -5,13 +5,16 @@
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install some Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     hipblas                                                           \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Setup HIP environment.
 ENV ROCM_PATH /opt/rocm
@@ -23,7 +26,13 @@ RUN hipconfig
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi50
@@ -5,13 +5,16 @@
 
 FROM rocm/dev-ubuntu-22.04:5.3.2-complete
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install some Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     hipblas                                                           \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Setup HIP environment.
 ENV ROCM_PATH /opt/rocm
@@ -23,7 +26,13 @@ RUN hipconfig
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_i-pi
+++ b/tools/docker/Dockerfile.test_i-pi
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_intel-oneapi-hpckit-psmp
+++ b/tools/docker/Dockerfile.test_intel-oneapi-hpckit-psmp
@@ -8,7 +8,13 @@ FROM intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_intel-oneapi-hpckit-ssmp
+++ b/tools/docker/Dockerfile.test_intel-oneapi-hpckit-ssmp
@@ -8,7 +8,13 @@ FROM intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_intel-psmp
+++ b/tools/docker/Dockerfile.test_intel-psmp
@@ -8,7 +8,13 @@ FROM intel/hpckit:2024.2.1-0-devel-ubuntu22.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_intel-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ssmp
@@ -8,7 +8,13 @@ FROM intel/hpckit:2024.2.1-0-devel-ubuntu22.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_manual
+++ b/tools/docker/Dockerfile.test_manual
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_minimal
+++ b/tools/docker/Dockerfile.test_minimal
@@ -5,8 +5,13 @@
 
 FROM ubuntu:24.04
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
 # Install Ubuntu packages.
-RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     apt-get update -qq && apt-get install -qq --no-install-recommends \
     cmake \
     less \
@@ -25,8 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && \
     libxc-dev \
     libhdf5-dev \
     libxsmm-dev \
-    libspglib-f08-dev \
-   && rm -rf /var/lib/apt/lists/*
+    libspglib-f08-dev
 
 # Create links in /usr/local/bin to overrule links in /usr/bin.
 RUN ln -sf /usr/bin/gcc-13      /usr/local/bin/gcc  && \

--- a/tools/docker/Dockerfile.test_nvhpc
+++ b/tools/docker/Dockerfile.test_nvhpc
@@ -5,8 +5,12 @@
 
 FROM ubuntu:22.04
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     apt-transport-https \
     ca-certificates \
     dirmngr \
@@ -15,16 +19,16 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     make \
     nano \
     python3 \
-    wget \
-   && rm -rf /var/lib/apt/lists/*
+    wget
 
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK
 RUN echo 'deb https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' > /etc/apt/sources.list.d/nvhpc.list
 
 # Install NVIDIA's HPC SDK but only keep the compilers to reduce Docker image size.
-RUN apt-get update -qq && \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && \
     apt-get install -qq --no-install-recommends nvhpc-22-11 && \
-    rm -rf /var/lib/apt/lists/* && \
     rm -rf /opt/nvidia/hpc_sdk/Linux_x86_64/22.11/math_libs && \
     rm -rf /opt/nvidia/hpc_sdk/Linux_x86_64/22.11/comm_libs && \
     rm -rf /opt/nvidia/hpc_sdk/Linux_x86_64/22.11/profilers && \

--- a/tools/docker/Dockerfile.test_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_openmpi-psmp
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_performance
+++ b/tools/docker/Dockerfile.test_performance
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_performance_cuda_A100
+++ b/tools/docker/Dockerfile.test_performance_cuda_A100
@@ -13,17 +13,26 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
 # See also https://github.com/cp2k/cp2k/pull/2337
 ENV CUDA_CACHE_DISABLE 1
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_performance_cuda_P100
+++ b/tools/docker/Dockerfile.test_performance_cuda_P100
@@ -13,17 +13,26 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
 # See also https://github.com/cp2k/cp2k/pull/2337
 ENV CUDA_CACHE_DISABLE 1
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_performance_cuda_V100
+++ b/tools/docker/Dockerfile.test_performance_cuda_V100
@@ -13,17 +13,26 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/lib64
 # See also https://github.com/cp2k/cp2k/pull/2337
 ENV CUDA_CACHE_DISABLE 1
 
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # Install Ubuntu packages.
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     gfortran                                                          \
     mpich                                                             \
-    libmpich-dev                                                      \
-   && rm -rf /var/lib/apt/lists/*
+    libmpich-dev
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_phonopy
+++ b/tools/docker/Dockerfile.test_phonopy
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_psmp
+++ b/tools/docker/Dockerfile.test_psmp
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_sdbg
+++ b/tools/docker/Dockerfile.test_sdbg
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/docker/Dockerfile.test_spack
+++ b/tools/docker/Dockerfile.test_spack
@@ -6,7 +6,9 @@
 FROM ubuntu:24.04
 
 # Install packages required to build the CP2K dependencies with Spack
-RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update -qq && apt-get install -qq --no-install-recommends \
     bzip2 \
     ca-certificates \
     cmake \
@@ -34,7 +36,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     wget \
     xxd \
     xz-utils \
-    zstd && rm -rf /var/lib/apt/lists/*
+    zstd
 
 # Create and activate a virtual environment for Python packages
 RUN python3 -m venv /opt/venv

--- a/tools/docker/Dockerfile.test_ssmp
+++ b/tools/docker/Dockerfile.test_ssmp
@@ -8,7 +8,13 @@ FROM ubuntu:24.04
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
 COPY ./tools/toolchain/install_requirements*.sh ./
-RUN ./install_requirements.sh ubuntu:24.04
+# keep cache files
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/var/cache/libdnf5,sharing=locked \
+    --mount=type=cache,target=/var/lib/dnf,sharing=locked \
+    ./install_requirements.sh ubuntu:24.04
 
 # Install the toolchain.
 RUN mkdir scripts

--- a/tools/toolchain/install_requirements_fedora.sh
+++ b/tools/toolchain/install_requirements_fedora.sh
@@ -33,6 +33,4 @@ dnf -qy install \
   zlib-devel \
   zlib-static
 
-dnf clean -q all
-
 #EOF

--- a/tools/toolchain/install_requirements_ubuntu.sh
+++ b/tools/toolchain/install_requirements_ubuntu.sh
@@ -38,6 +38,4 @@ apt-get install -qq --no-install-recommends \
   xxd \
   zlib1g-dev
 
-rm -rf /var/lib/apt/lists/*
-
 #EOF


### PR DESCRIPTION
to optimize cache usage

<https://docs.docker.com/build/cache/optimize/#use-cache-mounts>