### PR TITLE
CMake/OpenCL: fixed dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1514,9 +1514,14 @@ if(CP2K_USE_CUDA
                 ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}
         OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}.h
         COMMENT "Generating OpenCL kernel for DBM")
+      add_custom_target(
+        dbm_multiply_opencl
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}.h)
+      add_dependencies(${CP2K_LIBS} dbm_multiply_opencl)
+      list(APPEND CP2K_DBM_SRCS_C ${CP2K_DBM_SRCS_GPU_C})
+    else()
+      list(APPEND CP2K_SRCS_GPU ${CP2K_DBM_SRCS_GPU})
     endif()
-    list(APPEND CP2K_DBM_SRCS_C ${CP2K_DBM_SRCS_GPU_C})
-    list(APPEND CP2K_SRCS_GPU ${CP2K_DBM_SRCS_GPU})
   endif()
 
   if(CP2K_ENABLE_GRID_GPU)


### PR DESCRIPTION
- Under some circumstances (CMake), add_custom_command does not run.
- However, add_custom_target using a command always runs.
- This combines the two and seems to get minimal rebuild.
- Some cleanup (C-sources only in case of OpenCL, etc.).