### PR TITLE
BSE: Minor features

### DIFF
--- a/src/bse_print.F
+++ b/src/bse_print.F
@@ -691,8 +691,13 @@ CONTAINS
          WRITE (unit_nr, '(T2,A4,T15,A7,F10.4,A2,F10.4,A2,F10.4,A1)') prefix_output, &
             'r_0 = (', ref_point_multipole(1)*angstrom, ', ', ref_point_multipole(2)*angstrom, ', ', &
             ref_point_multipole(3)*angstrom, ')'
-         WRITE (unit_nr, '(T2,A4,T7,A,A,A)') prefix_output, &
-            'we further obtain r_e and r_h from solving the ', method_name, ' within the TDA'
+         IF (exc_descr(1)%flag_TDA) THEN
+            WRITE (unit_nr, '(T2,A4,T7,A,A,A)') prefix_output, &
+               'we further obtain r_e and r_h from solving the ', method_name, ' within the TDA'
+         ELSE
+            WRITE (unit_nr, '(T2,A4,T7,A,A,A)') prefix_output, &
+               'we further obtain r_e and r_h from solving the ', method_name, ' without the TDA'
+         END IF
          WRITE (unit_nr, '(T2,A4)') prefix_output
          WRITE (unit_nr, '(T2,A4,T8,A12,1X,13X,A9,13X,A9,13X,A9)') prefix_output, &
             'Excitation n', 'x_e [Å]', 'y_e [Å]', 'z_e [Å]'

--- a/src/bse_print.F
+++ b/src/bse_print.F
@@ -520,8 +520,6 @@ CONTAINS
       CHARACTER(LEN=1), DIMENSION(3)                     :: array_direction_str
       CHARACTER(LEN=5)                                   :: method_name
       INTEGER                                            :: handle, i_dir, i_exc
-      REAL(KIND=dp)                                      :: d_eh_dir, d_exc_dir, sigma_e_dir, &
-                                                            sigma_h_dir
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       IF (prefix_output == 'BSE|') THEN
@@ -670,18 +668,36 @@ CONTAINS
             DO i_exc = 1, num_print_exc_descr
                DO i_dir = 1, 3
                   array_direction_str = (/"x", "y", "z"/)
-                  d_eh_dir = ABS(exc_descr(i_exc)%r_h(i_dir) - exc_descr(i_exc)%r_e(i_dir))
-                  sigma_e_dir = SQRT(exc_descr(i_exc)%r_e_sq(i_dir) - exc_descr(i_exc)%r_e(i_dir)**2)
-                  sigma_h_dir = SQRT(exc_descr(i_exc)%r_h_sq(i_dir) - exc_descr(i_exc)%r_h(i_dir)**2)
-                  d_exc_dir = SQRT(d_eh_dir**2 + sigma_e_dir**2 + sigma_h_dir**2 &
-                                   - 2*exc_descr(i_exc)%cov_e_h(i_dir))
                   WRITE (unit_nr, '(T2,A4,T9,I4,10X,A1,1X,4(4X,F10.4))') &
                      prefix_output, i_exc, array_direction_str(i_dir), &
-                     d_eh_dir*angstrom, &
-                     sigma_e_dir*angstrom, sigma_h_dir*angstrom, &
-                     d_exc_dir*angstrom
+                     exc_descr(i_exc)%d_eh_dir(i_dir)*angstrom, &
+                     exc_descr(i_exc)%sigma_e_dir(i_dir)*angstrom, &
+                     exc_descr(i_exc)%sigma_h_dir(i_dir)*angstrom, &
+                     exc_descr(i_exc)%d_exc_dir(i_dir)*angstrom
                END DO
                WRITE (unit_nr, '(T2,A4)') prefix_output
+            END DO
+            WRITE (unit_nr, '(T2,A4)') prefix_output
+            WRITE (unit_nr, '(T2,A4)') prefix_output
+            IF (exc_descr(1)%flag_TDA) THEN
+               WRITE (unit_nr, '(T2,A4,T7,A,A,A)') prefix_output, &
+                  'Crosscorrelation matrix from solving the ', method_name, ' within the TDA:'
+            ELSE
+               WRITE (unit_nr, '(T2,A4,T7,A,A,A)') prefix_output, &
+                  'Crosscorrelation matrix from solving the ', method_name, ' without the TDA:'
+            END IF
+            WRITE (unit_nr, '(T2,A4)') prefix_output
+            WRITE (unit_nr, '(T2,A4,T12,A1,8X,6(8X,A2))') prefix_output, &
+               'n', 'xx', 'yy', 'zz', 'xy', 'xz', 'yz'
+            DO i_exc = 1, num_print_exc_descr
+               WRITE (unit_nr, '(T2,A4,T9,I4,8X,6(3X,F7.4))') &
+                  prefix_output, i_exc, &
+                  exc_descr(i_exc)%corr_e_h_matrix(1, 1), &
+                  exc_descr(i_exc)%corr_e_h_matrix(2, 2), &
+                  exc_descr(i_exc)%corr_e_h_matrix(3, 3), &
+                  exc_descr(i_exc)%corr_e_h_matrix(1, 2), &
+                  exc_descr(i_exc)%corr_e_h_matrix(1, 3), &
+                  exc_descr(i_exc)%corr_e_h_matrix(2, 3)
             END DO
             WRITE (unit_nr, '(T2,A4)') prefix_output
          END IF

--- a/src/bse_print.F
+++ b/src/bse_print.F
@@ -645,14 +645,20 @@ CONTAINS
                'σ_h^x    = sqrt( <x_h^2>_exc - <x_h>_exc^2 )'
             WRITE (unit_nr, '(T2,A4)') prefix_output
             WRITE (unit_nr, '(T2,A4,T15,A)') prefix_output, &
-               'COV_eh^x = <x_e x_h>_exc - <x_e>_exc <x_h>_exc'
+               "COV_eh^{μμ'} = <r^μ_e r^μ'_h>_exc - <r^μ_e>_exc <r^μ'_h>_exc"
             WRITE (unit_nr, '(T2,A4)') prefix_output
             WRITE (unit_nr, '(T2,A4,T15,A)') prefix_output, &
                'd_exc^x  = sqrt( | < |x_h - x_e|^2 >_exc )'
             WRITE (unit_nr, '(T2,A4,T15,A)') prefix_output, &
                '         = sqrt( (d_eh^x)^2 + (σ_e^x)^2'
             WRITE (unit_nr, '(T2,A4,T15,A)') prefix_output, &
-               '                 + (σ_h^x)^2 - 2 * (COV_eh^x) )'
+               "                 + (σ_h^x)^2 - 2 * (COV_eh^{xx}) )"
+            WRITE (unit_nr, '(T2,A4)') prefix_output
+            WRITE (unit_nr, '(T2,A4,T7,A)') prefix_output, &
+               "Subsequently, the cross-correlation matrix R_eh^{μμ'} is printed"
+            WRITE (unit_nr, '(T2,A4)') prefix_output
+            WRITE (unit_nr, '(T2,A4,T15,A)') prefix_output, &
+               "R_eh^{μμ'} = COV_eh^{μμ'}/(σ^μ_e σ^μ_h) "
             WRITE (unit_nr, '(T2,A4)') prefix_output
             WRITE (unit_nr, '(T2,A4)') prefix_output
             IF (exc_descr(1)%flag_TDA) THEN
@@ -690,7 +696,7 @@ CONTAINS
             WRITE (unit_nr, '(T2,A4,T12,A1,8X,6(8X,A2))') prefix_output, &
                'n', 'xx', 'yy', 'zz', 'xy', 'xz', 'yz'
             DO i_exc = 1, num_print_exc_descr
-               WRITE (unit_nr, '(T2,A4,T9,I4,8X,6(3X,F7.4))') &
+               WRITE (unit_nr, '(T2,A4,T9,I4,8X,6(3X,F7.4),3X,F7.4)') &
                   prefix_output, i_exc, &
                   exc_descr(i_exc)%corr_e_h_matrix(1, 1), &
                   exc_descr(i_exc)%corr_e_h_matrix(2, 2), &

--- a/src/bse_properties.F
+++ b/src/bse_properties.F
@@ -178,6 +178,8 @@ CONTAINS
 
       ! Get oscillator strengths themselves
       ALLOCATE (oscill_str(homo_red*virtual_red))
+      ! trans_mom_bse needs to be a 2D array per direction idir, such that cp_fm_get_submatrix can directly
+      !  write to it
       ALLOCATE (trans_mom_bse(3, 1, homo_red*virtual_red))
       ALLOCATE (polarizability_residues(3, 3, homo_red*virtual_red))
       trans_mom_bse(:, :, :) = 0.0_dp
@@ -193,7 +195,7 @@ CONTAINS
                polarizability_residues(idir, jdir, n) = 2.0_dp*Exc_ens(n)*trans_mom_bse(idir, 1, n)*trans_mom_bse(jdir, 1, n)
             END DO
          END DO
-         oscill_str(n) = 2.0_dp/3.0_dp*Exc_ens(n)*SUM(ABS(trans_mom_bse(:, :, n))**2)
+         oscill_str(n) = 2.0_dp/3.0_dp*Exc_ens(n)*SUM(ABS(trans_mom_bse(:, 1, n))**2)
       END DO
 
       CALL cp_fm_struct_release(fm_struct_dipole_MO_trunc_reordered)

--- a/src/bse_properties.F
+++ b/src/bse_properties.F
@@ -895,76 +895,77 @@ CONTAINS
       END DO
       exc_descr(i_exc)%r_e_sq(:) = r_e_sq_X(:) + r_e_sq_Y(:)
 
-      ! <r_h r_e>_X
-      !   = Tr[ X^T µ_ij X µ_ab  +  Y^T µ_ij Y µ_ab + X µ_ai Y µ_ai + Y µ_ai X µ_ai]
-      !   = X_bj µ_ji X_ia µ_ab + Y_bj µ_ji Y_ia µ_ab + X_ia µ_aj Y_jb µ_bi + Y_ia µ_aj X_jb µ_bi
+      ! <r_e^\mu r_h^\mu'>_X
+      !   = Tr[ X^T µ'_ij X µ_ab  +  Y^T µ_ij Y µ'_ab + X µ'_ai Y µ_ai + Y µ_ai X µ'_ai]
+      !   = X_bj µ'_ji X_ia µ_ab + Y_bj µ_ji Y_ia µ'_ab + X_ia µ'_aj Y_jb µ_bi + Y_ia µ_aj X_jb µ'_bi
+      ! The i_dir and j_dir convert to mu and mu'
       CALL cp_fm_create(fm_work_ia, fm_struct_ia)
       CALL cp_fm_create(fm_work_ia_2, fm_struct_ia)
       CALL cp_fm_create(fm_work_ba, fm_struct_ab)
       DO i_dir = 1, 3
          DO j_dir = 1, 3
-            ! First term - X^T µ_ij X µ_ab
+            ! First term - X^T µ'_ij X µ_ab
             CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
             CALL cp_fm_set_all(fm_work_ia_2, 0.0_dp)
             ! work_ib = X_ia µ_ab
             CALL parallel_gemm("N", "N", homo, virtual, virtual, 1.0_dp, &
                                fm_X_ia, fm_multipole_ab_trunc(i_dir), 0.0_dp, fm_work_ia)
-            ! work_ja_2 = µ_ji work_ia
+            ! work_ja_2 = µ'_ji work_ia
             CALL parallel_gemm("N", "N", homo, virtual, homo, 1.0_dp, &
                                fm_multipole_ij_trunc(j_dir), fm_work_ia, 0.0_dp, fm_work_ia_2)
-            ! <r_h r_e>_X = work_ia_2 X_bj + ... = X^T work_ia_2 + ...
+            ! <r_e^\mu r_h^\mu'>_X = work_ia_2 X_bj + ... = X^T work_ia_2 + ...
             CALL cp_fm_trace(fm_X_ia, fm_work_ia_2, r_e_h_XX(i_dir, j_dir))
             r_e_h_XX(i_dir, j_dir) = r_e_h_XX(i_dir, j_dir)/norm_XpY
             IF (.NOT. flag_TDA) THEN
-               ! Second term -  Y^T µ_ij Y µ_ab
+               ! Second term -  Y^T µ_ij Y µ'_ab
                CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
                CALL cp_fm_set_all(fm_work_ia_2, 0.0_dp)
-               ! work_ib = Y_ia µ_ab
+               ! work_ib = Y_ia µ'_ab
                CALL parallel_gemm("N", "N", homo, virtual, virtual, 1.0_dp, &
-                                  fm_Y_ia, fm_multipole_ab_trunc(i_dir), 0.0_dp, fm_work_ia)
+                                  fm_Y_ia, fm_multipole_ab_trunc(j_dir), 0.0_dp, fm_work_ia)
                ! work_ja_2 = µ_ji work_ia
                CALL parallel_gemm("N", "N", homo, virtual, homo, 1.0_dp, &
-                                  fm_multipole_ij_trunc(j_dir), fm_work_ia, 0.0_dp, fm_work_ia_2)
+                                  fm_multipole_ij_trunc(i_dir), fm_work_ia, 0.0_dp, fm_work_ia_2)
                ! <r_h r_e>_X = work_ia_2 Y_bj + ... = Y^T work_ia_2 + ...
                CALL cp_fm_trace(fm_Y_ia, fm_work_ia_2, r_e_h_YY(i_dir, j_dir))
                r_e_h_YY(i_dir, j_dir) = r_e_h_YY(i_dir, j_dir)/norm_XpY
 
-               ! Third term - X µ_ai Y µ_ai = X_ia µ_aj Y_jb µ_bi
+               ! Third term - X µ'_ai Y µ_ai = X_ia µ'_aj Y_jb µ_bi
                !     Reshuffle for usage of trace (where first argument is transposed)
-               !     = µ_aj Y_jb µ_bi X_ia =
-               !        \__________/
-               !         fm_work_ai
-               !     fm_work_ai = µ_aj Y_jb µ_bi
-               !     fm_work_ia = µ_ib Y_bj µ_ja
+               !     = µ'_aj Y_jb µ_bi X_ia =
+               !        \___________/
+               !          fm_work_ai
+               !     fm_work_ai = µ'_aj Y_jb µ_bi
+               !     fm_work_ia = µ_ib Y_bj µ'_ja
                !                        \_____/
                !                       fm_work_ba
                CALL cp_fm_set_all(fm_work_ba, 0.0_dp)
                CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
-               ! fm_work_ba = Y_bj µ_ja
+               ! fm_work_ba = Y_bj µ'_ja
                CALL parallel_gemm("T", "T", virtual, virtual, homo, 1.0_dp, &
-                                  fm_Y_ia, fm_multipole_ai_trunc(i_dir), 0.0_dp, fm_work_ba)
+                                  fm_Y_ia, fm_multipole_ai_trunc(j_dir), 0.0_dp, fm_work_ba)
                ! fm_work_ia = µ_ib fm_work_ba
                CALL parallel_gemm("T", "N", homo, virtual, virtual, 1.0_dp, &
-                                  fm_multipole_ai_trunc(j_dir), fm_work_ba, 0.0_dp, fm_work_ia)
+                                  fm_multipole_ai_trunc(i_dir), fm_work_ba, 0.0_dp, fm_work_ia)
                ! <r_h r_e>_X = ... + X_ia µ_aj Y_jb µ_bi
                CALL cp_fm_trace(fm_work_ia, fm_X_ia, r_e_h_XY(i_dir, j_dir))
                r_e_h_XY(i_dir, j_dir) = r_e_h_XY(i_dir, j_dir)/norm_XpY
 
-               ! Fourth term - Y µ_ai X µ_ai = Y_ia µ_aj X_jb µ_bi
+               ! Fourth term - Y µ_ai X µ'_ai = Y_ia µ_aj X_jb µ'_bi
                !     Reshuffle for usage of trace (where first argument is transposed)
-               !     = µ_aj X_jb µ_bi Y_ia =
-               !        \__________/
+               !     = µ_aj X_jb µ'_bi Y_ia =
+               !        \___________/
                !         fm_work_ai
-               !     fm_work_ai = µ_aj X_jb µ_bi
-               !     fm_work_ia = µ_ib X_bj µ_ja
-               !                        \_____/
+               !     fm_work_ai = µ_aj X_jb µ'_bi
+               !     fm_work_ia = µ'_ib X_bj µ_ja
+               !                         \_____/
                !                       fm_work_ba
                CALL cp_fm_set_all(fm_work_ba, 0.0_dp)
                CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
                ! fm_work_ba = Y_bj µ_ja
                CALL parallel_gemm("T", "T", virtual, virtual, homo, 1.0_dp, &
                                   fm_X_ia, fm_multipole_ai_trunc(i_dir), 0.0_dp, fm_work_ba)
-               ! fm_work_ia = µ_ib fm_work_ba
+               ! fm_work_ia = µ'_ib fm_work_ba
                CALL parallel_gemm("T", "N", homo, virtual, virtual, 1.0_dp, &
                                   fm_multipole_ai_trunc(j_dir), fm_work_ba, 0.0_dp, fm_work_ia)
                ! <r_h r_e>_X = ... + X_ia µ_aj Y_jb µ_bi

--- a/src/bse_properties.F
+++ b/src/bse_properties.F
@@ -69,10 +69,15 @@ MODULE bse_properties
                                                             r_h = 0.0_dp, &
                                                             r_e_sq = 0.0_dp, &
                                                             r_h_sq = 0.0_dp, &
-                                                            r_e_h = 0.0_dp, &
                                                             r_e_shift = 0.0_dp, &
                                                             r_h_shift = 0.0_dp, &
-                                                            cov_e_h = 0.0_dp
+                                                            d_eh_dir = 0.0_dp, &
+                                                            sigma_e_dir = 0.0_dp, &
+                                                            sigma_h_dir = 0.0_dp, &
+                                                            d_exc_dir = 0.0_dp
+      REAL(KIND=dp), DIMENSION(3, 3)                      :: r_e_h = 0.0_dp, &
+                                                             cov_e_h = 0.0_dp, &
+                                                             corr_e_h_matrix = 0.0_dp
       REAL(KIND=dp)                                      :: sigma_e = 0.0_dp, &
                                                             sigma_h = 0.0_dp, &
                                                             cov_e_h_sum = 0.0_dp, &
@@ -768,13 +773,13 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_exciton_descriptors'
 
-      INTEGER                                            :: handle, i_dir
+      INTEGER                                            :: handle, i_dir, j_dir
       INTEGER, DIMENSION(3)                              :: mask_quadrupole
       LOGICAL                                            :: flag_TDA
       REAL(KIND=dp)                                      :: norm_X, norm_XpY, norm_Y
-      REAL(KIND=dp), DIMENSION(3)                        :: r_e_h_XX, r_e_h_XY, r_e_h_YX, r_e_h_YY, &
-                                                            r_e_sq_X, r_e_sq_Y, r_e_X, r_e_Y, &
+      REAL(KIND=dp), DIMENSION(3)                        :: r_e_sq_X, r_e_sq_Y, r_e_X, r_e_Y, &
                                                             r_h_sq_X, r_h_sq_Y, r_h_X, r_h_Y
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: r_e_h_XX, r_e_h_XY, r_e_h_YX, r_e_h_YY
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_ab, fm_struct_ia
       TYPE(cp_fm_type)                                   :: fm_work_ba, fm_work_ia, fm_work_ia_2
 
@@ -802,10 +807,10 @@ CONTAINS
       r_h_sq_X(:) = 0.0_dp
       r_e_sq_Y(:) = 0.0_dp
       r_h_sq_Y(:) = 0.0_dp
-      r_e_h_XX(:) = 0.0_dp
-      r_e_h_XY(:) = 0.0_dp
-      r_e_h_YX(:) = 0.0_dp
-      r_e_h_YY(:) = 0.0_dp
+      r_e_h_XX(:, :) = 0.0_dp
+      r_e_h_XY(:, :) = 0.0_dp
+      r_e_h_YX(:, :) = 0.0_dp
+      r_e_h_YY(:, :) = 0.0_dp
 
       norm_X = 0.0_dp
       norm_Y = 0.0_dp
@@ -816,7 +821,7 @@ CONTAINS
       exc_descr(i_exc)%r_h(:) = 0.0_dp
       exc_descr(i_exc)%r_e_sq(:) = 0.0_dp
       exc_descr(i_exc)%r_h_sq(:) = 0.0_dp
-      exc_descr(i_exc)%r_e_h(:) = 0.0_dp
+      exc_descr(i_exc)%r_e_h(:, :) = 0.0_dp
 
       exc_descr(i_exc)%flag_TDA = flag_TDA
       exc_descr(i_exc)%norm_XpY = 0.0_dp
@@ -895,80 +900,85 @@ CONTAINS
       CALL cp_fm_create(fm_work_ia_2, fm_struct_ia)
       CALL cp_fm_create(fm_work_ba, fm_struct_ab)
       DO i_dir = 1, 3
-         ! First term - X^T µ_ij X µ_ab
-         CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
-         CALL cp_fm_set_all(fm_work_ia_2, 0.0_dp)
-         ! work_ib = X_ia µ_ab
-         CALL parallel_gemm("N", "N", homo, virtual, virtual, 1.0_dp, &
-                            fm_X_ia, fm_multipole_ab_trunc(i_dir), 0.0_dp, fm_work_ia)
-         ! work_ja_2 = µ_ji work_ia
-         CALL parallel_gemm("N", "N", homo, virtual, homo, 1.0_dp, &
-                            fm_multipole_ij_trunc(i_dir), fm_work_ia, 0.0_dp, fm_work_ia_2)
-         ! <r_h r_e>_X = work_ia_2 X_bj + ... = X^T work_ia_2 + ...
-         CALL cp_fm_trace(fm_X_ia, fm_work_ia_2, r_e_h_XX(i_dir))
-         r_e_h_XX(i_dir) = r_e_h_XX(i_dir)/norm_XpY
-         IF (.NOT. flag_TDA) THEN
-            ! Second term -  Y^T µ_ij Y µ_ab
+         DO j_dir = 1, 3
+            ! First term - X^T µ_ij X µ_ab
             CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
             CALL cp_fm_set_all(fm_work_ia_2, 0.0_dp)
-            ! work_ib = Y_ia µ_ab
+            ! work_ib = X_ia µ_ab
             CALL parallel_gemm("N", "N", homo, virtual, virtual, 1.0_dp, &
-                               fm_Y_ia, fm_multipole_ab_trunc(i_dir), 0.0_dp, fm_work_ia)
+                               fm_X_ia, fm_multipole_ab_trunc(i_dir), 0.0_dp, fm_work_ia)
             ! work_ja_2 = µ_ji work_ia
             CALL parallel_gemm("N", "N", homo, virtual, homo, 1.0_dp, &
-                               fm_multipole_ij_trunc(i_dir), fm_work_ia, 0.0_dp, fm_work_ia_2)
-            ! <r_h r_e>_X = work_ia_2 Y_bj + ... = Y^T work_ia_2 + ...
-            CALL cp_fm_trace(fm_Y_ia, fm_work_ia_2, r_e_h_YY(i_dir))
-            r_e_h_YY(i_dir) = r_e_h_YY(i_dir)/norm_XpY
+                               fm_multipole_ij_trunc(j_dir), fm_work_ia, 0.0_dp, fm_work_ia_2)
+            ! <r_h r_e>_X = work_ia_2 X_bj + ... = X^T work_ia_2 + ...
+            CALL cp_fm_trace(fm_X_ia, fm_work_ia_2, r_e_h_XX(i_dir, j_dir))
+            r_e_h_XX(i_dir, j_dir) = r_e_h_XX(i_dir, j_dir)/norm_XpY
+            IF (.NOT. flag_TDA) THEN
+               ! Second term -  Y^T µ_ij Y µ_ab
+               CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
+               CALL cp_fm_set_all(fm_work_ia_2, 0.0_dp)
+               ! work_ib = Y_ia µ_ab
+               CALL parallel_gemm("N", "N", homo, virtual, virtual, 1.0_dp, &
+                                  fm_Y_ia, fm_multipole_ab_trunc(i_dir), 0.0_dp, fm_work_ia)
+               ! work_ja_2 = µ_ji work_ia
+               CALL parallel_gemm("N", "N", homo, virtual, homo, 1.0_dp, &
+                                  fm_multipole_ij_trunc(j_dir), fm_work_ia, 0.0_dp, fm_work_ia_2)
+               ! <r_h r_e>_X = work_ia_2 Y_bj + ... = Y^T work_ia_2 + ...
+               CALL cp_fm_trace(fm_Y_ia, fm_work_ia_2, r_e_h_YY(i_dir, j_dir))
+               r_e_h_YY(i_dir, j_dir) = r_e_h_YY(i_dir, j_dir)/norm_XpY
 
-            ! Third term - X µ_ai Y µ_ai = X_ia µ_aj Y_jb µ_bi
-            !     Reshuffle for usage of trace (where first argument is transposed)
-            !     = µ_aj Y_jb µ_bi X_ia =
-            !        \__________/
-            !         fm_work_ai
-            !     fm_work_ai = µ_aj Y_jb µ_bi
-            !     fm_work_ia = µ_ib Y_bj µ_ja
-            !                        \_____/
-            !                       fm_work_ba
-            CALL cp_fm_set_all(fm_work_ba, 0.0_dp)
-            CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
-            ! fm_work_ba = Y_bj µ_ja
-            CALL parallel_gemm("T", "T", virtual, virtual, homo, 1.0_dp, &
-                               fm_Y_ia, fm_multipole_ai_trunc(i_dir), 0.0_dp, fm_work_ba)
-            ! fm_work_ia = µ_ib fm_work_ba
-            CALL parallel_gemm("T", "N", homo, virtual, virtual, 1.0_dp, &
-                               fm_multipole_ai_trunc(i_dir), fm_work_ba, 0.0_dp, fm_work_ia)
-            ! <r_h r_e>_X = ... + X_ia µ_aj Y_jb µ_bi
-            CALL cp_fm_trace(fm_work_ia, fm_X_ia, r_e_h_XY(i_dir))
-            r_e_h_XY(i_dir) = r_e_h_XY(i_dir)/norm_XpY
+               ! Third term - X µ_ai Y µ_ai = X_ia µ_aj Y_jb µ_bi
+               !     Reshuffle for usage of trace (where first argument is transposed)
+               !     = µ_aj Y_jb µ_bi X_ia =
+               !        \__________/
+               !         fm_work_ai
+               !     fm_work_ai = µ_aj Y_jb µ_bi
+               !     fm_work_ia = µ_ib Y_bj µ_ja
+               !                        \_____/
+               !                       fm_work_ba
+               CALL cp_fm_set_all(fm_work_ba, 0.0_dp)
+               CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
+               ! fm_work_ba = Y_bj µ_ja
+               CALL parallel_gemm("T", "T", virtual, virtual, homo, 1.0_dp, &
+                                  fm_Y_ia, fm_multipole_ai_trunc(i_dir), 0.0_dp, fm_work_ba)
+               ! fm_work_ia = µ_ib fm_work_ba
+               CALL parallel_gemm("T", "N", homo, virtual, virtual, 1.0_dp, &
+                                  fm_multipole_ai_trunc(j_dir), fm_work_ba, 0.0_dp, fm_work_ia)
+               ! <r_h r_e>_X = ... + X_ia µ_aj Y_jb µ_bi
+               CALL cp_fm_trace(fm_work_ia, fm_X_ia, r_e_h_XY(i_dir, j_dir))
+               r_e_h_XY(i_dir, j_dir) = r_e_h_XY(i_dir, j_dir)/norm_XpY
 
-            ! Fourth term - Y µ_ai X µ_ai = Y_ia µ_aj X_jb µ_bi
-            !     Reshuffle for usage of trace (where first argument is transposed)
-            !     = µ_aj X_jb µ_bi Y_ia =
-            !        \__________/
-            !         fm_work_ai
-            !     fm_work_ai = µ_aj X_jb µ_bi
-            !     fm_work_ia = µ_ib X_bj µ_ja
-            !                        \_____/
-            !                       fm_work_ba
-            CALL cp_fm_set_all(fm_work_ba, 0.0_dp)
-            CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
-            ! fm_work_ba = Y_bj µ_ja
-            CALL parallel_gemm("T", "T", virtual, virtual, homo, 1.0_dp, &
-                               fm_X_ia, fm_multipole_ai_trunc(i_dir), 0.0_dp, fm_work_ba)
-            ! fm_work_ia = µ_ib fm_work_ba
-            CALL parallel_gemm("T", "N", homo, virtual, virtual, 1.0_dp, &
-                               fm_multipole_ai_trunc(i_dir), fm_work_ba, 0.0_dp, fm_work_ia)
-            ! <r_h r_e>_X = ... + X_ia µ_aj Y_jb µ_bi
-            CALL cp_fm_trace(fm_work_ia, fm_Y_ia, r_e_h_YX(i_dir))
-            r_e_h_YX(i_dir) = r_e_h_YX(i_dir)/norm_XpY
-         END IF
+               ! Fourth term - Y µ_ai X µ_ai = Y_ia µ_aj X_jb µ_bi
+               !     Reshuffle for usage of trace (where first argument is transposed)
+               !     = µ_aj X_jb µ_bi Y_ia =
+               !        \__________/
+               !         fm_work_ai
+               !     fm_work_ai = µ_aj X_jb µ_bi
+               !     fm_work_ia = µ_ib X_bj µ_ja
+               !                        \_____/
+               !                       fm_work_ba
+               CALL cp_fm_set_all(fm_work_ba, 0.0_dp)
+               CALL cp_fm_set_all(fm_work_ia, 0.0_dp)
+               ! fm_work_ba = Y_bj µ_ja
+               CALL parallel_gemm("T", "T", virtual, virtual, homo, 1.0_dp, &
+                                  fm_X_ia, fm_multipole_ai_trunc(i_dir), 0.0_dp, fm_work_ba)
+               ! fm_work_ia = µ_ib fm_work_ba
+               CALL parallel_gemm("T", "N", homo, virtual, virtual, 1.0_dp, &
+                                  fm_multipole_ai_trunc(j_dir), fm_work_ba, 0.0_dp, fm_work_ia)
+               ! <r_h r_e>_X = ... + X_ia µ_aj Y_jb µ_bi
+               CALL cp_fm_trace(fm_work_ia, fm_Y_ia, r_e_h_YX(i_dir, j_dir))
+               r_e_h_YX(i_dir, j_dir) = r_e_h_YX(i_dir, j_dir)/norm_XpY
+            END IF
+         END DO
       END DO
-      exc_descr(i_exc)%r_e_h(:) = r_e_h_XX(:) + r_e_h_XY(:) + r_e_h_YX(:) + r_e_h_YY(:)
+      exc_descr(i_exc)%r_e_h(:, :) = r_e_h_XX(:, :) + r_e_h_XY(:, :) + r_e_h_YX(:, :) + r_e_h_YY(:, :)
 
       CALL cp_fm_release(fm_work_ia)
       CALL cp_fm_release(fm_work_ia_2)
       CALL cp_fm_release(fm_work_ba)
+
+      ! Now we compute all the descriptors and correlation coefficients
+      ! Order is: Directional ones, then covariances and correlation coefficients and
 
       ! diff_r_abs = |<r_h>_X - <r_e>_X|
       exc_descr(i_exc)%diff_r_abs = SQRT(SUM((exc_descr(i_exc)%r_h(:) - exc_descr(i_exc)%r_e(:))**2))
@@ -979,23 +989,45 @@ CONTAINS
       ! σ_h = sqrt( <r_h^2>_X - <r_h>_X^2 )
       exc_descr(i_exc)%sigma_h = SQRT(SUM(exc_descr(i_exc)%r_h_sq(:)) - SUM(exc_descr(i_exc)%r_h(:)**2))
 
+      ! Now directed ones
+      DO i_dir = 1, 3
+         exc_descr(i_exc)%d_eh_dir(i_dir) = ABS(exc_descr(i_exc)%r_h(i_dir) - exc_descr(i_exc)%r_e(i_dir))
+         exc_descr(i_exc)%sigma_e_dir(i_dir) = SQRT(exc_descr(i_exc)%r_e_sq(i_dir) - exc_descr(i_exc)%r_e(i_dir)**2)
+         exc_descr(i_exc)%sigma_h_dir(i_dir) = SQRT(exc_descr(i_exc)%r_h_sq(i_dir) - exc_descr(i_exc)%r_h(i_dir)**2)
+      END DO
+
+      ! Covariance and correlation coefficient (as well as crosscorrelation matrices)
       ! COV(r_e, r_h) = < r_e r_h >_X - < r_e >_X < r_h >_X
       exc_descr(i_exc)%cov_e_h_sum = 0.0_dp
-      exc_descr(i_exc)%cov_e_h(:) = 0.0_dp
+      exc_descr(i_exc)%cov_e_h(:, :) = 0.0_dp
+      exc_descr(i_exc)%corr_e_h_matrix(:, :) = 0.0_dp
       DO i_dir = 1, 3
-         exc_descr(i_exc)%cov_e_h(i_dir) = exc_descr(i_exc)%r_e_h(i_dir) &
-                                           - exc_descr(i_exc)%r_e(i_dir)*exc_descr(i_exc)%r_h(i_dir)
+         DO j_dir = 1, 3
+            exc_descr(i_exc)%cov_e_h(i_dir, j_dir) = exc_descr(i_exc)%r_e_h(i_dir, j_dir) &
+                                                     - exc_descr(i_exc)%r_e(i_dir)*exc_descr(i_exc)%r_h(j_dir)
+            exc_descr(i_exc)%corr_e_h_matrix(i_dir, j_dir) = &
+               exc_descr(i_exc)%cov_e_h(i_dir, j_dir)/ &
+               (exc_descr(i_exc)%sigma_e_dir(i_dir)*exc_descr(i_exc)%sigma_h_dir(j_dir))
+         END DO
          exc_descr(i_exc)%cov_e_h_sum = exc_descr(i_exc)%cov_e_h_sum + &
-                                        exc_descr(i_exc)%r_e_h(i_dir) - exc_descr(i_exc)%r_e(i_dir)*exc_descr(i_exc)%r_h(i_dir)
+                                        exc_descr(i_exc)%r_e_h(i_dir, i_dir) - &
+                                        exc_descr(i_exc)%r_e(i_dir)*exc_descr(i_exc)%r_h(i_dir)
       END DO
+
+      ! e-h-correlation coefficient R_eh = COV(r_e, r_h) / ( σ_e σ_h )
+      exc_descr(i_exc)%corr_e_h = exc_descr(i_exc)%cov_e_h_sum/(exc_descr(i_exc)%sigma_e*exc_descr(i_exc)%sigma_h)
 
       ! root-mean-square e-h separation
       exc_descr(i_exc)%diff_r_sqr = SQRT(exc_descr(i_exc)%diff_r_abs**2 + &
                                          exc_descr(i_exc)%sigma_e**2 + exc_descr(i_exc)%sigma_h**2 &
                                          - 2*exc_descr(i_exc)%cov_e_h_sum)
 
-      ! e-h-correlation coefficient R_eh = COV(r_e, r_h) / ( σ_e σ_h )
-      exc_descr(i_exc)%corr_e_h = exc_descr(i_exc)%cov_e_h_sum/(exc_descr(i_exc)%sigma_e*exc_descr(i_exc)%sigma_h)
+      DO i_dir = 1, 3
+         exc_descr(i_exc)%d_exc_dir(i_dir) = SQRT(exc_descr(i_exc)%d_eh_dir(i_dir)**2 + &
+                                                  exc_descr(i_exc)%sigma_e_dir(i_dir)**2 + &
+                                                  exc_descr(i_exc)%sigma_h_dir(i_dir)**2 - &
+                                                  2*exc_descr(i_exc)%cov_e_h(i_dir, i_dir))
+      END DO
 
       ! Expectation values of r_e and r_h
       exc_descr(i_exc)%r_e_shift(:) = exc_descr(i_exc)%r_e(:)

--- a/src/bse_util.F
+++ b/src/bse_util.F
@@ -1030,7 +1030,7 @@ CONTAINS
          END IF
          DO ii = 1, nrow_local
             eigvec_idx = row_indices(ii)
-            eigvec_entry = fm_eigvec%local_data(ii, jj)/SQRT(2.0_dp)
+            eigvec_entry = fm_eigvec%local_data(ii, jj)
             IF (ABS(eigvec_entry) > mp2_env%bse%eps_x) THEN
                num_entries_to_comm(para_env%mepos) = num_entries_to_comm(para_env%mepos) + 1
             END IF
@@ -1059,7 +1059,7 @@ CONTAINS
          END IF
          DO ii = 1, nrow_local
             eigvec_idx = row_indices(ii)
-            eigvec_entry = fm_eigvec%local_data(ii, jj)/SQRT(2.0_dp)
+            eigvec_entry = fm_eigvec%local_data(ii, jj)
             IF (ABS(eigvec_entry) > mp2_env%bse%eps_x) THEN
                buffer_entries(para_env%mepos)%indx(kk, 1) = (eigvec_idx - 1)/virtual + 1
                buffer_entries(para_env%mepos)%indx(kk, 2) = MOD(eigvec_idx - 1, virtual) + 1


### PR DESCRIPTION
This PR introduces a number of minor changes to the BSE module:
- remove scaling factor 1/sqrt(2) from print of transition amplitudes X_ia^n and Y_ia^n
- fix for TDA on/off print statement
- add cross-correlation matrix to the exciton descriptors