### PR TITLE
Toolchain: add --enable-sse2 option for fftw with target-cpu=native

### DIFF
--- a/tools/toolchain/scripts/stage3/install_fftw.sh
+++ b/tools/toolchain/scripts/stage3/install_fftw.sh
@@ -52,6 +52,7 @@ case "$with_fftw" in
           grep '\bavx\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-avx"
           grep '\bavx2\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-avx2"
           grep '\bavx512f\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-avx512"
+          grep '\bsse2\b' /proc/cpuinfo 1> /dev/null && FFTW_FLAGS="${FFTW_FLAGS} --enable-sse2"
         fi
       fi
       ./configure CFLAGS="${CFLAGS} -std=c17" \


### PR DESCRIPTION
This simple PR is based on one item in #4667 I made as well as the [fftw document on installation](https://fftw.org/fftw3_doc/Installation-on-Unix.html). Only `sse2` is detected for now to keep support the single/double precision.