### PR TITLE
Toolchain: Try update of libint

### DIFF
--- a/tools/toolchain/install_requirements_fedora.sh
+++ b/tools/toolchain/install_requirements_fedora.sh
@@ -10,9 +10,11 @@ dnf -qy install \
   autoconf \
   autogen \
   automake \
+  boost-devel \
   bzip2 \
   ca-certificates \
   diffutils \
+  eigen3-devel \
   g++ \
   gcc \
   gfortran \

--- a/tools/toolchain/install_requirements_ubuntu.sh
+++ b/tools/toolchain/install_requirements_ubuntu.sh
@@ -23,6 +23,8 @@ apt-get install -qq --no-install-recommends \
   gfortran \
   git \
   less \
+  libboost-dev \
+  libeigen3-dev \
   libtool \
   libtool-bin \
   make \

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -12,21 +12,21 @@ source "${SCRIPT_DIR}"/signal_trap.sh
 source "${INSTALLDIR}"/toolchain.conf
 source "${INSTALLDIR}"/toolchain.env
 
-libint_ver="2.6.0"
-libint_pkg="libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}.tgz"
+libint_ver="2.13.1"
+libint_pkg="libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}.tar.xz"
 
 case "$LIBINT_LMAX" in
   4)
-    libint_sha256="7c8d28bfb03920936231228b79686ba0fd87ea922c267199789bc131cf21ac08"
+    libint_sha256="97bcc62de2c33dda9e96fc52ca47a7ab17fdfa200d15417354165d5579d6932a"
     ;;
   5)
-    libint_sha256="1cd72206afddb232bcf2179c6229fbf6e42e4ba8440e701e6aa57ff1e871e9db"
+    libint_sha256="988e35e2cad5a3e28974d33185135c57fa9800a336e33052c0579f5ebb5cf354"
     ;;
   6)
-    libint_sha256="bea76a433cd32bde280879f73b5fc8228c78b62e3ea57ace4c6d74b65910b8af"
+    libint_sha256="eae01c15a0cf56940ba21751c09aa5be4d35eeed454cd54b629babcce243aa71"
     ;;
   7)
-    libint_sha256="3bcdcc55e1dbafe38a785d4af171df8e300bb8b7775894b57186cdf35807c334"
+    libint_sha256="1f43901e9528efa06f3ab7d1b68a219d06ece2bca0d4083750f174b70fdaf64a"
     ;;
   *)
     report_error "Unsupported value --libint-lmax=${LIBINT_LMAX}."
@@ -50,11 +50,12 @@ case "$with_libint" in
       if [ -f ${libint_pkg} ]; then
         echo "${libint_pkg} is found"
       else
-        download_pkg_from_cp2k_org "${libint_sha256}" "${libint_pkg}"
+        #download_pkg_from_cp2k_org "${libint_sha256}" "${libint_pkg}"
+        download_pkg_from_urlpath "${libint_sha256}" "${libint_pkg}" https://github.com/Growl1234/RTDProject/releases/download/libint-cp2k
       fi
 
       [ -d libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX} ] && rm -rf libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}
-      tar -xzf ${libint_pkg}
+      tar -xJf ${libint_pkg}
 
       echo "Installing from scratch into ${pkg_install_dir}"
       cd libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}
@@ -64,41 +65,25 @@ case "$with_libint" in
       LIBINT_CXXFLAGS="$CXXFLAGS -g1"
       LIBINT_FCFLAGS="$FCFLAGS -g1"
 
-      # cmake build broken with libint 2.6, uncomment for libint 2.7 and above
-      #cmake . -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
-      #        -DCMAKE_CXX_COMPILER="$CXX" \
-      #        -DLIBINT2_INSTALL_LIBDIR="${pkg_install_dir}/lib" \
-      #        -DENABLE_FORTRAN=ON \
-      #        -DCXXFLAGS="$LIBINT_CXXFLAGS" > configure.log 2>&1
-      #cmake --build . > cmake.log 2>&1
-      #cmake --build . --target install > install.log 2>&1
-      ./configure --prefix=${pkg_install_dir} \
-        --with-cxx="$CXX $LIBINT_CXXFLAGS" \
-        --with-cxx-optflags="$LIBINT_CXXFLAGS" \
-        --with-fc="$FC $LIBINT_FCFLAGS" \
-        --disable-unrolling \
-        --enable-fortran \
-        --enable-fma \
-        --with-pic \
-        --libdir="${pkg_install_dir}/lib" \
+      mkdir build
+      cd build
+      # Avoid requiring system-installed boost and eigen3
+      CXXFLAGS="$LIBINT_CXXFLAGS" cmake .. \
+        -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
+        -DCMAKE_CXX_COMPILER="$CXX" \
+        -DLIBINT2_INSTALL_LIBDIR="${pkg_install_dir}/lib" \
+        -DLIBINT2_ENABLE_FORTRAN=ON \
+        -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON \
+        -DLIBINT2_REQUIRE_CXX_API=OFF \
         > configure.log 2>&1 || tail_excerpt configure.log
-
-      if [ "${with_intel}" != "__DONTUSE__" ]; then
-        # Fix bug in makefile for Fortran module
-        sed -i -e "s/\$(CXX) \$(CXXFLAGS)/\$(FC) \$(FCFLAGS)/g" -e "s/\$(FCLIBS) -o/\$(FCLIBS) -lstdc++ -o/" fortran/Makefile
-        # Fix bug about autoconf spilling -loopopt option into link list
-        sed -i -e "s/-loopopt //g" MakeVars
-      fi
-
-      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-      make install > install.log 2>&1 || tail_excerpt install.log
+      make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
 
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"
     fi
 
-    LIBINT_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBINT_LDFLAGS="-L'${pkg_install_dir}/lib'"
+    LIBINT_CFLAGS="-I${pkg_install_dir}/include"
+    LIBINT_LDFLAGS="-L${pkg_install_dir}/lib"
     ;;
   __SYSTEM__)
     echo "==================== Finding LIBINT from system paths ===================="
@@ -113,8 +98,8 @@ case "$with_libint" in
     pkg_install_dir="$with_libint"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
-    LIBINT_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBINT_LDFLAGS="-L'${pkg_install_dir}/lib'"
+    LIBINT_CFLAGS="-I${pkg_install_dir}/include"
+    LIBINT_LDFLAGS="-L${pkg_install_dir}/lib"
     ;;
 esac
 if [ "$with_libint" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -67,14 +67,11 @@ case "$with_libint" in
 
       mkdir build
       cd build
-      # Avoid requiring system-installed boost and eigen3
       CXXFLAGS="$LIBINT_CXXFLAGS" cmake .. \
         -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
         -DCMAKE_CXX_COMPILER="$CXX" \
         -DLIBINT2_INSTALL_LIBDIR="${pkg_install_dir}/lib" \
         -DLIBINT2_ENABLE_FORTRAN=ON \
-        -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON \
-        -DLIBINT2_REQUIRE_CXX_API=OFF \
         > configure.log 2>&1 || tail_excerpt configure.log
       make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
 


### PR DESCRIPTION
This PR tries to update libint to the latest version and is mainly intended to test whether this update introduces any issues.

One question: 
Previously, when the old Makefiles were used, some modifications of them were required to address certain bugs. Now that libint has migrated to CMake, those previous adjustments seem no longer applicable. Are similar changes still needed?