### PR TITLE
Toolchain: libint 2.6.0 -> 2.13.1

### DIFF
--- a/tools/toolchain/install_requirements_fedora.sh
+++ b/tools/toolchain/install_requirements_fedora.sh
@@ -10,9 +10,11 @@ dnf -qy install \
   autoconf \
   autogen \
   automake \
+  boost-devel \
   bzip2 \
   ca-certificates \
   diffutils \
+  eigen3-devel \
   g++ \
   gcc \
   gfortran \

--- a/tools/toolchain/install_requirements_ubuntu.sh
+++ b/tools/toolchain/install_requirements_ubuntu.sh
@@ -23,6 +23,8 @@ apt-get install -qq --no-install-recommends \
   gfortran \
   git \
   less \
+  libboost-dev \
+  libeigen3-dev \
   libtool \
   libtool-bin \
   make \

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -12,21 +12,21 @@ source "${SCRIPT_DIR}"/signal_trap.sh
 source "${INSTALLDIR}"/toolchain.conf
 source "${INSTALLDIR}"/toolchain.env
 
-libint_ver="2.6.0"
-libint_pkg="libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}.tgz"
+libint_ver="2.13.1"
+libint_pkg="libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}.tar.xz"
 
 case "$LIBINT_LMAX" in
   4)
-    libint_sha256="7c8d28bfb03920936231228b79686ba0fd87ea922c267199789bc131cf21ac08"
+    libint_sha256="97bcc62de2c33dda9e96fc52ca47a7ab17fdfa200d15417354165d5579d6932a"
     ;;
   5)
-    libint_sha256="1cd72206afddb232bcf2179c6229fbf6e42e4ba8440e701e6aa57ff1e871e9db"
+    libint_sha256="988e35e2cad5a3e28974d33185135c57fa9800a336e33052c0579f5ebb5cf354"
     ;;
   6)
-    libint_sha256="bea76a433cd32bde280879f73b5fc8228c78b62e3ea57ace4c6d74b65910b8af"
+    libint_sha256="eae01c15a0cf56940ba21751c09aa5be4d35eeed454cd54b629babcce243aa71"
     ;;
   7)
-    libint_sha256="3bcdcc55e1dbafe38a785d4af171df8e300bb8b7775894b57186cdf35807c334"
+    libint_sha256="1f43901e9528efa06f3ab7d1b68a219d06ece2bca0d4083750f174b70fdaf64a"
     ;;
   *)
     report_error "Unsupported value --libint-lmax=${LIBINT_LMAX}."
@@ -50,11 +50,12 @@ case "$with_libint" in
       if [ -f ${libint_pkg} ]; then
         echo "${libint_pkg} is found"
       else
-        download_pkg_from_cp2k_org "${libint_sha256}" "${libint_pkg}"
+        #download_pkg_from_cp2k_org "${libint_sha256}" "${libint_pkg}"
+        download_pkg_from_urlpath "${libint_sha256}" "${libint_pkg}" https://github.com/Growl1234/RTDProject/releases/download/libint-cp2k
       fi
 
       [ -d libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX} ] && rm -rf libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}
-      tar -xzf ${libint_pkg}
+      tar -xJf ${libint_pkg}
 
       echo "Installing from scratch into ${pkg_install_dir}"
       cd libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}
@@ -64,41 +65,25 @@ case "$with_libint" in
       LIBINT_CXXFLAGS="$CXXFLAGS -g1"
       LIBINT_FCFLAGS="$FCFLAGS -g1"
 
-      # cmake build broken with libint 2.6, uncomment for libint 2.7 and above
-      #cmake . -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
-      #        -DCMAKE_CXX_COMPILER="$CXX" \
-      #        -DLIBINT2_INSTALL_LIBDIR="${pkg_install_dir}/lib" \
-      #        -DENABLE_FORTRAN=ON \
-      #        -DCXXFLAGS="$LIBINT_CXXFLAGS" > configure.log 2>&1
-      #cmake --build . > cmake.log 2>&1
-      #cmake --build . --target install > install.log 2>&1
-      ./configure --prefix=${pkg_install_dir} \
-        --with-cxx="$CXX $LIBINT_CXXFLAGS" \
-        --with-cxx-optflags="$LIBINT_CXXFLAGS" \
-        --with-fc="$FC $LIBINT_FCFLAGS" \
-        --disable-unrolling \
-        --enable-fortran \
-        --enable-fma \
-        --with-pic \
-        --libdir="${pkg_install_dir}/lib" \
+      mkdir build
+      cd build
+      # Avoid requiring system-installed boost and eigen3
+      CXXFLAGS="$LIBINT_CXXFLAGS" cmake .. \
+        -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
+        -DCMAKE_CXX_COMPILER="$CXX" \
+        -DLIBINT2_INSTALL_LIBDIR="${pkg_install_dir}/lib" \
+        -DLIBINT2_ENABLE_FORTRAN=ON \
+        -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON \
+        -DLIBINT2_REQUIRE_CXX_API=OFF \
         > configure.log 2>&1 || tail_excerpt configure.log
-
-      if [ "${with_intel}" != "__DONTUSE__" ]; then
-        # Fix bug in makefile for Fortran module
-        sed -i -e "s/\$(CXX) \$(CXXFLAGS)/\$(FC) \$(FCFLAGS)/g" -e "s/\$(FCLIBS) -o/\$(FCLIBS) -lstdc++ -o/" fortran/Makefile
-        # Fix bug about autoconf spilling -loopopt option into link list
-        sed -i -e "s/-loopopt //g" MakeVars
-      fi
-
-      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-      make install > install.log 2>&1 || tail_excerpt install.log
+      make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
 
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage3/$(basename ${SCRIPT_NAME})"
     fi
 
-    LIBINT_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBINT_LDFLAGS="-L'${pkg_install_dir}/lib'"
+    LIBINT_CFLAGS="-I${pkg_install_dir}/include"
+    LIBINT_LDFLAGS="-L${pkg_install_dir}/lib"
     ;;
   __SYSTEM__)
     echo "==================== Finding LIBINT from system paths ===================="
@@ -113,8 +98,8 @@ case "$with_libint" in
     pkg_install_dir="$with_libint"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
-    LIBINT_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBINT_LDFLAGS="-L'${pkg_install_dir}/lib'"
+    LIBINT_CFLAGS="-I${pkg_install_dir}/include"
+    LIBINT_LDFLAGS="-L${pkg_install_dir}/lib"
     ;;
 esac
 if [ "$with_libint" != "__DONTUSE__" ]; then

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -67,14 +67,11 @@ case "$with_libint" in
 
       mkdir build
       cd build
-      # Avoid requiring system-installed boost and eigen3
       CXXFLAGS="$LIBINT_CXXFLAGS" cmake .. \
         -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
         -DCMAKE_CXX_COMPILER="$CXX" \
         -DLIBINT2_INSTALL_LIBDIR="${pkg_install_dir}/lib" \
         -DLIBINT2_ENABLE_FORTRAN=ON \
-        -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON \
-        -DLIBINT2_REQUIRE_CXX_API=OFF \
         > configure.log 2>&1 || tail_excerpt configure.log
       make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
 

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -67,7 +67,8 @@ case "$with_libint" in
 
       mkdir build
       cd build
-      CXXFLAGS="$LIBINT_CXXFLAGS" cmake .. \
+      CXXFLAGS="$LIBINT_CXXFLAGS" \
+        FCFLAGS="$LIBINT_FCFLAGS" cmake .. \
         -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
         -DCMAKE_CXX_COMPILER="$CXX" \
         -DLIBINT2_INSTALL_LIBDIR="${pkg_install_dir}/lib" \
@@ -109,7 +110,6 @@ EOF
 prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 export LIBINT2_ROOT="${pkg_install_dir}"
 EOF

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -17,16 +17,16 @@ libint_pkg="libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}.tar.xz"
 
 case "$LIBINT_LMAX" in
   4)
-    libint_sha256="97bcc62de2c33dda9e96fc52ca47a7ab17fdfa200d15417354165d5579d6932a"
+    libint_sha256="8ff388fbf171635420fdfdbafc7dc949e9cf4c0b6a62f23dac3af8b1c942d407"
     ;;
   5)
-    libint_sha256="988e35e2cad5a3e28974d33185135c57fa9800a336e33052c0579f5ebb5cf354"
+    libint_sha256="527000f915bea9879391273b96689a8c2b98beeec37cb64637e3c11dd421a5e8"
     ;;
   6)
-    libint_sha256="eae01c15a0cf56940ba21751c09aa5be4d35eeed454cd54b629babcce243aa71"
+    libint_sha256="a7990c4862d549e6328596f20b8a7ece40ded396b953d5d5d7c3200f13e37429"
     ;;
   7)
-    libint_sha256="1f43901e9528efa06f3ab7d1b68a219d06ece2bca0d4083750f174b70fdaf64a"
+    libint_sha256="ba19571deefa5c3063e620210c87cf706ef8d75b47f3b0d66547f889f906b3dd"
     ;;
   *)
     report_error "Unsupported value --libint-lmax=${LIBINT_LMAX}."
@@ -50,8 +50,7 @@ case "$with_libint" in
       if [ -f ${libint_pkg} ]; then
         echo "${libint_pkg} is found"
       else
-        #download_pkg_from_cp2k_org "${libint_sha256}" "${libint_pkg}"
-        download_pkg_from_urlpath "${libint_sha256}" "${libint_pkg}" https://github.com/Growl1234/RTDProject/releases/download/libint-cp2k
+        download_pkg_from_cp2k_org "${libint_sha256}" "${libint_pkg}"
       fi
 
       [ -d libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX} ] && rm -rf libint-v${libint_ver}-cp2k-lmax-${LIBINT_LMAX}

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -128,7 +128,8 @@ case "${with_elpa}" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage5/$(basename ${SCRIPT_NAME})"
     fi
     [ "$enable_openmp" != "yes" ] && elpa_dir_openmp=""
-    ELPA_CFLAGS="-I'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa${elpa_dir_openmp}-${elpa_ver}/modules' -I'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa${elpa_dir_openmp}-${elpa_ver}/elpa'"
+    elpa_include="${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa${elpa_dir_openmp}-${elpa_ver}"
+    ELPA_CFLAGS="-I'$elpa_include/modules' -I'$elpa_include/elpa'"
     ELPA_LDFLAGS="-L'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib' -Wl,-rpath,'${pkg_install_dir}/IF_CUDA(nvidia|cpu)/lib'"
     ;;
   __SYSTEM__)
@@ -170,7 +171,6 @@ if [ "$with_elpa" != "__DONTUSE__" ]; then
   ELPA_LIBS="-lelpa${elpa_dir_openmp}"
   if [ "$with_elpa" != "__SYSTEM__" ]; then
     cat << EOF >> "${BUILDDIR}/setup_elpa"
-export ELPA_ROOT="${pkg_install_dir}"
 prepend_path PATH "${pkg_install_dir}/cpu/bin"
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/cpu/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/cpu/lib"
@@ -192,6 +192,7 @@ EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_elpa"
 export ELPA_VER="${elpa_ver}"
+export ELPA_ROOT="${pkg_install_dir}"
 export ELPA_CFLAGS="${ELPA_CFLAGS}"
 export ELPA_LDFLAGS="${ELPA_LDFLAGS}"
 export ELPA_LIBS="${ELPA_LIBS}"
@@ -199,7 +200,6 @@ export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__ELPA IF_CUDA(-D__ELPA_NVIDIA_GPU|)|)"
 export CP_CFLAGS="\${CP_CFLAGS} IF_MPI(${ELPA_CFLAGS}|)"
 export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${ELPA_LDFLAGS}|)"
 export CP_LIBS="IF_MPI(${ELPA_LIBS}|) \${CP_LIBS}"
-export ELPA_ROOT="${pkg_install_dir}"
 EOF
   filter_setup "${BUILDDIR}/setup_elpa" "${SETUPFILE}"
 fi


### PR DESCRIPTION
This PR tries to update libint to the latest version and is mainly intended to test whether this update introduces any issues.

One question:
Previously, when the old Makefiles were used, some modifications of them were required to address certain bugs. Now that libint has migrated to CMake, those previous adjustments seem no longer applicable. Are similar changes still needed?
