### PR TITLE
Temporarily disable tests/QS/regtest-tddfpt-bse

### DIFF
--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -23,7 +23,6 @@ QS/regtest-dlaf-2                                           dlaf libint !ifx
 QS/regtest-pao-2
 QS/regtest-tddfpt-force-gapw                                libint libxc !ifx
 QS/regtest-tddfpt-4                                         libint libxc !ifx
-QS/regtest-tddfpt-bse                                       libint libxc 
 QS/regtest-tddfpt-force-3                                   libint !ifx
 QS/regtest-debug-5                                          libint !ifx
 QS/regtest-gpw-4
@@ -399,3 +398,6 @@ QS/regtest-trexio                                           trexio
 QS/regtest-trexio-2                                         trexio libgrpp
 QS/regtest-rtbse-gxac                                       libint greenx !ifx
 QS/regtest-cneo
+
+# TODO: Re-enable once problems with MPI are resolved (https://github.com/cp2k/cp2k/pull/4445)
+# QS/regtest-tddfpt-bse                                       libint libxc


### PR DESCRIPTION
Follow up to #4445. This is a temporary measure to recover the dashboard while we're working on an actual fix. 