### PR TITLE
Fix ipi_driver boundary condition handling

### DIFF
--- a/src/ipi_driver.F
+++ b/src/ipi_driver.F
@@ -105,6 +105,8 @@ CONTAINS
       TYPE(section_vals_type), POINTER         :: drv_section, motion_section
       TYPE(virial_type), POINTER               :: virial
       REAL(KIND=dp)                            :: sleeptime
+      INTEGER, DIMENSION(3)                    :: perd 
+      TYPE(cell_type), POINTER                 :: oldcell
 
       CALL timeset(routineN, handle)
 
@@ -219,7 +221,11 @@ CONTAINS
                   subsys%particles%els(ip)%r(idir) = combuf(ii)
                END DO
             END DO
-            CALL init_cell(cpcell, hmat=cellh)
+            NULLIFY(oldcell) 
+            CALL cp_subsys_get(subsys, cell=oldcell)
+            perd = oldcell%perd
+
+            CALL init_cell(cpcell, hmat=cellh, periodic=perd)
             CALL cp_subsys_set(subsys, cell=cpcell)
 
             CALL force_env_calc_energy_force(force_env, calc_force=.TRUE.)


### PR DESCRIPTION
When cp2k is employed with the according I-PI interface, there seems to be a bug concerning the assignment of the boundary conditions of a system which are extracted from the accompanying cp2k-input file (required to initialise the computation). To be more precise, if in an I-PI calculation the according cp2k-input file employs a non periodic cell

&CELL
  PERIODIC NONE
  ! x, y, z coordinates
&END CELL

the cell is being forwarded in subsequent evaluations to be fully periodic (i.e. XYZ). This turns out to be due to the fact that in src/ipi_driver.F the cell is created via CALL cell_create(cpcell) , without specifying any boundary conditions followed by  CALL init_cell(cpcell, hmat=cellh), which again does not specify any boundary conditions. Hence, with the default of cell_create being fully xyz periodic, the resulting cell will, no matter the input, always be periodic.