### PR TITLE
Add local Spack package file for MiMiC (MCL)

### DIFF
--- a/ci/docker/build_cp2k_spack.Dockerfile
+++ b/ci/docker/build_cp2k_spack.Dockerfile
@@ -97,7 +97,7 @@ RUN CP2K_VERSION=$(cat /CP2K_VERSION) && \
     ln -sf cp2k.${CP2K_VERSION} cp2k_shell
 
 # Update library search path
-RUN echo "/opt/cp2k/lib\n/opt/spack/view/lib\n$(dirname $(find /opt/spack ! -type l -name libtorch.so 2>/dev/null || true) 2>/dev/null || true)" >/etc/ld.so.conf.d/cp2k.conf && ldconfig
+RUN echo "/opt/cp2k/lib\n/opt/spack/view/lib\n/opt/spack/view/lib/MiMiC\n$(dirname $(find /opt/spack ! -type l -name libtorch.so 2>/dev/null || true) 2>/dev/null || true)" >/etc/ld.so.conf.d/cp2k.conf && ldconfig
 
 # Create entrypoint script file
 RUN printf "#!/bin/bash\n\

--- a/cmake/cmake_cp2k.sh
+++ b/cmake/cmake_cp2k.sh
@@ -51,7 +51,6 @@ if [[ "${PROFILE}" == "spack" ]] && [[ "${VERSION}" == "psmp" ]]; then
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_LIBXSMM=OFF \
     -DCP2K_USE_TBLITE=OFF \
-    -DCP2K_USE_MIMIC=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?

--- a/tools/spack/cp2k_deps_psmp.yaml
+++ b/tools/spack/cp2k_deps_psmp.yaml
@@ -130,6 +130,7 @@ spack:
     - "libvori@220621"
     - "libxc@7.0.0"
 #   - "libxsmm@1.17"
+    - "mimic-mcl@3.0.0"
     - "pexsi@2.0.0"
     - "plumed@2.9.2"
     - "py-torch@2.9.0"

--- a/tools/spack/cp2k_dev_repo/packages/mimic_mcl/package.py
+++ b/tools/spack/cp2k_dev_repo/packages/mimic_mcl/package.py
@@ -1,0 +1,68 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage
+
+from spack.package import *
+
+
+class MimicMcl(CMakePackage):
+    """MiMiC is a high-performance framework for multiscale molecular dynamics simulations.
+    MCL, or MiMiC Communication Library, enables communication between external programs
+    coupled through the MiMiC framework. See https://mimic-project.org/ for further information.
+    """
+
+    homepage = "https://gitlab.com/mimic-project/mcl"
+    url = "https://gitlab.com/mimic-project/mcl/-/archive/3.0.0/mcl-3.0.0.tar.gz"
+    git = "https://gitlab.com/mimic-project/mcl.git"
+
+    license("GPL-3.0", checked_by="mkrack")
+
+    maintainers("mkrack")
+
+    version("3.0.0", sha256="3e740582836fe90e04a693cfc5a219826bcac03217f70ea5570bad6aeafda685")
+
+    variant("cxx_standard", default="17", description="Required CXX standard")
+    variant("cxx_standard_required", default=True, description="Require a specific CXX standard")
+    variant("cxx_extensions", default=False, description="Require CXX extensions")
+
+    variant("build_tests", default=False, description="Build tests")
+    variant("enable_coverage", default=False, description="Enable code coverage report")
+    variant("build_fortran_api", default=True, description="Build Fortran API module")
+    variant("build_shared_libs", default=True, description="Build using shared libraries")
+    variant(
+        "disable_mpi_f08",
+        default=False,
+        description="Disable MPI F08 Fortran module (even if it is available)",
+    )
+    variant(
+        "build_type",
+        default="Release",
+        description="CMake build type",
+        values=("Debug", "Release"),
+    )
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("fortran", when="+build_fortran_api", type="build")
+
+    depends_on("cmake@3.12:", type="build")
+    depends_on("mpi@2.1:", type="build")
+    depends_on("python@3.6:", type="build")
+
+    build_targets = ["mcl"]
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("CXX_STANDARD", "cxx_standard"),
+            self.define_from_variant("CXX_STANDARD_REQUIRED", "cxx_standard_required"),
+            self.define_from_variant("CXX_EXTENSIONS", "cxx_extensions"),
+            self.define_from_variant("BUILD_TESTS", "build_tests"),
+            self.define_from_variant("ENABLE_COVERAGE", "enable_coverage"),
+            self.define_from_variant("BUILD_FORTRAN_API", "build_fortran_api"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "build_shared_libs"),
+            self.define_from_variant("DISABLE_MPI_F08", "disable_mpi_f08"),
+        ]
+        return args


### PR DESCRIPTION
The MiMiC regression test in `MIMIC/regtest-qmmm` works with 4 MPI ranks.