### PR TITLE
Fixed a rare matrix distribution bug which sometimes caused crashes i…

### DIFF
--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -1623,7 +1623,6 @@ CONTAINS
          nmo = gs_mos(ispin)%nmo_active
          CALL cp_fm_struct_create(fm_struct, template_fmstruct=gs_mos(ispin)%mos_occ%matrix_struct, &
                                   ncol_global=nmo, context=blacs_env)
-         ! CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nmo, context=blacs_env)
          NULLIFY (gs_mos(ispin)%mos_active)
          ALLOCATE (gs_mos(ispin)%mos_active)
          CALL cp_fm_create(gs_mos(ispin)%mos_active, fm_struct)

--- a/src/qs_tddfpt2_methods.F
+++ b/src/qs_tddfpt2_methods.F
@@ -1621,7 +1621,9 @@ CONTAINS
          CALL get_qs_env(qs_env, blacs_env=blacs_env)
          CALL cp_fm_get_info(gs_mos(ispin)%mos_occ, nrow_global=nao)
          nmo = gs_mos(ispin)%nmo_active
-         CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nmo, context=blacs_env)
+         CALL cp_fm_struct_create(fm_struct, template_fmstruct=gs_mos(ispin)%mos_occ%matrix_struct, &
+                                  ncol_global=nmo, context=blacs_env)
+         ! CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nmo, context=blacs_env)
          NULLIFY (gs_mos(ispin)%mos_active)
          ALLOCATE (gs_mos(ispin)%mos_active)
          CALL cp_fm_create(gs_mos(ispin)%mos_active, fm_struct)

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -306,7 +306,6 @@ CONTAINS
       DO ispin = 1, nspins
          NULLIFY (work_matrices%fm_pool_ao_mo_active(ispin)%pool)
          CALL cp_fm_struct_create(fm_struct, template_fmstruct=gs_mos(ispin)%mos_active%matrix_struct, context=blacs_env)
-         ! CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nactive(ispin), context=blacs_env)
          CALL fm_pool_create(work_matrices%fm_pool_ao_mo_active(ispin)%pool, fm_struct)
          CALL cp_fm_struct_release(fm_struct)
       END DO
@@ -321,7 +320,6 @@ CONTAINS
       ALLOCATE (work_matrices%S_C0(nspins))
       DO ispin = 1, nspins
          CALL cp_fm_struct_create(fm_struct, template_fmstruct=gs_mos(ispin)%mos_occ%matrix_struct, context=blacs_env)
-         ! CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nmo_occ(ispin), context=blacs_env)
          CALL cp_fm_create(work_matrices%S_C0(ispin), fm_struct)
          CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, gs_mos(ispin)%mos_occ, work_matrices%S_C0(ispin), &
                                       ncol=nmo_occ(ispin), alpha=1.0_dp, beta=0.0_dp)
@@ -334,8 +332,6 @@ CONTAINS
          DO ispin = 1, evecs_dim
             CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, template_fmstruct=gs_mos(ispin)%mos_active%matrix_struct, &
                                      context=sub_env%blacs_env)
-            ! CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, nrow_global=nao, &
-            !                          ncol_global=nactive(ispin), context=sub_env%blacs_env)
          END DO
 
          ALLOCATE (work_matrices%evects_sub(evecs_dim, nstates), work_matrices%Aop_evects_sub(evecs_dim, nstates))
@@ -540,8 +536,6 @@ CONTAINS
          DO ispin = 1, nspins
             CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, template_fmstruct=gs_mos(ispin)%mos_active%matrix_struct, &
                                      context=sub_env%blacs_env)
-            ! CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, nrow_global=nao, &
-            !                          ncol_global=nactive(ispin), context=sub_env%blacs_env)
          END DO
          CALL dbcsr_init_p(work_matrices%shalf)
          CALL dbcsr_create(work_matrices%shalf, template=matrix_s(1)%matrix)

--- a/src/qs_tddfpt2_types.F
+++ b/src/qs_tddfpt2_types.F
@@ -305,7 +305,8 @@ CONTAINS
       ALLOCATE (work_matrices%fm_pool_ao_mo_active(nspins))
       DO ispin = 1, nspins
          NULLIFY (work_matrices%fm_pool_ao_mo_active(ispin)%pool)
-         CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nactive(ispin), context=blacs_env)
+         CALL cp_fm_struct_create(fm_struct, template_fmstruct=gs_mos(ispin)%mos_active%matrix_struct, context=blacs_env)
+         ! CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nactive(ispin), context=blacs_env)
          CALL fm_pool_create(work_matrices%fm_pool_ao_mo_active(ispin)%pool, fm_struct)
          CALL cp_fm_struct_release(fm_struct)
       END DO
@@ -319,7 +320,8 @@ CONTAINS
 
       ALLOCATE (work_matrices%S_C0(nspins))
       DO ispin = 1, nspins
-         CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nmo_occ(ispin), context=blacs_env)
+         CALL cp_fm_struct_create(fm_struct, template_fmstruct=gs_mos(ispin)%mos_occ%matrix_struct, context=blacs_env)
+         ! CALL cp_fm_struct_create(fm_struct, nrow_global=nao, ncol_global=nmo_occ(ispin), context=blacs_env)
          CALL cp_fm_create(work_matrices%S_C0(ispin), fm_struct)
          CALL cp_dbcsr_sm_fm_multiply(matrix_s(1)%matrix, gs_mos(ispin)%mos_occ, work_matrices%S_C0(ispin), &
                                       ncol=nmo_occ(ispin), alpha=1.0_dp, beta=0.0_dp)
@@ -330,8 +332,10 @@ CONTAINS
 
       IF (sub_env%is_split) THEN
          DO ispin = 1, evecs_dim
-            CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, nrow_global=nao, &
-                                     ncol_global=nactive(ispin), context=sub_env%blacs_env)
+            CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, template_fmstruct=gs_mos(ispin)%mos_active%matrix_struct, &
+                                     context=sub_env%blacs_env)
+            ! CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, nrow_global=nao, &
+            !                          ncol_global=nactive(ispin), context=sub_env%blacs_env)
          END DO
 
          ALLOCATE (work_matrices%evects_sub(evecs_dim, nstates), work_matrices%Aop_evects_sub(evecs_dim, nstates))
@@ -534,8 +538,10 @@ CONTAINS
       ! matrices needed to do HFX long range calllculations
       IF (do_hfxlr) THEN
          DO ispin = 1, nspins
-            CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, nrow_global=nao, &
-                                     ncol_global=nactive(ispin), context=sub_env%blacs_env)
+            CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, template_fmstruct=gs_mos(ispin)%mos_active%matrix_struct, &
+                                     context=sub_env%blacs_env)
+            ! CALL cp_fm_struct_create(fm_struct_evects(ispin)%struct, nrow_global=nao, &
+            !                          ncol_global=nactive(ispin), context=sub_env%blacs_env)
          END DO
          CALL dbcsr_init_p(work_matrices%shalf)
          CALL dbcsr_create(work_matrices%shalf, template=matrix_s(1)%matrix)

--- a/src/qs_tddfpt2_utils.F
+++ b/src/qs_tddfpt2_utils.F
@@ -318,8 +318,6 @@ CONTAINS
                                ncol_global=nmo_occ, context=blacs_env)
       CALL cp_fm_struct_create(ao_mo_virt_fm_struct, template_fmstruct=mo_set%mo_coeff%matrix_struct, &
                                ncol_global=nmo_virt, context=blacs_env)
-      ! CALL cp_fm_struct_create(ao_mo_occ_fm_struct, nrow_global=nao, ncol_global=nmo_occ, context=blacs_env)
-      ! CALL cp_fm_struct_create(ao_mo_virt_fm_struct, nrow_global=nao, ncol_global=nmo_virt, context=blacs_env)
 
       NULLIFY (gs_mos%mos_occ, gs_mos%mos_virt, gs_mos%evals_occ_matrix)
       ALLOCATE (gs_mos%mos_occ, gs_mos%mos_virt)

--- a/src/qs_tddfpt2_utils.F
+++ b/src/qs_tddfpt2_utils.F
@@ -313,8 +313,13 @@ CONTAINS
 
       ! ++ allocate storage space for gs_mos
       NULLIFY (ao_mo_occ_fm_struct, ao_mo_virt_fm_struct)
-      CALL cp_fm_struct_create(ao_mo_occ_fm_struct, nrow_global=nao, ncol_global=nmo_occ, context=blacs_env)
-      CALL cp_fm_struct_create(ao_mo_virt_fm_struct, nrow_global=nao, ncol_global=nmo_virt, context=blacs_env)
+      ! Tiny fix (A.Sinyavskiy)
+      CALL cp_fm_struct_create(ao_mo_occ_fm_struct, template_fmstruct=mo_set%mo_coeff%matrix_struct, &
+                               ncol_global=nmo_occ, context=blacs_env)
+      CALL cp_fm_struct_create(ao_mo_virt_fm_struct, template_fmstruct=mo_set%mo_coeff%matrix_struct, &
+                               ncol_global=nmo_virt, context=blacs_env)
+      ! CALL cp_fm_struct_create(ao_mo_occ_fm_struct, nrow_global=nao, ncol_global=nmo_occ, context=blacs_env)
+      ! CALL cp_fm_struct_create(ao_mo_virt_fm_struct, nrow_global=nao, ncol_global=nmo_virt, context=blacs_env)
 
       NULLIFY (gs_mos%mos_occ, gs_mos%mos_virt, gs_mos%evals_occ_matrix)
       ALLOCATE (gs_mos%mos_occ, gs_mos%mos_virt)


### PR DESCRIPTION
Fixed a rare matrix distribution bug which sometimes caused crashes in linres_solver when num_pe(1) /= num_pe(2).
Here is what caused it for this case (309 AOs, 32 occupied, num_pe = [4, 8]):
- some (but not all) matrices involved in response calculation were created using _square_ 309 x 309 mo_coeff matrix as a template
- square matrix gets row block size (309 + 4 - 1) / 4 = 78 > default 64 = 64 and col block size (309 + 8 - 1) / 8 = 38, **they are forced to be equal**, so the smaller one is used for both dimensions, thus 38 x 38
- when you create a _rectangular_ 309 x 32 matrix struct using a _square_ one as a template, you get 38 row block size and (32 + 8 - 1) / 8 = 4 col block size
- when you create a _rectangular_ 309 x 32 matrix struct without a template, you get default 64 row block size and 4 col block size
- matrices with different block sizes are incompatible, hence the crash during cp_fm_to_fm_matrix
- this fix changes most work matrices to use the same template and get 38 row block size, my example works now
- I may have missed a few, so please point me if you find another rectangular matrix created without a template 

See Alps output attached:
[_tddfpt_fm_dist_fix.zip](https://github.com/user-attachments/files/23821747/_tddfpt_fm_dist_fix.zip)