### PR TITLE
Renamed oneAPI testers and fixed/suppressed issues

### DIFF
--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -93,7 +93,12 @@ CONTAINS
       END IF
 
 !$    flags = TRIM(flags)//" omp"
-#if defined(__LIBINT)
+
+      ! TODO: remove __INTEL_LLVM_COMPILER conditions (regtests)
+#if defined(__INTEL_LLVM_COMPILER)
+      flags = TRIM(flags)//" ifx"
+#endif
+#if defined(__LIBINT) && !defined(__INTEL_LLVM_COMPILER)
       flags = TRIM(flags)//" libint"
 #endif
 #if defined(__FFTW3)
@@ -129,35 +134,27 @@ CONTAINS
 #if defined(__COSMA)
       flags = TRIM(flags)//" cosma"
 #endif
-
 #if defined(__QUIP)
       flags = TRIM(flags)//" quip"
 #endif
-
 #if defined(__HAS_PATCHED_CUFFT_70)
       flags = TRIM(flags)//" patched_cufft_70"
 #endif
-
 #if defined(__ACE)
       flags = TRIM(flags)//" ace"
 #endif
-
 #if defined(__DEEPMD)
       flags = TRIM(flags)//" deepmd"
 #endif
-
 #if defined(__PW_FPGA)
       flags = TRIM(flags)//" pw_fpga"
 #endif
-
 #if defined(__PW_FPGA_SP)
       flags = TRIM(flags)//" pw_fpga_sp"
 #endif
-
 #if defined(__LIBXSMM)
       flags = TRIM(flags)//" xsmm"
 #endif
-
 #if defined(__CRAY_PM_ACCEL_ENERGY)
       flags = TRIM(flags)//" cray_pm_accel_energy"
 #endif
@@ -266,39 +263,30 @@ CONTAINS
 #if defined(__OFFLOAD_PROFILING)
       flags = TRIM(flags)//" offload_profiling"
 #endif
-
 #if defined(__SPLA) && defined(__OFFLOAD_GEMM)
       flags = TRIM(flags)//" spla_gemm_offloading"
 #endif
-
 #if defined(__CUSOLVERMP)
       flags = TRIM(flags)//" cusolvermp"
 #endif
-
 #if defined(__DLAF)
       flags = TRIM(flags)//" dlaf"
 #endif
-
 #if defined(__LIBVDWXC)
       flags = TRIM(flags)//" libvdwxc"
 #endif
-
 #if defined(__HDF5)
       flags = TRIM(flags)//" hdf5"
 #endif
-
 #if defined(__TREXIO)
       flags = TRIM(flags)//" trexio"
 #endif
-
 #if defined(__OFFLOAD_UNIFIED_MEMORY)
       flags = TRIM(flags)//" offload_unified_memory"
 #endif
-
 #if defined(__SMEAGOL)
       flags = TRIM(flags)//" libsmeagol"
 #endif
-
 #if defined(__GREENX)
       flags = TRIM(flags)//" greenx"
 #endif

--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -103,7 +103,7 @@ QS/regtest-libxc                                            libxc libint
 QS/regtest-debug-1
 QS/regtest-tddfpt-stda                                      libint
 QS/regtest-tddfpt-static                                    libint
-QS/regtest-scalable-gw                                       libint
+QS/regtest-scalable-gw                                      libint
 QS/regtest-hfx-periodic                                     libint
 QS/regtest-gapw                                             libvori
 QS/regtest-ot-2
@@ -302,9 +302,9 @@ QS/regtest-ri-laplace-mp2                                   libint
 QS/regtest-ri-rpa-exchange                                  libint
 QS/regtest-cdft-4-1
 QS/regtest-epr-2
-QS/regtest-double-hybrid-grad-numer-meta                    libxc
+QS/regtest-double-hybrid-grad-numer-meta                    libxc !ifx
 xTB/regtest-stda
-QS/regtest-double-hybrid-grad-numer
+QS/regtest-double-hybrid-grad-numer                         !ifx
 QS/regtest-nlmo
 QS/regtest-admm-type                                        libint
 QS/regtest-rs-dhft                                          libint libxc
@@ -346,7 +346,7 @@ QS/regtest-nmr-3
 QS/regtest-cdft-3-1
 QS/regtest-tddfpt-prop
 QS/regtest-pao-3
-QS/regtest-double-hybrid-stress-numer-laplace               libxc
+QS/regtest-double-hybrid-stress-numer-laplace               libxc !ifx
 QS/regtest-as                                               libint
 QS/regtest-double-hybrid-2                                  libint
 QS/regtest-sccs-2
@@ -354,10 +354,10 @@ FE/regtest-3
 QS/regtest-properties/resp
 QS/regtest-negf-fft                                         fftw3
 NEB/regtest-1
-QS/regtest-double-hybrid-stress-numer-meta                  libxc
+QS/regtest-double-hybrid-stress-numer-meta                  libxc !ifx
 QS/regtest-elpa-qr                                          elpa mpiranks==1||mpiranks%2==0
 SE/regtest-3-1
-QS/regtest-double-hybrid-stress-numer
+QS/regtest-double-hybrid-stress-numer                       !ifx
 QS/regtest-double-hybrid-stress-meta                        libxc
 QS/regtest-nmr-2
 QS/regtest-double-hybrid-stress
@@ -394,4 +394,4 @@ QS/regtest-eht-guess                                        libdftd4
 QS/regtest-trexio                                           trexio
 QS/regtest-trexio-2                                         trexio libgrpp
 QS/regtest-rtbse-gxac                                       libint greenx
-QS/regtest-cneo
+QS/regtest-cneo                                             !ifx

--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -223,33 +223,33 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_hip-rocm-build_rep
 
 # ==============================================================================
 
-[intel-oneapi-hpckit-ssmp]
+[intel-ifx-ssmp]
 sortkey:     1028
-name:        Intel oneAPI HPC Toolkit (ssmp)
+name:        Intel oneAPI (ssmp, ifx)
 timeout:     170
 host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-oneapi-hpckit-ssmp_report.txt
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-ifx-ssmp_report.txt
 
-[intel-oneapi-hpckit-psmp]
+[intel-ifx-psmp]
 sortkey:     1029
-name:        Intel oneAPI HPC Toolkit (psmp)
+name:        Intel oneAPI (psmp, ifx)
 timeout:     170
 host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-oneapi-hpckit-psmp_report.txt
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-ifx-psmp_report.txt
 
-[intel-ssmp]
+[intel-ifort-ssmp]
 sortkey:     1030
-name:        Intel oneAPI (ssmp)
+name:        Intel oneAPI (ssmp, ifort)
 timeout:     170
 host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-ssmp_report.txt
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-ifort-ssmp_report.txt
 
-[intel-psmp]
+[intel-ifort-psmp]
 sortkey:     1031
-name:        Intel oneAPI (psmp)
+name:        Intel oneAPI (psmp, ifort)
 timeout:     170
 host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-psmp_report.txt
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-ifort-psmp_report.txt
 
 [openmpi-psmp]
 sortkey:     1032

--- a/tools/docker/Dockerfile.test_intel-ifort-psmp
+++ b/tools/docker/Dockerfile.test_intel-ifort-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-psmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-ifort-psmp ../../
 #
 
 FROM intel/hpckit:2024.2.1-0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_intel-ifort-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ifort-ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-ssmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-ifort-ssmp ../../
 #
 
 FROM intel/hpckit:2024.2.1-0-devel-ubuntu22.04

--- a/tools/docker/Dockerfile.test_intel-ifx-psmp
+++ b/tools/docker/Dockerfile.test_intel-ifx-psmp
@@ -1,9 +1,9 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-oneapi-hpckit-ssmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-ifx-psmp ../../
 #
 
-FROM intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04
+FROM intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu24.04
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
@@ -68,7 +68,7 @@ COPY ./tools/toolchain/scripts/arch_base.tmpl \
      ./scripts/
 RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
-# Install CP2K using local.ssmp.
+# Install CP2K using local.psmp.
 WORKDIR /opt/cp2k
 COPY ./Makefile .
 COPY ./src ./src
@@ -76,7 +76,7 @@ COPY ./exts ./exts
 COPY ./tools/build_utils ./tools/build_utils
 RUN /bin/bash -c " \
     mkdir -p arch && \
-    ln -vs /opt/cp2k-toolchain/install/arch/local.ssmp ./arch/"
+    ln -vs /opt/cp2k-toolchain/install/arch/local.psmp ./arch/"
 COPY ./data ./data
 COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
@@ -86,7 +86,7 @@ ARG TESTOPTS="--mpiexec mpiexec"
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -o pipefail -c " \
     TESTOPTS='${TESTOPTS}' \
-    ./test_regtest.sh 'local' 'ssmp' |& tee report.log && \
+    ./test_regtest.sh 'local' 'psmp' |& tee report.log && \
     rm -rf regtesting"
 
 # Output the report if the image is old and was therefore pulled from the build cache.

--- a/tools/docker/Dockerfile.test_intel-ifx-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ifx-ssmp
@@ -1,9 +1,9 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-oneapi-hpckit-psmp ../../
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_intel-ifx-ssmp ../../
 #
 
-FROM intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04
+FROM intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu24.04
 
 # Install requirements for the toolchain.
 WORKDIR /opt/cp2k-toolchain
@@ -68,7 +68,7 @@ COPY ./tools/toolchain/scripts/arch_base.tmpl \
      ./scripts/
 RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
-# Install CP2K using local.psmp.
+# Install CP2K using local.ssmp.
 WORKDIR /opt/cp2k
 COPY ./Makefile .
 COPY ./src ./src
@@ -76,7 +76,7 @@ COPY ./exts ./exts
 COPY ./tools/build_utils ./tools/build_utils
 RUN /bin/bash -c " \
     mkdir -p arch && \
-    ln -vs /opt/cp2k-toolchain/install/arch/local.psmp ./arch/"
+    ln -vs /opt/cp2k-toolchain/install/arch/local.ssmp ./arch/"
 COPY ./data ./data
 COPY ./tests ./tests
 COPY ./tools/regtesting ./tools/regtesting
@@ -86,7 +86,7 @@ ARG TESTOPTS="--mpiexec mpiexec"
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -o pipefail -c " \
     TESTOPTS='${TESTOPTS}' \
-    ./test_regtest.sh 'local' 'psmp' |& tee report.log && \
+    ./test_regtest.sh 'local' 'ssmp' |& tee report.log && \
     rm -rf regtesting"
 
 # Output the report if the image is old and was therefore pulled from the build cache.

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -267,37 +267,37 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_openmpi-psmp
 
-[intel-oneapi-hpckit-ssmp]
-display_name: Intel oneAPI HPC Toolkit (ssmp)
+[intel-ifx-ssmp]
+display_name: Intel oneAPI (ssmp, ifx)
 tags:         weekly-morning
 cpu:          20
 nodepools:    pool-intel
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_intel-oneapi-hpckit-ssmp
+dockerfile:   /tools/docker/Dockerfile.test_intel-ifx-ssmp
 
-[intel-oneapi-hpckit-psmp]
-display_name: Intel oneAPI HPC Toolkit (psmp)
+[intel-ifx-psmp]
+display_name: Intel oneAPI (psmp, ifx)
 tags:         weekly-afternoon
 cpu:          20
 nodepools:    pool-intel
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_intel-oneapi-hpckit-psmp
+dockerfile:   /tools/docker/Dockerfile.test_intel-ifx-psmp
 
-[intel-ssmp]
-display_name: Intel oneAPI (ssmp)
+[intel-ifort-ssmp]
+display_name: Intel oneAPI (ssmp, ifort)
 tags:         weekly-morning
 cpu:          20
 nodepools:    pool-intel
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_intel-ssmp
+dockerfile:   /tools/docker/Dockerfile.test_intel-ifort-ssmp
 
-[intel-psmp]
-display_name: Intel oneAPI (psmp)
+[intel-ifort-psmp]
+display_name: Intel oneAPI (psmp, ifort)
 tags:         weekly-afternoon
 cpu:          20
 nodepools:    pool-intel
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_intel-psmp
+dockerfile:   /tools/docker/Dockerfile.test_intel-ifort-psmp
 
 [fedora-psmp]
 display_name: Fedora

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -33,12 +33,12 @@ def main() -> None:
         f.write(regtest_cmake("toolchain", "psmp"))
 
     for ver in "ssmp", "psmp":
-        with OutputFile(f"Dockerfile.test_intel-{ver}", args.check) as f:
+        with OutputFile(f"Dockerfile.test_intel-ifort-{ver}", args.check) as f:
             base_image = "intel/hpckit:2024.2.1-0-devel-ubuntu22.04"
             f.write(install_deps_toolchain_intel(base_image=base_image, with_ifx="no"))
             f.write(regtest(ver, intel=True, testopts="--mpiexec mpiexec"))
-        with OutputFile(f"Dockerfile.test_intel-oneapi-hpckit-{ver}", args.check) as f:
-            base_image = "intel/oneapi-hpckit:2025.1.3-0-devel-ubuntu24.04"
+        with OutputFile(f"Dockerfile.test_intel-ifx-{ver}", args.check) as f:
+            base_image = "intel/oneapi-hpckit:2025.2.2-0-devel-ubuntu24.04"
             f.write(install_deps_toolchain_intel(base_image=base_image, with_ifx="yes"))
             f.write(regtest(ver, intel=True, testopts="--mpiexec mpiexec"))
 

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -65,6 +65,7 @@ case "$with_libint" in
       # reduce debug information to level 1 since
       # level 2 (default for -g flag) leads to very large binary size
       LIBINT_CXXFLAGS="$CXXFLAGS -g1"
+      LIBINT_FCFLAGS="$FCFLAGS -g1"
 
       # cmake build broken with libint 2.6, uncomment for libint 2.7 and above
       #cmake . -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
@@ -77,7 +78,10 @@ case "$with_libint" in
       ./configure --prefix=${pkg_install_dir} \
         --with-cxx="$CXX $LIBINT_CXXFLAGS" \
         --with-cxx-optflags="$LIBINT_CXXFLAGS" \
+        --with-fc="$FC $LIBINT_FCFLAGS" \
+        --disable-unrolling \
         --enable-fortran \
+        --enable-fma \
         --with-pic \
         --libdir="${pkg_install_dir}/lib" \
         > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
@@ -85,6 +89,8 @@ case "$with_libint" in
       if [ "${with_intel}" != "__DONTUSE__" ]; then
         # Fix bug in makefile for Fortran module
         sed -i -e "s/\$(CXX) \$(CXXFLAGS)/\$(FC) \$(FCFLAGS)/g" -e "s/\$(FCLIBS) -o/\$(FCLIBS) -lstdc++ -o/" fortran/Makefile
+        # Fix bug about autoconf spilling -loopopt option into link list
+        sed -i -e "s/-loopopt //g" MakeVars
       fi
 
       make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log


### PR DESCRIPTION
- Distinction is IFORT vs IFX or "classic vs new/next-gen".
- Intel Fortran Classic is available up to and incl. 2024.2 packages.
- Intel Fortran (next-gen) is default (still not ready for CP2K).
- Fix bug about Autoconf spilling -loopopt option into link list.
- Drop names derived from packaging images like "hpckit".
- Renamed Dockerfiles for tests and internal names.
- Suppress "libint" flag until regtests pass.
- Introduced "ifx" flag and suppress tests.