### PR TITLE
Fix ERI calculation in the active space model with subgroups

### DIFF
--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1954,8 +1954,12 @@ CONTAINS
                ! This is identical to the truncated Coulomb operator integrated
                ! over all space, when the truncation radius is equal to the radius of
                ! the Poisson solver
-            CASE (eri_operator_coulomb)
-               Rc = green%radius
+            CASE (eri_operator_coulomb, eri_operator_trunc)
+               IF (eri_env%operator == eri_operator_coulomb) THEN
+                  Rc = green%radius
+               ELSE
+                  Rc = eri_env%cutoff_radius
+               END IF
                DO ig = grid%first_gne0, grid%ngpts_cut_local
                   g2 = grid%gsq(ig)
                   g = SQRT(g2)
@@ -1984,8 +1988,12 @@ CONTAINS
 
                ! Long-range Coulomb
                ! TODO: this should be equivalent to LR truncated Coulomb from above!
-            CASE (eri_operator_erf)
-               Rc = green%radius
+            CASE (eri_operator_erf, eri_operator_lr_trunc)
+               IF (eri_env%operator == eri_operator_erf) THEN
+                  Rc = green%radius
+               ELSE
+                  Rc = eri_env%cutoff_radius
+               END IF
                omega2 = eri_env%omega**2
                DO ig = grid%first_gne0, grid%ngpts_cut_local
                   g2 = grid%gsq(ig)
@@ -2010,10 +2018,6 @@ CONTAINS
                END DO
                IF (grid%have_g0) gf%array(1) = pi/omega2
 
-            CASE (eri_operator_trunc)
-               CPABORT("Truncated Coulomb with ANALYTIC0D is equivalent to normal Coulomb")
-            CASE (eri_operator_lr_trunc)
-               CPABORT("LR truncated Coulomb with ANALYTIC0D is equivalent to normal longrange")
             CASE DEFAULT
                CPABORT("Unsupported operator")
             END SELECT

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1329,7 +1329,7 @@ CONTAINS
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_matrix_pq_rnu, fm_matrix_pq_rs, &
                                                             fm_mo_coeff_as
-      TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff1, mo_coeff2
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type)                                 :: mat_munu
       TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: matrix_pq_rnu, mo_coeff_as
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -1607,7 +1607,7 @@ CONTAINS
       ! calculate the integrals
       stored_integrals = 0
       DO isp1 = 1, nspins
-         CALL get_mo_set(mo_set=mos(isp1), nmo=nmo1, mo_coeff=mo_coeff1)
+         CALL get_mo_set(mo_set=mos(isp1), nmo=nmo1)
          nmm = (nmo1*(nmo1 + 1))/2
          irange = get_irange_csr(nmm, eri_env%comm_exchange)
          DO i1 = 1, SIZE(orbitals, 1)
@@ -1615,7 +1615,7 @@ CONTAINS
             IF (eri_env%eri_gpw%store_wfn) THEN
                wfn1 => wfn_a(iwa1, isp1)
             ELSE
-               CALL calculate_wavefunction(mo_coeff1, iwa1, wfn1, rho_g, atomic_kind_set, &
+               CALL calculate_wavefunction(fm_mo_coeff_as(isp1), iwa1, wfn1, rho_g, atomic_kind_set, &
                                            qs_kind_set, cell, dft_control, particle_set, pw_env_sub)
             END IF
             DO i2 = i1, SIZE(orbitals, 1)
@@ -1627,7 +1627,7 @@ CONTAINS
                IF (eri_env%eri_gpw%store_wfn) THEN
                   wfn2 => wfn_a(iwa2, isp1)
                ELSE
-                  CALL calculate_wavefunction(mo_coeff1, iwa2, wfn2, rho_g, atomic_kind_set, &
+                  CALL calculate_wavefunction(fm_mo_coeff_as(isp1), iwa2, wfn2, rho_g, atomic_kind_set, &
                                               qs_kind_set, cell, dft_control, particle_set, pw_env_sub)
                END IF
                ! calculate charge distribution and potential
@@ -1676,7 +1676,7 @@ CONTAINS
                            IF (iwb1 <= iwb2) THEN
                               iwb12 = csr_idx_to_combined(iwb1, iwb2, nmo2)
                               erint = fm_matrix_pq_rs(isp2)%local_data(row_local, col_local)
-                              IF (ABS(erint) > eri_env%eps_integral .AND. (iwa12 <= iwb12 .OR. isp1 /= isp2)) THEN
+                              IF (ABS(erint) > eri_env%eps_integral .AND. (irange(1) - 1 + iwa12 <= iwb12 .OR. isp1 /= isp2)) THEN
                                  icount2 = icount2 + 1
                                  eri(icount2) = erint
                                  eri_index(icount2) = iwb12
@@ -1693,7 +1693,7 @@ CONTAINS
                   END DO
                ELSEIF (eri_env%method == eri_method_full_gpw) THEN
                   DO isp2 = isp1, nspins
-                     CALL get_mo_set(mo_set=mos(isp2), nmo=nmo2, mo_coeff=mo_coeff2)
+                     CALL get_mo_set(mo_set=mos(isp2), nmo=nmo2)
                      nx = (nmo2*(nmo2 + 1))/2
                      ALLOCATE (eri(nx), eri_index(nx))
                      icount2 = 0
@@ -1705,7 +1705,7 @@ CONTAINS
                         IF (eri_env%eri_gpw%store_wfn) THEN
                            wfn3 => wfn_a(iwb1, isp2)
                         ELSE
-                           CALL calculate_wavefunction(mo_coeff2, iwb1, wfn3, rho_g, atomic_kind_set, &
+                           CALL calculate_wavefunction(fm_mo_coeff_as(isp1), iwb1, wfn3, rho_g, atomic_kind_set, &
                                                        qs_kind_set, cell, dft_control, particle_set, pw_env_sub)
                         END IF
                         CALL pw_zero(wfn_r)
@@ -1717,7 +1717,7 @@ CONTAINS
                            IF (eri_env%eri_gpw%store_wfn) THEN
                               wfn4 => wfn_a(iwb2, isp2)
                            ELSE
-                              CALL calculate_wavefunction(mo_coeff2, iwb2, wfn4, rho_g, atomic_kind_set, &
+                              CALL calculate_wavefunction(fm_mo_coeff_as(isp1), iwb2, wfn4, rho_g, atomic_kind_set, &
                                                           qs_kind_set, cell, dft_control, particle_set, pw_env_sub)
                            END IF
                            ! We reduce the amount of communication by collecting the local sums first and sum globally later
@@ -2405,7 +2405,7 @@ CONTAINS
          ! compute ks_ref = V_H[rho^A] + V_HFX[rho^A]
          eri => active_space_env%eri%eri(1)%csr_mat
          CALL build_subspace_fock_matrix(active_space_env%active_orbitals, eri, p_mat, ks_ref, &
-                                         active_space_env%eri%method, active_space_env%eri%comm_exchange)
+                                         active_space_env%eri%comm_exchange)
 
          ! compute eeri = E_H[rho^A] + E_HFX[rho^A] as
          ! eeri = 1/2 * (SUM_pq (V_H[rho^A] + V_HFX[rho^A])_pq * D^A_pq)
@@ -2459,9 +2459,9 @@ CONTAINS
          eri_ab => active_space_env%eri%eri(2)%csr_mat
          eri_bb => active_space_env%eri%eri(3)%csr_mat
          CALL build_subspace_spin_fock_matrix(active_space_env%active_orbitals, eri_aa, eri_ab, p_a_mat, p_b_mat, ks_a_ref, &
-                     tr_mixed_eri=.FALSE., eri_method=active_space_env%eri%method, comm_exchange=active_space_env%eri%comm_exchange)
+                                              tr_mixed_eri=.FALSE., comm_exchange=active_space_env%eri%comm_exchange)
          CALL build_subspace_spin_fock_matrix(active_space_env%active_orbitals, eri_bb, eri_ab, p_b_mat, p_a_mat, ks_b_ref, &
-                      tr_mixed_eri=.TRUE., eri_method=active_space_env%eri%method, comm_exchange=active_space_env%eri%comm_exchange)
+                                              tr_mixed_eri=.TRUE., comm_exchange=active_space_env%eri%comm_exchange)
          !
          ! calculate energy
          eeri = 0.0_dp
@@ -2505,15 +2505,13 @@ CONTAINS
 !> \param eri two electon integrals in MO
 !> \param p_mat density matrix
 !> \param ks_ref fockian matrix
-!> \param eri_method ...
 !> \param comm_exchange ...
 ! **************************************************************************************************
-   SUBROUTINE build_subspace_fock_matrix(active_orbitals, eri, p_mat, ks_ref, eri_method, comm_exchange)
+   SUBROUTINE build_subspace_fock_matrix(active_orbitals, eri, p_mat, ks_ref, comm_exchange)
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: active_orbitals
       TYPE(dbcsr_csr_type), INTENT(IN)                   :: eri
       REAL(dp), DIMENSION(:, :), INTENT(IN)              :: p_mat
       REAL(dp), DIMENSION(:, :), INTENT(INOUT)           :: ks_ref
-      INTEGER, INTENT(IN)                                :: eri_method
       TYPE(mp_comm_type), INTENT(IN)                     :: comm_exchange
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_subspace_fock_matrix'
@@ -2532,11 +2530,7 @@ CONTAINS
       nmo_total = SIZE(p_mat, 1)
       nindex = (nmo_total*(nmo_total + 1))/2
       CALL mp_group%set_handle(eri%mp_group%get_handle())
-      IF (eri_method == eri_method_gpw_ht) THEN
-         irange = [1, nindex]
-      ELSE
-         irange = get_irange_csr(nindex, comm_exchange)
-      END IF
+      irange = get_irange_csr(nindex, comm_exchange)
       DO m1 = 1, norb
          i1 = active_orbitals(m1, 1)
          DO m2 = m1, norb
@@ -2599,17 +2593,15 @@ CONTAINS
 !> \param p_b_mat density matrix for down-spin
 !> \param ks_a_ref fockian matrix for up-spin
 !> \param tr_mixed_eri boolean to indicate Coulomb interaction alignment
-!> \param eri_method ...
 !> \param comm_exchange ...
 ! **************************************************************************************************
    SUBROUTINE build_subspace_spin_fock_matrix(active_orbitals, eri_aa, eri_ab, p_a_mat, p_b_mat, ks_a_ref, tr_mixed_eri, &
-                                              eri_method, comm_exchange)
+                                              comm_exchange)
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: active_orbitals
       TYPE(dbcsr_csr_type), INTENT(IN)                   :: eri_aa, eri_ab
       REAL(dp), DIMENSION(:, :), INTENT(IN)              :: p_a_mat, p_b_mat
       REAL(dp), DIMENSION(:, :), INTENT(INOUT)           :: ks_a_ref
       LOGICAL, INTENT(IN)                                :: tr_mixed_eri
-      INTEGER, INTENT(IN)                                :: eri_method
       TYPE(mp_comm_type), INTENT(IN)                     :: comm_exchange
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_subspace_spin_fock_matrix'
@@ -2626,11 +2618,7 @@ CONTAINS
       norb = SIZE(active_orbitals, 1)
       nmo_total = SIZE(p_a_mat, 1)
       nindex = (nmo_total*(nmo_total + 1))/2
-      IF (eri_method == eri_method_gpw_ht) THEN
-         irange = [1, nindex]
-      ELSE
-         irange = get_irange_csr(nindex, comm_exchange)
-      END IF
+      irange = get_irange_csr(nindex, comm_exchange)
       IF (tr_mixed_eri) THEN
          spin1 = 2
          spin2 = 1
@@ -2679,11 +2667,7 @@ CONTAINS
       END DO
       !
 
-      IF (eri_method == eri_method_gpw_ht) THEN
-         irange = [1, nindex]
-      ELSE
-         irange = get_irange_csr(nindex, comm_exchange)
-      END IF
+      irange = get_irange_csr(nindex, comm_exchange)
       DO m1 = 1, norb
          i1 = active_orbitals(m1, 1)
          DO m2 = m1, norb

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1384,10 +1384,8 @@ CONTAINS
       IF (eri_env%eri_gpw%group_size == para_env%num_pe) THEN
          eri_env%para_env_sub => para_env
          CALL eri_env%para_env_sub%retain()
-         IF (eri_env%method == eri_method_gpw_ht) THEN
-            blacs_env_sub => blacs_env
-            CALL blacs_env_sub%retain()
-         END IF
+         blacs_env_sub => blacs_env
+         CALL blacs_env_sub%retain()
          number_of_subgroups = 1
          color = 0
       ELSE
@@ -1395,10 +1393,8 @@ CONTAINS
          color = para_env%mepos/eri_env%eri_gpw%group_size
          ALLOCATE (eri_env%para_env_sub)
          CALL eri_env%para_env_sub%from_split(para_env, color)
-         IF (eri_env%method == eri_method_gpw_ht) THEN
-            NULLIFY (blacs_env_sub)
-            CALL cp_blacs_env_create(blacs_env_sub, eri_env%para_env_sub, BLACS_GRID_SQUARE, .TRUE.)
-         END IF
+         NULLIFY (blacs_env_sub)
+         CALL cp_blacs_env_create(blacs_env_sub, eri_env%para_env_sub, BLACS_GRID_SQUARE, .TRUE.)
       END IF
       CALL eri_env%comm_exchange%from_split(para_env, eri_env%para_env_sub%mepos)
 
@@ -1422,13 +1418,11 @@ CONTAINS
       END DO
       qs_control%relative_cutoff = eri_env%eri_gpw%rel_cutoff*0.5_dp
 
-      IF (eri_env%method == eri_method_gpw_ht) THEN
-         ! For now, we will distribute neighbor lists etc. within the global communicator
-         CALL get_qs_env(qs_env, ks_env=ks_env)
-         CALL create_mat_munu(mat_munu, qs_env, eri_env%eri_gpw%eps_grid, blacs_env_sub, sab_orb_sub=sab_orb_sub, &
-                              do_alloc_blocks_from_nbl=.TRUE., dbcsr_sym_type=dbcsr_type_symmetric)
-         CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
-      END IF
+      ! For now, we will distribute neighbor lists etc. within the global communicator
+      CALL get_qs_env(qs_env, ks_env=ks_env)
+      CALL create_mat_munu(mat_munu, qs_env, eri_env%eri_gpw%eps_grid, blacs_env_sub, sab_orb_sub=sab_orb_sub, &
+                           do_alloc_blocks_from_nbl=.TRUE., dbcsr_sym_type=dbcsr_type_symmetric)
+      CALL dbcsr_set(mat_munu%matrix, 0.0_dp)
 
       ! Generate the appropriate pw_env
       NULLIFY (pw_env_sub)
@@ -1490,6 +1484,33 @@ CONTAINS
          END IF
       END IF
 
+      ALLOCATE (mo_coeff_as(nspins), fm_mo_coeff_as(nspins))
+      DO ispin = 1, nspins
+         BLOCK
+            REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE :: C
+            INTEGER :: nmo
+            TYPE(group_dist_d1_type) :: gd_array
+            TYPE(cp_fm_type), POINTER :: mo_coeff
+            CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff, nmo=nmo)
+            CALL grep_rows_in_subgroups(para_env, eri_env%para_env_sub, mo_coeff, gd_array, C)
+
+            CALL build_dbcsr_from_rows(eri_env%para_env_sub, mo_coeff_as(ispin), &
+                                       C(:, :nmo), mat_munu%matrix, gd_array, eri_env%eri_gpw%eps_filter)
+            CALL release_group_dist(gd_array)
+            DEALLOCATE (C)
+         END BLOCK
+
+         CALL dbcsr_get_info(mo_coeff_as(ispin), nfullrows_total=nrow_global, nfullcols_total=ncol_global)
+
+         NULLIFY (fm_struct)
+         CALL cp_fm_struct_create(fm_struct, context=blacs_env_sub, para_env=eri_env%para_env_sub, &
+                                  nrow_global=nrow_global, ncol_global=ncol_global)
+         CALL cp_fm_create(fm_mo_coeff_as(ispin), fm_struct)
+         CALL cp_fm_struct_release(fm_struct)
+
+         CALL copy_dbcsr_to_fm(mo_coeff_as(ispin), fm_mo_coeff_as(ispin))
+      END DO
+
       IF (eri_env%method == eri_method_gpw_ht) THEN
          ! We need a task list
          NULLIFY (task_list_sub)
@@ -1503,39 +1524,21 @@ CONTAINS
          ! Create sparse matrices carrying the matrix products, Code borrowed from the MP2 GPW method
          ! Create equal distributions for them (no sparsity present)
          ! We use the routines from mp2 suggesting that one may replicate the grids later for better performance
-         ALLOCATE (mo_coeff_as(nspins), matrix_pq_rnu(nspins), &
-                   fm_matrix_pq_rnu(nspins), fm_mo_coeff_as(nspins), fm_matrix_pq_rs(nspins))
+         ALLOCATE (matrix_pq_rnu(nspins), fm_matrix_pq_rnu(nspins), fm_matrix_pq_rs(nspins))
          DO ispin = 1, nspins
-            BLOCK
-               REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE :: C
-               TYPE(group_dist_d1_type) :: gd_array
-               TYPE(cp_fm_type), POINTER :: mo_coeff
-               CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
-               CALL grep_rows_in_subgroups(para_env, eri_env%para_env_sub, mo_coeff, gd_array, C)
-
-               CALL build_dbcsr_from_rows(eri_env%para_env_sub, mo_coeff_as(ispin), &
-                                          C(:, MINVAL(orbitals(:, ispin)):MAXVAL(orbitals(:, ispin))), &
-                                          mat_munu%matrix, gd_array, eri_env%eri_gpw%eps_filter)
-               CALL release_group_dist(gd_array)
-               DEALLOCATE (C)
-            END BLOCK
-
             CALL dbcsr_create(matrix_pq_rnu(ispin), template=mo_coeff_as(ispin))
             CALL dbcsr_set(matrix_pq_rnu(ispin), 0.0_dp)
 
             CALL dbcsr_get_info(matrix_pq_rnu(ispin), nfullrows_total=nrow_global, nfullcols_total=ncol_global)
 
             NULLIFY (fm_struct)
-            CALL cp_fm_struct_create(fm_struct, context=blacs_env, para_env=eri_env%para_env_sub, &
+            CALL cp_fm_struct_create(fm_struct, context=blacs_env_sub, para_env=eri_env%para_env_sub, &
                                      nrow_global=nrow_global, ncol_global=ncol_global)
             CALL cp_fm_create(fm_matrix_pq_rnu(ispin), fm_struct)
-            CALL cp_fm_create(fm_mo_coeff_as(ispin), fm_struct)
             CALL cp_fm_struct_release(fm_struct)
 
-            CALL copy_dbcsr_to_fm(mo_coeff_as(ispin), fm_mo_coeff_as(ispin))
-
             NULLIFY (fm_struct)
-            CALL cp_fm_struct_create(fm_struct, context=blacs_env, para_env=eri_env%para_env_sub, &
+            CALL cp_fm_struct_create(fm_struct, context=blacs_env_sub, para_env=eri_env%para_env_sub, &
                                      nrow_global=ncol_global, ncol_global=ncol_global)
             CALL cp_fm_create(fm_matrix_pq_rs(ispin), fm_struct)
             CALL cp_fm_struct_release(fm_struct)
@@ -1793,18 +1796,21 @@ CONTAINS
          DO ispin = 1, nspins
             CALL dbcsr_release(mo_coeff_as(ispin))
             CALL dbcsr_release(matrix_pq_rnu(ispin))
-            CALL cp_fm_release(fm_mo_coeff_as(ispin))
             CALL cp_fm_release(fm_matrix_pq_rnu(ispin))
             CALL cp_fm_release(fm_matrix_pq_rs(ispin))
          END DO
-         DEALLOCATE (mo_coeff_as, matrix_pq_rnu, &
-                     fm_mo_coeff_as, fm_matrix_pq_rnu, fm_matrix_pq_rs)
+         DEALLOCATE (matrix_pq_rnu, fm_matrix_pq_rnu, fm_matrix_pq_rs)
          CALL deallocate_task_list(task_list_sub)
-         CALL dbcsr_release(mat_munu%matrix)
-         DEALLOCATE (mat_munu%matrix)
-         CALL release_neighbor_list_sets(sab_orb_sub)
-         CALL cp_blacs_env_release(blacs_env_sub)
       END IF
+      DO ispin = 1, nspins
+         CALL dbcsr_release(mo_coeff_as(ispin))
+         CALL cp_fm_release(fm_mo_coeff_as(ispin))
+      END DO
+      DEALLOCATE (mo_coeff_as, fm_mo_coeff_as)
+      CALL release_neighbor_list_sets(sab_orb_sub)
+      CALL cp_blacs_env_release(blacs_env_sub)
+      CALL dbcsr_release(mat_munu%matrix)
+      DEALLOCATE (mat_munu%matrix)
       CALL pw_env_release(pw_env_sub)
       ! Return to the old qs_control
       dft_control%qs_control => qs_control_old

--- a/src/qs_active_space_methods.F
+++ b/src/qs_active_space_methods.F
@@ -1313,9 +1313,9 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'calculate_eri_gpw'
 
       INTEGER :: col_local, color, handle, i1, i2, i3, i4, i_multigrid, icount2, intcount, &
-         irange(2), irange_sub(2), isp, isp1, isp2, ispin, iwa1, iwa12, iwa2, iwb1, iwb12, iwb2, &
-         iwbs, iwbt, iwfn, n_multigrid, ncol_global, ncol_local, nmm, nmo, nmo1, nmo2, &
-         nrow_global, nrow_local, nspins, number_of_subgroups, nx, row_local, stored_integrals
+         irange(2), isp, isp1, isp2, ispin, iwa1, iwa12, iwa2, iwb1, iwb12, iwb2, iwbs, iwbt, &
+         iwfn, n_multigrid, ncol_global, ncol_local, nmm, nmo, nmo1, nmo2, nrow_global, &
+         nrow_local, nspins, number_of_subgroups, nx, row_local, stored_integrals
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: eri_index
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       LOGICAL                                            :: print1, print2, &
@@ -1333,8 +1333,7 @@ CONTAINS
       TYPE(dbcsr_p_type)                                 :: mat_munu
       TYPE(dbcsr_type), ALLOCATABLE, DIMENSION(:)        :: matrix_pq_rnu, mo_coeff_as
       TYPE(dft_control_type), POINTER                    :: dft_control
-      TYPE(mp_comm_type)                                 :: mp_group
-      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_sub
+      TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_orb_sub
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1383,8 +1382,8 @@ CONTAINS
          CPABORT("Group size must be a divisor of the total number of processes!")
       ! Create a new para_env or reuse the old one
       IF (eri_env%eri_gpw%group_size == para_env%num_pe) THEN
-         para_env_sub => para_env
-         CALL para_env_sub%retain()
+         eri_env%para_env_sub => para_env
+         CALL eri_env%para_env_sub%retain()
          IF (eri_env%method == eri_method_gpw_ht) THEN
             blacs_env_sub => blacs_env
             CALL blacs_env_sub%retain()
@@ -1394,13 +1393,14 @@ CONTAINS
       ELSE
          number_of_subgroups = para_env%num_pe/eri_env%eri_gpw%group_size
          color = para_env%mepos/eri_env%eri_gpw%group_size
-         ALLOCATE (para_env_sub)
-         CALL para_env_sub%from_split(para_env, color)
+         ALLOCATE (eri_env%para_env_sub)
+         CALL eri_env%para_env_sub%from_split(para_env, color)
          IF (eri_env%method == eri_method_gpw_ht) THEN
             NULLIFY (blacs_env_sub)
-            CALL cp_blacs_env_create(blacs_env_sub, para_env_sub, BLACS_GRID_SQUARE, .TRUE.)
+            CALL cp_blacs_env_create(blacs_env_sub, eri_env%para_env_sub, BLACS_GRID_SQUARE, .TRUE.)
          END IF
       END IF
+      CALL eri_env%comm_exchange%from_split(para_env, eri_env%para_env_sub%mepos)
 
       ! This should be done differently! Copied from MP2 code
       CALL get_qs_env(qs_env, dft_control=dft_control)
@@ -1433,7 +1433,7 @@ CONTAINS
       ! Generate the appropriate pw_env
       NULLIFY (pw_env_sub)
       CALL pw_env_create(pw_env_sub)
-      CALL pw_env_rebuild(pw_env_sub, qs_env, external_para_env=para_env_sub)
+      CALL pw_env_rebuild(pw_env_sub, qs_env, external_para_env=eri_env%para_env_sub)
       CALL pw_env_get(pw_env_sub, auxbas_pw_pool=auxbas_pw_pool, poisson_env=poisson_env)
 
       ! TODO: maybe we can let `pw_env_rebuild` do what we manually overwrite here?
@@ -1511,9 +1511,9 @@ CONTAINS
                TYPE(group_dist_d1_type) :: gd_array
                TYPE(cp_fm_type), POINTER :: mo_coeff
                CALL get_mo_set(mos(ispin), mo_coeff=mo_coeff)
-               CALL grep_rows_in_subgroups(para_env, para_env_sub, mo_coeff, gd_array, C)
+               CALL grep_rows_in_subgroups(para_env, eri_env%para_env_sub, mo_coeff, gd_array, C)
 
-               CALL build_dbcsr_from_rows(para_env_sub, mo_coeff_as(ispin), &
+               CALL build_dbcsr_from_rows(eri_env%para_env_sub, mo_coeff_as(ispin), &
                                           C(:, MINVAL(orbitals(:, ispin)):MAXVAL(orbitals(:, ispin))), &
                                           mat_munu%matrix, gd_array, eri_env%eri_gpw%eps_filter)
                CALL release_group_dist(gd_array)
@@ -1526,7 +1526,7 @@ CONTAINS
             CALL dbcsr_get_info(matrix_pq_rnu(ispin), nfullrows_total=nrow_global, nfullcols_total=ncol_global)
 
             NULLIFY (fm_struct)
-            CALL cp_fm_struct_create(fm_struct, context=blacs_env, para_env=para_env_sub, &
+            CALL cp_fm_struct_create(fm_struct, context=blacs_env, para_env=eri_env%para_env_sub, &
                                      nrow_global=nrow_global, ncol_global=ncol_global)
             CALL cp_fm_create(fm_matrix_pq_rnu(ispin), fm_struct)
             CALL cp_fm_create(fm_mo_coeff_as(ispin), fm_struct)
@@ -1535,7 +1535,7 @@ CONTAINS
             CALL copy_dbcsr_to_fm(mo_coeff_as(ispin), fm_mo_coeff_as(ispin))
 
             NULLIFY (fm_struct)
-            CALL cp_fm_struct_create(fm_struct, context=blacs_env, para_env=para_env_sub, &
+            CALL cp_fm_struct_create(fm_struct, context=blacs_env, para_env=eri_env%para_env_sub, &
                                      nrow_global=ncol_global, ncol_global=ncol_global)
             CALL cp_fm_create(fm_matrix_pq_rs(ispin), fm_struct)
             CALL cp_fm_struct_release(fm_struct)
@@ -1597,7 +1597,6 @@ CONTAINS
       CALL pw_zero(rho_r)
       CALL pw_transfer(rho_r, rho_g)
       dvol = rho_r%pw_grid%dvol
-      CALL mp_group%set_handle(eri_env%eri(1)%csr_mat%mp_group%get_handle())
 
       IF (iw > 0) THEN
          CALL m_flush(iw)
@@ -1607,12 +1606,7 @@ CONTAINS
       DO isp1 = 1, nspins
          CALL get_mo_set(mo_set=mos(isp1), nmo=nmo1, mo_coeff=mo_coeff1)
          nmm = (nmo1*(nmo1 + 1))/2
-         IF (eri_env%method == eri_method_gpw_ht) THEN
-            irange = [1, nmm]
-         ELSE
-            irange = get_irange_csr(nmm, para_env)
-         END IF
-         irange_sub = get_limit(nmm, number_of_subgroups, color)
+         irange = get_irange_csr(nmm, eri_env%comm_exchange)
          DO i1 = 1, SIZE(orbitals, 1)
             iwa1 = orbitals(i1, isp1)
             IF (eri_env%eri_gpw%store_wfn) THEN
@@ -1625,12 +1619,8 @@ CONTAINS
                iwa2 = orbitals(i2, isp1)
                iwa12 = csr_idx_to_combined(iwa1, iwa2, nmo1)
                ! Skip calculation directly if the pair is not part of our subgroup
-               IF (iwa12 < irange_sub(1) .OR. iwa12 > irange_sub(2)) CYCLE
-               IF (iwa12 >= irange(1) .AND. iwa12 <= irange(2)) THEN
-                  iwa12 = iwa12 - irange(1) + 1
-               ELSE
-                  iwa12 = 0
-               END IF
+               IF (iwa12 < irange(1) .OR. iwa12 > irange(2)) CYCLE
+               iwa12 = iwa12 - irange(1) + 1
                IF (eri_env%eri_gpw%store_wfn) THEN
                   wfn2 => wfn_a(iwa2, isp1)
                ELSE
@@ -1735,7 +1725,7 @@ CONTAINS
                         END DO
                      END DO
                      ! Now, we sum the integrals globally
-                     CALL wfn_r%pw_grid%para%group%sum(eri)
+                     CALL eri_env%para_env_sub%sum(eri)
                      ! and we reorder the integrals to prevent storing too small integrals
                      intcount = 0
                      icount2 = 0
@@ -1751,9 +1741,11 @@ CONTAINS
                            intcount = intcount + 1
                            erint = eri(intcount)
                            IF (ABS(erint) > eri_env%eps_integral) THEN
-                              icount2 = icount2 + 1
-                              eri(icount2) = erint
-                              eri_index(icount2) = eri_index(intcount)
+                              IF (MOD(intcount, eri_env%para_env_sub%num_pe) == eri_env%para_env_sub%mepos) THEN
+                                 icount2 = icount2 + 1
+                                 eri(icount2) = erint
+                                 eri_index(icount2) = eri_index(intcount)
+                              END IF
                            END IF
                         END DO
                      END DO
@@ -1796,7 +1788,6 @@ CONTAINS
       CALL auxbas_pw_pool%give_back_pw(rho_g)
       CALL auxbas_pw_pool%give_back_pw(rho_r)
       CALL auxbas_pw_pool%give_back_pw(pot_g)
-      CALL mp_para_env_release(para_env_sub)
 
       IF (eri_env%method == eri_method_gpw_ht) THEN
          DO ispin = 1, nspins
@@ -2407,7 +2398,8 @@ CONTAINS
 
          ! compute ks_ref = V_H[rho^A] + V_HFX[rho^A]
          eri => active_space_env%eri%eri(1)%csr_mat
-         CALL build_subspace_fock_matrix(active_space_env%active_orbitals, eri, p_mat, ks_ref, active_space_env%eri%method)
+         CALL build_subspace_fock_matrix(active_space_env%active_orbitals, eri, p_mat, ks_ref, &
+                                         active_space_env%eri%method, active_space_env%eri%comm_exchange)
 
          ! compute eeri = E_H[rho^A] + E_HFX[rho^A] as
          ! eeri = 1/2 * (SUM_pq (V_H[rho^A] + V_HFX[rho^A])_pq * D^A_pq)
@@ -2461,9 +2453,9 @@ CONTAINS
          eri_ab => active_space_env%eri%eri(2)%csr_mat
          eri_bb => active_space_env%eri%eri(3)%csr_mat
          CALL build_subspace_spin_fock_matrix(active_space_env%active_orbitals, eri_aa, eri_ab, p_a_mat, p_b_mat, ks_a_ref, &
-                                              tr_mixed_eri=.FALSE., eri_method=active_space_env%eri%method)
+                     tr_mixed_eri=.FALSE., eri_method=active_space_env%eri%method, comm_exchange=active_space_env%eri%comm_exchange)
          CALL build_subspace_spin_fock_matrix(active_space_env%active_orbitals, eri_bb, eri_ab, p_b_mat, p_a_mat, ks_b_ref, &
-                                              tr_mixed_eri=.TRUE., eri_method=active_space_env%eri%method)
+                      tr_mixed_eri=.TRUE., eri_method=active_space_env%eri%method, comm_exchange=active_space_env%eri%comm_exchange)
          !
          ! calculate energy
          eeri = 0.0_dp
@@ -2508,19 +2500,26 @@ CONTAINS
 !> \param p_mat density matrix
 !> \param ks_ref fockian matrix
 !> \param eri_method ...
+!> \param comm_exchange ...
 ! **************************************************************************************************
-   SUBROUTINE build_subspace_fock_matrix(active_orbitals, eri, p_mat, ks_ref, eri_method)
+   SUBROUTINE build_subspace_fock_matrix(active_orbitals, eri, p_mat, ks_ref, eri_method, comm_exchange)
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: active_orbitals
       TYPE(dbcsr_csr_type), INTENT(IN)                   :: eri
       REAL(dp), DIMENSION(:, :), INTENT(IN)              :: p_mat
       REAL(dp), DIMENSION(:, :), INTENT(INOUT)           :: ks_ref
       INTEGER, INTENT(IN)                                :: eri_method
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm_exchange
 
-      INTEGER                                            :: i1, i12, i12l, i2, i3, i34, i34l, i4, &
-                                                            irptr, m1, m2, nindex, nmo_total, norb
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'build_subspace_fock_matrix'
+
+      INTEGER                                            :: handle, i1, i12, i12l, i2, i3, i34, &
+                                                            i34l, i4, irptr, m1, m2, nindex, &
+                                                            nmo_total, norb
       INTEGER, DIMENSION(2)                              :: irange
       REAL(dp)                                           :: erint
       TYPE(mp_comm_type)                                 :: mp_group
+
+      CALL timeset(routineN, handle)
 
       ! Nothing to do
       norb = SIZE(active_orbitals, 1)
@@ -2530,7 +2529,7 @@ CONTAINS
       IF (eri_method == eri_method_gpw_ht) THEN
          irange = [1, nindex]
       ELSE
-         irange = get_irange_csr(nindex, mp_group)
+         irange = get_irange_csr(nindex, comm_exchange)
       END IF
       DO m1 = 1, norb
          i1 = active_orbitals(m1, 1)
@@ -2581,6 +2580,8 @@ CONTAINS
       END DO
       CALL mp_group%sum(ks_ref)
 
+      CALL timestop(handle)
+
    END SUBROUTINE build_subspace_fock_matrix
 
 ! **************************************************************************************************
@@ -2593,30 +2594,36 @@ CONTAINS
 !> \param ks_a_ref fockian matrix for up-spin
 !> \param tr_mixed_eri boolean to indicate Coulomb interaction alignment
 !> \param eri_method ...
+!> \param comm_exchange ...
 ! **************************************************************************************************
-   SUBROUTINE build_subspace_spin_fock_matrix(active_orbitals, eri_aa, eri_ab, p_a_mat, p_b_mat, ks_a_ref, tr_mixed_eri, eri_method)
+   SUBROUTINE build_subspace_spin_fock_matrix(active_orbitals, eri_aa, eri_ab, p_a_mat, p_b_mat, ks_a_ref, tr_mixed_eri, &
+                                              eri_method, comm_exchange)
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: active_orbitals
       TYPE(dbcsr_csr_type), INTENT(IN)                   :: eri_aa, eri_ab
       REAL(dp), DIMENSION(:, :), INTENT(IN)              :: p_a_mat, p_b_mat
       REAL(dp), DIMENSION(:, :), INTENT(INOUT)           :: ks_a_ref
       LOGICAL, INTENT(IN)                                :: tr_mixed_eri
       INTEGER, INTENT(IN)                                :: eri_method
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm_exchange
 
-      INTEGER                                            :: i1, i12, i12l, i2, i3, i34, i34l, i4, &
-                                                            irptr, m1, m2, nindex, nmo_total, &
-                                                            norb, spin1, spin2
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'build_subspace_spin_fock_matrix'
+
+      INTEGER                                            :: handle, i1, i12, i12l, i2, i3, i34, &
+                                                            i34l, i4, irptr, m1, m2, nindex, &
+                                                            nmo_total, norb, spin1, spin2
       INTEGER, DIMENSION(2)                              :: irange
       REAL(dp)                                           :: erint
       TYPE(mp_comm_type)                                 :: mp_group
 
+      CALL timeset(routineN, handle)
+
       norb = SIZE(active_orbitals, 1)
       nmo_total = SIZE(p_a_mat, 1)
       nindex = (nmo_total*(nmo_total + 1))/2
-      CALL mp_group%set_handle(eri_aa%mp_group%get_handle())
       IF (eri_method == eri_method_gpw_ht) THEN
          irange = [1, nindex]
       ELSE
-         irange = get_irange_csr(nindex, mp_group)
+         irange = get_irange_csr(nindex, comm_exchange)
       END IF
       IF (tr_mixed_eri) THEN
          spin1 = 2
@@ -2666,11 +2673,10 @@ CONTAINS
       END DO
       !
 
-      CALL mp_group%set_handle(eri_ab%mp_group%get_handle())
       IF (eri_method == eri_method_gpw_ht) THEN
          irange = [1, nindex]
       ELSE
-         irange = get_irange_csr(nindex, mp_group)
+         irange = get_irange_csr(nindex, comm_exchange)
       END IF
       DO m1 = 1, norb
          i1 = active_orbitals(m1, 1)
@@ -2706,6 +2712,8 @@ CONTAINS
       END DO
       CALL mp_group%set_handle(eri_aa%mp_group%get_handle())
       CALL mp_group%sum(ks_a_ref)
+
+      CALL timestop(handle)
 
    END SUBROUTINE build_subspace_spin_fock_matrix
 

--- a/src/qs_active_space_types.F
+++ b/src/qs_active_space_types.F
@@ -19,11 +19,12 @@ MODULE qs_active_space_types
    USE cp_dbcsr_operations,             ONLY: dbcsr_deallocate_matrix_set
    USE cp_fm_types,                     ONLY: cp_fm_release,&
                                               cp_fm_type
-   USE input_constants,                 ONLY: eri_method_gpw_ht
    USE input_section_types,             ONLY: section_vals_type
    USE kinds,                           ONLY: default_path_length,&
                                               dp
-   USE message_passing,                 ONLY: mp_comm_type
+   USE message_passing,                 ONLY: mp_comm_type,&
+                                              mp_para_env_release,&
+                                              mp_para_env_type
    USE qs_mo_types,                     ONLY: deallocate_mo_set,&
                                               mo_set_type
 #include "./base/base_uses.f90"
@@ -66,7 +67,8 @@ MODULE qs_active_space_types
       TYPE(dbcsr_csr_p_type), &
          DIMENSION(:), POINTER      :: eri => NULL()
       INTEGER                       :: norb = 0
-
+      TYPE(mp_para_env_type), POINTER :: para_env_sub => NULL()
+      TYPE(mp_comm_type) :: comm_exchange
    CONTAINS
       PROCEDURE :: eri_foreach => eri_type_eri_foreach
    END TYPE eri_type
@@ -221,6 +223,8 @@ CONTAINS
             CALL dbcsr_csr_destroy(eri_env%eri(i)%csr_mat)
             DEALLOCATE (eri_env%eri(i)%csr_mat)
          END DO
+         CALL mp_para_env_release(eri_env%para_env_sub)
+         CALL eri_env%comm_exchange%free()
          DEALLOCATE (eri_env%eri)
 
       END IF
@@ -334,12 +338,17 @@ CONTAINS
       CLASS(eri_type_eri_element_func)         :: fobj
       INTEGER, DIMENSION(:, :), INTENT(IN)     :: active_orbitals
       INTEGER, OPTIONAL                        :: spin1, spin2
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = "eri_type_eri_foreach"
+
       INTEGER                                  :: i1, i12, i12l, i2, i3, i34, i34l, i4, m1, m2, m3, m4, &
-                                                  irange(2), irptr, nspin, nindex, nmo, proc, nonzero_elements_local
+                                                  irange(2), irptr, nspin, nindex, nmo, proc, nonzero_elements_local, handle
       INTEGER, ALLOCATABLE, DIMENSION(:)       :: colind, offsets, nonzero_elements_global
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:) :: erival
       REAL(KIND=dp)                            :: erint
       TYPE(mp_comm_type) :: mp_group
+
+      CALL timeset(routineN, handle)
 
       IF (.NOT. PRESENT(spin1)) THEN
          spin1 = nspin
@@ -353,62 +362,41 @@ CONTAINS
          CALL mp_group%set_handle(eri%mp_group%get_handle())
          nmo = SIZE(active_orbitals, 1)
          ! Irrelevant in case of half-transformed integrals
-         irange = get_irange_csr(nindex, mp_group)
+         irange = get_irange_csr(nindex, this%comm_exchange)
          ALLOCATE (erival(nindex), colind(nindex))
-
-         IF (this%method == eri_method_gpw_ht) THEN
-            ALLOCATE (offsets(0:mp_group%num_pe - 1), &
-                      nonzero_elements_global(0:mp_group%num_pe - 1))
-         END IF
+         ALLOCATE (offsets(0:mp_group%num_pe - 1), &
+                   nonzero_elements_global(0:mp_group%num_pe - 1))
 
          DO m1 = 1, nmo
             i1 = active_orbitals(m1, spin1)
             DO m2 = m1, nmo
                i2 = active_orbitals(m2, spin1)
                i12 = csr_idx_to_combined(i1, i2, norb)
+               i12l = i12 - irange(1) + 1
 
-               IF (this%method == eri_method_gpw_ht) THEN
-                  ! In case of half-transformed integrals, every process might carry integrals of a row
-                  ! The number of integrals varies between processes and rows (related to the randomized
-                  ! distribution of matrix blocks)
+               ! In case of half-transformed integrals, every process might carry integrals of a row
+               ! The number of integrals varies between processes and rows (related to the randomized
+               ! distribution of matrix blocks)
 
-                  ! 1) Collect the amount of local data from each process
-                  nonzero_elements_local = eri%nzerow_local(i12)
-                  CALL mp_group%allgather(nonzero_elements_local, nonzero_elements_global)
+               ! 1) Collect the amount of local data from each process
+               nonzero_elements_local = 0
+               IF (i12 >= irange(1) .AND. i12 <= irange(2)) nonzero_elements_local = eri%nzerow_local(i12l)
+               CALL mp_group%allgather(nonzero_elements_local, nonzero_elements_global)
+               WRITE (*, *) "nonzero_elements_global (", i12, ")", nonzero_elements_global
 
-                  ! 2) Prepare arrays for communication (calculate the offsets and the total number of elements)
-                  offsets(0) = 0
-                  DO proc = 1, mp_group%num_pe - 1
-                     offsets(proc) = offsets(proc - 1) + nonzero_elements_global(proc - 1)
-                  END DO
-                  nindex = offsets(mp_group%num_pe - 1) + nonzero_elements_global(mp_group%num_pe - 1)
-                  irptr = eri%rowptr_local(i12)
+               ! 2) Prepare arrays for communication (calculate the offsets and the total number of elements)
+               offsets(0) = 0
+               DO proc = 1, mp_group%num_pe - 1
+                  offsets(proc) = offsets(proc - 1) + nonzero_elements_global(proc - 1)
+               END DO
+               nindex = offsets(mp_group%num_pe - 1) + nonzero_elements_global(mp_group%num_pe - 1)
+               irptr = eri%rowptr_local(i12l)
 
-                  ! Exchange actual data
-                  CALL mp_group%allgatherv(eri%colind_local(irptr:irptr + nonzero_elements_local - 1), &
-                                           colind(1:nindex), nonzero_elements_global, offsets)
-                  CALL mp_group%allgatherv(eri%nzval_local%r_dp(irptr:irptr + nonzero_elements_local - 1), &
-                                           erival(1:nindex), nonzero_elements_global, offsets)
-               ELSE
-                  ! Here, the rows are distributed among the processes such that each process
-                  ! carries all integral of a set of rows
-                  IF (i12 >= irange(1) .AND. i12 <= irange(2)) THEN
-                     i12l = i12 - irange(1) + 1
-                     irptr = eri%rowptr_local(i12l)
-                     nindex = eri%nzerow_local(i12l)
-                     colind(1:nindex) = eri%colind_local(irptr:irptr + nindex - 1)
-                     erival(1:nindex) = eri%nzval_local%r_dp(irptr:irptr + nindex - 1)
-                  ELSE
-                     erival = 0.0_dp
-                     colind = 0
-                     nindex = 0
-                  END IF
-
-                  ! Thus, a simple summation is sufficient
-                  CALL mp_group%sum(nindex)
-                  CALL mp_group%sum(colind(1:nindex))
-                  CALL mp_group%sum(erival(1:nindex))
-               END IF
+               ! Exchange actual data
+               CALL mp_group%allgatherv(eri%colind_local(irptr:irptr + nonzero_elements_local - 1), &
+                                        colind(1:nindex), nonzero_elements_global, offsets)
+               CALL mp_group%allgatherv(eri%nzval_local%r_dp(irptr:irptr + nonzero_elements_local - 1), &
+                                        erival(1:nindex), nonzero_elements_global, offsets)
 
                DO i34l = 1, nindex
                   i34 = colind(i34l)
@@ -434,6 +422,8 @@ CONTAINS
             END DO
          END DO
       END ASSOCIATE
+
+      CALL timestop(handle)
    END SUBROUTINE eri_type_eri_foreach
 
 END MODULE qs_active_space_types

--- a/src/qs_active_space_types.F
+++ b/src/qs_active_space_types.F
@@ -342,10 +342,10 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = "eri_type_eri_foreach"
 
       INTEGER                                  :: i1, i12, i12l, i2, i3, i34, i34l, i4, m1, m2, m3, m4, &
-                                                  irange(2), irptr, nspin, nindex, nmo, proc, nonzero_elements_local, handle
+                                            irange(2), irptr, nspin, nindex, nmo, proc, nonzero_elements_local, handle, dummy_int(1)
       INTEGER, ALLOCATABLE, DIMENSION(:)       :: colind, offsets, nonzero_elements_global
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:) :: erival
-      REAL(KIND=dp)                            :: erint
+      REAL(KIND=dp)                            :: erint, dummy_real(1)
       TYPE(mp_comm_type) :: mp_group
 
       CALL timeset(routineN, handle)
@@ -356,6 +356,9 @@ CONTAINS
       IF (.NOT. PRESENT(spin2)) THEN
          spin2 = nspin
       END IF
+
+      dummy_int = 0
+      dummy_real = 0.0_dp
 
       ASSOCIATE (eri => this%eri(nspin)%csr_mat, norb => this%norb)
          nindex = (norb*(norb + 1))/2
@@ -389,13 +392,19 @@ CONTAINS
                   offsets(proc) = offsets(proc - 1) + nonzero_elements_global(proc - 1)
                END DO
                nindex = offsets(mp_group%num_pe - 1) + nonzero_elements_global(mp_group%num_pe - 1)
-               irptr = eri%rowptr_local(i12l)
+               irptr = 1
+               IF (i12 >= irange(1) .AND. i12 <= irange(2)) THEN
+                  irptr = eri%rowptr_local(i12l)
 
-               ! Exchange actual data
-               CALL mp_group%allgatherv(eri%colind_local(irptr:irptr + nonzero_elements_local - 1), &
-                                        colind(1:nindex), nonzero_elements_global, offsets)
-               CALL mp_group%allgatherv(eri%nzval_local%r_dp(irptr:irptr + nonzero_elements_local - 1), &
-                                        erival(1:nindex), nonzero_elements_global, offsets)
+                  ! Exchange actual data
+                  CALL mp_group%allgatherv(eri%colind_local(irptr:irptr + nonzero_elements_local - 1), &
+                                           colind(1:nindex), nonzero_elements_global, offsets)
+                  CALL mp_group%allgatherv(eri%nzval_local%r_dp(irptr:irptr + nonzero_elements_local - 1), &
+                                           erival(1:nindex), nonzero_elements_global, offsets)
+               ELSE
+                  CALL mp_group%allgatherv(dummy_int(1:1), colind(1:nindex), nonzero_elements_global, offsets)
+                  CALL mp_group%allgatherv(dummy_real(1:1), erival(1:nindex), nonzero_elements_global, offsets)
+               END IF
 
                DO i34l = 1, nindex
                   i34 = colind(i34l)

--- a/src/qs_active_space_types.F
+++ b/src/qs_active_space_types.F
@@ -382,7 +382,6 @@ CONTAINS
                nonzero_elements_local = 0
                IF (i12 >= irange(1) .AND. i12 <= irange(2)) nonzero_elements_local = eri%nzerow_local(i12l)
                CALL mp_group%allgather(nonzero_elements_local, nonzero_elements_global)
-               WRITE (*, *) "nonzero_elements_global (", i12, ")", nonzero_elements_global
 
                ! 2) Prepare arrays for communication (calculate the offsets and the total number of elements)
                offsets(0) = 0


### PR DESCRIPTION
Fixes #3789 
The ERI calculation used the wrong context for subgroups (global instead of one for the subgroups) leading to issues with BLACS.
This PR unifies the ranges of both implemented integration schemes and removes some CPABORTs by merging them with the related branches (if someone wants to make use of this feature).