### PR TITLE
Improved OpenMP synchronization

### DIFF
--- a/src/common/gamma.F
+++ b/src/common/gamma.F
@@ -545,7 +545,7 @@ CONTAINS
                        "incomplete Gamma function is invalid")
       END IF
 
-!$OMP CRITICAL
+!$OMP CRITICAL(init_md_ftable)
       !   *** Check, if the current initialization is sufficient ***
       IF (nmax > current_nmax) THEN
          CALL deallocate_md_ftable()
@@ -553,7 +553,7 @@ CONTAINS
          !     *** for the Taylor series expansion      ***
          CALL create_md_ftable(nmax, 0.0_dp, 12.0_dp, 0.1_dp)
       END IF
-!$OMP END CRITICAL
+!$OMP END CRITICAL(init_md_ftable)
 
    END SUBROUTINE init_md_ftable
 

--- a/src/dbt/dbt_block.F
+++ b/src/dbt/dbt_block.F
@@ -371,11 +371,11 @@ CONTAINS
             IF (checker_tr(ind_2d(1), ind_2d(2))) CYCLE
             IF (ind_2d(1) > ind_2d(2)) CALL swap(ind_2d(1), ind_2d(2))
          END IF
-!$OMP CRITICAL
+!$OMP CRITICAL(dbt_reserve_blocks_tensor_to_matrix)
          iblk = iblk + 1
          blk_ind_1(iblk) = ind_2d(1)
          blk_ind_2(iblk) = ind_2d(2)
-!$OMP END CRITICAL
+!$OMP END CRITICAL(dbt_reserve_blocks_tensor_to_matrix)
       END DO
       CALL dbt_iterator_stop(iter)
 !$OMP END PARALLEL

--- a/src/dbt/dbt_reshape_ops.F
+++ b/src/dbt/dbt_reshape_ops.F
@@ -116,12 +116,12 @@ CONTAINS
          ndata_send_mythread(iproc) = ndata_send_mythread(iproc) + PRODUCT(blk_size)
       END DO
       CALL dbt_iterator_stop(iter)
-!$OMP CRITICAL
+!$OMP CRITICAL(dbt_reshape)
       nblks_send_total(:) = nblks_send_total(:) + nblks_send_mythread(:)
       ndata_send_total(:) = ndata_send_total(:) + ndata_send_mythread(:)
       nblks_send_mythread(:) = nblks_send_total(:) ! current totals indicate slot for this thread
       ndata_send_mythread(:) = ndata_send_total(:)
-!$OMP END CRITICAL
+!$OMP END CRITICAL(dbt_reshape)
 !$OMP BARRIER
 
 !$OMP MASTER
@@ -160,6 +160,7 @@ CONTAINS
          CALL destroy_block(blk_data)
       END DO
       CALL dbt_iterator_stop(iter)
+      DEALLOCATE (nblks_send_mythread, ndata_send_mythread)
 !$OMP BARRIER
 
       CALL dbt_communicate_buffer(mp_comm, buffer_recv, buffer_send)

--- a/src/dbt/dbt_test.F
+++ b/src/dbt/dbt_test.F
@@ -94,9 +94,9 @@ CONTAINS
          IF (.NOT. found) CPABORT("Tensor block 2 not found")
 
          IF (.NOT. blocks_equal(blk_data1, blk_data2)) THEN
-!$OMP CRITICAL
+!$OMP ATOMIC WRITE
             dbt_equal = .FALSE.
-!$OMP END CRITICAL
+!$OMP END ATOMIC
          END IF
       END DO
 

--- a/src/eip_silicon.F
+++ b/src/eip_silicon.F
@@ -1152,9 +1152,9 @@ CONTAINS
                END DO loop_l1
             END DO loop_l2
          END DO loop_l3
-!$OMP CRITICAL
+!$OMP ATOMIC UPDATE
          indlstx = MAX(indlstx, indlst)
-!$OMP END CRITICAL
+!$OMP END ATOMIC
 !$OMP END PARALLEL
 
          IF (indlstx >= myspaceout) THEN
@@ -1184,10 +1184,10 @@ CONTAINS
 ! PARALLEL CASE
 ! create temporary private scalars for reduction sum on energies and
 !        temporary private array for reduction sum on forces
-!$OMP CRITICAL
+!$OMP CRITICAL(eip_bazant_silicon)
          ALLOCATE (txyz(3, nat), s2(max_nbrs, 8), s3(max_nbrs, 7), sz(max_nbrs, 6), &
                    num2(max_nbrs), num3(max_nbrs), numz(max_nbrs))
-!$OMP END CRITICAL
+!$OMP END CRITICAL(eip_bazant_silicon)
          IF (iam == 0) THEN
             ener = 0.e0_dp
             ener2 = 0.e0_dp
@@ -1213,7 +1213,7 @@ CONTAINS
                           num2, s3(1, 1), s3(1, 2), s3(1, 3), s3(1, 4), s3(1, 5), s3(1, 6), s3(1, 7), &
                           num3, sz(1, 1), sz(1, 2), sz(1, 3), sz(1, 4), sz(1, 5), sz(1, 6), numz)
 
-!$OMP CRITICAL
+!$OMP CRITICAL(eip_bazant_silicon)
          ener = ener + tener
          ener2 = ener2 + tener2
          coord = coord + tcoord
@@ -1225,7 +1225,7 @@ CONTAINS
             fxyz(3, iat) = fxyz(3, iat) + txyz(3, iat)
          END DO
          DEALLOCATE (txyz, s2, s3, sz, num2, num3, numz)
-!$OMP END CRITICAL
+!$OMP END CRITICAL(eip_bazant_silicon)
 
       ELSE
 ! SERIAL CASE
@@ -2318,9 +2318,9 @@ CONTAINS
             END DO loop_l2
          END DO loop_l3
 
-!$OMP CRITICAL
+!$OMP ATOMIC UPDATE
          indlstx = MAX(indlstx, indlst)
-!$OMP END CRITICAL
+!$OMP END ATOMIC
 !$OMP END PARALLEL
 
          IF (indlstx >= myspaceout) THEN
@@ -2349,9 +2349,9 @@ CONTAINS
 ! PARALLEL CASE
 ! create temporary private scalars for reduction sum on energies and
 !        temporary private array for reduction sum on forces
-!$OMP CRITICAL
+!$OMP CRITICAL(eip_lenosky_silicon)
          ALLOCATE (txyz(3, nat), f2ij(3, npjx), f3ij(3, npjkx), f3ik(3, npjkx))
-!$OMP END CRITICAL
+!$OMP END CRITICAL(eip_lenosky_silicon)
          IF (iam == 0) THEN
             ener = 0.e0_dp
             ener2 = 0.e0_dp
@@ -2373,7 +2373,7 @@ CONTAINS
 !       write(*,*) 'subfeniat:iat1,iat2,iam',iat1,iat2,iam
          CALL subfeniat_l(iat1, iat2, nat, lsta, lstb, rel, tener, tener2, &
                           tcoord, tcoord2, nnbrx, txyz, f2ij, npjx, f3ij, npjkx, f3ik, istop)
-!$OMP CRITICAL
+!$OMP CRITICAL(eip_lenosky_silicon)
          ener = ener + tener
          ener2 = ener2 + tener2
          coord = coord + tcoord
@@ -2385,7 +2385,7 @@ CONTAINS
             fxyz(3, iat) = fxyz(3, iat) + txyz(3, iat)
          END DO
          DEALLOCATE (txyz, f2ij, f3ij, f3ik)
-!$OMP END CRITICAL
+!$OMP END CRITICAL(eip_lenosky_silicon)
 
       ELSE
 ! SERIAL CASE

--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -4062,11 +4062,11 @@ CONTAINS
          CALL dbt_iterator_next_block(iter, ind)
          CALL dbt_get_block(rho_ao_t, ind, blk, found)
          IF (found) THEN
-!$OMP CRITICAL
+!$OMP CRITICAL(get_RI_density_coeffs)
             nblks = nblks + 1
             idx1(nblks) = ind(1)
             idx2(nblks) = ind(2)
-!$OMP END CRITICAL
+!$OMP END CRITICAL(get_RI_density_coeffs)
             DEALLOCATE (blk)
          END IF
       END DO
@@ -4090,9 +4090,9 @@ CONTAINS
          IF (found) THEN
             ALLOCATE (blk_3d(SIZE(blk, 1), SIZE(blk, 2), 1))
             blk_3d(:, :, 1) = blk(:, :)
-!$OMP CRITICAL
+!$OMP CRITICAL(get_RI_density_coeffs)
             CALL dbt_put_block(rho_ao_t_3d, [ind(1), ind(2), 1], [SIZE(blk, 1), SIZE(blk, 2), 1], blk_3d)
-!$OMP END CRITICAL
+!$OMP END CRITICAL(get_RI_density_coeffs)
             DEALLOCATE (blk, blk_3d)
          END IF
       END DO
@@ -4202,9 +4202,9 @@ CONTAINS
          IF (found) THEN
 
             idx = SUM(ri_data%bsizes_RI_split(1:ind(1) - 1))
-!$OMP CRITICAL
+!$OMP CRITICAL(get_RI_density_coeffs)
             density_coeffs(idx + 1:idx + ri_data%bsizes_RI_split(ind(1))) = blk(:, 1)
-!$OMP END CRITICAL
+!$OMP END CRITICAL(get_RI_density_coeffs)
             DEALLOCATE (blk)
          END IF
       END DO

--- a/src/qs_o3c_methods.F
+++ b/src/qs_o3c_methods.F
@@ -463,10 +463,10 @@ CONTAINS
             ! to access the dbcsr block at the same time. Prevent that by CRITICAL section but keep
             ! computations before hand in order to retain speed
 
-!$OMP CRITICAL
+!$OMP CRITICAL(contract3_o3c)
             CALL dbcsr_get_block_p(matrix=matrix, row=irow, col=icol, BLOCK=pblock, found=found)
             CALL daxpy(s1*s2, 1.0_dp, work(:, :), 1, pblock(:, :), 1)
-!$OMP END CRITICAL
+!$OMP END CRITICAL(contract3_o3c)
 
             DEALLOCATE (work)
          END IF


### PR DESCRIPTION
- Make use of ATOMCS WRITE/UPDATE instead of critical.
- Named critical sections.