### PR TITLE
CMake: Fix ssmp build with CP2K_BLAS_VENDOR set

### DIFF
--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -177,11 +177,13 @@ add_compile_options(
 
 # =================================== Tweaks ===================================
 # Workaround https://gitlab.kitware.com/cmake/cmake/-/issues/27231
-get_target_property(opts MPI::MPI_Fortran INTERFACE_COMPILE_OPTIONS)
-set_target_properties(
-  MPI::MPI_Fortran PROPERTIES INTERFACE_COMPILE_OPTIONS
-                              "$<$<COMPILE_LANGUAGE:Fortran>:${opts}>")
-unset(opts)
+if(TARGET MPI::MPI_Fortran)
+  get_target_property(opts MPI::MPI_Fortran INTERFACE_COMPILE_OPTIONS)
+  set_target_properties(
+    MPI::MPI_Fortran PROPERTIES INTERFACE_COMPILE_OPTIONS
+                                "$<$<COMPILE_LANGUAGE:Fortran>:${opts}>")
+  unset(opts)
+endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
   set(CMAKE_Fortran_MODOUT_FLAG "-ef") # override to get lower-case module file


### PR DESCRIPTION
Fixes #4746

---

Before (master branch):
```console
❯ cmake -S. -Bbuild -DCP2K_USE_MPI=OFF -DCP2K_BLAS_VENDOR=OpenBLAS
...
-- Setting build type to 'Release' as none was specified.
CMake Error at cmake/CompilerConfiguration.cmake:180 (get_target_property):
  get_target_property() called with non-existent target "MPI::MPI_Fortran".
Call Stack (most recent call first):
  CMakeLists.txt:891 (include)
...
-- Configuring incomplete, errors occurred!
```

After (this PR):
```console
❯ cmake -S. -Bbuild -DCP2K_USE_MPI=OFF -DCP2K_BLAS_VENDOR=OpenBLAS
...
-- Configuring done (4.2s)
-- Generating done (0.3s)
```
