### PR TITLE
Correct the error metric terminology in the BASIS_RI_AUG_MOLOPT file

### DIFF
--- a/data/BASIS_RI_AUG_MOLOPT
+++ b/data/BASIS_RI_AUG_MOLOPT
@@ -1,4 +1,4 @@
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.5e-02
+# RI basis set for H (all-electron) relative DI metric: 1.5e-02
 H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_002_s_p_d_f_g_h_i_2_0_0_0_0_0_0_error_1.5e-02
    2
      1   0   0   1   1
@@ -6,7 +6,7 @@ H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_002_s_p_d_f_g_h_i_2_0_0_0_0_0_0_error_1.5e-02
      2   0   0   1   1
       2.4579249207    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 3.0e-03
+# RI basis set for H (all-electron) relative DI metric: 3.0e-03
 H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_3.0e-03
    3
      1   0   0   1   1
@@ -16,7 +16,7 @@ H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_3.0e-03
      3   1   1   1   1
       0.7007968815    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 2.7e-04
+# RI basis set for H (all-electron) relative DI metric: 2.7e-04
 H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_2.7e-04
    4
      1   0   0   1   1
@@ -28,7 +28,7 @@ H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_2.7e-04
      4   1   1   1   1
       0.5432074796    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.3e-04
+# RI basis set for H (all-electron) relative DI metric: 1.3e-04
 H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_008_s_p_d_f_g_h_i_5_1_0_0_0_0_0_error_1.3e-04
    6
      1   0   0   1   1
@@ -44,7 +44,7 @@ H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_008_s_p_d_f_g_h_i_5_1_0_0_0_0_0_error_1.3e-04
      6   1   1   1   1
       0.4900456184    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.3e-06
+# RI basis set for H (all-electron) relative DI metric: 1.3e-06
 H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_011_s_p_d_f_g_h_i_5_2_0_0_0_0_0_error_1.3e-06
    7
      1   0   0   1   1
@@ -62,7 +62,7 @@ H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_011_s_p_d_f_g_h_i_5_2_0_0_0_0_0_error_1.3e-06
      7   1   1   1   1
       1.5273474371    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 4.7e-07
+# RI basis set for H (all-electron) relative DI metric: 4.7e-07
 H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_018_s_p_d_f_g_h_i_6_4_0_0_0_0_0_error_4.7e-07
    10
      1   0   0   1   1
@@ -86,7 +86,7 @@ H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_018_s_p_d_f_g_h_i_6_4_0_0_0_0_0_error_4.7e-07
     10   1   1   1   1
       1.9915266663    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 3.5e-08
+# RI basis set for H (all-electron) relative DI metric: 3.5e-08
 H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_025_s_p_d_f_g_h_i_7_6_0_0_0_0_0_error_3.5e-08
    13
      1   0   0   1   1
@@ -116,7 +116,7 @@ H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_025_s_p_d_f_g_h_i_7_6_0_0_0_0_0_error_3.5e-08
     13   1   1   1   1
       1.9915266667    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.3e-08
+# RI basis set for H (all-electron) relative DI metric: 1.3e-08
 H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_035_s_p_d_f_g_h_i_7_6_2_0_0_0_0_error_1.3e-08
    15
      1   0   0   1   1
@@ -150,7 +150,7 @@ H  RI_aug-SZV-MOLOPT-ae-SR_N_RI_035_s_p_d_f_g_h_i_7_6_2_0_0_0_0_error_1.3e-08
     15   2   2   1   1
       1.2860533333    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.3e-02
+# RI basis set for H (all-electron) relative DI metric: 1.3e-02
 H  RI_aug-SZV-MOLOPT-ae_N_RI_002_s_p_d_f_g_h_i_2_0_0_0_0_0_0_error_1.3e-02
    2
      1   0   0   1   1
@@ -158,7 +158,7 @@ H  RI_aug-SZV-MOLOPT-ae_N_RI_002_s_p_d_f_g_h_i_2_0_0_0_0_0_0_error_1.3e-02
      2   0   0   1   1
       2.1834666323    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.3e-04
+# RI basis set for H (all-electron) relative DI metric: 1.3e-04
 H  RI_aug-SZV-MOLOPT-ae_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_1.3e-04
    4
      1   0   0   1   1
@@ -170,7 +170,7 @@ H  RI_aug-SZV-MOLOPT-ae_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_1.3e-04
      4   1   1   1   1
       0.3741982228    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 4.4e-05
+# RI basis set for H (all-electron) relative DI metric: 4.4e-05
 H  RI_aug-SZV-MOLOPT-ae_N_RI_007_s_p_d_f_g_h_i_4_1_0_0_0_0_0_error_4.4e-05
    5
      1   0   0   1   1
@@ -184,7 +184,7 @@ H  RI_aug-SZV-MOLOPT-ae_N_RI_007_s_p_d_f_g_h_i_4_1_0_0_0_0_0_error_4.4e-05
      5   1   1   1   1
       0.3674521516    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 2.4e-06
+# RI basis set for H (all-electron) relative DI metric: 2.4e-06
 H  RI_aug-SZV-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_4_2_0_0_0_0_0_error_2.4e-06
    6
      1   0   0   1   1
@@ -200,7 +200,7 @@ H  RI_aug-SZV-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_4_2_0_0_0_0_0_error_2.4e-06
      6   1   1   1   1
       1.6074447029    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 9.8e-07
+# RI basis set for H (all-electron) relative DI metric: 9.8e-07
 H  RI_aug-SZV-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_5_2_0_0_0_0_0_error_9.8e-07
    7
      1   0   0   1   1
@@ -218,7 +218,7 @@ H  RI_aug-SZV-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_5_2_0_0_0_0_0_error_9.8e-07
      7   1   1   1   1
       1.3163036644    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 3.4e-07
+# RI basis set for H (all-electron) relative DI metric: 3.4e-07
 H  RI_aug-SZV-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_6_3_1_0_0_0_0_error_3.4e-07
    10
      1   0   0   1   1
@@ -242,7 +242,7 @@ H  RI_aug-SZV-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_6_3_1_0_0_0_0_error_3.4e-07
     10   2   2   1   1
       0.9794814801    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.1e-07
+# RI basis set for H (all-electron) relative DI metric: 1.1e-07
 H  RI_aug-SZV-MOLOPT-ae_N_RI_026_s_p_d_f_g_h_i_7_3_2_0_0_0_0_error_1.1e-07
    12
      1   0   0   1   1
@@ -270,7 +270,7 @@ H  RI_aug-SZV-MOLOPT-ae_N_RI_026_s_p_d_f_g_h_i_7_3_2_0_0_0_0_error_1.1e-07
     12   2   2   1   1
       1.2340233898    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 5.1e-08
+# RI basis set for H (all-electron) relative DI metric: 5.1e-08
 H  RI_aug-SZV-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_7_6_2_0_0_0_0_error_5.1e-08
    15
      1   0   0   1   1
@@ -304,7 +304,7 @@ H  RI_aug-SZV-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_7_6_2_0_0_0_0_error_5.1e-08
     15   2   2   1   1
       1.2860533333    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 2.9e-03
+# RI basis set for H (all-electron) relative DI metric: 2.9e-03
 H  RI_aug-DZVP-MOLOPT-ae_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_2.9e-03
    3
      1   0   0   1   1
@@ -314,7 +314,7 @@ H  RI_aug-DZVP-MOLOPT-ae_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_2.9e-03
      3   1   1   1   1
       1.1065929596    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 4.4e-05
+# RI basis set for H (all-electron) relative DI metric: 4.4e-05
 H  RI_aug-DZVP-MOLOPT-ae_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_4.4e-05
    5
      1   0   0   1   1
@@ -328,7 +328,7 @@ H  RI_aug-DZVP-MOLOPT-ae_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_4.4e-05
      5   1   1   1   1
       1.4513187711    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.6e-05
+# RI basis set for H (all-electron) relative DI metric: 1.6e-05
 H  RI_aug-DZVP-MOLOPT-ae_N_RI_013_s_p_d_f_g_h_i_4_3_0_0_0_0_0_error_1.6e-05
    7
      1   0   0   1   1
@@ -346,7 +346,7 @@ H  RI_aug-DZVP-MOLOPT-ae_N_RI_013_s_p_d_f_g_h_i_4_3_0_0_0_0_0_error_1.6e-05
      7   1   1   1   1
       1.8253246023    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 6.3e-07
+# RI basis set for H (all-electron) relative DI metric: 6.3e-07
 H  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_6.3e-07
    8
      1   0   0   1   1
@@ -366,7 +366,7 @@ H  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_6.3e-07
      8   2   2   1   1
       1.2035077028    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.5e-07
+# RI basis set for H (all-electron) relative DI metric: 1.5e-07
 H  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_1.5e-07
    9
      1   0   0   1   1
@@ -388,7 +388,7 @@ H  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_1.5e-07
      9   2   2   1   1
       1.5281545369    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 6.1e-08
+# RI basis set for H (all-electron) relative DI metric: 6.1e-08
 H  RI_aug-DZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_5_3_2_1_0_0_0_error_6.1e-08
    11
      1   0   0   1   1
@@ -414,7 +414,7 @@ H  RI_aug-DZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_5_3_2_1_0_0_0_error_6.1e-08
     11   3   3   1   1
       1.3312038025    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 2.9e-08
+# RI basis set for H (all-electron) relative DI metric: 2.9e-08
 H  RI_aug-DZVP-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_7_6_3_1_0_0_0_error_2.9e-08
    17
      1   0   0   1   1
@@ -452,7 +452,7 @@ H  RI_aug-DZVP-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_7_6_3_1_0_0_0_error_2.9e-08
     17   3   3   1   1
       1.1981100000    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 9.0e-03
+# RI basis set for H (all-electron) relative DI metric: 9.0e-03
 H  RI_aug-TZVP-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_9.0e-03
    5
      1   0   0   1   1
@@ -466,7 +466,7 @@ H  RI_aug-TZVP-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_9.0e-03
      5   2   2   1   1
       1.2033086289    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 5.9e-04
+# RI basis set for H (all-electron) relative DI metric: 5.9e-04
 H  RI_aug-TZVP-MOLOPT-ae_N_RI_015_s_p_d_f_g_h_i_4_2_1_0_0_0_0_error_5.9e-04
    7
      1   0   0   1   1
@@ -484,7 +484,7 @@ H  RI_aug-TZVP-MOLOPT-ae_N_RI_015_s_p_d_f_g_h_i_4_2_1_0_0_0_0_error_5.9e-04
      7   2   2   1   1
       1.3115890895    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 1.0e-04
+# RI basis set for H (all-electron) relative DI metric: 1.0e-04
 H  RI_aug-TZVP-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_4_2_2_0_0_0_0_error_1.0e-04
    8
      1   0   0   1   1
@@ -504,7 +504,7 @@ H  RI_aug-TZVP-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_4_2_2_0_0_0_0_error_1.0e-04
      8   2   2   1   1
       1.5673930803    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 4.6e-05
+# RI basis set for H (all-electron) relative DI metric: 4.6e-05
 H  RI_aug-TZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_4.6e-05
    9
      1   0   0   1   1
@@ -526,7 +526,7 @@ H  RI_aug-TZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_4.6e-05
      9   2   2   1   1
       1.4863697565    1.0000000000
 
-# RI basis set for H (all-electron) relative accuracy of RI-MP2: 4.5e-06
+# RI basis set for H (all-electron) relative DI metric: 4.5e-06
 H  RI_aug-TZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_6_5_2_0_0_0_0_error_4.5e-06
    13
      1   0   0   1   1
@@ -556,7 +556,7 @@ H  RI_aug-TZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_6_5_2_0_0_0_0_error_4.5e-06
     13   2   2   1   1
       1.4730352119    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 4.2e-03
+# RI basis set for He (all-electron) relative DI metric: 4.2e-03
 He  RI_aug-SZV-MOLOPT-ae_N_RI_003_s_p_d_f_g_h_i_3_0_0_0_0_0_0_error_4.2e-03
    3
      1   0   0   1   1
@@ -566,7 +566,7 @@ He  RI_aug-SZV-MOLOPT-ae_N_RI_003_s_p_d_f_g_h_i_3_0_0_0_0_0_0_error_4.2e-03
      3   0   0   1   1
      11.9714078591    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 2.5e-06
+# RI basis set for He (all-electron) relative DI metric: 2.5e-06
 He  RI_aug-SZV-MOLOPT-ae_N_RI_009_s_p_d_f_g_h_i_6_1_0_0_0_0_0_error_2.5e-06
    7
      1   0   0   1   1
@@ -584,7 +584,7 @@ He  RI_aug-SZV-MOLOPT-ae_N_RI_009_s_p_d_f_g_h_i_6_1_0_0_0_0_0_error_2.5e-06
      7   1   1   1   1
       0.3001402433    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 7.2e-07
+# RI basis set for He (all-electron) relative DI metric: 7.2e-07
 He  RI_aug-SZV-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_6_4_0_0_0_0_0_error_7.2e-07
    10
      1   0   0   1   1
@@ -608,7 +608,7 @@ He  RI_aug-SZV-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_6_4_0_0_0_0_0_error_7.2e-07
     10   1   1   1   1
       4.1899471264    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 1.4e-07
+# RI basis set for He (all-electron) relative DI metric: 1.4e-07
 He  RI_aug-SZV-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_7_4_1_1_0_0_0_error_1.4e-07
    13
      1   0   0   1   1
@@ -638,7 +638,7 @@ He  RI_aug-SZV-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_7_4_1_1_0_0_0_error_1.4e-07
     13   3   3   1   1
       5.4484895350    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 8.4e-03
+# RI basis set for He (all-electron) relative DI metric: 8.4e-03
 He  RI_aug-DZVP-MOLOPT-ae_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_8.4e-03
    3
      1   0   0   1   1
@@ -648,7 +648,7 @@ He  RI_aug-DZVP-MOLOPT-ae_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_8.4e-03
      3   1   1   1   1
       1.5526672041    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 1.8e-04
+# RI basis set for He (all-electron) relative DI metric: 1.8e-04
 He  RI_aug-DZVP-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_1.8e-04
    5
      1   0   0   1   1
@@ -662,7 +662,7 @@ He  RI_aug-DZVP-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_1.8e-04
      5   2   2   1   1
       0.8890133475    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 4.5e-05
+# RI basis set for He (all-electron) relative DI metric: 4.5e-05
 He  RI_aug-DZVP-MOLOPT-ae_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_4.5e-05
    6
      1   0   0   1   1
@@ -678,7 +678,7 @@ He  RI_aug-DZVP-MOLOPT-ae_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_4.5e-05
      6   2   2   1   1
       0.9644685161    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 9.7e-06
+# RI basis set for He (all-electron) relative DI metric: 9.7e-06
 He  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_9.7e-06
    8
      1   0   0   1   1
@@ -698,7 +698,7 @@ He  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_9.7e-06
      8   2   2   1   1
       0.8998154095    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 1.3e-06
+# RI basis set for He (all-electron) relative DI metric: 1.3e-06
 He  RI_aug-DZVP-MOLOPT-ae_N_RI_024_s_p_d_f_g_h_i_5_3_2_0_0_0_0_error_1.3e-06
    10
      1   0   0   1   1
@@ -722,7 +722,7 @@ He  RI_aug-DZVP-MOLOPT-ae_N_RI_024_s_p_d_f_g_h_i_5_3_2_0_0_0_0_error_1.3e-06
     10   2   2   1   1
       2.9127472641    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 2.2e-07
+# RI basis set for He (all-electron) relative DI metric: 2.2e-07
 He  RI_aug-DZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_6_5_2_0_0_0_0_error_2.2e-07
    13
      1   0   0   1   1
@@ -752,7 +752,7 @@ He  RI_aug-DZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_6_5_2_0_0_0_0_error_2.2e-07
     13   2   2   1   1
       2.6660108059    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 5.9e-08
+# RI basis set for He (all-electron) relative DI metric: 5.9e-08
 He  RI_aug-DZVP-MOLOPT-ae_N_RI_036_s_p_d_f_g_h_i_6_5_3_0_0_0_0_error_5.9e-08
    14
      1   0   0   1   1
@@ -784,7 +784,7 @@ He  RI_aug-DZVP-MOLOPT-ae_N_RI_036_s_p_d_f_g_h_i_6_5_3_0_0_0_0_error_5.9e-08
     14   2   2   1   1
       3.5925551628    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 3.7e-02
+# RI basis set for He (all-electron) relative DI metric: 3.7e-02
 He  RI_aug-TZVP-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_3.7e-02
    5
      1   0   0   1   1
@@ -798,7 +798,7 @@ He  RI_aug-TZVP-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_3.7e-02
      5   2   2   1   1
       2.8667761206    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 1.7e-03
+# RI basis set for He (all-electron) relative DI metric: 1.7e-03
 He  RI_aug-TZVP-MOLOPT-ae_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_1.7e-03
    6
      1   0   0   1   1
@@ -814,7 +814,7 @@ He  RI_aug-TZVP-MOLOPT-ae_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_1.7e-03
      6   2   2   1   1
       2.8517757422    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 4.3e-04
+# RI basis set for He (all-electron) relative DI metric: 4.3e-04
 He  RI_aug-TZVP-MOLOPT-ae_N_RI_021_s_p_d_f_g_h_i_3_2_1_1_0_0_0_error_4.3e-04
    7
      1   0   0   1   1
@@ -832,7 +832,7 @@ He  RI_aug-TZVP-MOLOPT-ae_N_RI_021_s_p_d_f_g_h_i_3_2_1_1_0_0_0_error_4.3e-04
      7   3   3   1   1
       1.1880376992    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 3.9e-05
+# RI basis set for He (all-electron) relative DI metric: 3.9e-05
 He  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_3.9e-05
    9
      1   0   0   1   1
@@ -854,7 +854,7 @@ He  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_3.9e-05
      9   3   3   1   1
       0.8764308672    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 3.9e-06
+# RI basis set for He (all-electron) relative DI metric: 3.9e-06
 He  RI_aug-TZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_4_3_2_1_0_0_0_error_3.9e-06
    10
      1   0   0   1   1
@@ -878,7 +878,7 @@ He  RI_aug-TZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_4_3_2_1_0_0_0_error_3.9e-06
     10   3   3   1   1
       0.9253742267    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 8.1e-07
+# RI basis set for He (all-electron) relative DI metric: 8.1e-07
 He  RI_aug-TZVP-MOLOPT-ae_N_RI_038_s_p_d_f_g_h_i_5_3_2_2_0_0_0_error_8.1e-07
    12
      1   0   0   1   1
@@ -906,7 +906,7 @@ He  RI_aug-TZVP-MOLOPT-ae_N_RI_038_s_p_d_f_g_h_i_5_3_2_2_0_0_0_error_8.1e-07
     12   3   3   1   1
       1.9854582875    1.0000000000
 
-# RI basis set for He (all-electron) relative accuracy of RI-MP2: 1.7e-07
+# RI basis set for He (all-electron) relative DI metric: 1.7e-07
 He  RI_aug-TZVP-MOLOPT-ae_N_RI_042_s_p_d_f_g_h_i_6_4_2_2_0_0_0_error_1.7e-07
    14
      1   0   0   1   1
@@ -938,7 +938,7 @@ He  RI_aug-TZVP-MOLOPT-ae_N_RI_042_s_p_d_f_g_h_i_6_4_2_2_0_0_0_error_1.7e-07
     14   3   3   1   1
       1.4760179520    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 4.7e-04
+# RI basis set for Li (all-electron) relative DI metric: 4.7e-04
 Li  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_4.7e-04
    5
      1   0   0   1   1
@@ -952,7 +952,7 @@ Li  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_4.7e-04
      5   1   1   1   1
       1.4263325185    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 9.8e-05
+# RI basis set for Li (all-electron) relative DI metric: 9.8e-05
 Li  RI_aug-SZV-MOLOPT-ae-mini_N_RI_012_s_p_d_f_g_h_i_6_2_0_0_0_0_0_error_9.8e-05
    8
      1   0   0   1   1
@@ -972,7 +972,7 @@ Li  RI_aug-SZV-MOLOPT-ae-mini_N_RI_012_s_p_d_f_g_h_i_6_2_0_0_0_0_0_error_9.8e-05
      8   1   1   1   1
       1.4399827773    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 9.2e-07
+# RI basis set for Li (all-electron) relative DI metric: 9.2e-07
 Li  RI_aug-SZV-MOLOPT-ae-mini_N_RI_015_s_p_d_f_g_h_i_6_3_0_0_0_0_0_error_9.2e-07
    9
      1   0   0   1   1
@@ -994,7 +994,7 @@ Li  RI_aug-SZV-MOLOPT-ae-mini_N_RI_015_s_p_d_f_g_h_i_6_3_0_0_0_0_0_error_9.2e-07
      9   1   1   1   1
       4.0128832489    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 4.8e-02
+# RI basis set for Li (all-electron) relative DI metric: 4.8e-02
 Li  RI_aug-SZV-MOLOPT-ae_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_4.8e-02
    3
      1   0   0   1   1
@@ -1004,7 +1004,7 @@ Li  RI_aug-SZV-MOLOPT-ae_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_4.8e-02
      3   1   1   1   1
       1.3737602394    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 1.0e-02
+# RI basis set for Li (all-electron) relative DI metric: 1.0e-02
 Li  RI_aug-SZV-MOLOPT-ae_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_1.0e-02
    4
      1   0   0   1   1
@@ -1016,7 +1016,7 @@ Li  RI_aug-SZV-MOLOPT-ae_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_1.0e-02
      4   1   1   1   1
       1.3997738808    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 3.8e-03
+# RI basis set for Li (all-electron) relative DI metric: 3.8e-03
 Li  RI_aug-SZV-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_3.8e-03
    5
      1   0   0   1   1
@@ -1030,7 +1030,7 @@ Li  RI_aug-SZV-MOLOPT-ae_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_3.8e-03
      5   2   2   1   1
       0.7672789281    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 1.1e-04
+# RI basis set for Li (all-electron) relative DI metric: 1.1e-04
 Li  RI_aug-SZV-MOLOPT-ae_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_1.1e-04
    6
      1   0   0   1   1
@@ -1046,7 +1046,7 @@ Li  RI_aug-SZV-MOLOPT-ae_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_1.1e-04
      6   2   2   1   1
       0.7673096620    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 2.2e-05
+# RI basis set for Li (all-electron) relative DI metric: 2.2e-05
 Li  RI_aug-SZV-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_2.2e-05
    8
      1   0   0   1   1
@@ -1066,7 +1066,7 @@ Li  RI_aug-SZV-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_2.2e-05
      8   2   2   1   1
       0.7686702585    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 3.5e-06
+# RI basis set for Li (all-electron) relative DI metric: 3.5e-06
 Li  RI_aug-SZV-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_3.5e-06
    9
      1   0   0   1   1
@@ -1088,7 +1088,7 @@ Li  RI_aug-SZV-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_3.5e-06
      9   2   2   1   1
       2.5158456830    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 8.0e-07
+# RI basis set for Li (all-electron) relative DI metric: 8.0e-07
 Li  RI_aug-SZV-MOLOPT-ae_N_RI_028_s_p_d_f_g_h_i_4_3_3_0_0_0_0_error_8.0e-07
    10
      1   0   0   1   1
@@ -1112,7 +1112,7 @@ Li  RI_aug-SZV-MOLOPT-ae_N_RI_028_s_p_d_f_g_h_i_4_3_3_0_0_0_0_error_8.0e-07
     10   2   2   1   1
       2.3378216974    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 3.9e-07
+# RI basis set for Li (all-electron) relative DI metric: 3.9e-07
 Li  RI_aug-SZV-MOLOPT-ae_N_RI_104_s_p_d_f_g_h_i_5_4_4_2_2_2_1_error_3.9e-07
    20
      1   0   0   1   1
@@ -1156,7 +1156,7 @@ Li  RI_aug-SZV-MOLOPT-ae_N_RI_104_s_p_d_f_g_h_i_5_4_4_2_2_2_1_error_3.9e-07
     20   6   6   1   1
       0.7349241171    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 1.1e-02
+# RI basis set for Li (all-electron) relative DI metric: 1.1e-02
 Li  RI_aug-DZVP-MOLOPT-ae_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_1.1e-02
    4
      1   0   0   1   1
@@ -1168,7 +1168,7 @@ Li  RI_aug-DZVP-MOLOPT-ae_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_1.1e-02
      4   1   1   1   1
       1.7928072978    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 3.5e-03
+# RI basis set for Li (all-electron) relative DI metric: 3.5e-03
 Li  RI_aug-DZVP-MOLOPT-ae_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_3.5e-03
    5
      1   0   0   1   1
@@ -1182,7 +1182,7 @@ Li  RI_aug-DZVP-MOLOPT-ae_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_3.5e-03
      5   1   1   1   1
       2.7844011814    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 1.2e-03
+# RI basis set for Li (all-electron) relative DI metric: 1.2e-03
 Li  RI_aug-DZVP-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_4_2_0_0_0_0_0_error_1.2e-03
    6
      1   0   0   1   1
@@ -1198,7 +1198,7 @@ Li  RI_aug-DZVP-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_4_2_0_0_0_0_0_error_1.2e-03
      6   1   1   1   1
       2.6158194473    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 2.7e-04
+# RI basis set for Li (all-electron) relative DI metric: 2.7e-04
 Li  RI_aug-DZVP-MOLOPT-ae_N_RI_015_s_p_d_f_g_h_i_4_2_1_0_0_0_0_error_2.7e-04
    7
      1   0   0   1   1
@@ -1216,7 +1216,7 @@ Li  RI_aug-DZVP-MOLOPT-ae_N_RI_015_s_p_d_f_g_h_i_4_2_1_0_0_0_0_error_2.7e-04
      7   2   2   1   1
       0.7742805827    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 1.1e-05
+# RI basis set for Li (all-electron) relative DI metric: 1.1e-05
 Li  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_1.1e-05
    8
      1   0   0   1   1
@@ -1236,7 +1236,7 @@ Li  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_1.1e-05
      8   2   2   1   1
       0.9071235587    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 4.6e-06
+# RI basis set for Li (all-electron) relative DI metric: 4.6e-06
 Li  RI_aug-DZVP-MOLOPT-ae_N_RI_022_s_p_d_f_g_h_i_5_4_1_0_0_0_0_error_4.6e-06
    10
      1   0   0   1   1
@@ -1260,7 +1260,7 @@ Li  RI_aug-DZVP-MOLOPT-ae_N_RI_022_s_p_d_f_g_h_i_5_4_1_0_0_0_0_error_4.6e-06
     10   2   2   1   1
       0.9121088287    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 1.0e-06
+# RI basis set for Li (all-electron) relative DI metric: 1.0e-06
 Li  RI_aug-DZVP-MOLOPT-ae_N_RI_080_s_p_d_f_g_h_i_5_4_3_3_3_0_0_error_1.0e-06
    18
      1   0   0   1   1
@@ -1300,7 +1300,7 @@ Li  RI_aug-DZVP-MOLOPT-ae_N_RI_080_s_p_d_f_g_h_i_5_4_3_3_3_0_0_error_1.0e-06
     18   4   4   1   1
       0.6179790344    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 1.5e-02
+# RI basis set for Li (all-electron) relative DI metric: 1.5e-02
 Li  RI_aug-TZVP-MOLOPT-ae_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_1.5e-02
    4
      1   0   0   1   1
@@ -1312,7 +1312,7 @@ Li  RI_aug-TZVP-MOLOPT-ae_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_1.5e-02
      4   1   1   1   1
       3.9377584450    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 1.8e-03
+# RI basis set for Li (all-electron) relative DI metric: 1.8e-03
 Li  RI_aug-TZVP-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_4_2_0_0_0_0_0_error_1.8e-03
    6
      1   0   0   1   1
@@ -1328,7 +1328,7 @@ Li  RI_aug-TZVP-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_4_2_0_0_0_0_0_error_1.8e-03
      6   1   1   1   1
       4.5563339803    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 9.9e-05
+# RI basis set for Li (all-electron) relative DI metric: 9.9e-05
 Li  RI_aug-TZVP-MOLOPT-ae_N_RI_015_s_p_d_f_g_h_i_4_2_1_0_0_0_0_error_9.9e-05
    7
      1   0   0   1   1
@@ -1346,7 +1346,7 @@ Li  RI_aug-TZVP-MOLOPT-ae_N_RI_015_s_p_d_f_g_h_i_4_2_1_0_0_0_0_error_9.9e-05
      7   2   2   1   1
       0.9143737140    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 2.0e-05
+# RI basis set for Li (all-electron) relative DI metric: 2.0e-05
 Li  RI_aug-TZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_2.0e-05
    8
      1   0   0   1   1
@@ -1366,7 +1366,7 @@ Li  RI_aug-TZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_2.0e-05
      8   2   2   1   1
       0.9125372407    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 9.2e-06
+# RI basis set for Li (all-electron) relative DI metric: 9.2e-06
 Li  RI_aug-TZVP-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_6_3_1_0_0_0_0_error_9.2e-06
    10
      1   0   0   1   1
@@ -1390,7 +1390,7 @@ Li  RI_aug-TZVP-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_6_3_1_0_0_0_0_error_9.2e-06
     10   2   2   1   1
       0.9338389900    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 4.5e-06
+# RI basis set for Li (all-electron) relative DI metric: 4.5e-06
 Li  RI_aug-TZVP-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_7_5_1_0_0_0_0_error_4.5e-06
    13
      1   0   0   1   1
@@ -1420,7 +1420,7 @@ Li  RI_aug-TZVP-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_7_5_1_0_0_0_0_error_4.5e-06
     13   2   2   1   1
       0.9131331057    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 6.6e-07
+# RI basis set for Li (all-electron) relative DI metric: 6.6e-07
 Li  RI_aug-TZVP-MOLOPT-ae_N_RI_032_s_p_d_f_g_h_i_7_5_2_0_0_0_0_error_6.6e-07
    14
      1   0   0   1   1
@@ -1452,7 +1452,7 @@ Li  RI_aug-TZVP-MOLOPT-ae_N_RI_032_s_p_d_f_g_h_i_7_5_2_0_0_0_0_error_6.6e-07
     14   2   2   1   1
       1.3997999782    1.0000000000
 
-# RI basis set for Li (all-electron) relative accuracy of RI-MP2: 3.2e-07
+# RI basis set for Li (all-electron) relative DI metric: 3.2e-07
 Li  RI_aug-TZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_7_5_4_2_0_0_0_error_3.2e-07
    18
      1   0   0   1   1
@@ -1492,7 +1492,7 @@ Li  RI_aug-TZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_7_5_4_2_0_0_0_error_3.2e-07
     18   3   3   1   1
       1.0835696307    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 1.3e-02
+# RI basis set for Be (all-electron) relative DI metric: 1.3e-02
 Be  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_1.3e-02
    5
      1   0   0   1   1
@@ -1506,7 +1506,7 @@ Be  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_1.3e-02
      5   1   1   1   1
       0.4903269990    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 5.2e-06
+# RI basis set for Be (all-electron) relative DI metric: 5.2e-06
 Be  RI_aug-SZV-MOLOPT-ae-mini_N_RI_016_s_p_d_f_g_h_i_7_3_0_0_0_0_0_error_5.2e-06
    10
      1   0   0   1   1
@@ -1530,7 +1530,7 @@ Be  RI_aug-SZV-MOLOPT-ae-mini_N_RI_016_s_p_d_f_g_h_i_7_3_0_0_0_0_0_error_5.2e-06
     10   1   1   1   1
       3.3446943618    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 4.2e-02
+# RI basis set for Be (all-electron) relative DI metric: 4.2e-02
 Be  RI_aug-SZV-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_4.2e-02
    4
      1   0   0   1   1
@@ -1542,7 +1542,7 @@ Be  RI_aug-SZV-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_4.2e-02
      4   2   2   1   1
       0.3346038588    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 1.2e-02
+# RI basis set for Be (all-electron) relative DI metric: 1.2e-02
 Be  RI_aug-SZV-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_5_1_1_1_0_0_0_error_1.2e-02
    8
      1   0   0   1   1
@@ -1562,7 +1562,7 @@ Be  RI_aug-SZV-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_5_1_1_1_0_0_0_error_1.2e-02
      8   3   3   1   1
       0.1442126443    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 5.5e-03
+# RI basis set for Be (all-electron) relative DI metric: 5.5e-03
 Be  RI_aug-SZV-MOLOPT-ae_N_RI_024_s_p_d_f_g_h_i_6_2_1_1_0_0_0_error_5.5e-03
    10
      1   0   0   1   1
@@ -1586,7 +1586,7 @@ Be  RI_aug-SZV-MOLOPT-ae_N_RI_024_s_p_d_f_g_h_i_6_2_1_1_0_0_0_error_5.5e-03
     10   3   3   1   1
       1.3313985884    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 4.1e-06
+# RI basis set for Be (all-electron) relative DI metric: 4.1e-06
 Be  RI_aug-SZV-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_6_3_1_1_0_0_0_error_4.1e-06
    11
      1   0   0   1   1
@@ -1612,7 +1612,7 @@ Be  RI_aug-SZV-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_6_3_1_1_0_0_0_error_4.1e-06
     11   3   3   1   1
       0.5216014710    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 4.8e-07
+# RI basis set for Be (all-electron) relative DI metric: 4.8e-07
 Be  RI_aug-SZV-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_4.8e-07
    13
      1   0   0   1   1
@@ -1642,7 +1642,7 @@ Be  RI_aug-SZV-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_4.8e-07
     13   3   3   1   1
       0.4962152098    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 2.2e-07
+# RI basis set for Be (all-electron) relative DI metric: 2.2e-07
 Be  RI_aug-SZV-MOLOPT-ae_N_RI_038_s_p_d_f_g_h_i_6_5_2_1_0_0_0_error_2.2e-07
    14
      1   0   0   1   1
@@ -1674,7 +1674,7 @@ Be  RI_aug-SZV-MOLOPT-ae_N_RI_038_s_p_d_f_g_h_i_6_5_2_1_0_0_0_error_2.2e-07
     14   3   3   1   1
       0.4980086817    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 6.2e-08
+# RI basis set for Be (all-electron) relative DI metric: 6.2e-08
 Be  RI_aug-SZV-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_5_4_1_0_0_0_error_6.2e-08
    16
      1   0   0   1   1
@@ -1710,7 +1710,7 @@ Be  RI_aug-SZV-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_5_4_1_0_0_0_error_6.2e-08
     16   3   3   1   1
       0.4982903298    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 2.9e-08
+# RI basis set for Be (all-electron) relative DI metric: 2.9e-08
 Be  RI_aug-SZV-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_5_5_1_1_0_0_error_2.9e-08
    19
      1   0   0   1   1
@@ -1752,7 +1752,7 @@ Be  RI_aug-SZV-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_5_5_1_1_0_0_error_2.9e-08
     19   4   4   1   1
       0.5156063055    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 7.3e-09
+# RI basis set for Be (all-electron) relative DI metric: 7.3e-09
 Be  RI_aug-SZV-MOLOPT-ae_N_RI_117_s_p_d_f_g_h_i_7_6_6_5_3_0_0_error_7.3e-09
    27
      1   0   0   1   1
@@ -1810,7 +1810,7 @@ Be  RI_aug-SZV-MOLOPT-ae_N_RI_117_s_p_d_f_g_h_i_7_6_6_5_3_0_0_error_7.3e-09
     27   4   4   1   1
       0.7857014957    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 2.6e-03
+# RI basis set for Be (all-electron) relative DI metric: 2.6e-03
 Be  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_2.6e-03
    9
      1   0   0   1   1
@@ -1832,7 +1832,7 @@ Be  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_2.6e-03
      9   2   2   1   1
       0.3886492407    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 5.7e-04
+# RI basis set for Be (all-electron) relative DI metric: 5.7e-04
 Be  RI_aug-DZVP-MOLOPT-ae_N_RI_026_s_p_d_f_g_h_i_7_3_2_0_0_0_0_error_5.7e-04
    12
      1   0   0   1   1
@@ -1860,7 +1860,7 @@ Be  RI_aug-DZVP-MOLOPT-ae_N_RI_026_s_p_d_f_g_h_i_7_3_2_0_0_0_0_error_5.7e-04
     12   2   2   1   1
       0.7771889181    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 1.3e-04
+# RI basis set for Be (all-electron) relative DI metric: 1.3e-04
 Be  RI_aug-DZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_7_4_2_0_0_0_0_error_1.3e-04
    13
      1   0   0   1   1
@@ -1890,7 +1890,7 @@ Be  RI_aug-DZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_7_4_2_0_0_0_0_error_1.3e-04
     13   2   2   1   1
       0.4744052978    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 5.7e-05
+# RI basis set for Be (all-electron) relative DI metric: 5.7e-05
 Be  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_7_5_2_1_0_0_0_error_5.7e-05
    15
      1   0   0   1   1
@@ -1924,7 +1924,7 @@ Be  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_7_5_2_1_0_0_0_error_5.7e-05
     15   3   3   1   1
       0.3562115345    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 2.1e-05
+# RI basis set for Be (all-electron) relative DI metric: 2.1e-05
 Be  RI_aug-DZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_5_5_4_0_0_0_error_2.1e-05
    21
      1   0   0   1   1
@@ -1970,7 +1970,7 @@ Be  RI_aug-DZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_5_5_4_0_0_0_error_2.1e-05
     21   3   3   1   1
       1.2898409224    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 2.1e-02
+# RI basis set for Be (all-electron) relative DI metric: 2.1e-02
 Be  RI_aug-TZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_2.1e-02
    9
      1   0   0   1   1
@@ -1992,7 +1992,7 @@ Be  RI_aug-TZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_2.1e-02
      9   2   2   1   1
       0.3705402825    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 5.7e-03
+# RI basis set for Be (all-electron) relative DI metric: 5.7e-03
 Be  RI_aug-TZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_5.7e-03
    11
      1   0   0   1   1
@@ -2018,7 +2018,7 @@ Be  RI_aug-TZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_5.7e-03
     11   3   3   1   1
       0.3272528852    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 2.3e-03
+# RI basis set for Be (all-electron) relative DI metric: 2.3e-03
 Be  RI_aug-TZVP-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_5_4_2_1_0_0_0_error_2.3e-03
    12
      1   0   0   1   1
@@ -2046,7 +2046,7 @@ Be  RI_aug-TZVP-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_5_4_2_1_0_0_0_error_2.3e-03
     12   3   3   1   1
       0.3471314856    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 9.3e-04
+# RI basis set for Be (all-electron) relative DI metric: 9.3e-04
 Be  RI_aug-TZVP-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_9.3e-04
    15
      1   0   0   1   1
@@ -2080,7 +2080,7 @@ Be  RI_aug-TZVP-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_9.3e-04
     15   3   3   1   1
       0.3289432139    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 4.3e-04
+# RI basis set for Be (all-electron) relative DI metric: 4.3e-04
 Be  RI_aug-TZVP-MOLOPT-ae_N_RI_049_s_p_d_f_g_h_i_7_5_4_1_0_0_0_error_4.3e-04
    17
      1   0   0   1   1
@@ -2118,7 +2118,7 @@ Be  RI_aug-TZVP-MOLOPT-ae_N_RI_049_s_p_d_f_g_h_i_7_5_4_1_0_0_0_error_4.3e-04
     17   3   3   1   1
       0.3536736931    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 1.5e-04
+# RI basis set for Be (all-electron) relative DI metric: 1.5e-04
 Be  RI_aug-TZVP-MOLOPT-ae_N_RI_058_s_p_d_f_g_h_i_7_5_4_1_1_0_0_error_1.5e-04
    18
      1   0   0   1   1
@@ -2158,7 +2158,7 @@ Be  RI_aug-TZVP-MOLOPT-ae_N_RI_058_s_p_d_f_g_h_i_7_5_4_1_1_0_0_error_1.5e-04
     18   4   4   1   1
       0.1369188316    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 6.6e-05
+# RI basis set for Be (all-electron) relative DI metric: 6.6e-05
 Be  RI_aug-TZVP-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_5_5_1_1_0_0_error_6.6e-05
    19
      1   0   0   1   1
@@ -2200,7 +2200,7 @@ Be  RI_aug-TZVP-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_5_5_1_1_0_0_error_6.6e-05
     19   4   4   1   1
       0.1576113299    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 2.1e-05
+# RI basis set for Be (all-electron) relative DI metric: 2.1e-05
 Be  RI_aug-TZVP-MOLOPT-ae_N_RI_093_s_p_d_f_g_h_i_7_5_5_4_2_0_0_error_2.1e-05
    23
      1   0   0   1   1
@@ -2250,7 +2250,7 @@ Be  RI_aug-TZVP-MOLOPT-ae_N_RI_093_s_p_d_f_g_h_i_7_5_5_4_2_0_0_error_2.1e-05
     23   4   4   1   1
       0.6724171726    1.0000000000
 
-# RI basis set for Be (all-electron) relative accuracy of RI-MP2: 9.1e-06
+# RI basis set for Be (all-electron) relative DI metric: 9.1e-06
 Be  RI_aug-TZVP-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_5_5_3_0_0_error_9.1e-06
    26
      1   0   0   1   1
@@ -2308,7 +2308,7 @@ Be  RI_aug-TZVP-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_5_5_3_0_0_error_9.1e-06
 
 
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 2.0e-02
+# RI basis set for B (all-electron) relative DI metric: 2.0e-02
 B  RI_aug-SZV-MOLOPT-ae_N_RI_017_s_p_d_f_g_h_i_2_1_1_1_0_0_0_error_2.0e-02
    5
      1   0   0   1   1
@@ -2322,7 +2322,7 @@ B  RI_aug-SZV-MOLOPT-ae_N_RI_017_s_p_d_f_g_h_i_2_1_1_1_0_0_0_error_2.0e-02
      5   3   3   1   1
       0.2266443541    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 5.8e-07
+# RI basis set for B (all-electron) relative DI metric: 5.8e-07
 B  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_5.8e-07
    5
      1   0   0   1   1
@@ -2336,7 +2336,7 @@ B  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_5.8e-07
      5   1   1   1   1
       0.8635069462    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 1.2e-07
+# RI basis set for B (all-electron) relative DI metric: 1.2e-07
 B  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_5_3_0_0_0_0_0_error_1.2e-07
    8
      1   0   0   1   1
@@ -2356,7 +2356,7 @@ B  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_5_3_0_0_0_0_0_error_1.2e-07
      8   1   1   1   1
       3.3360177769    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 1.9e-08
+# RI basis set for B (all-electron) relative DI metric: 1.9e-08
 B  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_7_6_0_0_0_0_0_error_1.9e-08
    13
      1   0   0   1   1
@@ -2386,7 +2386,7 @@ B  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_7_6_0_0_0_0_0_error_1.9e-08
     13   1   1   1   1
       3.7282599999    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 7.4e-06
+# RI basis set for B (all-electron) relative DI metric: 7.4e-06
 B  RI_aug-SZV-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_7.4e-06
    9
      1   0   0   1   1
@@ -2408,7 +2408,7 @@ B  RI_aug-SZV-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_7.4e-06
      9   3   3   1   1
       0.6759737321    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 2.2e-06
+# RI basis set for B (all-electron) relative DI metric: 2.2e-06
 B  RI_aug-SZV-MOLOPT-ae_N_RI_032_s_p_d_f_g_h_i_6_3_2_1_0_0_0_error_2.2e-06
    12
      1   0   0   1   1
@@ -2436,7 +2436,7 @@ B  RI_aug-SZV-MOLOPT-ae_N_RI_032_s_p_d_f_g_h_i_6_3_2_1_0_0_0_error_2.2e-06
     12   3   3   1   1
       0.5504494161    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 8.4e-07
+# RI basis set for B (all-electron) relative DI metric: 8.4e-07
 B  RI_aug-SZV-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_8.4e-07
    13
      1   0   0   1   1
@@ -2466,7 +2466,7 @@ B  RI_aug-SZV-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_8.4e-07
     13   3   3   1   1
       0.5245098254    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 2.0e-02
+# RI basis set for B (all-electron) relative DI metric: 2.0e-02
 B  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_2.0e-02
    9
      1   0   0   1   1
@@ -2488,7 +2488,7 @@ B  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_2.0e-02
      9   2   2   1   1
       0.7924889026    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 2.3e-03
+# RI basis set for B (all-electron) relative DI metric: 2.3e-03
 B  RI_aug-DZVP-MOLOPT-ae_N_RI_026_s_p_d_f_g_h_i_5_3_1_1_0_0_0_error_2.3e-03
    10
      1   0   0   1   1
@@ -2512,7 +2512,7 @@ B  RI_aug-DZVP-MOLOPT-ae_N_RI_026_s_p_d_f_g_h_i_5_3_1_1_0_0_0_error_2.3e-03
     10   3   3   1   1
       0.5130681309    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 4.1e-05
+# RI basis set for B (all-electron) relative DI metric: 4.1e-05
 B  RI_aug-DZVP-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_4.1e-05
    13
      1   0   0   1   1
@@ -2542,7 +2542,7 @@ B  RI_aug-DZVP-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_4.1e-05
     13   3   3   1   1
       0.4017000541    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 1.5e-05
+# RI basis set for B (all-electron) relative DI metric: 1.5e-05
 B  RI_aug-DZVP-MOLOPT-ae_N_RI_045_s_p_d_f_g_h_i_6_5_2_2_0_0_0_error_1.5e-05
    15
      1   0   0   1   1
@@ -2576,7 +2576,7 @@ B  RI_aug-DZVP-MOLOPT-ae_N_RI_045_s_p_d_f_g_h_i_6_5_2_2_0_0_0_error_1.5e-05
     15   3   3   1   1
       1.5468148392    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 5.2e-06
+# RI basis set for B (all-electron) relative DI metric: 5.2e-06
 B  RI_aug-DZVP-MOLOPT-ae_N_RI_060_s_p_d_f_g_h_i_6_5_5_2_0_0_0_error_5.2e-06
    18
      1   0   0   1   1
@@ -2616,7 +2616,7 @@ B  RI_aug-DZVP-MOLOPT-ae_N_RI_060_s_p_d_f_g_h_i_6_5_5_2_0_0_0_error_5.2e-06
     18   3   3   1   1
       1.3274783395    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 9.1e-07
+# RI basis set for B (all-electron) relative DI metric: 9.1e-07
 B  RI_aug-DZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_7_5_5_2_1_0_0_error_9.1e-07
    20
      1   0   0   1   1
@@ -2660,7 +2660,7 @@ B  RI_aug-DZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_7_5_5_2_1_0_0_error_9.1e-07
     20   4   4   1   1
       0.6493287535    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 3.5e-07
+# RI basis set for B (all-electron) relative DI metric: 3.5e-07
 B  RI_aug-DZVP-MOLOPT-ae_N_RI_115_s_p_d_f_g_h_i_7_5_5_5_1_1_1_error_3.5e-07
    25
      1   0   0   1   1
@@ -2714,7 +2714,7 @@ B  RI_aug-DZVP-MOLOPT-ae_N_RI_115_s_p_d_f_g_h_i_7_5_5_5_1_1_1_error_3.5e-07
     25   6   6   1   1
       1.1280327774    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 3.8e-03
+# RI basis set for B (all-electron) relative DI metric: 3.8e-03
 B  RI_aug-TZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_3.8e-03
    11
      1   0   0   1   1
@@ -2740,7 +2740,7 @@ B  RI_aug-TZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_3.8e-03
     11   3   3   1   1
       0.8247722601    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 5.1e-04
+# RI basis set for B (all-electron) relative DI metric: 5.1e-04
 B  RI_aug-TZVP-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_5_4_2_1_0_0_0_error_5.1e-04
    12
      1   0   0   1   1
@@ -2768,7 +2768,7 @@ B  RI_aug-TZVP-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_5_4_2_1_0_0_0_error_5.1e-04
     12   3   3   1   1
       0.7666416517    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 2.6e-04
+# RI basis set for B (all-electron) relative DI metric: 2.6e-04
 B  RI_aug-TZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_2.6e-04
    15
      1   0   0   1   1
@@ -2802,7 +2802,7 @@ B  RI_aug-TZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_2.6e-04
     15   3   3   1   1
       0.7813893372    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 4.2e-05
+# RI basis set for B (all-electron) relative DI metric: 4.2e-05
 B  RI_aug-TZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_6_5_3_2_1_0_0_error_4.2e-05
    17
      1   0   0   1   1
@@ -2840,7 +2840,7 @@ B  RI_aug-TZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_6_5_3_2_1_0_0_error_4.2e-05
     17   4   4   1   1
       0.5089116277    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 1.2e-05
+# RI basis set for B (all-electron) relative DI metric: 1.2e-05
 B  RI_aug-TZVP-MOLOPT-ae_N_RI_073_s_p_d_f_g_h_i_6_5_4_2_2_0_0_error_1.2e-05
    19
      1   0   0   1   1
@@ -2882,7 +2882,7 @@ B  RI_aug-TZVP-MOLOPT-ae_N_RI_073_s_p_d_f_g_h_i_6_5_4_2_2_0_0_error_1.2e-05
     19   4   4   1   1
       0.9679395434    1.0000000000
 
-# RI basis set for B (all-electron) relative accuracy of RI-MP2: 2.1e-06
+# RI basis set for B (all-electron) relative DI metric: 2.1e-06
 B  RI_aug-TZVP-MOLOPT-ae_N_RI_100_s_p_d_f_g_h_i_6_5_4_3_3_1_0_error_2.1e-06
    22
      1   0   0   1   1
@@ -2930,7 +2930,7 @@ B  RI_aug-TZVP-MOLOPT-ae_N_RI_100_s_p_d_f_g_h_i_6_5_4_3_3_1_0_error_2.1e-06
     22   5   5   1   1
       1.0470452584    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 4.2e-03
+# RI basis set for C (all-electron) relative DI metric: 4.2e-03
 C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_011_s_p_d_f_g_h_i_5_2_0_0_0_0_0_error_4.2e-03
    7
      1   0   0   1   1
@@ -2948,7 +2948,7 @@ C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_011_s_p_d_f_g_h_i_5_2_0_0_0_0_0_error_4.2e-03
      7   1   1   1   1
       1.5558271972    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 7.2e-04
+# RI basis set for C (all-electron) relative DI metric: 7.2e-04
 C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_017_s_p_d_f_g_h_i_6_2_1_0_0_0_0_error_7.2e-04
    9
      1   0   0   1   1
@@ -2970,7 +2970,7 @@ C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_017_s_p_d_f_g_h_i_6_2_1_0_0_0_0_error_7.2e-04
      9   2   2   1   1
       2.8337941285    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.4e-06
+# RI basis set for C (all-electron) relative DI metric: 1.4e-06
 C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_022_s_p_d_f_g_h_i_6_2_2_0_0_0_0_error_1.4e-06
    10
      1   0   0   1   1
@@ -2994,7 +2994,7 @@ C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_022_s_p_d_f_g_h_i_6_2_2_0_0_0_0_error_1.4e-06
     10   2   2   1   1
       1.9687565083    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 6.8e-07
+# RI basis set for C (all-electron) relative DI metric: 6.8e-07
 C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_6.8e-07
    11
      1   0   0   1   1
@@ -3020,7 +3020,7 @@ C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_6.8e-07
     11   2   2   1   1
       1.9084499044    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 2.1e-07
+# RI basis set for C (all-electron) relative DI metric: 2.1e-07
 C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_040_s_p_d_f_g_h_i_7_6_3_0_0_0_0_error_2.1e-07
    16
      1   0   0   1   1
@@ -3056,7 +3056,7 @@ C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_040_s_p_d_f_g_h_i_7_6_3_0_0_0_0_error_2.1e-07
     16   2   2   1   1
       4.6198641560    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.3e-10
+# RI basis set for C (all-electron) relative DI metric: 1.3e-10
 C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_050_s_p_d_f_g_h_i_7_6_5_0_0_0_0_error_1.3e-10
    18
      1   0   0   1   1
@@ -3096,7 +3096,7 @@ C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_050_s_p_d_f_g_h_i_7_6_5_0_0_0_0_error_1.3e-10
     18   2   2   1   1
       4.9020816667    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 2.0e-11
+# RI basis set for C (all-electron) relative DI metric: 2.0e-11
 C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_055_s_p_d_f_g_h_i_7_6_6_0_0_0_0_error_2.0e-11
    19
      1   0   0   1   1
@@ -3138,7 +3138,7 @@ C  RI_aug-SZV-MOLOPT-ae-mini_N_RI_055_s_p_d_f_g_h_i_7_6_6_0_0_0_0_error_2.0e-11
     19   2   2   1   1
       4.9020816667    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.2e-02
+# RI basis set for C (all-electron) relative DI metric: 1.2e-02
 C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_1.2e-02
    4
      1   0   0   1   1
@@ -3150,7 +3150,7 @@ C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_1.2e-02
      4   2   2   1   1
       0.7411049496    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 3.2e-03
+# RI basis set for C (all-electron) relative DI metric: 3.2e-03
 C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_3.2e-03
    8
      1   0   0   1   1
@@ -3170,7 +3170,7 @@ C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_3.2e-03
      8   2   2   1   1
       0.5456040832    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.0e-04
+# RI basis set for C (all-electron) relative DI metric: 1.0e-04
 C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_1.0e-04
    11
      1   0   0   1   1
@@ -3196,7 +3196,7 @@ C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_1.0e-04
     11   3   3   1   1
       1.0356515402    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 3.3e-05
+# RI basis set for C (all-electron) relative DI metric: 3.3e-05
 C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_045_s_p_d_f_g_h_i_6_5_2_2_0_0_0_error_3.3e-05
    15
      1   0   0   1   1
@@ -3230,7 +3230,7 @@ C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_045_s_p_d_f_g_h_i_6_5_2_2_0_0_0_error_3.3e-05
     15   3   3   1   1
       2.5197345063    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 9.8e-06
+# RI basis set for C (all-electron) relative DI metric: 9.8e-06
 C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_054_s_p_d_f_g_h_i_6_5_2_2_1_0_0_error_9.8e-06
    16
      1   0   0   1   1
@@ -3266,7 +3266,7 @@ C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_054_s_p_d_f_g_h_i_6_5_2_2_1_0_0_error_9.8e-06
     16   4   4   1   1
       1.1084873393    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 9.1e-07
+# RI basis set for C (all-electron) relative DI metric: 9.1e-07
 C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_075_s_p_d_f_g_h_i_6_5_3_3_2_0_0_error_9.1e-07
    19
      1   0   0   1   1
@@ -3308,7 +3308,7 @@ C  RI_aug-SZV-MOLOPT-ae-SR_N_RI_075_s_p_d_f_g_h_i_6_5_3_3_2_0_0_error_9.1e-07
     19   4   4   1   1
       1.5355888317    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.1e-02
+# RI basis set for C (all-electron) relative DI metric: 1.1e-02
 C  RI_aug-SZV-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_1.1e-02
    4
      1   0   0   1   1
@@ -3320,7 +3320,7 @@ C  RI_aug-SZV-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_1.1e-02
      4   2   2   1   1
       0.6928828507    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 6.7e-04
+# RI basis set for C (all-electron) relative DI metric: 6.7e-04
 C  RI_aug-SZV-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_5_2_1_1_0_0_0_error_6.7e-04
    9
      1   0   0   1   1
@@ -3342,7 +3342,7 @@ C  RI_aug-SZV-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_5_2_1_1_0_0_0_error_6.7e-04
      9   3   3   1   1
       1.1168326622    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.7e-04
+# RI basis set for C (all-electron) relative DI metric: 1.7e-04
 C  RI_aug-SZV-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_5_3_2_2_1_0_0_error_1.7e-04
    13
      1   0   0   1   1
@@ -3372,7 +3372,7 @@ C  RI_aug-SZV-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_5_3_2_2_1_0_0_error_1.7e-04
     13   4   4   1   1
       1.0891285069    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 8.4e-05
+# RI basis set for C (all-electron) relative DI metric: 8.4e-05
 C  RI_aug-SZV-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_3_2_2_1_0_0_error_8.4e-05
    14
      1   0   0   1   1
@@ -3404,7 +3404,7 @@ C  RI_aug-SZV-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_3_2_2_1_0_0_error_8.4e-05
     14   4   4   1   1
       1.2176655648    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 3.9e-02
+# RI basis set for C (all-electron) relative DI metric: 3.9e-02
 C  RI_aug-DZVP-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_3.9e-02
    4
      1   0   0   1   1
@@ -3416,7 +3416,7 @@ C  RI_aug-DZVP-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_3.9e-02
      4   2   2   1   1
       1.0578164454    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 9.3e-03
+# RI basis set for C (all-electron) relative DI metric: 9.3e-03
 C  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_9.3e-03
    8
      1   0   0   1   1
@@ -3436,7 +3436,7 @@ C  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_9.3e-03
      8   2   2   1   1
       1.0207681204    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 2.6e-03
+# RI basis set for C (all-electron) relative DI metric: 2.6e-03
 C  RI_aug-DZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_2.6e-03
    11
      1   0   0   1   1
@@ -3462,7 +3462,7 @@ C  RI_aug-DZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_2.6e-03
     11   3   3   1   1
       1.0420807849    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 4.2e-04
+# RI basis set for C (all-electron) relative DI metric: 4.2e-04
 C  RI_aug-DZVP-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_4.2e-04
    13
      1   0   0   1   1
@@ -3492,7 +3492,7 @@ C  RI_aug-DZVP-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_4.2e-04
     13   3   3   1   1
       0.9496592034    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.2e-04
+# RI basis set for C (all-electron) relative DI metric: 1.2e-04
 C  RI_aug-DZVP-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_6_4_3_2_0_0_0_error_1.2e-04
    15
      1   0   0   1   1
@@ -3526,7 +3526,7 @@ C  RI_aug-DZVP-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_6_4_3_2_0_0_0_error_1.2e-04
     15   3   3   1   1
       1.3511942136    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 4.4e-05
+# RI basis set for C (all-electron) relative DI metric: 4.4e-05
 C  RI_aug-DZVP-MOLOPT-ae_N_RI_060_s_p_d_f_g_h_i_7_5_3_2_1_0_0_error_4.4e-05
    18
      1   0   0   1   1
@@ -3566,7 +3566,7 @@ C  RI_aug-DZVP-MOLOPT-ae_N_RI_060_s_p_d_f_g_h_i_7_5_3_2_1_0_0_error_4.4e-05
     18   4   4   1   1
       0.7351949451    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 8.9e-06
+# RI basis set for C (all-electron) relative DI metric: 8.9e-06
 C  RI_aug-DZVP-MOLOPT-ae_N_RI_067_s_p_d_f_g_h_i_7_5_3_3_1_0_0_error_8.9e-06
    19
      1   0   0   1   1
@@ -3608,7 +3608,7 @@ C  RI_aug-DZVP-MOLOPT-ae_N_RI_067_s_p_d_f_g_h_i_7_5_3_3_1_0_0_error_8.9e-06
     19   4   4   1   1
       0.2503300668    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.4e-06
+# RI basis set for C (all-electron) relative DI metric: 1.4e-06
 C  RI_aug-DZVP-MOLOPT-ae_N_RI_077_s_p_d_f_g_h_i_7_5_5_3_1_0_0_error_1.4e-06
    21
      1   0   0   1   1
@@ -3654,7 +3654,7 @@ C  RI_aug-DZVP-MOLOPT-ae_N_RI_077_s_p_d_f_g_h_i_7_5_5_3_1_0_0_error_1.4e-06
     21   4   4   1   1
       0.2837293445    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 6.7e-07
+# RI basis set for C (all-electron) relative DI metric: 6.7e-07
 C  RI_aug-DZVP-MOLOPT-ae_N_RI_102_s_p_d_f_g_h_i_7_5_5_4_3_0_0_error_6.7e-07
    24
      1   0   0   1   1
@@ -3706,7 +3706,7 @@ C  RI_aug-DZVP-MOLOPT-ae_N_RI_102_s_p_d_f_g_h_i_7_5_5_4_3_0_0_error_6.7e-07
     24   4   4   1   1
       1.3562318230    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 3.4e-02
+# RI basis set for C (all-electron) relative DI metric: 3.4e-02
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_3_1_1_1_0_0_0_error_3.4e-02
    6
      1   0   0   1   1
@@ -3722,7 +3722,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_3_1_1_1_0_0_0_error_3.4e-02
      6   3   3   1   1
       1.3318123137    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.2e-02
+# RI basis set for C (all-electron) relative DI metric: 1.2e-02
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_022_s_p_d_f_g_h_i_4_2_1_1_0_0_0_error_1.2e-02
    8
      1   0   0   1   1
@@ -3742,7 +3742,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_022_s_p_d_f_g_h_i_4_2_1_1_0_0_0_error_1.2e-02
      8   3   3   1   1
       1.1497038199    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 4.6e-03
+# RI basis set for C (all-electron) relative DI metric: 4.6e-03
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_6_2_2_1_0_0_0_error_4.6e-03
    11
      1   0   0   1   1
@@ -3768,7 +3768,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_6_2_2_1_0_0_0_error_4.6e-03
     11   3   3   1   1
       1.0957881873    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 2.3e-03
+# RI basis set for C (all-electron) relative DI metric: 2.3e-03
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_6_3_2_1_1_0_0_error_2.3e-03
    13
      1   0   0   1   1
@@ -3798,7 +3798,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_6_3_2_1_1_0_0_error_2.3e-03
     13   4   4   1   1
       1.1590919683    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 6.0e-04
+# RI basis set for C (all-electron) relative DI metric: 6.0e-04
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_3_2_2_1_0_0_error_6.0e-04
    14
      1   0   0   1   1
@@ -3830,7 +3830,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_3_2_2_1_0_0_error_6.0e-04
     14   4   4   1   1
       1.0099496878    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 2.8e-04
+# RI basis set for C (all-electron) relative DI metric: 2.8e-04
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_6_4_2_2_1_0_0_error_2.8e-04
    15
      1   0   0   1   1
@@ -3864,7 +3864,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_6_4_2_2_1_0_0_error_2.8e-04
     15   4   4   1   1
       1.0062094734    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 1.0e-04
+# RI basis set for C (all-electron) relative DI metric: 1.0e-04
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_065_s_p_d_f_g_h_i_6_4_3_2_2_0_0_error_1.0e-04
    17
      1   0   0   1   1
@@ -3902,7 +3902,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_065_s_p_d_f_g_h_i_6_4_3_2_2_0_0_error_1.0e-04
     17   4   4   1   1
       1.5043818154    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 4.5e-05
+# RI basis set for C (all-electron) relative DI metric: 4.5e-05
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_073_s_p_d_f_g_h_i_7_4_3_3_2_0_0_error_4.5e-05
    19
      1   0   0   1   1
@@ -3944,7 +3944,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_073_s_p_d_f_g_h_i_7_4_3_3_2_0_0_error_4.5e-05
     19   4   4   1   1
       1.6172510149    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 2.0e-05
+# RI basis set for C (all-electron) relative DI metric: 2.0e-05
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_076_s_p_d_f_g_h_i_7_5_3_3_2_0_0_error_2.0e-05
    20
      1   0   0   1   1
@@ -3988,7 +3988,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_076_s_p_d_f_g_h_i_7_5_3_3_2_0_0_error_2.0e-05
     20   4   4   1   1
       1.5606725484    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 6.6e-06
+# RI basis set for C (all-electron) relative DI metric: 6.6e-06
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_084_s_p_d_f_g_h_i_7_6_4_3_2_0_0_error_6.6e-06
    22
      1   0   0   1   1
@@ -4036,7 +4036,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_084_s_p_d_f_g_h_i_7_6_4_3_2_0_0_error_6.6e-06
     22   4   4   1   1
       1.7384751607    1.0000000000
 
-# RI basis set for C (all-electron) relative accuracy of RI-MP2: 3.2e-06
+# RI basis set for C (all-electron) relative DI metric: 3.2e-06
 C  RI_aug-TZVP-MOLOPT-ae_N_RI_094_s_p_d_f_g_h_i_7_6_6_3_2_0_0_error_3.2e-06
    24
      1   0   0   1   1
@@ -4088,7 +4088,7 @@ C  RI_aug-TZVP-MOLOPT-ae_N_RI_094_s_p_d_f_g_h_i_7_6_6_3_2_0_0_error_3.2e-06
     24   4   4   1   1
       1.5483278866    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 2.7e-02
+# RI basis set for N (all-electron) relative DI metric: 2.7e-02
 N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_2.7e-02
    4
      1   0   0   1   1
@@ -4100,7 +4100,7 @@ N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_2.7e-02
      4   1   1   1   1
       4.0271620921    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 6.9e-04
+# RI basis set for N (all-electron) relative DI metric: 6.9e-04
 N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_6.9e-04
    8
      1   0   0   1   1
@@ -4120,7 +4120,7 @@ N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_6.9e-04
      8   2   2   1   1
       2.9780390367    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 1.0e-06
+# RI basis set for N (all-electron) relative DI metric: 1.0e-06
 N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_1.0e-06
    9
      1   0   0   1   1
@@ -4142,7 +4142,7 @@ N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_1.0e-06
      9   2   2   1   1
       2.3684737679    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 2.8e-07
+# RI basis set for N (all-electron) relative DI metric: 2.8e-07
 N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_037_s_p_d_f_g_h_i_5_4_4_0_0_0_0_error_2.8e-07
    13
      1   0   0   1   1
@@ -4172,7 +4172,7 @@ N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_037_s_p_d_f_g_h_i_5_4_4_0_0_0_0_error_2.8e-07
     13   2   2   1   1
       6.3007583275    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 1.3e-07
+# RI basis set for N (all-electron) relative DI metric: 1.3e-07
 N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_038_s_p_d_f_g_h_i_6_4_4_0_0_0_0_error_1.3e-07
    14
      1   0   0   1   1
@@ -4204,7 +4204,7 @@ N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_038_s_p_d_f_g_h_i_6_4_4_0_0_0_0_error_1.3e-07
     14   2   2   1   1
       6.3007583311    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 3.0e-08
+# RI basis set for N (all-electron) relative DI metric: 3.0e-08
 N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_041_s_p_d_f_g_h_i_6_5_4_0_0_0_0_error_3.0e-08
    15
      1   0   0   1   1
@@ -4238,7 +4238,7 @@ N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_041_s_p_d_f_g_h_i_6_5_4_0_0_0_0_error_3.0e-08
     15   2   2   1   1
       6.3007583311    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 6.8e-09
+# RI basis set for N (all-electron) relative DI metric: 6.8e-09
 N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_047_s_p_d_f_g_h_i_7_5_5_0_0_0_0_error_6.8e-09
    17
      1   0   0   1   1
@@ -4276,7 +4276,7 @@ N  RI_aug-SZV-MOLOPT-ae-mini_N_RI_047_s_p_d_f_g_h_i_7_5_5_0_0_0_0_error_6.8e-09
     17   2   2   1   1
       6.3007583332    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 4.8e-02
+# RI basis set for N (all-electron) relative DI metric: 4.8e-02
 N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_007_s_p_d_f_g_h_i_4_1_0_0_0_0_0_error_4.8e-02
    5
      1   0   0   1   1
@@ -4290,7 +4290,7 @@ N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_007_s_p_d_f_g_h_i_4_1_0_0_0_0_0_error_4.8e-02
      5   1   1   1   1
       1.0160173719    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 6.3e-03
+# RI basis set for N (all-electron) relative DI metric: 6.3e-03
 N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_012_s_p_d_f_g_h_i_4_1_1_0_0_0_0_error_6.3e-03
    6
      1   0   0   1   1
@@ -4306,7 +4306,7 @@ N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_012_s_p_d_f_g_h_i_4_1_1_0_0_0_0_error_6.3e-03
      6   2   2   1   1
       0.7486022890    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 2.0e-04
+# RI basis set for N (all-electron) relative DI metric: 2.0e-04
 N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_2.0e-04
    9
      1   0   0   1   1
@@ -4328,7 +4328,7 @@ N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_2.0e-04
      9   3   3   1   1
       0.6870253810    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 7.1e-05
+# RI basis set for N (all-electron) relative DI metric: 7.1e-05
 N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_036_s_p_d_f_g_h_i_5_3_3_1_0_0_0_error_7.1e-05
    12
      1   0   0   1   1
@@ -4356,7 +4356,7 @@ N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_036_s_p_d_f_g_h_i_5_3_3_1_0_0_0_error_7.1e-05
     12   3   3   1   1
       0.7366054611    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 1.9e-05
+# RI basis set for N (all-electron) relative DI metric: 1.9e-05
 N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_044_s_p_d_f_g_h_i_6_3_3_2_0_0_0_error_1.9e-05
    14
      1   0   0   1   1
@@ -4388,7 +4388,7 @@ N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_044_s_p_d_f_g_h_i_6_3_3_2_0_0_0_error_1.9e-05
     14   3   3   1   1
       3.9566890997    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 2.1e-06
+# RI basis set for N (all-electron) relative DI metric: 2.1e-06
 N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_050_s_p_d_f_g_h_i_6_5_3_2_0_0_0_error_2.1e-06
    16
      1   0   0   1   1
@@ -4424,7 +4424,7 @@ N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_050_s_p_d_f_g_h_i_6_5_3_2_0_0_0_error_2.1e-06
     16   3   3   1   1
       3.0267596576    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 7.2e-07
+# RI basis set for N (all-electron) relative DI metric: 7.2e-07
 N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_057_s_p_d_f_g_h_i_6_5_3_3_0_0_0_error_7.2e-07
    17
      1   0   0   1   1
@@ -4462,7 +4462,7 @@ N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_057_s_p_d_f_g_h_i_6_5_3_3_0_0_0_error_7.2e-07
     17   3   3   1   1
       3.4529556155    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 1.5e-07
+# RI basis set for N (all-electron) relative DI metric: 1.5e-07
 N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_089_s_p_d_f_g_h_i_6_5_4_3_3_0_0_error_1.5e-07
    21
      1   0   0   1   1
@@ -4508,7 +4508,7 @@ N  RI_aug-SZV-MOLOPT-ae-SR_N_RI_089_s_p_d_f_g_h_i_6_5_4_3_3_0_0_error_1.5e-07
     21   4   4   1   1
       1.8203166985    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 3.1e-02
+# RI basis set for N (all-electron) relative DI metric: 3.1e-02
 N  RI_aug-SZV-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_3.1e-02
    4
      1   0   0   1   1
@@ -4520,7 +4520,7 @@ N  RI_aug-SZV-MOLOPT-ae_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_3.1e-02
      4   2   2   1   1
       1.1902917242    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 8.1e-03
+# RI basis set for N (all-electron) relative DI metric: 8.1e-03
 N  RI_aug-SZV-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_4_1_1_1_0_0_0_error_8.1e-03
    7
      1   0   0   1   1
@@ -4538,7 +4538,7 @@ N  RI_aug-SZV-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_4_1_1_1_0_0_0_error_8.1e-03
      7   3   3   1   1
       0.3604259987    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 2.3e-03
+# RI basis set for N (all-electron) relative DI metric: 2.3e-03
 N  RI_aug-SZV-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_6_5_1_1_0_0_0_error_2.3e-03
    13
      1   0   0   1   1
@@ -4568,7 +4568,7 @@ N  RI_aug-SZV-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_6_5_1_1_0_0_0_error_2.3e-03
     13   3   3   1   1
       1.3064331409    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 2.2e-05
+# RI basis set for N (all-electron) relative DI metric: 2.2e-05
 N  RI_aug-SZV-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_2.2e-05
    15
      1   0   0   1   1
@@ -4602,7 +4602,7 @@ N  RI_aug-SZV-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_2.2e-05
     15   3   3   1   1
       1.1978072490    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 1.0e-06
+# RI basis set for N (all-electron) relative DI metric: 1.0e-06
 N  RI_aug-SZV-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_7_5_3_2_0_0_0_error_1.0e-06
    17
      1   0   0   1   1
@@ -4640,7 +4640,7 @@ N  RI_aug-SZV-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_7_5_3_2_0_0_0_error_1.0e-06
     17   3   3   1   1
       2.0818956914    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 4.2e-07
+# RI basis set for N (all-electron) relative DI metric: 4.2e-07
 N  RI_aug-SZV-MOLOPT-ae_N_RI_054_s_p_d_f_g_h_i_7_6_3_2_0_0_0_error_4.2e-07
    18
      1   0   0   1   1
@@ -4680,7 +4680,7 @@ N  RI_aug-SZV-MOLOPT-ae_N_RI_054_s_p_d_f_g_h_i_7_6_3_2_0_0_0_error_4.2e-07
     18   3   3   1   1
       2.3342893057    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 1.8e-07
+# RI basis set for N (all-electron) relative DI metric: 1.8e-07
 N  RI_aug-SZV-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_1.8e-07
    19
      1   0   0   1   1
@@ -4722,7 +4722,7 @@ N  RI_aug-SZV-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_1.8e-07
     19   3   3   1   1
       2.1764165813    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 8.3e-08
+# RI basis set for N (all-electron) relative DI metric: 8.3e-08
 N  RI_aug-SZV-MOLOPT-ae_N_RI_078_s_p_d_f_g_h_i_7_6_5_4_0_0_0_error_8.3e-08
    22
      1   0   0   1   1
@@ -4770,7 +4770,7 @@ N  RI_aug-SZV-MOLOPT-ae_N_RI_078_s_p_d_f_g_h_i_7_6_5_4_0_0_0_error_8.3e-08
     22   3   3   1   1
       3.3878483320    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 3.2e-02
+# RI basis set for N (all-electron) relative DI metric: 3.2e-02
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_4_1_1_1_0_0_0_error_3.2e-02
    7
      1   0   0   1   1
@@ -4788,7 +4788,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_4_1_1_1_0_0_0_error_3.2e-02
      7   3   3   1   1
       0.7435641067    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 3.5e-03
+# RI basis set for N (all-electron) relative DI metric: 3.5e-03
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_4_2_1_1_1_0_0_error_3.5e-03
    9
      1   0   0   1   1
@@ -4810,7 +4810,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_4_2_1_1_1_0_0_error_3.5e-03
      9   4   4   1   1
       0.5883866521    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 9.2e-04
+# RI basis set for N (all-electron) relative DI metric: 9.2e-04
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_4_3_2_1_1_0_0_error_9.2e-04
    11
      1   0   0   1   1
@@ -4836,7 +4836,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_4_3_2_1_1_0_0_error_9.2e-04
     11   4   4   1   1
       1.2910568292    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 3.5e-04
+# RI basis set for N (all-electron) relative DI metric: 3.5e-04
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_5_4_2_1_1_0_0_error_3.5e-04
    13
      1   0   0   1   1
@@ -4866,7 +4866,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_5_4_2_1_1_0_0_error_3.5e-04
     13   4   4   1   1
       1.0016913950    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 1.6e-04
+# RI basis set for N (all-electron) relative DI metric: 1.6e-04
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_6_4_2_2_1_0_0_error_1.6e-04
    15
      1   0   0   1   1
@@ -4900,7 +4900,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_6_4_2_2_1_0_0_error_1.6e-04
     15   4   4   1   1
       1.0178044814    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 6.6e-05
+# RI basis set for N (all-electron) relative DI metric: 6.6e-05
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_6_4_3_2_1_0_0_error_6.6e-05
    16
      1   0   0   1   1
@@ -4936,7 +4936,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_6_4_3_2_1_0_0_error_6.6e-05
     16   4   4   1   1
       1.3371746309    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 3.1e-05
+# RI basis set for N (all-electron) relative DI metric: 3.1e-05
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_6_5_3_2_1_0_0_error_3.1e-05
    17
      1   0   0   1   1
@@ -4974,7 +4974,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_6_5_3_2_1_0_0_error_3.1e-05
     17   4   4   1   1
       1.3020622384    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 9.7e-06
+# RI basis set for N (all-electron) relative DI metric: 9.7e-06
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_6_5_3_2_2_0_0_error_9.7e-06
    18
      1   0   0   1   1
@@ -5014,7 +5014,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_6_5_3_2_2_0_0_error_9.7e-06
     18   4   4   1   1
       2.0011179420    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 2.7e-06
+# RI basis set for N (all-electron) relative DI metric: 2.7e-06
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_6_5_3_3_2_0_0_error_2.7e-06
    19
      1   0   0   1   1
@@ -5056,7 +5056,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_6_5_3_3_2_0_0_error_2.7e-06
     19   4   4   1   1
       2.1367859617    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 1.0e-06
+# RI basis set for N (all-electron) relative DI metric: 1.0e-06
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_084_s_p_d_f_g_h_i_7_6_4_3_2_0_0_error_1.0e-06
    22
      1   0   0   1   1
@@ -5104,7 +5104,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_084_s_p_d_f_g_h_i_7_6_4_3_2_0_0_error_1.0e-06
     22   4   4   1   1
       1.9847660952    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 4.5e-07
+# RI basis set for N (all-electron) relative DI metric: 4.5e-07
 N  RI_aug-DZVP-MOLOPT-ae_N_RI_089_s_p_d_f_g_h_i_7_6_5_3_2_0_0_error_4.5e-07
    23
      1   0   0   1   1
@@ -5154,7 +5154,7 @@ N  RI_aug-DZVP-MOLOPT-ae_N_RI_089_s_p_d_f_g_h_i_7_6_5_3_2_0_0_error_4.5e-07
     23   4   4   1   1
       2.1268127230    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 2.7e-02
+# RI basis set for N (all-electron) relative DI metric: 2.7e-02
 N  RI_aug-TZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_5_2_1_1_0_0_0_error_2.7e-02
    9
      1   0   0   1   1
@@ -5176,7 +5176,7 @@ N  RI_aug-TZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_5_2_1_1_0_0_0_error_2.7e-02
      9   3   3   1   1
       1.5383058496    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 8.5e-03
+# RI basis set for N (all-electron) relative DI metric: 8.5e-03
 N  RI_aug-TZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_5_3_2_1_0_0_0_error_8.5e-03
    11
      1   0   0   1   1
@@ -5202,7 +5202,7 @@ N  RI_aug-TZVP-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_5_3_2_1_0_0_0_error_8.5e-03
     11   3   3   1   1
       1.4085901621    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 3.7e-03
+# RI basis set for N (all-electron) relative DI metric: 3.7e-03
 N  RI_aug-TZVP-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_6_4_2_1_1_0_0_error_3.7e-03
    14
      1   0   0   1   1
@@ -5234,7 +5234,7 @@ N  RI_aug-TZVP-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_6_4_2_1_1_0_0_error_3.7e-03
     14   4   4   1   1
       1.2961955778    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 9.9e-04
+# RI basis set for N (all-electron) relative DI metric: 9.9e-04
 N  RI_aug-TZVP-MOLOPT-ae_N_RI_055_s_p_d_f_g_h_i_7_5_2_2_1_0_0_error_9.9e-04
    17
      1   0   0   1   1
@@ -5272,7 +5272,7 @@ N  RI_aug-TZVP-MOLOPT-ae_N_RI_055_s_p_d_f_g_h_i_7_5_2_2_1_0_0_error_9.9e-04
     17   4   4   1   1
       1.2498956211    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 4.1e-04
+# RI basis set for N (all-electron) relative DI metric: 4.1e-04
 N  RI_aug-TZVP-MOLOPT-ae_N_RI_060_s_p_d_f_g_h_i_7_5_3_2_1_0_0_error_4.1e-04
    18
      1   0   0   1   1
@@ -5312,7 +5312,7 @@ N  RI_aug-TZVP-MOLOPT-ae_N_RI_060_s_p_d_f_g_h_i_7_5_3_2_1_0_0_error_4.1e-04
     18   4   4   1   1
       1.3981231793    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 1.7e-04
+# RI basis set for N (all-electron) relative DI metric: 1.7e-04
 N  RI_aug-TZVP-MOLOPT-ae_N_RI_069_s_p_d_f_g_h_i_7_5_3_2_2_0_0_error_1.7e-04
    19
      1   0   0   1   1
@@ -5354,7 +5354,7 @@ N  RI_aug-TZVP-MOLOPT-ae_N_RI_069_s_p_d_f_g_h_i_7_5_3_2_2_0_0_error_1.7e-04
     19   4   4   1   1
       2.1464845239    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 5.6e-05
+# RI basis set for N (all-electron) relative DI metric: 5.6e-05
 N  RI_aug-TZVP-MOLOPT-ae_N_RI_081_s_p_d_f_g_h_i_7_5_4_3_2_0_0_error_5.6e-05
    21
      1   0   0   1   1
@@ -5400,7 +5400,7 @@ N  RI_aug-TZVP-MOLOPT-ae_N_RI_081_s_p_d_f_g_h_i_7_5_4_3_2_0_0_error_5.6e-05
     21   4   4   1   1
       1.7472098325    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 2.2e-05
+# RI basis set for N (all-electron) relative DI metric: 2.2e-05
 N  RI_aug-TZVP-MOLOPT-ae_N_RI_091_s_p_d_f_g_h_i_7_6_4_4_2_0_0_error_2.2e-05
    23
      1   0   0   1   1
@@ -5450,7 +5450,7 @@ N  RI_aug-TZVP-MOLOPT-ae_N_RI_091_s_p_d_f_g_h_i_7_6_4_4_2_0_0_error_2.2e-05
     23   4   4   1   1
       1.7777103546    1.0000000000
 
-# RI basis set for N (all-electron) relative accuracy of RI-MP2: 8.5e-06
+# RI basis set for N (all-electron) relative DI metric: 8.5e-06
 N  RI_aug-TZVP-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_6_4_2_1_0_error_8.5e-06
    26
      1   0   0   1   1
@@ -5506,7 +5506,7 @@ N  RI_aug-TZVP-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_6_4_2_1_0_error_8.5e-06
     26   5   5   1   1
       0.7186725960    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 4.8e-02
+# RI basis set for O (all-electron) relative DI metric: 4.8e-02
 O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_4.8e-02
    4
      1   0   0   1   1
@@ -5518,7 +5518,7 @@ O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_4.8e-02
      4   1   1   1   1
       4.1669751099    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 2.1e-02
+# RI basis set for O (all-electron) relative DI metric: 2.1e-02
 O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_2.1e-02
    5
      1   0   0   1   1
@@ -5532,7 +5532,7 @@ O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_2.1e-02
      5   2   2   1   1
       4.3887768259    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 2.9e-03
+# RI basis set for O (all-electron) relative DI metric: 2.9e-03
 O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_2.9e-03
    8
      1   0   0   1   1
@@ -5552,7 +5552,7 @@ O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_2.9e-03
      8   2   2   1   1
       4.2358612041    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.0e-06
+# RI basis set for O (all-electron) relative DI metric: 1.0e-06
 O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_028_s_p_d_f_g_h_i_4_3_3_0_0_0_0_error_1.0e-06
    10
      1   0   0   1   1
@@ -5576,7 +5576,7 @@ O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_028_s_p_d_f_g_h_i_4_3_3_0_0_0_0_error_1.0e-06
     10   2   2   1   1
       8.0124493305    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 4.0e-07
+# RI basis set for O (all-electron) relative DI metric: 4.0e-07
 O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_032_s_p_d_f_g_h_i_5_4_3_0_0_0_0_error_4.0e-07
    12
      1   0   0   1   1
@@ -5604,7 +5604,7 @@ O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_032_s_p_d_f_g_h_i_5_4_3_0_0_0_0_error_4.0e-07
     12   2   2   1   1
       8.1013192044    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.6e-07
+# RI basis set for O (all-electron) relative DI metric: 1.6e-07
 O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_1.6e-07
    16
      1   0   0   1   1
@@ -5640,7 +5640,7 @@ O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_1.6e-07
     16   2   2   1   1
       8.3885850057    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 2.2e-08
+# RI basis set for O (all-electron) relative DI metric: 2.2e-08
 O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_047_s_p_d_f_g_h_i_7_5_5_0_0_0_0_error_2.2e-08
    17
      1   0   0   1   1
@@ -5678,7 +5678,7 @@ O  RI_aug-SZV-MOLOPT-ae-mini_N_RI_047_s_p_d_f_g_h_i_7_5_5_0_0_0_0_error_2.2e-08
     17   2   2   1   1
       8.3885850000    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.6e-02
+# RI basis set for O (all-electron) relative DI metric: 1.6e-02
 O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_027_s_p_d_f_g_h_i_5_4_2_0_0_0_0_error_1.6e-02
    11
      1   0   0   1   1
@@ -5704,7 +5704,7 @@ O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_027_s_p_d_f_g_h_i_5_4_2_0_0_0_0_error_1.6e-02
     11   2   2   1   1
       3.2736961110    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.1e-05
+# RI basis set for O (all-electron) relative DI metric: 1.1e-05
 O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_034_s_p_d_f_g_h_i_5_4_2_1_0_0_0_error_1.1e-05
    12
      1   0   0   1   1
@@ -5732,7 +5732,7 @@ O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_034_s_p_d_f_g_h_i_5_4_2_1_0_0_0_error_1.1e-05
     12   3   3   1   1
       1.2293462032    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 5.0e-06
+# RI basis set for O (all-electron) relative DI metric: 5.0e-06
 O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_041_s_p_d_f_g_h_i_5_4_2_2_0_0_0_error_5.0e-06
    13
      1   0   0   1   1
@@ -5762,7 +5762,7 @@ O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_041_s_p_d_f_g_h_i_5_4_2_2_0_0_0_error_5.0e-06
     13   3   3   1   1
       4.5931523228    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 7.1e-07
+# RI basis set for O (all-electron) relative DI metric: 7.1e-07
 O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_046_s_p_d_f_g_h_i_5_4_3_2_0_0_0_error_7.1e-07
    14
      1   0   0   1   1
@@ -5794,7 +5794,7 @@ O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_046_s_p_d_f_g_h_i_5_4_3_2_0_0_0_error_7.1e-07
     14   3   3   1   1
       4.4458153677    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 2.9e-07
+# RI basis set for O (all-electron) relative DI metric: 2.9e-07
 O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_051_s_p_d_f_g_h_i_5_4_4_2_0_0_0_error_2.9e-07
    15
      1   0   0   1   1
@@ -5828,7 +5828,7 @@ O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_051_s_p_d_f_g_h_i_5_4_4_2_0_0_0_error_2.9e-07
     15   3   3   1   1
       2.9203372730    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.4e-07
+# RI basis set for O (all-electron) relative DI metric: 1.4e-07
 O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_063_s_p_d_f_g_h_i_7_5_4_3_0_0_0_error_1.4e-07
    19
      1   0   0   1   1
@@ -5870,7 +5870,7 @@ O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_063_s_p_d_f_g_h_i_7_5_4_3_0_0_0_error_1.4e-07
     19   3   3   1   1
       4.6605621473    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 5.0e-08
+# RI basis set for O (all-electron) relative DI metric: 5.0e-08
 O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_084_s_p_d_f_g_h_i_7_6_4_3_2_0_0_error_5.0e-08
    22
      1   0   0   1   1
@@ -5918,7 +5918,7 @@ O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_084_s_p_d_f_g_h_i_7_6_4_3_2_0_0_error_5.0e-08
     22   4   4   1   1
       2.2587729939    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.9e-08
+# RI basis set for O (all-electron) relative DI metric: 1.9e-08
 O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_094_s_p_d_f_g_h_i_7_6_6_3_2_0_0_error_1.9e-08
    24
      1   0   0   1   1
@@ -5970,7 +5970,7 @@ O  RI_aug-SZV-MOLOPT-ae-SR_N_RI_094_s_p_d_f_g_h_i_7_6_6_3_2_0_0_error_1.9e-08
     24   4   4   1   1
       2.2699013156    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 4.2e-02
+# RI basis set for O (all-electron) relative DI metric: 4.2e-02
 O  RI_aug-SZV-MOLOPT-ae_N_RI_013_s_p_d_f_g_h_i_5_1_1_0_0_0_0_error_4.2e-02
    7
      1   0   0   1   1
@@ -5988,7 +5988,7 @@ O  RI_aug-SZV-MOLOPT-ae_N_RI_013_s_p_d_f_g_h_i_5_1_1_0_0_0_0_error_4.2e-02
      7   2   2   1   1
       1.7411130613    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.6e-02
+# RI basis set for O (all-electron) relative DI metric: 1.6e-02
 O  RI_aug-SZV-MOLOPT-ae_N_RI_024_s_p_d_f_g_h_i_6_2_1_1_0_0_0_error_1.6e-02
    10
      1   0   0   1   1
@@ -6012,7 +6012,7 @@ O  RI_aug-SZV-MOLOPT-ae_N_RI_024_s_p_d_f_g_h_i_6_2_1_1_0_0_0_error_1.6e-02
     10   3   3   1   1
       0.4642475464    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.8e-04
+# RI basis set for O (all-electron) relative DI metric: 1.8e-04
 O  RI_aug-SZV-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_1.8e-04
    15
      1   0   0   1   1
@@ -6046,7 +6046,7 @@ O  RI_aug-SZV-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_1.8e-04
     15   3   3   1   1
       1.1372702684    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 5.3e-05
+# RI basis set for O (all-electron) relative DI metric: 5.3e-05
 O  RI_aug-SZV-MOLOPT-ae_N_RI_054_s_p_d_f_g_h_i_7_6_3_2_0_0_0_error_5.3e-05
    18
      1   0   0   1   1
@@ -6086,7 +6086,7 @@ O  RI_aug-SZV-MOLOPT-ae_N_RI_054_s_p_d_f_g_h_i_7_6_3_2_0_0_0_error_5.3e-05
     18   3   3   1   1
       6.0008377772    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 7.1e-06
+# RI basis set for O (all-electron) relative DI metric: 7.1e-06
 O  RI_aug-SZV-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_7.1e-06
    19
      1   0   0   1   1
@@ -6128,7 +6128,7 @@ O  RI_aug-SZV-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_7.1e-06
     19   3   3   1   1
       2.9755479849    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 4.1e-07
+# RI basis set for O (all-electron) relative DI metric: 4.1e-07
 O  RI_aug-SZV-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_7_6_4_3_0_0_0_error_4.1e-07
    20
      1   0   0   1   1
@@ -6172,7 +6172,7 @@ O  RI_aug-SZV-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_7_6_4_3_0_0_0_error_4.1e-07
     20   3   3   1   1
      13.9368062469    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.8e-07
+# RI basis set for O (all-electron) relative DI metric: 1.8e-07
 O  RI_aug-SZV-MOLOPT-ae_N_RI_108_s_p_d_f_g_h_i_7_6_6_5_2_0_0_error_1.8e-07
    26
      1   0   0   1   1
@@ -6228,7 +6228,7 @@ O  RI_aug-SZV-MOLOPT-ae_N_RI_108_s_p_d_f_g_h_i_7_6_6_5_2_0_0_error_1.8e-07
     26   4   4   1   1
       7.0126131855    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 3.1e-02
+# RI basis set for O (all-electron) relative DI metric: 3.1e-02
 O  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_3.1e-02
    8
      1   0   0   1   1
@@ -6248,7 +6248,7 @@ O  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_3.1e-02
      8   2   2   1   1
       1.6346574773    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.2e-02
+# RI basis set for O (all-electron) relative DI metric: 1.2e-02
 O  RI_aug-DZVP-MOLOPT-ae_N_RI_028_s_p_d_f_g_h_i_7_3_1_1_0_0_0_error_1.2e-02
    12
      1   0   0   1   1
@@ -6276,7 +6276,7 @@ O  RI_aug-DZVP-MOLOPT-ae_N_RI_028_s_p_d_f_g_h_i_7_3_1_1_0_0_0_error_1.2e-02
     12   3   3   1   1
       1.6812064943    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.5e-03
+# RI basis set for O (all-electron) relative DI metric: 1.5e-03
 O  RI_aug-DZVP-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_7_3_2_1_0_0_0_error_1.5e-03
    13
      1   0   0   1   1
@@ -6306,7 +6306,7 @@ O  RI_aug-DZVP-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_7_3_2_1_0_0_0_error_1.5e-03
     13   3   3   1   1
       1.2487837087    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 7.2e-04
+# RI basis set for O (all-electron) relative DI metric: 7.2e-04
 O  RI_aug-DZVP-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_7.2e-04
    15
      1   0   0   1   1
@@ -6340,7 +6340,7 @@ O  RI_aug-DZVP-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_7.2e-04
     15   3   3   1   1
       1.4856489001    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 3.4e-04
+# RI basis set for O (all-electron) relative DI metric: 3.4e-04
 O  RI_aug-DZVP-MOLOPT-ae_N_RI_053_s_p_d_f_g_h_i_7_5_3_1_1_0_0_error_3.4e-04
    17
      1   0   0   1   1
@@ -6378,7 +6378,7 @@ O  RI_aug-DZVP-MOLOPT-ae_N_RI_053_s_p_d_f_g_h_i_7_5_3_1_1_0_0_error_3.4e-04
     17   4   4   1   1
       0.6192247138    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.2e-04
+# RI basis set for O (all-electron) relative DI metric: 1.2e-04
 O  RI_aug-DZVP-MOLOPT-ae_N_RI_060_s_p_d_f_g_h_i_7_5_3_2_1_0_0_error_1.2e-04
    18
      1   0   0   1   1
@@ -6418,7 +6418,7 @@ O  RI_aug-DZVP-MOLOPT-ae_N_RI_060_s_p_d_f_g_h_i_7_5_3_2_1_0_0_error_1.2e-04
     18   4   4   1   1
       0.6879130615    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 4.9e-06
+# RI basis set for O (all-electron) relative DI metric: 4.9e-06
 O  RI_aug-DZVP-MOLOPT-ae_N_RI_072_s_p_d_f_g_h_i_7_5_4_3_1_0_0_error_4.9e-06
    20
      1   0   0   1   1
@@ -6462,7 +6462,7 @@ O  RI_aug-DZVP-MOLOPT-ae_N_RI_072_s_p_d_f_g_h_i_7_5_4_3_1_0_0_error_4.9e-06
     20   4   4   1   1
       0.7109823428    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.8e-06
+# RI basis set for O (all-electron) relative DI metric: 1.8e-06
 O  RI_aug-DZVP-MOLOPT-ae_N_RI_095_s_p_d_f_g_h_i_7_5_5_3_3_0_0_error_1.8e-06
    23
      1   0   0   1   1
@@ -6512,7 +6512,7 @@ O  RI_aug-DZVP-MOLOPT-ae_N_RI_095_s_p_d_f_g_h_i_7_5_5_3_3_0_0_error_1.8e-06
     23   4   4   1   1
       2.5977990388    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 4.7e-07
+# RI basis set for O (all-electron) relative DI metric: 4.7e-07
 O  RI_aug-DZVP-MOLOPT-ae_N_RI_105_s_p_d_f_g_h_i_7_6_5_4_3_0_0_error_4.7e-07
    25
      1   0   0   1   1
@@ -6566,7 +6566,7 @@ O  RI_aug-DZVP-MOLOPT-ae_N_RI_105_s_p_d_f_g_h_i_7_6_5_4_3_0_0_error_4.7e-07
     25   4   4   1   1
       3.1881423137    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 3.7e-02
+# RI basis set for O (all-electron) relative DI metric: 3.7e-02
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_3.7e-02
    9
      1   0   0   1   1
@@ -6588,7 +6588,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_3.7e-02
      9   3   3   1   1
       1.9137454195    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.5e-02
+# RI basis set for O (all-electron) relative DI metric: 1.5e-02
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_4_3_2_1_0_0_0_error_1.5e-02
    10
      1   0   0   1   1
@@ -6612,7 +6612,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_4_3_2_1_0_0_0_error_1.5e-02
     10   3   3   1   1
       1.6294342555    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 7.2e-03
+# RI basis set for O (all-electron) relative DI metric: 7.2e-03
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_5_3_3_2_0_0_0_error_7.2e-03
    13
      1   0   0   1   1
@@ -6642,7 +6642,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_5_3_3_2_0_0_0_error_7.2e-03
     13   3   3   1   1
       2.3332781584    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.9e-03
+# RI basis set for O (all-electron) relative DI metric: 1.9e-03
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_052_s_p_d_f_g_h_i_5_3_3_2_1_0_0_error_1.9e-03
    14
      1   0   0   1   1
@@ -6674,7 +6674,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_052_s_p_d_f_g_h_i_5_3_3_2_1_0_0_error_1.9e-03
     14   4   4   1   1
       1.5453806960    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 9.4e-04
+# RI basis set for O (all-electron) relative DI metric: 9.4e-04
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_7_4_3_2_2_0_0_error_9.4e-04
    18
      1   0   0   1   1
@@ -6714,7 +6714,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_7_4_3_2_2_0_0_error_9.4e-04
     18   4   4   1   1
       2.5102684412    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 3.1e-04
+# RI basis set for O (all-electron) relative DI metric: 3.1e-04
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_073_s_p_d_f_g_h_i_7_4_3_3_2_0_0_error_3.1e-04
    19
      1   0   0   1   1
@@ -6756,7 +6756,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_073_s_p_d_f_g_h_i_7_4_3_3_2_0_0_error_3.1e-04
     19   4   4   1   1
       2.2698060698    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 6.7e-05
+# RI basis set for O (all-electron) relative DI metric: 6.7e-05
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_084_s_p_d_f_g_h_i_7_4_3_3_2_1_0_error_6.7e-05
    20
      1   0   0   1   1
@@ -6800,7 +6800,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_084_s_p_d_f_g_h_i_7_4_3_3_2_1_0_error_6.7e-05
     20   5   5   1   1
       0.7626379089    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 2.7e-05
+# RI basis set for O (all-electron) relative DI metric: 2.7e-05
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_089_s_p_d_f_g_h_i_7_4_4_3_2_1_0_error_2.7e-05
    21
      1   0   0   1   1
@@ -6846,7 +6846,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_089_s_p_d_f_g_h_i_7_4_4_3_2_1_0_error_2.7e-05
     21   5   5   1   1
       0.8731087504    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 1.2e-05
+# RI basis set for O (all-electron) relative DI metric: 1.2e-05
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_100_s_p_d_f_g_h_i_7_6_5_3_2_1_0_error_1.2e-05
    24
      1   0   0   1   1
@@ -6898,7 +6898,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_100_s_p_d_f_g_h_i_7_6_5_3_2_1_0_error_1.2e-05
     24   5   5   1   1
       0.7711588260    1.0000000000
 
-# RI basis set for O (all-electron) relative accuracy of RI-MP2: 5.1e-06
+# RI basis set for O (all-electron) relative DI metric: 5.1e-06
 O  RI_aug-TZVP-MOLOPT-ae_N_RI_119_s_p_d_f_g_h_i_7_6_6_5_2_1_0_error_5.1e-06
    27
      1   0   0   1   1
@@ -6956,7 +6956,7 @@ O  RI_aug-TZVP-MOLOPT-ae_N_RI_119_s_p_d_f_g_h_i_7_6_6_5_2_1_0_error_5.1e-06
     27   5   5   1   1
       0.9226622435    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 4.4e-02
+# RI basis set for F (all-electron) relative DI metric: 4.4e-02
 F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_4.4e-02
    4
      1   0   0   1   1
@@ -6968,7 +6968,7 @@ F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_4.4e-02
      4   1   1   1   1
       4.3689624046    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 4.7e-03
+# RI basis set for F (all-electron) relative DI metric: 4.7e-03
 F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_4.7e-03
    5
      1   0   0   1   1
@@ -6982,7 +6982,7 @@ F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_4.7e-03
      5   2   2   1   1
       4.9651244178    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 2.1e-03
+# RI basis set for F (all-electron) relative DI metric: 2.1e-03
 F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_2.1e-03
    8
      1   0   0   1   1
@@ -7002,7 +7002,7 @@ F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_2.1e-03
      8   2   2   1   1
       5.0043452160    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 4.7e-06
+# RI basis set for F (all-electron) relative DI metric: 4.7e-06
 F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_4.7e-06
    9
      1   0   0   1   1
@@ -7024,7 +7024,7 @@ F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_4.7e-06
      9   2   2   1   1
       3.6943557033    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 2.2e-06
+# RI basis set for F (all-electron) relative DI metric: 2.2e-06
 F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_024_s_p_d_f_g_h_i_5_3_2_0_0_0_0_error_2.2e-06
    10
      1   0   0   1   1
@@ -7048,7 +7048,7 @@ F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_024_s_p_d_f_g_h_i_5_3_2_0_0_0_0_error_2.2e-06
     10   2   2   1   1
       3.6395284305    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 1.0e-06
+# RI basis set for F (all-electron) relative DI metric: 1.0e-06
 F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_029_s_p_d_f_g_h_i_5_3_3_0_0_0_0_error_1.0e-06
    11
      1   0   0   1   1
@@ -7074,7 +7074,7 @@ F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_029_s_p_d_f_g_h_i_5_3_3_0_0_0_0_error_1.0e-06
     11   2   2   1   1
       6.4569329891    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 2.5e-07
+# RI basis set for F (all-electron) relative DI metric: 2.5e-07
 F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_033_s_p_d_f_g_h_i_6_4_3_0_0_0_0_error_2.5e-07
    13
      1   0   0   1   1
@@ -7104,7 +7104,7 @@ F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_033_s_p_d_f_g_h_i_6_4_3_0_0_0_0_error_2.5e-07
     13   2   2   1   1
       6.3411194253    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 5.6e-08
+# RI basis set for F (all-electron) relative DI metric: 5.6e-08
 F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_038_s_p_d_f_g_h_i_6_4_4_0_0_0_0_error_5.6e-08
    14
      1   0   0   1   1
@@ -7136,7 +7136,7 @@ F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_038_s_p_d_f_g_h_i_6_4_4_0_0_0_0_error_5.6e-08
     14   2   2   1   1
       6.1676280497    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 2.7e-08
+# RI basis set for F (all-electron) relative DI metric: 2.7e-08
 F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_055_s_p_d_f_g_h_i_7_6_6_0_0_0_0_error_2.7e-08
    19
      1   0   0   1   1
@@ -7178,7 +7178,7 @@ F  RI_aug-SZV-MOLOPT-ae-mini_N_RI_055_s_p_d_f_g_h_i_7_6_6_0_0_0_0_error_2.7e-08
     19   2   2   1   1
      10.7840477353    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 3.9e-02
+# RI basis set for F (all-electron) relative DI metric: 3.9e-02
 F  RI_aug-SZV-MOLOPT-ae_N_RI_012_s_p_d_f_g_h_i_4_1_1_0_0_0_0_error_3.9e-02
    6
      1   0   0   1   1
@@ -7194,7 +7194,7 @@ F  RI_aug-SZV-MOLOPT-ae_N_RI_012_s_p_d_f_g_h_i_4_1_1_0_0_0_0_error_3.9e-02
      6   2   2   1   1
       2.1527687985    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 5.2e-03
+# RI basis set for F (all-electron) relative DI metric: 5.2e-03
 F  RI_aug-SZV-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_4_1_1_1_0_0_0_error_5.2e-03
    7
      1   0   0   1   1
@@ -7212,7 +7212,7 @@ F  RI_aug-SZV-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_4_1_1_1_0_0_0_error_5.2e-03
      7   3   3   1   1
       3.0370656606    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 1.0e-03
+# RI basis set for F (all-electron) relative DI metric: 1.0e-03
 F  RI_aug-SZV-MOLOPT-ae_N_RI_022_s_p_d_f_g_h_i_7_1_1_1_0_0_0_error_1.0e-03
    10
      1   0   0   1   1
@@ -7236,7 +7236,7 @@ F  RI_aug-SZV-MOLOPT-ae_N_RI_022_s_p_d_f_g_h_i_7_1_1_1_0_0_0_error_1.0e-03
     10   3   3   1   1
       3.2504863578    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 2.4e-04
+# RI basis set for F (all-electron) relative DI metric: 2.4e-04
 F  RI_aug-SZV-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_7_5_1_1_0_0_0_error_2.4e-04
    14
      1   0   0   1   1
@@ -7268,7 +7268,7 @@ F  RI_aug-SZV-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_7_5_1_1_0_0_0_error_2.4e-04
     14   3   3   1   1
       3.0726651097    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 6.9e-05
+# RI basis set for F (all-electron) relative DI metric: 6.9e-05
 F  RI_aug-SZV-MOLOPT-ae_N_RI_046_s_p_d_f_g_h_i_7_6_1_1_1_0_0_error_6.9e-05
    16
      1   0   0   1   1
@@ -7304,7 +7304,7 @@ F  RI_aug-SZV-MOLOPT-ae_N_RI_046_s_p_d_f_g_h_i_7_6_1_1_1_0_0_error_6.9e-05
     16   4   4   1   1
       0.3922152109    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 1.4e-05
+# RI basis set for F (all-electron) relative DI metric: 1.4e-05
 F  RI_aug-SZV-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_6_3_2_1_0_0_error_1.4e-05
    19
      1   0   0   1   1
@@ -7346,7 +7346,7 @@ F  RI_aug-SZV-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_6_3_2_1_0_0_error_1.4e-05
     19   4   4   1   1
       2.6607386482    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 5.8e-06
+# RI basis set for F (all-electron) relative DI metric: 5.8e-06
 F  RI_aug-SZV-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_5.8e-06
    20
      1   0   0   1   1
@@ -7390,7 +7390,7 @@ F  RI_aug-SZV-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_5.8e-06
     20   4   4   1   1
       2.7452017599    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 1.3e-06
+# RI basis set for F (all-electron) relative DI metric: 1.3e-06
 F  RI_aug-SZV-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_6_4_3_1_0_0_error_1.3e-06
    21
      1   0   0   1   1
@@ -7436,7 +7436,7 @@ F  RI_aug-SZV-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_6_4_3_1_0_0_error_1.3e-06
     21   4   4   1   1
       2.8362867058    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 4.0e-07
+# RI basis set for F (all-electron) relative DI metric: 4.0e-07
 F  RI_aug-SZV-MOLOPT-ae_N_RI_119_s_p_d_f_g_h_i_7_6_4_3_2_2_1_error_4.0e-07
    25
      1   0   0   1   1
@@ -7490,7 +7490,7 @@ F  RI_aug-SZV-MOLOPT-ae_N_RI_119_s_p_d_f_g_h_i_7_6_4_3_2_2_1_error_4.0e-07
     25   6   6   1   1
       3.2327123206    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 1.9e-02
+# RI basis set for F (all-electron) relative DI metric: 1.9e-02
 F  RI_aug-DZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_5_2_1_1_0_0_0_error_1.9e-02
    9
      1   0   0   1   1
@@ -7512,7 +7512,7 @@ F  RI_aug-DZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_5_2_1_1_0_0_0_error_1.9e-02
      9   3   3   1   1
       3.7676917266    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 5.6e-03
+# RI basis set for F (all-electron) relative DI metric: 5.6e-03
 F  RI_aug-DZVP-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_6_2_1_1_1_0_0_error_5.6e-03
    11
      1   0   0   1   1
@@ -7538,7 +7538,7 @@ F  RI_aug-DZVP-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_6_2_1_1_1_0_0_error_5.6e-03
     11   4   4   1   1
       0.7757779476    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 2.2e-04
+# RI basis set for F (all-electron) relative DI metric: 2.2e-04
 F  RI_aug-DZVP-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_7_3_3_1_1_0_0_error_2.2e-04
    15
      1   0   0   1   1
@@ -7572,7 +7572,7 @@ F  RI_aug-DZVP-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_7_3_3_1_1_0_0_error_2.2e-04
     15   4   4   1   1
       1.1943211072    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 8.1e-05
+# RI basis set for F (all-electron) relative DI metric: 8.1e-05
 F  RI_aug-DZVP-MOLOPT-ae_N_RI_061_s_p_d_f_g_h_i_7_3_3_3_1_0_0_error_8.1e-05
    17
      1   0   0   1   1
@@ -7610,7 +7610,7 @@ F  RI_aug-DZVP-MOLOPT-ae_N_RI_061_s_p_d_f_g_h_i_7_3_3_3_1_0_0_error_8.1e-05
     17   4   4   1   1
       1.2312585162    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 3.8e-05
+# RI basis set for F (all-electron) relative DI metric: 3.8e-05
 F  RI_aug-DZVP-MOLOPT-ae_N_RI_085_s_p_d_f_g_h_i_7_5_3_3_3_0_0_error_3.8e-05
    21
      1   0   0   1   1
@@ -7656,7 +7656,7 @@ F  RI_aug-DZVP-MOLOPT-ae_N_RI_085_s_p_d_f_g_h_i_7_5_3_3_3_0_0_error_3.8e-05
     21   4   4   1   1
       8.8641110940    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 8.6e-06
+# RI basis set for F (all-electron) relative DI metric: 8.6e-06
 F  RI_aug-DZVP-MOLOPT-ae_N_RI_093_s_p_d_f_g_h_i_7_6_4_3_3_0_0_error_8.6e-06
    23
      1   0   0   1   1
@@ -7706,7 +7706,7 @@ F  RI_aug-DZVP-MOLOPT-ae_N_RI_093_s_p_d_f_g_h_i_7_6_4_3_3_0_0_error_8.6e-06
     23   4   4   1   1
       8.7621378759    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 2.8e-06
+# RI basis set for F (all-electron) relative DI metric: 2.8e-06
 F  RI_aug-DZVP-MOLOPT-ae_N_RI_105_s_p_d_f_g_h_i_7_6_5_4_3_0_0_error_2.8e-06
    25
      1   0   0   1   1
@@ -7762,7 +7762,7 @@ F  RI_aug-DZVP-MOLOPT-ae_N_RI_105_s_p_d_f_g_h_i_7_6_5_4_3_0_0_error_2.8e-06
 
 
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 4.5e-02
+# RI basis set for F (all-electron) relative DI metric: 4.5e-02
 F  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_4.5e-02
    9
      1   0   0   1   1
@@ -7784,7 +7784,7 @@ F  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_4.5e-02
      9   3   3   1   1
       2.9286689087    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 2.0e-02
+# RI basis set for F (all-electron) relative DI metric: 2.0e-02
 F  RI_aug-TZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_4_3_2_1_0_0_0_error_2.0e-02
    10
      1   0   0   1   1
@@ -7808,7 +7808,7 @@ F  RI_aug-TZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_4_3_2_1_0_0_0_error_2.0e-02
     10   3   3   1   1
       2.6218953220    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 7.7e-03
+# RI basis set for F (all-electron) relative DI metric: 7.7e-03
 F  RI_aug-TZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_4_3_2_1_1_0_0_error_7.7e-03
    11
      1   0   0   1   1
@@ -7834,7 +7834,7 @@ F  RI_aug-TZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_4_3_2_1_1_0_0_error_7.7e-03
     11   4   4   1   1
       2.1941646423    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 3.7e-03
+# RI basis set for F (all-electron) relative DI metric: 3.7e-03
 F  RI_aug-TZVP-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_3_2_2_1_0_0_error_3.7e-03
    14
      1   0   0   1   1
@@ -7866,7 +7866,7 @@ F  RI_aug-TZVP-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_3_2_2_1_0_0_error_3.7e-03
     14   4   4   1   1
       1.9577130841    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 1.5e-03
+# RI basis set for F (all-electron) relative DI metric: 1.5e-03
 F  RI_aug-TZVP-MOLOPT-ae_N_RI_062_s_p_d_f_g_h_i_6_4_2_2_1_1_0_error_1.5e-03
    16
      1   0   0   1   1
@@ -7902,7 +7902,7 @@ F  RI_aug-TZVP-MOLOPT-ae_N_RI_062_s_p_d_f_g_h_i_6_4_2_2_1_1_0_error_1.5e-03
     16   5   5   1   1
       2.3914561801    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 3.1e-04
+# RI basis set for F (all-electron) relative DI metric: 3.1e-04
 F  RI_aug-TZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_6_5_3_2_1_1_0_error_3.1e-04
    18
      1   0   0   1   1
@@ -7942,7 +7942,7 @@ F  RI_aug-TZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_6_5_3_2_1_1_0_error_3.1e-04
     18   5   5   1   1
       2.2858043998    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 1.4e-04
+# RI basis set for F (all-electron) relative DI metric: 1.4e-04
 F  RI_aug-TZVP-MOLOPT-ae_N_RI_085_s_p_d_f_g_h_i_7_5_4_2_2_1_0_error_1.4e-04
    21
      1   0   0   1   1
@@ -7988,7 +7988,7 @@ F  RI_aug-TZVP-MOLOPT-ae_N_RI_085_s_p_d_f_g_h_i_7_5_4_2_2_1_0_error_1.4e-04
     21   5   5   1   1
       2.2769874868    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 2.5e-05
+# RI basis set for F (all-electron) relative DI metric: 2.5e-05
 F  RI_aug-TZVP-MOLOPT-ae_N_RI_092_s_p_d_f_g_h_i_7_5_4_3_2_1_0_error_2.5e-05
    22
      1   0   0   1   1
@@ -8036,7 +8036,7 @@ F  RI_aug-TZVP-MOLOPT-ae_N_RI_092_s_p_d_f_g_h_i_7_5_4_3_2_1_0_error_2.5e-05
     22   5   5   1   1
       2.5990780387    1.0000000000
 
-# RI basis set for F (all-electron) relative accuracy of RI-MP2: 1.0e-05
+# RI basis set for F (all-electron) relative DI metric: 1.0e-05
 F  RI_aug-TZVP-MOLOPT-ae_N_RI_109_s_p_d_f_g_h_i_7_6_5_3_3_1_0_error_1.0e-05
    25
      1   0   0   1   1
@@ -8090,7 +8090,7 @@ F  RI_aug-TZVP-MOLOPT-ae_N_RI_109_s_p_d_f_g_h_i_7_6_5_3_3_1_0_error_1.0e-05
     25   5   5   1   1
       2.6911348806    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 4.6e-02
+# RI basis set for Ne (all-electron) relative DI metric: 4.6e-02
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_4.6e-02
    3
      1   0   0   1   1
@@ -8100,7 +8100,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_4.6e-02
      3   1   1   1   1
       7.7663691038    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.2e-02
+# RI basis set for Ne (all-electron) relative DI metric: 1.2e-02
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_1.2e-02
    4
      1   0   0   1   1
@@ -8112,7 +8112,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_010_s_p_d_f_g_h_i_2_1_1_0_0_0_0_error_1.2e-02
      4   2   2   1   1
      10.6951494256    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 5.5e-03
+# RI basis set for Ne (all-electron) relative DI metric: 5.5e-03
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_5.5e-03
    6
      1   0   0   1   1
@@ -8128,7 +8128,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_5.5e-03
      6   2   2   1   1
      10.6900477387    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.9e-04
+# RI basis set for Ne (all-electron) relative DI metric: 2.9e-04
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_019_s_p_d_f_g_h_i_3_2_2_0_0_0_0_error_2.9e-04
    7
      1   0   0   1   1
@@ -8146,7 +8146,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_019_s_p_d_f_g_h_i_3_2_2_0_0_0_0_error_2.9e-04
      7   2   2   1   1
       6.4182032895    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 8.5e-05
+# RI basis set for Ne (all-electron) relative DI metric: 8.5e-05
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_022_s_p_d_f_g_h_i_6_2_2_0_0_0_0_error_8.5e-05
    10
      1   0   0   1   1
@@ -8170,7 +8170,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_022_s_p_d_f_g_h_i_6_2_2_0_0_0_0_error_8.5e-05
     10   2   2   1   1
       6.9552605104    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 5.6e-06
+# RI basis set for Ne (all-electron) relative DI metric: 5.6e-06
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_5.6e-06
    11
      1   0   0   1   1
@@ -8196,7 +8196,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_5.6e-06
     11   2   2   1   1
       6.9716018890    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.3e-06
+# RI basis set for Ne (all-electron) relative DI metric: 1.3e-06
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_030_s_p_d_f_g_h_i_6_3_3_0_0_0_0_error_1.3e-06
    12
      1   0   0   1   1
@@ -8224,7 +8224,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_030_s_p_d_f_g_h_i_6_3_3_0_0_0_0_error_1.3e-06
     12   2   2   1   1
       8.4938858380    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 6.5e-07
+# RI basis set for Ne (all-electron) relative DI metric: 6.5e-07
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_037_s_p_d_f_g_h_i_7_5_3_0_0_0_0_error_6.5e-07
    15
      1   0   0   1   1
@@ -8258,7 +8258,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_037_s_p_d_f_g_h_i_7_5_3_0_0_0_0_error_6.5e-07
     15   2   2   1   1
       8.1910779146    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.4e-08
+# RI basis set for Ne (all-electron) relative DI metric: 1.4e-08
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_1.4e-08
    16
      1   0   0   1   1
@@ -8294,7 +8294,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_1.4e-08
     16   2   2   1   1
      13.7438583291    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.7e-09
+# RI basis set for Ne (all-electron) relative DI metric: 1.7e-09
 Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_045_s_p_d_f_g_h_i_7_6_4_0_0_0_0_error_1.7e-09
    17
      1   0   0   1   1
@@ -8332,7 +8332,7 @@ Ne  RI_aug-SZV-MOLOPT-ae-mini_N_RI_045_s_p_d_f_g_h_i_7_6_4_0_0_0_0_error_1.7e-09
     17   2   2   1   1
      13.7438583291    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 4.6e-02
+# RI basis set for Ne (all-electron) relative DI metric: 4.6e-02
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_013_s_p_d_f_g_h_i_4_3_0_0_0_0_0_error_4.6e-02
    7
      1   0   0   1   1
@@ -8350,7 +8350,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_013_s_p_d_f_g_h_i_4_3_0_0_0_0_0_error_4.6e-02
      7   1   1   1   1
       4.7178484985    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 5.4e-03
+# RI basis set for Ne (all-electron) relative DI metric: 5.4e-03
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_5.4e-03
    9
      1   0   0   1   1
@@ -8372,7 +8372,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_5.4e-03
      9   2   2   1   1
       7.9367141797    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 4.7e-04
+# RI basis set for Ne (all-electron) relative DI metric: 4.7e-04
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_032_s_p_d_f_g_h_i_6_3_2_1_0_0_0_error_4.7e-04
    12
      1   0   0   1   1
@@ -8400,7 +8400,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_032_s_p_d_f_g_h_i_6_3_2_1_0_0_0_error_4.7e-04
     12   3   3   1   1
       1.3996533273    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.2e-04
+# RI basis set for Ne (all-electron) relative DI metric: 2.2e-04
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_2.2e-04
    13
      1   0   0   1   1
@@ -8430,7 +8430,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_2.2e-04
     13   3   3   1   1
       1.4750730154    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 6.4e-05
+# RI basis set for Ne (all-electron) relative DI metric: 6.4e-05
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_7_5_2_1_0_0_0_error_6.4e-05
    15
      1   0   0   1   1
@@ -8464,7 +8464,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_7_5_2_1_0_0_0_error_6.4e-05
     15   3   3   1   1
       1.3228713604    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.4e-05
+# RI basis set for Ne (all-electron) relative DI metric: 2.4e-05
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_2.4e-05
    16
      1   0   0   1   1
@@ -8500,7 +8500,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_2.4e-05
     16   3   3   1   1
       1.3704206901    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.2e-05
+# RI basis set for Ne (all-electron) relative DI metric: 1.2e-05
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_052_s_p_d_f_g_h_i_7_6_4_1_0_0_0_error_1.2e-05
    18
      1   0   0   1   1
@@ -8540,7 +8540,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_052_s_p_d_f_g_h_i_7_6_4_1_0_0_0_error_1.2e-05
     18   3   3   1   1
       1.3842971113    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 3.5e-06
+# RI basis set for Ne (all-electron) relative DI metric: 3.5e-06
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_3.5e-06
    19
      1   0   0   1   1
@@ -8582,7 +8582,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_3.5e-06
     19   3   3   1   1
       7.1577113915    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 9.4e-07
+# RI basis set for Ne (all-electron) relative DI metric: 9.4e-07
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_064_s_p_d_f_g_h_i_7_6_5_2_0_0_0_error_9.4e-07
    20
      1   0   0   1   1
@@ -8626,7 +8626,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_064_s_p_d_f_g_h_i_7_6_5_2_0_0_0_error_9.4e-07
     20   3   3   1   1
       4.8368320762    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 3.7e-07
+# RI basis set for Ne (all-electron) relative DI metric: 3.7e-07
 Ne  RI_aug-SZV-MOLOPT-ae_N_RI_078_s_p_d_f_g_h_i_7_6_5_4_0_0_0_error_3.7e-07
    22
      1   0   0   1   1
@@ -8674,7 +8674,7 @@ Ne  RI_aug-SZV-MOLOPT-ae_N_RI_078_s_p_d_f_g_h_i_7_6_5_4_0_0_0_error_3.7e-07
     22   3   3   1   1
       8.0136192364    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.5e-02
+# RI basis set for Ne (all-electron) relative DI metric: 2.5e-02
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_4_2_2_0_0_0_0_error_2.5e-02
    8
      1   0   0   1   1
@@ -8694,7 +8694,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_4_2_2_0_0_0_0_error_2.5e-02
      8   2   2   1   1
       8.5613192368    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.1e-03
+# RI basis set for Ne (all-electron) relative DI metric: 2.1e-03
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_6_2_2_1_0_0_0_error_2.1e-03
    11
      1   0   0   1   1
@@ -8720,7 +8720,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_6_2_2_1_0_0_0_error_2.1e-03
     11   3   3   1   1
       1.9172489113    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 9.2e-04
+# RI basis set for Ne (all-electron) relative DI metric: 9.2e-04
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_9.2e-04
    13
      1   0   0   1   1
@@ -8750,7 +8750,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_035_s_p_d_f_g_h_i_6_4_2_1_0_0_0_error_9.2e-04
     13   3   3   1   1
       1.9468669080    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.8e-04
+# RI basis set for Ne (all-electron) relative DI metric: 2.8e-04
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_040_s_p_d_f_g_h_i_6_4_3_1_0_0_0_error_2.8e-04
    14
      1   0   0   1   1
@@ -8782,7 +8782,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_040_s_p_d_f_g_h_i_6_4_3_1_0_0_0_error_2.8e-04
     14   3   3   1   1
       1.6711478410    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 7.3e-05
+# RI basis set for Ne (all-electron) relative DI metric: 7.3e-05
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_7.3e-05
    15
      1   0   0   1   1
@@ -8816,7 +8816,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_7.3e-05
     15   3   3   1   1
       1.9214450206    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.3e-05
+# RI basis set for Ne (all-electron) relative DI metric: 2.3e-05
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_054_s_p_d_f_g_h_i_7_6_3_2_0_0_0_error_2.3e-05
    18
      1   0   0   1   1
@@ -8856,7 +8856,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_054_s_p_d_f_g_h_i_7_6_3_2_0_0_0_error_2.3e-05
     18   3   3   1   1
       2.7739076724    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.1e-05
+# RI basis set for Ne (all-electron) relative DI metric: 1.1e-05
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_6_3_2_1_0_0_error_1.1e-05
    19
      1   0   0   1   1
@@ -8898,7 +8898,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_6_3_2_1_0_0_error_1.1e-05
     19   4   4   1   1
       2.6885512306    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.9e-06
+# RI basis set for Ne (all-electron) relative DI metric: 1.9e-06
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_6_4_3_1_0_0_error_1.9e-06
    21
      1   0   0   1   1
@@ -8944,7 +8944,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_6_4_3_1_0_0_error_1.9e-06
     21   4   4   1   1
       0.9492710411    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 9.0e-07
+# RI basis set for Ne (all-electron) relative DI metric: 9.0e-07
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_087_s_p_d_f_g_h_i_7_6_5_4_1_0_0_error_9.0e-07
    23
      1   0   0   1   1
@@ -8994,7 +8994,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_087_s_p_d_f_g_h_i_7_6_5_4_1_0_0_error_9.0e-07
     23   4   4   1   1
       1.1401915323    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 3.3e-07
+# RI basis set for Ne (all-electron) relative DI metric: 3.3e-07
 Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_115_s_p_d_f_g_h_i_7_6_6_6_2_0_0_error_3.3e-07
    27
      1   0   0   1   1
@@ -9052,7 +9052,7 @@ Ne  RI_aug-DZVP-MOLOPT-ae_N_RI_115_s_p_d_f_g_h_i_7_6_6_6_2_0_0_error_3.3e-07
     27   4   4   1   1
       3.4191739506    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.0e-02
+# RI basis set for Ne (all-electron) relative DI metric: 2.0e-02
 Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_6_2_2_1_0_0_0_error_2.0e-02
    11
      1   0   0   1   1
@@ -9078,7 +9078,7 @@ Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_6_2_2_1_0_0_0_error_2.0e-02
     11   3   3   1   1
       4.2793240118    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.0e-02
+# RI basis set for Ne (all-electron) relative DI metric: 1.0e-02
 Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_6_3_2_2_0_0_0_error_1.0e-02
    13
      1   0   0   1   1
@@ -9108,7 +9108,7 @@ Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_6_3_2_2_0_0_0_error_1.0e-02
     13   3   3   1   1
       5.4450970581    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 3.5e-03
+# RI basis set for Ne (all-electron) relative DI metric: 3.5e-03
 Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_3_2_2_1_0_0_error_3.5e-03
    14
      1   0   0   1   1
@@ -9140,7 +9140,7 @@ Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_6_3_2_2_1_0_0_error_3.5e-03
     14   4   4   1   1
       4.4844153752    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.2e-03
+# RI basis set for Ne (all-electron) relative DI metric: 1.2e-03
 Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_6_4_3_2_1_0_0_error_1.2e-03
    16
      1   0   0   1   1
@@ -9176,7 +9176,7 @@ Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_6_4_3_2_1_0_0_error_1.2e-03
     16   4   4   1   1
       4.4288823901    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 5.7e-04
+# RI basis set for Ne (all-electron) relative DI metric: 5.7e-04
 Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_6_4_4_3_1_0_0_error_5.7e-04
    18
      1   0   0   1   1
@@ -9216,7 +9216,7 @@ Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_6_4_4_3_1_0_0_error_5.7e-04
     18   4   4   1   1
       4.9723209504    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.0e-04
+# RI basis set for Ne (all-electron) relative DI metric: 2.0e-04
 Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_077_s_p_d_f_g_h_i_6_4_4_3_2_0_0_error_2.0e-04
    19
      1   0   0   1   1
@@ -9258,7 +9258,7 @@ Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_077_s_p_d_f_g_h_i_6_4_4_3_2_0_0_error_2.0e-04
     19   4   4   1   1
       6.4304735805    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 2.7e-05
+# RI basis set for Ne (all-electron) relative DI metric: 2.7e-05
 Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_089_s_p_d_f_g_h_i_7_4_4_3_2_1_0_error_2.7e-05
    21
      1   0   0   1   1
@@ -9304,7 +9304,7 @@ Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_089_s_p_d_f_g_h_i_7_4_4_3_2_1_0_error_2.7e-05
     21   5   5   1   1
       1.1056232814    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 1.2e-05
+# RI basis set for Ne (all-electron) relative DI metric: 1.2e-05
 Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_104_s_p_d_f_g_h_i_7_5_5_4_2_1_0_error_1.2e-05
    24
      1   0   0   1   1
@@ -9356,7 +9356,7 @@ Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_104_s_p_d_f_g_h_i_7_5_5_4_2_1_0_error_1.2e-05
     24   5   5   1   1
       0.8608216383    1.0000000000
 
-# RI basis set for Ne (all-electron) relative accuracy of RI-MP2: 5.8e-06
+# RI basis set for Ne (all-electron) relative DI metric: 5.8e-06
 Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_113_s_p_d_f_g_h_i_7_5_5_4_3_1_0_error_5.8e-06
    25
      1   0   0   1   1
@@ -9410,7 +9410,7 @@ Ne  RI_aug-TZVP-MOLOPT-ae_N_RI_113_s_p_d_f_g_h_i_7_5_5_4_3_1_0_error_5.8e-06
     25   5   5   1   1
       1.0193582738    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 3.8e-02
+# RI basis set for Na (all-electron) relative DI metric: 3.8e-02
 Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_3.8e-02
    3
      1   0   0   1   1
@@ -9420,7 +9420,7 @@ Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_005_s_p_d_f_g_h_i_2_1_0_0_0_0_0_error_3.8e-02
      3   1   1   1   1
       9.4222426315    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 1.9e-03
+# RI basis set for Na (all-electron) relative DI metric: 1.9e-03
 Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_1.9e-03
    6
      1   0   0   1   1
@@ -9436,7 +9436,7 @@ Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_1.9e-03
      6   2   2   1   1
       9.4317708295    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 7.2e-04
+# RI basis set for Na (all-electron) relative DI metric: 7.2e-04
 Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_019_s_p_d_f_g_h_i_3_2_2_0_0_0_0_error_7.2e-04
    7
      1   0   0   1   1
@@ -9454,7 +9454,7 @@ Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_019_s_p_d_f_g_h_i_3_2_2_0_0_0_0_error_7.2e-04
      7   2   2   1   1
       9.0861714161    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 1.7e-04
+# RI basis set for Na (all-electron) relative DI metric: 1.7e-04
 Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_020_s_p_d_f_g_h_i_4_2_2_0_0_0_0_error_1.7e-04
    8
      1   0   0   1   1
@@ -9474,7 +9474,7 @@ Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_020_s_p_d_f_g_h_i_4_2_2_0_0_0_0_error_1.7e-04
      8   2   2   1   1
       7.0230466319    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 3.9e-05
+# RI basis set for Na (all-electron) relative DI metric: 3.9e-05
 Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_028_s_p_d_f_g_h_i_4_3_3_0_0_0_0_error_3.9e-05
    10
      1   0   0   1   1
@@ -9498,7 +9498,7 @@ Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_028_s_p_d_f_g_h_i_4_3_3_0_0_0_0_error_3.9e-05
     10   2   2   1   1
       7.4339450521    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 8.2e-07
+# RI basis set for Na (all-electron) relative DI metric: 8.2e-07
 Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_8.2e-07
    16
      1   0   0   1   1
@@ -9534,7 +9534,7 @@ Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_8.2e-07
     16   2   2   1   1
      15.1367531967    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 2.4e-07
+# RI basis set for Na (all-electron) relative DI metric: 2.4e-07
 Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_055_s_p_d_f_g_h_i_7_6_6_0_0_0_0_error_2.4e-07
    19
      1   0   0   1   1
@@ -9576,7 +9576,7 @@ Na  RI_aug-SZV-MOLOPT-ae-mini_N_RI_055_s_p_d_f_g_h_i_7_6_6_0_0_0_0_error_2.4e-07
     19   2   2   1   1
      20.0669883688    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 2.4e-02
+# RI basis set for Na (all-electron) relative DI metric: 2.4e-02
 Na  RI_aug-SZV-MOLOPT-ae_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_2.4e-02
    5
      1   0   0   1   1
@@ -9590,7 +9590,7 @@ Na  RI_aug-SZV-MOLOPT-ae_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_2.4e-02
      5   1   1   1   1
       7.7007017924    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 1.4e-03
+# RI basis set for Na (all-electron) relative DI metric: 1.4e-03
 Na  RI_aug-SZV-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_1.4e-03
    9
      1   0   0   1   1
@@ -9612,7 +9612,7 @@ Na  RI_aug-SZV-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_1.4e-03
      9   2   2   1   1
      10.6234344169    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 7.2e-05
+# RI basis set for Na (all-electron) relative DI metric: 7.2e-05
 Na  RI_aug-SZV-MOLOPT-ae_N_RI_028_s_p_d_f_g_h_i_6_4_2_0_0_0_0_error_7.2e-05
    12
      1   0   0   1   1
@@ -9640,7 +9640,7 @@ Na  RI_aug-SZV-MOLOPT-ae_N_RI_028_s_p_d_f_g_h_i_6_4_2_0_0_0_0_error_7.2e-05
     12   2   2   1   1
       7.4085082238    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 2.8e-05
+# RI basis set for Na (all-electron) relative DI metric: 2.8e-05
 Na  RI_aug-SZV-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_6_4_3_0_0_0_0_error_2.8e-05
    13
      1   0   0   1   1
@@ -9670,7 +9670,7 @@ Na  RI_aug-SZV-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_6_4_3_0_0_0_0_error_2.8e-05
     13   2   2   1   1
       7.4776468823    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 7.8e-06
+# RI basis set for Na (all-electron) relative DI metric: 7.8e-06
 Na  RI_aug-SZV-MOLOPT-ae_N_RI_050_s_p_d_f_g_h_i_6_5_3_2_0_0_0_error_7.8e-06
    16
      1   0   0   1   1
@@ -9706,7 +9706,7 @@ Na  RI_aug-SZV-MOLOPT-ae_N_RI_050_s_p_d_f_g_h_i_6_5_3_2_0_0_0_error_7.8e-06
     16   3   3   1   1
       1.8233632511    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 1.6e-06
+# RI basis set for Na (all-electron) relative DI metric: 1.6e-06
 Na  RI_aug-SZV-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_6_3_2_1_0_0_error_1.6e-06
    19
      1   0   0   1   1
@@ -9748,7 +9748,7 @@ Na  RI_aug-SZV-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_7_6_3_2_1_0_0_error_1.6e-06
     19   4   4   1   1
       0.4464535805    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 2.8e-02
+# RI basis set for Na (all-electron) relative DI metric: 2.8e-02
 Na  RI_aug-DZVP-MOLOPT-ae_N_RI_013_s_p_d_f_g_h_i_4_3_0_0_0_0_0_error_2.8e-02
    7
      1   0   0   1   1
@@ -9766,7 +9766,7 @@ Na  RI_aug-DZVP-MOLOPT-ae_N_RI_013_s_p_d_f_g_h_i_4_3_0_0_0_0_0_error_2.8e-02
      7   1   1   1   1
       9.7702122514    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 1.4e-02
+# RI basis set for Na (all-electron) relative DI metric: 1.4e-02
 Na  RI_aug-DZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_1.4e-02
    9
      1   0   0   1   1
@@ -9788,7 +9788,7 @@ Na  RI_aug-DZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_1.4e-02
      9   2   2   1   1
       8.2100385770    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 5.4e-03
+# RI basis set for Na (all-electron) relative DI metric: 5.4e-03
 Na  RI_aug-DZVP-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_5_4_2_0_0_0_0_error_5.4e-03
    11
      1   0   0   1   1
@@ -9814,7 +9814,7 @@ Na  RI_aug-DZVP-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_5_4_2_0_0_0_0_error_5.4e-03
     11   2   2   1   1
       4.2528661252    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 9.7e-04
+# RI basis set for Na (all-electron) relative DI metric: 9.7e-04
 Na  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_5_4_3_1_0_0_0_error_9.7e-04
    13
      1   0   0   1   1
@@ -9844,7 +9844,7 @@ Na  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_5_4_3_1_0_0_0_error_9.7e-04
     13   3   3   1   1
       2.4004644175    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 1.5e-04
+# RI basis set for Na (all-electron) relative DI metric: 1.5e-04
 Na  RI_aug-DZVP-MOLOPT-ae_N_RI_069_s_p_d_f_g_h_i_7_5_4_1_1_1_0_error_1.5e-04
    19
      1   0   0   1   1
@@ -9886,7 +9886,7 @@ Na  RI_aug-DZVP-MOLOPT-ae_N_RI_069_s_p_d_f_g_h_i_7_5_4_1_1_1_0_error_1.5e-04
     19   5   5   1   1
       0.3097677618    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 1.6e-02
+# RI basis set for Na (all-electron) relative DI metric: 1.6e-02
 Na  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_1.6e-02
    9
      1   0   0   1   1
@@ -9908,7 +9908,7 @@ Na  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_4_3_1_1_0_0_0_error_1.6e-02
      9   3   3   1   1
       3.0052673142    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 2.2e-03
+# RI basis set for Na (all-electron) relative DI metric: 2.2e-03
 Na  RI_aug-TZVP-MOLOPT-ae_N_RI_046_s_p_d_f_g_h_i_5_4_3_2_0_0_0_error_2.2e-03
    14
      1   0   0   1   1
@@ -9940,7 +9940,7 @@ Na  RI_aug-TZVP-MOLOPT-ae_N_RI_046_s_p_d_f_g_h_i_5_4_3_2_0_0_0_error_2.2e-03
     14   3   3   1   1
       3.5522045146    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 2.7e-04
+# RI basis set for Na (all-electron) relative DI metric: 2.7e-04
 Na  RI_aug-TZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_6_5_3_2_1_0_0_error_2.7e-04
    17
      1   0   0   1   1
@@ -9978,7 +9978,7 @@ Na  RI_aug-TZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_6_5_3_2_1_0_0_error_2.7e-04
     17   4   4   1   1
       2.4742737549    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 7.6e-05
+# RI basis set for Na (all-electron) relative DI metric: 7.6e-05
 Na  RI_aug-TZVP-MOLOPT-ae_N_RI_065_s_p_d_f_g_h_i_7_5_4_2_1_0_0_error_7.6e-05
    19
      1   0   0   1   1
@@ -10020,7 +10020,7 @@ Na  RI_aug-TZVP-MOLOPT-ae_N_RI_065_s_p_d_f_g_h_i_7_5_4_2_1_0_0_error_7.6e-05
     19   4   4   1   1
       2.8759816146    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 3.3e-05
+# RI basis set for Na (all-electron) relative DI metric: 3.3e-05
 Na  RI_aug-TZVP-MOLOPT-ae_N_RI_087_s_p_d_f_g_h_i_7_6_5_4_1_0_0_error_3.3e-05
    23
      1   0   0   1   1
@@ -10070,7 +10070,7 @@ Na  RI_aug-TZVP-MOLOPT-ae_N_RI_087_s_p_d_f_g_h_i_7_6_5_4_1_0_0_error_3.3e-05
     23   4   4   1   1
       2.7475340858    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 1.6e-05
+# RI basis set for Na (all-electron) relative DI metric: 1.6e-05
 Na  RI_aug-TZVP-MOLOPT-ae_N_RI_094_s_p_d_f_g_h_i_7_6_5_5_1_0_0_error_1.6e-05
    24
      1   0   0   1   1
@@ -10122,7 +10122,7 @@ Na  RI_aug-TZVP-MOLOPT-ae_N_RI_094_s_p_d_f_g_h_i_7_6_5_5_1_0_0_error_1.6e-05
     24   4   4   1   1
       2.7157180157    1.0000000000
 
-# RI basis set for Na (all-electron) relative accuracy of RI-MP2: 4.3e-06
+# RI basis set for Na (all-electron) relative DI metric: 4.3e-06
 Na  RI_aug-TZVP-MOLOPT-ae_N_RI_117_s_p_d_f_g_h_i_7_6_6_5_3_0_0_error_4.3e-06
    27
      1   0   0   1   1
@@ -10180,7 +10180,7 @@ Na  RI_aug-TZVP-MOLOPT-ae_N_RI_117_s_p_d_f_g_h_i_7_6_6_5_3_0_0_error_4.3e-06
     27   4   4   1   1
       2.8181169662    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 3.4e-02
+# RI basis set for Mg (all-electron) relative DI metric: 3.4e-02
 Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_3.4e-02
    5
      1   0   0   1   1
@@ -10194,7 +10194,7 @@ Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_3.4e-02
      5   1   1   1   1
      12.7576069267    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.5e-02
+# RI basis set for Mg (all-electron) relative DI metric: 1.5e-02
 Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_015_s_p_d_f_g_h_i_6_3_0_0_0_0_0_error_1.5e-02
    9
      1   0   0   1   1
@@ -10216,7 +10216,7 @@ Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_015_s_p_d_f_g_h_i_6_3_0_0_0_0_0_error_1.5e-02
      9   1   1   1   1
       7.0692745964    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.1e-03
+# RI basis set for Mg (all-electron) relative DI metric: 1.1e-03
 Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_024_s_p_d_f_g_h_i_7_4_1_0_0_0_0_error_1.1e-03
    12
      1   0   0   1   1
@@ -10244,7 +10244,7 @@ Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_024_s_p_d_f_g_h_i_7_4_1_0_0_0_0_error_1.1e-03
     12   2   2   1   1
      11.7369785276    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 3.9e-06
+# RI basis set for Mg (all-electron) relative DI metric: 3.9e-06
 Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_034_s_p_d_f_g_h_i_7_4_3_0_0_0_0_error_3.9e-06
    14
      1   0   0   1   1
@@ -10276,7 +10276,7 @@ Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_034_s_p_d_f_g_h_i_7_4_3_0_0_0_0_error_3.9e-06
     14   2   2   1   1
       8.5016927123    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.6e-06
+# RI basis set for Mg (all-electron) relative DI metric: 1.6e-06
 Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_037_s_p_d_f_g_h_i_7_5_3_0_0_0_0_error_1.6e-06
    15
      1   0   0   1   1
@@ -10310,7 +10310,7 @@ Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_037_s_p_d_f_g_h_i_7_5_3_0_0_0_0_error_1.6e-06
     15   2   2   1   1
       9.3237396067    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 2.9e-07
+# RI basis set for Mg (all-electron) relative DI metric: 2.9e-07
 Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_045_s_p_d_f_g_h_i_7_6_4_0_0_0_0_error_2.9e-07
    17
      1   0   0   1   1
@@ -10348,7 +10348,7 @@ Mg  RI_aug-SZV-MOLOPT-ae-mini_N_RI_045_s_p_d_f_g_h_i_7_6_4_0_0_0_0_error_2.9e-07
     17   2   2   1   1
      15.8676238442    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.3e-02
+# RI basis set for Mg (all-electron) relative DI metric: 1.3e-02
 Mg  RI_aug-SZV-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_6_3_1_0_0_0_0_error_1.3e-02
    10
      1   0   0   1   1
@@ -10372,7 +10372,7 @@ Mg  RI_aug-SZV-MOLOPT-ae_N_RI_020_s_p_d_f_g_h_i_6_3_1_0_0_0_0_error_1.3e-02
     10   2   2   1   1
       0.1678555406    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 4.3e-03
+# RI basis set for Mg (all-electron) relative DI metric: 4.3e-03
 Mg  RI_aug-SZV-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_4.3e-03
    11
      1   0   0   1   1
@@ -10398,7 +10398,7 @@ Mg  RI_aug-SZV-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_4.3e-03
     11   2   2   1   1
      12.1555511383    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 7.7e-04
+# RI basis set for Mg (all-electron) relative DI metric: 7.7e-04
 Mg  RI_aug-SZV-MOLOPT-ae_N_RI_028_s_p_d_f_g_h_i_6_4_2_0_0_0_0_error_7.7e-04
    12
      1   0   0   1   1
@@ -10426,7 +10426,7 @@ Mg  RI_aug-SZV-MOLOPT-ae_N_RI_028_s_p_d_f_g_h_i_6_4_2_0_0_0_0_error_7.7e-04
     12   2   2   1   1
      12.0275842468    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 3.6e-04
+# RI basis set for Mg (all-electron) relative DI metric: 3.6e-04
 Mg  RI_aug-SZV-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_6_4_3_0_0_0_0_error_3.6e-04
    13
      1   0   0   1   1
@@ -10456,7 +10456,7 @@ Mg  RI_aug-SZV-MOLOPT-ae_N_RI_033_s_p_d_f_g_h_i_6_4_3_0_0_0_0_error_3.6e-04
     13   2   2   1   1
       9.1854836847    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.2e-05
+# RI basis set for Mg (all-electron) relative DI metric: 1.2e-05
 Mg  RI_aug-SZV-MOLOPT-ae_N_RI_037_s_p_d_f_g_h_i_7_5_3_0_0_0_0_error_1.2e-05
    15
      1   0   0   1   1
@@ -10490,7 +10490,7 @@ Mg  RI_aug-SZV-MOLOPT-ae_N_RI_037_s_p_d_f_g_h_i_7_5_3_0_0_0_0_error_1.2e-05
     15   2   2   1   1
       9.3363931765    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.8e-06
+# RI basis set for Mg (all-electron) relative DI metric: 1.8e-06
 Mg  RI_aug-SZV-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_1.8e-06
    16
      1   0   0   1   1
@@ -10526,7 +10526,7 @@ Mg  RI_aug-SZV-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_1.8e-06
     16   3   3   1   1
       0.6047690570    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 6.7e-07
+# RI basis set for Mg (all-electron) relative DI metric: 6.7e-07
 Mg  RI_aug-SZV-MOLOPT-ae_N_RI_071_s_p_d_f_g_h_i_7_6_6_1_1_0_0_error_6.7e-07
    21
      1   0   0   1   1
@@ -10572,7 +10572,7 @@ Mg  RI_aug-SZV-MOLOPT-ae_N_RI_071_s_p_d_f_g_h_i_7_6_6_1_1_0_0_error_6.7e-07
     21   4   4   1   1
       0.5536024977    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 3.2e-07
+# RI basis set for Mg (all-electron) relative DI metric: 3.2e-07
 Mg  RI_aug-SZV-MOLOPT-ae_N_RI_085_s_p_d_f_g_h_i_7_6_6_3_1_0_0_error_3.2e-07
    23
      1   0   0   1   1
@@ -10622,7 +10622,7 @@ Mg  RI_aug-SZV-MOLOPT-ae_N_RI_085_s_p_d_f_g_h_i_7_6_6_3_1_0_0_error_3.2e-07
     23   4   4   1   1
       0.5530610059    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.5e-07
+# RI basis set for Mg (all-electron) relative DI metric: 1.5e-07
 Mg  RI_aug-SZV-MOLOPT-ae_N_RI_110_s_p_d_f_g_h_i_7_6_6_4_3_0_0_error_1.5e-07
    26
      1   0   0   1   1
@@ -10678,7 +10678,7 @@ Mg  RI_aug-SZV-MOLOPT-ae_N_RI_110_s_p_d_f_g_h_i_7_6_6_4_3_0_0_error_1.5e-07
     26   4   4   1   1
       0.8175883887    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.9e-02
+# RI basis set for Mg (all-electron) relative DI metric: 1.9e-02
 Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_1.9e-02
    9
      1   0   0   1   1
@@ -10700,7 +10700,7 @@ Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_023_s_p_d_f_g_h_i_4_3_2_0_0_0_0_error_1.9e-02
      9   2   2   1   1
      13.4574256888    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 7.0e-03
+# RI basis set for Mg (all-electron) relative DI metric: 7.0e-03
 Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_7_4_3_0_0_0_0_error_7.0e-03
    14
      1   0   0   1   1
@@ -10732,7 +10732,7 @@ Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_7_4_3_0_0_0_0_error_7.0e-03
     14   2   2   1   1
      10.0746342527    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 2.9e-03
+# RI basis set for Mg (all-electron) relative DI metric: 2.9e-03
 Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_046_s_p_d_f_g_h_i_7_4_4_1_0_0_0_error_2.9e-03
    16
      1   0   0   1   1
@@ -10768,7 +10768,7 @@ Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_046_s_p_d_f_g_h_i_7_4_4_1_0_0_0_error_2.9e-03
     16   3   3   1   1
       1.7163613523    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 2.3e-04
+# RI basis set for Mg (all-electron) relative DI metric: 2.3e-04
 Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_7_5_4_2_0_0_0_error_2.3e-04
    18
      1   0   0   1   1
@@ -10808,7 +10808,7 @@ Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_7_5_4_2_0_0_0_error_2.3e-04
     18   3   3   1   1
       2.2268858235    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.0e-04
+# RI basis set for Mg (all-electron) relative DI metric: 1.0e-04
 Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_1.0e-04
    19
      1   0   0   1   1
@@ -10850,7 +10850,7 @@ Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_1.0e-04
     19   3   3   1   1
       2.2998506615    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 4.2e-05
+# RI basis set for Mg (all-electron) relative DI metric: 4.2e-05
 Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_7_6_4_3_0_0_0_error_4.2e-05
    20
      1   0   0   1   1
@@ -10894,7 +10894,7 @@ Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_7_6_4_3_0_0_0_error_4.2e-05
     20   3   3   1   1
       2.9173155221    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.2e-05
+# RI basis set for Mg (all-electron) relative DI metric: 1.2e-05
 Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_078_s_p_d_f_g_h_i_7_6_5_4_0_0_0_error_1.2e-05
    22
      1   0   0   1   1
@@ -10942,7 +10942,7 @@ Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_078_s_p_d_f_g_h_i_7_6_5_4_0_0_0_error_1.2e-05
     22   3   3   1   1
       2.8995781052    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 5.2e-06
+# RI basis set for Mg (all-electron) relative DI metric: 5.2e-06
 Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_5_5_3_0_0_error_5.2e-06
    26
      1   0   0   1   1
@@ -10998,7 +10998,7 @@ Mg  RI_aug-DZVP-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_5_5_3_0_0_error_5.2e-06
     26   4   4   1   1
       0.9376332299    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 4.3e-02
+# RI basis set for Mg (all-electron) relative DI metric: 4.3e-02
 Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_4.3e-02
    11
      1   0   0   1   1
@@ -11024,7 +11024,7 @@ Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_4.3e-02
     11   2   2   1   1
       6.7865536540    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 9.2e-03
+# RI basis set for Mg (all-electron) relative DI metric: 9.2e-03
 Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_6_3_3_2_0_0_0_error_9.2e-03
    14
      1   0   0   1   1
@@ -11056,7 +11056,7 @@ Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_6_3_3_2_0_0_0_error_9.2e-03
     14   3   3   1   1
       5.6905416713    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 3.4e-03
+# RI basis set for Mg (all-electron) relative DI metric: 3.4e-03
 Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_6_4_3_2_0_0_0_error_3.4e-03
    15
      1   0   0   1   1
@@ -11090,7 +11090,7 @@ Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_047_s_p_d_f_g_h_i_6_4_3_2_0_0_0_error_3.4e-03
     15   3   3   1   1
       4.1486947963    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 1.3e-03
+# RI basis set for Mg (all-electron) relative DI metric: 1.3e-03
 Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_052_s_p_d_f_g_h_i_6_4_4_2_0_0_0_error_1.3e-03
    16
      1   0   0   1   1
@@ -11126,7 +11126,7 @@ Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_052_s_p_d_f_g_h_i_6_4_4_2_0_0_0_error_1.3e-03
     16   3   3   1   1
       4.6711872048    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 5.3e-04
+# RI basis set for Mg (all-electron) relative DI metric: 5.3e-04
 Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_5.3e-04
    19
      1   0   0   1   1
@@ -11168,7 +11168,7 @@ Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_059_s_p_d_f_g_h_i_7_6_4_2_0_0_0_error_5.3e-04
     19   3   3   1   1
       4.9147198489    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 2.0e-04
+# RI basis set for Mg (all-electron) relative DI metric: 2.0e-04
 Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_7_6_4_3_0_0_0_error_2.0e-04
    20
      1   0   0   1   1
@@ -11212,7 +11212,7 @@ Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_7_6_4_3_0_0_0_error_2.0e-04
     20   3   3   1   1
       5.1945360810    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 9.0e-05
+# RI basis set for Mg (all-electron) relative DI metric: 9.0e-05
 Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_071_s_p_d_f_g_h_i_7_6_5_3_0_0_0_error_9.0e-05
    21
      1   0   0   1   1
@@ -11258,7 +11258,7 @@ Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_071_s_p_d_f_g_h_i_7_6_5_3_0_0_0_error_9.0e-05
     21   3   3   1   1
       5.8040188033    1.0000000000
 
-# RI basis set for Mg (all-electron) relative accuracy of RI-MP2: 2.6e-05
+# RI basis set for Mg (all-electron) relative DI metric: 2.6e-05
 Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_090_s_p_d_f_g_h_i_7_6_6_5_0_0_0_error_2.6e-05
    24
      1   0   0   1   1
@@ -11310,7 +11310,7 @@ Mg  RI_aug-TZVP-MOLOPT-ae_N_RI_090_s_p_d_f_g_h_i_7_6_6_5_0_0_0_error_2.6e-05
     24   3   3   1   1
       5.5136554193    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 3.5e-07
+# RI basis set for Al (all-electron) relative DI metric: 3.5e-07
 Al  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_3.5e-07
    5
      1   0   0   1   1
@@ -11324,7 +11324,7 @@ Al  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_3.5e-07
      5   1   1   1   1
       0.3908787346    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 2.0e-09
+# RI basis set for Al (all-electron) relative DI metric: 2.0e-09
 Al  RI_aug-SZV-MOLOPT-ae-mini_N_RI_021_s_p_d_f_g_h_i_6_5_0_0_0_0_0_error_2.0e-09
    11
      1   0   0   1   1
@@ -11350,7 +11350,7 @@ Al  RI_aug-SZV-MOLOPT-ae-mini_N_RI_021_s_p_d_f_g_h_i_6_5_0_0_0_0_0_error_2.0e-09
     11   1   1   1   1
       2.3257466667    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 5.0e-11
+# RI basis set for Al (all-electron) relative DI metric: 5.0e-11
 Al  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_7_6_0_0_0_0_0_error_5.0e-11
    13
      1   0   0   1   1
@@ -11380,7 +11380,7 @@ Al  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_7_6_0_0_0_0_0_error_5.0e-11
     13   1   1   1   1
       2.3257466667    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 1.8e-02
+# RI basis set for Al (all-electron) relative DI metric: 1.8e-02
 Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_1.8e-02
    9
      1   0   0   1   1
@@ -11402,7 +11402,7 @@ Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_1.8e-02
      9   2   2   1   1
       0.3187332304    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 3.2e-03
+# RI basis set for Al (all-electron) relative DI metric: 3.2e-03
 Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_030_s_p_d_f_g_h_i_6_4_1_1_0_0_0_error_3.2e-03
    12
      1   0   0   1   1
@@ -11430,7 +11430,7 @@ Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_030_s_p_d_f_g_h_i_6_4_1_1_0_0_0_error_3.2e-03
     12   3   3   1   1
       0.7818307706    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 2.3e-04
+# RI basis set for Al (all-electron) relative DI metric: 2.3e-04
 Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_031_s_p_d_f_g_h_i_7_4_1_1_0_0_0_error_2.3e-04
    13
      1   0   0   1   1
@@ -11460,7 +11460,7 @@ Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_031_s_p_d_f_g_h_i_7_4_1_1_0_0_0_error_2.3e-04
     13   3   3   1   1
       0.7011450216    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 1.4e-05
+# RI basis set for Al (all-electron) relative DI metric: 1.4e-05
 Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_1.4e-05
    16
      1   0   0   1   1
@@ -11496,7 +11496,7 @@ Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_1.4e-05
     16   3   3   1   1
       0.5292616794    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 3.2e-06
+# RI basis set for Al (all-electron) relative DI metric: 3.2e-06
 Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_049_s_p_d_f_g_h_i_7_5_4_1_0_0_0_error_3.2e-06
    17
      1   0   0   1   1
@@ -11534,7 +11534,7 @@ Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_049_s_p_d_f_g_h_i_7_5_4_1_0_0_0_error_3.2e-06
     17   3   3   1   1
       0.3670211484    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 5.9e-07
+# RI basis set for Al (all-electron) relative DI metric: 5.9e-07
 Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_056_s_p_d_f_g_h_i_7_5_4_2_0_0_0_error_5.9e-07
    18
      1   0   0   1   1
@@ -11574,7 +11574,7 @@ Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_056_s_p_d_f_g_h_i_7_5_4_2_0_0_0_error_5.9e-07
     18   3   3   1   1
       3.0152123180    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 2.4e-07
+# RI basis set for Al (all-electron) relative DI metric: 2.4e-07
 Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_103_s_p_d_f_g_h_i_7_5_5_2_2_1_1_error_2.4e-07
    23
      1   0   0   1   1
@@ -11624,7 +11624,7 @@ Al  RI_aug-SZV-MOLOPT-ae-SR_N_RI_103_s_p_d_f_g_h_i_7_5_5_2_2_1_1_error_2.4e-07
     23   6   6   1   1
       0.5835397040    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 8.9e-04
+# RI basis set for Al (all-electron) relative DI metric: 8.9e-04
 Al  RI_aug-SZV-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_6_3_1_1_0_0_0_error_8.9e-04
    11
      1   0   0   1   1
@@ -11650,7 +11650,7 @@ Al  RI_aug-SZV-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_6_3_1_1_0_0_0_error_8.9e-04
     11   3   3   1   1
       1.3863267342    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 7.3e-05
+# RI basis set for Al (all-electron) relative DI metric: 7.3e-05
 Al  RI_aug-SZV-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_6_4_1_1_1_0_0_error_7.3e-05
    13
      1   0   0   1   1
@@ -11680,7 +11680,7 @@ Al  RI_aug-SZV-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_6_4_1_1_1_0_0_error_7.3e-05
     13   4   4   1   1
       0.1595857001    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 2.2e-05
+# RI basis set for Al (all-electron) relative DI metric: 2.2e-05
 Al  RI_aug-SZV-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_7_5_2_1_1_0_0_error_2.2e-05
    16
      1   0   0   1   1
@@ -11716,7 +11716,7 @@ Al  RI_aug-SZV-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_7_5_2_1_1_0_0_error_2.2e-05
     16   4   4   1   1
       1.1215509910    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 1.0e-05
+# RI basis set for Al (all-electron) relative DI metric: 1.0e-05
 Al  RI_aug-SZV-MOLOPT-ae_N_RI_053_s_p_d_f_g_h_i_7_5_3_1_1_0_0_error_1.0e-05
    17
      1   0   0   1   1
@@ -11754,7 +11754,7 @@ Al  RI_aug-SZV-MOLOPT-ae_N_RI_053_s_p_d_f_g_h_i_7_5_3_1_1_0_0_error_1.0e-05
     17   4   4   1   1
       0.6472513927    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 6.1e-07
+# RI basis set for Al (all-electron) relative DI metric: 6.1e-07
 Al  RI_aug-SZV-MOLOPT-ae_N_RI_058_s_p_d_f_g_h_i_7_5_4_1_1_0_0_error_6.1e-07
    18
      1   0   0   1   1
@@ -11794,7 +11794,7 @@ Al  RI_aug-SZV-MOLOPT-ae_N_RI_058_s_p_d_f_g_h_i_7_5_4_1_1_0_0_error_6.1e-07
     18   4   4   1   1
       0.6467670730    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 1.9e-07
+# RI basis set for Al (all-electron) relative DI metric: 1.9e-07
 Al  RI_aug-SZV-MOLOPT-ae_N_RI_095_s_p_d_f_g_h_i_7_5_5_4_1_1_0_error_1.9e-07
    23
      1   0   0   1   1
@@ -11844,7 +11844,7 @@ Al  RI_aug-SZV-MOLOPT-ae_N_RI_095_s_p_d_f_g_h_i_7_5_5_4_1_1_0_error_1.9e-07
     23   5   5   1   1
       0.5968196068    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 2.9e-02
+# RI basis set for Al (all-electron) relative DI metric: 2.9e-02
 Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_023_s_p_d_f_g_h_i_6_4_1_0_0_0_0_error_2.9e-02
    11
      1   0   0   1   1
@@ -11870,7 +11870,7 @@ Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_023_s_p_d_f_g_h_i_6_4_1_0_0_0_0_error_2.9e-02
     11   2   2   1   1
       0.4467425568    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 1.4e-02
+# RI basis set for Al (all-electron) relative DI metric: 1.4e-02
 Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_045_s_p_d_f_g_h_i_6_4_4_1_0_0_0_error_1.4e-02
    15
      1   0   0   1   1
@@ -11904,7 +11904,7 @@ Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_045_s_p_d_f_g_h_i_6_4_4_1_0_0_0_error_1.4e-02
     15   3   3   1   1
       0.1250839652    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 3.6e-04
+# RI basis set for Al (all-electron) relative DI metric: 3.6e-04
 Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_049_s_p_d_f_g_h_i_7_5_4_1_0_0_0_error_3.6e-04
    17
      1   0   0   1   1
@@ -11942,7 +11942,7 @@ Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_049_s_p_d_f_g_h_i_7_5_4_1_0_0_0_error_3.6e-04
     17   3   3   1   1
       0.2124515418    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 3.6e-05
+# RI basis set for Al (all-electron) relative DI metric: 3.6e-05
 Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_061_s_p_d_f_g_h_i_7_6_4_1_1_0_0_error_3.6e-05
    19
      1   0   0   1   1
@@ -11984,7 +11984,7 @@ Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_061_s_p_d_f_g_h_i_7_6_4_1_1_0_0_error_3.6e-05
     19   4   4   1   1
       0.7918944001    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 1.3e-05
+# RI basis set for Al (all-electron) relative DI metric: 1.3e-05
 Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_082_s_p_d_f_g_h_i_7_6_5_2_2_0_0_error_1.3e-05
    22
      1   0   0   1   1
@@ -12032,7 +12032,7 @@ Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_082_s_p_d_f_g_h_i_7_6_5_2_2_0_0_error_1.3e-05
     22   4   4   1   1
       1.1799200029    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 5.8e-06
+# RI basis set for Al (all-electron) relative DI metric: 5.8e-06
 Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_100_s_p_d_f_g_h_i_7_6_5_3_2_1_0_error_5.8e-06
    24
      1   0   0   1   1
@@ -12084,7 +12084,7 @@ Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_100_s_p_d_f_g_h_i_7_6_5_3_2_1_0_error_5.8e-06
     24   5   5   1   1
       0.5655098133    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 2.8e-06
+# RI basis set for Al (all-electron) relative DI metric: 2.8e-06
 Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_111_s_p_d_f_g_h_i_7_6_5_3_2_2_0_error_2.8e-06
    25
      1   0   0   1   1
@@ -12138,7 +12138,7 @@ Al  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_111_s_p_d_f_g_h_i_7_6_5_3_2_2_0_error_2.8e-06
     25   5   5   1   1
       0.6324307990    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 3.6e-02
+# RI basis set for Al (all-electron) relative DI metric: 3.6e-02
 Al  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_4_1_1_1_0_0_0_error_3.6e-02
    7
      1   0   0   1   1
@@ -12156,7 +12156,7 @@ Al  RI_aug-DZVP-MOLOPT-ae_N_RI_019_s_p_d_f_g_h_i_4_1_1_1_0_0_0_error_3.6e-02
      7   3   3   1   1
       1.3042395869    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 1.4e-02
+# RI basis set for Al (all-electron) relative DI metric: 1.4e-02
 Al  RI_aug-DZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_6_4_1_1_0_0_0_error_1.4e-02
    12
      1   0   0   1   1
@@ -12184,7 +12184,7 @@ Al  RI_aug-DZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_6_4_1_1_0_0_0_error_1.4e-02
     12   3   3   1   1
       0.5952661157    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 5.4e-03
+# RI basis set for Al (all-electron) relative DI metric: 5.4e-03
 Al  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_6_4_1_1_1_0_0_error_5.4e-03
    13
      1   0   0   1   1
@@ -12214,7 +12214,7 @@ Al  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_6_4_1_1_1_0_0_error_5.4e-03
     13   4   4   1   1
       0.1071744059    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 4.8e-04
+# RI basis set for Al (all-electron) relative DI metric: 4.8e-04
 Al  RI_aug-DZVP-MOLOPT-ae_N_RI_053_s_p_d_f_g_h_i_7_5_3_1_1_0_0_error_4.8e-04
    17
      1   0   0   1   1
@@ -12252,7 +12252,7 @@ Al  RI_aug-DZVP-MOLOPT-ae_N_RI_053_s_p_d_f_g_h_i_7_5_3_1_1_0_0_error_4.8e-04
     17   4   4   1   1
       0.5788995771    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 5.9e-05
+# RI basis set for Al (all-electron) relative DI metric: 5.9e-05
 Al  RI_aug-DZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_7_6_3_1_1_0_0_error_5.9e-05
    18
      1   0   0   1   1
@@ -12292,7 +12292,7 @@ Al  RI_aug-DZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_7_6_3_1_1_0_0_error_5.9e-05
     18   4   4   1   1
       0.6737137230    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 2.9e-05
+# RI basis set for Al (all-electron) relative DI metric: 2.9e-05
 Al  RI_aug-DZVP-MOLOPT-ae_N_RI_091_s_p_d_f_g_h_i_7_6_5_3_1_1_0_error_2.9e-05
    23
      1   0   0   1   1
@@ -12342,7 +12342,7 @@ Al  RI_aug-DZVP-MOLOPT-ae_N_RI_091_s_p_d_f_g_h_i_7_6_5_3_1_1_0_error_2.9e-05
     23   5   5   1   1
       0.4529777996    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 4.0e-02
+# RI basis set for Al (all-electron) relative DI metric: 4.0e-02
 Al  RI_aug-TZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_6_4_1_1_0_0_0_error_4.0e-02
    12
      1   0   0   1   1
@@ -12370,7 +12370,7 @@ Al  RI_aug-TZVP-MOLOPT-ae_N_RI_030_s_p_d_f_g_h_i_6_4_1_1_0_0_0_error_4.0e-02
     12   3   3   1   1
       0.5352041202    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 1.9e-02
+# RI basis set for Al (all-electron) relative DI metric: 1.9e-02
 Al  RI_aug-TZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_7_5_1_1_1_0_0_error_1.9e-02
    15
      1   0   0   1   1
@@ -12404,7 +12404,7 @@ Al  RI_aug-TZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_7_5_1_1_1_0_0_error_1.9e-02
     15   4   4   1   1
       0.2592360415    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 5.5e-03
+# RI basis set for Al (all-electron) relative DI metric: 5.5e-03
 Al  RI_aug-TZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_7_6_3_1_1_0_0_error_5.5e-03
    18
      1   0   0   1   1
@@ -12444,7 +12444,7 @@ Al  RI_aug-TZVP-MOLOPT-ae_N_RI_056_s_p_d_f_g_h_i_7_6_3_1_1_0_0_error_5.5e-03
     18   4   4   1   1
       0.4406243897    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 1.2e-03
+# RI basis set for Al (all-electron) relative DI metric: 1.2e-03
 Al  RI_aug-TZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_7_6_3_3_1_0_0_error_1.2e-03
    20
      1   0   0   1   1
@@ -12488,7 +12488,7 @@ Al  RI_aug-TZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_7_6_3_3_1_0_0_error_1.2e-03
     20   4   4   1   1
       0.2932748019    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 5.6e-04
+# RI basis set for Al (all-electron) relative DI metric: 5.6e-04
 Al  RI_aug-TZVP-MOLOPT-ae_N_RI_088_s_p_d_f_g_h_i_7_6_3_3_3_0_0_error_5.6e-04
    22
      1   0   0   1   1
@@ -12536,7 +12536,7 @@ Al  RI_aug-TZVP-MOLOPT-ae_N_RI_088_s_p_d_f_g_h_i_7_6_3_3_3_0_0_error_5.6e-04
     22   4   4   1   1
       0.8720677539    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 2.1e-04
+# RI basis set for Al (all-electron) relative DI metric: 2.1e-04
 Al  RI_aug-TZVP-MOLOPT-ae_N_RI_103_s_p_d_f_g_h_i_7_6_6_3_3_0_0_error_2.1e-04
    25
      1   0   0   1   1
@@ -12590,7 +12590,7 @@ Al  RI_aug-TZVP-MOLOPT-ae_N_RI_103_s_p_d_f_g_h_i_7_6_6_3_3_0_0_error_2.1e-04
     25   4   4   1   1
       1.0675377716    1.0000000000
 
-# RI basis set for Al (all-electron) relative accuracy of RI-MP2: 9.4e-05
+# RI basis set for Al (all-electron) relative DI metric: 9.4e-05
 Al  RI_aug-TZVP-MOLOPT-ae_N_RI_117_s_p_d_f_g_h_i_7_6_6_5_3_0_0_error_9.4e-05
    27
      1   0   0   1   1
@@ -12648,7 +12648,7 @@ Al  RI_aug-TZVP-MOLOPT-ae_N_RI_117_s_p_d_f_g_h_i_7_6_6_5_3_0_0_error_9.4e-05
     27   4   4   1   1
       1.0466606305    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 3.9e-02
+# RI basis set for Si (all-electron) relative DI metric: 3.9e-02
 Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_3.9e-02
    5
      1   0   0   1   1
@@ -12662,7 +12662,7 @@ Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_009_s_p_d_f_g_h_i_3_2_0_0_0_0_0_error_3.9e-02
      5   1   1   1   1
       0.4922516821    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 2.4e-03
+# RI basis set for Si (all-electron) relative DI metric: 2.4e-03
 Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_2.4e-03
    6
      1   0   0   1   1
@@ -12678,7 +12678,7 @@ Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_2.4e-03
      6   2   2   1   1
       0.3865257808    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 7.4e-05
+# RI basis set for Si (all-electron) relative DI metric: 7.4e-05
 Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_020_s_p_d_f_g_h_i_4_2_2_0_0_0_0_error_7.4e-05
    8
      1   0   0   1   1
@@ -12698,7 +12698,7 @@ Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_020_s_p_d_f_g_h_i_4_2_2_0_0_0_0_error_7.4e-05
      8   2   2   1   1
       0.6536273161    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 5.7e-07
+# RI basis set for Si (all-electron) relative DI metric: 5.7e-07
 Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_021_s_p_d_f_g_h_i_5_2_2_0_0_0_0_error_5.7e-07
    9
      1   0   0   1   1
@@ -12720,7 +12720,7 @@ Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_021_s_p_d_f_g_h_i_5_2_2_0_0_0_0_error_5.7e-07
      9   2   2   1   1
       0.5718799572    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 2.5e-07
+# RI basis set for Si (all-electron) relative DI metric: 2.5e-07
 Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_033_s_p_d_f_g_h_i_6_4_3_0_0_0_0_error_2.5e-07
    13
      1   0   0   1   1
@@ -12750,7 +12750,7 @@ Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_033_s_p_d_f_g_h_i_6_4_3_0_0_0_0_error_2.5e-07
     13   2   2   1   1
       2.4473404638    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 4.8e-08
+# RI basis set for Si (all-electron) relative DI metric: 4.8e-08
 Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_039_s_p_d_f_g_h_i_7_4_4_0_0_0_0_error_4.8e-08
    15
      1   0   0   1   1
@@ -12784,7 +12784,7 @@ Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_039_s_p_d_f_g_h_i_7_4_4_0_0_0_0_error_4.8e-08
     15   2   2   1   1
       2.4645683333    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 7.9e-09
+# RI basis set for Si (all-electron) relative DI metric: 7.9e-09
 Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_7.9e-09
    16
      1   0   0   1   1
@@ -12820,7 +12820,7 @@ Si  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_7.9e-09
     16   2   2   1   1
       2.4645683333    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 2.7e-02
+# RI basis set for Si (all-electron) relative DI metric: 2.7e-02
 Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_2.7e-02
    9
      1   0   0   1   1
@@ -12842,7 +12842,7 @@ Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_019_s_p_d_f_g_h_i_5_3_1_0_0_0_0_error_2.7e-02
      9   2   2   1   1
       0.4824179975    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 1.1e-03
+# RI basis set for Si (all-electron) relative DI metric: 1.1e-03
 Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_034_s_p_d_f_g_h_i_7_5_1_1_0_0_0_error_1.1e-03
    14
      1   0   0   1   1
@@ -12874,7 +12874,7 @@ Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_034_s_p_d_f_g_h_i_7_5_1_1_0_0_0_error_1.1e-03
     14   3   3   1   1
       0.3342848887    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 1.0e-04
+# RI basis set for Si (all-electron) relative DI metric: 1.0e-04
 Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_053_s_p_d_f_g_h_i_7_5_3_1_1_0_0_error_1.0e-04
    17
      1   0   0   1   1
@@ -12912,7 +12912,7 @@ Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_053_s_p_d_f_g_h_i_7_5_3_1_1_0_0_error_1.0e-04
     17   4   4   1   1
       0.9877232823    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 6.2e-06
+# RI basis set for Si (all-electron) relative DI metric: 6.2e-06
 Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_069_s_p_d_f_g_h_i_7_5_4_1_1_1_0_error_6.2e-06
    19
      1   0   0   1   1
@@ -12954,7 +12954,7 @@ Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_069_s_p_d_f_g_h_i_7_5_4_1_1_1_0_error_6.2e-06
     19   5   5   1   1
       1.5446348872    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 9.6e-07
+# RI basis set for Si (all-electron) relative DI metric: 9.6e-07
 Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_105_s_p_d_f_g_h_i_7_5_4_3_2_1_1_error_9.6e-07
    23
      1   0   0   1   1
@@ -13004,7 +13004,7 @@ Si  RI_aug-SZV-MOLOPT-ae-SR_N_RI_105_s_p_d_f_g_h_i_7_5_4_3_2_1_1_error_9.6e-07
     23   6   6   1   1
       0.7609785222    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 1.3e-02
+# RI basis set for Si (all-electron) relative DI metric: 1.3e-02
 Si  RI_aug-SZV-MOLOPT-ae_N_RI_021_s_p_d_f_g_h_i_7_3_1_0_0_0_0_error_1.3e-02
    11
      1   0   0   1   1
@@ -13030,7 +13030,7 @@ Si  RI_aug-SZV-MOLOPT-ae_N_RI_021_s_p_d_f_g_h_i_7_3_1_0_0_0_0_error_1.3e-02
     11   2   2   1   1
       0.4401352998    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 5.1e-03
+# RI basis set for Si (all-electron) relative DI metric: 5.1e-03
 Si  RI_aug-SZV-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_5.1e-03
    15
      1   0   0   1   1
@@ -13064,7 +13064,7 @@ Si  RI_aug-SZV-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_5.1e-03
     15   3   3   1   1
       0.8119225063    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 5.1e-04
+# RI basis set for Si (all-electron) relative DI metric: 5.1e-04
 Si  RI_aug-SZV-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_5.1e-04
    16
      1   0   0   1   1
@@ -13100,7 +13100,7 @@ Si  RI_aug-SZV-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_5.1e-04
     16   3   3   1   1
       0.4383282583    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 1.8e-04
+# RI basis set for Si (all-electron) relative DI metric: 1.8e-04
 Si  RI_aug-SZV-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_7_5_3_2_0_0_0_error_1.8e-04
    17
      1   0   0   1   1
@@ -13138,7 +13138,7 @@ Si  RI_aug-SZV-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_7_5_3_2_0_0_0_error_1.8e-04
     17   3   3   1   1
       4.1567115861    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 7.9e-05
+# RI basis set for Si (all-electron) relative DI metric: 7.9e-05
 Si  RI_aug-SZV-MOLOPT-ae_N_RI_081_s_p_d_f_g_h_i_7_6_3_3_1_1_0_error_7.9e-05
    21
      1   0   0   1   1
@@ -13184,7 +13184,7 @@ Si  RI_aug-SZV-MOLOPT-ae_N_RI_081_s_p_d_f_g_h_i_7_6_3_3_1_1_0_error_7.9e-05
     21   5   5   1   1
       0.8432105206    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 5.0e-03
+# RI basis set for Si (all-electron) relative DI metric: 5.0e-03
 Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_5.0e-03
    15
      1   0   0   1   1
@@ -13218,7 +13218,7 @@ Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_5.0e-03
     15   3   3   1   1
       0.5302519482    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 1.1e-04
+# RI basis set for Si (all-electron) relative DI metric: 1.1e-04
 Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_065_s_p_d_f_g_h_i_7_5_4_2_1_0_0_error_1.1e-04
    19
      1   0   0   1   1
@@ -13260,7 +13260,7 @@ Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_065_s_p_d_f_g_h_i_7_5_4_2_1_0_0_error_1.1e-04
     19   4   4   1   1
       0.4041851474    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 4.5e-05
+# RI basis set for Si (all-electron) relative DI metric: 4.5e-05
 Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_4.5e-05
    20
      1   0   0   1   1
@@ -13304,7 +13304,7 @@ Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_4.5e-05
     20   4   4   1   1
       0.3489091707    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 1.8e-05
+# RI basis set for Si (all-electron) relative DI metric: 1.8e-05
 Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_080_s_p_d_f_g_h_i_7_6_5_3_1_0_0_error_1.8e-05
    22
      1   0   0   1   1
@@ -13352,7 +13352,7 @@ Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_080_s_p_d_f_g_h_i_7_6_5_3_1_0_0_error_1.8e-05
     22   4   4   1   1
       0.3219403731    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 8.8e-06
+# RI basis set for Si (all-electron) relative DI metric: 8.8e-06
 Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_094_s_p_d_f_g_h_i_7_6_5_5_1_0_0_error_8.8e-06
    24
      1   0   0   1   1
@@ -13404,7 +13404,7 @@ Si  RI_aug-DZVP-MOLOPT-ae-SR_N_RI_094_s_p_d_f_g_h_i_7_6_5_5_1_0_0_error_8.8e-06
     24   4   4   1   1
       0.3257400060    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 7.3e-03
+# RI basis set for Si (all-electron) relative DI metric: 7.3e-03
 Si  RI_aug-DZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_7.3e-03
    15
      1   0   0   1   1
@@ -13438,7 +13438,7 @@ Si  RI_aug-DZVP-MOLOPT-ae_N_RI_043_s_p_d_f_g_h_i_6_5_3_1_0_0_0_error_7.3e-03
     15   3   3   1   1
       0.5175002308    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 2.3e-03
+# RI basis set for Si (all-electron) relative DI metric: 2.3e-03
 Si  RI_aug-DZVP-MOLOPT-ae_N_RI_057_s_p_d_f_g_h_i_6_5_3_3_0_0_0_error_2.3e-03
    17
      1   0   0   1   1
@@ -13476,7 +13476,7 @@ Si  RI_aug-DZVP-MOLOPT-ae_N_RI_057_s_p_d_f_g_h_i_6_5_3_3_0_0_0_error_2.3e-03
     17   3   3   1   1
       4.3238280850    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 9.3e-04
+# RI basis set for Si (all-electron) relative DI metric: 9.3e-04
 Si  RI_aug-DZVP-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_6_5_3_3_1_0_0_error_9.3e-04
    18
      1   0   0   1   1
@@ -13516,7 +13516,7 @@ Si  RI_aug-DZVP-MOLOPT-ae_N_RI_066_s_p_d_f_g_h_i_6_5_3_3_1_0_0_error_9.3e-04
     18   4   4   1   1
       0.7358443877    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 9.4e-05
+# RI basis set for Si (all-electron) relative DI metric: 9.4e-05
 Si  RI_aug-DZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_7_6_3_3_1_0_0_error_9.4e-05
    20
      1   0   0   1   1
@@ -13560,7 +13560,7 @@ Si  RI_aug-DZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_7_6_3_3_1_0_0_error_9.4e-05
     20   4   4   1   1
       0.3067086688    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 4.1e-05
+# RI basis set for Si (all-electron) relative DI metric: 4.1e-05
 Si  RI_aug-DZVP-MOLOPT-ae_N_RI_080_s_p_d_f_g_h_i_7_6_5_3_1_0_0_error_4.1e-05
    22
      1   0   0   1   1
@@ -13608,7 +13608,7 @@ Si  RI_aug-DZVP-MOLOPT-ae_N_RI_080_s_p_d_f_g_h_i_7_6_5_3_1_0_0_error_4.1e-05
     22   4   4   1   1
       0.2904248227    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 7.3e-06
+# RI basis set for Si (all-electron) relative DI metric: 7.3e-06
 Si  RI_aug-DZVP-MOLOPT-ae_N_RI_115_s_p_d_f_g_h_i_7_6_6_6_2_0_0_error_7.3e-06
    27
      1   0   0   1   1
@@ -13666,7 +13666,7 @@ Si  RI_aug-DZVP-MOLOPT-ae_N_RI_115_s_p_d_f_g_h_i_7_6_6_6_2_0_0_error_7.3e-06
     27   4   4   1   1
       0.3847349515    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 6.1e-03
+# RI basis set for Si (all-electron) relative DI metric: 6.1e-03
 Si  RI_aug-TZVP-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_6.1e-03
    16
      1   0   0   1   1
@@ -13702,7 +13702,7 @@ Si  RI_aug-TZVP-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_7_5_3_1_0_0_0_error_6.1e-03
     16   3   3   1   1
       0.4771794519    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 2.2e-03
+# RI basis set for Si (all-electron) relative DI metric: 2.2e-03
 Si  RI_aug-TZVP-MOLOPT-ae_N_RI_061_s_p_d_f_g_h_i_7_6_3_3_0_0_0_error_2.2e-03
    19
      1   0   0   1   1
@@ -13744,7 +13744,7 @@ Si  RI_aug-TZVP-MOLOPT-ae_N_RI_061_s_p_d_f_g_h_i_7_6_3_3_0_0_0_error_2.2e-03
     19   3   3   1   1
       2.3399734109    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 1.0e-03
+# RI basis set for Si (all-electron) relative DI metric: 1.0e-03
 Si  RI_aug-TZVP-MOLOPT-ae_N_RI_081_s_p_d_f_g_h_i_7_6_3_3_1_1_0_error_1.0e-03
    21
      1   0   0   1   1
@@ -13790,7 +13790,7 @@ Si  RI_aug-TZVP-MOLOPT-ae_N_RI_081_s_p_d_f_g_h_i_7_6_3_3_1_1_0_error_1.0e-03
     21   5   5   1   1
       0.7274774545    1.0000000000
 
-# RI basis set for Si (all-electron) relative accuracy of RI-MP2: 3.1e-04
+# RI basis set for Si (all-electron) relative DI metric: 3.1e-04
 Si  RI_aug-TZVP-MOLOPT-ae_N_RI_104_s_p_d_f_g_h_i_7_6_4_3_3_1_0_error_3.1e-04
    24
      1   0   0   1   1
@@ -13842,7 +13842,7 @@ Si  RI_aug-TZVP-MOLOPT-ae_N_RI_104_s_p_d_f_g_h_i_7_6_4_3_3_1_0_error_3.1e-04
     24   5   5   1   1
       0.6001819968    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 3.5e-02
+# RI basis set for P (all-electron) relative DI metric: 3.5e-02
 P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_3.5e-02
    4
      1   0   0   1   1
@@ -13854,7 +13854,7 @@ P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_006_s_p_d_f_g_h_i_3_1_0_0_0_0_0_error_3.5e-02
      4   1   1   1   1
       0.6333235789    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 1.7e-03
+# RI basis set for P (all-electron) relative DI metric: 1.7e-03
 P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_010_s_p_d_f_g_h_i_4_2_0_0_0_0_0_error_1.7e-03
    6
      1   0   0   1   1
@@ -13870,7 +13870,7 @@ P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_010_s_p_d_f_g_h_i_4_2_0_0_0_0_0_error_1.7e-03
      6   1   1   1   1
       0.4890657101    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 1.5e-05
+# RI basis set for P (all-electron) relative DI metric: 1.5e-05
 P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_015_s_p_d_f_g_h_i_4_2_1_0_0_0_0_error_1.5e-05
    7
      1   0   0   1   1
@@ -13888,7 +13888,7 @@ P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_015_s_p_d_f_g_h_i_4_2_1_0_0_0_0_error_1.5e-05
      7   2   2   1   1
       1.6246175929    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 1.6e-06
+# RI basis set for P (all-electron) relative DI metric: 1.6e-06
 P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_1.6e-06
    8
      1   0   0   1   1
@@ -13908,7 +13908,7 @@ P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_1.6e-06
      8   2   2   1   1
       1.0780338463    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 4.6e-07
+# RI basis set for P (all-electron) relative DI metric: 4.6e-07
 P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_029_s_p_d_f_g_h_i_5_3_3_0_0_0_0_error_4.6e-07
    11
      1   0   0   1   1
@@ -13934,7 +13934,7 @@ P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_029_s_p_d_f_g_h_i_5_3_3_0_0_0_0_error_4.6e-07
     11   2   2   1   1
       2.9046195532    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 4.1e-08
+# RI basis set for P (all-electron) relative DI metric: 4.1e-08
 P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_036_s_p_d_f_g_h_i_6_5_3_0_0_0_0_error_4.1e-08
    14
      1   0   0   1   1
@@ -13966,7 +13966,7 @@ P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_036_s_p_d_f_g_h_i_6_5_3_0_0_0_0_error_4.1e-08
     14   2   2   1   1
       2.9051716666    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 1.4e-08
+# RI basis set for P (all-electron) relative DI metric: 1.4e-08
 P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_1.4e-08
    16
      1   0   0   1   1
@@ -14002,7 +14002,7 @@ P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_1.4e-08
     16   2   2   1   1
       2.9051716667    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 2.5e-09
+# RI basis set for P (all-electron) relative DI metric: 2.5e-09
 P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_045_s_p_d_f_g_h_i_7_6_4_0_0_0_0_error_2.5e-09
    17
      1   0   0   1   1
@@ -14040,7 +14040,7 @@ P  RI_aug-SZV-MOLOPT-ae-mini_N_RI_045_s_p_d_f_g_h_i_7_6_4_0_0_0_0_error_2.5e-09
     17   2   2   1   1
       2.9051716667    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 1.1e-02
+# RI basis set for P (all-electron) relative DI metric: 1.1e-02
 P  RI_aug-SZV-MOLOPT-ae_N_RI_022_s_p_d_f_g_h_i_7_1_1_1_0_0_0_error_1.1e-02
    10
      1   0   0   1   1
@@ -14064,7 +14064,7 @@ P  RI_aug-SZV-MOLOPT-ae_N_RI_022_s_p_d_f_g_h_i_7_1_1_1_0_0_0_error_1.1e-02
     10   3   3   1   1
       1.2789537381    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 5.4e-04
+# RI basis set for P (all-electron) relative DI metric: 5.4e-04
 P  RI_aug-SZV-MOLOPT-ae_N_RI_037_s_p_d_f_g_h_i_7_6_1_1_0_0_0_error_5.4e-04
    15
      1   0   0   1   1
@@ -14098,7 +14098,7 @@ P  RI_aug-SZV-MOLOPT-ae_N_RI_037_s_p_d_f_g_h_i_7_6_1_1_0_0_0_error_5.4e-04
     15   3   3   1   1
       0.5399090909    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 2.2e-04
+# RI basis set for P (all-electron) relative DI metric: 2.2e-04
 P  RI_aug-SZV-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_7_6_2_1_1_0_0_error_2.2e-04
    17
      1   0   0   1   1
@@ -14136,7 +14136,7 @@ P  RI_aug-SZV-MOLOPT-ae_N_RI_051_s_p_d_f_g_h_i_7_6_2_1_1_0_0_error_2.2e-04
     17   4   4   1   1
       1.7206756859    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 6.8e-05
+# RI basis set for P (all-electron) relative DI metric: 6.8e-05
 P  RI_aug-SZV-MOLOPT-ae_N_RI_067_s_p_d_f_g_h_i_7_6_3_1_1_1_0_error_6.8e-05
    19
      1   0   0   1   1
@@ -14178,7 +14178,7 @@ P  RI_aug-SZV-MOLOPT-ae_N_RI_067_s_p_d_f_g_h_i_7_6_3_1_1_1_0_error_6.8e-05
     19   5   5   1   1
       0.8078459226    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 2.7e-05
+# RI basis set for P (all-electron) relative DI metric: 2.7e-05
 P  RI_aug-SZV-MOLOPT-ae_N_RI_079_s_p_d_f_g_h_i_7_6_4_2_1_1_0_error_2.7e-05
    21
      1   0   0   1   1
@@ -14224,7 +14224,7 @@ P  RI_aug-SZV-MOLOPT-ae_N_RI_079_s_p_d_f_g_h_i_7_6_4_2_1_1_0_error_2.7e-05
     21   5   5   1   1
       1.3418205458    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 5.9e-06
+# RI basis set for P (all-electron) relative DI metric: 5.9e-06
 P  RI_aug-SZV-MOLOPT-ae_N_RI_091_s_p_d_f_g_h_i_7_6_5_3_1_1_0_error_5.9e-06
    23
      1   0   0   1   1
@@ -14274,7 +14274,7 @@ P  RI_aug-SZV-MOLOPT-ae_N_RI_091_s_p_d_f_g_h_i_7_6_5_3_1_1_0_error_5.9e-06
     23   5   5   1   1
       1.1074917370    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 4.5e-02
+# RI basis set for P (all-electron) relative DI metric: 4.5e-02
 P  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_3_1_1_1_0_0_0_error_4.5e-02
    6
      1   0   0   1   1
@@ -14290,7 +14290,7 @@ P  RI_aug-DZVP-MOLOPT-ae_N_RI_018_s_p_d_f_g_h_i_3_1_1_1_0_0_0_error_4.5e-02
      6   3   3   1   1
       0.7614069144    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 1.5e-02
+# RI basis set for P (all-electron) relative DI metric: 1.5e-02
 P  RI_aug-DZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_1.5e-02
    11
      1   0   0   1   1
@@ -14316,7 +14316,7 @@ P  RI_aug-DZVP-MOLOPT-ae_N_RI_029_s_p_d_f_g_h_i_5_4_1_1_0_0_0_error_1.5e-02
     11   3   3   1   1
       0.7459846397    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 5.3e-03
+# RI basis set for P (all-electron) relative DI metric: 5.3e-03
 P  RI_aug-DZVP-MOLOPT-ae_N_RI_050_s_p_d_f_g_h_i_6_5_3_2_0_0_0_error_5.3e-03
    16
      1   0   0   1   1
@@ -14352,7 +14352,7 @@ P  RI_aug-DZVP-MOLOPT-ae_N_RI_050_s_p_d_f_g_h_i_6_5_3_2_0_0_0_error_5.3e-03
     16   3   3   1   1
       4.0410788412    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 1.2e-03
+# RI basis set for P (all-electron) relative DI metric: 1.2e-03
 P  RI_aug-DZVP-MOLOPT-ae_N_RI_064_s_p_d_f_g_h_i_6_5_4_2_1_0_0_error_1.2e-03
    18
      1   0   0   1   1
@@ -14392,7 +14392,7 @@ P  RI_aug-DZVP-MOLOPT-ae_N_RI_064_s_p_d_f_g_h_i_6_5_4_2_1_0_0_error_1.2e-03
     18   4   4   1   1
       0.7921155406    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 5.5e-04
+# RI basis set for P (all-electron) relative DI metric: 5.5e-04
 P  RI_aug-DZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_5.5e-04
    20
      1   0   0   1   1
@@ -14436,7 +14436,7 @@ P  RI_aug-DZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_5.5e-04
     20   4   4   1   1
       0.5343303195    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 1.2e-04
+# RI basis set for P (all-electron) relative DI metric: 1.2e-04
 P  RI_aug-DZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_6_4_3_1_0_0_error_1.2e-04
    21
      1   0   0   1   1
@@ -14482,7 +14482,7 @@ P  RI_aug-DZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_6_4_3_1_0_0_error_1.2e-04
     21   4   4   1   1
       0.6369322866    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 5.3e-05
+# RI basis set for P (all-electron) relative DI metric: 5.3e-05
 P  RI_aug-DZVP-MOLOPT-ae_N_RI_095_s_p_d_f_g_h_i_7_6_4_3_2_1_0_error_5.3e-05
    23
      1   0   0   1   1
@@ -14532,7 +14532,7 @@ P  RI_aug-DZVP-MOLOPT-ae_N_RI_095_s_p_d_f_g_h_i_7_6_4_3_2_1_0_error_5.3e-05
     23   5   5   1   1
       1.0634773833    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 2.4e-05
+# RI basis set for P (all-electron) relative DI metric: 2.4e-05
 P  RI_aug-DZVP-MOLOPT-ae_N_RI_105_s_p_d_f_g_h_i_7_6_6_3_2_1_0_error_2.4e-05
    25
      1   0   0   1   1
@@ -14586,7 +14586,7 @@ P  RI_aug-DZVP-MOLOPT-ae_N_RI_105_s_p_d_f_g_h_i_7_6_6_3_2_1_0_error_2.4e-05
     25   5   5   1   1
       0.1921287791    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 2.0e-02
+# RI basis set for P (all-electron) relative DI metric: 2.0e-02
 P  RI_aug-TZVP-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_5_4_2_1_0_0_0_error_2.0e-02
    12
      1   0   0   1   1
@@ -14614,7 +14614,7 @@ P  RI_aug-TZVP-MOLOPT-ae_N_RI_034_s_p_d_f_g_h_i_5_4_2_1_0_0_0_error_2.0e-02
     12   3   3   1   1
       0.8459724215    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 7.8e-03
+# RI basis set for P (all-electron) relative DI metric: 7.8e-03
 P  RI_aug-TZVP-MOLOPT-ae_N_RI_055_s_p_d_f_g_h_i_7_4_4_1_1_0_0_error_7.8e-03
    17
      1   0   0   1   1
@@ -14652,7 +14652,7 @@ P  RI_aug-TZVP-MOLOPT-ae_N_RI_055_s_p_d_f_g_h_i_7_4_4_1_1_0_0_error_7.8e-03
     17   4   4   1   1
       0.7964839133    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 3.7e-03
+# RI basis set for P (all-electron) relative DI metric: 3.7e-03
 P  RI_aug-TZVP-MOLOPT-ae_N_RI_061_s_p_d_f_g_h_i_7_6_4_1_1_0_0_error_3.7e-03
    19
      1   0   0   1   1
@@ -14694,7 +14694,7 @@ P  RI_aug-TZVP-MOLOPT-ae_N_RI_061_s_p_d_f_g_h_i_7_6_4_1_1_0_0_error_3.7e-03
     19   4   4   1   1
       0.5225410505    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 1.5e-03
+# RI basis set for P (all-electron) relative DI metric: 1.5e-03
 P  RI_aug-TZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_6_4_3_1_0_0_error_1.5e-03
    21
      1   0   0   1   1
@@ -14740,7 +14740,7 @@ P  RI_aug-TZVP-MOLOPT-ae_N_RI_075_s_p_d_f_g_h_i_7_6_4_3_1_0_0_error_1.5e-03
     21   4   4   1   1
       0.7145775777    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 6.9e-04
+# RI basis set for P (all-electron) relative DI metric: 6.9e-04
 P  RI_aug-TZVP-MOLOPT-ae_N_RI_086_s_p_d_f_g_h_i_7_6_4_3_1_1_0_error_6.9e-04
    22
      1   0   0   1   1
@@ -14788,7 +14788,7 @@ P  RI_aug-TZVP-MOLOPT-ae_N_RI_086_s_p_d_f_g_h_i_7_6_4_3_1_1_0_error_6.9e-04
     22   5   5   1   1
       0.7900005992    1.0000000000
 
-# RI basis set for P (all-electron) relative accuracy of RI-MP2: 3.3e-04
+# RI basis set for P (all-electron) relative DI metric: 3.3e-04
 P  RI_aug-TZVP-MOLOPT-ae_N_RI_111_s_p_d_f_g_h_i_7_6_4_4_3_1_0_error_3.3e-04
    25
      1   0   0   1   1
@@ -14842,7 +14842,7 @@ P  RI_aug-TZVP-MOLOPT-ae_N_RI_111_s_p_d_f_g_h_i_7_6_4_4_3_1_0_error_3.3e-04
     25   5   5   1   1
       0.3576840752    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 3.1e-02
+# RI basis set for S (all-electron) relative DI metric: 3.1e-02
 S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_013_s_p_d_f_g_h_i_4_3_0_0_0_0_0_error_3.1e-02
    7
      1   0   0   1   1
@@ -14860,7 +14860,7 @@ S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_013_s_p_d_f_g_h_i_4_3_0_0_0_0_0_error_3.1e-02
      7   1   1   1   1
       2.1455282027    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 4.3e-03
+# RI basis set for S (all-electron) relative DI metric: 4.3e-03
 S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_4.3e-03
    8
      1   0   0   1   1
@@ -14880,7 +14880,7 @@ S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_018_s_p_d_f_g_h_i_4_3_1_0_0_0_0_error_4.3e-03
      8   2   2   1   1
       1.8558999609    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 3.2e-06
+# RI basis set for S (all-electron) relative DI metric: 3.2e-06
 S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_024_s_p_d_f_g_h_i_5_3_2_0_0_0_0_error_3.2e-06
    10
      1   0   0   1   1
@@ -14904,7 +14904,7 @@ S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_024_s_p_d_f_g_h_i_5_3_2_0_0_0_0_error_3.2e-06
     10   2   2   1   1
       0.9718065294    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 1.6e-06
+# RI basis set for S (all-electron) relative DI metric: 1.6e-06
 S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_031_s_p_d_f_g_h_i_7_3_3_0_0_0_0_error_1.6e-06
    13
      1   0   0   1   1
@@ -14934,7 +14934,7 @@ S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_031_s_p_d_f_g_h_i_7_3_3_0_0_0_0_error_1.6e-06
     13   2   2   1   1
       3.3587056559    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 1.5e-07
+# RI basis set for S (all-electron) relative DI metric: 1.5e-07
 S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_037_s_p_d_f_g_h_i_7_5_3_0_0_0_0_error_1.5e-07
    15
      1   0   0   1   1
@@ -14968,7 +14968,7 @@ S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_037_s_p_d_f_g_h_i_7_5_3_0_0_0_0_error_1.5e-07
     15   2   2   1   1
       3.3819900000    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 5.1e-08
+# RI basis set for S (all-electron) relative DI metric: 5.1e-08
 S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_5.1e-08
    16
      1   0   0   1   1
@@ -15004,7 +15004,7 @@ S  RI_aug-SZV-MOLOPT-ae-mini_N_RI_042_s_p_d_f_g_h_i_7_5_4_0_0_0_0_error_5.1e-08
     16   2   2   1   1
       3.3819899997    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 1.5e-02
+# RI basis set for S (all-electron) relative DI metric: 1.5e-02
 S  RI_aug-SZV-MOLOPT-ae_N_RI_021_s_p_d_f_g_h_i_6_1_1_1_0_0_0_error_1.5e-02
    9
      1   0   0   1   1
@@ -15026,7 +15026,7 @@ S  RI_aug-SZV-MOLOPT-ae_N_RI_021_s_p_d_f_g_h_i_6_1_1_1_0_0_0_error_1.5e-02
      9   3   3   1   1
       0.4410414853    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 2.6e-03
+# RI basis set for S (all-electron) relative DI metric: 2.6e-03
 S  RI_aug-SZV-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_7_4_1_1_0_0_0_error_2.6e-03
    13
      1   0   0   1   1
@@ -15056,7 +15056,7 @@ S  RI_aug-SZV-MOLOPT-ae_N_RI_031_s_p_d_f_g_h_i_7_4_1_1_0_0_0_error_2.6e-03
     13   3   3   1   1
       0.7022586239    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 8.0e-04
+# RI basis set for S (all-electron) relative DI metric: 8.0e-04
 S  RI_aug-SZV-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_8.0e-04
    15
      1   0   0   1   1
@@ -15090,7 +15090,7 @@ S  RI_aug-SZV-MOLOPT-ae_N_RI_041_s_p_d_f_g_h_i_7_4_3_1_0_0_0_error_8.0e-04
     15   3   3   1   1
       0.6832682757    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 1.9e-04
+# RI basis set for S (all-electron) relative DI metric: 1.9e-04
 S  RI_aug-SZV-MOLOPT-ae_N_RI_072_s_p_d_f_g_h_i_7_6_3_2_2_0_0_error_1.9e-04
    20
      1   0   0   1   1
@@ -15134,7 +15134,7 @@ S  RI_aug-SZV-MOLOPT-ae_N_RI_072_s_p_d_f_g_h_i_7_6_3_2_2_0_0_error_1.9e-04
     20   4   4   1   1
       1.4474892985    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 1.2e-02
+# RI basis set for S (all-electron) relative DI metric: 1.2e-02
 S  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_5_4_3_1_0_0_0_error_1.2e-02
    13
      1   0   0   1   1
@@ -15164,7 +15164,7 @@ S  RI_aug-DZVP-MOLOPT-ae_N_RI_039_s_p_d_f_g_h_i_5_4_3_1_0_0_0_error_1.2e-02
     13   3   3   1   1
       0.8570773350    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 5.2e-03
+# RI basis set for S (all-electron) relative DI metric: 5.2e-03
 S  RI_aug-DZVP-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_7_4_3_2_0_0_0_error_5.2e-03
    16
      1   0   0   1   1
@@ -15200,7 +15200,7 @@ S  RI_aug-DZVP-MOLOPT-ae_N_RI_048_s_p_d_f_g_h_i_7_4_3_2_0_0_0_error_5.2e-03
     16   3   3   1   1
       0.8676881869    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 2.1e-03
+# RI basis set for S (all-electron) relative DI metric: 2.1e-03
 S  RI_aug-DZVP-MOLOPT-ae_N_RI_065_s_p_d_f_g_h_i_7_5_4_2_1_0_0_error_2.1e-03
    19
      1   0   0   1   1
@@ -15242,7 +15242,7 @@ S  RI_aug-DZVP-MOLOPT-ae_N_RI_065_s_p_d_f_g_h_i_7_5_4_2_1_0_0_error_2.1e-03
     19   4   4   1   1
       0.7646178679    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 1.8e-04
+# RI basis set for S (all-electron) relative DI metric: 1.8e-04
 S  RI_aug-DZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_7_5_5_2_1_0_0_error_1.8e-04
    20
      1   0   0   1   1
@@ -15286,7 +15286,7 @@ S  RI_aug-DZVP-MOLOPT-ae_N_RI_070_s_p_d_f_g_h_i_7_5_5_2_1_0_0_error_1.8e-04
     20   4   4   1   1
       0.5614499318    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 8.5e-05
+# RI basis set for S (all-electron) relative DI metric: 8.5e-05
 S  RI_aug-DZVP-MOLOPT-ae_N_RI_073_s_p_d_f_g_h_i_7_6_5_2_1_0_0_error_8.5e-05
    21
      1   0   0   1   1
@@ -15332,7 +15332,7 @@ S  RI_aug-DZVP-MOLOPT-ae_N_RI_073_s_p_d_f_g_h_i_7_6_5_2_1_0_0_error_8.5e-05
     21   4   4   1   1
       0.5497230114    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 3.0e-05
+# RI basis set for S (all-electron) relative DI metric: 3.0e-05
 S  RI_aug-DZVP-MOLOPT-ae_N_RI_098_s_p_d_f_g_h_i_7_6_5_3_3_0_0_error_3.0e-05
    24
      1   0   0   1   1
@@ -15384,7 +15384,7 @@ S  RI_aug-DZVP-MOLOPT-ae_N_RI_098_s_p_d_f_g_h_i_7_6_5_3_3_0_0_error_3.0e-05
     24   4   4   1   1
       1.7365900772    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 1.3e-05
+# RI basis set for S (all-electron) relative DI metric: 1.3e-05
 S  RI_aug-DZVP-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_5_5_3_0_0_error_1.3e-05
    26
      1   0   0   1   1
@@ -15440,7 +15440,7 @@ S  RI_aug-DZVP-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_5_5_3_0_0_error_1.3e-05
     26   4   4   1   1
       1.6995491395    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 3.4e-02
+# RI basis set for S (all-electron) relative DI metric: 3.4e-02
 S  RI_aug-TZVP-MOLOPT-ae_N_RI_040_s_p_d_f_g_h_i_6_4_3_1_0_0_0_error_3.4e-02
    14
      1   0   0   1   1
@@ -15472,7 +15472,7 @@ S  RI_aug-TZVP-MOLOPT-ae_N_RI_040_s_p_d_f_g_h_i_6_4_3_1_0_0_0_error_3.4e-02
     14   3   3   1   1
       1.0878420221    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 1.5e-02
+# RI basis set for S (all-electron) relative DI metric: 1.5e-02
 S  RI_aug-TZVP-MOLOPT-ae_N_RI_055_s_p_d_f_g_h_i_7_4_4_1_1_0_0_error_1.5e-02
    17
      1   0   0   1   1
@@ -15510,7 +15510,7 @@ S  RI_aug-TZVP-MOLOPT-ae_N_RI_055_s_p_d_f_g_h_i_7_4_4_1_1_0_0_error_1.5e-02
     17   4   4   1   1
       0.9879880714    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 7.0e-03
+# RI basis set for S (all-electron) relative DI metric: 7.0e-03
 S  RI_aug-TZVP-MOLOPT-ae_N_RI_061_s_p_d_f_g_h_i_7_6_4_1_1_0_0_error_7.0e-03
    19
      1   0   0   1   1
@@ -15552,7 +15552,7 @@ S  RI_aug-TZVP-MOLOPT-ae_N_RI_061_s_p_d_f_g_h_i_7_6_4_1_1_0_0_error_7.0e-03
     19   4   4   1   1
       0.7404516823    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 3.4e-03
+# RI basis set for S (all-electron) relative DI metric: 3.4e-03
 S  RI_aug-TZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_3.4e-03
    20
      1   0   0   1   1
@@ -15596,7 +15596,7 @@ S  RI_aug-TZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_3.4e-03
     20   4   4   1   1
       0.9288692530    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 1.7e-03
+# RI basis set for S (all-electron) relative DI metric: 1.7e-03
 S  RI_aug-TZVP-MOLOPT-ae_N_RI_079_s_p_d_f_g_h_i_7_6_4_2_1_1_0_error_1.7e-03
    21
      1   0   0   1   1
@@ -15642,7 +15642,7 @@ S  RI_aug-TZVP-MOLOPT-ae_N_RI_079_s_p_d_f_g_h_i_7_6_4_2_1_1_0_error_1.7e-03
     21   5   5   1   1
       1.3667021350    1.0000000000
 
-# RI basis set for S (all-electron) relative accuracy of RI-MP2: 4.9e-04
+# RI basis set for S (all-electron) relative DI metric: 4.9e-04
 S  RI_aug-TZVP-MOLOPT-ae_N_RI_107_s_p_d_f_g_h_i_7_6_5_4_2_1_0_error_4.9e-04
    25
      1   0   0   1   1
@@ -15696,7 +15696,7 @@ S  RI_aug-TZVP-MOLOPT-ae_N_RI_107_s_p_d_f_g_h_i_7_6_5_4_2_1_0_error_4.9e-04
     25   5   5   1   1
       0.9858921275    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 2.9e-02
+# RI basis set for Cl (all-electron) relative DI metric: 2.9e-02
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_2.9e-02
    5
      1   0   0   1   1
@@ -15710,7 +15710,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_011_s_p_d_f_g_h_i_3_1_1_0_0_0_0_error_2.9e-02
      5   2   2   1   1
       1.7800077813    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 4.1e-03
+# RI basis set for Cl (all-electron) relative DI metric: 4.1e-03
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_4.1e-03
    6
      1   0   0   1   1
@@ -15726,7 +15726,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_014_s_p_d_f_g_h_i_3_2_1_0_0_0_0_error_4.1e-03
      6   2   2   1   1
       1.8137182743    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 3.1e-04
+# RI basis set for Cl (all-electron) relative DI metric: 3.1e-04
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_019_s_p_d_f_g_h_i_3_2_2_0_0_0_0_error_3.1e-04
    7
      1   0   0   1   1
@@ -15744,7 +15744,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_019_s_p_d_f_g_h_i_3_2_2_0_0_0_0_error_3.1e-04
      7   2   2   1   1
       1.0993237991    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 7.8e-05
+# RI basis set for Cl (all-electron) relative DI metric: 7.8e-05
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_021_s_p_d_f_g_h_i_5_2_2_0_0_0_0_error_7.8e-05
    9
      1   0   0   1   1
@@ -15766,7 +15766,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_021_s_p_d_f_g_h_i_5_2_2_0_0_0_0_error_7.8e-05
      9   2   2   1   1
       1.1337598088    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 1.1e-05
+# RI basis set for Cl (all-electron) relative DI metric: 1.1e-05
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_024_s_p_d_f_g_h_i_5_3_2_0_0_0_0_error_1.1e-05
    10
      1   0   0   1   1
@@ -15790,7 +15790,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_024_s_p_d_f_g_h_i_5_3_2_0_0_0_0_error_1.1e-05
     10   2   2   1   1
       1.0189456200    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 2.1e-06
+# RI basis set for Cl (all-electron) relative DI metric: 2.1e-06
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_2.1e-06
    11
      1   0   0   1   1
@@ -15816,7 +15816,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_025_s_p_d_f_g_h_i_6_3_2_0_0_0_0_error_2.1e-06
     11   2   2   1   1
       1.1367750250    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 9.5e-07
+# RI basis set for Cl (all-electron) relative DI metric: 9.5e-07
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_030_s_p_d_f_g_h_i_6_3_3_0_0_0_0_error_9.5e-07
    12
      1   0   0   1   1
@@ -15844,7 +15844,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_030_s_p_d_f_g_h_i_6_3_3_0_0_0_0_error_9.5e-07
     12   2   2   1   1
       3.3934830750    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 7.1e-08
+# RI basis set for Cl (all-electron) relative DI metric: 7.1e-08
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_046_s_p_d_f_g_h_i_6_5_5_0_0_0_0_error_7.1e-08
    16
      1   0   0   1   1
@@ -15880,7 +15880,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_046_s_p_d_f_g_h_i_6_5_5_0_0_0_0_error_7.1e-08
     16   2   2   1   1
       3.5489766667    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 1.4e-08
+# RI basis set for Cl (all-electron) relative DI metric: 1.4e-08
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_047_s_p_d_f_g_h_i_7_5_5_0_0_0_0_error_1.4e-08
    17
      1   0   0   1   1
@@ -15918,7 +15918,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_047_s_p_d_f_g_h_i_7_5_5_0_0_0_0_error_1.4e-08
     17   2   2   1   1
       3.5489766666    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 6.9e-09
+# RI basis set for Cl (all-electron) relative DI metric: 6.9e-09
 Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_050_s_p_d_f_g_h_i_7_6_5_0_0_0_0_error_6.9e-09
    18
      1   0   0   1   1
@@ -15958,7 +15958,7 @@ Cl  RI_aug-SZV-MOLOPT-ae-mini_N_RI_050_s_p_d_f_g_h_i_7_6_5_0_0_0_0_error_6.9e-09
     18   2   2   1   1
       3.5489766666    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 7.0e-03
+# RI basis set for Cl (all-electron) relative DI metric: 7.0e-03
 Cl  RI_aug-SZV-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_6_3_1_1_0_0_0_error_7.0e-03
    11
      1   0   0   1   1
@@ -15984,7 +15984,7 @@ Cl  RI_aug-SZV-MOLOPT-ae_N_RI_027_s_p_d_f_g_h_i_6_3_1_1_0_0_0_error_7.0e-03
     11   3   3   1   1
       0.7501079429    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 1.3e-03
+# RI basis set for Cl (all-electron) relative DI metric: 1.3e-03
 Cl  RI_aug-SZV-MOLOPT-ae_N_RI_042_s_p_d_f_g_h_i_6_5_1_1_1_0_0_error_1.3e-03
    14
      1   0   0   1   1
@@ -16016,7 +16016,7 @@ Cl  RI_aug-SZV-MOLOPT-ae_N_RI_042_s_p_d_f_g_h_i_6_5_1_1_1_0_0_error_1.3e-03
     14   4   4   1   1
       0.3298038429    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 3.4e-04
+# RI basis set for Cl (all-electron) relative DI metric: 3.4e-04
 Cl  RI_aug-SZV-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_6_5_2_2_2_0_0_error_3.4e-04
    17
      1   0   0   1   1
@@ -16054,7 +16054,7 @@ Cl  RI_aug-SZV-MOLOPT-ae_N_RI_063_s_p_d_f_g_h_i_6_5_2_2_2_0_0_error_3.4e-04
     17   4   4   1   1
       2.3311468165    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 1.6e-04
+# RI basis set for Cl (all-electron) relative DI metric: 1.6e-04
 Cl  RI_aug-SZV-MOLOPT-ae_N_RI_079_s_p_d_f_g_h_i_6_5_3_2_2_1_0_error_1.6e-04
    19
      1   0   0   1   1
@@ -16096,7 +16096,7 @@ Cl  RI_aug-SZV-MOLOPT-ae_N_RI_079_s_p_d_f_g_h_i_6_5_3_2_2_1_0_error_1.6e-04
     19   5   5   1   1
       1.2372489257    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 6.4e-05
+# RI basis set for Cl (all-electron) relative DI metric: 6.4e-05
 Cl  RI_aug-SZV-MOLOPT-ae_N_RI_108_s_p_d_f_g_h_i_6_5_3_3_3_1_1_error_6.4e-05
    22
      1   0   0   1   1
@@ -16144,7 +16144,7 @@ Cl  RI_aug-SZV-MOLOPT-ae_N_RI_108_s_p_d_f_g_h_i_6_5_3_3_3_1_1_error_6.4e-05
     22   6   6   1   1
       1.9290113032    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 2.8e-05
+# RI basis set for Cl (all-electron) relative DI metric: 2.8e-05
 Cl  RI_aug-SZV-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_3_3_3_1_1_error_2.8e-05
    24
      1   0   0   1   1
@@ -16196,7 +16196,7 @@ Cl  RI_aug-SZV-MOLOPT-ae_N_RI_112_s_p_d_f_g_h_i_7_6_3_3_3_1_1_error_2.8e-05
     24   6   6   1   1
       1.9242475757    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 1.8e-02
+# RI basis set for Cl (all-electron) relative DI metric: 1.8e-02
 Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_6_4_2_1_1_0_0_error_1.8e-02
    14
      1   0   0   1   1
@@ -16228,7 +16228,7 @@ Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_044_s_p_d_f_g_h_i_6_4_2_1_1_0_0_error_1.8e-02
     14   4   4   1   1
       0.6243390565    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 2.1e-03
+# RI basis set for Cl (all-electron) relative DI metric: 2.1e-03
 Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_054_s_p_d_f_g_h_i_6_4_4_1_1_0_0_error_2.1e-03
    16
      1   0   0   1   1
@@ -16264,7 +16264,7 @@ Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_054_s_p_d_f_g_h_i_6_4_4_1_1_0_0_error_2.1e-03
     16   4   4   1   1
       1.3484642123    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 4.2e-04
+# RI basis set for Cl (all-electron) relative DI metric: 4.2e-04
 Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_4.2e-04
    20
      1   0   0   1   1
@@ -16308,7 +16308,7 @@ Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_068_s_p_d_f_g_h_i_7_6_4_2_1_0_0_error_4.2e-04
     20   4   4   1   1
       1.2172980904    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 1.3e-04
+# RI basis set for Cl (all-electron) relative DI metric: 1.3e-04
 Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_084_s_p_d_f_g_h_i_7_6_4_3_2_0_0_error_1.3e-04
    22
      1   0   0   1   1
@@ -16356,7 +16356,7 @@ Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_084_s_p_d_f_g_h_i_7_6_4_3_2_0_0_error_1.3e-04
     22   4   4   1   1
       1.6491856286    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 2.6e-05
+# RI basis set for Cl (all-electron) relative DI metric: 2.6e-05
 Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_114_s_p_d_f_g_h_i_7_6_5_4_4_0_0_error_2.6e-05
    26
      1   0   0   1   1
@@ -16412,7 +16412,7 @@ Cl  RI_aug-DZVP-MOLOPT-ae_N_RI_114_s_p_d_f_g_h_i_7_6_5_4_4_0_0_error_2.6e-05
     26   4   4   1   1
       2.1887627489    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 2.5e-02
+# RI basis set for Cl (all-electron) relative DI metric: 2.5e-02
 Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_042_s_p_d_f_g_h_i_6_5_1_1_1_0_0_error_2.5e-02
    14
      1   0   0   1   1
@@ -16444,7 +16444,7 @@ Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_042_s_p_d_f_g_h_i_6_5_1_1_1_0_0_error_2.5e-02
     14   4   4   1   1
       0.6070604168    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 1.1e-02
+# RI basis set for Cl (all-electron) relative DI metric: 1.1e-02
 Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_057_s_p_d_f_g_h_i_6_5_4_1_1_0_0_error_1.1e-02
    17
      1   0   0   1   1
@@ -16482,7 +16482,7 @@ Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_057_s_p_d_f_g_h_i_6_5_4_1_1_0_0_error_1.1e-02
     17   4   4   1   1
       1.1436987628    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 4.9e-03
+# RI basis set for Cl (all-electron) relative DI metric: 4.9e-03
 Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_064_s_p_d_f_g_h_i_6_5_4_2_1_0_0_error_4.9e-03
    18
      1   0   0   1   1
@@ -16522,7 +16522,7 @@ Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_064_s_p_d_f_g_h_i_6_5_4_2_1_0_0_error_4.9e-03
     18   4   4   1   1
       1.0746967009    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 1.9e-03
+# RI basis set for Cl (all-electron) relative DI metric: 1.9e-03
 Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_079_s_p_d_f_g_h_i_7_6_4_2_1_1_0_error_1.9e-03
    21
      1   0   0   1   1
@@ -16568,7 +16568,7 @@ Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_079_s_p_d_f_g_h_i_7_6_4_2_1_1_0_error_1.9e-03
     21   5   5   1   1
       1.9911109456    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 8.6e-04
+# RI basis set for Cl (all-electron) relative DI metric: 8.6e-04
 Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_102_s_p_d_f_g_h_i_7_6_4_4_2_1_0_error_8.6e-04
    24
      1   0   0   1   1
@@ -16620,7 +16620,7 @@ Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_102_s_p_d_f_g_h_i_7_6_4_4_2_1_0_error_8.6e-04
     24   5   5   1   1
       0.8845719378    1.0000000000
 
-# RI basis set for Cl (all-electron) relative accuracy of RI-MP2: 4.3e-04
+# RI basis set for Cl (all-electron) relative DI metric: 4.3e-04
 Cl  RI_aug-TZVP-MOLOPT-ae_N_RI_116_s_p_d_f_g_h_i_7_6_5_4_3_1_0_error_4.3e-04
    26
      1   0   0   1   1


### PR DESCRIPTION
In the newly generated RI basis sets for the newly generated aug-molopt basis set, we report the relative DI metric as a measure of convergence but it was mistakenly identified as the relative RI-MP2 error. This corrects this terminology issue.