### PR TITLE
Improve docs for function strings

### DIFF
--- a/src/common/fparser.F
+++ b/src/common/fparser.F
@@ -28,7 +28,8 @@ MODULE fparser
              parsef, & ! Parse single function string
              evalf, & ! Evaluate single function
              finalizef, & ! Finalize the function parser
-             evalfd
+             evalfd, &
+             docf
    INTEGER, PUBLIC            :: EvalErrType ! =0: no error occurred, >0: evaluation error
    !------- -------- --------- --------- --------- --------- --------- --------- -------
    PRIVATE
@@ -1141,5 +1142,33 @@ CONTAINS
       END IF
       vals(ipar) = xval
    END FUNCTION evalfd
+   !
+! **************************************************************************************************
+!> \brief ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION docf() RESULT(doc)
+      !----- -------- --------- --------- --------- --------- --------- --------- -------
+      ! Returns documentation for function parser and its available operators and functions
+      !----- -------- --------- --------- --------- --------- --------- --------- -------
+      CHARACTER(LEN=:), ALLOCATABLE                      :: doc
+
+      INTEGER                                            :: i
+
+!----- -------- --------- --------- --------- --------- --------- --------- -------
+
+      doc = doc//"A functional form is specified. Mathematical Operators recognized are "
+      DO i = cAdd, cPow
+         IF (i > cAdd) doc = doc//", "
+         doc = doc//Ops(i)
+      END DO
+      doc = doc//" or alternatively **, whereas symbols for brackets must be (). The function"// &
+            " parser recognizes the Fortran 90 intrinsic functions "
+      DO i = cAbs, cErfc
+         IF (i > cAbs) doc = doc//", "
+         doc = doc//TRIM(Funcs(i))
+      END DO
+      doc = doc//". Parsing for intrinsic functions is not case sensitive."
+   END FUNCTION docf
 
 END MODULE fparser

--- a/src/input_cp2k_colvar.F
+++ b/src/input_cp2k_colvar.F
@@ -20,6 +20,7 @@ MODULE input_cp2k_colvar
                                               high_print_level,&
                                               low_print_level
    USE cp_units,                        ONLY: cp_unit_to_cp2k
+   USE fparser,                         ONLY: docf
    USE input_constants,                 ONLY: gaussian,&
                                               numerical,&
                                               rmsd_all,&
@@ -2071,7 +2072,7 @@ CONTAINS
       CPASSERT(.NOT. ASSOCIATED(section))
       CALL section_create(section, __LOCATION__, name="COMBINE_COLVAR", &
                           description="Allows the possibility to combine several COLVARs into one COLVAR "// &
-                          "with a generic function.", &
+                          "with a generic function. "//docf(), &
                           n_keywords=1, n_subsections=0, repeats=.FALSE.)
 
       NULLIFY (keyword, subsection)

--- a/src/input_cp2k_mm.F
+++ b/src/input_cp2k_mm.F
@@ -29,6 +29,7 @@ MODULE input_cp2k_mm
         do_ff_amber, do_ff_charmm, do_ff_cubic, do_ff_fues, do_ff_g87, do_ff_g96, do_ff_harmonic, &
         do_ff_legendre, do_ff_mixed_bend_stretch, do_ff_mm2, do_ff_mm3, do_ff_mm4, do_ff_morse, &
         do_ff_opls, do_ff_quartic, do_ff_undef
+   USE fparser,                         ONLY: docf
    USE input_constants,                 ONLY: use_mom_ref_coac,&
                                               use_mom_ref_com,&
                                               use_mom_ref_user,&
@@ -1300,11 +1301,7 @@ CONTAINS
       CPASSERT(.NOT. ASSOCIATED(section))
       CALL section_create(section, __LOCATION__, name="GENPOT", &
                           description="This section specifies the input parameters for a generic potential type. "// &
-                          "A functional form is specified. Mathematical Operators recognized are +, -, *, /, ** "// &
-                          "or alternatively ^, whereas symbols for brackets must be (). "// &
-                          "The function parser recognizes the (single argument) Fortran 90 intrinsic functions "// &
-                          "abs, exp, log10, log, sqrt, sinh, cosh, tanh, sin, cos, tan, asin, acos, atan, erf, erfc. "// &
-                          "Parsing for intrinsic functions is not case sensitive.", &
+                          docf(), &
                           n_keywords=1, n_subsections=0, repeats=.TRUE.)
 
       NULLIFY (keyword)

--- a/src/input_cp2k_mm.F
+++ b/src/input_cp2k_mm.F
@@ -1315,7 +1315,7 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="FUNCTION", &
                           description="Specifies the functional form in mathematical notation.", &
-                          usage="FUNCTION a*EXP(-b*x^2)/x+D*log10(x)", type_of_var=lchar_t, &
+                          usage="FUNCTION a\*EXP(-b\*x^2)/x+D\*log10(x)", type_of_var=lchar_t, &
                           n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)


### PR DESCRIPTION
**When merged this pull request will:**
- Refactor docs on function strings to `fparser::docf`, which compiles available operators and functions.
- Append `docf` result to `COMBINE_COLVAR` description.
- Fix asterisks getting interpreted as italic in `FUNCTION` usage of `GENPOT` section (https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/QMMM/FORCEFIELD/NONBONDED14/GENPOT.html#CP2K_INPUT.FORCE_EVAL.QMMM.FORCEFIELD.NONBONDED14.GENPOT.FUNCTION).