### PR TITLE
Let builds succeed

### DIFF
--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -35,7 +35,7 @@ endif()
 
 # Baseline
 add_compile_options(
-  "$<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-std=f2008;-ffree-form;-fimplicit-none>"
+  "$<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-std=f2008;-ffree-form;-fimplicit-none;-ffree-line-length-none>"
   "$<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-g;-fno-omit-frame-pointer;-fbacktrace>"
   "$<$<COMPILE_LANG_AND_ID:Fortran,GNU>:$<$<VERSION_GREATER_EQUAL:${CMAKE_Fortran_COMPILER_VERSION},11>:-fallow-argument-mismatch>>"
   "$<$<COMPILE_LANG_AND_ID:Fortran,GNU>:-Wno-deprecated-declarations;-Wno-maybe-uninitialized;-Wuninitialized;-Wuse-without-only>"

--- a/src/gx_ac_unittest.F
+++ b/src/gx_ac_unittest.F
@@ -14,7 +14,7 @@ PROGRAM gx_ac_unittest
 #if !defined(__GREENX)
    ! Abort and inform that GreenX was not included in the compilation
    ! Ideally, this will be avoided in testing by the conditional tests
-   CPABORT("CP2K not compiled with GreenX link - please recompile to access GXAC.")
+   CPABORT("CP2K not compiled with GreenX library.")
 #else
    USE kinds, ONLY: dp
    USE gx_ac, ONLY: create_thiele_pade, &

--- a/src/nequip_unittest.F
+++ b/src/nequip_unittest.F
@@ -226,7 +226,7 @@ PROGRAM nequip_unittest
    CALL torch_model_release(model)
    DEALLOCATE (edge_index, edge_cell_shift, pos, cell, atom_types)
 
-   WRITE (*, *) "NequIP unittest was successfully :-)"
+   WRITE (*, *) "NequIP unittest was success :-)"
 
 CONTAINS
 


### PR DESCRIPTION
- It seems -Wno-error does not cover line truncation warning.
- It seems -ffree-line-length-none is necessary on top.
- Issues came up with Spack/CMake based builds.
- Cleanup/typos.