### PR TITLE
Don't assume MPI_COMM_WORLD in init_cp2k in f77 API

### DIFF
--- a/src/f77_interface.F
+++ b/src/f77_interface.F
@@ -212,11 +212,14 @@ CONTAINS
 !>      other functions when using cp2k as library
 !> \param init_mpi if the mpi environment should be initialized
 !> \param ierr returns a number different from 0 if there was an error
+!> \param mpi_comm an existing mpi communicator (if not given mp_comm_world
+!>      will be used)
 !> \author fawzi
 ! **************************************************************************************************
-   SUBROUTINE init_cp2k(init_mpi, ierr)
+   SUBROUTINE init_cp2k(init_mpi, ierr, mpi_comm)
       LOGICAL, INTENT(in)                                :: init_mpi
       INTEGER, INTENT(out)                               :: ierr
+      TYPE(mp_comm_type), INTENT(in), OPTIONAL           :: mpi_comm
 
       INTEGER                                            :: offload_device_count, unit_nr
       INTEGER, POINTER                                   :: active_device_id
@@ -246,7 +249,11 @@ CONTAINS
             ! get the default system wide communicator
             CALL mp_world_init(default_para_env)
          ELSE
-            default_para_env = mp_comm_world
+            IF (PRESENT(mpi_comm)) THEN
+               default_para_env = mpi_comm
+            ELSE
+               default_para_env = mp_comm_world
+            END IF
          END IF
 
          CALL string_table_allocate()

--- a/src/start/libcp2k.F
+++ b/src/start/libcp2k.F
@@ -114,7 +114,7 @@ CONTAINS
       CALL my_mpi_comm%set_handle(INT(mpi_comm))
       CALL init_cp2k(.FALSE., ierr, my_mpi_comm)
       CPASSERT(ierr == 0)
-   END SUBROUTINE cp2k_init_without_mpi
+   END SUBROUTINE cp2k_init_without_mpi_comm
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/start/libcp2k.F
+++ b/src/start/libcp2k.F
@@ -103,6 +103,21 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
+!> \param mpi_comm ...
+! **************************************************************************************************
+   SUBROUTINE cp2k_init_without_mpi_comm(mpi_comm) BIND(C)
+      INTEGER(C_INT), VALUE                              :: mpi_comm
+
+      INTEGER                                            :: ierr
+      TYPE(mp_comm_type)                                 :: my_mpi_comm
+
+      CALL my_mpi_comm%set_handle(INT(mpi_comm))
+      CALL init_cp2k(.FALSE., ierr, my_mpi_comm)
+      CPASSERT(ierr == 0)
+   END SUBROUTINE cp2k_init_without_mpi
+
+! **************************************************************************************************
+!> \brief ...
 ! **************************************************************************************************
    SUBROUTINE cp2k_finalize() BIND(C)
       INTEGER                                            :: ierr

--- a/src/start/libcp2k.h
+++ b/src/start/libcp2k.h
@@ -35,10 +35,17 @@ void cp2k_get_version(char *version_str, int str_length);
 void cp2k_init(void);
 
 /*******************************************************************************
- * \brief Initialize CP2K without initializing MPI
+ * \brief Initialize CP2K without initializing MPI (on MPI_COMM_WORLD)
  * \warning You are supposed to call cp2k_finalize() before exiting the program.
  ******************************************************************************/
 void cp2k_init_without_mpi(void);
+
+/*******************************************************************************
+ * \brief Initialize CP2K without initializing MPI on the given comm
+ * \warning You are supposed to call cp2k_finalize() before exiting the program.
+ * \param mpi_comm Fortran MPI communicator if MPI is not managed by CP2K
+ ******************************************************************************/
+void cp2k_init_without_mpi_comm(int mpi_comm);
 
 /*******************************************************************************
  * \brief Finalize CP2K and MPI


### PR DESCRIPTION
Hi cp2k team,

I have been running into a problem where the function `init_cp2k` in the f77 API is assuming that the initialisation is occurring on the `MPI_COMM_WORLD` communicator. This is a problem for my application, where only a subset of MPI ranks are involved in running cp2k.

I have made a minor change to the relevant function to add an optional argument, so that the user can supply an MPI communicator to this function, without the assumption that `MPI_COMM_WORLD` will be used.

Looking at the rest of the API functions, I think this should be following the style of other functions that allow the same thing.

I am not very experienced with cp2k's API, so just let me know if I am using the wrong function or this change doesn't make sense.

All the best,
Tom