### PR TITLE
Toolchain: Several tweaks and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,9 @@ cmake_dependent_option(
 cmake_dependent_option(CP2K_USE_SIRIUS_NLCG "Enable nlcg method in SIRIUS" OFF
                        "CP2K_USE_SIRIUS" OFF)
 
+cmake_dependent_option(CP2K_USE_SpFFT "Enable spare FFT in SIRIUS" OFF
+                       "CP2K_USE_SIRIUS" OFF)
+
 cmake_dependent_option(
   CP2K_DBCSR_USE_CPU_ONLY "Disable the DBCSR accelerated backend" OFF
   "NOT CP2K_USE_ACCEL MATCHES \"OPENCL|HIP|CUDA\"" OFF)
@@ -216,8 +219,7 @@ cmake_dependent_option(CP2K_ENABLE_FFTW3_THREADS_SUPPORT
                        "Enable FFTW3 threads support" OFF "CP2K_USE_FFTW3" OFF)
 
 cmake_dependent_option(
-  CP2K_USE_CUSOLVER_MP
-  "Use Nvidia GPU accelerated eigensolver. Only active when CUDA is ON" OFF
+  CP2K_USE_CUSOLVER_MP "Enable cuSOLVERMp. Only active when CUDA is ON" OFF
   "CP2K_USE_ACCEL MATCHES \"CUDA\"" OFF)
 
 cmake_dependent_option(CP2K_USE_NVHPC OFF "Enable Nvidia NVHPC kit"

--- a/docs/technologies/libraries.md
+++ b/docs/technologies/libraries.md
@@ -154,6 +154,13 @@ SIRIUS is a domain specific library for electronic structure calculations.
   <https://brehm-research.de/bqb> for more information as well as the `bqbtool` to inspect BQB
   files.
 
+## SpFFT (Sparse 3D FFT)
+
+- SpFFT is a 3D FFT library for sparse frequency domain data written in C++ with support for MPI,
+  OpenMP, CUDA and ROCm.
+- Pass `-DCP2K_USE_SpFFT=ON` to CMake to enable support for SpFFT.
+- See <https://github.com/eth-cscs/SpFFT> for more information.
+
 ## Torch (Machine Learning Framework needed for NequIP)
 
 - The C++ API of PyTorch can be downloaded from https://pytorch.org/get-started/locally/.

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi100
@@ -38,6 +38,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi50
@@ -38,6 +38,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_aiida
+++ b/tools/docker/Dockerfile.test_aiida
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_arm64-psmp
+++ b/tools/docker/Dockerfile.test_arm64-psmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_asan-psmp
+++ b/tools/docker/Dockerfile.test_asan-psmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_ase
+++ b/tools/docker/Dockerfile.test_ase
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_conventions
+++ b/tools/docker/Dockerfile.test_conventions
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_coverage
+++ b/tools/docker/Dockerfile.test_coverage
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_cuda_A100
+++ b/tools/docker/Dockerfile.test_cuda_A100
@@ -31,6 +31,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_cuda_P100
+++ b/tools/docker/Dockerfile.test_cuda_P100
@@ -31,6 +31,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_cuda_V100
+++ b/tools/docker/Dockerfile.test_cuda_V100
@@ -31,6 +31,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_fedora-psmp
+++ b/tools/docker/Dockerfile.test_fedora-psmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_gcc10
+++ b/tools/docker/Dockerfile.test_gcc10
@@ -47,6 +47,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_gcc11
+++ b/tools/docker/Dockerfile.test_gcc11
@@ -47,6 +47,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_gcc12
+++ b/tools/docker/Dockerfile.test_gcc12
@@ -47,6 +47,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_gcc13
+++ b/tools/docker/Dockerfile.test_gcc13
@@ -47,6 +47,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_gcc14
+++ b/tools/docker/Dockerfile.test_gcc14
@@ -51,6 +51,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_gcc8
+++ b/tools/docker/Dockerfile.test_gcc8
@@ -47,6 +47,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_gcc9
+++ b/tools/docker/Dockerfile.test_gcc9
@@ -47,6 +47,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_gromacs
+++ b/tools/docker/Dockerfile.test_gromacs
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_i-pi
+++ b/tools/docker/Dockerfile.test_i-pi
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_intel-ifort-psmp
+++ b/tools/docker/Dockerfile.test_intel-ifort-psmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_intel-ifort-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ifort-ssmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_intel-ifx-psmp
+++ b/tools/docker/Dockerfile.test_intel-ifx-psmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_intel-ifx-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ifx-ssmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_manual
+++ b/tools/docker/Dockerfile.test_manual
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_minimal
+++ b/tools/docker/Dockerfile.test_minimal
@@ -47,6 +47,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_openmpi-psmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -63,7 +63,6 @@ RUN  ./scripts/stage9/install_stage9.sh && rm -rf ./build
 WORKDIR /opt/cp2k
 COPY ./src ./src
 COPY ./data ./data
-COPY ./tests ./tests
 COPY ./tools/build_utils ./tools/build_utils
 COPY ./cmake ./cmake
 COPY ./CMakeLists.txt .
@@ -74,6 +73,7 @@ RUN ./build_cp2k.sh toolchain pdbg
 
 # Run regression tests.
 ARG TESTOPTS=""
+COPY ./tests ./tests
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -o pipefail -c " \
     TESTOPTS='${TESTOPTS}' \

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -18,7 +18,6 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
-     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
@@ -64,6 +63,7 @@ RUN  ./scripts/stage9/install_stage9.sh && rm -rf ./build
 WORKDIR /opt/cp2k
 COPY ./src ./src
 COPY ./data ./data
+COPY ./tests ./tests
 COPY ./tools/build_utils ./tools/build_utils
 COPY ./cmake ./cmake
 COPY ./CMakeLists.txt .
@@ -74,7 +74,6 @@ RUN ./build_cp2k.sh toolchain pdbg
 
 # Run regression tests.
 ARG TESTOPTS=""
-COPY ./tests ./tests
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -o pipefail -c " \
     TESTOPTS='${TESTOPTS}' \

--- a/tools/docker/Dockerfile.test_performance
+++ b/tools/docker/Dockerfile.test_performance
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_performance_cuda_A100
+++ b/tools/docker/Dockerfile.test_performance_cuda_A100
@@ -31,6 +31,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_performance_cuda_P100
+++ b/tools/docker/Dockerfile.test_performance_cuda_P100
@@ -31,6 +31,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_performance_cuda_V100
+++ b/tools/docker/Dockerfile.test_performance_cuda_V100
@@ -31,6 +31,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_phonopy
+++ b/tools/docker/Dockerfile.test_phonopy
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_psmp
+++ b/tools/docker/Dockerfile.test_psmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_psmp_4ranks
+++ b/tools/docker/Dockerfile.test_psmp_4ranks
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_sdbg
+++ b/tools/docker/Dockerfile.test_sdbg
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/Dockerfile.test_ssmp
+++ b/tools/docker/Dockerfile.test_ssmp
@@ -18,6 +18,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -514,6 +514,7 @@ COPY ./tools/toolchain/scripts/VERSION \
      ./tools/toolchain/scripts/common_vars.sh \
      ./tools/toolchain/scripts/signal_trap.sh \
      ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./tools/toolchain/scripts/generate_cmake_options.sh \
      ./scripts/
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -1037,6 +1037,7 @@ write_toolchain_env ${INSTALLDIR}
 
 # write toolchain config
 echo "tool_list=\"${tool_list}\"" > ${INSTALLDIR}/toolchain.conf
+echo "dry_run=\"${dry_run}\"" >> ${INSTALLDIR}/toolchain.conf
 for ii in ${package_list}; do
   install_mode="$(eval echo \${with_${ii}})"
   echo "with_${ii}=\"${install_mode}\"" >> ${INSTALLDIR}/toolchain.conf
@@ -1047,6 +1048,7 @@ done
 # ------------------------------------------------------------------------
 if [ "${dry_run}" = "__TRUE__" ]; then
   echo "Wrote only configuration files (--dry-run)."
+  ./scripts/generate_cmake_options.sh
 else
   echo "# Leak suppressions" > ${INSTALLDIR}/lsan.supp
   ./scripts/stage0/install_stage0.sh

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -1049,7 +1049,7 @@ done
 if [ "${dry_run}" = "__TRUE__" ]; then
   echo "Wrote only configuration files (--dry-run)."
   # Avoid error in Regtest_pdbg
-  if [ -n "$(pwd |grep toolchain)" ]; then
+  if [ -n "$(pwd |grep 'tools/toolchain')" ]; then
     ./scripts/generate_cmake_options.sh
   fi
 else

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -1048,7 +1048,10 @@ done
 # ------------------------------------------------------------------------
 if [ "${dry_run}" = "__TRUE__" ]; then
   echo "Wrote only configuration files (--dry-run)."
-  ./scripts/generate_cmake_options.sh
+  # Avoid error in Regtest_pdbg
+  if [ -n "$(pwd |grep toolchain)" ]; then
+    ./scripts/generate_cmake_options.sh
+  fi
 else
   echo "# Leak suppressions" > ${INSTALLDIR}/lsan.supp
   ./scripts/stage0/install_stage0.sh

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -1048,10 +1048,7 @@ done
 # ------------------------------------------------------------------------
 if [ "${dry_run}" = "__TRUE__" ]; then
   echo "Wrote only configuration files (--dry-run)."
-  # Avoid error in Regtest_pdbg
-  if [ -n "$(pwd |grep 'tools/toolchain')" ]; then
-    ./scripts/generate_cmake_options.sh
-  fi
+  ./scripts/generate_cmake_options.sh
 else
   echo "# Leak suppressions" > ${INSTALLDIR}/lsan.supp
   ./scripts/stage0/install_stage0.sh

--- a/tools/toolchain/scripts/generate_cmake_options.sh
+++ b/tools/toolchain/scripts/generate_cmake_options.sh
@@ -22,12 +22,9 @@ CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=../install -DCP2K_DATA_DIR=${CP2K_ROOT}/da
 if [ -n "$(grep -- "--install-all" ${INSTALLDIR}/setup)" ]; then
   CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_USE_EVERYTHING=ON -DCP2K_USE_DLAF=OFF -DCP2K_USE_PEXSI=OFF"
   # Since "--install-all" can be used together with "--with-PKG=no", an extra safeguard is added here
-  if [ "${with_dftd4}" = "__DONTUSE__" ] && [ "${with_tblite}" = "__DONTUSE__" ]; then
-    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_USE_DFTD4=OFF"
-  fi
-  for toolchain_option in $(grep -i "dontuse" ${INSTALLDIR}/toolchain.conf | grep -vi "dftd4" | cut -d'_' -f2 | cut -d'=' -f1); do
+  for toolchain_option in $(grep -i "dontuse" ${INSTALLDIR}/toolchain.conf | grep -vi "gcc" | cut -d'_' -f2 | cut -d'=' -f1); do
     if [ $(eval echo "$with_"'$toolchain_option') != "__DONTUSE__" ]; then
-      ADDED_CMAKE_OPTION=$(sed -n '/target_compile_definitions(/,/)/p' ${CP2K_ROOT}/src/CMakeLists.txt | grep -i $toolchain_option | cut -d'{' -f2 | cut -d'}' -f1 | head -n 1)
+      ADDED_CMAKE_OPTION=$(sed -n '/option(/,/)/p' ${CP2K_ROOT}/CMakeLists.txt | grep -i $toolchain_option | awk '{print $1}' | cut -d'(' -f2 | head -n 1)
       # Use "if-then" below can avoid generating empty "-D=OFF" options
       if [ -n "${ADDED_CMAKE_OPTION}" ]; then
         CMAKE_OPTIONS="${CMAKE_OPTIONS} -D${ADDED_CMAKE_OPTION}=OFF"
@@ -55,18 +52,14 @@ else
   if [ "${with_fftw}" != "__DONTUSE__" ] || [ "${MATH_MODE}" = "mkl" ]; then
     CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_USE_FFTW3=ON"
   fi
-  # When user chooses dftd4 rather than tblite in toolchain, the ADDED_CMAKE_OPTION below is set to CP2K_USE_TBLITE by mistake.
-  if [ "${with_dftd4}" != "__DONTUSE__" ] && [ "${with_tblite}" = "__DONTUSE__" ]; then
-    CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_USE_DFTD4=ON"
-  fi
   # There is only MCL (MiMiC Communication Library) and no MiMiC that can be installed via toolchain, but if one chooses to install MCL then MiMiC should have been installed?
   if [ "${with_mcl}" != "__DONTUSE__" ]; then
     CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_USE_MIMIC=ON"
   fi
   # Detect if any other dependencies is used and add the proper cmake option. Since "pugixml" and "gsl" are not mentioned in CMakeLists.txt, they will not be considered.
-  for toolchain_option in $(grep -vi "dontuse\|list\|cmake\|fftw\|dbcsr\|dftd4" ${INSTALLDIR}/toolchain.conf | cut -d'_' -f2 | cut -d'=' -f1); do
+  for toolchain_option in $(grep -vi "dry\|list\|dontuse\|gcc\|cmake\|fftw\|mkl\|dbcsr" ${INSTALLDIR}/toolchain.conf | cut -d'_' -f2 | cut -d'=' -f1); do
     if [ $(eval echo "$with_"'$toolchain_option') != "__DONTUSE__" ]; then
-      ADDED_CMAKE_OPTION=$(sed -n '/target_compile_definitions(/,/)/p' ${CP2K_ROOT}/src/CMakeLists.txt | grep -i $toolchain_option | cut -d'{' -f2 | cut -d'}' -f1 | head -n 1)
+      ADDED_CMAKE_OPTION=$(sed -n '/option(/,/)/p' ${CP2K_ROOT}/CMakeLists.txt | grep -i $toolchain_option | awk '{print $1}' | cut -d'(' -f2 | head -n 1)
       # Use "if-then" below can avoid generating empty "-D=ON" options
       if [ -n "${ADDED_CMAKE_OPTION}" ]; then
         CMAKE_OPTIONS="${CMAKE_OPTIONS} -D${ADDED_CMAKE_OPTION}=ON"
@@ -84,9 +77,8 @@ Suggested cmake command if toolchain is built with your options:
   cmake .. ${CMAKE_OPTIONS}
 EOF
 else
-  echo ${CMAKE_OPTIONS} > "${INSTALLDIR}"/cmake.txt
-  cat << EOF
-
+  echo
+  cat << EOF | tee ${ROOTDIR}/installation_guide.txt
 ========================== usage =========================
 Done! The "build" directory can now be removed.
 
@@ -101,8 +93,8 @@ It's recommended for you to build CP2K like this after executing above command:
 
 When completed, you can run "make clean" or delete this build directory to free up some space.
 
-The suggested cmake options above is saved to "${INSTALLDIR}/cmake.txt".
-For more information about available build options, see: https://manual.cp2k.org/trunk/getting-started/build-from-source.html
+For more information about available build options, see: https://manual.cp2k.org/trunk/getting-started/build-from-source.html.
+This message is saved to "installation_guide.txt".
 EOF
 fi
 

--- a/tools/toolchain/scripts/stage3/install_fftw.sh
+++ b/tools/toolchain/scripts/stage3/install_fftw.sh
@@ -70,11 +70,14 @@ case "$with_fftw" in
     check_lib -lfftw3 "FFTW"
     check_lib -lfftw3_omp "FFTW"
     [ "${MPI_MODE}" != "no" ] && check_lib -lfftw3_mpi "FFTW"
-    pkg_install_dir=$(dirname $(dirname $(find_in_paths "libfftw3.a" $LIB_PATHS)))
+    pkg_install_dir=$(
+      result=$(find_in_paths "libfftw3.a" $LIB_PATHS)
+      [ "$result" = "__FALSE__" ] && result=$(find_in_paths "libfftw3.so" $LIB_PATHS)
+      [ "$result" != "__FALSE__" ] && dirname $(dirname "$result")
+    )
+    INCLUDE_PATHS=${INCLUDE_PATHS}:"$pkg_install_dir/include"
     add_include_from_paths FFTW_CFLAGS "fftw3.h" FFTW_INC ${INCLUDE_PATHS}
     add_lib_from_paths FFTW_LDFLAGS "libfftw3.*" ${LIB_PATHS}
-    FFTW_CFLAGS="-I'${pkg_install_dir}/include'"
-    FFTW_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __DONTUSE__)
     # Nothing to do

--- a/tools/toolchain/scripts/stage3/install_fftw.sh
+++ b/tools/toolchain/scripts/stage3/install_fftw.sh
@@ -18,9 +18,6 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_fftw" ] && rm "${BUILDDIR}/setup_fftw"
 
-FFTW_CFLAGS=''
-FFTW_LDFLAGS=''
-FFTW_LIBS=''
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
@@ -73,8 +70,11 @@ case "$with_fftw" in
     check_lib -lfftw3 "FFTW"
     check_lib -lfftw3_omp "FFTW"
     [ "${MPI_MODE}" != "no" ] && check_lib -lfftw3_mpi "FFTW"
+    pkg_install_dir=$(dirname $(dirname $(find_in_paths "libfftw3.a" $LIB_PATHS)))
     add_include_from_paths FFTW_CFLAGS "fftw3.h" FFTW_INC ${INCLUDE_PATHS}
     add_lib_from_paths FFTW_LDFLAGS "libfftw3.*" ${LIB_PATHS}
+    FFTW_CFLAGS="-I'${pkg_install_dir}/include'"
+    FFTW_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __DONTUSE__)
     # Nothing to do
@@ -113,8 +113,8 @@ export CP_DFLAGS="\${CP_DFLAGS} -D__FFTW3 IF_COVERAGE(IF_MPI(|-U__FFTW3)|)"
 export CP_CFLAGS="\${CP_CFLAGS} ${FFTW_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${FFTW_LDFLAGS}"
 export CP_LIBS="${FFTW_LIBS} \${CP_LIBS}"
-export FFTW_ROOT=${FFTW_ROOT:-${pkg_install_dir}}
-export FFTW3_ROOT=${pkg_install_dir}
+export FFTW_ROOT="${FFTW_ROOT:-${pkg_install_dir}}"
+export FFTW3_ROOT="${FFTW_ROOT:-${pkg_install_dir}}"
 EOF
   cat "${BUILDDIR}/setup_fftw" >> $SETUPFILE
 fi

--- a/tools/toolchain/scripts/stage4/install_scalapack.sh
+++ b/tools/toolchain/scripts/stage4/install_scalapack.sh
@@ -18,9 +18,6 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_scalapack" ] && rm "${BUILDDIR}/setup_scalapack"
 
-SCALAPACK_CFLAGS=''
-SCALAPACK_LDFLAGS=''
-SCALAPACK_LIBS=''
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
@@ -75,6 +72,11 @@ case "$with_scalapack" in
   __SYSTEM__)
     echo "==================== Finding ScaLAPACK from system paths ===================="
     check_lib -lscalapack "ScaLAPACK"
+    pkg_install_dir=$(
+      result=$(find_in_paths "libscalapack.a" $LIB_PATHS)
+      [ "$result" = "__FALSE__" ] && result=$(find_in_paths "libscalapack.so" $LIB_PATHS)
+      [ "$result" != "__FALSE__" ] && dirname $(dirname "$result")
+    )
     add_lib_from_paths SCALAPACK_LDFLAGS "libscalapack.*" $LIB_PATHS
     ;;
   __DONTUSE__) ;;
@@ -100,7 +102,6 @@ prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 export SCALAPACK_ROOT="${pkg_install_dir}"
 EOF
-    cat "${BUILDDIR}/setup_scalapack" >> $SETUPFILE
   fi
   cat << EOF >> "${BUILDDIR}/setup_scalapack"
 export SCALAPACK_LDFLAGS="${SCALAPACK_LDFLAGS}"
@@ -110,6 +111,7 @@ export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__parallel|)"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${SCALAPACK_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(-lscalapack|) \${CP_LIBS}"
 EOF
+  cat "${BUILDDIR}/setup_scalapack" >> $SETUPFILE
 fi
 cd "${ROOTDIR}"
 


### PR DESCRIPTION
1. Print expected cmake options when running toolchain with `--dry-run`
2. Improve the message printed at last
3. Toolchain scripts: Fix the issue that `PKG_ROOT`, `PKG_CFLAGS` and `PKG_INCLUDES` are blank when finding from paths of self-installed PKG refers to FFTW, OpenBLAS and ScaLAPACK. (Some people may prefer compiling these basic math libraries by themselves rather than installing directly from package manager for better performance, in which case the installation paths of them may not be in `/usr` but paths like `/opt/openblas` and `/opt/fftw`. This fix ensure these paths can be read in install scripts of toolchain.)
4. Make `generate_cmake_options.sh` use `${CP2K_ROOT}/CMakeLists.txt` instead of `${CP2K_ROOT}/src/CMakeLists.txt` to fix regtest issue brought by operation 1