### PR TITLE
Toolchain: fix tblite-0.5.0.tar.xz install behavior

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -295,13 +295,15 @@ Specific options:
   --with-spglib           Enable the spg library for symmetry groups detection.
                           This package depends on CMake.
                           Default = install
-  --with-dftd4            Enable the DFTD4 package by Grimme for the DFT-D4
-                          dispersion correction method.
+  --with-dftd4            Enable the standalone DFTD4 package by Grimme for the
+                          DFT-D4 dispersion correction method.
                           This package requires CMake.
-                          Default = install
+                          Default = no
   --with-tblite           Enable the tblite package by Grimme for GFN-xtb and
-                          DFT-D4 methods. If tblite is used then standalone
-                          DFTD4 is not used.
+                          DFT-D4 methods, bundled with multicharge, mctc-lib,
+                          mstore, s-dftd3, and toml-f libraries as backends.
+                          If tblite is used, standalone DFTD4 package specified
+                          by --with-dftd4 will not be used.
                           This package requires CMake.
                           Default = no
   --with-sirius           Enable interface to the plane wave SIRIUS library.
@@ -1005,8 +1007,11 @@ fi
 
 # Since tblite includes dftd4, a separate dftd4 is not needed.
 if [ "${with_tblite}" != "__DONTUSE__" ]; then
-  report_warning ${LINENO} "When using tblite, do not use standalone dft-d4."
-  with_dftd4="__DONTUSE__"
+  if [ "${with_dftd4}" != "__DONTUSE__" ]; then
+    report_warning ${LINENO} "Since tblite includes dft-d4, a standalone dft-d4
+package will not be used separately."
+    with_dftd4="__DONTUSE__"
+  fi
 fi
 
 # Several packages require cmake.

--- a/tools/toolchain/scripts/stage8/install_tblite.sh
+++ b/tools/toolchain/scripts/stage8/install_tblite.sh
@@ -44,6 +44,15 @@ case "$with_tblite" in
       [ -d tblite-${tblite_ver} ] && rm -rf tblite-${tblite_ver}
       tar -xJf tblite-${tblite_ver}.tar.xz
       cd tblite-${tblite_ver}
+      # Interim fix for tblite-0.5.0.tar.xz: the subprojects are found in order
+      # specified by tblite-0.5.0/CMakeLists.txt as
+      # mctc-lib, mstore, toml-f (, test-drive), dft-d4 (, multicharge), s-dftd3.
+      # Despite all subprojects already included in the package, test-drive and
+      # multicharge cannot be located, necessitating separate downloads from
+      # github repositories. Two soft links are created to resolve this issue.
+      ln -s ${PWD}/subprojects/test-drive ${PWD}/subprojects/toml-f/subprojects/test-drive
+      ln -s ${PWD}/subprojects/multicharge ${PWD}/subprojects/dftd4/subprojects/multicharge
+      # See https://github.com/tblite/tblite/issues/313 for the full story.
 
       rm -Rf build
       mkdir build
@@ -114,6 +123,7 @@ EOF
     TBLITE_LDFLAGS="-L'${TBLITE_LINK_LIBRARIES}' -Wl,-rpath,'${TBLITE_LINK_LIBRARIES}'"
 
     cat << EOF >> "${BUILDDIR}/setup_tblite"
+prepend_path PATH "${pkg_install_dir}/bin"
 prepend_path LD_LIBRARY_PATH "${TBLITE_LINK_LIBRARIES}"
 prepend_path LD_RUN_PATH "${TBLITE_LINK_LIBRARIES}"
 prepend_path LIBRARY_PATH "${TBLITE_LINK_LIBRARIES}"


### PR DESCRIPTION
Ever since #4653, the toolchain has been installing tblite from
`tblite-0.5.0.tar.xz` which includes readily usable subprojects from other
repositories. However, attempts to perform an offline installation will still
reveal problems about dependencies not being located properly and requiring
duplicated downloads from github. I found a simple solution by creating two
soft links; see tblite/tblite#313 for the full story.

Also, the path to `install/tblite-0.5.0/bin` is added to the `$PATH` variable
in the `setup_tblite` file pointing to executables like `tblite`, `dftd4`, etc.