### PR TITLE
Fix HDF5 installation path detection

### DIFF
--- a/tools/toolchain/scripts/stage7/install_hdf5.sh
+++ b/tools/toolchain/scripts/stage7/install_hdf5.sh
@@ -56,7 +56,7 @@ case "$with_hdf5" in
   __SYSTEM__)
     echo "==================== Finding HDF5 from system paths ===================="
     check_command pkg-config --modversion hdf5
-    pkg_install_dir=$(h5cc -showconfig | grep "Installation point" | cut -d: -f2)
+    pkg_install_dir=$(h5cc -showconfig | grep "Installation point" | awk '{print $3}')
     if [ -d ${pkg_install_dir}/include ]; then
       HDF5_INCLUDE_DIR=${pkg_install_dir}/include
     else


### PR DESCRIPTION
The command `cut -d: -f2` results in a leading space in the output path, such as "` /opt/hdf5`" instead of `/opt/hdf5`. This causes CMake to fail in locating the HDF5 path, reporting the error: "`Could NOT find HDF5 (missing: HDF5_LIBRARIES HDF5_INCLUDE_DIRS C Fortran) (found version "")`". Alternatively, replacing `cut -d: -f2` with `awk '{print $3}'` can avoid the problem.