### PR TITLE
DBM: result validation

### DIFF
--- a/src/dbm/dbm_matrix.h
+++ b/src/dbm/dbm_matrix.h
@@ -167,6 +167,12 @@ double dbm_checksum(const dbm_matrix_t *matrix);
 double dbm_maxabs(const dbm_matrix_t *matrix);
 
 /*******************************************************************************
+ * \brief Calculates maximum relative difference between matrix_a and matrix_b.
+ * \author Hans Pabst
+ ******************************************************************************/
+double dbm_maxeps(const dbm_matrix_t *matrix_a, const dbm_matrix_t *matrix_b);
+
+/*******************************************************************************
  * \brief Returns the name of the matrix of the given matrix.
  * \author Ole Schuett
  ******************************************************************************/

--- a/src/dbm/dbm_multiply_cpu.h
+++ b/src/dbm/dbm_multiply_cpu.h
@@ -10,13 +10,19 @@
 #include "dbm_internal.h"
 #include "dbm_shard.h"
 
+enum dbm_multiply_cpu_options {
+  DBM_MULTIPLY_BLAS_LIBRARY = 1,
+  DBM_MULTIPLY_TASK_REORDER = 2
+};
+
 /*******************************************************************************
  * \brief Internal routine for executing the tasks in given batch on the CPU.
  * \author Ole Schuett
  ******************************************************************************/
-void dbm_multiply_cpu_process_batch(
-    const int ntasks, const dbm_task_t batch[ntasks], const double alpha,
-    const dbm_pack_t *pack_a, const dbm_pack_t *pack_b, dbm_shard_t *shard_c);
+void dbm_multiply_cpu_process_batch(int ntasks, const dbm_task_t batch[ntasks],
+                                    double alpha, const dbm_pack_t *pack_a,
+                                    const dbm_pack_t *pack_b,
+                                    dbm_shard_t *shard_c, int options);
 
 #endif
 


### PR DESCRIPTION
- Removed compile-time option (DBM_VALIDATE_AGAINST_LIBXSMM).
- Allow to enable validation at runtime (DBM_MULTIPLY_VERIFY).
  - DBM_MULTIPLY_VERIFY=1: print warning message (console).
  - DBM_MULTIPLY_VERIFY=2 (or !=1): exit on error.
  - DBM_MULTIPLY_MAXEPS: threshold, e.g., 1E-8.
- Fail instead of warning if difference is discovered/exceeded.
- Fix: use master thread for MPI-communication
  - Avoid to depend on MPI-initialization or support-level.
  - Funneled support-level is invalid with "omp single".
- Introduced dbm_multiply_cpu_options to select, e.g., BLAS.
  - Validate host/xsmm and device results against BLAS.
- Built-in/transparent validation for miniapp/driver.
  - Reuses the same code as built-in validation.
  - Keep performance/validation pass separate.
- Miniapp now uses non-trivial matrix values.
- Miniapp now uses non-trivial block sizes.
- Validation uses largest relative difference.