### PR TITLE
Adjusted CRITICIAL section names for Intel Fortran Compiler

### DIFF
--- a/src/common/gamma.F
+++ b/src/common/gamma.F
@@ -545,7 +545,7 @@ CONTAINS
                        "incomplete Gamma function is invalid")
       END IF
 
-!$OMP CRITICAL(init_md_ftable)
+!$OMP CRITICAL(omp_init_md_ftable)
       !   *** Check, if the current initialization is sufficient ***
       IF (nmax > current_nmax) THEN
          CALL deallocate_md_ftable()
@@ -553,7 +553,7 @@ CONTAINS
          !     *** for the Taylor series expansion      ***
          CALL create_md_ftable(nmax, 0.0_dp, 12.0_dp, 0.1_dp)
       END IF
-!$OMP END CRITICAL(init_md_ftable)
+!$OMP END CRITICAL(omp_init_md_ftable)
 
    END SUBROUTINE init_md_ftable
 

--- a/src/dbt/dbt_block.F
+++ b/src/dbt/dbt_block.F
@@ -371,11 +371,11 @@ CONTAINS
             IF (checker_tr(ind_2d(1), ind_2d(2))) CYCLE
             IF (ind_2d(1) > ind_2d(2)) CALL swap(ind_2d(1), ind_2d(2))
          END IF
-!$OMP CRITICAL(dbt_reserve_blocks_tensor_to_matrix)
+!$OMP CRITICAL(omp_dbt_reserve_blocks_tensor_to_matrix)
          iblk = iblk + 1
          blk_ind_1(iblk) = ind_2d(1)
          blk_ind_2(iblk) = ind_2d(2)
-!$OMP END CRITICAL(dbt_reserve_blocks_tensor_to_matrix)
+!$OMP END CRITICAL(omp_dbt_reserve_blocks_tensor_to_matrix)
       END DO
       CALL dbt_iterator_stop(iter)
 !$OMP END PARALLEL

--- a/src/dbt/dbt_reshape_ops.F
+++ b/src/dbt/dbt_reshape_ops.F
@@ -116,12 +116,12 @@ CONTAINS
          ndata_send_mythread(iproc) = ndata_send_mythread(iproc) + PRODUCT(blk_size)
       END DO
       CALL dbt_iterator_stop(iter)
-!$OMP CRITICAL(dbt_reshape)
+!$OMP CRITICAL(omp_dbt_reshape)
       nblks_send_total(:) = nblks_send_total(:) + nblks_send_mythread(:)
       ndata_send_total(:) = ndata_send_total(:) + ndata_send_mythread(:)
       nblks_send_mythread(:) = nblks_send_total(:) ! current totals indicate slot for this thread
       ndata_send_mythread(:) = ndata_send_total(:)
-!$OMP END CRITICAL(dbt_reshape)
+!$OMP END CRITICAL(omp_dbt_reshape)
 !$OMP BARRIER
 
 !$OMP MASTER

--- a/src/eip_silicon.F
+++ b/src/eip_silicon.F
@@ -1184,10 +1184,10 @@ CONTAINS
 ! PARALLEL CASE
 ! create temporary private scalars for reduction sum on energies and
 !        temporary private array for reduction sum on forces
-!$OMP CRITICAL(eip_bazant_silicon)
+!$OMP CRITICAL(omp_eip_bazant_silicon)
          ALLOCATE (txyz(3, nat), s2(max_nbrs, 8), s3(max_nbrs, 7), sz(max_nbrs, 6), &
                    num2(max_nbrs), num3(max_nbrs), numz(max_nbrs))
-!$OMP END CRITICAL(eip_bazant_silicon)
+!$OMP END CRITICAL(omp_eip_bazant_silicon)
          IF (iam == 0) THEN
             ener = 0.e0_dp
             ener2 = 0.e0_dp
@@ -1213,7 +1213,7 @@ CONTAINS
                           num2, s3(1, 1), s3(1, 2), s3(1, 3), s3(1, 4), s3(1, 5), s3(1, 6), s3(1, 7), &
                           num3, sz(1, 1), sz(1, 2), sz(1, 3), sz(1, 4), sz(1, 5), sz(1, 6), numz)
 
-!$OMP CRITICAL(eip_bazant_silicon)
+!$OMP CRITICAL(omp_eip_bazant_silicon)
          ener = ener + tener
          ener2 = ener2 + tener2
          coord = coord + tcoord
@@ -1225,7 +1225,7 @@ CONTAINS
             fxyz(3, iat) = fxyz(3, iat) + txyz(3, iat)
          END DO
          DEALLOCATE (txyz, s2, s3, sz, num2, num3, numz)
-!$OMP END CRITICAL(eip_bazant_silicon)
+!$OMP END CRITICAL(omp_eip_bazant_silicon)
 
       ELSE
 ! SERIAL CASE
@@ -2349,9 +2349,9 @@ CONTAINS
 ! PARALLEL CASE
 ! create temporary private scalars for reduction sum on energies and
 !        temporary private array for reduction sum on forces
-!$OMP CRITICAL(eip_lenosky_silicon)
+!$OMP CRITICAL(omp_eip_lenosky_silicon)
          ALLOCATE (txyz(3, nat), f2ij(3, npjx), f3ij(3, npjkx), f3ik(3, npjkx))
-!$OMP END CRITICAL(eip_lenosky_silicon)
+!$OMP END CRITICAL(omp_eip_lenosky_silicon)
          IF (iam == 0) THEN
             ener = 0.e0_dp
             ener2 = 0.e0_dp
@@ -2373,7 +2373,7 @@ CONTAINS
 !       write(*,*) 'subfeniat:iat1,iat2,iam',iat1,iat2,iam
          CALL subfeniat_l(iat1, iat2, nat, lsta, lstb, rel, tener, tener2, &
                           tcoord, tcoord2, nnbrx, txyz, f2ij, npjx, f3ij, npjkx, f3ik, istop)
-!$OMP CRITICAL(eip_lenosky_silicon)
+!$OMP CRITICAL(omp_eip_lenosky_silicon)
          ener = ener + tener
          ener2 = ener2 + tener2
          coord = coord + tcoord
@@ -2385,7 +2385,7 @@ CONTAINS
             fxyz(3, iat) = fxyz(3, iat) + txyz(3, iat)
          END DO
          DEALLOCATE (txyz, f2ij, f3ij, f3ik)
-!$OMP END CRITICAL(eip_lenosky_silicon)
+!$OMP END CRITICAL(omp_eip_lenosky_silicon)
 
       ELSE
 ! SERIAL CASE

--- a/src/hfx_ri.F
+++ b/src/hfx_ri.F
@@ -4062,11 +4062,11 @@ CONTAINS
          CALL dbt_iterator_next_block(iter, ind)
          CALL dbt_get_block(rho_ao_t, ind, blk, found)
          IF (found) THEN
-!$OMP CRITICAL(get_RI_density_coeffs)
+!$OMP CRITICAL(omp_get_RI_density_coeffs)
             nblks = nblks + 1
             idx1(nblks) = ind(1)
             idx2(nblks) = ind(2)
-!$OMP END CRITICAL(get_RI_density_coeffs)
+!$OMP END CRITICAL(omp_get_RI_density_coeffs)
             DEALLOCATE (blk)
          END IF
       END DO
@@ -4090,9 +4090,9 @@ CONTAINS
          IF (found) THEN
             ALLOCATE (blk_3d(SIZE(blk, 1), SIZE(blk, 2), 1))
             blk_3d(:, :, 1) = blk(:, :)
-!$OMP CRITICAL(get_RI_density_coeffs)
+!$OMP CRITICAL(omp_get_RI_density_coeffs)
             CALL dbt_put_block(rho_ao_t_3d, [ind(1), ind(2), 1], [SIZE(blk, 1), SIZE(blk, 2), 1], blk_3d)
-!$OMP END CRITICAL(get_RI_density_coeffs)
+!$OMP END CRITICAL(omp_get_RI_density_coeffs)
             DEALLOCATE (blk, blk_3d)
          END IF
       END DO
@@ -4202,9 +4202,9 @@ CONTAINS
          IF (found) THEN
 
             idx = SUM(ri_data%bsizes_RI_split(1:ind(1) - 1))
-!$OMP CRITICAL(get_RI_density_coeffs)
+!$OMP CRITICAL(omp_get_RI_density_coeffs)
             density_coeffs(idx + 1:idx + ri_data%bsizes_RI_split(ind(1))) = blk(:, 1)
-!$OMP END CRITICAL(get_RI_density_coeffs)
+!$OMP END CRITICAL(omp_get_RI_density_coeffs)
             DEALLOCATE (blk)
          END IF
       END DO

--- a/src/qs_o3c_methods.F
+++ b/src/qs_o3c_methods.F
@@ -463,10 +463,10 @@ CONTAINS
             ! to access the dbcsr block at the same time. Prevent that by CRITICAL section but keep
             ! computations before hand in order to retain speed
 
-!$OMP CRITICAL(contract3_o3c)
+!$OMP CRITICAL(omp_contract3_o3c)
             CALL dbcsr_get_block_p(matrix=matrix, row=irow, col=icol, BLOCK=pblock, found=found)
             CALL daxpy(s1*s2, 1.0_dp, work(:, :), 1, pblock(:, :), 1)
-!$OMP END CRITICAL(contract3_o3c)
+!$OMP END CRITICAL(omp_contract3_o3c)
 
             DEALLOCATE (work)
          END IF

--- a/src/xas_tdp_integrals.F
+++ b/src/xas_tdp_integrals.F
@@ -606,9 +606,9 @@ CONTAINS
          END DO !iset
 
          !Add the integral to the proper tensor block
-!$OMP CRITICAL
+!$OMP CRITICAL(omp_fill_pqX_tensor)
          CALL dbt_put_block(pq_X, [iatom, jatom, katom], SHAPE(iabc), iabc, summation=.TRUE.)
-!$OMP END CRITICAL
+!$OMP END CRITICAL(omp_fill_pqX_tensor)
 
          DEALLOCATE (iabc)
       END DO !o3c_iterator

--- a/tools/toolchain/scripts/generate_arch_files.sh
+++ b/tools/toolchain/scripts/generate_arch_files.sh
@@ -400,14 +400,10 @@ EOF
     cat << EOF >> $__filename
 #
 # Required due to memory leak that occurs if high optimisations are used
-mp2_optimize_ri_basis.o: mp2_optimize_ri_basis.F
-	\\\$(FC) -c \\\$(subst -O2,-O0,\\\$(FCFLAGS)) \\\$<
+#mp2_optimize_ri_basis.o: FCFLAGS += -O0
 # Required due to SEGFAULTS occurring for higher optimisation levels
-paw_basis_types.o: paw_basis_types.F
-	\\\$(FC) -c \\\$(subst -O2,-O1,\\\$(FCFLAGS)) \\\$<
-# Reduce compilation time
-hfx_contraction_methods.o: hfx_contraction_methods.F
-	\\\$(FC) -c \\\$(subst -O2,-O1,\\\$(FCFLAGS)) \\\$<
+hfx_contraction_methods.o: FCFLAGS += -O1
+#paw_basis_types.o: FCFLAGS += -O1
 EOF
   fi
   # replace variable values in output file using eval


### PR DESCRIPTION
With Intel Fortran Compiler (ifx and ifort), the name of an OpenMP critical section cannot be named like the subroutine containing it. The issue will be reported.