### PR TITLE
Monovalent atoms

### DIFF
--- a/src/atom_kind_orbitals.F
+++ b/src/atom_kind_orbitals.F
@@ -492,7 +492,7 @@ CONTAINS
       INTEGER, DIMENSION(0:lmat)                         :: starti
       INTEGER, DIMENSION(0:lmat, 10)                     :: ncalc, ncore, nelem
       INTEGER, DIMENSION(:), POINTER                     :: econf
-      LOGICAL                                            :: do_basopt, ecp_semi_local
+      LOGICAL                                            :: do_basopt, ecp_semi_local, monovalent
       REAL(KIND=dp)                                      :: al, aval, cc, cval, ear, rk, xx, zeff
       REAL(KIND=dp), DIMENSION(num_gto+2)                :: results
       TYPE(all_potential_type), POINTER                  :: all_potential
@@ -513,7 +513,8 @@ CONTAINS
       CALL get_qs_kind(qs_kind, zeff=zeff, &
                        all_potential=all_potential, &
                        gth_potential=gth_potential, &
-                       sgp_potential=sgp_potential)
+                       sgp_potential=sgp_potential, &
+                       monovalent=monovalent)
 
       IF (PRESENT(iunit)) THEN
          iw = iunit
@@ -656,7 +657,10 @@ CONTAINS
       nelem = 0
       ncore = 0
       ncalc = 0
-      IF (ASSOCIATED(gth_potential)) THEN
+      IF (monovalent) THEN
+         ncalc(0, 1) = 1
+         nelem(0, 1) = 1
+      ELSE IF (ASSOCIATED(gth_potential)) THEN
          CALL get_potential(gth_potential, elec_conf=econf)
          CALL set_pseudo_state(econf, z, ncalc, ncore, nelem)
       ELSE IF (ASSOCIATED(sgp_potential)) THEN

--- a/src/input_cp2k_subsys.F
+++ b/src/input_cp2k_subsys.F
@@ -1038,7 +1038,7 @@ CONTAINS
 
       CALL section_create(section, __LOCATION__, name="KIND", &
                           description="The description of the kind of the atoms (mostly for QM)", &
-                          n_keywords=19, n_subsections=1, repeats=.TRUE.)
+                          n_keywords=20, n_subsections=1, repeats=.TRUE.)
 
       NULLIFY (keyword)
 
@@ -1299,6 +1299,17 @@ CONTAINS
                           "Useful to just have the basis set at that position (e.g. BSSE calculations), "// &
                           "or to have a non-interacting particle with BASIS_SET NONE", &
                           usage="GHOST", &
+                          default_l_val=.FALSE., &
+                          lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, &
+                          name="MONOVALENT", &
+                          description="This keyword makes all atoms of this kind monovalent, i.e., with "// &
+                          "a single electron and nuclear charge set to 1.0. Used to saturate dangling bonds, "// &
+                          "ideally in conjunction with a monovalent pseudopotential. Currently GTH only.", &
+                          usage="MONOVALENT", &
                           default_l_val=.FALSE., &
                           lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(section, keyword)

--- a/src/input_cp2k_subsys.F
+++ b/src/input_cp2k_subsys.F
@@ -1306,7 +1306,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, &
                           name="MONOVALENT", &
-                          description="This keyword makes all atoms of this kind monovalent, i.e., with "// &
+                          description="This keyword makes all atoms of this kind monovalent, i.e. with "// &
                           "a single electron and nuclear charge set to 1.0. Used to saturate dangling bonds, "// &
                           "ideally in conjunction with a monovalent pseudopotential. Currently GTH only.", &
                           usage="MONOVALENT", &

--- a/src/qs_kind_types.F
+++ b/src/qs_kind_types.F
@@ -203,6 +203,7 @@ MODULE qs_kind_types
       LOGICAL                                :: gpw_type_forced = .FALSE. ! gpw atom even if with hard exponents
       !
       LOGICAL                                :: ghost = .FALSE.
+      LOGICAL                                :: monovalent = .FALSE.
       LOGICAL                                :: floating = .FALSE.
       INTEGER                                :: lmax_dftb = -1
       REAL(KIND=dp)                          :: dudq_dftb3 = 0.0_dp
@@ -437,6 +438,7 @@ CONTAINS
 !> \param init_u_ramping_each_scf ...
 !> \param reltmat ...
 !> \param ghost ...
+!> \param monovalent ...
 !> \param floating ...
 !> \param name ...
 !> \param element_symbol ...
@@ -461,7 +463,7 @@ CONTAINS
                           alpha_of_dft_plus_u, beta_of_dft_plus_u, J0_of_dft_plus_u, occupation_of_dft_plus_u, dispersion, &
                           bs_occupation, magnetization, no_optimize, addel, laddel, naddel, orbitals, &
                           max_scf, eps_scf, smear, u_ramping, u_minus_j_target, eps_u_ramping, &
-                          init_u_ramping_each_scf, reltmat, ghost, floating, name, element_symbol, &
+                          init_u_ramping_each_scf, reltmat, ghost, monovalent, floating, name, element_symbol, &
                           pao_basis_size, pao_model_file, pao_potentials, pao_descriptors, nelec)
 
       TYPE(qs_kind_type)                                 :: qs_kind
@@ -512,6 +514,7 @@ CONTAINS
       LOGICAL, OPTIONAL                                  :: init_u_ramping_each_scf
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: reltmat
       LOGICAL, OPTIONAL                                  :: ghost, floating
+      LOGICAL, INTENT(OUT), OPTIONAL                     :: monovalent
       CHARACTER(LEN=default_string_length), &
          INTENT(OUT), OPTIONAL                           :: name
       CHARACTER(LEN=2), INTENT(OUT), OPTIONAL            :: element_symbol
@@ -702,6 +705,7 @@ CONTAINS
       IF (PRESENT(ngrid_rad)) ngrid_rad = qs_kind%ngrid_rad
       IF (PRESENT(lmax_rho0)) lmax_rho0 = qs_kind%lmax_rho0
       IF (PRESENT(ghost)) ghost = qs_kind%ghost
+      IF (PRESENT(monovalent)) monovalent = qs_kind%monovalent
       IF (PRESENT(floating)) floating = qs_kind%floating
       IF (PRESENT(dft_plus_u_atom)) dft_plus_u_atom = ASSOCIATED(qs_kind%dft_plus_u)
       IF (PRESENT(l_of_dft_plus_u)) THEN
@@ -1960,6 +1964,13 @@ CONTAINS
          CALL section_vals_val_get(kind_section, i_rep_section=k_rep, &
                                    keyword_name="MAO", i_val=qs_kind%mao)
 
+         ! Use monovalent pseudopotential 
+         CALL section_vals_val_get(kind_section, i_rep_section=k_rep, &
+                                   keyword_name="MONOVALENT", l_val=qs_kind%monovalent)
+         IF (qs_kind%monovalent .AND. TRIM(potential_type) /= 'GTH') THEN
+            CPABORT("Monovalent pseudopotentials currently implemented for GTH only!")
+         END IF
+
          ! Read the BS subsection of the current atomic kind, if enabled
          NULLIFY (bs_section)
          bs_section => section_vals_get_subs_vals(kind_section, "BS", &
@@ -2338,7 +2349,8 @@ CONTAINS
                CALL allocate_potential(qs_kind%gth_potential)
                CALL read_potential(qs_kind%element_symbol, potential_name, &
                                    qs_kind%gth_potential, zeff_correction, para_env, &
-                                   potential_file_name, potential_section, update_input)
+                                   potential_file_name, potential_section, update_input, &
+                                   monovalent=qs_kind%monovalent)
                CALL set_potential(qs_kind%gth_potential, z=z)
                CALL get_qs_kind(qs_kind, elec_conf=elec_conf)
                IF (.NOT. ASSOCIATED(elec_conf)) THEN
@@ -2478,7 +2490,8 @@ CONTAINS
                   CALL allocate_potential(qs_kind%gth_potential)
                   CALL read_potential(qs_kind%element_symbol, potential_name, &
                                       qs_kind%gth_potential, zeff_correction, para_env, &
-                                      potential_file_name, potential_section, update_input)
+                                      potential_file_name, potential_section, update_input, &
+                                      monovalent=qs_kind%monovalent)
                   CALL set_potential(qs_kind%gth_potential, z=z)
                   CALL get_qs_kind(qs_kind, elec_conf=elec_conf)
                   IF (.NOT. ASSOCIATED(elec_conf)) THEN
@@ -3145,6 +3158,10 @@ CONTAINS
                WRITE (UNIT=output_unit, FMT="(/,T6,A)") &
                   "The atoms of this atomic kind are GHOST atoms!"
             END IF
+            IF (qs_kind%monovalent) THEN
+               WRITE (UNIT=output_unit, FMT="(/,T6,A)") &
+                  "The atoms of this atomic kind are MONOVALENT!"
+            END IF
             IF (qs_kind%floating) THEN
                WRITE (UNIT=output_unit, FMT="(/,T6,A)") &
                   "The atoms of this atomic kind are FLOATING BASIS FUNCTIONS."
@@ -3399,7 +3416,7 @@ CONTAINS
       INTEGER                                            :: i, ii, is, l, ll, ne, nn, z
       INTEGER, DIMENSION(:), POINTER                     :: econf
       INTEGER, DIMENSION(:, :), POINTER                  :: addel, laddel, naddel
-      LOGICAL                                            :: bs_occupation
+      LOGICAL                                            :: bs_occupation, monovalent
       REAL(KIND=dp)                                      :: dmag, magnetization
       TYPE(gth_potential_type), POINTER                  :: gth_potential
       TYPE(sgp_potential_type), POINTER                  :: sgp_potential
@@ -3411,6 +3428,7 @@ CONTAINS
                        sgp_potential=sgp_potential, &
                        magnetization=magnetization, &
                        bs_occupation=bs_occupation, &
+                       monovalent=monovalent, &
                        addel=addel, laddel=laddel, naddel=naddel)
 
       ! electronic state
@@ -3418,7 +3436,10 @@ CONTAINS
       ncore = 0
       ncalc = 0
       edelta = 0.0_dp
-      IF (ASSOCIATED(gth_potential)) THEN
+      IF (monovalent) THEN
+         ncalc(0, 1) = 1
+         nelem(0, 1) = 1
+      ELSE IF (ASSOCIATED(gth_potential)) THEN
          CALL get_potential(gth_potential, elec_conf=econf)
          CALL set_pseudo_state(econf, z, ncalc, ncore, nelem)
       ELSE IF (ASSOCIATED(sgp_potential)) THEN

--- a/src/qs_kind_types.F
+++ b/src/qs_kind_types.F
@@ -513,8 +513,9 @@ CONTAINS
                                                             eps_u_ramping
       LOGICAL, OPTIONAL                                  :: init_u_ramping_each_scf
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: reltmat
-      LOGICAL, OPTIONAL                                  :: ghost, floating
+      LOGICAL, OPTIONAL                                  :: ghost
       LOGICAL, INTENT(OUT), OPTIONAL                     :: monovalent
+      LOGICAL, OPTIONAL                                  :: floating
       CHARACTER(LEN=default_string_length), &
          INTENT(OUT), OPTIONAL                           :: name
       CHARACTER(LEN=2), INTENT(OUT), OPTIONAL            :: element_symbol
@@ -1964,7 +1965,7 @@ CONTAINS
          CALL section_vals_val_get(kind_section, i_rep_section=k_rep, &
                                    keyword_name="MAO", i_val=qs_kind%mao)
 
-         ! Use monovalent pseudopotential 
+         ! Use monovalent pseudopotential
          CALL section_vals_val_get(kind_section, i_rep_section=k_rep, &
                                    keyword_name="MONOVALENT", l_val=qs_kind%monovalent)
          IF (qs_kind%monovalent .AND. TRIM(potential_type) /= 'GTH') THEN

--- a/src/subsys/external_potential_types.F
+++ b/src/subsys/external_potential_types.F
@@ -811,7 +811,7 @@ CONTAINS
       IF (PRESENT(alpha_nlcc)) alpha_nlcc => potential%alpha_nlcc
       IF (PRESENT(nct_nlcc)) nct_nlcc => potential%nct_nlcc
       IF (PRESENT(cval_nlcc)) cval_nlcc => potential%cval_nlcc
-                                
+
       IF (PRESENT(monovalent)) monovalent = potential%monovalent
 
    END SUBROUTINE get_gth_potential

--- a/src/subsys/external_potential_types.F
+++ b/src/subsys/external_potential_types.F
@@ -167,6 +167,8 @@ MODULE external_potential_types
       REAL(KIND=dp), DIMENSION(:), POINTER       :: alpha_lpot => NULL()
       INTEGER, DIMENSION(:), POINTER             :: nct_lpot => NULL()
       REAL(KIND=dp), DIMENSION(:, :), POINTER    :: cval_lpot => NULL()
+      ! monovalent pseudopotential
+      LOGICAL                                    :: monovalent = .FALSE.
    END TYPE gth_potential_type
 
    TYPE sgp_potential_type
@@ -708,6 +710,7 @@ CONTAINS
 !> \param alpha_nlcc ...
 !> \param nct_nlcc ...
 !> \param cval_nlcc ...
+!> \param monovalent ...
 !> \date    11.01.2002
 !> \author  MK
 !> \version 1.0
@@ -722,7 +725,8 @@ CONTAINS
                                 cprj_ppnl, vprj_ppnl, wprj_ppnl, hprj_ppnl, kprj_ppnl, &
                                 lpot_present, nexp_lpot, alpha_lpot, nct_lpot, cval_lpot, &
                                 lsd_present, nexp_lsd, alpha_lsd, nct_lsd, cval_lsd, &
-                                nlcc_present, nexp_nlcc, alpha_nlcc, nct_nlcc, cval_nlcc)
+                                nlcc_present, nexp_nlcc, alpha_nlcc, nct_nlcc, cval_nlcc, &
+                                monovalent)
 
       TYPE(gth_potential_type), INTENT(IN)               :: potential
       CHARACTER(LEN=default_string_length), &
@@ -755,6 +759,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), OPTIONAL, POINTER     :: alpha_nlcc
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: nct_nlcc
       REAL(KIND=dp), DIMENSION(:, :), OPTIONAL, POINTER  :: cval_nlcc
+      LOGICAL, INTENT(OUT), OPTIONAL                     :: monovalent
 
       IF (PRESENT(name)) name = potential%name
       IF (PRESENT(aliases)) aliases = potential%aliases
@@ -806,6 +811,8 @@ CONTAINS
       IF (PRESENT(alpha_nlcc)) alpha_nlcc => potential%alpha_nlcc
       IF (PRESENT(nct_nlcc)) nct_nlcc => potential%nct_nlcc
       IF (PRESENT(cval_nlcc)) cval_nlcc => potential%cval_nlcc
+                                
+      IF (PRESENT(monovalent)) monovalent = potential%monovalent
 
    END SUBROUTINE get_gth_potential
 
@@ -1653,6 +1660,7 @@ CONTAINS
 !> \param potential_file_name ...
 !> \param potential_section ...
 !> \param update_input ...
+!> \param monovalent ...
 !> \date    14.05.2000
 !> \par  Literature
 !>         - S. Goedecker, M. Teter and J. Hutter,
@@ -1665,7 +1673,8 @@ CONTAINS
 !> \version 1.0
 ! **************************************************************************************************
    SUBROUTINE read_gth_potential(element_symbol, potential_name, potential, zeff_correction, &
-                                 para_env, potential_file_name, potential_section, update_input)
+                                 para_env, potential_file_name, potential_section, update_input, &
+                                 monovalent)
 
       CHARACTER(LEN=*), INTENT(IN)                       :: element_symbol, potential_name
       TYPE(gth_potential_type), INTENT(INOUT)            :: potential
@@ -1674,6 +1683,7 @@ CONTAINS
       CHARACTER(len=default_path_length), INTENT(IN)     :: potential_file_name
       TYPE(section_vals_type), INTENT(IN), POINTER       :: potential_section
       LOGICAL, INTENT(IN)                                :: update_input
+      LOGICAL, INTENT(IN), OPTIONAL                      :: monovalent
 
       CHARACTER(LEN=240)                                 :: line
       CHARACTER(LEN=242)                                 :: line2
@@ -1702,6 +1712,9 @@ CONTAINS
       CALL cite_reference(Goedecker1996)
       CALL cite_reference(Hartwigsen1998)
       CALL cite_reference(Krack2005)
+
+      potential%monovalent = .FALSE.
+      IF (PRESENT(monovalent)) potential%monovalent = monovalent
 
       potential%name = potential_name
       potential%aliases = potential_name
@@ -1790,10 +1803,14 @@ CONTAINS
                END IF
 
                CALL reallocate(potential%elec_conf, 0, l)
-               potential%elec_conf(:) = elec_conf(:)
+               IF (potential%monovalent) THEN
+                  potential%elec_conf(0) = 1
+               ELSE
+                  potential%elec_conf(:) = elec_conf(:)
+               END IF
 
                potential%zeff_correction = zeff_correction
-               potential%zeff = REAL(SUM(elec_conf), dp) + zeff_correction
+               potential%zeff = REAL(SUM(potential%elec_conf), dp) + zeff_correction
 
                DEALLOCATE (elec_conf)
 

--- a/tests/QS/regtest-monovalent/TEST_FILES.toml
+++ b/tests/QS/regtest-monovalent/TEST_FILES.toml
@@ -1,0 +1,7 @@
+# runs are executed in the same order as in this file
+# the second field tells which test should be run in order to compare with the last available output
+# e.g. 0 means do not compare anything, running is enough
+#      1 compares the last total energy in the file
+#      for details see cp2k/tools/do_regtest
+
+"ethane_stub.inp"                       = [{matcher="E_total", tol=1e-11, ref=-7.70882067473086}]

--- a/tests/QS/regtest-monovalent/ethane_stub.inp
+++ b/tests/QS/regtest-monovalent/ethane_stub.inp
@@ -1,0 +1,80 @@
+&GLOBAL
+   Run_Type Energy_Force
+   Print_Level Medium
+&end
+
+&FORCE_EVAL
+  Method QS
+ &DFT
+    Basis_Set_File_Name BASIS_MOLOPT
+    Potential_File_Name POTENTIAL
+    Charge 0
+    Multiplicity 0
+    &Poisson
+      Poisson_Solver Periodic
+      Periodic       XYZ
+    &end
+
+    &QS
+      EPS_Default 1.0e-12
+    &end
+
+    &mGrid
+      Cutoff 160
+      Rel_Cutoff 20
+    &end
+
+    &SCF
+      SCF_Guess Restart
+      Max_SCF 100
+      EPS_SCF 1.0e-6
+      &OT
+        Preconditioner Full_All
+        Minimizer      DIIS
+      &end
+      &Outer_SCF
+        EPS_SCF 1.0e-6
+        Max_SCF 100
+      &end
+    &end
+
+    &XC
+      &XC_Functional BLYP
+      &end
+    &end
+  &end
+
+  &SUBSYS
+    &Cell
+      ABC 10.0 10.0 10.0
+      Alpha_Beta_Gamma 90.0 90.0 90.0
+      Periodic XYZ
+    &end
+
+    &Coord
+    Unit Bohr
+      C 10.61063379 8.01580946 9.28344333
+      H 12.04610745 7.79825476 7.80170540
+      H 11.65789915 8.41402953 11.03304613
+      H 9.52040174 6.26896944 9.51997466
+      X 8.89362498 10.22534512 8.71113603
+    &end
+
+    &Kind C
+      Basis_Set DZVP-MOLOPT-GTH
+      Potential GTH-BLYP-q4
+    &end
+    
+    &Kind H
+      Basis_Set DZVP-MOLOPT-GTH
+      Potential GTH-BLYP-q1
+    &end
+
+    &Kind X
+      Element C
+      Basis_Set DZVP-MOLOPT-GTH
+      Potential GTH-BLYP-q4
+      Monovalent      
+    &end
+  &end
+&end

--- a/tests/QS/regtest-monovalent/ethane_stub.inp
+++ b/tests/QS/regtest-monovalent/ethane_stub.inp
@@ -1,80 +1,71 @@
 &GLOBAL
-   Run_Type Energy_Force
-   Print_Level Medium
-&end
+  PRINT_LEVEL Medium
+  RUN_TYPE Energy_Force
+&END GLOBAL
 
 &FORCE_EVAL
-  Method QS
- &DFT
-    Basis_Set_File_Name BASIS_MOLOPT
-    Potential_File_Name POTENTIAL
-    Charge 0
-    Multiplicity 0
-    &Poisson
-      Poisson_Solver Periodic
-      Periodic       XYZ
-    &end
-
+  METHOD QS
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT
+    CHARGE 0
+    MULTIPLICITY 0
+    POTENTIAL_FILE_NAME POTENTIAL
+    &MGRID
+      CUTOFF 160
+      REL_CUTOFF 20
+    &END MGRID
+    &POISSON
+      PERIODIC XYZ
+      POISSON_SOLVER Periodic
+    &END POISSON
     &QS
-      EPS_Default 1.0e-12
-    &end
-
-    &mGrid
-      Cutoff 160
-      Rel_Cutoff 20
-    &end
-
+      EPS_DEFAULT 1.0e-12
+    &END QS
     &SCF
-      SCF_Guess Restart
-      Max_SCF 100
       EPS_SCF 1.0e-6
+      MAX_SCF 100
+      SCF_GUESS Restart
       &OT
-        Preconditioner Full_All
-        Minimizer      DIIS
-      &end
-      &Outer_SCF
+        MINIMIZER DIIS
+        PRECONDITIONER Full_All
+      &END OT
+      &OUTER_SCF
         EPS_SCF 1.0e-6
-        Max_SCF 100
-      &end
-    &end
-
+        MAX_SCF 100
+      &END OUTER_SCF
+    &END SCF
     &XC
-      &XC_Functional BLYP
-      &end
-    &end
-  &end
-
+      &XC_FUNCTIONAL BLYP
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
   &SUBSYS
-    &Cell
+    &CELL
       ABC 10.0 10.0 10.0
-      Alpha_Beta_Gamma 90.0 90.0 90.0
-      Periodic XYZ
-    &end
-
-    &Coord
-    Unit Bohr
+      ALPHA_BETA_GAMMA 90.0 90.0 90.0
+      PERIODIC XYZ
+    &END CELL
+    &COORD
+      Unit Bohr
       C 10.61063379 8.01580946 9.28344333
       H 12.04610745 7.79825476 7.80170540
       H 11.65789915 8.41402953 11.03304613
       H 9.52040174 6.26896944 9.51997466
       X 8.89362498 10.22534512 8.71113603
-    &end
-
-    &Kind C
-      Basis_Set DZVP-MOLOPT-GTH
-      Potential GTH-BLYP-q4
-    &end
-    
-    &Kind H
-      Basis_Set DZVP-MOLOPT-GTH
-      Potential GTH-BLYP-q1
-    &end
-
-    &Kind X
-      Element C
-      Basis_Set DZVP-MOLOPT-GTH
-      Potential GTH-BLYP-q4
-      Monovalent      
-    &end
-  &end
-&end
+    &END COORD
+    &KIND C
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-BLYP-q4
+    &END KIND
+    &KIND H
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-BLYP-q1
+    &END KIND
+    &KIND X
+      BASIS_SET DZVP-MOLOPT-GTH
+      ELEMENT C
+      MONOVALENT
+      POTENTIAL GTH-BLYP-q4
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -3,6 +3,7 @@
 # Directories have been reordered according the execution time needed for a gfortran pdbg run using 2 MPI tasks
 # in case a new directory is added just add it at the top of the list..
 # the order will be regularly checked and modified...
+QS/regtest-monovalent                                       libint !ifx
 QS/regtest-tddfpt-sf-force                                  libint !ifx
 QS/regtest-tddfpt-sf                                        libint !ifx
 xTB/regtest-tblite-gfn1-grad                                tblite

--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -3,7 +3,7 @@
 # Directories have been reordered according the execution time needed for a gfortran pdbg run using 2 MPI tasks
 # in case a new directory is added just add it at the top of the list..
 # the order will be regularly checked and modified...
-QS/regtest-monovalent                                       libint !ifx
+QS/regtest-monovalent
 QS/regtest-tddfpt-sf-force                                  libint !ifx
 QS/regtest-tddfpt-sf                                        libint !ifx
 xTB/regtest-tblite-gfn1-grad                                tblite


### PR DESCRIPTION
Added an option to turn any atomic kind into monovalent, i.e., with nuclear charge 1.0 and contributing a single electron. It is primarily intended for saturating dangling bonds in QM/MM and should ideally be used in conjunction with pseudopotentials developed for such a purpose.