### PR TITLE
OpenCL: fixed finding backend if dbcsr is external

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,27 +582,6 @@ elseif(CP2K_USE_ACCEL MATCHES "HIP")
       set(CMAKE_HIP_ARCHITECTURES "gfx942:xnack+")
     endif()
   endif()
-elseif(CP2K_USE_ACCEL MATCHES "OPENCL")
-  find_package(OpenCL REQUIRED)
-
-  # common header files used by OpenCL kernels
-  set(CP2K_OPENCL_COMMON opencl_atomics.h opencl_common.h)
-
-  set(CP2K_OPENCL_TOOLDIR ${DBCSR_DIR}/share/opencl)
-  if(NOT EXISTS ${CP2K_OPENCL_TOOLDIR}/acc_opencl.sh)
-    set(CP2K_OPENCL_TOOLDIR
-        ${CMAKE_CURRENT_SOURCE_DIR}/exts/dbcsr/src/acc/opencl)
-    list(TRANSFORM CP2K_OPENCL_COMMON PREPEND common/)
-  endif()
-
-  if(EXISTS ${CP2K_OPENCL_TOOLDIR}/acc_opencl.sh)
-    list(TRANSFORM CP2K_OPENCL_COMMON PREPEND ${CP2K_OPENCL_TOOLDIR}/)
-    set(CP2K_USE_OPENCL ON)
-  else()
-    message(
-      FATAL_ERROR
-        "OpenCL backend: cannot find tool directory (${CP2K_OPENCL_TOOLDIR})")
-  endif()
 endif()
 
 message("\n------------------------------------------------------------")
@@ -612,9 +591,42 @@ message("------------------------------------------------------------\n")
 # PACKAGE DISCOVERY (compiler configuration can impact package discovery)
 find_package(OpenMP REQUIRED COMPONENTS Fortran C CXX)
 
+message("\n------------------------------------------------------------")
+message("-                          DBCSR                           -")
+message("------------------------------------------------------------\n")
+
 find_package(DBCSR 2.6 REQUIRED)
 
-# ==================================
+# Discover CP2K_OPENCL_BACKEND. DBCSR must be discovered prior (DBCSR_DIR).
+if(CP2K_USE_ACCEL MATCHES "OPENCL")
+  message("\n------------------------------------------------------------")
+  message("-                          OPENCL                          -")
+  message("------------------------------------------------------------\n")
+  find_package(OpenCL REQUIRED)
+
+  set(CP2K_OPENCL_BACKEND "${DBCSR_DIR}/../../../include/acc/opencl")
+  if(NOT EXISTS ${CP2K_OPENCL_BACKEND})
+    get_target_property(CP2K_DBCSR_INCLUDE_DIRS DBCSR::dbcsr
+                        INTERFACE_INCLUDE_DIRECTORIES)
+    list(GET CP2K_DBCSR_INCLUDE_DIRS 0 CP2K_DBCSR_INCLUDE_DIR)
+    set(CP2K_OPENCL_BACKEND "${CP2K_DBCSR_INCLUDE_DIR}/acc/opencl")
+  endif()
+
+  set(CP2K_OPENCL_SCRIPT
+      "${CP2K_OPENCL_BACKEND}/../../../share/opencl/acc_opencl.sh")
+  if(EXISTS ${CP2K_OPENCL_SCRIPT})
+    set(CP2K_OPENCL_COMMON common/opencl_atomics.h common/opencl_common.h)
+    list(TRANSFORM CP2K_OPENCL_COMMON PREPEND ${CP2K_OPENCL_BACKEND}/)
+    set(CP2K_USE_OPENCL ON)
+  else()
+    message(FATAL_ERROR "OpenCL backend not found")
+  endif()
+endif()
+
+message("\n------------------------------------------------------------")
+message("-                    Other dependencies                    -")
+message("------------------------------------------------------------\n")
+
 if(CP2K_USE_ELPA)
   find_package(Elpa REQUIRED)
 endif()
@@ -847,8 +859,7 @@ get_target_property(CP2K_LIBS cp2k_link_libs INTERFACE_LINK_LIBRARIES)
 configure_file(cmake/libcp2k.pc.in libcp2k.pc @ONLY)
 
 message(
-  ""
-  "--------------------------------------------------------------------\n"
+  "\n--------------------------------------------------------------------\n"
   "-                                                                  -\n"
   "-               Summary of enabled dependencies                    -\n"
   "-                                                                  -\n"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1504,16 +1504,16 @@ if(CP2K_USE_CUDA
 
   if(CP2K_ENABLE_DBM_GPU)
     if(CP2K_USE_OPENCL)
-      # DBM-kernel: OpenCL code is packaged into string-literal (include file)
-      add_custom_target(
-        CP2K_DBM_OPENCL_TARGET ALL
+      add_custom_command(
         COMMAND
-          ${CP2K_OPENCL_TOOLDIR}/acc_opencl.sh -b 6 -p \"\"
+          # generate header file with OpenCL code as string-literal
+          ${CP2K_OPENCL_SCRIPT} -b 6 -p \"\"
           ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}
           ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}.h
-        DEPENDS ${CP2K_OPENCL_TOOLDIR}/acc_opencl.sh ${CP2K_OPENCL_COMMON}
+        DEPENDS ${CP2K_OPENCL_SCRIPT} ${CP2K_OPENCL_COMMON}
                 ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}
-        BYPRODUCTS ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}.h)
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}.h
+        COMMENT "Generating OpenCL kernel for DBM")
     endif()
     list(APPEND CP2K_DBM_SRCS_C ${CP2K_DBM_SRCS_GPU_C})
     list(APPEND CP2K_SRCS_GPU ${CP2K_DBM_SRCS_GPU})
@@ -1660,7 +1660,8 @@ elseif(CP2K_USE_ACCEL MATCHES "HIP")
   set_property(TARGET cp2k PROPERTY HIP_ARCHITECTURES
                                     ${CMAKE_HIP_ARCHITECTURES})
 elseif(CP2K_USE_ACCEL MATCHES "OPENCL")
-  include_directories(${CP2K_OPENCL_TOOLDIR})
+  include_directories(${CP2K_OPENCL_BACKEND})
+  include_directories(${OpenCL_INCLUDE_DIR})
 endif()
 
 # mix the target and variables pointing to the include directories.


### PR DESCRIPTION
- Find external DBCSR via CMAKE_PREFIX_PATH or DBCSR_DIR.
- Warning message about legacy tool directory.
- Search DBCSR prior to relying on DBCSR_DIR.
- General: improved output during configure.