### PR TITLE
Print ls_scf_env%do_pao only once

### DIFF
--- a/src/dm_ls_scf_create.F
+++ b/src/dm_ls_scf_create.F
@@ -459,15 +459,11 @@ CONTAINS
             CPABORT("Unknown cluster type")
          END SELECT
 
+         WRITE (unit_nr, '(T2,A,T61,L20)') "Computing Chebyshev", ls_scf_env%chebyshev%compute_chebyshev
          IF (ls_scf_env%chebyshev%compute_chebyshev) THEN
-            WRITE (unit_nr, '(T2,A,T61,A20)') "Computing Chebyshev", ADJUSTR("TRUE")
             WRITE (unit_nr, '(T2,A,T61,I20)') "N_CHEBYSHEV:", ls_scf_env%chebyshev%n_chebyshev
             WRITE (unit_nr, '(T2,A,T61,I20)') "N_GRIDPOINT_DOS:", ls_scf_env%chebyshev%n_gridpoint_dos
-         ELSE
-            WRITE (unit_nr, '(T2,A,T61,A20)') "Computing Chebyshev", ADJUSTR("FALSE")
          END IF
-
-         WRITE (unit_nr, '(T2,A,T61,L20)') "Using PAO", ls_scf_env%do_pao
 
          WRITE (unit_nr, '(T2,A)') REPEAT("-", 79)
          WRITE (unit_nr, '()')


### PR DESCRIPTION
- Prints "Polarized Atomic Orbitals (PAO)".
- Duplicated info printing "Using PAO".
- Print logicals consistently.