### PR TITLE
Toolchain: mark segments of setup file by source

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -900,15 +900,6 @@ export CP_CFLAGS=""
 export CP_LDFLAGS="-Wl,--enable-new-dtags"
 
 # ------------------------------------------------------------------------
-# Start writing setup file
-# ------------------------------------------------------------------------
-cat << EOF > "$SETUPFILE"
-#!/bin/bash
-source "${SCRIPTDIR}/tool_kit.sh"
-export CP2K_TOOLCHAIN_OPTIONS="${TOOLCHAIN_OPTIONS}"
-EOF
-
-# ------------------------------------------------------------------------
 # Special settings for CRAY Linux Environment (CLE)
 # TODO: CLE should be handle like gcc or Intel using a with_cray flag and
 #       this section should be moved to a separate file install_cray.
@@ -1032,6 +1023,18 @@ case ${GPUVER} in
     exit 1
     ;;
 esac
+
+# ------------------------------------------------------------------------
+# Start writing overall setup file
+# ------------------------------------------------------------------------
+cat << EOF > "$SETUPFILE"
+#!/bin/bash
+# This setup file is to be sourced before building and running CP2K.
+# Read tool_kit.sh for definitions and purposes of custom functions active
+# in current shell, such as prepend_path().
+source "${SCRIPTDIR}/tool_kit.sh"
+export CP2K_TOOLCHAIN_OPTIONS="${TOOLCHAIN_OPTIONS}"
+EOF
 
 write_toolchain_env ${INSTALLDIR}
 

--- a/tools/toolchain/scripts/stage0/install_amd.sh
+++ b/tools/toolchain/scripts/stage0/install_amd.sh
@@ -14,6 +14,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_amd" ] && rm "${BUILDDIR}/setup_amd"
 
+WHAT="AMD Compiler"
 AMD_CFLAGS=""
 AMD_LDFLAGS=""
 AMD_LIBS=""
@@ -22,12 +23,12 @@ cd "${BUILDDIR}"
 
 case "${with_amd}" in
   __INSTALL__)
-    echo "==================== Installing the AMD compiler ======================"
-    echo "__INSTALL__ is not supported; please install the AMD compiler manually"
+    echo "==================== Installing ${WHAT} ======================"
+    report_error ${LINENO} "__INSTALL__ is not supported; please install manually"
     exit 1
     ;;
   __SYSTEM__)
-    echo "==================== Finding AMD compiler from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command clang "amd" && CC="$(realpath $(command -v clang))" || exit 1
     check_command clang++ "amd" && CXX="$(realpath $(command -v clang++))" || exit 1
     check_command flang "amd" && FC="$(realpath $(command -v flang))" || exit 1
@@ -38,7 +39,7 @@ case "${with_amd}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking AMD compiler to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_amd}"
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
@@ -80,9 +81,11 @@ export AMD_CFLAGS="${AMD_CFLAGS}"
 export AMD_LDFLAGS="${AMD_LDFLAGS}"
 export AMD_LIBS="${AMD_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_amd" >> ${SETUPFILE}
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_amd"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage0/install_cmake.sh
+++ b/tools/toolchain/scripts/stage0/install_cmake.sh
@@ -14,12 +14,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_cmake" ] && rm "${BUILDDIR}/setup_cmake"
 
+WHAT="CMake"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_cmake}" in
   __INSTALL__)
-    echo "==================== Installing CMake ===================="
+    echo "==================== Installing ${WHAT} ===================="
     cmake_ver="3.31.7"
     cmake_ext="sh"
     if [ "${OPENBLAS_ARCH}" = "arm64" ]; then
@@ -63,14 +64,14 @@ case "${with_cmake}" in
     fi
     ;;
   __SYSTEM__)
-    echo "==================== Finding CMake from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command cmake "cmake"
     ;;
   __DONTUSE__)
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking CMake to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_cmake}"
     check_dir "${with_cmake}/bin"
     ;;
@@ -80,10 +81,12 @@ if [ "${with_cmake}" != "__DONTUSE__" ]; then
     cat << EOF > "${BUILDDIR}/setup_cmake"
 prepend_path PATH "${pkg_install_dir}/bin"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_cmake" >> $SETUPFILE
   fi
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_cmake"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage0/install_gcc.sh
+++ b/tools/toolchain/scripts/stage0/install_gcc.sh
@@ -19,6 +19,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_gcc" ] && rm "${BUILDDIR}/setup_gcc"
 
+WHAT="GCC"
 GCC_LDFLAGS=""
 GCC_CFLAGS=""
 TSANFLAGS=""
@@ -27,7 +28,7 @@ cd "${BUILDDIR}"
 
 case "${with_gcc}" in
   __INSTALL__)
-    echo "==================== Installing GCC ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/gcc-${gcc_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -120,7 +121,7 @@ case "${with_gcc}" in
     GCC_LDFLAGS="-L'${pkg_install_dir}/lib64' -L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib64' -Wl,-rpath,'${pkg_install_dir}/lib64'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding GCC from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command gcc "gcc" && CC="$(command -v gcc)" || exit 1
     check_command g++ "gcc" && CXX="$(command -v g++)" || exit 1
     check_command gfortran "gcc" && FC="$(command -v gfortran)" || exit 1
@@ -134,7 +135,7 @@ case "${with_gcc}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking GCC to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_gcc}"
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
@@ -180,6 +181,7 @@ export GCC_CFLAGS="${GCC_CFLAGS}"
 export GCC_LDFLAGS="${GCC_LDFLAGS}"
 export TSANFLAGS="${TSANFLAGS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_gcc" >> ${SETUPFILE}
 fi
 
@@ -216,6 +218,7 @@ export LSAN_OPTIONS=suppressions=${INSTALLDIR}/lsan.supp
 export TSAN_OPTIONS=suppressions=${INSTALLDIR}/tsan.supp
 EOF
 
+unset WHAT
 load "${BUILDDIR}/setup_gcc"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage0/install_intel.sh
+++ b/tools/toolchain/scripts/stage0/install_intel.sh
@@ -14,6 +14,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_intel" ] && rm "${BUILDDIR}/setup_intel"
 
+WHAT="Intel Compiler"
 INTEL_CFLAGS=""
 INTEL_LDFLAGS=""
 INTEL_LIBS=""
@@ -22,12 +23,12 @@ cd "${BUILDDIR}"
 
 case "${with_intel}" in
   __INSTALL__)
-    echo "==================== Installing the Intel compiler ===================="
-    echo "__INSTALL__ is not supported; please install the Intel compiler manually"
+    echo "==================== Installing ${WHAT} ===================="
+    report_error ${LINENO} "__INSTALL__ is not supported; please install manually"
     exit 1
     ;;
   __SYSTEM__)
-    echo "==================== Finding Intel compiler from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command icx "intel" && CC="$(realpath $(command -v icx))" || exit 1
     check_command icpx "intel" && CXX="$(realpath $(command -v icpx))" || exit 1
     if [ "${with_ifx}" = "yes" ]; then
@@ -42,7 +43,7 @@ case "${with_intel}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking Intel compiler to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_intel}"
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
@@ -85,9 +86,11 @@ export INTEL_CFLAGS="${INTEL_CFLAGS}"
 export INTEL_LDFLAGS="${INTEL_LDFLAGS}"
 export INTEL_LIBS="${INTEL_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_intel" >> ${SETUPFILE}
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_intel"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage0/install_ninja.sh
+++ b/tools/toolchain/scripts/stage0/install_ninja.sh
@@ -14,12 +14,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_ninja" ] && rm "${BUILDDIR}/setup_ninja"
 
+WHAT="Ninja"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_ninja}" in
   __INSTALL__)
-    echo "==================== Installing Ninja  ===================="
+    echo "==================== Installing ${WHAT} ===================="
     ninja_ver="1.13.1"
     ninja_sha256="f0055ad0369bf2e372955ba55128d000cfcc21777057806015b45e4accbebf23"
 
@@ -49,7 +50,7 @@ case "${with_ninja}" in
     fi
     ;;
   __SYSTEM__)
-    echo "==================== Finding Ninja from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command ninja "ninja"
     ;;
   __DONTUSE__)
@@ -57,7 +58,7 @@ case "${with_ninja}" in
     echo "Ninja required for DFTD4"
     ;;
   *)
-    echo "==================== Linking Ninja to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_ninja}"
     check_dir "${with_ninja}/bin"
     ;;
@@ -67,10 +68,12 @@ if [ "${with_ninja}" != "__DONTUSE__" ]; then
     cat << EOF > "${BUILDDIR}/setup_ninja"
 prepend_path PATH "${pkg_install_dir}/bin"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_ninja" >> $SETUPFILE
   fi
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_ninja"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_intelmpi.sh
@@ -15,6 +15,7 @@ source "${INSTALLDIR}"/toolchain.env
 [ ${MPI_MODE} != "intelmpi" ] && exit 0
 rm -f "${BUILDDIR}/setup_intelmpi"
 
+WHAT="Intel MPI"
 INTELMPI_CFLAGS=""
 INTELMPI_LDFLAGS=""
 INTELMPI_LIBS=""
@@ -23,12 +24,12 @@ cd "${BUILDDIR}"
 
 case "${with_intelmpi}" in
   __INSTALL__)
-    echo "==================== Installing Intel MPI ===================="
-    echo '__INSTALL__ is not supported; please manually install Intel MPI'
+    echo "==================== Installing ${WHAT} ===================="
+    report_error ${LINENO} "__INSTALL__ is not supported; please install manually"
     exit 1
     ;;
   __SYSTEM__)
-    echo "==================== Finding Intel MPI from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command mpiexec "intelmpi" && MPIEXEC="$(realpath $(command -v mpiexec))"
     if [ "${with_intel}" != "__DONTUSE__" ]; then
       if [ "${with_ifx}" = "yes" ]; then
@@ -56,7 +57,7 @@ case "${with_intelmpi}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking Intel MPI to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_intelmpi}"
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
@@ -123,9 +124,11 @@ prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path CPATH "${pkg_install_dir}/include"
 EOF
   fi
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_intelmpi" >> ${SETUPFILE}
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_intelmpi"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage1/install_mpich.sh
+++ b/tools/toolchain/scripts/stage1/install_mpich.sh
@@ -19,6 +19,7 @@ source "${INSTALLDIR}"/toolchain.env
 [ ${MPI_MODE} != "mpich" ] && exit 0
 [ -f "${BUILDDIR}/setup_mpich" ] && rm "${BUILDDIR}/setup_mpich"
 
+WHAT="MPICH"
 MPICH_CFLAGS=""
 MPICH_LDFLAGS=""
 MPICH_LIBS=""
@@ -27,7 +28,7 @@ cd "${BUILDDIR}"
 
 case "${with_mpich}" in
   __INSTALL__)
-    echo "==================== Installing MPICH ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/mpich-${mpich_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -78,7 +79,7 @@ case "${with_mpich}" in
     MPICH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding MPICH from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command mpiexec "mpich" && MPIEXEC="$(command -v mpiexec)"
     check_command mpicc "mpich" && MPICC="$(command -v mpicc)" || exit 1
     if [ $(command -v mpic++ > /dev/null 2>&1) ]; then
@@ -99,7 +100,7 @@ case "${with_mpich}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking MPICH to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_mpich}"
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
@@ -152,6 +153,7 @@ append_path CPATH "${pkg_install_dir}/include"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 EOF
   fi
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_mpich" >> ${SETUPFILE}
 fi
 
@@ -164,6 +166,7 @@ leak:MPIU_Find_local_and_external
 leak:MPL_malloc
 EOF
 
+unset WHAT
 load "${BUILDDIR}/setup_mpich"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -19,6 +19,7 @@ source "${INSTALLDIR}"/toolchain.env
 [ ${MPI_MODE} != "openmpi" ] && exit 0
 [ -f "${BUILDDIR}/setup_openmpi" ] && rm "${BUILDDIR}/setup_openmpi"
 
+WHAT="OpenMPI"
 OPENMPI_CFLAGS=""
 OPENMPI_LDFLAGS=""
 OPENMPI_LIBS=""
@@ -27,7 +28,7 @@ cd "${BUILDDIR}"
 
 case "${with_openmpi}" in
   __INSTALL__)
-    echo "==================== Installing OpenMPI ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/openmpi-${openmpi_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -82,7 +83,7 @@ case "${with_openmpi}" in
     OPENMPI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding OpenMPI from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command mpiexec "openmpi" && MPIEXEC="$(command -v mpiexec)"
     check_command mpicc "openmpi" && MPICC="$(command -v mpicc)" || exit 1
     check_command mpic++ "openmpi" && MPICXX="$(command -v mpic++)" || exit 1
@@ -98,7 +99,7 @@ case "${with_openmpi}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking OpenMPI to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_openmpi}"
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"
@@ -166,6 +167,7 @@ prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path CPATH "${pkg_install_dir}/include"
 EOF
   fi
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_openmpi" >> ${SETUPFILE}
 fi
 
@@ -229,6 +231,7 @@ leak:progress_engine
 leak:__GI___strdup
 EOF
 
+unset WHAT
 load "${BUILDDIR}/setup_openmpi"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage2/install_acml.sh
+++ b/tools/toolchain/scripts/stage2/install_acml.sh
@@ -14,6 +14,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_acml" ] && rm "${BUILDDIR}/setup_acml"
 
+WHAT="ACML"
 ACML_CFLAGS=''
 ACML_LDFLAGS=''
 ACML_LIBS=''
@@ -22,12 +23,12 @@ cd "${BUILDDIR}"
 
 case "$with_acml" in
   __INSTALL__)
-    echo "==================== Installing ACML ===================="
+    echo "==================== Installing ${WHAT} ===================="
     report_error $LINENO "To install ACML you should either contact your system administrator or go to https://developer.amd.com/tools-and-sdks/archive/amd-core-math-library-acml/acml-downloads-resources/ and download the correct version for your system."
     exit 1
     ;;
   __SYSTEM__)
-    echo "==================== Finding ACML from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lacml "ACML"
     add_include_from_paths ACML_CFLAGS "acml.h" $INCLUDE_PATHS
     add_lib_from_paths ACML_LDFLAGS "libacml.*" $LIB_PATHS
@@ -35,7 +36,7 @@ case "$with_acml" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking ACML to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_acml"
     check_dir "${pkg_install_dir}/lib"
     ACML_CFLAGS="-I'${pkg_install_dir}/include'"
@@ -51,6 +52,7 @@ prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path CPATH "$pkg_install_dir/include"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_acml" >> $SETUPFILE
   fi
   cat << EOF >> "${BUILDDIR}/setup_acml"
@@ -63,6 +65,7 @@ export MATH_LIBS="\${MATH_LIBS} ${ACML_LIBS}"
 EOF
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_acml"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage2/install_gmp.sh
+++ b/tools/toolchain/scripts/stage2/install_gmp.sh
@@ -1,19 +1,18 @@
 #!/bin/bash -e
 
+# TODO: Review and if possible fix shellcheck errors.
+# shellcheck disable=all
+
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
 gmp_ver="6.3.0"
 gmp_sha256="e56fd59d76810932a0555aa15a14b61c16bed66110d3c75cc2ac49ddaa9ab24c"
-# shellcheck disable=SC1091
+
 source "${SCRIPT_DIR}"/common_vars.sh
-# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/tool_kit.sh
-# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/signal_trap.sh
-# shellcheck disable=SC1091
 source "${INSTALLDIR}"/toolchain.conf
-# shellcheck disable=SC1091
 source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_gmp" ] && rm "${BUILDDIR}/setup_gmp"

--- a/tools/toolchain/scripts/stage2/install_gmp.sh
+++ b/tools/toolchain/scripts/stage2/install_gmp.sh
@@ -18,6 +18,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_gmp" ] && rm "${BUILDDIR}/setup_gmp"
 
+WHAT="GMP"
 GMP_CFLAGS=""
 GMP_LDFLAGS=""
 GMP_LIBS=""
@@ -26,7 +27,7 @@ cd "${BUILDDIR}"
 with_gmp=${with_gmp:__DONTUSE__}
 case "$with_gmp" in
   __INSTALL__)
-    echo "==================== Installing GMP ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/gmp-${gmp_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -59,7 +60,7 @@ case "$with_gmp" in
     GMP_LDFLAGS="-L'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding GMP from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lgmp "gmp"
     check_lib -lgmpxx "gmpxx"
     add_include_from_paths GMP_CFLAGS "gmp.h" "$INCLUDE_PATHS"
@@ -69,7 +70,7 @@ case "$with_gmp" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking GMP to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_gmp"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
@@ -101,9 +102,11 @@ export CP_LDFLAGS="\${CP_LDFLAGS} ${GMP_LDFLAGS}"
 export CP_LIBS="${GMP_LIBS} \${CP_LIBS}"
 export GMP_ROOT="${pkg_install_dir}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_gmp" >> "$SETUPFILE"
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_gmp"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage2/install_mkl.sh
+++ b/tools/toolchain/scripts/stage2/install_mkl.sh
@@ -14,6 +14,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_mkl" ] && rm "${BUILDDIR}/setup_mkl"
 
+WHAT="Intel MKL"
 MKL_CFLAGS=""
 MKL_LDFLAGS=""
 MKL_LIBS=""
@@ -29,12 +30,12 @@ cd "${BUILDDIR}"
 
 case "${with_mkl}" in
   __INSTALL__)
-    echo "==================== Installing MKL ===================="
-    report_error ${LINENO} "To install MKL, please contact your system administrator."
+    echo "==================== Installing ${WHAT} ===================="
+    report_error ${LINENO} "__INSTALL__ is not supported; please install manually"
     exit 1
     ;;
   __SYSTEM__)
-    echo "==================== Finding MKL from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     if ! [ -z "${MKLROOT}" ]; then
       echo "MKLROOT is found to be ${MKLROOT}"
     else
@@ -48,7 +49,7 @@ case "${with_mkl}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking MKL to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     check_dir "${with_mkl}"
     MKLROOT="${with_mkl}"
     ;;
@@ -128,9 +129,11 @@ export FFTW_LDFLAGS="${MKL_LDFLAGS}"
 export FFTW_LIBS="${MKL_LIBS}"
 EOF
   fi
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_mkl" >> ${SETUPFILE}
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_mkl"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage2/install_openblas.sh
+++ b/tools/toolchain/scripts/stage2/install_openblas.sh
@@ -18,12 +18,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_openblas" ] && rm "${BUILDDIR}/setup_openblas"
 
+WHAT="OpenBLAS"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_openblas}" in
   __INSTALL__)
-    echo "==================== Installing OpenBLAS ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/openblas-${openblas_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -102,7 +103,7 @@ case "${with_openblas}" in
     fi
     ;;
   __SYSTEM__)
-    echo "==================== Finding OpenBLAS from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     # assume that system openblas is threaded
     check_lib -lopenblas "OpenBLAS"
     pkg_install_dir=$(
@@ -121,7 +122,7 @@ case "${with_openblas}" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking OpenBLAS to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_openblas"
     check_dir "${pkg_install_dir}/include"
     check_dir "${pkg_install_dir}/lib"
@@ -159,9 +160,11 @@ export MATH_LIBS="\${MATH_LIBS} ${OPENBLAS_LIBS}"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_openblas" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_openblas"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage3/install_fftw.sh
+++ b/tools/toolchain/scripts/stage3/install_fftw.sh
@@ -18,13 +18,14 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_fftw" ] && rm "${BUILDDIR}/setup_fftw"
 
+WHAT="FFTW"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "$with_fftw" in
   __INSTALL__)
     require_env MPI_LIBS
-    echo "==================== Installing FFTW ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/fftw-${fftw_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
 
@@ -66,7 +67,7 @@ case "$with_fftw" in
     FFTW_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding FFTW from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lfftw3 "FFTW"
     check_lib -lfftw3_omp "FFTW"
     [ "${MPI_MODE}" != "no" ] && check_lib -lfftw3_mpi "FFTW"
@@ -83,7 +84,7 @@ case "$with_fftw" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking FFTW to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_fftw"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
@@ -119,6 +120,7 @@ export CP_LIBS="${FFTW_LIBS} \${CP_LIBS}"
 export FFTW_ROOT="${FFTW_ROOT:-${pkg_install_dir}}"
 export FFTW3_ROOT="${FFTW_ROOT:-${pkg_install_dir}}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_fftw" >> $SETUPFILE
 fi
 cd "${ROOTDIR}"
@@ -137,6 +139,7 @@ cat << EOF >> ${INSTALLDIR}/valgrind.supp
 }
 EOF
 
+unset WHAT
 load "${BUILDDIR}/setup_fftw"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -19,6 +19,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_greenx" ] && rm "${BUILDDIR}/setup_greenx"
 
+WHAT="GreenX"
 GREENX_CFLAGS=""
 GREENX_LDFLAGS=""
 GREENX_LIBS=""
@@ -28,7 +29,7 @@ with_greenx=${with_greenx:__DONTUSE__}
 with_gmp=${with_greenx:__DONTUSE__}
 case "$with_greenx" in
   __INSTALL__)
-    echo "==================== Installing GreenX ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/greenX-${greenx_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -69,7 +70,7 @@ case "$with_greenx" in
     GREENX_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding GreenX from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lGXCommon "greenx"
     check_lib -lgx_ac "greenx"
     check_lib -lgx_minimax "greenx"
@@ -77,7 +78,7 @@ case "$with_greenx" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking GreenX to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_greenx"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include/modules"
@@ -109,9 +110,11 @@ export CP_LDFLAGS="\${CP_LDFLAGS} ${GREENX_LDFLAGS}"
 export CP_LIBS="${GREENX_LIBS} \${CP_LIBS}"
 export GREENX_ROOT="${pkg_install_dir}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_greenx" >> "$SETUPFILE"
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_greenx"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -1,20 +1,18 @@
 #!/bin/bash -e
 
+# TODO: Review and if possible fix shellcheck errors.
+# shellcheck disable=all
+
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
 greenx_ver="2.2"
 greenx_sha256="cf0abb77cc84a3381a690a6ac7ca839da0007bb9e6120f3f25e47de50e29431f"
 
-# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/common_vars.sh
-# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/tool_kit.sh
-# shellcheck disable=SC1091
 source "${SCRIPT_DIR}"/signal_trap.sh
-# shellcheck disable=SC1091
 source "${INSTALLDIR}"/toolchain.conf
-# shellcheck disable=SC1091
 source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_greenx" ] && rm "${BUILDDIR}/setup_greenx"

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -36,6 +36,7 @@ esac
 
 [ -f "${BUILDDIR}/setup_libint" ] && rm "${BUILDDIR}/setup_libint"
 
+WHAT="LIBINT"
 LIBINT_CFLAGS=""
 LIBINT_LDFLAGS=""
 LIBINT_LIBS=""
@@ -44,7 +45,7 @@ cd "${BUILDDIR}"
 
 case "$with_libint" in
   __INSTALL__)
-    echo "==================== Installing LIBINT ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -104,7 +105,7 @@ case "$with_libint" in
     LIBINT_LDFLAGS="-L'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding LIBINT from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lint2 "libint"
     add_include_from_paths -p LIBINT_CFLAGS "libint" $INCLUDE_PATHS
     add_lib_from_paths LIBINT_LDFLAGS "libint2.*" $LIB_PATHS
@@ -112,7 +113,7 @@ case "$with_libint" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking LIBINT to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_libint"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
@@ -134,6 +135,7 @@ prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 export LIBINT2_ROOT="${pkg_install_dir}"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_libint" >> $SETUPFILE
   fi
   cat << EOF >> "${BUILDDIR}/setup_libint"
@@ -147,6 +149,7 @@ export CP_LIBS="${LIBINT_LIBS} \${CP_LIBS}"
 EOF
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_libint"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage3/install_libxc.sh
+++ b/tools/toolchain/scripts/stage3/install_libxc.sh
@@ -16,6 +16,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_libxc" ] && rm "${BUILDDIR}/setup_libxc"
 
+WHAT="LIBXC"
 LIBXC_CFLAGS=""
 LIBXC_LDFLAGS=""
 LIBXC_LIBS=""
@@ -24,7 +25,7 @@ cd "${BUILDDIR}"
 
 case "$with_libxc" in
   __INSTALL__)
-    echo "==================== Installing LIBXC ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/libxc-${libxc_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -59,7 +60,7 @@ case "$with_libxc" in
     LIBXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding LIBXC from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lxcf03 "libxc"
     check_lib -lxc "libxc"
     add_include_from_paths LIBXC_CFLAGS "xc.h" $INCLUDE_PATHS
@@ -68,7 +69,7 @@ case "$with_libxc" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking LIBXC to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_libxc"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
@@ -90,6 +91,7 @@ prepend_path CPATH "$pkg_install_dir/include"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_libxc" >> $SETUPFILE
   fi
   cat << EOF >> "${BUILDDIR}/setup_libxc"
@@ -104,6 +106,7 @@ export LIBXC_ROOT="${pkg_install_dir}"
 EOF
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_libxc"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -21,6 +21,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_cosma" ] && rm "${BUILDDIR}/setup_cosma"
 
+WHAT="COSMA"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
@@ -29,7 +30,7 @@ case "$with_cosma" in
     require_env OPENBLAS_ROOT
     require_env SCALAPACK_ROOT
 
-    echo "==================== Installing COSMA ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/COSMA-${cosma_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
 
@@ -221,7 +222,7 @@ case "$with_cosma" in
     COSMA_HIP_LDFLAGS="-L'${COSMA_HIP_LIBDIR}' -Wl,-rpath,'${COSMA_HIP_LIBDIR}'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding COSMA from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion cosma
     add_include_from_paths COSMA_CFLAGS "cosma.h" $INCLUDE_PATHS
     add_lib_from_paths COSMA_LDFLAGS "libcosma.*" $LIB_PATHS
@@ -229,7 +230,7 @@ case "$with_cosma" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking COSMA to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_cosma"
 
     # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
@@ -274,6 +275,7 @@ export COSMA_ROOT="$pkg_install_dir"
 export COSMA_INCLUDE_DIR="$pkg_install_dir/include"
 export CP_LIBS="IF_MPI(${COSMA_LIBS}|) \${CP_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_cosma" >> $SETUPFILE
 
   cat << EOF >> ${INSTALLDIR}/lsan.supp
@@ -285,6 +287,7 @@ leak:cosma::cosma_context<std::complex<double> >::register_state
 EOF
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_cosma"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -16,6 +16,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_libxsmm" ] && rm "${BUILDDIR}/setup_libxsmm"
 
+WHAT="LIBXSMM"
 LIBXSMM_CFLAGS=''
 LIBXSMM_LDFLAGS=''
 LIBXSMM_LIBS=''
@@ -24,7 +25,7 @@ cd "${BUILDDIR}"
 
 case "$with_libxsmm" in
   __INSTALL__)
-    echo "==================== Installing Libxsmm ===================="
+    echo "==================== Installing ${WHAT} ===================="
     if [[ ("$OPENBLAS_ARCH" != "x86_64") && ("$OPENBLAS_ARCH" != "arm64") ]]; then
       report_warning $LINENO "libxsmm is not supported on arch ${OPENBLAS_ARCH}"
       cat << EOF > "${BUILDDIR}/setup_libxsmm"
@@ -89,7 +90,7 @@ EOF
     LIBXSMM_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding Libxsmm from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lxsmm "libxsmm"
     check_lib -lxsmmf "libxsmm"
     check_lib -lxsmmext "libxsmm"
@@ -99,7 +100,7 @@ EOF
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking Libxsmm to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_libxsmm"
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/include"
@@ -121,6 +122,7 @@ prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_libxsmm" >> $SETUPFILE
   fi
   cat << EOF >> "${BUILDDIR}/setup_libxsmm"
@@ -135,6 +137,7 @@ EOF
 fi
 cd "${ROOTDIR}"
 
+unset WHAT
 load "${BUILDDIR}/setup_libxsmm"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage4/install_scalapack.sh
+++ b/tools/toolchain/scripts/stage4/install_scalapack.sh
@@ -18,12 +18,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_scalapack" ] && rm "${BUILDDIR}/setup_scalapack"
 
+WHAT="ScaLAPACK"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "$with_scalapack" in
   __INSTALL__)
-    echo "==================== Installing ScaLAPACK ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/scalapack-${scalapack_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -70,7 +71,7 @@ case "$with_scalapack" in
     SCALAPACK_LDFLAGS="-L${pkg_install_dir}/lib -Wl,-rpath,${pkg_install_dir}/lib"
     ;;
   __SYSTEM__)
-    echo "==================== Finding ScaLAPACK from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lscalapack "ScaLAPACK"
     pkg_install_dir=$(
       result=$(find_in_paths "libscalapack.a" $LIB_PATHS)
@@ -82,7 +83,7 @@ case "$with_scalapack" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking ScaLAPACK to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_scalapack"
     check_dir "${pkg_install_dir}/lib"
     SCALAPACK_LDFLAGS="-L${pkg_install_dir}/lib -Wl,-rpath,${pkg_install_dir}/lib"
@@ -111,6 +112,7 @@ export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__parallel|)"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${SCALAPACK_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(-lscalapack|) \${CP_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_scalapack" >> $SETUPFILE
 fi
 cd "${ROOTDIR}"
@@ -123,6 +125,7 @@ cat << EOF >> ${INSTALLDIR}/lsan.supp
 leak:pdpotrf_
 EOF
 
+unset WHAT
 load "${BUILDDIR}/setup_scalapack"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -18,6 +18,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_elpa" ] && rm "${BUILDDIR}/setup_elpa"
 
+WHAT="ELPA"
 ELPA_CFLAGS=''
 ELPA_LDFLAGS=''
 ELPA_LIBS=''
@@ -34,7 +35,7 @@ fi
 
 case "${with_elpa}" in
   __INSTALL__)
-    echo "==================== Installing ELPA ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/elpa-${elpa_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     enable_openmp="yes"
@@ -135,7 +136,7 @@ case "${with_elpa}" in
     ELPA_LDFLAGS="-L'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib' -Wl,-rpath,'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding ELPA from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lelpa_openmp "ELPA"
     # get the include paths
     elpa_include="$(find_in_paths "elpa_openmp-*" $INCLUDE_PATHS)"
@@ -152,7 +153,7 @@ case "${with_elpa}" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking ELPA to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_elpa"
     check_dir "${pkg_install_dir}/include"
     check_dir "${pkg_install_dir}/lib"
@@ -196,6 +197,7 @@ prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}/nvidia"
 EOF
     fi
   fi
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_elpa" >> $SETUPFILE
   cat << EOF >> "${BUILDDIR}/setup_elpa"
 export ELPA_CFLAGS="${ELPA_CFLAGS}"
@@ -210,6 +212,7 @@ EOF
 
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_elpa"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage6/install_ace.sh
+++ b/tools/toolchain/scripts/stage6/install_ace.sh
@@ -20,6 +20,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_ace" ] && rm "${BUILDDIR}/setup_ace"
 
+WHAT="ACE"
 ACE_LDFLAGS=''
 ACE_LIBS=''
 
@@ -28,7 +29,7 @@ cd "${BUILDDIR}"
 
 case "$with_ace" in
   __INSTALL__)
-    echo "==================== Installing Ace ======================="
+    echo "==================== Installing ${WHAT} ======================="
     pkg_install_dir="${INSTALLDIR}/${ace_dir}"
     install_lock_file="${pkg_install_dir}/install_successful"
     ace_root="${pkg_install_dir}"
@@ -86,17 +87,18 @@ case "$with_ace" in
     ACE_DFLAGS="-D__ACE ${ACE_CFLAGS}"
     ACE_LDFLAGS="-L'${pkg_install_dir}/lib'"
     ;;
-    #    not supported
-    #  __SYSTEM__)
-    #    echo "==================== Finding Ace from system paths ===================="
+  __SYSTEM__)
+    echo "==================== Finding ${WHAT} from system paths ===================="
+    report_error ${LINENO} "__SYSTEM__ is not supported"
+    exit 1
     #    check_lib -lace "ACE"
     #    add_lib_from_paths ACE_LDFLAGS "libpace*" $LIB_PATHS
     #    add_include_from_paths ACE_CFLAGS "ace" $INCLUDE_PATHS
     #    ACE_DFLAGS="-D__ACE"
-    #    ;;
+    ;;
   __DONTUSE__) ;;
   *)
-    echo "==================== Linking ACE to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_ace"
     check_dir "${pkg_install_dir}/include/ace"
     check_dir "${pkg_install_dir}/include/ace-evaluator"
@@ -121,6 +123,7 @@ prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_ace" >> $SETUPFILE
   fi
 
@@ -139,6 +142,7 @@ EOF
 #EOF
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_ace"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage6/install_deepmd.sh
+++ b/tools/toolchain/scripts/stage6/install_deepmd.sh
@@ -19,6 +19,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_deepmd" ] && rm "${BUILDDIR}/setup_deepmd"
 
+WHAT="DeePMD-kit"
 DEEPMD_LDFLAGS=''
 DEEPMD_LIBS=''
 
@@ -27,7 +28,7 @@ cd "${BUILDDIR}"
 
 case "$with_deepmd" in
   __INSTALL__)
-    echo "==================== Installing DeePMD ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/deepmd-kit-${deepmd_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
     deepmd_root="${pkg_install_dir}"
@@ -61,7 +62,7 @@ case "$with_deepmd" in
     DEEPMD_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,--no-as-needed -ldeepmd_c -Wl,-rpath='${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding DeePMD from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -ldeepmd "DEEPMD"
     add_lib_from_paths DEEPMD_LDFLAGS "libdeepmd*" $LIB_PATHS
     add_include_from_paths DEEPMD_CFLAGS "deepmd" $INCLUDE_PATHS
@@ -69,7 +70,7 @@ case "$with_deepmd" in
     ;;
   __DONTUSE__) ;;
   *)
-    echo "==================== Linking DEEPMD to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_deepmd"
     check_dir "${pkg_install_dir}/include/deepmd"
     check_dir "${pkg_install_dir}/lib"
@@ -91,6 +92,7 @@ prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_deepmd" >> $SETUPFILE
   fi
 
@@ -111,6 +113,7 @@ leak:deepmd::AtomMap::AtomMap
 EOF
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_deepmd"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage6/install_gsl.sh
+++ b/tools/toolchain/scripts/stage6/install_gsl.sh
@@ -16,12 +16,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_gsl" ] && rm "${BUILDDIR}/setup_gsl"
 
+WHAT="GSL"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "$with_gsl" in
   __INSTALL__)
-    echo "==================== Installing GSL ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/gsl-${gsl_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -51,7 +52,7 @@ case "$with_gsl" in
     GSL_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding GSL from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion gsl
     add_include_from_paths GSL_CFLAGS "gsl.h" $INCLUDE_PATHS
     add_lib_from_paths GSL_LDFLAGS "libgsl.*" $LIB_PATHS
@@ -60,7 +61,7 @@ case "$with_gsl" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking GSL to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_gsl"
     check_dir "$pkg_install_dir/lib"
     check_dir "$pkg_install_dir/include"
@@ -94,9 +95,11 @@ prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib64/pkgconfig"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 export CP_LIBS="IF_MPI(${GSL_LIBS}|) \${CP_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_gsl" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_gsl"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage6/install_libtorch.sh
+++ b/tools/toolchain/scripts/stage6/install_libtorch.sh
@@ -20,12 +20,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_libtorch" ] && rm "${BUILDDIR}/setup_libtorch"
 
+WHAT="LibTorch"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_libtorch}" in
   __INSTALL__)
-    echo "==================== Installing libtorch ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/libtorch-${libtorch_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
     archive_file="libtorch-cxx11-abi-shared-with-deps-${libtorch_ver}+cpu.zip"
@@ -51,7 +52,7 @@ case "${with_libtorch}" in
     LIBTORCH_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding libtorch from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -ltorch "libtorch"
     add_include_from_paths LIBTORCH_CXXFLAGS "libtorch.h" $INCLUDE_PATHS
     add_lib_from_paths LIBTORCH_LDFLAGS "libtorch.*" "$LIB_PATHS"
@@ -59,7 +60,7 @@ case "${with_libtorch}" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking libtorch to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_libtorch}"
 
     # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
@@ -96,7 +97,6 @@ export CXXFLAGS="\${CXXFLAGS} ${LIBTORCH_CXXFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${LIBTORCH_LDFLAGS}"
 export CP_LIBS="\${CP_LIBS} -lc10 -ltorch_cpu -ltorch"
 EOF
-    cat "${BUILDDIR}/setup_libtorch" >> "${SETUPFILE}"
   else
     cat << EOF >> "${BUILDDIR}/setup_libtorch"
 export CP_DFLAGS="\${CP_DFLAGS} -D__LIBTORCH"
@@ -104,10 +104,12 @@ export CXXFLAGS="\${CXXFLAGS} ${LIBTORCH_CXXFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${LIBTORCH_LDFLAGS}"
 export CP_LIBS="\${CP_LIBS} -lc10 -ltorch_cpu -ltorch"
 EOF
-    cat "${BUILDDIR}/setup_libtorch" >> "${SETUPFILE}"
   fi
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
+  cat "${BUILDDIR}/setup_libtorch" >> "${SETUPFILE}"
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_libtorch"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage6/install_plumed.sh
+++ b/tools/toolchain/scripts/stage6/install_plumed.sh
@@ -18,6 +18,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_plumed" ] && rm "${BUILDDIR}/setup_plumed"
 
+WHAT="PLUMED"
 PLUMED_LDFLAGS=''
 PLUMED_LIBS=''
 
@@ -32,7 +33,7 @@ fi
 
 case "$with_plumed" in
   __INSTALL__)
-    echo "==================== Installing PLUMED ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/plumed-${plumed_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -82,14 +83,14 @@ case "$with_plumed" in
     PLUMED_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding PLUMED from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lplumed "PLUMED"
     add_lib_from_paths PLUMED_LDFLAGS "libplumed*" $LIB_PATHS
     ;;
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking PLUMED to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_plumed"
     check_dir "${pkg_install_dir}/lib"
     PLUMED_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
@@ -114,6 +115,7 @@ prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_plumed" >> $SETUPFILE
   fi
   cat << EOF >> "${BUILDDIR}/setup_plumed"
@@ -126,6 +128,7 @@ export PLUMED_ROOT="${pkg_install_dir}"
 EOF
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_plumed"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage7/install_hdf5.sh
+++ b/tools/toolchain/scripts/stage7/install_hdf5.sh
@@ -17,12 +17,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_hdf5" ] && rm "${BUILDDIR}/setup_hdf5"
 
+WHAT="HDF5"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "$with_hdf5" in
   __INSTALL__)
-    echo "==================== Installing HDF5 ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/hdf5-${hdf5_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -55,7 +56,7 @@ case "$with_hdf5" in
     HDF5_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding HDF5 from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion hdf5
     pkg_install_dir=$(h5cc -showconfig | grep "Installation point" | awk '{print $3}')
     if [ -d ${pkg_install_dir}/include ]; then
@@ -75,7 +76,7 @@ case "$with_hdf5" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking HDF5 to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_hdf5}"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
@@ -131,9 +132,11 @@ export HDF5_LIBRARIES="${HDF5_LIBS}"
 export HDF5_HL_LIBRARIES="${HDF5_LIBS}"
 export HDF5_INCLUDE_DIRS="${pkg_install_dir}/include"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_hdf5" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_hdf5"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage7/install_libsmeagol.sh
+++ b/tools/toolchain/scripts/stage7/install_libsmeagol.sh
@@ -16,6 +16,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_libsmeagol" ] && rm "${BUILDDIR}/setup_libsmeagol"
 
+WHAT="libsmeagol"
 LIBSMEAGOL_CFLAGS=""
 LIBSMEAGOL_LDFLAGS=""
 LIBSMEAGOL_LIBS=""
@@ -30,7 +31,7 @@ fi
 
 case "${with_libsmeagol}" in
   __INSTALL__)
-    echo "==================== Installing libsmeagol ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/libsmeagol-${libsmeagol_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -68,13 +69,13 @@ case "${with_libsmeagol}" in
     LIBSMEAGOL_LDFLAGS="-L${pkg_install_dir}/lib -Wl,-rpath,${pkg_install_dir}/lib"
     ;;
   __SYSTEM__)
-    echo "==================== Finding libsmeagol from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     echo "Please rerun the toolchain using --with-libsmeagol=<path> option"
     exit 1
     ;;
   __DONTUSE__) ;;
   *)
-    echo "==================== Linking libsmeagol to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_libsmeagol}"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/obj"
@@ -108,9 +109,11 @@ export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${LIBSMEAGOL_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(${LIBSMEAGOL_LIBS}|) \${CP_LIBS}"
 export LIBSMEAGOL_ROOT="${pkg_install_dir}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_libsmeagol" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_libsmeagol"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage7/install_libvdwxc.sh
+++ b/tools/toolchain/scripts/stage7/install_libvdwxc.sh
@@ -16,6 +16,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_libvdwxc" ] && rm "${BUILDDIR}/setup_libvdwxc"
 
+WHAT="libvdwxc"
 if [ "$MPI_MODE" = "no" ] && [ $with_sirius = "__FALSE__" ]; then
   report_warning $LINENO "MPI and SIRIUS are disabled, skipping libvdwxc installation"
   exit 0
@@ -29,7 +30,7 @@ case "$with_libvdwxc" in
     require_env FFTW3_INCLUDES
     require_env FFTW3_LIBS
 
-    echo "==================== Installing libvdwxc ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/libvdwxc-${libvdwxc_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -80,7 +81,7 @@ case "$with_libvdwxc" in
     LIBVDWXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding libvdwxc from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion libvdwxc
     add_include_from_paths LIBVDWXC_CFLAGS "vdwxc.h" $INCLUDE_PATHS
     add_lib_from_paths LIBVDWXC_LDFLAGS "libvdwxc*" $LIB_PATHS
@@ -89,7 +90,7 @@ case "$with_libvdwxc" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking libvdwxc to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_libvdwxc"
     check_dir "$pkg_install_dir/lib"
     check_dir "$pkg_install_dir/include"
@@ -120,9 +121,11 @@ export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${LIBVDWXC_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(${LIBVDWXC_LIBS}|) \${CP_LIBS}"
 export VDWXC_ROOT="${pkg_install_dir}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_libvdwxc" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_libvdwxc"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage7/install_libvori.sh
+++ b/tools/toolchain/scripts/stage7/install_libvori.sh
@@ -19,12 +19,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_libvori" ] && rm "${BUILDDIR}/setup_libvori"
 
+WHAT="libvori"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_libvori:=__INSTALL__}" in
   __INSTALL__)
-    echo "==================== Installing libvori ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/libvori-${libvori_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -58,14 +59,14 @@ case "${with_libvori:=__INSTALL__}" in
     LIBVORI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding libvori from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lvori "libvori"
     add_lib_from_paths LIBVORI_LDFLAGS "libvori.*" "$LIB_PATHS"
     ;;
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking libvori to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_libvori}"
 
     # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
@@ -99,9 +100,11 @@ export CP_DFLAGS="\${CP_DFLAGS} -D__LIBVORI"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${LIBVORI_LDFLAGS}"
 export CP_LIBS="\${CP_LIBS} ${LIBVORI_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_libvori" >> "${SETUPFILE}"
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_libvori"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage7/install_spglib.sh
+++ b/tools/toolchain/scripts/stage7/install_spglib.sh
@@ -16,12 +16,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_spglib" ] && rm "${BUILDDIR}/setup_spglib"
 
+WHAT="Spglib"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "$with_spglib" in
   __INSTALL__)
-    echo "==================== Installing Spglib ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/spglib-${spglib_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -63,7 +64,7 @@ case "$with_spglib" in
     fi
     ;;
   __SYSTEM__)
-    echo "==================== Finding Spglib from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion spglib
     add_include_from_paths SPGLIB_CFLAGS "spglib.h" $INCLUDE_PATHS
     add_lib_from_paths SPGLIB_LDFLAGS "libspglib.*" $LIB_PATHS
@@ -71,7 +72,7 @@ case "$with_spglib" in
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking Spglib to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_spglib"
     check_dir "$pkg_install_dir/lib"
     check_dir "$pkg_install_dir/include"
@@ -100,9 +101,11 @@ export CP_CFLAGS="\${CP_CFLAGS} ${SPGLIB_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${SPGLIB_LDFLAGS}"
 export CP_LIBS="${SPGLIB_LIBS} \${CP_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_spglib" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_spglib"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage8/install_dftd4.sh
+++ b/tools/toolchain/scripts/stage8/install_dftd4.sh
@@ -17,6 +17,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_dftd4" ] && rm "${BUILDDIR}/setup_dftd4"
 
+WHAT="DFTD4"
 DFTD4_DFLAGS=''
 DFTD4_CFLAGS=''
 DFTD4_LDFLAGS=''
@@ -28,7 +29,7 @@ case "$with_dftd4" in
   __DONTUSE__) ;;
 
   __INSTALL__)
-    echo "==================== Installing DFTD4 ===================="
+    echo "==================== Installing ${WHAT} ===================="
     require_env OPENBLAS_ROOT
     require_env MATH_LIBS
 
@@ -69,7 +70,7 @@ case "$with_dftd4" in
     ;;
 
   __SYSTEM__)
-    echo "==================== Finding DFTD4 from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion dftd4
     add_include_from_paths DFTD4_CFLAGS "dftd4.h" $INCLUDE_PATHS
     add_include_from_paths DFTD4_CFLAGS "dftd4.mod" $INCLUDE_PATHS
@@ -78,7 +79,7 @@ case "$with_dftd4" in
     ;;
 
   *)
-    echo "==================== Linking DFTD4 to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_dftd4"
     check_dir "${pkg_install_dir}/include"
     ;;
@@ -137,9 +138,11 @@ export CP_CFLAGS="\${CP_CFLAGS} \${DFTD4_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} \${DFTD4_LDFLAGS}"
 export CP_LIBS="\${DFTD4_LIBS} \${CP_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_dftd4" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_dftd4"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage8/install_mcl.sh
+++ b/tools/toolchain/scripts/stage8/install_mcl.sh
@@ -19,12 +19,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_mcl" ] && rm "${BUILDDIR}/setup_mcl"
 
+WHAT="MCL"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_mcl:=__INSTALL__}" in
   __INSTALL__)
-    echo "==================== Installing MCL ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/mcl-${mcl_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -102,7 +103,7 @@ EOF
     MCL_LDFLAGS="-L'${pkg_install_dir}/lib/MiMiC' -Wl,-rpath,'${pkg_install_dir}/lib/MiMiC'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding MCL from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -lmclf "mcl"
     add_lib_from_paths MCL_LDFLAGS "mclf.*" "$LIB_PATHS"
     add_lib_from_paths MCL_LDFLAGS "mcl.*" "$LIB_PATHS"
@@ -110,7 +111,7 @@ EOF
   __DONTUSE__) ;;
 
   *)
-    echo "==================== Linking MCL to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_mcl}"
 
     # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
@@ -144,9 +145,11 @@ export CP_DFLAGS="\${CP_DFLAGS} -D__MIMIC"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${MCL_LDFLAGS}"
 export CP_LIBS="\${CP_LIBS} ${MCL_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_mcl" >> "${SETUPFILE}"
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_mcl"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage8/install_pugixml.sh
+++ b/tools/toolchain/scripts/stage8/install_pugixml.sh
@@ -16,12 +16,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_pugixml" ] && rm "${BUILDDIR}/setup_pugixml"
 
+WHAT="pugixml"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_pugixml}" in
   __INSTALL__)
-    echo "==================== Installing pugixml ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/pugixml-${pugixml_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -53,7 +54,7 @@ case "${with_pugixml}" in
     PUGIXML_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding pugixml from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion pugixml
     add_include_from_paths PUGIXML_CFLAGS "pugixml.hpp" ${INCLUDE_PATHS}
     add_lib_from_paths PUGIXML_LDFLAGS "libpugixml.*" ${LIB_PATHS}
@@ -62,7 +63,7 @@ case "${with_pugixml}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking pugixml to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_pugixml}"
     # Use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
     PUGIXML_LIBDIR="${pkg_install_dir}/lib"
@@ -97,9 +98,11 @@ export CP_CFLAGS="\${CP_CFLAGS} ${PUGIXML_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${PUGIXML_LDFLAGS}"
 export CP_LIBS="IF_MPI(${PUGIXML_LIBS}|) \${CP_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_pugixml" >> ${SETUPFILE}
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_pugixml"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage8/install_sirius.sh
+++ b/tools/toolchain/scripts/stage8/install_sirius.sh
@@ -23,6 +23,7 @@ fi
 
 [ -f "${BUILDDIR}/setup_sirius" ] && rm "${BUILDDIR}/setup_sirius"
 
+WHAT="SIRIUS"
 SIRIUS_CFLAGS=''
 SIRIUS_LDFLAGS=''
 SIRIUS_LIBS=''
@@ -33,7 +34,7 @@ case "$with_sirius" in
   __DONTUSE__) ;;
 
   __INSTALL__)
-    echo "==================== Installing SIRIUS ===================="
+    echo "==================== Installing ${WHAT} ===================="
     require_env FFTW_LDFLAGS
     require_env FFTW_LIBS
     require_env FFTW_CFLAGS
@@ -199,6 +200,7 @@ case "$with_sirius" in
     fi
     ;;
   __SYSTEM__)
+    echo "==================== Finding ${WHAT} from system paths ===================="
     require_env FFTW_LDFLAGS
     require_env FFTW_LIBS
     require_env FFTW_CFLAGS
@@ -244,7 +246,7 @@ case "$with_sirius" in
     add_lib_from_paths SIRIUS_LDFLAGS "libsirius_cxx.*" $LIB_PATHS
     ;;
   *)
-    echo "==================== Linking SIRIUS_Dist to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_sirius"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/lib64"
@@ -271,6 +273,7 @@ prepend_path CPATH "${pkg_install_dir}/include/sirius"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
+    echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
     cat "${BUILDDIR}/setup_sirius" >> $SETUPFILE
   fi
   cat << EOF >> "${BUILDDIR}/setup_sirius"
@@ -293,6 +296,7 @@ leak:sirius::sddk::memory_block_descriptor::free_subblock
 EOF
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_sirius"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage8/install_spfft.sh
+++ b/tools/toolchain/scripts/stage8/install_spfft.sh
@@ -16,12 +16,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_SpFFT" ] && rm "${BUILDDIR}/setup_SpFFT"
 
+WHAT="SpFFT"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_spfft}" in
   __INSTALL__)
-    echo "==================== Installing SpFFT ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/SpFFT-${spfft_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -147,7 +148,7 @@ case "${with_spfft}" in
     SPFFT_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath,'${pkg_install_dir}/lib/cuda'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding SpFFT from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion spfft
     add_include_from_paths SPFFT_CFLAGS "spfft.h" $INCLUDE_PATHS
     add_lib_from_paths SPFFT_LDFLAGS "libspfft.*" $LIB_PATHS
@@ -156,7 +157,7 @@ case "${with_spfft}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking SpFFT to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_spfft"
 
     # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
@@ -197,9 +198,11 @@ export SpFFT_ROOT="${pkg_install_dir}"
 export SPFFT_INCLUDE_DIR="${pkg_install_dir}/include"
 export CP_LIBS="IF_MPI(${SPFFT_LIBS}|) \${CP_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_spfft" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_spfft"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -16,12 +16,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_SpLA" ] && rm "${BUILDDIR}/setup_SpLA"
 
+WHAT="SpLA"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_spla}" in
   __INSTALL__)
-    echo "==================== Installing SpLA ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/SpLA-${spla_ver}"
     install_lock_file="$pkg_install_dir/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -127,7 +128,7 @@ case "${with_spla}" in
     SPLA_HIP_LDFLAGS="-L'${pkg_install_dir}/lib/hip' -Wl,-rpath,'${pkg_install_dir}/lib/hip'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding SpLA from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion spla
     add_include_from_paths SPLA_CFLAGS "spla.h" $INCLUDE_PATHS
     add_lib_from_paths SPLA_LDFLAGS "libspla.*" $LIB_PATHS
@@ -136,7 +137,7 @@ case "${with_spla}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking SpLA to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_spla"
 
     # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
@@ -190,9 +191,11 @@ EOF
 export CP_LDFLAGS="\${CP_LDFLAGS} ${SPLA_LDFLAGS}"
 EOF
   fi
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_spla" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_spla"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage8/install_tblite.sh
+++ b/tools/toolchain/scripts/stage8/install_tblite.sh
@@ -17,6 +17,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_tblite" ] && rm "${BUILDDIR}/setup_tblite"
 
+WHAT="tblite"
 TBLITE_DFLAGS=''
 TBLITE_CFLAGS=''
 TBLITE_LDFLAGS=''
@@ -28,7 +29,7 @@ case "$with_tblite" in
   __DONTUSE__) ;;
 
   __INSTALL__)
-    echo "==================== Installing tblite ===================="
+    echo "==================== Installing ${WHAT} ===================="
     require_env OPENBLAS_ROOT
     require_env MATH_LIBS
 
@@ -69,7 +70,7 @@ case "$with_tblite" in
     ;;
 
   __SYSTEM__)
-    echo "==================== Finding tblite from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_command pkg-config --modversion tblite
     add_include_from_paths TBLITE_CFLAGS "tblite.h" $INCLUDE_PATHS
     add_include_from_paths TBLITE_CFLAGS "tblite.mod" $INCLUDE_PATHS
@@ -78,7 +79,7 @@ case "$with_tblite" in
     ;;
 
   *)
-    echo "==================== Linking TBLITE to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_tblite"
     check_dir "${pkg_install_dir}/include"
     ;;
@@ -145,9 +146,11 @@ export CP_CFLAGS="\${CP_CFLAGS} \${TBLITE_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} \${TBLITE_LDFLAGS}"
 export CP_LIBS="\${TBLITE_LIBS} \${CP_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_tblite" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_tblite"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage8/install_trexio.sh
+++ b/tools/toolchain/scripts/stage8/install_trexio.sh
@@ -17,6 +17,7 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_trexio" ] && rm "${BUILDDIR}/setup_trexio"
 
+WHAT="TREXIO"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
@@ -24,7 +25,7 @@ case "$with_trexio" in
   __DONTUSE__) ;;
 
   __INSTALL__)
-    echo "==================== Installing TREXIO ===================="
+    echo "==================== Installing ${WHAT} ===================="
     require_env HDF5_LIBS
     require_env HDF5_CFLAGS
     require_env HDF5_LDFLAGS
@@ -57,7 +58,7 @@ case "$with_trexio" in
     TREXIO_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
-    echo "==================== Finding trexio from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     require_env HDF5_LIBS
     require_env HDF5_CFLAGS
     require_env HDF5_LDFLAGS
@@ -66,7 +67,7 @@ case "$with_trexio" in
     add_lib_from_paths trexio_LDFLAGS "libtrexio.*" $LIB_PATHS
     ;;
   *)
-    echo "==================== Linking TREXIO to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="$with_trexio"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
@@ -98,9 +99,11 @@ export CP_CFLAGS="\${CP_CFLAGS} ${TREXIO_CFLAGS}"
 export CP_LDFLAGS="\${CP_LDFLAGS} ${TREXIO_LDFLAGS}"
 export CP_LIBS="${TREXIO_LIBS} \${CP_LIBS}"
 EOF
+  echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
   cat "${BUILDDIR}/setup_trexio" >> $SETUPFILE
 fi
 
+unset WHAT
 load "${BUILDDIR}/setup_trexio"
 write_toolchain_env "${INSTALLDIR}"
 

--- a/tools/toolchain/scripts/stage9/install_dbcsr.sh
+++ b/tools/toolchain/scripts/stage9/install_dbcsr.sh
@@ -16,12 +16,13 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_dbcsr" ] && rm "${BUILDDIR}/setup_dbcsr"
 
+WHAT="DBCSR"
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 case "${with_dbcsr}" in
   __INSTALL__)
-    echo "==================== Installing DBCSR ===================="
+    echo "==================== Installing ${WHAT} ===================="
     pkg_install_dir="${INSTALLDIR}/dbcsr-${dbcsr_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
     if verify_checksums "${install_lock_file}"; then
@@ -94,7 +95,7 @@ case "${with_dbcsr}" in
     fi
     ;;
   __SYSTEM__)
-    echo "==================== Finding DBCSR from system paths ===================="
+    echo "==================== Finding ${WHAT} from system paths ===================="
     check_lib -ldbcsr "dbcsr"
     add_include_from_paths DBCSR_CFLAGS "dbcsr.h" $INCLUDE_PATHS
     add_lib_from_paths DBCSR_LDFLAGS "dbcsr.*" $LIB_PATHS
@@ -103,7 +104,7 @@ case "${with_dbcsr}" in
     # Nothing to do
     ;;
   *)
-    echo "==================== Linking DBCSR to user paths ===================="
+    echo "==================== Linking ${WHAT} to user paths ===================="
     pkg_install_dir="${with_dbcsr}"
     DBCSR_LIBDIR="${pkg_install_dir}/lib"
     check_dir "${DBCSR_LIBDIR}"
@@ -148,9 +149,10 @@ EOF
 else
   touch "${BUILDDIR}/setup_dbcsr"
 fi
-
+echo "# ==================== For ${WHAT} ==================== #" >> ${SETUPFILE}
 cat "${BUILDDIR}/setup_dbcsr" >> ${SETUPFILE}
 
+unset WHAT
 load "${BUILDDIR}/setup_dbcsr"
 write_toolchain_env "${INSTALLDIR}"
 


### PR DESCRIPTION
Related to fourth item in the task list of #4667: a delimiter marking start of
configurations from each individual setup files is now written to the overall
setup file so as to make it more human readable and dependency handling easier.
A variable WHAT is now used to refer to the package name in each install script.