### PR TITLE
Fix OpenMP in qs_moment_kpoints

### DIFF
--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -3722,9 +3722,9 @@ CONTAINS
       ALLOCATE (dipole_to_store(nspin, num_copy, 3, nao, nao), source=z_zero)
       ALLOCATE (bc_to_store(nspin, num_copy, 3, nao), source=0.0_dp)
 
-!$OMP PARALLEL PRIVATE(ikp, S_k, H_k, eigenvals, C_k, &
+!$OMP PARALLEL DEFAULT(NONE) PRIVATE(ispin, ikp, S_k, H_k, eigenvals, C_k, &
 !$OMP dS_dk_i, dH_dk_i, D_k, dip, bc, C_dS_C, C_dH_C, CDC, tmp_max, phase) &
-!$OMP SHARED(num_pe, mepos, dipole_to_store, bc_to_store, nmo, nao, ispin, &
+!$OMP SHARED(num_pe, mepos, dipole_to_store, bc_to_store, nmo, nao, nspin, &
 !$OMP nkp, xkp, S_rs, H_rs, D_rs, index_to_cell_all, hmat)
       ALLOCATE (dS_dk_i(nao, nao), C_dS_C(nao, nao), dH_dk_i(nao, nao), C_dH_C(nao, nao), source=z_zero)
       ALLOCATE (CDC(nao, nao), dip(3, nao, nao), S_k(nao, nao), H_k(nao, nao), source=z_zero)

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -256,12 +256,6 @@ topology_pdb.F: Found READ with unchecked STAT in "read_coordinate_pdb" https://
 trexio.F: Found STOP statement in procedure "trexio_assert" https://cp2k.org/conv#c205
 trexio.F: Found WRITE statement with hardcoded unit in "trexio_assert" https://cp2k.org/conv#c012
 trexio_utils.F: Module "trexio" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
-xc.F: Found CLOSE statement in procedure "xc_vxc_pw_create_debug" https://cp2k.org/conv#c204
-xc.F: Found CLOSE statement in procedure "xc_vxc_pw_create_test_lsd" https://cp2k.org/conv#c204
-xc.F: Found OPEN statement in procedure "xc_vxc_pw_create_debug" https://cp2k.org/conv#c203
-xc.F: Found OPEN statement in procedure "xc_vxc_pw_create_test_lsd" https://cp2k.org/conv#c203
-xc.F: Found WRITE statement with hardcoded unit in "xc_vxc_pw_create_debug" https://cp2k.org/conv#c012
-xc.F: Found WRITE statement with hardcoded unit in "xc_vxc_pw_create_test_lsd" https://cp2k.org/conv#c012
 xyz2dcd.F: Found CLOSE statement in procedure "xyz2dcd" https://cp2k.org/conv#c204
 xyz2dcd.F: Found OPEN statement in procedure "xyz2dcd" https://cp2k.org/conv#c203
 xyz2dcd.F: Found STOP statement in procedure "abort_program" https://cp2k.org/conv#c205


### PR DESCRIPTION
Follow up to #4738.

I noticed that `ispin` was declared as shared, which is most likely a bug. Hence, I've now moved it to private.

CC: @ShridharShanbhag