### PR TITLE
Update input_cp2k_xc.F

### DIFF
--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -1014,7 +1014,7 @@ CONTAINS
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="D2_SCALING", &
                           variants=["SCALING"], &
-                          description="XC Functional dependent scaling parameter, if set to zero CP2K attempts"// &
+                          description="XC Functional dependent scaling parameter. If omitted, CP2K attempts"// &
                           " to guess the xc functional that is in use and sets the associated scaling parameter.", &
                           usage="SCALING 0.2", default_r_val=0._dp)
       CALL section_add_keyword(subsection, keyword)
@@ -1031,24 +1031,24 @@ CONTAINS
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="D3_SCALING", &
-                          description="XC Functional dependent scaling parameters (s6,sr6,s8) for the DFT-D3 method,"// &
-                          " if set to zero CP2K attempts"// &
+                          description="XC Functional dependent scaling parameters (s6,sr6,s8) for the DFT-D3 method."// &
+                          " If omitted, CP2K attempts"// &
                           " to guess the xc functional from REFERENCE_FUNCTIONAL and sets the associated scaling parameter.", &
                           usage="D3_SCALING 1.0 1.0 1.0", n_var=3, &
                           default_r_vals=[0.0_dp, 0.0_dp, 0.0_dp])
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="D3BJ_SCALING", &
-                          description="XC Functional dependent scaling parameters (s6,a1,s8,a2) for the DFT-D3(BJ) method,"// &
-                          " if set to zero CP2K attempts"// &
+                          description="XC Functional dependent scaling parameters (s6,a1,s8,a2) for the DFT-D3(BJ) method."// &
+                          " If omitted, CP2K attempts"// &
                           " to guess the xc functional from REFERENCE_FUNCTIONAL and sets the associated scaling parameter.", &
                           usage="D3BJ_SCALING 1.0 1.0 1.0 1.0", n_var=4, &
                           default_r_vals=[0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp])
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="D4_SCALING", &
-                          description="XC Functional dependent scaling parameters (s6,a1,s8,a2) for the DFT-D4 method,"// &
-                          " if set to zero CP2K attempts"// &
+                          description="XC Functional dependent scaling parameters (s6,a1,s8,a2) for the DFT-D4 method."// &
+                          " If omitted, CP2K attempts"// &
                           " to guess the xc functional from REFERENCE_FUNCTIONAL and sets the associated scaling parameter.", &
                           usage="D4_SCALING 1.0 1.0 1.0 1.0", n_var=4, &
                           default_r_vals=[0.0_dp, 0.0_dp, 0.0_dp, 0.0_dp])


### PR DESCRIPTION
Changed description scaling parameters Grimme dispersion corrections to make clear that 0 values do not trigger automatic parameter determination. See also the forum https://groups.google.com/g/cp2k/c/dY9nQWnWeIQ