### PR TITLE
Fixed random NaN problem in RPA_AXK_H2O_hfx.inp for CUDA regtest

### DIFF
--- a/src/hfx_communication.F
+++ b/src/hfx_communication.F
@@ -98,6 +98,8 @@ CONTAINS
       full_density = 0.0_dp
       ALLOCATE (sendbuffer(number_of_p_entries))
       ALLOCATE (recbuffer(number_of_p_entries))
+      sendbuffer = 0.0_dp
+      recbuffer = 0.0_dp
 
       i = 1
       CALL dbcsr_iterator_start(iter, rho, shared=.FALSE.)


### PR DESCRIPTION
## Fix Random NaN in `RPA_AXK_H2O_hfx.inp` on A100

This PR fixes a non-deterministic `NaN` issue observed when running the test case  
`tests/QS/regtest-ri-rpa-exchange/RPA_AXK_H2O_hfx.inp` on NVIDIA A100 GPUs.

When executing this input file 10 times consecutively on an A100, the **RI-RPA-AXK energy** resulted in `NaN` in 3 out of 10 runs.

**Example of the failure:**

<img width="1040" height="255" alt="image" src="https://github.com/user-attachments/assets/c8cbe83d-e282-408d-8f06-d99c1ac43031" />


### Root Cause

After debugging, the issue was traced to the `get_full_density` subroutine in `src/hfx_communication.F`. Specifically:

- The `sendbuffer` array was **not initialized** before use.
- In certain execution paths, the code **skipped the `do while` loop** that assigns values to `sendbuffer`.
- As a result, uninitialized (garbage) values from `sendbuffer` were later used to construct `full_density`, leading to `NaN` in the **RI-RPA-AXK energy**.

### Fix

This PR initializes the `sendbuffer` array to zero at the beginning of the subroutine, ensuring consistent behavior regardless of control flow path.

### Verification

After the fix, the same test was run 10 times on A100 with **zero `NaN` occurrences**. The RI-RPA-AXK energy is now stable and reproducible.

<img width="1050" height="261" alt="image" src="https://github.com/user-attachments/assets/0313510e-4053-4b46-b796-69dcfd03f32d" />