### PR TITLE
Trexio bugfix

### DIFF
--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -163,7 +163,7 @@ CONTAINS
                                                             mo_num, ispin, ikp, imo, ikp_loc, nsgf, &
                                                             i, j, k, l, m, unit_dE, &
                                                             row, col, row_size, col_size, &
-                                                            row_offset, col_offset
+                                                            row_offset, col_offset, i_trex
       INTEGER, DIMENSION(2)                              :: nel_spin, kp_range, nmo_spin
       INTEGER, DIMENSION(3)                              :: nkp_grid
       INTEGER, DIMENSION(0:10)                           :: npot
@@ -179,7 +179,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp, norm_cgf
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: coord, mo_coefficient, mo_coefficient_im, &
                                                             mos_sgf, diag_nsgf, diag_ncgf, temp, dEdP
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: zetas, data_block
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: zetas, data_block, xkp
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: gcc
 
       CALL timeset(routineN, handle)
@@ -304,12 +304,12 @@ CONTAINS
          CALL trexio_error(rc)
 
          IF (do_kpoints) THEN
-            CALL get_kpoint_info(kpoints, nkp=nkp, nkp_grid=nkp_grid, wkp=wkp)
+            CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, wkp=wkp)
 
             rc = trexio_write_pbc_k_point_num(f, nkp)
             CALL trexio_error(rc)
 
-            rc = trexio_write_pbc_k_point(f, REAL(nkp_grid, KIND=dp))
+            rc = trexio_write_pbc_k_point(f, xkp)
             CALL trexio_error(rc)
 
             rc = trexio_write_pbc_k_point_weight(f, wkp)
@@ -637,6 +637,23 @@ CONTAINS
       ALLOCATE (ao_shell(ao_num))         ! ..shells
       ALLOCATE (ao_normalization(ao_num)) ! ..normalization factors
 
+      IF (.NOT. save_cartesian) THEN
+         ! AO order map from CP2K to TREXIO convention
+         ! from m = -l, -l+1, ..., 0, ..., l-1, l   of CP2K
+         ! to   m =  0, +1, -1, +2, -2, ..., +l, -l of TREXIO
+         ALLOCATE (cp2k_to_trexio_ang_mom(nsgf))
+         i = 0
+         DO ishell = 1, shell_num
+            l = shell_ang_mom(ishell)
+            DO k = 1, 2*l + 1
+               m = (-1)**k*FLOOR(REAL(k, KIND=dp)/2.0_dp)
+               cp2k_to_trexio_ang_mom(i + k) = i + l + 1 + m
+            END DO
+            i = i + 2*l + 1
+         END DO
+         CPASSERT(i == nsgf)
+      END IF
+
       ! we need to be consistent with the basis group on the shell indices
       ishell = 0  ! global shell index
       igf = 0     ! global AO index
@@ -692,7 +709,8 @@ CONTAINS
                   temp(:, :) = MATMUL(orbtramat(lshell)%c2s, diag_ncgf)
                   diag_nsgf(:, :) = MATMUL(temp, TRANSPOSE(orbtramat(lshell)%s2c))
                   DO i = 1, nso(lshell)
-                     ao_normalization(igf + i) = diag_nsgf(i, i)
+                     i_trex = cp2k_to_trexio_ang_mom(i)
+                     ao_normalization(igf + i) = diag_nsgf(i_trex, i_trex)
                   END DO
 
                   DEALLOCATE (diag_ncgf)
@@ -834,21 +852,6 @@ CONTAINS
          CALL para_env_inter_kp%sum(mo_energy)
          CALL para_env_inter_kp%sum(mo_occupation)
       END IF
-
-      ! AO order map from CP2K to TREXIO convention
-      ! from m = -l, -l+1, ..., 0, ..., l-1, l   of CP2K
-      ! to   m =  0, +1, -1, +2, -2, ..., +l, -l of TREXIO
-      ALLOCATE (cp2k_to_trexio_ang_mom(nsgf))
-      i = 0
-      DO ishell = 1, shell_num
-         l = shell_ang_mom(ishell)
-         DO k = 1, 2*l + 1
-            m = (-1)**k*FLOOR(REAL(k, KIND=dp)/2.0_dp)
-            cp2k_to_trexio_ang_mom(i + k) = i + l + 1 + m
-         END DO
-         i = i + 2*l + 1
-      END DO
-      CPASSERT(i == nsgf)
 
       ! second step: here we actually put everything in the local arrays for writing to trexio
       DO ispin = 1, nspins
@@ -1025,9 +1028,9 @@ CONTAINS
          DEALLOCATE (dEdP)
       END IF
 
-      ! Ddeallocate arrays used throughout the subroutine
+      ! Deallocate arrays used throughout the subroutine
       DEALLOCATE (shell_ang_mom)
-      DEALLOCATE (cp2k_to_trexio_ang_mom)
+      IF (ALLOCATED(cp2k_to_trexio_ang_mom)) DEALLOCATE (cp2k_to_trexio_ang_mom)
 
       !========================================================================================!
       ! Close the TREXIO file

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -151,9 +151,9 @@ CONTAINS
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: fm_mo_coeff, fm_dummy, fm_mo_coeff_im
-      TYPE(cp_fm_type), POINTER                          :: fm_overlap
+      ! TYPE(cp_fm_type), POINTER                          :: fm_overlap
       TYPE(dbcsr_iterator_type)                          :: iter
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+      ! TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
 
       CHARACTER(LEN=2)                                   :: element_symbol
       CHARACTER(LEN=2), DIMENSION(:), ALLOCATABLE        :: label
@@ -165,7 +165,8 @@ CONTAINS
                                                             mo_num, ispin, ikp, imo, ikp_loc, nsgf, &
                                                             i, j, k, l, m, unit_dE, &
                                                             row, col, row_size, col_size, &
-                                                            row_offset, col_offset, i_trex
+                                                            row_offset, col_offset, i_trex, nsgf_tot, ncgf_tot, &
+                                                            igf_c_tot
       INTEGER, DIMENSION(2)                              :: nel_spin, kp_range, nmo_spin
       INTEGER, DIMENSION(0:10)                           :: npot
       INTEGER, DIMENSION(:), ALLOCATABLE                 :: nucleus_index, shell_ang_mom, r_power, &
@@ -176,10 +177,10 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: l_shell_set
       REAL(KIND=dp), DIMENSION(:), ALLOCATABLE           :: charge, shell_factor, exponents, coefficients, &
                                                             prim_factor, ao_normalization, mo_energy, &
-                                                            mo_occupation
+                                                            mo_occupation, norm_cgf_tot
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp, norm_cgf
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: coord, mo_coefficient, mo_coefficient_im, &
-                                                            mos_sgf, diag_nsgf, diag_ncgf, temp, dEdP, ao_overlap
+                                                            mos_sgf, diag_nsgf, diag_ncgf, temp, dEdP, mos_cgf
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: zetas, data_block, xkp
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: gcc
 
@@ -614,7 +615,10 @@ CONTAINS
       !========================================================================================!
       CALL get_qs_env(qs_env, qs_kind_set=kind_set)
       CALL get_qs_kind_set(kind_set, ncgf=ncgf, nsgf=nsgf)
+      ! WRITE (output_unit, "((T2,A,I0,A,I0))") 'TREXIO| nsgf = ', nsgf, ', ncgf = ', ncgf
 
+      nsgf_tot = nsgf
+      ncgf_tot = ncgf
       CALL section_vals_val_get(trexio_section, "CARTESIAN", l_val=save_cartesian)
       IF (save_cartesian) THEN
          ao_num = ncgf
@@ -658,6 +662,8 @@ CONTAINS
       ! we need to be consistent with the basis group on the shell indices
       ishell = 0  ! global shell index
       igf = 0     ! global AO index
+      igf_c_tot = 0
+      ALLOCATE (norm_cgf_tot(ncgf_tot))
       DO iatom = 1, natoms
          ! get the qs_kind (index position in kind_set) for this atom (atomic_kind)
          CALL get_atomic_kind(particle_set(iatom)%atomic_kind, kind_number=ikind)
@@ -671,6 +677,11 @@ CONTAINS
                                 ncgf=ncgf, &
                                 nsgf=nsgf, &
                                 l=l_shell_set)
+         
+         ! WRITE (output_unit, "((T2,A, I0, A,I0,A,I0))") 'TREXIO| iatom = ', iatom, ', nsgf = ', nsgf, ', ncgf = ', ncgf
+         ! DO i = 1, SIZE(norm_cgf)
+         !   WRITE (output_unit, '(I5, 1X, *(F12.6, 1X))') i, norm_cgf(i)
+         ! END DO
 
          icgf = 0
          DO iset = 1, nset
@@ -698,23 +709,25 @@ CONTAINS
                   ALLOCATE (diag_ncgf(nco(lshell), nco(lshell)))
                   ALLOCATE (diag_nsgf(nso(lshell), nso(lshell)))
                   ALLOCATE (temp(nso(lshell), nco(lshell)))
-                  diag_ncgf = 0.0_dp
-                  diag_nsgf = 0.0_dp
-                  temp = 0.0_dp
+                  diag_ncgf(:,:) = 0.0_dp
+                  diag_nsgf(:,:) = 0.0_dp
+                  temp(:,:) = 0.0_dp
 
                   DO i = 1, nco(lshell)
-                     diag_ncgf(i, i) = norm_cgf(icgf + i)
+                     norm_cgf_tot(igf_c_tot + i) = norm_cgf(icgf + i)
                   END DO
 
                   ! transform the normalization factors from Cartesian to solid harmonics
-                  temp(:, :) = MATMUL(orbtramat(lshell)%c2s, diag_ncgf)
-                  diag_nsgf(:, :) = MATMUL(temp, TRANSPOSE(orbtramat(lshell)%s2c))
+                  ! temp(:, :) = MATMUL(orbtramat(lshell)%c2s, diag_ncgf)
+                  ! diag_nsgf(:, :) = MATMUL(temp, TRANSPOSE(orbtramat(lshell)%s2c))
+                  ! norm_sgf(:) = MATMUL(diag_nsgf, ones)
                   DO i = 1, nso(lshell)
                      ! cp2k_to_trexio contains the mapped global indices, but diag_nsgf
                      ! is a small local matrix of dimension 2l+1, so I need to shift back
                      ! the index by igf
                      i_trex = cp2k_to_trexio_ang_mom(igf+i) - igf
-                     ao_normalization(igf + i) = diag_nsgf(i_trex, i_trex)
+                     ! ao_normalization(igf + i) = norm_sgf(i_trex)
+                     ao_normalization(igf + i) = 1.0_dp
                   END DO
 
                   DEALLOCATE (diag_ncgf)
@@ -724,6 +737,7 @@ CONTAINS
 
                igf = igf + ngf_shell
                icgf = icgf + nco(lshell)
+               igf_c_tot = igf_c_tot + nco(lshell)
             END DO
          END DO
          ! just a failsafe check
@@ -731,28 +745,29 @@ CONTAINS
       END DO
 
       ! write overlap
-      CALL get_qs_env(qs_env, do_kpoints=do_kpoints, dft_control=dft_control)
-      nspins = dft_control%nspins
-      IF ( (nspins == 1) .AND. (.NOT. do_kpoints) ) THEN
-         CALL get_qs_env(qs_env, matrix_s=matrix_s, blacs_env=blacs_env)
-         CALL cp_fm_struct_create(fm_struct, para_env=para_env, context=blacs_env, &
-                                    nrow_global=ao_num, ncol_global=ao_num)
-         ALLOCATE(fm_overlap)
-         CALL cp_fm_create(fm_overlap, fm_struct)
-         CALL cp_fm_set_all(fm_overlap, 0.0_dp)
-         CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, fm_overlap)
-         ALLOCATE (ao_overlap(ao_num, ao_num))
-         ao_overlap(:,:) = 0.0_dp
-         CALL cp_fm_get_submatrix(fm_overlap, ao_overlap)
+      ! CALL get_qs_env(qs_env, do_kpoints=do_kpoints, dft_control=dft_control)
+      ! nspins = dft_control%nspins
+      ! IF ( (nspins == 1) .AND. (.NOT. do_kpoints) ) THEN
+      !    CALL get_qs_env(qs_env, matrix_s=matrix_s, blacs_env=blacs_env)
+      !    CALL cp_fm_struct_create(fm_struct, para_env=para_env, context=blacs_env, &
+      !                               nrow_global=ao_num, ncol_global=ao_num)
+      !    ALLOCATE(fm_overlap)
+      !    CALL cp_fm_create(fm_overlap, fm_struct)
+      !    CALL cp_fm_struct_release(fm_struct)
+      !    CALL cp_fm_set_all(fm_overlap, 0.0_dp)
+      !    CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, fm_overlap)
+      !    ALLOCATE (ao_overlap(ao_num, ao_num))
+      !    ao_overlap(:,:) = 0.0_dp
+      !    CALL cp_fm_get_submatrix(fm_overlap, ao_overlap)
 
-         IF (ionode) THEN
-            rc = trexio_write_ao_1e_int_overlap(f, ao_overlap)
-            CALL trexio_error(rc)
-         END IF
+      !    IF (ionode) THEN
+      !       rc = trexio_write_ao_1e_int_overlap(f, ao_overlap)
+      !       CALL trexio_error(rc)
+      !    END IF
 
-         DEALLOCATE(ao_overlap)
-         DEALLOCATE(fm_overlap)
-      END IF
+      !    DEALLOCATE(ao_overlap)
+      !    DEALLOCATE(fm_overlap)
+      ! END IF
 
       IF (ionode) THEN
          rc = trexio_write_ao_shell(f, ao_shell)
@@ -771,8 +786,9 @@ CONTAINS
       CALL get_qs_env(qs_env, do_kpoints=do_kpoints, kpoints=kpoints, dft_control=dft_control, &
                       particle_set=particle_set, qs_kind_set=kind_set, blacs_env=blacs_env)
       nspins = dft_control%nspins
-      CALL get_qs_kind_set(kind_set, nsgf=nsgf)
+      CALL get_qs_kind_set(kind_set, nsgf=nsgf, ncgf=ncgf)
       nmo_spin = 0
+      WRITE (output_unit, "((T2,A,I0,A,I0))") 'TREXIO| nsgf = ', nsgf, ', ncgf = ', ncgf
 
       ! figure out that total number of MOs
       mo_num = 0
@@ -887,6 +903,9 @@ CONTAINS
          nmo = nmo_spin(ispin)
          ! allocate local temp array to transform the MOs of each kpoint/spin
          ALLOCATE (mos_sgf(nsgf, nmo))
+         ALLOCATE (mos_cgf(ncgf, nmo))
+         mos_sgf(:,:) = 0.0_dp
+         mos_cgf(:,:) = 0.0_dp
 
          IF (do_kpoints) THEN
             DO ikp = 1, nkp
@@ -941,9 +960,23 @@ CONTAINS
             IF (save_cartesian) THEN
                CALL spherical_to_cartesian_mo(mos_sgf, particle_set, kind_set, mo_coefficient(:, imo + 1:imo + nmo))
             ELSE
+
+               ! transform MOs to cartesian to squash in the normalization factor
+               CALL spherical_to_cartesian_mo(mos_sgf, particle_set, kind_set, mos_cgf)
+               mos_sgf(:,:) = 0.0_dp
+
+               DO i = 1, SIZE(norm_cgf_tot)
+                  mos_cgf(i, :) = mos_cgf(i, :) * norm_cgf_tot(i)
+                  ! WRITE (output_unit, '(I5, 1X, *(F12.6, 1X))') i, norm_cgf_tot(i)
+               END DO
+
+               ! transform back
+               CALL cartesian_to_spherical_mo(mos_cgf, particle_set, kind_set, mos_sgf)
+               
                ! we have to reorder the MOs since CP2K and TREXIO have different conventions
                DO i = 1, nsgf
                   mo_coefficient(i, imo + 1:imo + nmo) = mos_sgf(cp2k_to_trexio_ang_mom(i), :)
+                  ! mo_coefficient(i, imo + 1:imo + nmo) = mos_sgf(i, :)
                END DO
             END IF
          END IF
@@ -1057,6 +1090,7 @@ CONTAINS
       END IF
 
       ! Deallocate arrays used throughout the subroutine
+      DEALLOCATE (norm_cgf_tot)
       DEALLOCATE (shell_ang_mom)
       IF (ALLOCATED(cp2k_to_trexio_ang_mom)) DEALLOCATE (cp2k_to_trexio_ang_mom)
 
@@ -1580,7 +1614,7 @@ CONTAINS
 
       CALL get_qs_kind_set(qs_kind_set, ncgf=ncgf, nsgf=nsgf)
 
-      mos_cgf = 0.0_dp
+      mos_cgf(:,:) = 0.0_dp
       nmo = SIZE(mos_sgf, 2)
 
       ! Transform spherical MOs to Cartesian MOs
@@ -1614,6 +1648,65 @@ CONTAINS
       END DO ! iatom
 
    END SUBROUTINE spherical_to_cartesian_mo
+
+
+! **************************************************************************************************
+!> \brief Computes a cartesian to spherical MO transformation
+!> \param mos_cgf the transformed MO coefficients in Cartesian AO basis
+!> \param particle_set the set of particles in the system
+!> \param qs_kind_set the set of qs_kinds in the system
+!> \param mos_sgf the MO coefficients in spherical AO basis
+! **************************************************************************************************
+   SUBROUTINE cartesian_to_spherical_mo(mos_cgf, particle_set, qs_kind_set, mos_sgf)
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: mos_cgf
+      TYPE(particle_type), DIMENSION(:), INTENT(IN), &
+         POINTER                                         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), INTENT(IN), &
+         POINTER                                         :: qs_kind_set
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: mos_sgf
+
+      INTEGER                                            :: iatom, icgf, ikind, iset, isgf, ishell, &
+                                                            lshell, ncgf, nmo, nset, nsgf
+      INTEGER, DIMENSION(:), POINTER                     :: nshell
+      INTEGER, DIMENSION(:, :), POINTER                  :: l
+      TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
+
+      CALL get_qs_kind_set(qs_kind_set, ncgf=ncgf, nsgf=nsgf)
+
+      mos_sgf(:,:) = 0.0_dp
+      nmo = SIZE(mos_cgf, 2)
+
+      ! Transform Cartesian MOs to spherical MOs
+      icgf = 1
+      isgf = 1
+      DO iatom = 1, SIZE(particle_set)
+         NULLIFY (orb_basis_set)
+         CALL get_atomic_kind(particle_set(iatom)%atomic_kind, kind_number=ikind)
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=orb_basis_set)
+
+         IF (ASSOCIATED(orb_basis_set)) THEN
+            CALL get_gto_basis_set(gto_basis_set=orb_basis_set, &
+                                   nset=nset, &
+                                   nshell=nshell, &
+                                   l=l)
+            DO iset = 1, nset
+               DO ishell = 1, nshell(iset)
+                  lshell = l(ishell, iset)
+                  CALL dgemm("N", "N", nso(lshell), nmo, nco(lshell), 1.0_dp, &
+                             orbtramat(lshell)%s2c, nso(lshell), &
+                             mos_cgf(icgf, 1), ncgf, 0.0_dp, &
+                             mos_sgf(isgf, 1), nsgf)
+                  icgf = icgf + nco(lshell)
+                  isgf = isgf + nso(lshell)
+               END DO
+            END DO
+         ELSE
+            ! assume atom without basis set
+            CPABORT("Unknown basis set type")
+         END IF
+      END DO ! iatom
+
+   END SUBROUTINE cartesian_to_spherical_mo
 #endif
 
 END MODULE trexio_utils

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -100,8 +100,7 @@ MODULE trexio_utils
                      trexio_write_mo_class, trexio_write_mo_coefficient, &
                      trexio_read_mo_class, trexio_read_mo_coefficient, &
                      trexio_write_mo_coefficient_im, trexio_write_mo_k_point, &
-                     trexio_write_mo_type, trexio_write_ao_1e_int_overlap, &
-                     trexio_write_ao_1e_int_core_hamiltonian
+                     trexio_write_mo_type
 #endif
 #include "./base/base_uses.f90"
 
@@ -155,7 +154,6 @@ CONTAINS
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: fm_mo_coeff, fm_dummy, fm_mo_coeff_im
       TYPE(dbcsr_iterator_type)                          :: iter
-      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, matrix_ks
 
       CHARACTER(LEN=2)                                   :: element_symbol
       CHARACTER(LEN=2), DIMENSION(:), ALLOCATABLE        :: label
@@ -182,8 +180,7 @@ CONTAINS
                                                             sgf_coefficients
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp, norm_cgf
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: coord, mo_coefficient, mo_coefficient_im, &
-                                                            mos_sgf, temp, dEdP, ao_overlap, ao_ks_matrix, &
-                                                            Sloc
+                                                            mos_sgf, dEdP, Sloc
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: zetas, data_block, xkp
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: gcc
 
@@ -741,59 +738,6 @@ CONTAINS
          ! just a failsafe check
          CPASSERT(icgf_atom == ncgf_atom)
       END DO
-
-      ! write overlap and kohn_sham matrix
-      CALL get_qs_env(qs_env, do_kpoints=do_kpoints, dft_control=dft_control)
-      nspins = dft_control%nspins
-      IF ((nspins == 1) .AND. (.NOT. do_kpoints)) THEN
-         CALL get_qs_env(qs_env, matrix_s=matrix_s, matrix_ks=matrix_ks, blacs_env=blacs_env)
-         CALL cp_fm_struct_create(fm_struct, para_env=para_env, context=blacs_env, &
-                                  nrow_global=ao_num, ncol_global=ao_num)
-         CALL cp_fm_create(fm_dummy, fm_struct)
-         CALL cp_fm_struct_release(fm_struct)
-
-         ALLOCATE (temp(ao_num, ao_num))
-         ALLOCATE (ao_overlap(ao_num, ao_num))
-         ALLOCATE (ao_ks_matrix(ao_num, ao_num))
-         temp(:, :) = 0.0_dp
-         ao_overlap(:, :) = 0.0_dp
-         ao_ks_matrix(:, :) = 0.0_dp
-
-         ! store the overlap
-         CALL cp_fm_set_all(fm_dummy, 0.0_dp)
-         CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, fm_dummy)
-         CALL cp_fm_get_submatrix(fm_dummy, temp)
-         DO i = 1, ao_num
-            DO j = 1, ao_num
-               ao_overlap(i, j) = temp(cp2k_to_trexio_ang_mom(i), cp2k_to_trexio_ang_mom(j))
-            END DO
-         END DO
-
-         ! store the KS matrix abusing the core hamiltonian container
-         temp(:, :) = 0.0_dp
-         CALL cp_fm_set_all(fm_dummy, 0.0_dp)
-         CALL copy_dbcsr_to_fm(matrix_ks(1)%matrix, fm_dummy)
-         CALL cp_fm_get_submatrix(fm_dummy, temp)
-         DO i = 1, ao_num
-            DO j = 1, ao_num
-               ao_ks_matrix(i, j) = temp(cp2k_to_trexio_ang_mom(i), cp2k_to_trexio_ang_mom(j))
-            END DO
-         END DO
-
-         IF (ionode) THEN
-            rc = trexio_write_ao_1e_int_overlap(f, ao_overlap)
-            CALL trexio_error(rc)
-
-            rc = trexio_write_ao_1e_int_core_hamiltonian(f, ao_ks_matrix)
-            CALL trexio_error(rc)
-         END IF
-
-         CALL cp_fm_release(fm_dummy)
-         NULLIFY (fm_struct)
-         DEALLOCATE (ao_overlap)
-         DEALLOCATE (ao_ks_matrix)
-         DEALLOCATE (temp)
-      END IF
 
       IF (ionode) THEN
          rc = trexio_write_ao_shell(f, ao_shell)

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -13,6 +13,7 @@
 ! **************************************************************************************************
 MODULE trexio_utils
 
+   USE ai_onecenter, ONLY: sg_overlap
    USE atomic_kind_types, ONLY: get_atomic_kind
    USE basis_set_types, ONLY: gto_basis_set_type, get_gto_basis_set
    USE cell_types, ONLY: cell_type
@@ -136,7 +137,7 @@ CONTAINS
                                                             ecp_local, sgp_potential_present, ionode, &
                                                             use_real_wfn, save_cartesian
       REAL(KIND=dp)                                      :: e_nn, zeff, expzet, prefac, zeta, gcca, &
-                                                            prim_cart_fac
+                                                            prim_cart_fac, Nsgto
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -162,7 +163,7 @@ CONTAINS
                                                             nspins, ikind, ishell_loc, ishell, &
                                                             shell_num, prim_num, nset, iset, ipgf, z, &
                                                             sl_lmax, ecp_num, nloc, nsemiloc, sl_l, iecp, &
-                                                            igf, icgf, ncgf, ngf_shell, lshell, ao_num, nmo, &
+                                                            iao, icgf_atom, ncgf, nao_shell, ao_num, nmo, &
                                                             mo_num, ispin, ikp, imo, ikp_loc, nsgf, ncgf_atom, &
                                                             i, j, k, l, m, unit_dE, &
                                                             row, col, row_size, col_size, &
@@ -177,10 +178,12 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: l_shell_set
       REAL(KIND=dp), DIMENSION(:), ALLOCATABLE           :: charge, shell_factor, exponents, coefficients, &
                                                             prim_factor, ao_normalization, mo_energy, &
-                                                            mo_occupation
+                                                            mo_occupation, Sgcc, ecp_coefficients, &
+                                                            sgf_coefficients
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp, norm_cgf
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: coord, mo_coefficient, mo_coefficient_im, &
-                                                            mos_sgf, temp, dEdP, ao_overlap, ao_ks_matrix
+                                                            mos_sgf, temp, dEdP, ao_overlap, ao_ks_matrix, &
+                                                            Sloc
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: zetas, data_block, xkp
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: gcc
 
@@ -384,9 +387,14 @@ CONTAINS
       ALLOCATE (exponents(prim_num))      ! ...primitive exponents
       ALLOCATE (coefficients(prim_num))   ! ...contraction coefficients
       ALLOCATE (prim_factor(prim_num))    ! ...primitive normalization factors
+      
+      ! needed in AO group
+      IF (.NOT. save_cartesian) THEN
+         ALLOCATE (sgf_coefficients(prim_num))   ! ...contraction coefficients
+      END IF
 
-      ishell = 0
-      ipgf = 0
+      ishell = 0  ! global shell index
+      ipgf = 0    ! global primitives index
       DO iatom = 1, natoms
          ! get the qs_kind (index position in kind_set) for this atom (atomic_kind)
          CALL get_atomic_kind(particle_set(iatom)%atomic_kind, kind_number=ikind)
@@ -428,14 +436,16 @@ CONTAINS
                   prim_cart_fac = prefac*zeta**expzet
 
                   ! contraction coefficients array
-                  coefficients(i + ipgf) = gcca/prim_cart_fac
+                  coefficients(ipgf + i) = gcca/prim_cart_fac
 
                   IF (save_cartesian) THEN
                      ! primitives normalization factors array
-                     prim_factor(i + ipgf) = prim_cart_fac
+                     prim_factor(ipgf + i) = prim_cart_fac
                   ELSE
                      ! for spherical harmonics we have a different factor
-                     prim_factor(i + ipgf) = sgf_norm(l, exponents(i + ipgf))
+                     prim_factor(ipgf + i) = sgf_norm(l, exponents(ipgf + i))
+                     ! we need these later in the AO group
+                     sgf_coefficients(ipgf + i) = coefficients(ipgf + i) * prim_factor(ipgf + i)
                   END IF
 
                END DO
@@ -531,7 +541,7 @@ CONTAINS
             ALLOCATE (ang_mom(ecp_num))
             ALLOCATE (nucleus_index(ecp_num))
             ALLOCATE (exponents(ecp_num))
-            ALLOCATE (coefficients(ecp_num))
+            ALLOCATE (ecp_coefficients(ecp_num))
             ALLOCATE (powers(ecp_num))
 
             iecp = 0
@@ -554,7 +564,7 @@ CONTAINS
                      ang_mom(iecp + 1:iecp + nloc) = sl_lmax + 1
                      nucleus_index(iecp + 1:iecp + nloc) = iatom
                      exponents(iecp + 1:iecp + nloc) = sgp_potential%bloc(1:nloc)
-                     coefficients(iecp + 1:iecp + nloc) = sgp_potential%aloc(1:nloc)
+                     ecp_coefficients(iecp + 1:iecp + nloc) = sgp_potential%aloc(1:nloc)
                      powers(iecp + 1:iecp + nloc) = sgp_potential%nrloc(1:nloc) - 2
                      iecp = iecp + nloc
                   END IF
@@ -569,7 +579,7 @@ CONTAINS
                         ang_mom(iecp + 1:iecp + nsemiloc) = sl_l
                         nucleus_index(iecp + 1:iecp + nsemiloc) = iatom
                         exponents(iecp + 1:iecp + nsemiloc) = sgp_potential%bpot(1:nsemiloc, sl_l)
-                        coefficients(iecp + 1:iecp + nsemiloc) = sgp_potential%apot(1:nsemiloc, sl_l)
+                        ecp_coefficients(iecp + 1:iecp + nsemiloc) = sgp_potential%apot(1:nsemiloc, sl_l)
                         powers(iecp + 1:iecp + nsemiloc) = sgp_potential%nrpot(1:nsemiloc, sl_l) - 2
                         iecp = iecp + nsemiloc
                      END DO
@@ -603,9 +613,9 @@ CONTAINS
             CALL trexio_error(rc)
             DEALLOCATE (exponents)
 
-            rc = trexio_write_ecp_coefficient(f, coefficients)
+            rc = trexio_write_ecp_coefficient(f, ecp_coefficients)
             CALL trexio_error(rc)
-            DEALLOCATE (coefficients)
+            DEALLOCATE (ecp_coefficients)
 
             rc = trexio_write_ecp_power(f, powers)
             CALL trexio_error(rc)
@@ -666,7 +676,8 @@ CONTAINS
 
       ! we need to be consistent with the basis group on the shell indices
       ishell = 0  ! global shell index
-      igf = 0     ! global AO index
+      iao = 0     ! global AO index
+      ipgf = 0    ! global primitives index
       DO iatom = 1, natoms
          ! get the qs_kind (index position in kind_set) for this atom (atomic_kind)
          CALL get_atomic_kind(particle_set(iatom)%atomic_kind, kind_number=ikind)
@@ -678,43 +689,57 @@ CONTAINS
                                 nshell=nshell, &
                                 norm_cgf=norm_cgf, &
                                 ncgf=ncgf_atom, &
+                                npgf=npgf, &
+                                zet=zetas, &
                                 l=l_shell_set)
          
-         icgf = 0
+         icgf_atom = 0
          DO iset = 1, nset
             DO ishell_loc = 1, nshell(iset)
                ! global shell index
                ishell = ishell + 1
                ! angular momentum l of this shell
-               lshell = l_shell_set(ishell_loc, iset)
+               l = l_shell_set(ishell_loc, iset)
 
                ! number of AOs in this shell
                IF (save_cartesian) THEN
-                  ngf_shell = nco(lshell)
+                  nao_shell = nco(l)
                ELSE
-                  ngf_shell = nso(lshell)
+                  nao_shell = nso(l)
                END IF
 
                ! one-to-one mapping between AOs and shells
-               ao_shell(igf + 1:igf + ngf_shell) = ishell
+               ao_shell(iao + 1:iao + nao_shell) = ishell
 
                ! one-to-one mapping between AOs and normalization factors
                IF (save_cartesian) THEN
-                  ao_normalization(igf + 1:igf + ngf_shell) = norm_cgf(icgf + 1:icgf + ngf_shell)
+                  ao_normalization(iao + 1:iao + nao_shell) = norm_cgf(icgf_atom + 1:icgf_atom + nao_shell)
                ELSE
+                  ! for each shell, compute the overlap between spherical primitives
+                  ALLOCATE (Sloc(npgf(iset), npgf(iset)))
+                  ALLOCATE (Sgcc(npgf(iset)))
+                  CALL sg_overlap(Sloc, l, zetas(1:npgf(iset), iset), zetas(1:npgf(iset), iset))
+
+                  ! and compute the normalizaztion factor for contracted spherical GTOs
+                  Sgcc(:) = MATMUL(Sloc, sgf_coefficients(ipgf + 1:ipgf + npgf(iset))) 
+                  Nsgto = 1.0_dp/SQRT(DOT_PRODUCT(sgf_coefficients(ipgf + 1:ipgf + npgf(iset)), Sgcc))
+
+                  DEALLOCATE (Sloc)
+                  DEALLOCATE (Sgcc)
+
                   ! TREXIO employs solid harmonics and not spherical harmonics like cp2k
-                  ! so we need an extra factor (which is nowhere to be found internally)
-                  DO i = 1, ngf_shell
-                     ao_normalization(igf + i) = SQRT((2*lshell+1)/(4*pi))
-                  END DO
+                  ! so we need the opposite of Racah normalization, multiplied by the Nsgto
+                  ! just computed above
+                  ao_normalization(iao + 1:iao + nao_shell) = Nsgto * SQRT((2*l+1)/(4*pi))
                END IF
 
-               igf = igf + ngf_shell
-               icgf = icgf + nco(lshell)
+               ipgf = ipgf + npgf(iset)
+               iao = iao + nao_shell
+               icgf_atom = icgf_atom + nco(l)
             END DO
          END DO
          ! just a failsafe check
-         CPASSERT(icgf == ncgf_atom)
+         CPASSERT(icgf_atom == ncgf_atom)
       END DO
 
       ! write overlap and kohn_sham matrix
@@ -780,6 +805,7 @@ CONTAINS
 
       DEALLOCATE (ao_shell)
       DEALLOCATE (ao_normalization)
+      IF (ALLOCATED(sgf_coefficients)) DEALLOCATE (sgf_coefficients)
 
       !========================================================================================!
       ! MO group

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -135,7 +135,8 @@ CONTAINS
       LOGICAL                                            :: explicit, do_kpoints, ecp_semi_local, &
                                                             ecp_local, sgp_potential_present, ionode, &
                                                             use_real_wfn, save_cartesian
-      REAL(KIND=dp)                                      :: e_nn, zeff, expzet, prefac, zeta, gcca
+      REAL(KIND=dp)                                      :: e_nn, zeff, expzet, prefac, zeta, gcca, &
+                                                            prim_cart_fac
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -424,17 +425,19 @@ CONTAINS
                DO i = 1, npgf(iset)
                   gcca = gcc(i, ishell_loc, iset)
                   zeta = zetas(i, iset)
+                  prim_cart_fac = prefac*zeta**expzet
+
+                  ! contraction coefficients array
+                  coefficients(i + ipgf) = gcca/prim_cart_fac
 
                   IF (save_cartesian) THEN
                      ! primitives normalization factors array
-                     prim_factor(i + ipgf) = prefac*zeta**expzet
+                     prim_factor(i + ipgf) = prim_cart_fac
                   ELSE
                      ! for spherical harmonics we have a different factor
                      prim_factor(i + ipgf) = sgf_norm(l, exponents(i + ipgf))
                   END IF
 
-                  ! contractio coefficients array
-                  coefficients(i + ipgf) = gcca/prim_factor(i + ipgf)
                END DO
 
                ipgf = ipgf + npgf(iset)

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -356,7 +356,7 @@ CONTAINS
          rc = trexio_write_state_id(f, 1)
          CALL trexio_error(rc)
 
-         rc = trexio_write_state_energy(f, energy%total)
+         ! rc = trexio_write_state_energy(f, energy%total)
          CALL trexio_error(rc)
 
       END IF ! ionode
@@ -366,7 +366,7 @@ CONTAINS
       !========================================================================================!
       CALL get_qs_env(qs_env, qs_kind_set=kind_set, natom=natoms, particle_set=particle_set)
       CALL get_qs_kind_set(kind_set, nshell=shell_num, npgf_seg=prim_num)
-      
+
       CALL section_vals_val_get(trexio_section, "CARTESIAN", l_val=save_cartesian)
 
       IF (ionode) THEN
@@ -387,7 +387,7 @@ CONTAINS
       ALLOCATE (exponents(prim_num))      ! ...primitive exponents
       ALLOCATE (coefficients(prim_num))   ! ...contraction coefficients
       ALLOCATE (prim_factor(prim_num))    ! ...primitive normalization factors
-      
+
       ! needed in AO group
       IF (.NOT. save_cartesian) THEN
          ALLOCATE (sgf_coefficients(prim_num))   ! ...contraction coefficients
@@ -445,7 +445,7 @@ CONTAINS
                      ! for spherical harmonics we have a different factor
                      prim_factor(ipgf + i) = sgf_norm(l, exponents(ipgf + i))
                      ! we need these later in the AO group
-                     sgf_coefficients(ipgf + i) = coefficients(ipgf + i) * prim_factor(ipgf + i)
+                     sgf_coefficients(ipgf + i) = coefficients(ipgf + i)*prim_factor(ipgf + i)
                   END IF
 
                END DO
@@ -692,7 +692,7 @@ CONTAINS
                                 npgf=npgf, &
                                 zet=zetas, &
                                 l=l_shell_set)
-         
+
          icgf_atom = 0
          DO iset = 1, nset
             DO ishell_loc = 1, nshell(iset)
@@ -721,7 +721,7 @@ CONTAINS
                   CALL sg_overlap(Sloc, l, zetas(1:npgf(iset), iset), zetas(1:npgf(iset), iset))
 
                   ! and compute the normalizaztion factor for contracted spherical GTOs
-                  Sgcc(:) = MATMUL(Sloc, sgf_coefficients(ipgf + 1:ipgf + npgf(iset))) 
+                  Sgcc(:) = MATMUL(Sloc, sgf_coefficients(ipgf + 1:ipgf + npgf(iset)))
                   Nsgto = 1.0_dp/SQRT(DOT_PRODUCT(sgf_coefficients(ipgf + 1:ipgf + npgf(iset)), Sgcc))
 
                   DEALLOCATE (Sloc)
@@ -730,7 +730,7 @@ CONTAINS
                   ! TREXIO employs solid harmonics and not spherical harmonics like cp2k
                   ! so we need the opposite of Racah normalization, multiplied by the Nsgto
                   ! just computed above
-                  ao_normalization(iao + 1:iao + nao_shell) = Nsgto * SQRT((2*l+1)/(4*pi))
+                  ao_normalization(iao + 1:iao + nao_shell) = Nsgto*SQRT((2*l + 1)/(4*pi))
                END IF
 
                ipgf = ipgf + npgf(iset)
@@ -745,20 +745,20 @@ CONTAINS
       ! write overlap and kohn_sham matrix
       CALL get_qs_env(qs_env, do_kpoints=do_kpoints, dft_control=dft_control)
       nspins = dft_control%nspins
-      IF ( (nspins == 1) .AND. (.NOT. do_kpoints) ) THEN
+      IF ((nspins == 1) .AND. (.NOT. do_kpoints)) THEN
          CALL get_qs_env(qs_env, matrix_s=matrix_s, matrix_ks=matrix_ks, blacs_env=blacs_env)
          CALL cp_fm_struct_create(fm_struct, para_env=para_env, context=blacs_env, &
-                                    nrow_global=ao_num, ncol_global=ao_num)
+                                  nrow_global=ao_num, ncol_global=ao_num)
          CALL cp_fm_create(fm_dummy, fm_struct)
          CALL cp_fm_struct_release(fm_struct)
-         
+
          ALLOCATE (temp(ao_num, ao_num))
          ALLOCATE (ao_overlap(ao_num, ao_num))
          ALLOCATE (ao_ks_matrix(ao_num, ao_num))
-         temp(:,:) = 0.0_dp
-         ao_overlap(:,:) = 0.0_dp
-         ao_ks_matrix(:,:) = 0.0_dp
-         
+         temp(:, :) = 0.0_dp
+         ao_overlap(:, :) = 0.0_dp
+         ao_ks_matrix(:, :) = 0.0_dp
+
          ! store the overlap
          CALL cp_fm_set_all(fm_dummy, 0.0_dp)
          CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, fm_dummy)
@@ -768,9 +768,9 @@ CONTAINS
                ao_overlap(i, j) = temp(cp2k_to_trexio_ang_mom(i), cp2k_to_trexio_ang_mom(j))
             END DO
          END DO
-         
+
          ! store the KS matrix abusing the core hamiltonian container
-         temp(:,:) = 0.0_dp
+         temp(:, :) = 0.0_dp
          CALL cp_fm_set_all(fm_dummy, 0.0_dp)
          CALL copy_dbcsr_to_fm(matrix_ks(1)%matrix, fm_dummy)
          CALL cp_fm_get_submatrix(fm_dummy, temp)
@@ -789,10 +789,10 @@ CONTAINS
          END IF
 
          CALL cp_fm_release(fm_dummy)
-         NULLIFY(fm_struct)
-         DEALLOCATE(ao_overlap)
-         DEALLOCATE(ao_ks_matrix)
-         DEALLOCATE(temp)
+         NULLIFY (fm_struct)
+         DEALLOCATE (ao_overlap)
+         DEALLOCATE (ao_ks_matrix)
+         DEALLOCATE (temp)
       END IF
 
       IF (ionode) THEN
@@ -929,7 +929,7 @@ CONTAINS
          nmo = nmo_spin(ispin)
          ! allocate local temp array to transform the MOs of each kpoint/spin
          ALLOCATE (mos_sgf(nsgf, nmo))
-         mos_sgf(:,:) = 0.0_dp
+         mos_sgf(:, :) = 0.0_dp
 
          IF (do_kpoints) THEN
             DO ikp = 1, nkp
@@ -983,7 +983,7 @@ CONTAINS
 
             IF (save_cartesian) THEN
                CALL spherical_to_cartesian_mo(mos_sgf, particle_set, kind_set, mo_coefficient(:, imo + 1:imo + nmo))
-            ELSE      
+            ELSE
                ! we have to reorder the MOs since CP2K and TREXIO have different conventions
                DO i = 1, nsgf
                   mo_coefficient(i, imo + 1:imo + nmo) = mos_sgf(cp2k_to_trexio_ang_mom(i), :)
@@ -1600,11 +1600,11 @@ CONTAINS
 
    END SUBROUTINE nuclear_repulsion_energy
 
-
 ! **************************************************************************************************
 !> \brief Returns the normalization coefficient for a spherical GTO
 !> \param l the angular momentum quantum number
 !> \param expnt the exponent of the Gaussian function
+!> \return ...
 ! **************************************************************************************************
    FUNCTION sgf_norm(l, expnt) RESULT(norm)
       INTEGER, INTENT(IN)                                :: l
@@ -1612,13 +1612,12 @@ CONTAINS
       REAL(KIND=dp)                                      :: norm
 
       IF (l >= 0) THEN
-         norm = SQRT(2**(2*l+3)*fac(l+1)*(2*expnt)**(l+1.5) / (fac(2*l+2)*SQRT(pi)))
+         norm = SQRT(2**(2*l + 3)*fac(l + 1)*(2*expnt)**(l + 1.5)/(fac(2*l + 2)*SQRT(pi)))
       ELSE
          CPABORT("The angular momentum should be >= 0!")
       END IF
 
    END FUNCTION sgf_norm
-
 
 ! **************************************************************************************************
 !> \brief Computes a spherical to cartesian MO transformation (solid harmonics in reality)
@@ -1643,7 +1642,7 @@ CONTAINS
 
       CALL get_qs_kind_set(qs_kind_set, ncgf=ncgf, nsgf=nsgf)
 
-      mos_cgf(:,:) = 0.0_dp
+      mos_cgf(:, :) = 0.0_dp
       nmo = SIZE(mos_sgf, 2)
 
       ! Transform spherical MOs to Cartesian MOs
@@ -1678,7 +1677,6 @@ CONTAINS
 
    END SUBROUTINE spherical_to_cartesian_mo
 
-
 ! **************************************************************************************************
 !> \brief Computes a cartesian to spherical MO transformation
 !> \param mos_cgf the transformed MO coefficients in Cartesian AO basis
@@ -1702,7 +1700,7 @@ CONTAINS
 
       CALL get_qs_kind_set(qs_kind_set, ncgf=ncgf, nsgf=nsgf)
 
-      mos_sgf(:,:) = 0.0_dp
+      mos_sgf(:, :) = 0.0_dp
       nmo = SIZE(mos_cgf, 2)
 
       ! Transform Cartesian MOs to spherical MOs

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -99,7 +99,7 @@ MODULE trexio_utils
                      trexio_write_mo_class, trexio_write_mo_coefficient, &
                      trexio_read_mo_class, trexio_read_mo_coefficient, &
                      trexio_write_mo_coefficient_im, trexio_write_mo_k_point, &
-                     trexio_write_mo_type
+                     trexio_write_mo_type, trexio_write_ao_1e_int_overlap
 #endif
 #include "./base/base_uses.f90"
 
@@ -151,7 +151,9 @@ CONTAINS
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: fm_mo_coeff, fm_dummy, fm_mo_coeff_im
+      TYPE(cp_fm_type), POINTER                          :: fm_overlap
       TYPE(dbcsr_iterator_type)                          :: iter
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
 
       CHARACTER(LEN=2)                                   :: element_symbol
       CHARACTER(LEN=2), DIMENSION(:), ALLOCATABLE        :: label
@@ -177,7 +179,7 @@ CONTAINS
                                                             mo_occupation
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp, norm_cgf
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: coord, mo_coefficient, mo_coefficient_im, &
-                                                            mos_sgf, diag_nsgf, diag_ncgf, temp, dEdP
+                                                            mos_sgf, diag_nsgf, diag_ncgf, temp, dEdP, ao_overlap
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: zetas, data_block, xkp
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: gcc
 
@@ -727,6 +729,30 @@ CONTAINS
          ! just a failsafe check
          CPASSERT(icgf == ncgf)
       END DO
+
+      ! write overlap
+      CALL get_qs_env(qs_env, do_kpoints=do_kpoints, dft_control=dft_control)
+      nspins = dft_control%nspins
+      IF ( (nspins == 1) .AND. (.NOT. do_kpoints) ) THEN
+         CALL get_qs_env(qs_env, matrix_s=matrix_s, blacs_env=blacs_env)
+         CALL cp_fm_struct_create(fm_struct, para_env=para_env, context=blacs_env, &
+                                    nrow_global=ao_num, ncol_global=ao_num)
+         ALLOCATE(fm_overlap)
+         CALL cp_fm_create(fm_overlap, fm_struct)
+         CALL cp_fm_set_all(fm_overlap, 0.0_dp)
+         CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, fm_overlap)
+         ALLOCATE (ao_overlap(ao_num, ao_num))
+         ao_overlap(:,:) = 0.0_dp
+         CALL cp_fm_get_submatrix(fm_overlap, ao_overlap)
+
+         IF (ionode) THEN
+            rc = trexio_write_ao_1e_int_overlap(f, ao_overlap)
+            CALL trexio_error(rc)
+         END IF
+
+         DEALLOCATE(ao_overlap)
+         DEALLOCATE(fm_overlap)
+      END IF
 
       IF (ionode) THEN
          rc = trexio_write_ao_shell(f, ao_shell)

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -165,7 +165,6 @@ CONTAINS
                                                             row, col, row_size, col_size, &
                                                             row_offset, col_offset, i_trex
       INTEGER, DIMENSION(2)                              :: nel_spin, kp_range, nmo_spin
-      INTEGER, DIMENSION(3)                              :: nkp_grid
       INTEGER, DIMENSION(0:10)                           :: npot
       INTEGER, DIMENSION(:), ALLOCATABLE                 :: nucleus_index, shell_ang_mom, r_power, &
                                                             shell_index, z_core, max_ang_mom_plus_1, &
@@ -709,7 +708,10 @@ CONTAINS
                   temp(:, :) = MATMUL(orbtramat(lshell)%c2s, diag_ncgf)
                   diag_nsgf(:, :) = MATMUL(temp, TRANSPOSE(orbtramat(lshell)%s2c))
                   DO i = 1, nso(lshell)
-                     i_trex = cp2k_to_trexio_ang_mom(i)
+                     ! cp2k_to_trexio contains the mapped global indices, but diag_nsgf
+                     ! is a small local matrix of dimension 2l+1, so I need to shift back
+                     ! the index by igf
+                     i_trex = cp2k_to_trexio_ang_mom(igf+i) - igf
                      ao_normalization(igf + i) = diag_nsgf(i_trex, i_trex)
                   END DO
 

--- a/src/trexio_utils.F
+++ b/src/trexio_utils.F
@@ -44,7 +44,7 @@ MODULE trexio_utils
    USE kinds, ONLY: default_path_length, dp
    USE kpoint_types, ONLY: kpoint_type, kpoint_env_p_type, &
                            get_kpoint_info, get_kpoint_env
-   USE mathconstants, ONLY: fourpi, pi
+   USE mathconstants, ONLY: fourpi, pi, fac
    USE mathlib, ONLY: symmetrize_matrix
    USE message_passing, ONLY: mp_para_env_type
    USE orbital_pointers, ONLY: nco, nso
@@ -99,7 +99,8 @@ MODULE trexio_utils
                      trexio_write_mo_class, trexio_write_mo_coefficient, &
                      trexio_read_mo_class, trexio_read_mo_coefficient, &
                      trexio_write_mo_coefficient_im, trexio_write_mo_k_point, &
-                     trexio_write_mo_type, trexio_write_ao_1e_int_overlap
+                     trexio_write_mo_type, trexio_write_ao_1e_int_overlap, &
+                     trexio_write_ao_1e_int_core_hamiltonian
 #endif
 #include "./base/base_uses.f90"
 
@@ -151,9 +152,8 @@ CONTAINS
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
       TYPE(cp_fm_type)                                   :: fm_mo_coeff, fm_dummy, fm_mo_coeff_im
-      ! TYPE(cp_fm_type), POINTER                          :: fm_overlap
       TYPE(dbcsr_iterator_type)                          :: iter
-      ! TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s, matrix_ks
 
       CHARACTER(LEN=2)                                   :: element_symbol
       CHARACTER(LEN=2), DIMENSION(:), ALLOCATABLE        :: label
@@ -162,11 +162,10 @@ CONTAINS
                                                             shell_num, prim_num, nset, iset, ipgf, z, &
                                                             sl_lmax, ecp_num, nloc, nsemiloc, sl_l, iecp, &
                                                             igf, icgf, ncgf, ngf_shell, lshell, ao_num, nmo, &
-                                                            mo_num, ispin, ikp, imo, ikp_loc, nsgf, &
+                                                            mo_num, ispin, ikp, imo, ikp_loc, nsgf, ncgf_atom, &
                                                             i, j, k, l, m, unit_dE, &
                                                             row, col, row_size, col_size, &
-                                                            row_offset, col_offset, i_trex, nsgf_tot, ncgf_tot, &
-                                                            igf_c_tot
+                                                            row_offset, col_offset
       INTEGER, DIMENSION(2)                              :: nel_spin, kp_range, nmo_spin
       INTEGER, DIMENSION(0:10)                           :: npot
       INTEGER, DIMENSION(:), ALLOCATABLE                 :: nucleus_index, shell_ang_mom, r_power, &
@@ -177,10 +176,10 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: l_shell_set
       REAL(KIND=dp), DIMENSION(:), ALLOCATABLE           :: charge, shell_factor, exponents, coefficients, &
                                                             prim_factor, ao_normalization, mo_energy, &
-                                                            mo_occupation, norm_cgf_tot
+                                                            mo_occupation
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp, norm_cgf
       REAL(KIND=dp), DIMENSION(:, :), ALLOCATABLE        :: coord, mo_coefficient, mo_coefficient_im, &
-                                                            mos_sgf, diag_nsgf, diag_ncgf, temp, dEdP, mos_cgf
+                                                            mos_sgf, temp, dEdP, ao_overlap, ao_ks_matrix
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: zetas, data_block, xkp
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: gcc
 
@@ -363,6 +362,8 @@ CONTAINS
       !========================================================================================!
       CALL get_qs_env(qs_env, qs_kind_set=kind_set, natom=natoms, particle_set=particle_set)
       CALL get_qs_kind_set(kind_set, nshell=shell_num, npgf_seg=prim_num)
+      
+      CALL section_vals_val_get(trexio_section, "CARTESIAN", l_val=save_cartesian)
 
       IF (ionode) THEN
          rc = trexio_write_basis_type(f, 'Gaussian', LEN_TRIM('Gaussian') + 1)
@@ -424,8 +425,13 @@ CONTAINS
                   gcca = gcc(i, ishell_loc, iset)
                   zeta = zetas(i, iset)
 
-                  ! primitives normalization factors array
-                  prim_factor(i + ipgf) = prefac*zeta**expzet
+                  IF (save_cartesian) THEN
+                     ! primitives normalization factors array
+                     prim_factor(i + ipgf) = prefac*zeta**expzet
+                  ELSE
+                     ! for spherical harmonics we have a different factor
+                     prim_factor(i + ipgf) = sgf_norm(l, exponents(i + ipgf))
+                  END IF
 
                   ! contractio coefficients array
                   coefficients(i + ipgf) = gcca/prim_factor(i + ipgf)
@@ -615,11 +621,7 @@ CONTAINS
       !========================================================================================!
       CALL get_qs_env(qs_env, qs_kind_set=kind_set)
       CALL get_qs_kind_set(kind_set, ncgf=ncgf, nsgf=nsgf)
-      ! WRITE (output_unit, "((T2,A,I0,A,I0))") 'TREXIO| nsgf = ', nsgf, ', ncgf = ', ncgf
 
-      nsgf_tot = nsgf
-      ncgf_tot = ncgf
-      CALL section_vals_val_get(trexio_section, "CARTESIAN", l_val=save_cartesian)
       IF (save_cartesian) THEN
          ao_num = ncgf
       ELSE
@@ -646,7 +648,7 @@ CONTAINS
          ! AO order map from CP2K to TREXIO convention
          ! from m = -l, -l+1, ..., 0, ..., l-1, l   of CP2K
          ! to   m =  0, +1, -1, +2, -2, ..., +l, -l of TREXIO
-         ALLOCATE (cp2k_to_trexio_ang_mom(nsgf))
+         ALLOCATE (cp2k_to_trexio_ang_mom(ao_num))
          i = 0
          DO ishell = 1, shell_num
             l = shell_ang_mom(ishell)
@@ -656,14 +658,12 @@ CONTAINS
             END DO
             i = i + 2*l + 1
          END DO
-         CPASSERT(i == nsgf)
+         CPASSERT(i == ao_num)
       END IF
 
       ! we need to be consistent with the basis group on the shell indices
       ishell = 0  ! global shell index
       igf = 0     ! global AO index
-      igf_c_tot = 0
-      ALLOCATE (norm_cgf_tot(ncgf_tot))
       DO iatom = 1, natoms
          ! get the qs_kind (index position in kind_set) for this atom (atomic_kind)
          CALL get_atomic_kind(particle_set(iatom)%atomic_kind, kind_number=ikind)
@@ -674,15 +674,9 @@ CONTAINS
                                 nset=nset, &
                                 nshell=nshell, &
                                 norm_cgf=norm_cgf, &
-                                ncgf=ncgf, &
-                                nsgf=nsgf, &
+                                ncgf=ncgf_atom, &
                                 l=l_shell_set)
          
-         ! WRITE (output_unit, "((T2,A, I0, A,I0,A,I0))") 'TREXIO| iatom = ', iatom, ', nsgf = ', nsgf, ', ncgf = ', ncgf
-         ! DO i = 1, SIZE(norm_cgf)
-         !   WRITE (output_unit, '(I5, 1X, *(F12.6, 1X))') i, norm_cgf(i)
-         ! END DO
-
          icgf = 0
          DO iset = 1, nset
             DO ishell_loc = 1, nshell(iset)
@@ -705,69 +699,73 @@ CONTAINS
                IF (save_cartesian) THEN
                   ao_normalization(igf + 1:igf + ngf_shell) = norm_cgf(icgf + 1:icgf + ngf_shell)
                ELSE
-                  ! allocate some temporary arrays
-                  ALLOCATE (diag_ncgf(nco(lshell), nco(lshell)))
-                  ALLOCATE (diag_nsgf(nso(lshell), nso(lshell)))
-                  ALLOCATE (temp(nso(lshell), nco(lshell)))
-                  diag_ncgf(:,:) = 0.0_dp
-                  diag_nsgf(:,:) = 0.0_dp
-                  temp(:,:) = 0.0_dp
-
-                  DO i = 1, nco(lshell)
-                     norm_cgf_tot(igf_c_tot + i) = norm_cgf(icgf + i)
+                  ! TREXIO employs solid harmonics and not spherical harmonics like cp2k
+                  ! so we need an extra factor (which is nowhere to be found internally)
+                  DO i = 1, ngf_shell
+                     ao_normalization(igf + i) = SQRT((2*lshell+1)/(4*pi))
                   END DO
-
-                  ! transform the normalization factors from Cartesian to solid harmonics
-                  ! temp(:, :) = MATMUL(orbtramat(lshell)%c2s, diag_ncgf)
-                  ! diag_nsgf(:, :) = MATMUL(temp, TRANSPOSE(orbtramat(lshell)%s2c))
-                  ! norm_sgf(:) = MATMUL(diag_nsgf, ones)
-                  DO i = 1, nso(lshell)
-                     ! cp2k_to_trexio contains the mapped global indices, but diag_nsgf
-                     ! is a small local matrix of dimension 2l+1, so I need to shift back
-                     ! the index by igf
-                     i_trex = cp2k_to_trexio_ang_mom(igf+i) - igf
-                     ! ao_normalization(igf + i) = norm_sgf(i_trex)
-                     ao_normalization(igf + i) = 1.0_dp
-                  END DO
-
-                  DEALLOCATE (diag_ncgf)
-                  DEALLOCATE (diag_nsgf)
-                  DEALLOCATE (temp)
                END IF
 
                igf = igf + ngf_shell
                icgf = icgf + nco(lshell)
-               igf_c_tot = igf_c_tot + nco(lshell)
             END DO
          END DO
          ! just a failsafe check
-         CPASSERT(icgf == ncgf)
+         CPASSERT(icgf == ncgf_atom)
       END DO
 
-      ! write overlap
-      ! CALL get_qs_env(qs_env, do_kpoints=do_kpoints, dft_control=dft_control)
-      ! nspins = dft_control%nspins
-      ! IF ( (nspins == 1) .AND. (.NOT. do_kpoints) ) THEN
-      !    CALL get_qs_env(qs_env, matrix_s=matrix_s, blacs_env=blacs_env)
-      !    CALL cp_fm_struct_create(fm_struct, para_env=para_env, context=blacs_env, &
-      !                               nrow_global=ao_num, ncol_global=ao_num)
-      !    ALLOCATE(fm_overlap)
-      !    CALL cp_fm_create(fm_overlap, fm_struct)
-      !    CALL cp_fm_struct_release(fm_struct)
-      !    CALL cp_fm_set_all(fm_overlap, 0.0_dp)
-      !    CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, fm_overlap)
-      !    ALLOCATE (ao_overlap(ao_num, ao_num))
-      !    ao_overlap(:,:) = 0.0_dp
-      !    CALL cp_fm_get_submatrix(fm_overlap, ao_overlap)
+      ! write overlap and kohn_sham matrix
+      CALL get_qs_env(qs_env, do_kpoints=do_kpoints, dft_control=dft_control)
+      nspins = dft_control%nspins
+      IF ( (nspins == 1) .AND. (.NOT. do_kpoints) ) THEN
+         CALL get_qs_env(qs_env, matrix_s=matrix_s, matrix_ks=matrix_ks, blacs_env=blacs_env)
+         CALL cp_fm_struct_create(fm_struct, para_env=para_env, context=blacs_env, &
+                                    nrow_global=ao_num, ncol_global=ao_num)
+         CALL cp_fm_create(fm_dummy, fm_struct)
+         CALL cp_fm_struct_release(fm_struct)
+         
+         ALLOCATE (temp(ao_num, ao_num))
+         ALLOCATE (ao_overlap(ao_num, ao_num))
+         ALLOCATE (ao_ks_matrix(ao_num, ao_num))
+         temp(:,:) = 0.0_dp
+         ao_overlap(:,:) = 0.0_dp
+         ao_ks_matrix(:,:) = 0.0_dp
+         
+         ! store the overlap
+         CALL cp_fm_set_all(fm_dummy, 0.0_dp)
+         CALL copy_dbcsr_to_fm(matrix_s(1)%matrix, fm_dummy)
+         CALL cp_fm_get_submatrix(fm_dummy, temp)
+         DO i = 1, ao_num
+            DO j = 1, ao_num
+               ao_overlap(i, j) = temp(cp2k_to_trexio_ang_mom(i), cp2k_to_trexio_ang_mom(j))
+            END DO
+         END DO
+         
+         ! store the KS matrix abusing the core hamiltonian container
+         temp(:,:) = 0.0_dp
+         CALL cp_fm_set_all(fm_dummy, 0.0_dp)
+         CALL copy_dbcsr_to_fm(matrix_ks(1)%matrix, fm_dummy)
+         CALL cp_fm_get_submatrix(fm_dummy, temp)
+         DO i = 1, ao_num
+            DO j = 1, ao_num
+               ao_ks_matrix(i, j) = temp(cp2k_to_trexio_ang_mom(i), cp2k_to_trexio_ang_mom(j))
+            END DO
+         END DO
 
-      !    IF (ionode) THEN
-      !       rc = trexio_write_ao_1e_int_overlap(f, ao_overlap)
-      !       CALL trexio_error(rc)
-      !    END IF
+         IF (ionode) THEN
+            rc = trexio_write_ao_1e_int_overlap(f, ao_overlap)
+            CALL trexio_error(rc)
 
-      !    DEALLOCATE(ao_overlap)
-      !    DEALLOCATE(fm_overlap)
-      ! END IF
+            rc = trexio_write_ao_1e_int_core_hamiltonian(f, ao_ks_matrix)
+            CALL trexio_error(rc)
+         END IF
+
+         CALL cp_fm_release(fm_dummy)
+         NULLIFY(fm_struct)
+         DEALLOCATE(ao_overlap)
+         DEALLOCATE(ao_ks_matrix)
+         DEALLOCATE(temp)
+      END IF
 
       IF (ionode) THEN
          rc = trexio_write_ao_shell(f, ao_shell)
@@ -788,7 +786,6 @@ CONTAINS
       nspins = dft_control%nspins
       CALL get_qs_kind_set(kind_set, nsgf=nsgf, ncgf=ncgf)
       nmo_spin = 0
-      WRITE (output_unit, "((T2,A,I0,A,I0))") 'TREXIO| nsgf = ', nsgf, ', ncgf = ', ncgf
 
       ! figure out that total number of MOs
       mo_num = 0
@@ -903,9 +900,7 @@ CONTAINS
          nmo = nmo_spin(ispin)
          ! allocate local temp array to transform the MOs of each kpoint/spin
          ALLOCATE (mos_sgf(nsgf, nmo))
-         ALLOCATE (mos_cgf(ncgf, nmo))
          mos_sgf(:,:) = 0.0_dp
-         mos_cgf(:,:) = 0.0_dp
 
          IF (do_kpoints) THEN
             DO ikp = 1, nkp
@@ -959,24 +954,10 @@ CONTAINS
 
             IF (save_cartesian) THEN
                CALL spherical_to_cartesian_mo(mos_sgf, particle_set, kind_set, mo_coefficient(:, imo + 1:imo + nmo))
-            ELSE
-
-               ! transform MOs to cartesian to squash in the normalization factor
-               CALL spherical_to_cartesian_mo(mos_sgf, particle_set, kind_set, mos_cgf)
-               mos_sgf(:,:) = 0.0_dp
-
-               DO i = 1, SIZE(norm_cgf_tot)
-                  mos_cgf(i, :) = mos_cgf(i, :) * norm_cgf_tot(i)
-                  ! WRITE (output_unit, '(I5, 1X, *(F12.6, 1X))') i, norm_cgf_tot(i)
-               END DO
-
-               ! transform back
-               CALL cartesian_to_spherical_mo(mos_cgf, particle_set, kind_set, mos_sgf)
-               
+            ELSE      
                ! we have to reorder the MOs since CP2K and TREXIO have different conventions
                DO i = 1, nsgf
                   mo_coefficient(i, imo + 1:imo + nmo) = mos_sgf(cp2k_to_trexio_ang_mom(i), :)
-                  ! mo_coefficient(i, imo + 1:imo + nmo) = mos_sgf(i, :)
                END DO
             END IF
          END IF
@@ -1090,8 +1071,7 @@ CONTAINS
       END IF
 
       ! Deallocate arrays used throughout the subroutine
-      DEALLOCATE (norm_cgf_tot)
-      DEALLOCATE (shell_ang_mom)
+      IF (ALLOCATED(shell_ang_mom)) DEALLOCATE (shell_ang_mom)
       IF (ALLOCATED(cp2k_to_trexio_ang_mom)) DEALLOCATE (cp2k_to_trexio_ang_mom)
 
       !========================================================================================!
@@ -1590,6 +1570,26 @@ CONTAINS
       END DO
 
    END SUBROUTINE nuclear_repulsion_energy
+
+
+! **************************************************************************************************
+!> \brief Returns the normalization coefficient for a spherical GTO
+!> \param l the angular momentum quantum number
+!> \param expnt the exponent of the Gaussian function
+! **************************************************************************************************
+   FUNCTION sgf_norm(l, expnt) RESULT(norm)
+      INTEGER, INTENT(IN)                                :: l
+      REAL(KIND=dp), INTENT(IN)                          :: expnt
+      REAL(KIND=dp)                                      :: norm
+
+      IF (l >= 0) THEN
+         norm = SQRT(2**(2*l+3)*fac(l+1)*(2*expnt)**(l+1.5) / (fac(2*l+2)*SQRT(pi)))
+      ELSE
+         CPABORT("The angular momentum should be >= 0!")
+      END IF
+
+   END FUNCTION sgf_norm
+
 
 ! **************************************************************************************************
 !> \brief Computes a spherical to cartesian MO transformation (solid harmonics in reality)


### PR DESCRIPTION
This PR fixes wrong basis set and atomic orbital normalization factors dumped to the trexio file for the case of spherical GTOs.
