### PR TITLE
Docker: Migrate HIP test to CMake

### DIFF
--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -154,7 +154,14 @@ add_compile_options(
   "$<$<AND:$<CONFIG:DEBUG>,$<COMPILE_LANG_AND_ID:C,AppleClang>>:-O0;-g>"
   "$<$<AND:$<CONFIG:DEBUG>,$<COMPILE_LANG_AND_ID:Fortran,NAG>>:-C=all>")
 
-# Tweaks
+# =================================== Tweaks ===================================
+# Workaround https://gitlab.kitware.com/cmake/cmake/-/issues/27231
+get_target_property(opts MPI::MPI_Fortran INTERFACE_COMPILE_OPTIONS)
+set_target_properties(
+  MPI::MPI_Fortran PROPERTIES INTERFACE_COMPILE_OPTIONS
+                              "$<$<COMPILE_LANGUAGE:Fortran>:${opts}>")
+unset(opts)
+
 if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
   set(CMAKE_Fortran_MODOUT_FLAG "-ef") # override to get lower-case module file
                                        # names

--- a/cmake/cmake_cp2k.sh
+++ b/cmake/cmake_cp2k.sh
@@ -136,7 +136,7 @@ elif [[ "${PROFILE}" == "toolchain_cuda_"* ]] && [[ "${VERSION}" == "psmp" ]]; t
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DDBCSR_DIR="${DBCSR_CUDA_ROOT}/lib/cmake/dbcsr" \
     -DSPLA_ROOT="${SPLA_ROOT}-cuda" \
-    -DCP2K_WITH_GPU="${PROFILE:(-4)}" \
+    -DCP2K_WITH_GPU="${PROFILE:15}" \
     -DCP2K_USE_ACCEL=CUDA \
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \
@@ -154,6 +154,19 @@ elif [[ "${PROFILE}" == "toolchain_cuda_"* ]] && [[ "${VERSION}" == "psmp" ]]; t
     -DCP2K_USE_VORI=OFF \
     -DCP2K_USE_TREXIO=OFF \
     -Werror=dev \
+    .. |& tee ./cmake.log
+  CMAKE_EXIT_CODE=$?
+
+elif [[ "${PROFILE}" == "toolchain_hip_"* ]] && [[ "${VERSION}" == "psmp" ]]; then
+  cmake \
+    -GNinja \
+    -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+    -DDBCSR_DIR="${DBCSR_HIP_ROOT}/lib/cmake/dbcsr" \
+    -DCP2K_WITH_GPU="${PROFILE:14}" \
+    -DCP2K_USE_ACCEL=HIP \
+    -DCP2K_USE_MPI=ON \
+    -DCP2K_USE_LIBXC=ON \
+    -DCP2K_USE_LIBINT2=ON \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?
 

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi100
@@ -13,6 +13,11 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     libmpich-dev                                                      \
    && rm -rf /var/lib/apt/lists/*
 
+# Remove LTO from Ubuntu's MPICH
+RUN sed -i -e 's/-flto=auto//g' -e 's/-ffat-lto-objects//g' \
+    /usr/lib/x86_64-linux-gnu/pkgconfig/mpich.pc \
+    /usr/bin/*.mpich
+
 # Setup HIP environment.
 ENV ROCM_PATH /opt/rocm
 ENV PATH ${PATH}:${ROCM_PATH}/bin
@@ -41,7 +46,7 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-hip=yes \
     --gpu-ver=Mi100 \
-    --with-dbcsr=no \
+    --with-dbcsr \
     --with-tblite=no \
     --dry-run
 
@@ -82,22 +87,22 @@ COPY ./tools/toolchain/scripts/arch_base.tmpl \
      ./scripts/
 RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
-# Install CP2K using local_hip.psmp.
+# Install CP2K sources.
 WORKDIR /opt/cp2k
-COPY ./Makefile .
 COPY ./src ./src
-COPY ./exts ./exts
-COPY ./tools/build_utils ./tools/build_utils
-RUN /bin/bash -c " \
-    mkdir -p arch && \
-    ln -vs /opt/cp2k-toolchain/install/arch/local_hip.psmp ./arch/"
 COPY ./data ./data
 COPY ./tests ./tests
-COPY ./tools/regtesting ./tools/regtesting
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
+
+# Compile CP2K.
+COPY ./tools/docker/scripts/build_cp2k_cmake.sh .
+RUN ./build_cp2k_cmake.sh toolchain_hip_Mi100 psmp
 
 # Run build test.
 COPY ./tools/docker/scripts/test_build.sh .
-RUN ./test_build.sh "local_hip" "psmp" 2>&1 | tee report.log
+RUN ./test_build.sh "toolchain_hip_Mi100" "psmp" 2>&1 | tee report.log
 
 # Output the report if the image is old and was therefore pulled from the build cache.
 CMD cat $(find ./report.log -mmin +10) | sed '/^Summary:/ s/$/ (cached)/'

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi50
@@ -13,6 +13,11 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     libmpich-dev                                                      \
    && rm -rf /var/lib/apt/lists/*
 
+# Remove LTO from Ubuntu's MPICH
+RUN sed -i -e 's/-flto=auto//g' -e 's/-ffat-lto-objects//g' \
+    /usr/lib/x86_64-linux-gnu/pkgconfig/mpich.pc \
+    /usr/bin/*.mpich
+
 # Setup HIP environment.
 ENV ROCM_PATH /opt/rocm
 ENV PATH ${PATH}:${ROCM_PATH}/bin
@@ -41,7 +46,7 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-hip=yes \
     --gpu-ver=Mi50 \
-    --with-dbcsr=no \
+    --with-dbcsr \
     --with-tblite=no \
     --dry-run
 
@@ -82,22 +87,22 @@ COPY ./tools/toolchain/scripts/arch_base.tmpl \
      ./scripts/
 RUN ./scripts/generate_arch_files.sh && rm -rf ./build
 
-# Install CP2K using local_hip.psmp.
+# Install CP2K sources.
 WORKDIR /opt/cp2k
-COPY ./Makefile .
 COPY ./src ./src
-COPY ./exts ./exts
-COPY ./tools/build_utils ./tools/build_utils
-RUN /bin/bash -c " \
-    mkdir -p arch && \
-    ln -vs /opt/cp2k-toolchain/install/arch/local_hip.psmp ./arch/"
 COPY ./data ./data
 COPY ./tests ./tests
-COPY ./tools/regtesting ./tools/regtesting
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
+
+# Compile CP2K.
+COPY ./tools/docker/scripts/build_cp2k_cmake.sh .
+RUN ./build_cp2k_cmake.sh toolchain_hip_Mi50 psmp
 
 # Run build test.
 COPY ./tools/docker/scripts/test_build.sh .
-RUN ./test_build.sh "local_hip" "psmp" 2>&1 | tee report.log
+RUN ./test_build.sh "toolchain_hip_Mi50" "psmp" 2>&1 | tee report.log
 
 # Output the report if the image is old and was therefore pulled from the build cache.
 CMD cat $(find ./report.log -mmin +10) | sed '/^Summary:/ s/$/ (cached)/'

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi100
@@ -13,6 +13,11 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     libmpich-dev                                                      \
    && rm -rf /var/lib/apt/lists/*
 
+# Remove LTO from Ubuntu's MPICH
+RUN sed -i -e 's/-flto=auto//g' -e 's/-ffat-lto-objects//g' \
+    /usr/lib/x86_64-linux-gnu/pkgconfig/mpich.pc \
+    /usr/bin/*.mpich
+
 # Setup HIP environment.
 ENV ROCM_PATH /opt/rocm
 ENV PATH ${PATH}:${ROCM_PATH}/bin
@@ -41,7 +46,7 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-hip=yes \
     --gpu-ver=Mi100 \
-    --with-dbcsr=no \
+    --with-dbcsr \
     --with-tblite=no \
     --dry-run
 

--- a/tools/docker/Dockerfile.test_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.test_hip_rocm_Mi50
@@ -13,6 +13,11 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     libmpich-dev                                                      \
    && rm -rf /var/lib/apt/lists/*
 
+# Remove LTO from Ubuntu's MPICH
+RUN sed -i -e 's/-flto=auto//g' -e 's/-ffat-lto-objects//g' \
+    /usr/lib/x86_64-linux-gnu/pkgconfig/mpich.pc \
+    /usr/bin/*.mpich
+
 # Setup HIP environment.
 ENV ROCM_PATH /opt/rocm
 ENV PATH ${PATH}:${ROCM_PATH}/bin
@@ -41,7 +46,7 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-hip=yes \
     --gpu-ver=Mi50 \
-    --with-dbcsr=no \
+    --with-dbcsr \
     --with-tblite=no \
     --dry-run
 

--- a/tools/docker/scripts/test_build.sh
+++ b/tools/docker/scripts/test_build.sh
@@ -3,28 +3,16 @@
 # author: Ole Schuett
 
 if (($# != 2)); then
-  echo "Usage: test_build.sh <ARCH> <VERSION>"
+  echo "Usage: test_build.sh <PROFILE> <VERSION>"
   exit 1
 fi
 
-ARCH=$1
 VERSION=$2
 
-# shellcheck disable=SC1091
-source /opt/cp2k-toolchain/install/setup
-
-# Compile cp2k.
-echo -en "Compiling cp2k... "
-cd /opt/cp2k || exit 1
-if make -j ARCH="${ARCH}" VERSION="${VERSION}" &> make.out; then
-  echo -e "done."
+if [ -f build/bin/cp2k."${VERSION}" ]; then
   echo -e "\nSummary: Compilation works fine."
   echo -e "Status: OK\n"
 else
-  echo -e "failed.\n\n"
-  tail -n 100 make.out
-  mkdir -p /workspace/artifacts/
-  cp make.out /workspace/artifacts/
   echo -e "\nSummary: Compilation failed."
   echo -e "Status: FAILED\n"
 fi


### PR DESCRIPTION
I'm trying to migrate our HIP test to CMake. Unfortunately, CMake adds invalid compiler options when MPI is enabled due to [this bug]( https://gitlab.kitware.com/cmake/cmake/-/issues/27231). While gcc simply ignores unknown options, the clang++ compiler used by HIP stops with an error:

```
clang++: error: unknown argument: '-fallow-invalid-boz'
clang++: error: unknown argument: '-fallow-argument-mismatch'
```



@alazzaro @mtaillefumier any thoughts?