### PR TITLE
offloadStreamWaitEvent: removed unused argument

### DIFF
--- a/src/dbm/dbm_multiply_gpu.c
+++ b/src/dbm/dbm_multiply_gpu.c
@@ -84,7 +84,7 @@ void dbm_multiply_gpu_upload_packs(const dbm_pack_t *pack_a,
   offloadEventCreate(&event);
   for (int i = 0; i < ctx->nshards; i++) {
     offloadEventRecord(event, ctx->shards_c_dev[i].stream);
-    offloadStreamWaitEvent(ctx->main_stream, event, 0);
+    offloadStreamWaitEvent(ctx->main_stream, event);
   }
 
   upload_pack(pack_a, &ctx->pack_a_dev, ctx->main_stream);
@@ -93,7 +93,7 @@ void dbm_multiply_gpu_upload_packs(const dbm_pack_t *pack_a,
   // Have all c-streams wait until new packs are uploaded.
   offloadEventRecord(event, ctx->main_stream);
   for (int i = 0; i < ctx->nshards; i++) {
-    offloadStreamWaitEvent(ctx->shards_c_dev[i].stream, event, 0);
+    offloadStreamWaitEvent(ctx->shards_c_dev[i].stream, event);
   }
   offloadEventDestroy(event);
 }

--- a/src/grid/gpu/grid_gpu_task_list.cu
+++ b/src/grid/gpu/grid_gpu_task_list.cu
@@ -394,7 +394,7 @@ void grid_gpu_collocate_task_list(const grid_gpu_task_list *task_list,
     offloadMemsetAsync(grid->device_buffer, 0, grid->size, level_stream);
 
     // launch kernel, but only after blocks have arrived
-    offloadStreamWaitEvent(level_stream, input_ready_event, 0);
+    offloadStreamWaitEvent(level_stream, input_ready_event);
     grid_gpu_collocate_one_grid_level(
         task_list, first_task, last_task, func, layout, level_stream,
         pab_blocks->device_buffer, grid->device_buffer, &lp_diff);
@@ -489,7 +489,7 @@ void grid_gpu_integrate_task_list(const grid_gpu_task_list *task_list,
                            level_stream);
 
     // launch kernel, but only after hab, pab, virial, etc are ready
-    offloadStreamWaitEvent(level_stream, input_ready_event, 0);
+    offloadStreamWaitEvent(level_stream, input_ready_event);
     grid_gpu_integrate_one_grid_level(
         task_list, first_task, last_task, compute_tau, layout, level_stream,
         pab_blocks_dev, grid->device_buffer, hab_blocks->device_buffer,
@@ -499,7 +499,7 @@ void grid_gpu_integrate_task_list(const grid_gpu_task_list *task_list,
     offloadEvent_t level_done_event;
     offloadEventCreate(&level_done_event);
     offloadEventRecord(level_done_event, level_stream);
-    offloadStreamWaitEvent(task_list->main_stream, level_done_event, 0);
+    offloadStreamWaitEvent(task_list->main_stream, level_done_event);
     offloadEventDestroy(level_done_event);
 
     first_task = last_task + 1;

--- a/src/offload/offload_runtime.h
+++ b/src/offload/offload_runtime.h
@@ -431,13 +431,12 @@ static inline void offloadFreeHost(void *ptr) {
  * \brief Wrapper around cudaStreamWaitEvent.
  ******************************************************************************/
 static inline void offloadStreamWaitEvent(offloadStream_t stream,
-                                          offloadEvent_t event, const int val) {
+                                          offloadEvent_t event) {
 #if defined(__OFFLOAD_CUDA)
-  OFFLOAD_CHECK(cudaStreamWaitEvent(stream, event, val));
+  OFFLOAD_CHECK(cudaStreamWaitEvent(stream, event, 0 /*flags*/));
 #elif defined(__OFFLOAD_HIP)
-  OFFLOAD_CHECK(hipStreamWaitEvent(stream, event, val));
+  OFFLOAD_CHECK(hipStreamWaitEvent(stream, event, 0 /*flags*/));
 #elif defined(__OFFLOAD_OPENCL)
-  assert(0 == val); /* TODO */
   OFFLOAD_CHECK(c_dbcsr_acc_stream_wait_event(stream, event));
 #endif
 }


### PR DESCRIPTION
- Rather add another function if flags are needed ever.
- Avoid promoting obscure flag-based API.