### PR TITLE
precommit: Add Fortitude linter

### DIFF
--- a/src/base/machine.F
+++ b/src/base/machine.F
@@ -33,12 +33,14 @@ MODULE machine
    (LIBXSMM_CONFIG_VERSION_MAJOR*1000000 + LIBXSMM_CONFIG_VERSION_MINOR*10000 + LIBXSMM_CONFIG_VERSION_UPDATE*100 + LIBXSMM_CONFIG_VERSION_PATCH)))
 #define __LIBXSMM2
 #endif
+#if defined(__LIBXSMM2)
    USE libxsmm, ONLY: libxsmm_timer_tick, libxsmm_timer_duration, libxsmm_get_target_archid, &
                       LIBXSMM_TARGET_ARCH_GENERIC, LIBXSMM_X86_SSE4, LIBXSMM_X86_AVX, LIBXSMM_X86_AVX2, &
-#if defined(__LIBXSMM2)
                       LIBXSMM_X86_AVX512_SKX, LIBXSMM_AARCH64_V81, LIBXSMM_AARCH64_SVE128
 #else
-   LIBXSMM_X86_AVX512_SKX => LIBXSMM_X86_AVX512_CORE
+   USE libxsmm, ONLY: libxsmm_timer_tick, libxsmm_timer_duration, libxsmm_get_target_archid, &
+                      LIBXSMM_TARGET_ARCH_GENERIC, LIBXSMM_X86_SSE4, LIBXSMM_X86_AVX, LIBXSMM_X86_AVX2, &
+                      LIBXSMM_X86_AVX512_SKX => LIBXSMM_X86_AVX512_CORE
 #endif
 #endif
 
@@ -193,31 +195,38 @@ CONTAINS
 ! **************************************************************************************************
    PURE FUNCTION m_cpuid()
       INTEGER :: m_cpuid
-#if defined(__LIBXSMM)
-      m_cpuid = libxsmm_get_target_archid()
-      IF (LIBXSMM_X86_SSE4 <= m_cpuid .AND. m_cpuid < LIBXSMM_X86_AVX) THEN
-         m_cpuid = MACHINE_X86_SSE4
-      ELSE IF (LIBXSMM_X86_AVX <= m_cpuid .AND. m_cpuid < LIBXSMM_X86_AVX2) THEN
-         m_cpuid = MACHINE_X86_AVX
-      ELSE IF (LIBXSMM_X86_AVX2 <= m_cpuid .AND. m_cpuid < LIBXSMM_X86_AVX512_SKX) THEN
-         m_cpuid = MACHINE_X86_AVX2
-      ELSE IF (LIBXSMM_X86_AVX512_SKX <= m_cpuid .AND. m_cpuid <= 1999) THEN
-         m_cpuid = MACHINE_X86_AVX512
-#if defined(__LIBXSMM2)
-      ELSE IF (LIBXSMM_AARCH64_V81 <= m_cpuid .AND. m_cpuid < LIBXSMM_AARCH64_SVE128) THEN
-         m_cpuid = MACHINE_ARM_ARCH64
-      ELSE IF (LIBXSMM_AARCH64_SVE128 <= m_cpuid .AND. m_cpuid < 2401) THEN ! LIBXSMM_AARCH64_SVE512
-         m_cpuid = MACHINE_ARM_SVE256
-      ELSE IF (2401 <= m_cpuid .AND. m_cpuid <= 2999) THEN
-         m_cpuid = MACHINE_ARM_SVE512
-#endif
-      ELSE IF (LIBXSMM_TARGET_ARCH_GENERIC <= m_cpuid .AND. m_cpuid <= 2999) THEN
-         m_cpuid = MACHINE_CPU_GENERIC
-      ELSE
-         m_cpuid = MACHINE_CPU_UNKNOWN
-      END IF
-#else
+#if !defined(__LIBXSMM)
       m_cpuid = m_cpuid_static()
+#else
+
+      INTEGER :: archid
+      m_cpuid = MACHINE_CPU_UNKNOWN
+      archid = libxsmm_get_target_archid()
+      IF (LIBXSMM_X86_SSE4 <= archid .AND. archid < LIBXSMM_X86_AVX) THEN
+         m_cpuid = MACHINE_X86_SSE4
+      ELSE IF (LIBXSMM_X86_AVX <= archid .AND. archid < LIBXSMM_X86_AVX2) THEN
+         m_cpuid = MACHINE_X86_AVX
+      ELSE IF (LIBXSMM_X86_AVX2 <= archid .AND. archid < LIBXSMM_X86_AVX512_SKX) THEN
+         m_cpuid = MACHINE_X86_AVX2
+      ELSE IF (LIBXSMM_X86_AVX512_SKX <= archid .AND. archid <= 1999) THEN
+         m_cpuid = MACHINE_X86_AVX512
+      END IF
+
+#if defined(__LIBXSMM2)
+      IF (m_cpuid == MACHINE_CPU_UNKNOWN) THEN
+         IF (LIBXSMM_AARCH64_V81 <= archid .AND. archid < LIBXSMM_AARCH64_SVE128) THEN
+            m_cpuid = MACHINE_ARM_ARCH64
+         ELSE IF (LIBXSMM_AARCH64_SVE128 <= archid .AND. archid < 2401) THEN ! LIBXSMM_AARCH64_SVE512
+            m_cpuid = MACHINE_ARM_SVE256
+         ELSE IF (2401 <= archid .AND. archid <= 2999) THEN
+            m_cpuid = MACHINE_ARM_SVE512
+         END IF
+      END IF
+#endif
+
+      IF (m_cpuid == MACHINE_CPU_UNKNOWN .AND. LIBXSMM_TARGET_ARCH_GENERIC <= archid .AND. archid <= 2999) THEN
+         m_cpuid = MACHINE_CPU_GENERIC
+      END IF
 #endif
    END FUNCTION m_cpuid
 
@@ -230,10 +239,10 @@ CONTAINS
 !>      09.2024 update+arm [Hans Pabst]
 ! **************************************************************************************************
    PURE FUNCTION m_cpuid_name(cpuid)
-      INTEGER, OPTIONAL, INTENT(IN)         :: cpuid
-      CHARACTER(len=default_string_length)  :: m_cpuid_name
+      INTEGER, INTENT(IN), OPTIONAL                      :: cpuid
+      CHARACTER(len=default_string_length)               :: m_cpuid_name
 
-      INTEGER                               :: isa
+      INTEGER                                            :: isa
 
       IF (PRESENT(cpuid)) THEN
          isa = cpuid
@@ -274,9 +283,10 @@ CONTAINS
 !>      12.2024 created [Hans Pabst]
 ! **************************************************************************************************
    PURE FUNCTION m_cpuid_vlen(cpuid, typesize)
-      INTEGER, OPTIONAL, INTENT(IN) :: cpuid, typesize
+      INTEGER, INTENT(IN), OPTIONAL                      :: cpuid, typesize
+      INTEGER                                            :: m_cpuid_vlen
 
-      INTEGER                       :: isa, m_cpuid_vlen, nbytes
+      INTEGER                                            :: isa, nbytes
 
       IF (PRESENT(typesize)) THEN
          nbytes = typesize
@@ -556,10 +566,10 @@ CONTAINS
 !> \return ...
 ! **************************************************************************************************
       INTEGER(int_8) FUNCTION get_field_value_in_bytes(field)
-         CHARACTER(LEN=*)                                   :: field
+      CHARACTER(LEN=*)                                   :: field
 
-         INTEGER                                            :: start
-         INTEGER(KIND=int_8)                                :: value
+      INTEGER                                            :: start
+      INTEGER(KIND=int_8)                                :: value
 
          get_field_value_in_bytes = 0
          start = INDEX(meminfo, field)

--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -1004,7 +1004,7 @@ CONTAINS
       COMPLEX(KIND=dp), DIMENSION(*), INTENT(IN)         :: zout
       INTEGER, INTENT(IN)                                :: plan_style
 #if defined(__FFTW3)
-      INTEGER                                            :: ii, di, io, DO, num_threads, num_rows
+      INTEGER                                            :: ii, di, jj, dj, num_threads, num_rows
 
       INTEGER :: fftw_plan_type
       SELECT CASE (plan_style)
@@ -1049,32 +1049,32 @@ CONTAINS
 !$    plan%num_rows = num_rows
       ii = 1
       di = plan%n
-      io = 1
-      DO = plan%n
+      jj = 1
+      dj = plan%n
       IF (plan%fsign == +1 .AND. plan%trans) THEN
          ii = plan%m
          di = 1
       ELSEIF (plan%fsign == -1 .AND. plan%trans) THEN
-         io = plan%m
-         DO = 1
+         jj = plan%m
+         dj = 1
       END IF
 
       IF (plan%fsign == +1) THEN
          CALL dfftw_plan_many_dft(plan%fftw_plan, 1, plan%n, num_rows, zin, 0, ii, di, &
-                                  zout, 0, io, DO, FFTW_FORWARD, fftw_plan_type)
+                                  zout, 0, jj, dj, FFTW_FORWARD, fftw_plan_type)
       ELSE
          CALL dfftw_plan_many_dft(plan%fftw_plan, 1, plan%n, num_rows, zin, 0, ii, di, &
-                                  zout, 0, io, DO, FFTW_BACKWARD, fftw_plan_type)
+                                  zout, 0, jj, dj, FFTW_BACKWARD, fftw_plan_type)
       END IF
 
 !$    IF (plan%need_alt_plan) THEN
 !$       plan%alt_num_rows = plan%m - (plan%num_threads_needed - 1)*num_rows
 !$       IF (plan%fsign == +1) THEN
 !$          CALL dfftw_plan_many_dft(plan%alt_fftw_plan, 1, plan%n, plan%alt_num_rows, zin, 0, ii, di, &
-!$                                   zout, 0, io, DO, FFTW_FORWARD, fftw_plan_type)
+!$                                   zout, 0, jj, dj, FFTW_FORWARD, fftw_plan_type)
 !$       ELSE
 !$          CALL dfftw_plan_many_dft(plan%alt_fftw_plan, 1, plan%n, plan%alt_num_rows, zin, 0, ii, di, &
-!$                                   zout, 0, io, DO, FFTW_BACKWARD, fftw_plan_type)
+!$                                   zout, 0, jj, dj, FFTW_BACKWARD, fftw_plan_type)
 !$       END IF
 !$    END IF
 

--- a/tools/precommit/Dockerfile
+++ b/tools/precommit/Dockerfile
@@ -3,13 +3,14 @@ FROM ubuntu:24.04
 # author: Ole Schuett
 
 WORKDIR /opt/cp2k-precommit
-COPY . /opt/cp2k-precommit/
+COPY install_requirements.sh requirements.txt ./
 RUN ./install_requirements.sh
 ENV PATH="/opt/venv/bin:/opt/cp2k-precommit:$PATH"
 
 ARG REVISION
 ENV REVISION=${REVISION}
 
+COPY . ./
 CMD ["gunicorn", "--bind=:8080", "--workers=1", "--threads=8", "--timeout=0", "precommit_server:app"]
 
 #EOF

--- a/tools/precommit/fortitude.toml
+++ b/tools/precommit/fortitude.toml
@@ -1,0 +1,40 @@
+[check]
+line-length = 132
+
+# Also see https://fortitude.readthedocs.io/en/stable/rules
+ignore = [
+    "non-standard-file-extension",
+    "old-style-array-literal",
+    "bad-quote-string",
+    "multiple-allocations-with-stat",
+    "missing-intent",
+    "misleading-inline-if-continuation",
+    "deprecated-relational-operator",
+    "missing-default-case",
+    "implicit-external-procedures",
+    "keywords-missing-space",
+    "superfluous-semicolon",
+    "missing-exit-or-cycle-label",
+    "assumed-size",
+    "unnamed-end-statement",
+    "unchecked-stat",
+    "assumed-size-character-intent",
+    "external-procedure",
+    "literal-kind",
+    "trailing-whitespace",
+    "specific-name",
+    "missing-default-pointer-initalisation",
+    "interface-implicit-typing",
+    "misleading-inline-if-semicolon",
+    "procedure-not-in-module",
+    "keyword-has-whitespace",
+    "implicit-typing",
+    "trailing-backslash",
+    "missing-accessibility-statement",
+    "line-too-long",
+    "initialisation-in-declaration",
+    "pointer-initialisation-in-declaration",
+    "nonportable-shortcircuit-inquiry",
+]
+
+#EOF

--- a/tools/precommit/precommit.py
+++ b/tools/precommit/precommit.py
@@ -29,8 +29,6 @@ SERVER = os.environ.get("CP2K_PRECOMMIT_SERVER", "https://precommit.cp2k.org")
 # The following Fortran files can not be parsed by Fortitude.
 # Typically because Fortran statements are inter-leafed with pre-processor macros.
 FORTITUDE_EXCLUDE = [
-    "machine.F",
-    "fftw3_lib.F",
     "pw_methods.F",
     "local_gemm_api.F",
     "cp_fm_diag.F",

--- a/tools/precommit/precommit_server.py
+++ b/tools/precommit/precommit_server.py
@@ -64,11 +64,18 @@ def clangformat():
 # ======================================================================================
 @app.route("/cmakeformat", methods=["POST"])
 def cmakeformat():
-    return run_tool(["cmake-format", "-i"])
+    return run_tool(["cmake-format", "-i"], timeout=30)
 
 
 # ======================================================================================
-def run_tool(cmd, timeout=30):
+@app.route("/fortitude", methods=["POST"])
+def fortitude():
+    config = f"--config-file={os.getcwd()}/fortitude.toml"
+    return run_tool(["fortitude", config, "check"])
+
+
+# ======================================================================================
+def run_tool(cmd, timeout=3):
     assert len(request.files) == 1
     orig_fn = list(request.files.keys())[0]
     data_before = request.files[orig_fn].read()
@@ -88,7 +95,6 @@ def run_tool(cmd, timeout=30):
         return f"Timeout while running {cmd[0]} - please try again.", 504
     t2 = time()
     app.logger.info(f"Ran {cmd[0]} on {data_kb:.1f}KB in {t2-t1:.1f}s.")
-
     if p.returncode != 0:
         return p.stdout, 422  # Unprocessable Entity
     data_after = open(abs_fn, "rb").read()

--- a/tools/precommit/requirements.txt
+++ b/tools/precommit/requirements.txt
@@ -4,6 +4,7 @@ click==8.1.7
 cmake-format==0.6.13
 cmakelang==0.6.13
 Flask==3.0.0
+fortitude-lint==0.7.5
 gunicorn==23.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.6


### PR DESCRIPTION
This add the new [Fortitude](https://github.com/PlasmaFAIR/fortitude/) linter to our precommit tool.


To get started, I added all the rules that are currently violated to the ignore list. Many of them can be fixed automatically with `--unsafe-fixes` but need to be reviewed. Furthermore, a number of files can not be parsed - typically because Fortran statements are inter-leafed with pre-processor macros. So, we can chip away at these issue in the coming weeks.

Huge shoutout to @LiamPattinson and @ZedThree for creating the amazing Fortitude tool!