### PR TITLE
CMake: Restore creation of popt/sopt symlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1259,3 +1259,20 @@ install(
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/cp2k"
   FILES_MATCHING
   PATTERN "*.cmake")
+
+# Create symlink: psmp -> popt, ssmp -> sopt
+foreach(__ext_pair "psmp:popt" "ssmp:sopt")
+  string(REPLACE ":" ";" __ext_list ${__ext_pair})
+  list(GET __ext_list 0 __src_ext)
+  list(GET __ext_list 1 __link_ext)
+  if(__cp2k_ext MATCHES ${__src_ext})
+    install(
+      CODE "
+      message(STATUS \"Creating symlink: cp2k.${__link_ext} -> cp2k.${__src_ext}\")
+      execute_process(
+        COMMAND ${CMAKE_COMMAND} -E create_symlink
+          cp2k.${__src_ext}
+          \${CMAKE_INSTALL_PREFIX}/bin/cp2k.${__link_ext})
+    ")
+  endif()
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1260,7 +1260,7 @@ install(
   FILES_MATCHING
   PATTERN "*.cmake")
 
-# Create symlink: psmp -> popt, ssmp -> sopt
+# Create symlink: popt -> psmp, sopt -> ssmp
 foreach(__ext_pair "psmp:popt" "ssmp:sopt")
   string(REPLACE ":" ";" __ext_list ${__ext_pair})
   list(GET __ext_list 0 __src_ext)


### PR DESCRIPTION
Previously, the popt/sopt symlink was created by the old GNU Makefile, but this step was missing after the transition to CMake. This change restores that behavior.