### PR TITLE
Fix bug part of issue #4353

### DIFF
--- a/src/qs_mo_io.F
+++ b/src/qs_mo_io.F
@@ -73,6 +73,7 @@ MODULE qs_mo_io
    USE qs_kind_types,                   ONLY: get_qs_kind,&
                                               get_qs_kind_set,&
                                               qs_kind_type
+   USE qs_mo_methods,                   ONLY: calculate_subspace_eigenvalues
    USE qs_mo_occupation,                ONLY: set_mo_occupation
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_type
@@ -102,13 +103,16 @@ CONTAINS
 !> \param particle_set ...
 !> \param dft_section ...
 !> \param qs_kind_set ...
+!> \param matrix_ks ...
 ! **************************************************************************************************
-   SUBROUTINE write_mo_set_to_restart(mo_array, particle_set, dft_section, qs_kind_set)
+   SUBROUTINE write_mo_set_to_restart(mo_array, particle_set, dft_section, qs_kind_set, matrix_ks)
 
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mo_array
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(section_vals_type), POINTER                   :: dft_section
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_ks
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'write_mo_set_to_restart'
       CHARACTER(LEN=30), DIMENSION(2), PARAMETER :: &
@@ -118,6 +122,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
 
       CALL timeset(routineN, handle)
+
       logger => cp_get_default_logger()
 
       IF (BTEST(cp_print_key_should_output(logger%iter_info, &
@@ -138,17 +143,18 @@ CONTAINS
          END IF
 
          DO ikey = 1, SIZE(keys)
-
             IF (BTEST(cp_print_key_should_output(logger%iter_info, &
                                                  dft_section, keys(ikey)), cp_p_file)) THEN
-
                ires = cp_print_key_unit_nr(logger, dft_section, keys(ikey), &
                                            extension=".wfn", file_status="REPLACE", file_action="WRITE", &
                                            do_backup=.TRUE., file_form="UNFORMATTED")
-
-               CALL write_mo_set_low(mo_array, particle_set=particle_set, &
-                                     qs_kind_set=qs_kind_set, ires=ires)
-
+               IF (PRESENT(matrix_ks)) THEN
+                  CALL write_mo_set_low(mo_array, particle_set=particle_set, qs_kind_set=qs_kind_set, &
+                                        ires=ires, matrix_ks=matrix_ks)
+               ELSE
+                  CALL write_mo_set_low(mo_array, particle_set=particle_set, qs_kind_set=qs_kind_set, &
+                                        ires=ires)
+               END IF
                CALL cp_print_key_finished_output(ires, logger, dft_section, TRIM(keys(ikey)))
             END IF
          END DO
@@ -228,8 +234,7 @@ CONTAINS
 !> \param dft_section ...
 !> \param qs_kind_set ...
 ! **************************************************************************************************
-   SUBROUTINE write_rt_mos_to_restart(mo_array, rt_mos, particle_set, dft_section, &
-                                      qs_kind_set)
+   SUBROUTINE write_rt_mos_to_restart(mo_array, rt_mos, particle_set, dft_section, qs_kind_set)
 
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mo_array
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: rt_mos
@@ -257,13 +262,11 @@ CONTAINS
 
             IF (BTEST(cp_print_key_should_output(logger%iter_info, &
                                                  dft_section, keys(ikey)), cp_p_file)) THEN
-
                ires = cp_print_key_unit_nr(logger, dft_section, keys(ikey), &
                                            extension=".rtpwfn", file_status="REPLACE", file_action="WRITE", &
                                            do_backup=.TRUE., file_form="UNFORMATTED")
-
-               CALL write_mo_set_low(mo_array, rt_mos=rt_mos, qs_kind_set=qs_kind_set, &
-                                     particle_set=particle_set, ires=ires)
+               CALL write_mo_set_low(mo_array, qs_kind_set=qs_kind_set, particle_set=particle_set, &
+                                     ires=ires, rt_mos=rt_mos)
                CALL cp_print_key_finished_output(ires, logger, dft_section, TRIM(keys(ikey)))
             END IF
          END DO
@@ -280,8 +283,9 @@ CONTAINS
 !> \param particle_set ...
 !> \param ires ...
 !> \param rt_mos ...
+!> \param matrix_ks ...
 ! **************************************************************************************************
-   SUBROUTINE write_mo_set_low(mo_array, qs_kind_set, particle_set, ires, rt_mos)
+   SUBROUTINE write_mo_set_low(mo_array, qs_kind_set, particle_set, ires, rt_mos, matrix_ks)
 
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mo_array
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
@@ -289,6 +293,8 @@ CONTAINS
       INTEGER                                            :: ires
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN), &
          OPTIONAL                                        :: rt_mos
+      TYPE(dbcsr_p_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: matrix_ks
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'write_mo_set_low'
 
@@ -299,15 +305,22 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: nset_info, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: l, nshell_info
       INTEGER, DIMENSION(:, :, :), POINTER               :: nso_info
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues, mo_occupation_numbers
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
       TYPE(qs_dftb_atom_type), POINTER                   :: dftb_parameter
 
       CALL timeset(routineN, handle)
+
+      NULLIFY (mo_coeff)
+      NULLIFY (mo_eigenvalues)
+      NULLIFY (mo_occupation_numbers)
+
       nspin = SIZE(mo_array)
       nao = mo_array(1)%nao
 
       IF (ires > 0) THEN
-         !     *** create some info about the basis set first ***
+         ! Create some info about the basis set first
          natom = SIZE(particle_set, 1)
          nset_max = 0
          nshell_max = 0
@@ -316,7 +329,8 @@ CONTAINS
             NULLIFY (orb_basis_set, dftb_parameter)
             CALL get_atomic_kind(particle_set(iatom)%atomic_kind, kind_number=ikind)
             CALL get_qs_kind(qs_kind_set(ikind), &
-                             basis_set=orb_basis_set, dftb_parameter=dftb_parameter)
+                             basis_set=orb_basis_set, &
+                             dftb_parameter=dftb_parameter)
             IF (ASSOCIATED(orb_basis_set)) THEN
                CALL get_gto_basis_set(gto_basis_set=orb_basis_set, &
                                       nset=nset, &
@@ -389,24 +403,34 @@ CONTAINS
          DEALLOCATE (nso_info)
       END IF
 
-      ! use the scalapack block size as a default for buffering columns
+      ! Use the ScaLAPACK block size as a default for buffering columns
       CALL cp_fm_get_info(mo_array(1)%mo_coeff, ncol_block=max_block)
       DO ispin = 1, nspin
+         mo_coeff => mo_array(ispin)%mo_coeff
          nmo = mo_array(ispin)%nmo
-         IF ((ires > 0) .AND. (nmo > 0)) THEN
-            WRITE (ires) nmo, &
-               mo_array(ispin)%homo, &
-               mo_array(ispin)%lfomo, &
-               mo_array(ispin)%nelectron
-            WRITE (ires) mo_array(ispin)%eigenvalues(1:nmo), &
-               mo_array(ispin)%occupation_numbers(1:nmo)
+         IF (nmo > 0) THEN
+            mo_eigenvalues => mo_array(ispin)%eigenvalues
+            mo_occupation_numbers => mo_array(ispin)%occupation_numbers
+            IF (PRESENT(matrix_ks)) THEN
+               ! With OT: use the Kohn-Sham matrix for the update of the MO eigenvalues
+               CALL calculate_subspace_eigenvalues(orbitals=mo_coeff, &
+                                                   ks_matrix=matrix_ks(ispin)%matrix, &
+                                                   evals_arg=mo_eigenvalues)
+            END IF
+            IF (ires > 0) THEN
+               WRITE (ires) nmo, &
+                  mo_array(ispin)%homo, &
+                  mo_array(ispin)%lfomo, &
+                  mo_array(ispin)%nelectron
+               WRITE (ires) mo_eigenvalues(1:nmo), mo_occupation_numbers(1:nmo)
+            END IF
          END IF
          IF (PRESENT(rt_mos)) THEN
             DO imat = 2*ispin - 1, 2*ispin
                CALL cp_fm_write_unformatted(rt_mos(imat), ires)
             END DO
          ELSE
-            CALL cp_fm_write_unformatted(mo_array(ispin)%mo_coeff, ires)
+            CALL cp_fm_write_unformatted(mo_coeff, ires)
          END IF
       END DO
 

--- a/src/qs_mo_methods.F
+++ b/src/qs_mo_methods.F
@@ -859,7 +859,7 @@ CONTAINS
                mo_coeff_deriv => NULL()
             END IF
 
-            ! ** If we do ADMM, we add have to modify the kohn-sham matrix
+            ! If we do ADMM, we add have to modify the Kohn-Sham matrix
             IF (PRESENT(admm_env)) THEN
                CALL admm_correct_for_eigenvalues(ispin, admm_env, ks_rmpv(ispin)%matrix)
             END IF
@@ -868,7 +868,7 @@ CONTAINS
                                                 scr=output_unit, ionode=output_unit > 0, do_rotation=.TRUE., &
                                                 co_rotate_dbcsr=mo_coeff_deriv)
 
-            ! ** If we do ADMM, we restore the original kohn-sham matrix
+            ! If we do ADMM, we restore the original Kohn-Sham matrix
             IF (PRESENT(admm_env)) THEN
                CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, ks_rmpv(ispin)%matrix)
             END IF

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -125,7 +125,8 @@ MODULE qs_scf
    USE qs_kind_types,                   ONLY: qs_kind_type
    USE qs_ks_methods,                   ONLY: evaluate_core_matrix_p_mix_new,&
                                               qs_ks_update_qs_env
-   USE qs_ks_types,                     ONLY: qs_ks_did_change,&
+   USE qs_ks_types,                     ONLY: get_ks_env,&
+                                              qs_ks_did_change,&
                                               qs_ks_env_type
    USE qs_mo_io,                        ONLY: write_mo_set_to_restart
    USE qs_mo_methods,                   ONLY: make_basis_simple,&
@@ -363,6 +364,7 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_result_type), POINTER                      :: results
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_ao_kp
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(energy_correction_type), POINTER              :: ec_env
@@ -560,8 +562,16 @@ CONTAINS
             IF (do_kpoints) THEN
                CALL write_kpoints_restart(rho_ao_kp, kpoints, scf_env, dft_section, particle_set, qs_kind_set)
             ELSE
-               ! Write Wavefunction restart file
-               CALL write_mo_set_to_restart(mos, particle_set, dft_section=dft_section, qs_kind_set=qs_kind_set)
+               ! Write wavefunction restart file
+               IF (scf_env%method == ot_method_nr) THEN
+                  ! With OT: provide the Kohn-Sham matrix for the calculation of the MO eigenvalues
+                  CALL get_ks_env(ks_env=ks_env, matrix_ks=matrix_ks)
+                  CALL write_mo_set_to_restart(mos, particle_set, dft_section=dft_section, qs_kind_set=qs_kind_set, &
+                                               matrix_ks=matrix_ks)
+               ELSE
+                  CALL write_mo_set_to_restart(mos, particle_set, dft_section=dft_section, qs_kind_set=qs_kind_set)
+               END IF
+
             END IF
 
             ! Exit if we have finished with the SCF inner loop
@@ -597,7 +607,7 @@ CONTAINS
          CALL qs_scf_outer_loop_info(output_unit, scf_control, scf_env, &
                                      energy, total_steps, should_stop, outer_loop_converged)
 
-!  save mos to converged mos if outer_loop_converged and surf_dip_correct_switch is true
+         ! Save MOs to converged MOs if outer_loop_converged and surf_dip_correct_switch is true
          IF (exit_outer_loop) THEN
             IF ((dft_control%switch_surf_dip) .AND. (outer_loop_converged) .AND. &
                 (dft_control%surf_dip_correct_switch)) THEN

--- a/src/qs_scf_initialization.F
+++ b/src/qs_scf_initialization.F
@@ -596,7 +596,7 @@ CONTAINS
       nmo_mat = dft_control%nspins
       IF (dft_control%restricted) nmo_mat = 1 ! right now, there might be more mos than needed derivs
 
-!   *** finish initialization of the MOs ***
+      ! Finish initialization of the MOs
       CPASSERT(ASSOCIATED(mos))
       DO ispin = 1, SIZE(mos)
          CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, mo_coeff_b=mo_coeff_b)
@@ -612,7 +612,7 @@ CONTAINS
                                                    sym=dbcsr_type_no_symmetry)
          END IF
       END DO
-!   *** get the mo_derivs OK if needed ***
+      ! Get the mo_derivs OK if needed
       IF (qs_env%requires_mo_derivs) THEN
          CALL get_qs_env(qs_env, mo_derivs=mo_derivs)
          IF (.NOT. ASSOCIATED(mo_derivs)) THEN
@@ -631,12 +631,12 @@ CONTAINS
          ! nothing should be done
       END IF
 
-!   *** finish initialization of the MOs for ADMM and derivs if needed ***
+      ! Finish initialization of the MOs for ADMM and derivs if needed ***
       IF (dft_control%do_admm) THEN
          IF (dft_control%restricted) CPABORT("ROKS with ADMM is not implemented")
       END IF
 
-! *** finish initialization of mos_last_converged *** [SGh]
+      ! Finish initialization of mos_last_converged [SGh]
       IF (dft_control%switch_surf_dip) THEN
          CPASSERT(ASSOCIATED(mos_last_converged))
          DO ispin = 1, SIZE(mos_last_converged)
@@ -945,13 +945,7 @@ CONTAINS
                       para_env=para_env, &
                       xas_env=xas_env)
 
-      output_unit = cp_print_key_unit_nr(logger, scf_section, "PRINT%PROGRAM_RUN_INFO", &
-                                         extension=".scfLog")
-      CALL qs_scf_initial_info(output_unit, mos, dft_control)
-      CALL cp_print_key_finished_output(output_unit, logger, scf_section, &
-                                        "PRINT%PROGRAM_RUN_INFO")
-
-      ! calc ortho matrix
+      ! Calculate ortho matrix
       ndep = 0
       IF (scf_env%needs_ortho) THEN
          CALL get_qs_env(qs_env, matrix_s=matrix_s)
@@ -1029,7 +1023,7 @@ CONTAINS
 
             CALL cp_fm_column_scale(scf_env%ortho_red, evals(ndep + 1:))
 
-            ! Copy the linear dependent columns to the mo sets and set their orbital energies
+            ! Copy the linear dependent columns to the MO sets and set their orbital energies
             ! to a very large value to reduce the probability of occupying them
             DO ispin = 1, SIZE(mos)
                CALL get_mo_set(mos(ispin), nmo=nmo, mo_coeff=mo_coeff, homo=homo, eigenvalues=eigenvalues)
@@ -1042,8 +1036,8 @@ CONTAINS
                   END IF
                   CALL cp_warn(__LOCATION__, &
                                "The numerical rank of the overlap matrix is lower than the number of requested MOs! "// &
-                             "Reduce the number of MOs to the number of available MOs. If necessary, request a lower number of "// &
-                               "MOs or increase EPS_DEFAULT or EPS_PGF_ORB.")
+                               "Reduce the number of MOs to the number of available MOs. If necessary, "// &
+                               "request a lower number of MOs or increase EPS_DEFAULT or EPS_PGF_ORB.")
                   CALL set_mo_set(mos(ispin), nmo=needed_evals)
                END IF
                ! Copy the last columns to mo_coeff if the container is large enough
@@ -1114,15 +1108,6 @@ CONTAINS
          END DO
       END IF
 
-      output_unit = cp_print_key_unit_nr(logger, scf_section, "PRINT%PROGRAM_RUN_INFO", &
-                                         extension=".scfLog")
-      IF (output_unit > 0) THEN
-         WRITE (UNIT=output_unit, FMT="(T2,A,T71,I10)") &
-            "Number of independent orbital functions:", nao - ndep
-      END IF
-      CALL cp_print_key_finished_output(output_unit, logger, scf_section, &
-                                        "PRINT%PROGRAM_RUN_INFO")
-
       ! extrapolate outer loop variables
       IF (scf_control%outer_scf%have_scf) THEN
          CALL outer_loop_extrapolate(qs_env)
@@ -1161,6 +1146,12 @@ CONTAINS
                                                qmmm_env=qs_env%qmmm_env_qm)
          END IF
       END IF
+
+      output_unit = cp_print_key_unit_nr(logger, scf_section, "PRINT%PROGRAM_RUN_INFO", &
+                                         extension=".scfLog")
+      CALL qs_scf_initial_info(output_unit, mos, dft_control, ndep)
+      CALL cp_print_key_finished_output(output_unit, logger, scf_section, &
+                                        "PRINT%PROGRAM_RUN_INFO")
 
       CALL timestop(handle)
 

--- a/src/qs_scf_output.F
+++ b/src/qs_scf_output.F
@@ -137,13 +137,20 @@ CONTAINS
 !> \param output_unit ...
 !> \param mos ...
 !> \param dft_control ...
+!> \param ndep ...
 ! **************************************************************************************************
-   SUBROUTINE qs_scf_initial_info(output_unit, mos, dft_control)
+   SUBROUTINE qs_scf_initial_info(output_unit, mos, dft_control, ndep)
       INTEGER                                            :: output_unit
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
       TYPE(dft_control_type), POINTER                    :: dft_control
+      INTEGER, INTENT(IN)                                :: ndep
 
-      INTEGER                                            :: homo, ispin, nao, nelectron_spin, nmo
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'qs_scf_initial_info'
+
+      INTEGER                                            :: handle, homo, ispin, nao, &
+                                                            nelectron_spin, nmo
+
+      CALL timeset(routineN, handle)
 
       IF (output_unit > 0) THEN
          DO ispin = 1, dft_control%nspins
@@ -160,9 +167,12 @@ CONTAINS
                "Number of occupied orbitals:", homo, &
                "Number of molecular orbitals:", nmo
          END DO
-         WRITE (UNIT=output_unit, FMT="(/,T2,A,T71,I10)") &
-            "Number of orbital functions:", nao
+         WRITE (UNIT=output_unit, FMT="(/,(T2,A,T71,I10))") &
+            "Number of orbital functions:", nao, &
+            "Number of independent orbital functions:", nao - ndep
       END IF
+
+      CALL timestop(handle)
 
    END SUBROUTINE qs_scf_initial_info
 
@@ -190,7 +200,7 @@ CONTAINS
                                                             nao, nelectron, nkp, nmo, nspin, numo
       INTEGER, DIMENSION(2)                              :: nmos_occ
       INTEGER, DIMENSION(:), POINTER                     :: mo_index_range
-      LOGICAL                                            :: do_kpoints, print_eigvals, &
+      LOGICAL                                            :: do_kpoints, do_printout, print_eigvals, &
                                                             print_eigvecs, print_mo_info, &
                                                             print_occup, print_occup_stats
       REAL(KIND=dp)                                      :: flexible_electron_count, maxocc, n_el_f, &
@@ -264,6 +274,7 @@ CONTAINS
       NULLIFY (umo_eigenvalues)
       NULLIFY (umo_set)
 
+      do_printout = .TRUE.
       nspin = dft_control%nspins
       nmos_occ = 0
 
@@ -278,7 +289,7 @@ CONTAINS
          nkp = 1
       END IF
 
-      DO ikp = 1, nkp
+      kp_loop: DO ikp = 1, nkp
 
          IF (do_kpoints) THEN
             mos => kpoints%kp_env(ikp)%kpoint_env%mos(1, :)
@@ -301,69 +312,62 @@ CONTAINS
                   CPABORT("The OT method is not implemented for k points")
                END IF
 
-               matrix_ks => ks(ispin)%matrix
-               matrix_s => s(1)%matrix
+               IF (final_mos) THEN
 
-               ! With ADMM, we have to modify the Kohn-Sham matrix
-               IF (dft_control%do_admm) THEN
-                  CALL get_qs_env(qs_env, admm_env=admm_env)
-                  CALL admm_correct_for_eigenvalues(ispin, admm_env, matrix_ks)
-               END IF
+                  matrix_ks => ks(ispin)%matrix
+                  matrix_s => s(1)%matrix
 
-               mo_set => mos(ispin)
-               CALL get_mo_set(mo_set=mo_set, &
-                               mo_coeff=mo_coeff, &
-                               eigenvalues=mo_eigenvalues, &
-                               homo=homo, &
-                               maxocc=maxocc, &
-                               nelectron=nelectron, &
-                               n_el_f=n_el_f, &
-                               nao=nao, &
-                               nmo=nmo, &
-                               flexible_electron_count=flexible_electron_count)
+                  ! With ADMM, we have to modify the Kohn-Sham matrix
+                  IF (dft_control%do_admm) THEN
+                     CALL get_qs_env(qs_env, admm_env=admm_env)
+                     CALL admm_correct_for_eigenvalues(ispin, admm_env, matrix_ks)
+                  END IF
 
-               ! Retrieve the index of the last MO for which a printout is requested
-               mo_index_range => section_get_ivals(dft_section, "PRINT%MO%MO_INDEX_RANGE")
-               CPASSERT(ASSOCIATED(mo_index_range))
-               numo = MIN(mo_index_range(2) - homo, nao - homo)
+                  mo_set => mos(ispin)
+                  CALL get_mo_set(mo_set=mo_set, &
+                                  mo_coeff=mo_coeff, &
+                                  eigenvalues=mo_eigenvalues, &
+                                  homo=homo, &
+                                  maxocc=maxocc, &
+                                  nelectron=nelectron, &
+                                  n_el_f=n_el_f, &
+                                  nao=nao, &
+                                  nmo=nmo, &
+                                  flexible_electron_count=flexible_electron_count)
 
-               IF (.NOT. final_mos) THEN
-                  numo = 0
-                  message = "The MO information for unoccupied MOs is only calculated after "// &
-                            "SCF convergence is achieved when the orbital transformation (OT) "// &
-                            "method is used"
-                  CPWARN(TRIM(message))
-               END IF
+                  ! Retrieve the index of the last MO for which a printout is requested
+                  mo_index_range => section_get_ivals(dft_section, "PRINT%MO%MO_INDEX_RANGE")
+                  CPASSERT(ASSOCIATED(mo_index_range))
+                  numo = MIN(mo_index_range(2) - homo, nao - homo)
 
-               ! Calculate the unoccupied MO set (umo_set) with OT if needed
-               IF (numo > 0) THEN
+                  ! Calculate the unoccupied MO set (umo_set) with OT if needed
+                  IF (numo > 0) THEN
 
-                  ! Create temporary virtual MO set for printout
-                  CALL cp_fm_struct_create(fm_struct_tmp, &
-                                           context=blacs_env, &
-                                           para_env=para_env, &
-                                           nrow_global=nao, &
-                                           ncol_global=numo)
-                  ALLOCATE (umo_set)
-                  CALL allocate_mo_set(mo_set=umo_set, &
-                                       nao=nao, &
-                                       nmo=numo, &
-                                       nelectron=0, &
-                                       n_el_f=n_el_f, &
-                                       maxocc=maxocc, &
-                                       flexible_electron_count=flexible_electron_count)
-                  CALL init_mo_set(mo_set=umo_set, &
-                                   fm_struct=fm_struct_tmp, &
-                                   name="Temporary MO set (unoccupied MOs only)for printout")
-                  CALL cp_fm_struct_release(fm_struct_tmp)
-                  CALL get_mo_set(mo_set=umo_set, &
-                                  mo_coeff=umo_coeff, &
-                                  eigenvalues=umo_eigenvalues)
+                     ! Create temporary virtual MO set for printout
+                     CALL cp_fm_struct_create(fm_struct_tmp, &
+                                              context=blacs_env, &
+                                              para_env=para_env, &
+                                              nrow_global=nao, &
+                                              ncol_global=numo)
+                     ALLOCATE (umo_set)
+                     CALL allocate_mo_set(mo_set=umo_set, &
+                                          nao=nao, &
+                                          nmo=numo, &
+                                          nelectron=0, &
+                                          n_el_f=n_el_f, &
+                                          maxocc=maxocc, &
+                                          flexible_electron_count=flexible_electron_count)
+                     CALL init_mo_set(mo_set=umo_set, &
+                                      fm_struct=fm_struct_tmp, &
+                                      name="Temporary MO set (unoccupied MOs only) for printout")
+                     CALL cp_fm_struct_release(fm_struct_tmp)
+                     CALL get_mo_set(mo_set=umo_set, &
+                                     mo_coeff=umo_coeff, &
+                                     eigenvalues=umo_eigenvalues)
 
-                  ! Calculate the MO information for the request MO index range
-                  IF (final_mos) THEN
                      ! Prepare printout of the additional unoccupied MOs when OT is being employed
                      CALL cp_fm_init_random(umo_coeff)
+
                      ! The FULL_ALL preconditioner makes not much sense for the unoccupied orbitals
                      NULLIFY (local_preconditioner)
                      IF (ASSOCIATED(scf_env%ot_preconditioner)) THEN
@@ -372,6 +376,8 @@ CONTAINS
                            NULLIFY (local_preconditioner)
                         END IF
                      END IF
+
+                     ! Calculate the MO information for the request MO index range
                      CALL ot_eigensolver(matrix_h=matrix_ks, &
                                          matrix_s=matrix_s, &
                                          matrix_c_fm=umo_coeff, &
@@ -380,24 +386,29 @@ CONTAINS
                                          preconditioner=local_preconditioner, &
                                          iter_max=scf_control%max_iter_lumos, &
                                          size_ortho_space=nmo)
-                  END IF
 
-                  CALL calculate_subspace_eigenvalues(orbitals=umo_coeff, &
-                                                      ks_matrix=matrix_ks, &
-                                                      evals_arg=umo_eigenvalues, &
-                                                      do_rotation=.TRUE.)
-                  CALL set_mo_occupation(mo_set=umo_set)
+                     CALL calculate_subspace_eigenvalues(orbitals=umo_coeff, &
+                                                         ks_matrix=matrix_ks, &
+                                                         evals_arg=umo_eigenvalues, &
+                                                         do_rotation=.TRUE.)
+                     CALL set_mo_occupation(mo_set=umo_set)
 
-                  ! With ADMM, we have to undo the modification of the Kohn-Sham matrix
-                  IF (dft_control%do_admm) THEN
-                     CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, matrix_ks)
-                  END IF
+                     ! With ADMM, we have to undo the modification of the Kohn-Sham matrix
+                     IF (dft_control%do_admm) THEN
+                        CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, matrix_ks)
+                     END IF
+
+                  END IF ! numo > 0
 
                ELSE
 
-                  NULLIFY (umo_set)
+                  message = "The MO information is only calculated after SCF convergence "// &
+                            "is achieved when the orbital transformation (OT) method is used"
+                  CPWARN(TRIM(message))
+                  do_printout = .FALSE.
+                  EXIT kp_loop
 
-               END IF ! numo > 0
+               END IF ! final MOs
 
             ELSE
 
@@ -453,9 +464,9 @@ CONTAINS
 
          END DO ! ispin
 
-      END DO ! k point loop
+      END DO kp_loop
 
-      IF (print_mo_info .AND. print_occup_stats) THEN
+      IF (do_printout .AND. print_mo_info .AND. print_occup_stats) THEN
          iw = cp_print_key_unit_nr(logger, dft_section, "PRINT%MO", &
                                    ignore_should_output=print_mo_info, &
                                    extension=".MOLog")

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -902,7 +902,7 @@ CONTAINS
             END IF
          END IF
 
-         ! ** If we do ADMM, we add have to modify the kohn-sham matrix
+         ! If we do ADMM, we add have to modify the Kohn-Sham matrix
          IF (dft_control%do_admm) THEN
             CALL admm_correct_for_eigenvalues(ispin, admm_env, ks_rmpv(ispin)%matrix)
          END IF
@@ -919,7 +919,7 @@ CONTAINS
                                              unoccupied_evals(ispin)%array, scr=output_unit, &
                                              ionode=output_unit > 0)
 
-         ! ** If we do ADMM, we restore the original kohn-sham matrix
+         ! If we do ADMM, we restore the original Kohn-Sham matrix
          IF (dft_control%do_admm) THEN
             CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, ks_rmpv(ispin)%matrix)
          END IF

--- a/src/qs_scf_wfn_mix.F
+++ b/src/qs_scf_wfn_mix.F
@@ -274,14 +274,12 @@ CONTAINS
             END IF
 
             IF (output_unit > 0) THEN
-               WRITE (output_unit, '()')
-               WRITE (output_unit, '(T2,A,T61,E20.4)') &
+               WRITE (UNIT=output_unit, FMT="(/,T2,A,T61,E20.4)") &
                   "Maximum deviation from MO S-orthonormality", orthonormality
-               WRITE (output_unit, '(T2,A)') "Writing new MOs to file"
+               WRITE (UNIT=output_unit, FMT="(T2,A)") "Writing new MOs to file"
             END IF
 
-            ! *** Write WaveFunction restart file ***
-
+            ! Write wavefunction restart file
             DO ispin = 1, SIZE(mos_new)
                IF (overwrite_mos) THEN
                   CALL cp_fm_to_fm(mos_new(ispin)%mo_coeff, mos(ispin)%mo_coeff)
@@ -291,7 +289,8 @@ CONTAINS
                IF (mos(1)%use_mo_coeff_b) &
                   CALL copy_fm_to_dbcsr(mos_new(ispin)%mo_coeff, mos(ispin)%mo_coeff_b)
             END DO
-            CALL write_mo_set_to_restart(mos_new, particle_set, dft_section=dft_section, qs_kind_set=qs_kind_set)
+            CALL write_mo_set_to_restart(mos_new, particle_set, dft_section=dft_section, &
+                                         qs_kind_set=qs_kind_set)
          END IF
 
          DO ispin = 1, SIZE(mos_new)

--- a/tests/QS/regtest-gpw-2-3/TEST_FILES.toml
+++ b/tests/QS/regtest-gpw-2-3/TEST_FILES.toml
@@ -8,9 +8,9 @@
 "hcn_ts_fix_z.inp"                      = [{matcher="M065", tol=1e-14, ref=0.0000000000}]
 # chain of two coordination numbers
 "hcn_md.inp"                            = [{matcher="E_total", tol=6e-14, ref=-16.50121471895406}]
-"hcn_meta_coord.inp"                    = [{matcher="E_total", tol=6e-14, ref=-16.65113632013810}]
-"hcn_meta_chaincoord.inp"               = [{matcher="E_total", tol=2e-13, ref=-16.64019903493714}]
-"hcn_meta_chaincoord_kind.inp"          = [{matcher="E_total", tol=2e-13, ref=-16.64019903493714}]
+"hcn_meta_coord.inp"                    = [{matcher="E_total", tol=6e-14, ref=-16.65113632013922}]
+"hcn_meta_chaincoord.inp"               = [{matcher="E_total", tol=2e-13, ref=-16.64019903504688}]
+"hcn_meta_chaincoord_kind.inp"          = [{matcher="E_total", tol=2e-13, ref=-16.64019903504687}]
 # Population colvar
 "H2O_meta_pop.inp"                      = [{matcher="E_total", tol=5e-08, ref=-17.155197480118499}]
 # Metadynamics with langevin on COLVAR

--- a/tests/QS/regtest-ot-1/TEST_FILES.toml
+++ b/tests/QS/regtest-ot-1/TEST_FILES.toml
@@ -38,8 +38,8 @@
 "H2O-OT-ASPC-2.inp"                     = [{matcher="E_total", tol=3e-14, ref=-17.13994191008365}]
 "H2O-OT-ASPC-3.inp"                     = [{matcher="E_total", tol=2e-14, ref=-17.13994199189048}]
 "H2O-OT-ASPC-4.inp"                     = [{matcher="E_total", tol=3e-14, ref=-17.13994198373829}]
-"H2O-OT-ASPC-5.inp"                     = [{matcher="E_total", tol=3e-14, ref=-17.13993068768173}]
-"H2O-OT-ASPC-6.inp"                     = [{matcher="E_total", tol=5e-14, ref=-17.13941008477993}]
+"H2O-OT-ASPC-5.inp"                     = [{matcher="E_total", tol=3e-14, ref=-17.13993068768056}]
+"H2O-OT-ASPC-6.inp"                     = [{matcher="E_total", tol=5e-14, ref=-17.13941008477894}]
 # Input driven basis set and potential
 "H2O-bs_input.inp"                      = [{matcher="E_total", tol=4e-14, ref=-17.13993294347306}]
 #broyden

--- a/tests/xTB/regtest-2/TEST_FILES.toml
+++ b/tests/xTB/regtest-2/TEST_FILES.toml
@@ -9,7 +9,7 @@
 "H2O-field.inp"                         = []
 "H2O-field-lsd.inp"                     = [{matcher="E_total", tol=4e-14, ref=-5.76959233315201}]
 "HF-field.inp"                          = [{matcher="E_total", tol=1e-12, ref=-5.70162277773935}]
-"HF-field-gopt.inp"                     = [{matcher="E_total", tol=5e-09, ref=-5.65593182181073}]
+"HF-field-gopt.inp"                     = [{matcher="E_total", tol=5e-09, ref=-5.65593242174518}]
 "HF-field-debug.inp"                    = []
 "HF-dfilter-debug.inp"                  = []
 "HF-dfield-gopt.inp"                    = [{matcher="E_total", tol=1e-09, ref=-5.66065888870620}]

--- a/tests/xTB/regtest-2/TEST_FILES.toml
+++ b/tests/xTB/regtest-2/TEST_FILES.toml
@@ -9,7 +9,7 @@
 "H2O-field.inp"                         = []
 "H2O-field-lsd.inp"                     = [{matcher="E_total", tol=4e-14, ref=-5.76959233315201}]
 "HF-field.inp"                          = [{matcher="E_total", tol=1e-12, ref=-5.70162277773935}]
-"HF-field-gopt.inp"                     = [{matcher="E_total", tol=5e-09, ref=-5.65593242174518}]
+"HF-field-gopt.inp"                     = [{matcher="E_total", tol=5e-07, ref=-5.65593182181073}]
 "HF-field-debug.inp"                    = []
 "HF-dfilter-debug.inp"                  = []
 "HF-dfield-gopt.inp"                    = [{matcher="E_total", tol=1e-09, ref=-5.66065888870620}]


### PR DESCRIPTION
When using OT, the occcupied orbital eigenvalues are now
- written after SCF convergence to the CP2K output file if requested
- dumped to the binary wavefunction restart file and are printed upon restart if requested
- printed to the MOLDEN output file
- not printed during the OT SCF cycle (only the final orbitals after convergence are printed for the given index range)