### PR TITLE
Toolchain: remove some legacy mentions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,9 +30,6 @@ or run in a subshell with:
 Note: it is recommended to install podman to take advantage of a spack cache. This will accelerate
 the build of the CP2K dependencies with Spack significantly.
 
-For more about building CP2K with Spack, see
-[manual](https://manual.cp2k.org/trunk/getting-started/build-with-spack.html).
-
 ### Method 2: Toolchain
 
 Alternatively, the [toolchain script](./tools/toolchain/install_cp2k_toolchain.sh) can also be run

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,8 @@ For more details on downloading CP2K, see <https://www.cp2k.org/download>.
 
 ## 2. Install prerequisites
 
+### Method 1: Spack
+
 The easiest way to build CP2K with all its dependencies is via the `make_cp2k.sh` script, which
 builds CP2K using Spack and CMake locally within the CP2K_ROOT folder.
 
@@ -27,6 +29,11 @@ or run in a subshell with:
 
 Note: it is recommended to install podman to take advantage of a spack cache. This will accelerate
 the build of the CP2K dependencies with Spack significantly.
+
+For more about building CP2K with Spack, see
+[manual](https://manual.cp2k.org/trunk/getting-started/build-with-spack.html).
+
+### Method 2: Toolchain
 
 Alternatively, the [toolchain script](./tools/toolchain/install_cp2k_toolchain.sh) can also be run
 directly.
@@ -50,14 +57,14 @@ a range of devices). If you wish to build with GPU support, please see the
 
 ```shell
 ./install_cp2k_toolchain.sh --with-libxsmm=install --with-openblas=system \
-     --with-fftw=system --with-reflapack=no  --enable-cuda
+     --with-fftw=system  --enable-cuda
 ```
 
 - For AMD/ROCm/HIP support, use:
 
 ```shell
 ./install_cp2k_toolchain.sh --with-libxsmm=install --with-openblas=system \
-     --with-fftw=system --with-reflapack=no  --enable-hip
+     --with-fftw=system  --enable-hip
 ```
 
 ## 3. Compile

--- a/tools/toolchain/README.md
+++ b/tools/toolchain/README.md
@@ -114,7 +114,6 @@ proprietary software packages, like e.g. MKL, these have to be installed separat
 | openblas  | [BSD 3-Clause](https://github.com/xianyi/OpenBLAS/blob/develop/LICENSE)            | Yes                                                                              |
 | openmpi   | [BSD 3-Clause](https://github.com/open-mpi/ompi/blob/master/LICENSE)               | Yes                                                                              |
 | plumed    | [LGPL](https://github.com/plumed/plumed2/blob/master/COPYING.LESSER)               | Yes                                                                              |
-| reflapack | [BSD 3-Clause](http://www.netlib.org/lapack/LICENSE.txt)                           | Yes                                                                              |
 | scalapack | [BSD 3-Clause](http://www.netlib.org/scalapack/LICENSE)                            | Yes                                                                              |
 | sirius    | [BSD 2-Clause](https://github.com/electronic-structure/SIRIUS/blob/master/LICENSE) | Yes                                                                              |
 | spfft     | [BSD 3-Clause](https://github.com/eth-cscs/SpFFT/blob/master/LICENSE)              | Yes                                                                              |
@@ -152,13 +151,6 @@ proprietary software packages, like e.g. MKL, these have to be installed separat
 - `script/parse_if.py` is a python code for parsing the `IF_XYZ(A|B)` constructs in the script.
   Nested structures will be parsed correctly. See
   [`IF_XYZ` constructs](./README_FOR_DEVELOPERS.md#the-if_xyz-constructs) below.
-
-- `checksums.sha256` contains the pre-calculated SHA256 checksums for the tar balls of all of the
-  packages. This is used by the `download_pkg` macro in `script/toolkit.sh`.
-
-- `arch_base.tmpl` contains the template skeleton structure for the arch files. The
-  `install_cp2k_toolchain` script will set all the variables used in the template file, and then do
-  an eval to expand all of `${VARIABLE}` items in `arch_base.tmpl` to give the cp2k arch files.
 
 ### `enable-FEATURE` options
 

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -32,7 +32,6 @@ export SCRIPTDIR="${ROOTDIR}/scripts"
 export BUILDDIR="${ROOTDIR}/build"
 export INSTALLDIR="${ROOTDIR}/install"
 export SETUPFILE="${INSTALLDIR}/setup"
-export SHA256_CHECKSUM="${SCRIPTDIR}/checksums.sha256"
 
 # ------------------------------------------------------------------------
 # Make a copy of all options for $SETUPFILE


### PR DESCRIPTION
Following #4819 where reference to `arch_base.tmpl` is removed due to commit 00026b9, two other legacy mentions are spotted:

- `checksums.sha256` is removed due to commit dc59bb0;
- `reflapack` is removed due to commit 907ab74.

Also, a link to the manual about building with Spack is added.