### PR TITLE
Toolchain: new tool_kit.sh function for tail excerpt of log files

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -248,7 +248,9 @@ Specific options:
                           This package requires CMake, BLAS and LAPACK.
                           Default = no
   --with-cosma            Enable COSMA as a replacement for ScaLAPACK in matrix
-                          multiplication. COSTA is bundled with COSMA.
+                          multiplication. If set to "install", COSTA and TileMM
+                          will also be installed; if CUDA and/or HIP support is
+                          enabled too, respective versions will all be built.
                           Default = install
   --with-libxsmm          Enable libxsmm as a small matrix multiplication
                           library. Installing is only supported on arch
@@ -653,7 +655,15 @@ Otherwise use option no."
       ;;
     --log-lines=*)
       user_input="${1#*=}"
-      export LOG_LINES="${user_input}"
+      case "${user_input}" in
+        [0-9]*)
+          export LOG_LINES="${user_input}"
+          ;;
+        *)
+          report_error ${LINENO} "Non-integer ${user_input} for --log-lines."
+          exit 1
+          ;;
+      esac
       ;;
     --libint-lmax=*)
       user_input="${1#*=}"

--- a/tools/toolchain/scripts/stage0/install_amd.sh
+++ b/tools/toolchain/scripts/stage0/install_amd.sh
@@ -25,9 +25,9 @@ case "${with_amd}" in
     ;;
   __SYSTEM__)
     echo "==================== Finding AMD compiler from system paths ===================="
-    check_command clang "amd" && CC="$(realpath $(command -v clang))" || exit 1
-    check_command clang++ "amd" && CXX="$(realpath $(command -v clang++))" || exit 1
-    check_command flang "amd" && FC="$(realpath $(command -v flang))" || exit 1
+    check_command clang "amd" && CC="$(real_path $(command -v clang))" || exit 1
+    check_command clang++ "amd" && CXX="$(real_path $(command -v clang++))" || exit 1
+    check_command flang "amd" && FC="$(real_path $(command -v flang))" || exit 1
     F90="${FC}"
     F77="${FC}"
     ;;
@@ -51,11 +51,11 @@ case "${with_amd}" in
 esac
 if [ "${with_amd}" != "__DONTUSE__" ]; then
   echo "CC  is ${CC}"
-  [ $(realpath $(command -v clang) | grep -e aocc-compiler) ] || echo "Check the AMD C compiler path"
+  [ $(real_path $(command -v clang) | grep -e aocc-compiler) ] || echo "Check the AMD C compiler path"
   echo "CXX is ${CXX}"
-  [ $(realpath $(command -v clang++) | grep -e aocc-compiler) ] || echo "Check the AMD C++ compiler path"
+  [ $(real_path $(command -v clang++) | grep -e aocc-compiler) ] || echo "Check the AMD C++ compiler path"
   echo "FC  is ${FC}"
-  [ $(realpath $(command -v flang) | grep -e aocc-compiler) ] || echo "Check the AMD Fortran compiler path"
+  [ $(real_path $(command -v flang) | grep -e aocc-compiler) ] || echo "Check the AMD Fortran compiler path"
   cat << EOF > "${BUILDDIR}/setup_amd"
 export CC="${CC}"
 export CXX="${CXX}"

--- a/tools/toolchain/scripts/stage0/install_cmake.sh
+++ b/tools/toolchain/scripts/stage0/install_cmake.sh
@@ -55,9 +55,9 @@ case "${with_cmake}" in
       echo "Installing from scratch into ${pkg_install_dir}"
       mkdir -p ${pkg_install_dir}
       if [ "${cmake_arch}" = "macos-universal" ]; then
-        tar --strip-components=3 -xvf cmake-${cmake_ver}-${cmake_arch}.${cmake_ext} -C ${pkg_install_dir} > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        tar --strip-components=3 -xvf cmake-${cmake_ver}-${cmake_arch}.${cmake_ext} -C ${pkg_install_dir} > install.log 2>&1 || tail_excerpt install.log
       else
-        /bin/sh cmake-${cmake_ver}-${cmake_arch}.${cmake_ext} --prefix=${pkg_install_dir} --skip-license > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        /bin/sh cmake-${cmake_ver}-${cmake_arch}.${cmake_ext} --prefix=${pkg_install_dir} --skip-license > install.log 2>&1 || tail_excerpt install.log
       fi
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage0/$(basename ${SCRIPT_NAME})"
     fi

--- a/tools/toolchain/scripts/stage0/install_gcc.sh
+++ b/tools/toolchain/scripts/stage0/install_gcc.sh
@@ -43,7 +43,7 @@ case "${with_gcc}" in
 
       # Download prerequisites from cp2k.org because gcc.gnu.org returns 403 when queried from GCP.
       sed -i 's|http://gcc.gnu.org/pub/gcc/infrastructure/|https://cp2k.org/static/downloads/|' ./contrib/download_prerequisites
-      ./contrib/download_prerequisites > prereq.log 2>&1 || tail -n ${LOG_LINES} prereq.log
+      ./contrib/download_prerequisites > prereq.log 2>&1 || tail_excerpt prereq.log
       GCCROOT=${PWD}
       mkdir obj
       cd obj
@@ -66,13 +66,13 @@ case "${with_gcc}" in
         --disable-multilib --disable-bootstrap \
         --enable-lto \
         --enable-plugins \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
+        > configure.log 2>&1 || tail_excerpt configure.log
       make -j $(get_nprocs) \
         CFLAGS="${CFLAGS}" \
         CXXFLAGS="${CXXFLAGS}" \
         FCFLAGS="${FCFLAGS}" \
-        > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > make.log 2>&1 || tail_excerpt make.log
+      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
       # thread sanitizer
       if [ ${ENABLE_TSAN} = "__TRUE__" ]; then
         # now the tricky bit... we need to recompile in particular
@@ -83,7 +83,7 @@ case "${with_gcc}" in
         # gcc, tested with 5.1.0 based on
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55374#c10
         cd x86_64*/libgfortran
-        make clean > clean.log 2>&1 || tail -n ${LOG_LINES} clean.log
+        make clean > clean.log 2>&1 || tail_excerpt clean.log
         CFLAGS="${CFLAGS} -fsanitize=thread"
         CXXFLAGS="${CXXFLAGS} -fsanitize=thread"
         FCFLAGS="${FCFLAGS} -fsanitize=thread"
@@ -92,17 +92,17 @@ case "${with_gcc}" in
           CXXFLAGS="${CXXFLAGS}" \
           FCFLAGS="${FCFLAGS}" \
           LDFLAGS="-B$(pwd)/../libsanitizer/tsan/.libs/ -Wl,-rpath,$(pwd)/../libsanitizer/tsan/.libs/ -fsanitize=thread" \
-          > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          > make.log 2>&1 || tail_excerpt make.log
+        make install > install.log 2>&1 || tail_excerpt install.log
         cd ../libgomp
-        make clean > clean.log 2>&1 || tail -n ${LOG_LINES} clean.log
+        make clean > clean.log 2>&1 || tail_excerpt clean.log
         make -j $(get_nprocs) \
           CFLAGS="${CFLAGS}" \
           CXXFLAGS="${CXXFLAGS}" \
           FCFLAGS="${FCFLAGS}" \
           LDFLAGS="-B$(pwd)/../libsanitizer/tsan/.libs/ -Wl,-rpath,$(pwd)/../libsanitizer/tsan/.libs/ -fsanitize=thread" \
-          > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          > make.log 2>&1 || tail_excerpt make.log
+        make install > install.log 2>&1 || tail_excerpt install.log
         cd ${GCCROOT}/obj/
       fi
       cd ../..

--- a/tools/toolchain/scripts/stage0/install_intel.sh
+++ b/tools/toolchain/scripts/stage0/install_intel.sh
@@ -25,12 +25,12 @@ case "${with_intel}" in
     ;;
   __SYSTEM__)
     echo "==================== Finding Intel compiler from system paths ===================="
-    check_command icx "intel" && CC="$(realpath $(command -v icx))" || exit 1
-    check_command icpx "intel" && CXX="$(realpath $(command -v icpx))" || exit 1
+    check_command icx "intel" && CC="$(real_path $(command -v icx))" || exit 1
+    check_command icpx "intel" && CXX="$(real_path $(command -v icpx))" || exit 1
     if [ "${with_ifx}" = "yes" ]; then
-      check_command ifx "intel" && FC="$(realpath $(command -v ifx))" || exit 1
+      check_command ifx "intel" && FC="$(real_path $(command -v ifx))" || exit 1
     else
-      check_command ifort "intel" && FC="$(realpath $(command -v ifort))" || exit 1
+      check_command ifort "intel" && FC="$(real_path $(command -v ifort))" || exit 1
     fi
     F90="${FC}"
     F77="${FC}"

--- a/tools/toolchain/scripts/stage0/install_ninja.sh
+++ b/tools/toolchain/scripts/stage0/install_ninja.sh
@@ -42,9 +42,9 @@ case "${with_ninja}" in
         -Bbuild-ninja \
         -DBUILD_TESTING=OFF \
         -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      cmake --build build-ninja -j $(get_nprocs) > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      cmake --install build-ninja > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > configure.log 2>&1 || tail_excerpt configure.log
+      cmake --build build-ninja -j $(get_nprocs) > cmake.log 2>&1 || tail_excerpt cmake.log
+      cmake --install build-ninja > install.log 2>&1 || tail_excerpt install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage0/$(basename ${SCRIPT_NAME})"
     fi
     ;;

--- a/tools/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_intelmpi.sh
@@ -26,16 +26,16 @@ case "${with_intelmpi}" in
     ;;
   __SYSTEM__)
     echo "==================== Finding Intel MPI from system paths ===================="
-    check_command mpiexec "intelmpi" && MPIEXEC="$(realpath $(command -v mpiexec))"
+    check_command mpiexec "intelmpi" && MPIEXEC="$(real_path $(command -v mpiexec))"
     if [ "${with_intel}" != "__DONTUSE__" ]; then
       if [ "${with_ifx}" = "yes" ]; then
-        check_command mpiicx "intelmpi" && MPICC="$(realpath $(command -v mpiicx))" || exit 1
-        check_command mpiicpx "intelmpi" && MPICXX="$(realpath $(command -v mpiicpx))" || exit 1
-        check_command mpiifx "intelmpi" && MPIFC="$(realpath $(command -v mpiifx))" || exit 1
+        check_command mpiicx "intelmpi" && MPICC="$(real_path $(command -v mpiicx))" || exit 1
+        check_command mpiicpx "intelmpi" && MPICXX="$(real_path $(command -v mpiicpx))" || exit 1
+        check_command mpiifx "intelmpi" && MPIFC="$(real_path $(command -v mpiifx))" || exit 1
       else
-        check_command mpiicc "intelmpi" && MPICC="$(realpath $(command -v mpiicc))" || exit 1
-        check_command mpiicpc "intelmpi" && MPICXX="$(realpath $(command -v mpiicpc))" || exit 1
-        check_command mpiifort "intelmpi" && MPIFC="$(realpath $(command -v mpiifort))" || exit 1
+        check_command mpiicc "intelmpi" && MPICC="$(real_path $(command -v mpiicc))" || exit 1
+        check_command mpiicpc "intelmpi" && MPICXX="$(real_path $(command -v mpiicpc))" || exit 1
+        check_command mpiifort "intelmpi" && MPIFC="$(real_path $(command -v mpiifort))" || exit 1
       fi
     else
       echo "The use of Intel MPI is only supported with the Intel compiler"

--- a/tools/toolchain/scripts/stage1/install_mpich.sh
+++ b/tools/toolchain/scripts/stage1/install_mpich.sh
@@ -56,9 +56,9 @@ case "${with_mpich}" in
         --without-x --without-slurm \
         --enable-gl=no \
         --with-device=${MPICH_DEVICE} \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > configure.log 2>&1 || tail_excerpt configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage1/$(basename ${SCRIPT_NAME})"
     fi

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -60,9 +60,9 @@ case "${with_openmpi}" in
         --enable-mpi1-compatibility \
         --enable-static \
         --with-libevent=internal \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > configure.log 2>&1 || tail_excerpt configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage1/$(basename ${SCRIPT_NAME})"
     fi

--- a/tools/toolchain/scripts/stage2/install_acml.sh
+++ b/tools/toolchain/scripts/stage2/install_acml.sh
@@ -20,7 +20,7 @@ cd "${BUILDDIR}"
 case "$with_acml" in
   __INSTALL__)
     echo "==================== Installing ACML ===================="
-    report_error $LINENO "To install ACML you should either contact your system administrator or go to https://developer.amd.com/tools-and-sdks/archive/amd-core-math-library-acml/acml-downloads-resources/ and download the correct version for your system."
+    report_error $LINENO "__INSTALL__ is not supported; please manually install ACML"
     exit 1
     ;;
   __SYSTEM__)

--- a/tools/toolchain/scripts/stage2/install_gmp.sh
+++ b/tools/toolchain/scripts/stage2/install_gmp.sh
@@ -46,9 +46,9 @@ case "$with_gmp" in
         --libdir="${pkg_install_dir}/lib" \
         --enable-cxx=yes \
         --includedir="${pkg_install_dir}/include" \
-        > configure.log 2>&1 || tail -n "${LOG_LINES}" configure.log
-      make -j "$(get_nprocs)" > make.log 2>&1 || tail -n "${LOG_LINES}" make.log
-      make install > install.log 2>&1 || tail -n "${LOG_LINES}" install.log
+        > configure.log 2>&1 || tail_excerpt configure.log
+      make -j "$(get_nprocs)" > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage2/$(basename "${SCRIPT_NAME}")"
       cd ..
     fi

--- a/tools/toolchain/scripts/stage2/install_openblas.sh
+++ b/tools/toolchain/scripts/stage2/install_openblas.sh
@@ -70,7 +70,7 @@ case "${with_openblas}" in
           FC="${FC}" \
           PREFIX="${pkg_install_dir}" \
           > make.${OPENBLAS_LIBCORE}.log 2>&1; then
-          tail -n ${LOG_LINES} make.${OPENBLAS_LIBCORE}.log
+          tail_excerpt make.${OPENBLAS_LIBCORE}.log
           BUILD_DYNAMIC=1
         fi
       fi
@@ -85,9 +85,9 @@ case "${with_openblas}" in
           CC="${CC}" \
           FC="${FC}" \
           PREFIX="${pkg_install_dir}" \
-          > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+          > make.log 2>&1 || tail_excerpt make.log
       fi
-      make MAKE_NB_JOBS=0 PREFIX="${pkg_install_dir}" install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+      make MAKE_NB_JOBS=0 PREFIX="${pkg_install_dir}" install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage2/$(basename ${SCRIPT_NAME})"
     fi

--- a/tools/toolchain/scripts/stage3/install_fftw.sh
+++ b/tools/toolchain/scripts/stage3/install_fftw.sh
@@ -56,9 +56,9 @@ case "$with_fftw" in
         --prefix=${pkg_install_dir} \
         --libdir="${pkg_install_dir}/lib" \
         ${FFTW_FLAGS} \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > configure.log 2>&1 || tail_excerpt configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"
     fi

--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -56,9 +56,9 @@ case "$with_greenx" in
         -DMINIMAX_COMPONENT=ON \
         -DENABLE_GNU_GMP=$gmp_flag \
         -DENABLE_GREENX_CTEST=OFF \
-        .. > configure.log 2>&1 || tail -n "${LOG_LINES}" configure.log
-      make -j "$(get_nprocs)" > make.log 2>&1 || tail -n "${LOG_LINES}" make.log
-      make install > install.log 2>&1 || tail -n "${LOG_LINES}" install.log
+        .. > configure.log 2>&1 || tail_excerpt configure.log
+      make -j "$(get_nprocs)" > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename "${SCRIPT_NAME}")"
       cd ..
     fi

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -81,7 +81,7 @@ case "$with_libint" in
         --enable-fma \
         --with-pic \
         --libdir="${pkg_install_dir}/lib" \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
+        > configure.log 2>&1 || tail_excerpt configure.log
 
       if [ "${with_intel}" != "__DONTUSE__" ]; then
         # Fix bug in makefile for Fortran module
@@ -90,8 +90,8 @@ case "$with_libint" in
         sed -i -e "s/-loopopt //g" MakeVars
       fi
 
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
 
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"

--- a/tools/toolchain/scripts/stage3/install_libxc.sh
+++ b/tools/toolchain/scripts/stage3/install_libxc.sh
@@ -46,9 +46,9 @@ case "$with_libxc" in
         -DBUILD_TESTING=OFF \
         -DENABLE_FORTRAN=ON \
         -DDISABLE_KXC=OFF \
-        .. > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        .. > configure.log 2>&1 || tail_excerpt configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"
       cd ..
     fi

--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -75,9 +75,9 @@ case "$with_cosma" in
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DBUILD_SHARED_LIBS=NO \
         -DCOSTA_SCALAPACK=${cosma_sl} \
-        .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make -j install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        .. > cmake.log 2>&1 || tail_excerpt cmake.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make -j install > install.log 2>&1 || tail_excerpt install.log
       cd ..
 
       if [ "$ENABLE_CUDA" = "__TRUE__" ]; then
@@ -89,9 +89,9 @@ case "$with_cosma" in
           -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
           -DBUILD_SHARED_LIBS=NO \
           -DCOSTA_SCALAPACK=${cosma_sl} \
-          .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make -j install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          .. > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make -j install > install.log 2>&1 || tail_excerpt install.log
         cd ..
       fi
 
@@ -105,9 +105,9 @@ case "$with_cosma" in
           -DBUILD_SHARED_LIBS=NO \
           -DCOSTA_BLAS=${cosma_blas} \
           -DCOSTA_SCALAPACK=${cosma_sl} \
-          .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make -j install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          .. > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make -j install > install.log 2>&1 || tail_excerpt install.log
         cd ..
       fi
       cd ..
@@ -123,9 +123,9 @@ case "$with_cosma" in
           -DTILEDMM_GPU_BACKEND=CUDA \
           -DTILEDMM_WITH_EXAMPLES=OFF \
           -DTILEDMM_WITH_TESTS=OFF \
-          .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make -j install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          .. > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make -j install > install.log 2>&1 || tail_excerpt install.log
         cd ..
       fi
 
@@ -139,9 +139,9 @@ case "$with_cosma" in
           -DTILEDMM_GPU_BACKEND=ROCM \
           -DTILEDMM_WITH_EXAMPLES=OFF \
           -DTILEDMM_WITH_TESTS=OFF \
-          .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make -j install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          .. > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make -j install > install.log 2>&1 || tail_excerpt install.log
         cd ..
       fi
       cd ..
@@ -158,9 +158,9 @@ case "$with_cosma" in
         -DCOSMA_WITH_TESTS=NO \
         -DCOSMA_WITH_APPS=NO \
         -DCOSMA_WITH_BENCHMARKS=NO .. \
-        > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > cmake.log 2>&1 || tail_excerpt cmake.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
       cd ..
 
       # Build CUDA version.
@@ -179,9 +179,9 @@ case "$with_cosma" in
           -DCOSMA_WITH_TESTS=NO \
           -DCOSMA_WITH_APPS=NO \
           -DCOSMA_WITH_BENCHMARKS=NO .. \
-          > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
         cd ..
       fi
 
@@ -201,9 +201,9 @@ case "$with_cosma" in
           -DCOSMA_WITH_TESTS=NO \
           -DCOSMA_WITH_APPS=NO \
           -DCOSMA_WITH_BENCHMARKS=NO .. \
-          > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
         cd ..
       fi
 

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -62,14 +62,14 @@ EOF
         FC=$FC \
         WRAP=0 \
         PREFIX=${pkg_install_dir} \
-        > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+        > make.log 2>&1 || tail_excerpt make.log
       make -j $(get_nprocs) \
         CXX=$CXX \
         CC=$CC \
         FC=$FC \
         WRAP=0 \
         PREFIX=${pkg_install_dir} \
-        install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage4/$(basename ${SCRIPT_NAME})"
       mkdir ${pkg_install_dir}/lib/pkgconfig

--- a/tools/toolchain/scripts/stage4/install_scalapack.sh
+++ b/tools/toolchain/scripts/stage4/install_scalapack.sh
@@ -60,9 +60,9 @@ case "$with_scalapack" in
         -DBUILD_SHARED_LIBS=NO \
         -DBUILD_TESTING=NO \
         -DSCALAPACK_BUILD_TESTS=NO \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install >> make.log 2>&1 || tail -n ${LOG_LINES} make.log
+        > configure.log 2>&1 || tail_excerpt configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make install >> make.log 2>&1 || tail_excerpt make.log
 
       popd > /dev/null
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage4/$(basename ${SCRIPT_NAME})"

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -119,9 +119,9 @@ case "${with_elpa}" in
           CXXFLAGS="${CXXFLAGS} ${MATH_CFLAGS} ${SCALAPACK_CFLAGS} ${AVX_flag} ${FMA_flag} ${SSE4_flag} ${AVX512_flags} -fno-lto" \
           LDFLAGS="${gnu_ldflags} ${MATH_LDFLAGS} ${SCALAPACK_LDFLAGS} ${cray_ldflags} -lstdc++" \
           LIBS="${SCALAPACK_LIBS} $(resolve_string "${MATH_LIBS}" "MPI")" \
-          > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          > configure.log 2>&1 || tail_excerpt configure.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make install > install.log 2>&1 || tail_excerpt install.log
         cd ..
       done
       cd ..

--- a/tools/toolchain/scripts/stage6/install_ace.sh
+++ b/tools/toolchain/scripts/stage6/install_ace.sh
@@ -61,11 +61,11 @@ case "$with_ace" in
       cmake -S . -B build \
         -DCMAKE_CXX_STANDARD=17 \
         -DCMAKE_DISABLE_FIND_PACKAGE_yaml-cpp=TRUE \
-        > build/cmake.log 2>&1 || tail -n ${LOG_LINES} build/cmake.log
+        > build/cmake.log 2>&1 || tail_excerpt build/cmake.log
 
       # build (uses the generator CMake picked: make/ninja)
       cmake --build build -j ${NPROCS:-16} \
-        > build/make.log 2>&1 || tail -n ${LOG_LINES} build/make.log
+        > build/make.log 2>&1 || tail_excerpt build/make.log
 
       cd build
       # no make install.

--- a/tools/toolchain/scripts/stage6/install_deepmd.sh
+++ b/tools/toolchain/scripts/stage6/install_deepmd.sh
@@ -51,9 +51,9 @@ case "$with_deepmd" in
         -DCMAKE_CXX_STANDARD=11 \
         -DCMAKE_CXX_STANDARD_REQUIRED=TRUE \
         -DENABLE_PYTORCH=TRUE \
-        .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      make -j deepmd_c > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        .. > cmake.log 2>&1 || tail_excerpt cmake.log
+      make -j deepmd_c > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage6/$(basename ${SCRIPT_NAME})"
     fi
     DEEPMD_DFLAGS="-D__DEEPMD"

--- a/tools/toolchain/scripts/stage6/install_gsl.sh
+++ b/tools/toolchain/scripts/stage6/install_gsl.sh
@@ -40,9 +40,9 @@ case "$with_gsl" in
         --libdir="${pkg_install_dir}/lib" \
         --disable-shared \
         --enable-static \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > configure.log 2>&1 || tail_excerpt configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage6/$(basename ${SCRIPT_NAME})"
     fi

--- a/tools/toolchain/scripts/stage6/install_plumed.sh
+++ b/tools/toolchain/scripts/stage6/install_plumed.sh
@@ -74,9 +74,9 @@ case "$with_plumed" in
         --prefix=${pkg_install_dir} \
         --libdir="${pkg_install_dir}/lib" \
         --enable-modules=all \
-        > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make VERBOSE=1 -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > configure.log 2>&1 || tail_excerpt configure.log
+      make VERBOSE=1 -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage6/$(basename ${SCRIPT_NAME})"
     fi
     PLUMED_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"

--- a/tools/toolchain/scripts/stage7/install_hdf5.sh
+++ b/tools/toolchain/scripts/stage7/install_hdf5.sh
@@ -45,9 +45,9 @@ case "$with_hdf5" in
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         -DHDF5_BUILD_FORTRAN=ON \
         -DHDF5_ENABLE_Z_LIB_SUPPORT=ON \
-        .. > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        .. > configure.log 2>&1 || tail_excerpt configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename ${SCRIPT_NAME})"
     fi

--- a/tools/toolchain/scripts/stage7/install_libsmeagol.sh
+++ b/tools/toolchain/scripts/stage7/install_libsmeagol.sh
@@ -53,7 +53,7 @@ case "${with_libsmeagol}" in
         FCFLAGS="-DMPI -fallow-argument-mismatch ${FCFLAGS}" \
         FCFLAGS_FIXEDFORM="${FCFLAGS_FIX}" \
         FCFLAGS_FREEFORM="${FCFLAGS_FREE}" \
-        > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+        > make.log 2>&1 || tail_excerpt make.log
       # The libsmeagol makefile does not provide an install target
       [ -d ${pkg_install_dir} ] && rm -rf ${pkg_install_dir}
       mkdir ${pkg_install_dir} && cp -a lib ${pkg_install_dir}

--- a/tools/toolchain/scripts/stage7/install_libvdwxc.sh
+++ b/tools/toolchain/scripts/stage7/install_libvdwxc.sh
@@ -60,7 +60,7 @@ case "$with_libvdwxc" in
           --prefix="${pkg_install_dir}" \
           --libdir="${pkg_install_dir}/lib" \
           --disable-shared \
-          > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
+          > configure.log 2>&1 || tail_excerpt configure.log
       else
         ./configure \
           CC="${MPICC}" CFLAGS="${CFLAGS} -fpermissive" \
@@ -70,10 +70,10 @@ case "$with_libvdwxc" in
           --prefix="${pkg_install_dir}" \
           --libdir="${pkg_install_dir}/lib" \
           --disable-shared \
-          > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
+          > configure.log 2>&1 || tail_excerpt configure.log
       fi
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename ${SCRIPT_NAME})"
     fi
     LIBVDWXC_CFLAGS="-I${pkg_install_dir}/include"

--- a/tools/toolchain/scripts/stage7/install_libvori.sh
+++ b/tools/toolchain/scripts/stage7/install_libvori.sh
@@ -48,10 +48,10 @@ case "${with_libvori:=__INSTALL__}" in
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
-        .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . > build.log 2>&1 || tail -n ${LOG_LINES} build.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . --target test > test.log 2>&1 || tail -n ${LOG_LINES} test.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . --target install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        .. > cmake.log 2>&1 || tail_excerpt cmake.log
+      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . > build.log 2>&1 || tail_excerpt build.log
+      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . --target test > test.log 2>&1 || tail_excerpt test.log
+      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . --target install > install.log 2>&1 || tail_excerpt install.log
 
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename "${SCRIPT_NAME}")"
     fi

--- a/tools/toolchain/scripts/stage7/install_spglib.sh
+++ b/tools/toolchain/scripts/stage7/install_spglib.sh
@@ -49,9 +49,9 @@ case "$with_spglib" in
         -DSPGLIB_USE_OMP=ON \
         -DSPGLIB_WITH_Fortran=ON \
         -DSPGLIB_WITH_TESTS=OFF \
-        .. > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        .. > configure.log 2>&1 || tail_excerpt configure.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename ${SCRIPT_NAME})"
     fi
 

--- a/tools/toolchain/scripts/stage8/install_dftd4.sh
+++ b/tools/toolchain/scripts/stage8/install_dftd4.sh
@@ -54,8 +54,8 @@ case "$with_dftd4" in
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         .. \
-        > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      make install -j $(get_nprocs) >> make.log 2>&1 || tail -n ${LOG_LINES} build.log
+        > cmake.log 2>&1 || tail_excerpt cmake.log
+      make install -j $(get_nprocs) >> make.log 2>&1 || tail_excerpt build.log
 
       cd ..
     fi

--- a/tools/toolchain/scripts/stage8/install_mcl.sh
+++ b/tools/toolchain/scripts/stage8/install_mcl.sh
@@ -93,9 +93,9 @@ EOF
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         "${CMAKE_MPI_COMPILERS[@]}" \
-        .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . > build.log 2>&1 || tail -n ${LOG_LINES} build.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . --target install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        .. > cmake.log 2>&1 || tail_excerpt cmake.log
+      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . > build.log 2>&1 || tail_excerpt build.log
+      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . --target install > install.log 2>&1 || tail_excerpt install.log
 
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename "${SCRIPT_NAME}")"
     fi

--- a/tools/toolchain/scripts/stage8/install_pugixml.sh
+++ b/tools/toolchain/scripts/stage8/install_pugixml.sh
@@ -43,9 +43,9 @@ case "${with_pugixml}" in
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_INSTALL_LIBDIR=lib \
         .. \
-        > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > cmake.log 2>&1 || tail_excerpt cmake.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi

--- a/tools/toolchain/scripts/stage8/install_sirius.sh
+++ b/tools/toolchain/scripts/stage8/install_sirius.sh
@@ -155,10 +155,10 @@ case "$with_sirius" in
         -DSIRIUS_USE_MEMORY_POOL=OFF \
         -DSIRIUS_USE_ELPA=OFF \
         ${EXTRA_CMAKE_FLAGS} .. \
-        > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
+        > cmake.log 2>&1 || tail_excerpt cmake.log
 
-      make -j $(get_nprocs) -C src >> make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install >> make.log 2>&1 || tail -n ${LOG_LINES} make.log
+      make -j $(get_nprocs) -C src >> make.log 2>&1 || tail_excerpt make.log
+      make install >> make.log 2>&1 || tail_excerpt make.log
       cd ..
 
       # now do we have cuda as well
@@ -184,9 +184,9 @@ case "$with_sirius" in
           -DCMAKE_C_COMPILER="${MPICC}" \
           -DCMAKE_Fortran_COMPILER="${MPIFC}" \
           ${EXTRA_CMAKE_FLAGS} .. \
-          >> cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) -C src >> make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make install >> make.log 2>&1 || tail -n ${LOG_LINES} make.log
+          >> cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) -C src >> make.log 2>&1 || tail_excerpt make.log
+        make install >> make.log 2>&1 || tail_excerpt make.log
         SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/cuda/lib' -Wl,-rpath,'${pkg_install_dir}/cuda/lib'"
         cd ..
       fi

--- a/tools/toolchain/scripts/stage8/install_spfft.sh
+++ b/tools/toolchain/scripts/stage8/install_spfft.sh
@@ -57,9 +57,9 @@ case "${with_spfft}" in
         -DSPFFT_FORTRAN=ON \
         -DSPFFT_INSTALL=ON \
         ${EXTRA_CMAKE_FLAGS} .. \
-        > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > cmake.log 2>&1 || tail_excerpt cmake.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
 
       cd ..
 
@@ -81,8 +81,8 @@ case "${with_spfft}" in
           -DSPFFT_FORTRAN=ON \
           -DSPFFT_INSTALL=ON \
           -DSPFFT_GPU_BACKEND=CUDA \
-          ${EXTRA_CMAKE_FLAGS} .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+          ${EXTRA_CMAKE_FLAGS} .. > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
         install -d ${pkg_install_dir}/lib/cuda
         [ -f src/libspfft.a ] && install -m 644 src/*.a ${pkg_install_dir}/lib/cuda >> install.log 2>&1
         [ -f src/libspfft.so ] && install -m 644 src/*.so ${pkg_install_dir}/lib/cuda >> install.log 2>&1
@@ -108,8 +108,8 @@ case "${with_spfft}" in
               -DSPFFT_FORTRAN=ON \
               -DSPFFT_INSTALL=ON \
               -DSPFFT_GPU_BACKEND=CUDA \
-              ${EXTRA_CMAKE_FLAGS} .. > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-            make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+              ${EXTRA_CMAKE_FLAGS} .. > cmake.log 2>&1 || tail_excerpt cmake.log
+            make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
             install -d ${pkg_install_dir}/lib/cuda
             [ -f src/libspfft.a ] && install -m 644 src/*.a ${pkg_install_dir}/lib/cuda >> install.log 2>&1
             [ -f src/libspfft.so ] && install -m 644 src/*.so ${pkg_install_dir}/lib/cuda >> install.log 2>&1
@@ -129,8 +129,8 @@ case "${with_spfft}" in
               -DSPLA_STATIC=ON \
               -DSPLA_GPU_BACKEND=ROCM \
               ${EXTRA_CMAKE_FLAGS} .. \
-              > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-            make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+              > cmake.log 2>&1 || tail_excerpt cmake.log
+            make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
             install -d ${pkg_install_dir}/lib/rocm
             [ -f src/libspla.a ] && install -m 644 src/*.a ${pkg_install_dir}/lib/rocm >> install.log 2>&1
             [ -f src/libspla.so ] && install -m 644 src/*.so ${pkg_install_dir}/lib/rocm >> install.log 2>&1

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -49,9 +49,9 @@ case "${with_spla}" in
         -DSPLA_INSTALL=ON \
         -DSPLA_STATIC=ON \
         .. \
-        > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > cmake.log 2>&1 || tail_excerpt cmake.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
       cd ..
 
       if [ "$ENABLE_CUDA" = "__TRUE__" ]; then
@@ -69,9 +69,9 @@ case "${with_spla}" in
           -DSPLA_STATIC=ON \
           -DSPLA_GPU_BACKEND=CUDA \
           .. \
-          > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
       fi
 
       if [ "$ENABLE_HIP" = "__TRUE__" ]; then
@@ -92,9 +92,9 @@ case "${with_spla}" in
               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
               -DSPLA_GPU_BACKEND=CUDA \
               .. \
-              > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-            make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-            make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+              > cmake.log 2>&1 || tail_excerpt cmake.log
+            make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+            make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
             ;;
           Mi50 | Mi100 | Mi200 | Mi250)
             [ -d build-hip ] && rm -rf "build-hip"
@@ -111,9 +111,9 @@ case "${with_spla}" in
               -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
               -DSPLA_GPU_BACKEND=ROCM \
               .. \
-              > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-            make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-            make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+              > cmake.log 2>&1 || tail_excerpt cmake.log
+            make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+            make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
             ;;
           *) ;;
         esac

--- a/tools/toolchain/scripts/stage8/install_tblite.sh
+++ b/tools/toolchain/scripts/stage8/install_tblite.sh
@@ -54,8 +54,8 @@ case "$with_tblite" in
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         .. \
-        > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      make install -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
+        > cmake.log 2>&1 || tail_excerpt cmake.log
+      make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
 
       cd ..
     fi

--- a/tools/toolchain/scripts/stage8/install_trexio.sh
+++ b/tools/toolchain/scripts/stage8/install_trexio.sh
@@ -46,10 +46,10 @@ case "$with_trexio" in
       tar -xzf trexio-${trexio_ver}.tar.gz
       cd trexio-${trexio_ver}
 
-      ./configure --prefix="${pkg_install_dir}" --libdir="${pkg_install_dir}/lib" > configure.log 2>&1 || tail -n ${LOG_LINES} configure.log
+      ./configure --prefix="${pkg_install_dir}" --libdir="${pkg_install_dir}/lib" > configure.log 2>&1 || tail_excerpt configure.log
 
-      make -j $(get_nprocs) >> make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+      make -j $(get_nprocs) >> make.log 2>&1 || tail_excerpt make.log
+      make install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi

--- a/tools/toolchain/scripts/stage9/install_dbcsr.sh
+++ b/tools/toolchain/scripts/stage9/install_dbcsr.sh
@@ -56,9 +56,9 @@ case "${with_dbcsr}" in
       cmake \
         -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
         ${CMAKE_OPTIONS} .. \
-        > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+        > cmake.log 2>&1 || tail_excerpt cmake.log
+      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
       cd ..
       if [ "${ENABLE_CUDA}" == "__TRUE__" ]; then
         mkdir build-cuda
@@ -67,9 +67,9 @@ case "${with_dbcsr}" in
         cmake \
           -DCMAKE_INSTALL_PREFIX=${pkg_install_dir}-cuda \
           ${CMAKE_OPTIONS} .. \
-          > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
         cd ..
       fi
       if [ "${ENABLE_HIP}" == "__TRUE__" ]; then
@@ -79,9 +79,9 @@ case "${with_dbcsr}" in
         cmake \
           -DCMAKE_INSTALL_PREFIX=${pkg_install_dir}-hip \
           ${CMAKE_OPTIONS} .. \
-          > cmake.log 2>&1 || tail -n ${LOG_LINES} cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail -n ${LOG_LINES} make.log
-        make -j $(get_nprocs) install > install.log 2>&1 || tail -n ${LOG_LINES} install.log
+          > cmake.log 2>&1 || tail_excerpt cmake.log
+        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+        make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
         cd ..
       fi
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage9/$(basename ${SCRIPT_NAME})"

--- a/tools/toolchain/scripts/tool_kit.sh
+++ b/tools/toolchain/scripts/tool_kit.sh
@@ -5,7 +5,6 @@
 # shellcheck disable=all
 # shellcheck shell=bash
 
-
 SYS_INCLUDE_PATH=${SYS_INCLUDE_PATH:-"/usr/local/include:/usr/include"}
 SYS_LIB_PATH=${SYS_LIB_PATH:-"/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib:/usr/lib/x86_64-linux-gnu:/usr/lib/aarch-linux-gnu:/lib64:/lib"}
 INCLUDE_PATHS=${INCLUDE_PATHS:-"CPATH SYS_INCLUDE_PATH"}


### PR DESCRIPTION
This PR introduces a `tail_excerpt` function in `tool_kit.sh`, which is meant to output the final `${LOG_LINES}` lines of the log file in case one of the configure or make steps in the toolchain has a non-zero exit status. The `-v` flag of `tail` command requests that a header pointing to the path of log file is printed at the start.

Also, I noticed that another custom function in `tool_kit.sh` called `realpath` is overriding the [native GNU coreutils command](https://www.gnu.org/software/coreutils/manual/html_node/realpath-invocation.html) of the same name once `tool_kit.sh` is sourced, and I renamed the custom function to `real_path` to avoid confusion.