### PR TITLE
Adjusted print_func similar to Offload and DBM library

### DIFF
--- a/src/grid/common/PACKAGE
+++ b/src/grid/common/PACKAGE
@@ -1,5 +1,5 @@
 {
     "description": "Common parts shared by the grid backends",
-    "requires": ["../../offload"],
+    "requires": ["../../offload", "../../mpiwrap"],
     "archive": "libcp2kgridcommon",
 }

--- a/src/grid/common/grid_library.h
+++ b/src/grid/common/grid_library.h
@@ -55,8 +55,9 @@ grid_library_config grid_library_get_config(void);
  * \brief Prints statistics gathered by the grid library.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_library_print_stats(void (*mpi_sum_func)(long *, int), int mpi_comm,
-                              void (*print_func)(char *, int), int output_unit);
+void grid_library_print_stats(const int fortran_comm,
+                              void (*print_func)(const char *, int, int),
+                              int output_unit);
 
 /*******************************************************************************
  * \brief Various kernels provided by the grid library.

--- a/src/grid/grid_api.F
+++ b/src/grid/grid_api.F
@@ -11,13 +11,11 @@
 ! **************************************************************************************************
 MODULE grid_api
    USE ISO_C_BINDING,                   ONLY: &
-        C_ASSOCIATED, C_BOOL, C_CHAR, C_DOUBLE, C_FUNLOC, C_FUNPTR, C_INT, C_LOC, C_LONG, &
-        C_NULL_PTR, C_PTR
+        C_ASSOCIATED, C_BOOL, C_CHAR, C_DOUBLE, C_FUNLOC, C_FUNPTR, C_INT, C_LOC, C_NULL_PTR, C_PTR
    USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_comm_type
    USE offload_api,                     ONLY: offload_buffer_type
    USE realspace_grid_types,            ONLY: realspace_grid_type
-   USE string_utilities,                ONLY: strlcpy_c2f
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -1193,10 +1191,9 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: output_unit
 
       INTERFACE
-         SUBROUTINE grid_library_print_stats_c(mpi_sum_func, mpi_comm, print_func, output_unit) &
+         SUBROUTINE grid_library_print_stats_c(mpi_comm, print_func, output_unit) &
             BIND(C, name="grid_library_print_stats")
             IMPORT :: C_FUNPTR, C_INT
-            TYPE(C_FUNPTR), VALUE                     :: mpi_sum_func
             INTEGER(KIND=C_INT), VALUE                :: mpi_comm
             TYPE(C_FUNPTR), VALUE                     :: print_func
             INTEGER(KIND=C_INT), VALUE                :: output_unit
@@ -1204,52 +1201,24 @@ CONTAINS
       END INTERFACE
 
       ! Since Fortran units and mpi groups can't be used from C, we pass function pointers instead.
-      CALL grid_library_print_stats_c(mpi_sum_func=C_FUNLOC(mpi_sum_func), &
-                                      mpi_comm=mpi_comm%get_handle(), &
+      CALL grid_library_print_stats_c(mpi_comm=mpi_comm%get_handle(), &
                                       print_func=C_FUNLOC(print_func), &
                                       output_unit=output_unit)
 
    END SUBROUTINE grid_library_print_stats
 
 ! **************************************************************************************************
-!> \brief Callback to run mpi_sum on a Fortran MPI communicator.
-!> \param number ...
-!> \param mpi_comm ...
-!> \author Ole Schuett
+!> \brief Callback to write to a Fortran output unit (called by C-side).
+!> \param msg to be printed.
+!> \param msglen number of characters excluding the terminating character.
+!> \param output_unit used for output.
+!> \author Ole Schuett and Hans Pabst
 ! **************************************************************************************************
-   SUBROUTINE mpi_sum_func(number, mpi_comm) BIND(C, name="grid_api_mpi_sum_func")
-      INTEGER(KIND=C_LONG), INTENT(INOUT)                :: number
-      INTEGER(KIND=C_INT), INTENT(IN), VALUE             :: mpi_comm
+   SUBROUTINE print_func(msg, msglen, output_unit) BIND(C, name="grid_api_print_func")
+      CHARACTER(KIND=C_CHAR), INTENT(IN)                 :: msg(*)
+      INTEGER(KIND=C_INT), INTENT(IN), VALUE             :: msglen, output_unit
 
-      TYPE(mp_comm_type)                                 :: my_mpi_comm
-
-      ! Convert the handle to the default integer kind and convert it to the communicator type
-      CALL my_mpi_comm%set_handle(INT(mpi_comm))
-
-      CALL my_mpi_comm%sum(number)
-   END SUBROUTINE mpi_sum_func
-
-! **************************************************************************************************
-!> \brief Callback to write to a Fortran output unit.
-!> \param message ...
-!> \param output_unit ...
-!> \author Ole Schuett
-! **************************************************************************************************
-   SUBROUTINE print_func(message, output_unit) BIND(C, name="grid_api_print_func")
-      CHARACTER(LEN=1, KIND=C_CHAR), INTENT(IN)          :: message(*)
-      INTEGER(KIND=C_INT), INTENT(IN), VALUE             :: output_unit
-
-      CHARACTER(LEN=1000)                                :: buffer
-      INTEGER                                            :: nchars
-
-      IF (output_unit <= 0) &
-         RETURN
-
-      ! Convert C char array into Fortran string.
-      nchars = strlcpy_c2f(buffer, message)
-
-      ! Print the message.
-      WRITE (output_unit, FMT="(A)", ADVANCE="NO") buffer(1:nchars)
+      IF (output_unit <= 0) RETURN ! Omit to print the message.
+      WRITE (output_unit, FMT="(100A)", ADVANCE="NO") msg(1:msglen)
    END SUBROUTINE print_func
-
 END MODULE grid_api

--- a/src/mpiwrap/cp_mpi.c
+++ b/src/mpiwrap/cp_mpi.c
@@ -319,6 +319,26 @@ void cp_mpi_sum_int(int *values, const int count, const cp_mpi_comm_t comm) {
 }
 
 /*******************************************************************************
+ * \brief Wrapper around MPI_Allreduce for op MPI_SUM and datatype MPI_LONG.
+ * \author Hans Pabst
+ ******************************************************************************/
+void cp_mpi_sum_long(long *values, const int count, const cp_mpi_comm_t comm) {
+#if defined(__parallel)
+  long value = 0;
+  void *recvbuf = (1 < count ? cp_mpi_alloc_mem(count * sizeof(long)) : &value);
+  CHECK(MPI_Allreduce(values, recvbuf, count, MPI_LONG, MPI_SUM, comm));
+  memcpy(values, recvbuf, count * sizeof(long));
+  if (1 < count) {
+    cp_mpi_free_mem(recvbuf);
+  }
+#else
+  (void)comm; // mark used
+  (void)values;
+  (void)count;
+#endif
+}
+
+/*******************************************************************************
  * \brief Wrapper around MPI_Allreduce for op MPI_SUM and datatype MPI_INT64_T.
  * \author Ole Schuett
  ******************************************************************************/

--- a/src/mpiwrap/cp_mpi.h
+++ b/src/mpiwrap/cp_mpi.h
@@ -134,6 +134,12 @@ void cp_mpi_max_double(double *values, const int count,
 void cp_mpi_sum_int(int *values, const int count, const cp_mpi_comm_t comm);
 
 /*******************************************************************************
+ * \brief Wrapper around MPI_Allreduce for op MPI_SUM and datatype MPI_LONG.
+ * \author Hans Pabst
+ ******************************************************************************/
+void cp_mpi_sum_long(long *values, const int count, const cp_mpi_comm_t comm);
+
+/*******************************************************************************
  * \brief Wrapper around MPI_Allreduce for op MPI_SUM and datatype MPI_INT64_T.
  * \author Ole Schuett
  ******************************************************************************/


### PR DESCRIPTION
- Print grid statistics (only if non-zero counter exists).
- Removed dependency from string_utilities (strlcpy_c2f).
- No copy of the message is necessary.
- Reduced PACKAGE dependencies.
- Print offload memory stats.