### PR TITLE
Update docs: RELAX_MULTIPLICITY + OT relation

### DIFF
--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -228,7 +228,7 @@ CONTAINS
                           "This option is only valid for unrestricted (i.e. spin polarised) "// &
                           "Kohn-Sham (UKS) calculations. It also needs non-zero "// &
                           "FORCE_EVAL/DFT/.../ADDED_MOS to actually affect the calculations, "// &
-                          "which is why it is not expected to work with FORCE_EVAL/DFT/SCF/OT "// &
+                          "which is why it is not expected to work with [OT](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.OT) "// &
                           "and may raise errors when used with OT."// &
                           "For more details see [this discussion](https://github.com/cp2k/cp2k/issues/4389).", &
                           usage="RELAX_MULTIPLICITY 0.00001", &

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -227,7 +227,7 @@ CONTAINS
                           "with spin-polarization. "// &
                           "This option is only valid for unrestricted (i.e. spin polarised) "// &
                           "Kohn-Sham (UKS) calculations. It also needs non-zero "// &
-                          "FORCE_EVAL/DFT/.../ADDED_MOS to actually affect the calculations, "// &
+                          "[ADDED_MOS](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.ADDED_MOS) to actually affect the calculations, "// &
                           "which is why it is not expected to work with [OT](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.OT) "// &
                           "and may raise errors when used with OT."// &
                           "For more details see [this discussion](https://github.com/cp2k/cp2k/issues/4389).", &

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -229,7 +229,7 @@ CONTAINS
                           "Kohn-Sham (UKS) calculations. It also needs non-zero "// &
                           "[ADDED_MOS](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.ADDED_MOS) to actually affect the calculations, "// &
                           "which is why it is not expected to work with [OT](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.OT) "// &
-                          "and may raise errors when used with OT."// &
+                          "and may raise errors when used with OT. "// &
                           "For more details see [this discussion](https://github.com/cp2k/cp2k/issues/4389).", &
                           usage="RELAX_MULTIPLICITY 0.00001", &
                           repeats=.FALSE., &

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -225,9 +225,12 @@ CONTAINS
                           "towards a spin-polarized solution. "// &
                           "Thus, larger tolerance increases chances of ending up "// &
                           "with spin-polarization. "// &
-                          "More details in a GitHub `thread <https://github.com/cp2k/cp2k/issues/4389>`. "// &
                           "This option is only valid for unrestricted (i.e. spin polarised) "// &
-                          "Kohn-Sham (UKS) calculations.", &
+                          "Kohn-Sham (UKS) calculations. It also needs non-zero "// &
+                          "FORCE_EVAL/DFT/.../ADDED_MOS to actually affect the calculations, "// &
+                          "which is why it is not expected to work with FORCE_EVAL/DFT/SCF/OT "// &
+                          "and may raise errors when used with OT."// &
+                          "More details in a thread `<https://github.com/cp2k/cp2k/issues/4389>`.", &
                           usage="RELAX_MULTIPLICITY 0.00001", &
                           repeats=.FALSE., &
                           default_r_val=0.0_dp)

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -230,7 +230,7 @@ CONTAINS
                           "FORCE_EVAL/DFT/.../ADDED_MOS to actually affect the calculations, "// &
                           "which is why it is not expected to work with FORCE_EVAL/DFT/SCF/OT "// &
                           "and may raise errors when used with OT."// &
-                          "More details in a thread `<https://github.com/cp2k/cp2k/issues/4389>`.", &
+                          "For more details see [this discussion](https://github.com/cp2k/cp2k/issues/4389).", &
                           usage="RELAX_MULTIPLICITY 0.00001", &
                           repeats=.FALSE., &
                           default_r_val=0.0_dp)


### PR DESCRIPTION
Another update of RELAX_MULTIPLICITY, now regarding its interaction with the OT solver.

OT seems to be
1. quite popular
2. not really compatible with RELAX_MULTIPLICITY
3. not mentioned in the RELAX_MULTIPLICITY docs

This commit tries to fix it by describing the OT compatibility. Addresses this [issue](https://github.com/cp2k/cp2k/issues/4389).