### PR TITLE
CUFFT: removed vanished enums

### DIFF
--- a/src/offload/offload_fft.h
+++ b/src/offload/offload_fft.h
@@ -65,109 +65,74 @@ static inline const char *offload_fftGetErrorString(offload_fftResult error) {
   switch (error) {
   case CUFFT_SUCCESS:
     return "CUFFT_SUCCESS";
-
   case CUFFT_INVALID_PLAN:
     return "CUFFT_INVALID_PLAN";
-
   case CUFFT_ALLOC_FAILED:
     return "CUFFT_ALLOC_FAILED";
-
   case CUFFT_INVALID_TYPE:
     return "CUFFT_INVALID_TYPE";
-
   case CUFFT_INVALID_VALUE:
     return "CUFFT_INVALID_VALUE";
-
   case CUFFT_INTERNAL_ERROR:
     return "CUFFT_INTERNAL_ERROR";
-
   case CUFFT_EXEC_FAILED:
     return "CUFFT_EXEC_FAILED";
-
   case CUFFT_SETUP_FAILED:
     return "CUFFT_SETUP_FAILED";
-
   case CUFFT_INVALID_SIZE:
     return "CUFFT_INVALID_SIZE";
-
-  case CUFFT_INCOMPLETE_PARAMETER_LIST:
-    return "CUFFT_INCOMPLETE_PARAMETER_LIST";
-
+  /*case CUFFT_INCOMPLETE_PARAMETER_LIST:
+    return "CUFFT_INCOMPLETE_PARAMETER_LIST";*/
   case CUFFT_INVALID_DEVICE:
     return "CUFFT_INVALID_DEVICE";
-
-  case CUFFT_PARSE_ERROR:
-    return "CUFFT_PARSE_ERROR";
-
+  /*case CUFFT_PARSE_ERROR:
+    return "CUFFT_PARSE_ERROR";*/
   case CUFFT_NO_WORKSPACE:
     return "CUFFT_NO_WORKSPACE";
-
   case CUFFT_NOT_IMPLEMENTED:
     return "CUFFT_NOT_IMPLEMENTED";
-
   case CUFFT_NOT_SUPPORTED:
     return "CUFFT_NOT_SUPPORTED";
-
   case CUFFT_UNALIGNED_DATA:
     return "CUFFT_UNALIGNED_DATA";
-
-  case CUFFT_LICENSE_ERROR:
-    return "CUFFT_LICENSE_ERROR";
+    /*case CUFFT_LICENSE_ERROR:
+      return "CUFFT_LICENSE_ERROR";*/
   }
 
 #elif defined(__OFFLOAD_HIP)
-
   switch (error) {
   case HIPFFT_SUCCESS:
     return "HIPFFT_SUCCESS";
-
   case HIPFFT_INVALID_PLAN:
     return "HIPFFT_INVALID_PLAN";
-
   case HIPFFT_ALLOC_FAILED:
     return "HIPFFT_ALLOC_FAILED";
-
   case HIPFFT_INVALID_TYPE:
     return "HIPFFT_INVALID_TYPE";
-
   case HIPFFT_INVALID_VALUE:
     return "HIPFFT_INVALID_VALUE";
-
   case HIPFFT_INTERNAL_ERROR:
     return "HIPFFT_INTERNAL_ERROR";
-
   case HIPFFT_EXEC_FAILED:
     return "HIPFFT_EXEC_FAILED";
-
   case HIPFFT_SETUP_FAILED:
     return "HIPFFT_SETUP_FAILED";
-
   case HIPFFT_INVALID_SIZE:
     return "HIPFFT_INVALID_SIZE";
-
   case HIPFFT_INCOMPLETE_PARAMETER_LIST:
     return "HIPFFT_INCOMPLETE_PARAMETER_LIST";
-
   case HIPFFT_INVALID_DEVICE:
     return "HIPFFT_INVALID_DEVICE";
-
   case HIPFFT_PARSE_ERROR:
     return "HIPFFT_PARSE_ERROR";
-
   case HIPFFT_NO_WORKSPACE:
     return "HIPFFT_NO_WORKSPACE";
-
   case HIPFFT_NOT_IMPLEMENTED:
     return "HIPFFT_NOT_IMPLEMENTED";
-
   case HIPFFT_NOT_SUPPORTED:
     return "HIPFFT_NOT_SUPPORTED";
-
   case HIPFFT_UNALIGNED_DATA:
     return "HIPFFT_UNALIGNED_DATA";
-
-    // case HIPFFT_LICENSE_ERROR:
-    //  return "HIPFFT_LICENSE_ERROR";
   }
 #endif
 

--- a/src/pw/gpu/pw_gpu_internal.c
+++ b/src/pw/gpu/pw_gpu_internal.c
@@ -4,19 +4,18 @@
 /*                                                                            */
 /*  SPDX-License-Identifier: GPL-2.0-or-later                                 */
 /*----------------------------------------------------------------------------*/
-
 #include "../../offload/offload_runtime.h"
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_PW)
+
+#include "../../offload/offload_fft.h"
+#include "../../offload/offload_library.h"
+#include "pw_gpu_kernels.h"
 
 #include <assert.h>
 #include <omp.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <string.h>
-
-#include "../../offload/offload_fft.h"
-#include "../../offload/offload_library.h"
-#include "pw_gpu_kernels.h"
 
 /*******************************************************************************
  * \brief Static variables for retaining objects that are expensive to create.


### PR DESCRIPTION
- Newer/recent HPC toolkits around CUDA 13 seem to miss some enums.