### PR TITLE
Dashboard: Add psmp test running with 4 MPI ranks

### DIFF
--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -246,7 +246,7 @@ QS/regtest-ps-implicit-2-3
 QS/regtest-nmr-5
 QS/regtest-ecp                                              libgrpp
 QS/regtest-as-3                                             libint mpiranks%2==0 !ifx
-QS/regtest-gpw-7
+QS/regtest-gpw-7                                            mpiranks<4
 QS/regtest-bse                                              libint !ifx
 QS/regtest-rtbse                                            libint !ifx
 QS/regtest-smeagol-1

--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -281,6 +281,13 @@ timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_generic-psmp_report.txt
 
+[psmp-4ranks]
+sortkey:     1036
+name:        4 MPI ranks (psmp)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_psmp-4ranks_report.txt
+
 # ==============================================================================
 
 [asan-psmp]
@@ -289,7 +296,5 @@ name:        Address Sanitizer
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_asan-psmp_report.txt
-
-
 
 #EOF

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -332,6 +332,15 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.build_hip_rocm_Mi100
 
+[psmp-4ranks]
+display_name: Regtest psmp (4 MPI ranks)
+tags:         weekly-morning
+cpu:          32
+nodepools:    pool-main
+cache_from:   pdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_psmp_4ranks
+
 [asan-psmp]
 display_name: Address Sanitizer
 tags:         weekly-afternoon
@@ -340,13 +349,5 @@ nodepools:    pool-main
 cache_from:   pdbg
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_asan-psmp
-
-[psmp-4ranks]
-display_name: Regtest psmp (4 MPI ranks)
-cpu:          32
-nodepools:    pool-main
-cache_from:   pdbg
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_psmp_4ranks
 
 #EOF


### PR DESCRIPTION
Follow up to #4592.

I had to exclude [tests/QS/regtest-gpw-7](https://github.com/cp2k/cp2k/tree/master/tests/QS/regtest-gpw-7) because of #4608.