### PR TITLE
Docker: Disable tblite until dftd4 installation is fixed

### DIFF
--- a/cmake/cmake_cp2k.sh
+++ b/cmake/cmake_cp2k.sh
@@ -74,6 +74,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "pdbg" ]]; then
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_PEXSI=OFF \
+    -DCP2K_USE_TBLITE=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -85,6 +86,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "sdbg" ]]; then
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_MPI=OFF \
+    -DCP2K_USE_TBLITE=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -96,6 +98,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_PEXSI=OFF \
+    -DCP2K_USE_TBLITE=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -106,6 +109,7 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "ssmp" ]]; then
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_MPI=OFF \
+    -DCP2K_USE_TBLITE=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -120,6 +124,7 @@ elif [[ "${PROFILE}" == "toolchain_arm64" ]] && [[ "${VERSION}" == "psmp" ]]; th
     -DCP2K_USE_ACE=OFF \
     -DCP2K_USE_DEEPMD=OFF \
     -DCP2K_USE_LIBTORCH=OFF \
+    -DCP2K_USE_TBLITE=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -160,6 +165,7 @@ elif [[ "${PROFILE}" == "toolchain_generic" ]] && [[ "${VERSION}" == "psmp" ]]; 
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_PEXSI=OFF \
+    -DCP2K_USE_TBLITE=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -172,6 +178,7 @@ elif [[ "${PROFILE}" == "toolchain_coverage" ]] && [[ "${VERSION}" == "psmp" ]];
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_PEXSI=OFF \
+    -DCP2K_USE_TBLITE=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
@@ -187,6 +194,7 @@ elif [[ "${PROFILE}" == "toolchain_asan" ]] && [[ "${VERSION}" == "psmp" ]]; the
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_PEXSI=OFF \
     -DCP2K_USE_GREENX=OFF \
+    -DCP2K_USE_TBLITE=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi100
@@ -35,11 +35,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-hip=yes \
     --gpu-ver=Mi100 \
     --with-dbcsr=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi50
@@ -35,11 +35,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-hip=yes \
     --gpu-ver=Mi50 \
     --with-dbcsr=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_aiida
+++ b/tools/docker/Dockerfile.test_aiida
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_arm64-psmp
+++ b/tools/docker/Dockerfile.test_arm64-psmp
@@ -20,6 +20,8 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
@@ -27,6 +29,7 @@ RUN ./install_cp2k_toolchain.sh \
     --with-gcc=system \
     --with-libtorch=no \
     --with-deepmd=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_asan-psmp
+++ b/tools/docker/Dockerfile.test_asan-psmp
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_ase
+++ b/tools/docker/Dockerfile.test_ase
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_conventions
+++ b/tools/docker/Dockerfile.test_conventions
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
     --with-dbcsr=no \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_coverage
+++ b/tools/docker/Dockerfile.test_coverage
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_cuda_A100
+++ b/tools/docker/Dockerfile.test_cuda_A100
@@ -33,11 +33,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --with-mpich=install \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=A100 \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_cuda_P100
+++ b/tools/docker/Dockerfile.test_cuda_P100
@@ -33,11 +33,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --with-mpich=install \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=P100 \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_cuda_V100
+++ b/tools/docker/Dockerfile.test_cuda_V100
@@ -33,11 +33,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --with-mpich=install \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=V100 \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_fedora-psmp
+++ b/tools/docker/Dockerfile.test_fedora-psmp
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_gcc8
+++ b/tools/docker/Dockerfile.test_gcc8
@@ -38,6 +38,8 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=no \
     --with-gcc=system \
@@ -53,6 +55,7 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libxsmm=install \
     --with-libvori=install \
     --with-spglib=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -20,12 +20,15 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
     --target-cpu=generic \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_gromacs
+++ b/tools/docker/Dockerfile.test_gromacs
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi100
@@ -35,11 +35,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-hip=yes \
     --gpu-ver=Mi100 \
     --with-dbcsr=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi50
@@ -35,11 +35,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-hip=yes \
     --gpu-ver=Mi50 \
     --with-dbcsr=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_i-pi
+++ b/tools/docker/Dockerfile.test_i-pi
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_intel-ifort-psmp
+++ b/tools/docker/Dockerfile.test_intel-ifort-psmp
@@ -20,6 +20,8 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --with-dbcsr=no \
@@ -29,6 +31,7 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libsmeagol \
     --with-libtorch=no \
     --with-deepmd=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_intel-ifort-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ifort-ssmp
@@ -20,6 +20,8 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --with-dbcsr=no \
@@ -29,6 +31,7 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libsmeagol \
     --with-libtorch=no \
     --with-deepmd=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_intel-ifx-psmp
+++ b/tools/docker/Dockerfile.test_intel-ifx-psmp
@@ -20,6 +20,8 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --with-dbcsr=no \
@@ -29,6 +31,7 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libsmeagol \
     --with-libtorch=no \
     --with-deepmd=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_intel-ifx-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ifx-ssmp
@@ -20,6 +20,8 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --with-dbcsr=no \
@@ -29,6 +31,7 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libsmeagol \
     --with-libtorch=no \
     --with-deepmd=no \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_manual
+++ b/tools/docker/Dockerfile.test_manual
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_openmpi-psmp
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=openmpi \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_performance
+++ b/tools/docker/Dockerfile.test_performance
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_performance_cuda_A100
+++ b/tools/docker/Dockerfile.test_performance_cuda_A100
@@ -33,11 +33,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --with-mpich=install \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=A100 \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_performance_cuda_P100
+++ b/tools/docker/Dockerfile.test_performance_cuda_P100
@@ -33,11 +33,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --with-mpich=install \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=P100 \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_performance_cuda_V100
+++ b/tools/docker/Dockerfile.test_performance_cuda_V100
@@ -33,11 +33,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --with-mpich=install \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=V100 \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_phonopy
+++ b/tools/docker/Dockerfile.test_phonopy
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_psmp
+++ b/tools/docker/Dockerfile.test_psmp
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_sdbg
+++ b/tools/docker/Dockerfile.test_sdbg
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/Dockerfile.test_ssmp
+++ b/tools/docker/Dockerfile.test_ssmp
@@ -20,11 +20,14 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
     --install-all \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -624,8 +624,11 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+# TODO: Re-enable tblite once the dftd4 installation is fixed.
+# https://github.com/cp2k/cp2k/issues/4362
 RUN ./install_cp2k_toolchain.sh \
 {install_args_str}
+    --with-tblite=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.


### PR DESCRIPTION
This temporarily disables the tests for tblite recover the dashboard while we're waiting for #4362.