### PR TITLE
Toolchain: Remove redundant "export PKG_CONFIG_PATH" commands

### DIFF
--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -256,7 +256,6 @@ prepend_path LIBRARY_PATH "${COSMA_LIBDIR}"
 prepend_path CPATH "$pkg_install_dir/include"
 export COSMA_INCLUDE_DIR="$pkg_install_dir/include"
 export COSMA_ROOT="${pkg_install_dir}"
-export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${COSMA_LIBDIR}/pkgconfig"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF
@@ -273,7 +272,6 @@ export CP_LDFLAGS="\${CP_LDFLAGS} IF_CUDA(${COSMA_CUDA_LDFLAGS}|IF_HIP(${COSMA_H
 export COSMA_LIBS="${COSMA_LIBS}"
 export COSMA_ROOT="$pkg_install_dir"
 export COSMA_INCLUDE_DIR="$pkg_install_dir/include"
-export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${COSMA_LIBDIR}/pkgconfig"
 export CP_LIBS="IF_MPI(${COSMA_LIBS}|) \${CP_LIBS}"
 EOF
   cat "${BUILDDIR}/setup_cosma" >> $SETUPFILE

--- a/tools/toolchain/scripts/stage7/install_libvdwxc.sh
+++ b/tools/toolchain/scripts/stage7/install_libvdwxc.sh
@@ -118,7 +118,6 @@ export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__LIBVDWXC|)"
 export CP_CFLAGS="\${CP_CFLAGS} IF_MPI(${LIBVDWXC_CFLAGS}|)"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${LIBVDWXC_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(${LIBVDWXC_LIBS}|) \${CP_LIBS}"
-export PKG_CONFIG_PATH="${pkg_install_dir}/lib/pkgconfig:${PKG_CONFIG_PATH}"
 export VDWXC_ROOT="${pkg_install_dir}"
 EOF
   cat "${BUILDDIR}/setup_libvdwxc" >> $SETUPFILE


### PR DESCRIPTION
Related to the 3rd checkbox of issue #4667. 