### PR TITLE
Use xpmem in CI

### DIFF
--- a/ci/docker/build_deps_spack.Dockerfile
+++ b/ci/docker/build_deps_spack.Dockerfile
@@ -89,7 +89,8 @@ RUN spack external find --all --not-buildable
 ARG CP2K_VERSION
 ENV CP2K_VERSION=${CP2K_VERSION:-psmp}
 COPY ./tools/spack/cp2k_deps_${CP2K_VERSION}.yaml ./
-RUN sed -e "s/~xpmem/+xpmem/" cp2k_deps_${CP2K_VERSION}.yaml
+RUN sed -e "s/~xpmem/+xpmem/" cp2k_deps_${CP2K_VERSION}.yaml > cp2k_deps_${CP2K_VERSION}_tmp.yaml && \
+    mv cp2k_deps_${CP2K_VERSION}_tmp.yaml cp2k_deps_${CP2K_VERSION}.yaml
 COPY ./tools/spack/cp2k_dev_repo ${SPACK_PACKAGES_ROOT}/repos/spack_repo/cp2k_dev_repo/
 RUN spack repo add --scope site ${SPACK_PACKAGES_ROOT}/repos/spack_repo/cp2k_dev_repo/
 RUN spack env create myenv cp2k_deps_${CP2K_VERSION}.yaml && \

--- a/ci/docker/build_deps_spack.Dockerfile
+++ b/ci/docker/build_deps_spack.Dockerfile
@@ -89,8 +89,7 @@ RUN spack external find --all --not-buildable
 ARG CP2K_VERSION
 ENV CP2K_VERSION=${CP2K_VERSION:-psmp}
 COPY ./tools/spack/cp2k_deps_${CP2K_VERSION}.yaml ./
-RUN sed -e "s/~xpmem/+xpmem/" cp2k_deps_${CP2K_VERSION}.yaml > cp2k_deps_${CP2K_VERSION}_tmp.yaml && \
-    mv cp2k_deps_${CP2K_VERSION}_tmp.yaml cp2k_deps_${CP2K_VERSION}.yaml
+RUN sed -i -e "s/~xpmem/+xpmem/" cp2k_deps_${CP2K_VERSION}.yaml
 COPY ./tools/spack/cp2k_dev_repo ${SPACK_PACKAGES_ROOT}/repos/spack_repo/cp2k_dev_repo/
 RUN spack repo add --scope site ${SPACK_PACKAGES_ROOT}/repos/spack_repo/cp2k_dev_repo/
 RUN spack env create myenv cp2k_deps_${CP2K_VERSION}.yaml && \


### PR DESCRIPTION
`xpmem` was installed in the container but not used by Spack.

Before (no `xpmem`):
```console
srun -p debug --environment=$PWD/cp2k.toml --mpi=pmi2 -N1 -n2 -p debug c/mpi/pt2pt/standard/osu_bw

# OSU MPI Bandwidth Test v7.5
# Datatype: MPI_CHAR.
# Size      Bandwidth (MB/s)
1                       1.48
2                       3.07
4                       6.27
8                      12.60
16                     24.98
32                     49.64
64                     90.22
128                   176.93
256                   416.55
512                   872.40
1024                 1140.86
2048                 2020.34
4096                 2626.78
8192                 3132.44
16384                2971.31
32768                3040.59
65536                3148.87
131072               3234.28
262144               3283.56
524288               3294.27
1048576              3291.32
2097152              3304.17
4194304              3301.20
```

After (with `xpmem`):
```console
$ srun -p debug --environment=$PWD/cp2k-xpmem.toml --mpi=pmi2 -N1 -n2 -p debug c/mpi/pt2pt/standard/osu_bw

# OSU MPI Bandwidth Test v7.5
# Datatype: MPI_CHAR.
# Size      Bandwidth (MB/s)
1                       1.49
2                       3.02
4                       6.10
8                      12.70
16                     24.12
32                     50.13
64                     87.28
128                   173.70
256                   345.20
512                   718.62
1024                 1481.82
2048                 2964.42
4096                 5738.34
8192                10630.33
16384               17673.10
32768               24510.88
65536               33951.12
131072              39858.11
262144              43038.89
524288              41639.42
1048576             43705.77
2097152             44775.45
4194304             44616.45
```