### PR TITLE
Disable SIRIUS for psmp to workaround COSMA performance issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,6 @@ option(CP2K_USE_SPGLIB "Enable Spglib support" ${CP2K_USE_EVERYTHING})
 option(CP2K_USE_TREXIO "Enable TREXIO support" ${CP2K_USE_EVERYTHING})
 option(CP2K_USE_VORI "Enable Libvori support" ${CP2K_USE_EVERYTHING})
 option(CP2K_USE_CRAY_PM_ENERGY "Enable Cray PM energy framework" OFF)
-option(CP2K_USE_STATIC_BLAS "Link against static version of BLAS/LAPACK" OFF)
 option(BUILD_SHARED_LIBS "Build CP2K shared library" ON)
 option(
   CP2K_USE_FFTW3_WITH_MKL

--- a/cmake/cmake_cp2k.sh
+++ b/cmake/cmake_cp2k.sh
@@ -91,12 +91,15 @@ elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "sdbg" ]]; then
   CMAKE_EXIT_CODE=$?
 
 elif [[ "${PROFILE}" == "toolchain" ]] && [[ "${VERSION}" == "psmp" ]]; then
+  # TODO Re-enable SIRIUS once performance regression of COSMA is fixed:
+  # https://github.com/cp2k/cp2k/issues/4663
   cmake \
     -GNinja \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_PEXSI=OFF \
+    -DCP2K_USE_SIRIUS=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?

--- a/docs/technologies/libraries.md
+++ b/docs/technologies/libraries.md
@@ -25,8 +25,6 @@ On the Mac, BLAS and LAPACK may be provided by Apple's Accelerate framework. If 
 framework, `-DCP2K_BLAS_VENDOR=Apple` must be passed to CMake to account for some interface
 incompatibilities between Accelerate and reference BLAS/LAPACK.
 
-To build against a static version of BLAS/LAPACK pass `-DCP2K_USE_STATIC_BLAS=ON` to CMake.
-
 ## MPI and ScaLAPACK (required for MPI parallel builds)
 
 MPI (version 3) and SCALAPACK are needed for parallel code. (Use the latest versions available and


### PR DESCRIPTION
A workaround for #4663.