### PR TITLE
low-scaling GW: fix blocksize-dependent deviations

### DIFF
--- a/src/gw_large_cell_gamma.F
+++ b/src/gw_large_cell_gamma.F
@@ -7,6 +7,8 @@
 
 ! **************************************************************************************************
 !> \brief Routines from paper [Graml2024]
+!> \par History
+!>      01.2026 Maximilian Graml: add more bounds to exploit sparsity in 3c integrals, fixes
 !> \author Jan Wilhelm
 !> \date 07.2023
 ! **************************************************************************************************
@@ -235,27 +237,29 @@ CONTAINS
                   DO inner_loop_atoms_interval_index = 1, bs_env%n_intervals_inner_loop_atoms
 
                      IL_atoms = bs_env%inner_loop_atom_intervals(1:2, inner_loop_atoms_interval_index)
-
+                     ! Idea: Use sparsity in 3c integrals behind χ_PQ(iτ,k=0)
+                     !   ->  λ   bounds from j_atoms -> sparse in IL_atoms through σ in
+                     !                                   N_Qλν(iτ) = sum_σ (Qλ|σ) G^vir_νσ(i|τ|,k=0)
+                     !   ->  ν   bounds from i_atoms -> sparse in IL_atoms through µ in
+                     !                                   M_Pνλ(iτ) = sum_µ (Pν|µ) G^occ_λµ(i|τ|,k=0)
                      CALL check_dist(i_atoms, IL_atoms, qs_env, bs_env, dist_too_long_i)
                      CALL check_dist(j_atoms, IL_atoms, qs_env, bs_env, dist_too_long_j)
-                     IF (dist_too_long_i .OR. dist_too_long_j) CYCLE
-
-                     ! 2. compute 3-center integrals (Pν|µ) ("|": truncated Coulomb operator)
-                     CALL compute_3c_integrals(qs_env, bs_env, t_3c_for_Gocc, &
-                                               atoms_AO_1=i_atoms, atoms_AO_2=IL_atoms)
-
-                     ! 3. tensor operation M_Pνλ(iτ) = sum_µ (Pν|µ) G^occ_λµ(i|τ|,k=0)
-                     CALL G_times_3c(t_3c_for_Gocc, t_2c_Gocc, t_3c_x_Gocc, bs_env, &
-                                     j_atoms, i_atoms, IL_atoms)
-
-                     ! 4. compute 3-center integrals (Qλ|σ) ("|": truncated Coulomb operator)
-                     CALL compute_3c_integrals(qs_env, bs_env, t_3c_for_Gvir, &
-                                               atoms_AO_1=j_atoms, atoms_AO_2=IL_atoms)
-
-                     ! 5. tensor operation N_Qλν(iτ) = sum_σ (Qλ|σ) G^vir_νσ(i|τ|,k=0)
-                     CALL G_times_3c(t_3c_for_Gvir, t_2c_Gvir, t_3c_x_Gvir, bs_env, &
-                                     i_atoms, j_atoms, IL_atoms)
-
+                     IF (.NOT. dist_too_long_i) THEN
+                        ! 2. compute 3-center integrals (Pν|µ) ("|": truncated Coulomb operator)
+                        CALL compute_3c_integrals(qs_env, bs_env, t_3c_for_Gocc, &
+                                                  atoms_AO_1=i_atoms, atoms_AO_2=IL_atoms)
+                        ! 3. tensor operation M_Pνλ(iτ) = sum_µ (Pν|µ) G^occ_λµ(i|τ|,k=0)
+                        CALL G_times_3c(t_3c_for_Gocc, t_2c_Gocc, t_3c_x_Gocc, bs_env, &
+                                        j_atoms, i_atoms, IL_atoms)
+                     END IF
+                     IF (.NOT. dist_too_long_j) THEN
+                        ! 4. compute 3-center integrals (Qλ|σ) ("|": truncated Coulomb operator)
+                        CALL compute_3c_integrals(qs_env, bs_env, t_3c_for_Gvir, &
+                                                  atoms_AO_1=j_atoms, atoms_AO_2=IL_atoms)
+                        ! 5. tensor operation N_Qλν(iτ) = sum_σ (Qλ|σ) G^vir_νσ(i|τ|,k=0)
+                        CALL G_times_3c(t_3c_for_Gvir, t_2c_Gvir, t_3c_x_Gvir, bs_env, &
+                                        i_atoms, j_atoms, IL_atoms)
+                     END IF
                   END DO ! IL_atoms
 
                   ! 6. reorder tensors: M_Pνλ -> M_Pλν
@@ -616,7 +620,6 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_3c_integrals'
 
       INTEGER                                            :: handle
-      INTEGER, DIMENSION(2)                              :: my_atoms_AO_1, my_atoms_AO_2, my_atoms_RI
       TYPE(dbt_type), ALLOCATABLE, DIMENSION(:, :)       :: t_3c_array
 
       CALL timeset(routineN, handle)
@@ -626,22 +629,6 @@ CONTAINS
 
       ALLOCATE (t_3c_array(1, 1))
       CALL dbt_create(t_3c, t_3c_array(1, 1))
-
-      IF (PRESENT(atoms_AO_1)) THEN
-         my_atoms_AO_1 = atoms_AO_1
-      ELSE
-         my_atoms_AO_1 = [1, bs_env%n_atom]
-      END IF
-      IF (PRESENT(atoms_AO_2)) THEN
-         my_atoms_AO_2 = atoms_AO_2
-      ELSE
-         my_atoms_AO_2 = [1, bs_env%n_atom]
-      END IF
-      IF (PRESENT(atoms_RI)) THEN
-         my_atoms_RI = atoms_RI
-      ELSE
-         my_atoms_RI = [1, bs_env%n_atom]
-      END IF
 
       CALL build_3c_integrals(t_3c_array, &
                               bs_env%eps_filter, &
@@ -776,7 +763,7 @@ CONTAINS
 
       CALL get_qs_env(qs_env, cell=cell, particle_set=particle_set)
 
-      min_dist_AO_atoms = 1.0E5_dp
+      min_dist_AO_atoms = HUGE(1.0_dp)
       DO atom_1 = atoms_1(1), atoms_1(2)
          DO atom_2 = atoms_2(1), atoms_2(2)
             rab = pbc(particle_set(atom_1)%r(1:3), particle_set(atom_2)%r(1:3), cell)
@@ -2311,7 +2298,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      n_pairs = bs_env%n_intervals_i*bs_env%n_intervals_j
+      n_pairs = bs_env%n_intervals_i*bs_env%n_intervals_j*bs_env%n_spin
 
       CALL bs_env%para_env_tensor%sum(bs_env%n_skip_sigma)
       CALL bs_env%para_env_tensor%sum(bs_env%n_skip_chi)

--- a/src/gw_utils.F
+++ b/src/gw_utils.F
@@ -7,6 +7,8 @@
 
 ! **************************************************************************************************
 !> \brief
+!> \par History
+!>      01.2026 Maximilian Graml: add more bounds to exploit sparsity in 3c integrals, fixes
 !> \author Jan Wilhelm
 !> \date 07.2023
 ! **************************************************************************************************
@@ -811,7 +813,7 @@ CONTAINS
       CALL dbt_create(bs_env%t_RI_AO__AO, t_3c_global_array(1, 1))
 
       ! Allocate arrays to store min/max indices for overlap with other AO/RI functions on each atom
-      ! (Filled during loop)
+      ! (Filled during loop via get_i_j_atom_ranges)
       ALLOCATE (bs_env%min_RI_idx_from_AO_AO_atom(bs_env%n_atom, bs_env%n_atom))
       ALLOCATE (bs_env%max_RI_idx_from_AO_AO_atom(bs_env%n_atom, bs_env%n_atom))
       ALLOCATE (bs_env%min_AO_idx_from_RI_AO_atom(bs_env%n_atom, bs_env%n_atom))
@@ -862,13 +864,15 @@ CONTAINS
 
       t2 = m_walltime()
 
+      ! Sync/max for max_dist_AO_atoms is done inside each get_max_dist_AO_atoms
+      bs_env%max_dist_AO_atoms = max_dist_AO_atoms
+      ! occupation_sum is a global quantity, also needs no sync here
+      bs_env%occupation_3c_int = occupation_sum
+
       CALL bs_env%para_env%min(bs_env%min_RI_idx_from_AO_AO_atom)
       CALL bs_env%para_env%max(bs_env%max_RI_idx_from_AO_AO_atom)
       CALL bs_env%para_env%min(bs_env%min_AO_idx_from_RI_AO_atom)
       CALL bs_env%para_env%max(bs_env%max_AO_idx_from_RI_AO_atom)
-
-      bs_env%occupation_3c_int = occupation_sum
-      bs_env%max_dist_AO_atoms = max_dist_AO_atoms
 
       CALL dbt_destroy(t_3c_global_array(1, 1))
       DEALLOCATE (t_3c_global_array)
@@ -878,9 +882,9 @@ CONTAINS
          WRITE (bs_env%unit_nr, '(T2,A,F27.1,A)') &
             'Computed 3-center integrals (µν|P), execution time', t2 - t1, ' s'
          WRITE (bs_env%unit_nr, '(T2,A,F48.3,A)') 'Percentage of non-zero (µν|P)', &
-            occupation_sum*100, ' %'
+            bs_env%occupation_3c_int*100, ' %'
          WRITE (bs_env%unit_nr, '(T2,A,F33.1,A)') 'Max. distance between µ,ν in non-zero (µν|P)', &
-            max_dist_AO_atoms*angstrom, ' A'
+            bs_env%max_dist_AO_atoms*angstrom, ' A'
          WRITE (bs_env%unit_nr, '(T2,2A,I20,A)') 'Required memory if storing all 3-center ', &
             'integrals (µν|P)', INT(REAL(non_zero_elements_sum, KIND=dp)*8.0E-9_dp), ' GB'
       END IF
@@ -1093,7 +1097,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE get_max_dist_AO_atoms(t_3c_int, max_dist_AO_atoms, qs_env)
       TYPE(dbt_type)                                     :: t_3c_int
-      REAL(KIND=dp)                                      :: max_dist_AO_atoms
+      REAL(KIND=dp), INTENT(INOUT)                       :: max_dist_AO_atoms
       TYPE(qs_environment_type), POINTER                 :: qs_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'get_max_dist_AO_atoms'
@@ -1112,6 +1116,9 @@ CONTAINS
 
       NULLIFY (cell, particle_set, para_env)
       CALL get_qs_env(qs_env, cell=cell, particle_set=particle_set, para_env=para_env)
+
+      ! max_dist_AO_atoms is compared to earlier steps in the loop with step n_atom_step
+      ! do not initialize/overwrite here
 
 ! IMPORTANT: Use thread-local copy for max_dist_AO_atoms via REDUCTION to avoid race conditions
 !$OMP PARALLEL DEFAULT(NONE) &


### PR DESCRIPTION
This PR fixes a deviation in G0W0 gaps computed from the low-scaling GW module for different user-specified computational resource parameters.
The bug is related to the sizes of atom blocks, which are influenced, among other things, by the input keyword `MEMORY_PER_PROC` and the number of MPI ranks.