### PR TITLE
DBM/CMake: fixed CUDA compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1480,7 +1480,6 @@ set(CP2K_GRID_SRCS_HIP
 
 set(CP2K_DBM_SRCS_GPU dbm/dbm_multiply_gpu_kernel.cu)
 set(CP2K_DBM_SRCS_GPU_C dbm/dbm_multiply_opencl.c dbm/dbm_multiply_gpu.c)
-set(CP2K_DBM_SRCS_OPENCL dbm/dbm_multiply_opencl.cl)
 
 set(CP2K_PW_SRCS_GPU pw/gpu/pw_gpu_kernels.cu)
 
@@ -1508,19 +1507,21 @@ if(CP2K_USE_CUDA
   endif()
 
   if(CP2K_ENABLE_DBM_GPU)
+    list(APPEND CP2K_DBM_SRCS_C dbm/dbm_multiply_gpu.c)
     if(CP2K_USE_OPENCL)
+      set(CP2K_DBM_OPENCL_KERNEL dbm/dbm_multiply_opencl.cl)
       add_custom_command(
         COMMAND
           # generate header file with OpenCL code as string-literal
           ${CP2K_OPENCL_SCRIPT} -b 6 -p \"\"
-          ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}
-          ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_OPENCL_KERNEL}
+          ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_OPENCL_KERNEL}.h
         DEPENDS ${CP2K_OPENCL_SCRIPT} ${CP2K_OPENCL_COMMON}
-                ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}
-        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_SRCS_OPENCL}.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_OPENCL_KERNEL}
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/${CP2K_DBM_OPENCL_KERNEL}.h
         COMMENT "Generating OpenCL kernel for DBM")
-      list(APPEND CP2K_DBM_SRCS_C ${CP2K_DBM_SRCS_GPU_C}
-           ${CP2K_DBM_SRCS_OPENCL}.h)
+      list(APPEND CP2K_DBM_SRCS_C dbm/dbm_multiply_opencl.c
+           ${CP2K_DBM_OPENCL_KERNEL}.h)
     else()
       list(APPEND CP2K_SRCS_GPU ${CP2K_DBM_SRCS_GPU})
     endif()


### PR DESCRIPTION
- Cleanup variables in related CMake section (CP2K_DBM_SRCS_GPU_C).
- The reason for GPU-SRCs is a separate compiler is req. (CUDA/HIP).
- On case of OpenCL, no ahead-of-time compiler needed.
- Before, CUDA compilation ended with unresolved symbols.