### PR TITLE
Add spack based fedora:43 psmp tester

### DIFF
--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -316,6 +316,13 @@ timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-4x2_report.txt
 
+[spack-psmp-fedora]
+sortkey:     1042
+name:        Spack (psmp, fedora)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-fedora_report.txt
+
 [spack-psmp-gcc10]
 sortkey:     1045
 name:        Spack (psmp, GCC 10)

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -374,6 +374,14 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-4x2
 
+[spack-psmp-fedora]
+display_name: Spack (psmp, fedora)
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-fedora
+
 [spack-psmp-gcc10]
 display_name: Spack (psmp, GCC 10)
 tags:         weekly-afternoon


### PR DESCRIPTION
Fedora:43 provides GCC 15.2.1 which includes backports and fixes missing in the GCC 15.2.0 version