### PR TITLE
Add cuSOLVERMp generalized eigensolver for no-k-point code path

### DIFF
--- a/src/environment.F
+++ b/src/environment.F
@@ -545,6 +545,7 @@ CONTAINS
       CALL section_vals_val_get(global_section, "BLACS_GRID", i_val=globenv%blacs_grid_layout)
       CALL section_vals_val_get(global_section, "BLACS_REPEATABLE", l_val=globenv%blacs_repeatable)
       CALL section_vals_val_get(global_section, "PREFERRED_DIAG_LIBRARY", i_val=i_diag)
+      CALL section_vals_val_get(global_section, "CUSOLVER_GENERALIZED", l_val=globenv%cusolver_generalized)
       CALL section_vals_val_get(global_section, "PREFERRED_CHOLESKY_LIBRARY", i_val=i_cholesky)
       CALL section_vals_val_get(global_section, "PREFERRED_DGEMM_LIBRARY", i_val=i_dgemm)
       CALL section_vals_val_get(global_section, "EPS_CHECK_DIAG", r_val=globenv%eps_check_diag)
@@ -1117,7 +1118,8 @@ CONTAINS
                      elpa_print=globenv%elpa_print, &
                      elpa_one_stage=globenv%elpa_one_stage, &
                      dlaf_neigvec_min_input=globenv%dlaf_neigvec_min, &
-                     eps_check_diag_input=globenv%eps_check_diag)
+                     eps_check_diag_input=globenv%eps_check_diag, &
+                     cusolver_generalized_input=globenv%cusolver_generalized)
 
       IF (fallback_applied) THEN
          message = "Diagonalization library "//TRIM(globenv%diag_library)// &

--- a/src/fm/cp_fm_cusolver.c
+++ b/src/fm/cp_fm_cusolver.c
@@ -441,10 +441,11 @@ void cp_fm_diag_cusolver_sygvd(const int fortran_comm,
   // Ensure consistency in block sizes and sources
   assert(mb_a == mb_b && nb_a == nb_b);
   assert(rsrc_a == rsrc_b && csrc_a == csrc_b);
-  (void)ldB; // Suppress unused variable warning
+  assert(ldA == ldB);
 
   const int np_a = cusolverMpNUMROC(n, mb_a, myprow, rsrc_a, nprow);
   const int nq_a = cusolverMpNUMROC(n, nb_a, mypcol, csrc_a, npcol);
+  assert(np_a == ldA);
 
   const cublasFillMode_t uplo = CUBLAS_FILL_MODE_LOWER;
   const cusolverEigType_t itype = CUSOLVER_EIG_TYPE_1;

--- a/src/fm/cp_fm_cusolver.c
+++ b/src/fm/cp_fm_cusolver.c
@@ -11,8 +11,10 @@
 #include <assert.h>
 #include <cuda_runtime.h>
 #include <cusolverMp.h>
+#include <math.h>
 #include <mpi.h>
 #include <stdlib.h>
+#include <string.h>
 
 #if defined(__CUSOLVERMP_NCCL)
 #include <nccl.h>
@@ -438,14 +440,13 @@ void cp_fm_diag_cusolver_sygvd(const int fortran_comm,
   const int csrc_b = b_matrix_desc[7];
   const int ldB = b_matrix_desc[8];
 
-  // Ensure consistency in block sizes and sources
+  // Ensure consistency in block sizes, sources, and leading dimensions
   assert(mb_a == mb_b && nb_a == nb_b);
   assert(rsrc_a == rsrc_b && csrc_a == csrc_b);
-  assert(ldA == ldB);
+  (void)ldB; // Suppress unused variable warning
 
   const int np_a = cusolverMpNUMROC(n, mb_a, myprow, rsrc_a, nprow);
   const int nq_a = cusolverMpNUMROC(n, nb_a, mypcol, csrc_a, npcol);
-  assert(np_a == ldA);
 
   const cublasFillMode_t uplo = CUBLAS_FILL_MODE_LOWER;
   const cusolverEigType_t itype = CUSOLVER_EIG_TYPE_1;
@@ -457,12 +458,14 @@ void cp_fm_diag_cusolver_sygvd(const int fortran_comm,
   cusolverMpMatrixDescriptor_t descrB = NULL;
   cusolverMpMatrixDescriptor_t descrZ = NULL;
 
+  // Create matrix descriptors using ldA as local leading dimension (LLD)
+  // Note: We use ldA for all matrices. The assertion above verifies ldA == ldB.
   CUSOLVER_CHECK(cusolverMpCreateMatrixDesc(&descrA, grid, data_type, n, n,
-                                            mb_a, nb_a, rsrc_a, csrc_a, np_a));
+                                            mb_a, nb_a, rsrc_a, csrc_a, ldA));
   CUSOLVER_CHECK(cusolverMpCreateMatrixDesc(&descrB, grid, data_type, n, n,
-                                            mb_b, nb_b, rsrc_b, csrc_b, np_a));
+                                            mb_b, nb_b, rsrc_b, csrc_b, ldA));
   CUSOLVER_CHECK(cusolverMpCreateMatrixDesc(&descrZ, grid, data_type, n, n,
-                                            mb_a, nb_a, rsrc_a, csrc_a, np_a));
+                                            mb_a, nb_a, rsrc_a, csrc_a, ldA));
 
   // Allocate device memory for matrices
   double *dev_A = NULL, *dev_B = NULL;
@@ -481,28 +484,45 @@ void cp_fm_diag_cusolver_sygvd(const int fortran_comm,
   CUDA_CHECK(cudaMalloc((void **)&dev_Z, matrix_local_size));
   CUDA_CHECK(cudaMalloc((void **)&eigenvalues_dev, n * sizeof(double)));
 
-  // Allocate workspace
+  // Query workspace size
   size_t work_dev_size = 0, work_host_size = 0;
-  CUSOLVER_CHECK(cusolverMpSygvd_bufferSize(
-      cusolvermp_handle, itype, jobz, uplo, n, 1, 1, descrA, 1, 1, descrB, 1, 1,
-      descrZ, data_type, &work_dev_size, &work_host_size));
+  const int64_t ia = 1, ja = 1, ib = 1, jb = 1, iz = 1, jz = 1;
+  const int64_t m = (int64_t)n;
+
+  cusolverStatus_t status_bufsize = cusolverMpSygvd_bufferSize(
+      cusolvermp_handle, itype, jobz, uplo, m, ia, ja, descrA, ib, jb, descrB,
+      iz, jz, descrZ, data_type, &work_dev_size, &work_host_size);
+  if (status_bufsize != CUSOLVER_STATUS_SUCCESS) {
+    fprintf(stderr, "ERROR: cusolverMpSygvd_bufferSize failed with status=%d\n",
+            (int)status_bufsize);
+    abort();
+  }
 
   void *work_dev = NULL, *work_host = NULL;
   CUDA_CHECK(cudaMalloc(&work_dev, work_dev_size));
   CUDA_CHECK(cudaMallocHost(&work_host, work_host_size));
 
-  // Allocate device memory for info
+  // Allocate and initialize device memory for info
   int *info_dev = NULL;
   CUDA_CHECK(cudaMalloc((void **)&info_dev, sizeof(int)));
+  CUDA_CHECK(cudaMemset(info_dev, 0, sizeof(int)));
 
   // Call cusolverMpSygvd
-  CUSOLVER_CHECK(cusolverMpSygvd(
-      cusolvermp_handle, itype, jobz, uplo, n, dev_A, 1, 1, descrA, dev_B, 1, 1,
-      descrB, eigenvalues_dev, dev_Z, 1, 1, descrZ, data_type, work_dev,
-      work_dev_size, work_host, work_host_size, info_dev));
+  cusolverStatus_t status_sygvd = cusolverMpSygvd(
+      cusolvermp_handle, itype, jobz, uplo, m, dev_A, ia, ja, descrA, dev_B, ib,
+      jb, descrB, eigenvalues_dev, dev_Z, iz, jz, descrZ, data_type, work_dev,
+      work_dev_size, work_host, work_host_size, info_dev);
+  if (status_sygvd != CUSOLVER_STATUS_SUCCESS) {
+    fprintf(stderr, "ERROR: cusolverMpSygvd failed with status=%d\n",
+            (int)status_sygvd);
+    abort();
+  }
 
   // Wait for computation to finish
   CUDA_CHECK(cudaStreamSynchronize(stream));
+#if !defined(__CUSOLVERMP_NCCL)
+  CAL_CHECK(cal_stream_sync(cal_comm, stream));
+#endif
 
   // Check info
   int info;

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -1364,7 +1364,9 @@ CONTAINS
 
       IF (diag_type == FM_DIAG_TYPE_CUSOLVER .AND. nao >= 64) THEN
          ! Use cuSolverMP generalized eigenvalue solver for large matrices
-         CALL cp_fm_general_cusolver(amatrix, bmatrix, eigenvectors, eigenvalues)
+         ! Use work as intermediate buffer since eigenvectors may be smaller (nao x nmo)
+         CALL cp_fm_general_cusolver(amatrix, bmatrix, work, eigenvalues)
+         CALL cp_fm_to_fm(work, eigenvectors, nmo)
 #if defined(__DLAF)
       ELSE IF (diag_type == FM_DIAG_TYPE_DLAF .AND. amatrix%matrix_struct%nrow_global >= dlaf_neigvec_min) THEN
          ! Use DLA-Future generalized eigenvalue solver for large matrices

--- a/src/fm/cp_fm_diag.F
+++ b/src/fm/cp_fm_diag.F
@@ -93,6 +93,7 @@ MODULE cp_fm_diag
    ! The ScaLAPACK eigensolver is used as fallback for all smaller cases.
    INTEGER, SAVE, PUBLIC    :: dlaf_neigvec_min = 0
 #endif
+   LOGICAL, SAVE, PUBLIC :: cusolver_generalized = .TRUE.
    ! Threshold value for the orthonormality check of the eigenvectors obtained
    ! after a diagonalization. A negative value disables the check.
    REAL(KIND=dp), SAVE :: eps_check_diag = -1.0_dp
@@ -138,18 +139,21 @@ CONTAINS
 !> \param elpa_one_stage logical that enables the one-stage solver
 !> \param dlaf_neigvec_min_input ...
 !> \param eps_check_diag_input ...
+!> \param cusolver_generalized_input ...
 !> \par History
 !>      - Add support for DLA-Future (05.09.2023, RMeli)
 !> \author  MI 11.2013
 ! **************************************************************************************************
    SUBROUTINE diag_init(diag_lib, fallback_applied, elpa_kernel, elpa_neigvec_min_input, elpa_qr, &
-                        elpa_print, elpa_one_stage, dlaf_neigvec_min_input, eps_check_diag_input)
+                        elpa_print, elpa_one_stage, dlaf_neigvec_min_input, eps_check_diag_input, &
+                        cusolver_generalized_input)
       CHARACTER(LEN=*), INTENT(IN)                       :: diag_lib
       LOGICAL, INTENT(OUT)                               :: fallback_applied
       INTEGER, INTENT(IN)                                :: elpa_kernel, elpa_neigvec_min_input
       LOGICAL, INTENT(IN)                                :: elpa_qr, elpa_print, elpa_one_stage
       INTEGER, INTENT(IN)                                :: dlaf_neigvec_min_input
       REAL(KIND=dp), INTENT(IN)                          :: eps_check_diag_input
+      LOGICAL, INTENT(IN), OPTIONAL                      :: cusolver_generalized_input
 
       LOGICAL, SAVE                                      :: initialized = .FALSE.
 
@@ -196,6 +200,11 @@ CONTAINS
 
       elpa_neigvec_min = elpa_neigvec_min_input
       eps_check_diag = eps_check_diag_input
+      IF (PRESENT(cusolver_generalized_input)) THEN
+         cusolver_generalized = cusolver_generalized_input
+      ELSE
+         cusolver_generalized = .TRUE.
+      END IF
 
    END SUBROUTINE diag_init
 
@@ -1362,7 +1371,7 @@ CONTAINS
       CALL cp_fm_get_info(amatrix, nrow_global=nao)
       nmo = SIZE(eigenvalues)
 
-      IF (diag_type == FM_DIAG_TYPE_CUSOLVER .AND. nao >= 64) THEN
+      IF (diag_type == FM_DIAG_TYPE_CUSOLVER .AND. cusolver_generalized .AND. nao >= 64) THEN
          ! Use cuSolverMP generalized eigenvalue solver for large matrices
          ! Use work as intermediate buffer since eigenvectors may be smaller (nao x nmo)
          CALL cp_fm_general_cusolver(amatrix, bmatrix, work, eigenvalues)

--- a/src/global_types.F
+++ b/src/global_types.F
@@ -85,6 +85,7 @@ MODULE global_types
       LOGICAL :: elpa_one_stage = .FALSE. ! enable one-stage ELPA solver
       INTEGER :: dlaf_neigvec_min = 0 ! Minimum number of eigenvectors for DLAF eigensolver usage
       INTEGER :: dlaf_cholesky_n_min = 0 ! Minimum matrix size for DLAF Cholesky decomposition usage
+      LOGICAL :: cusolver_generalized = .TRUE. ! use cuSOLVERMp generalized solver
       LOGICAL :: blacs_repeatable = .FALSE. ! will store the user preference for the repeatability of BLACS collectives
       REAL(KIND=dp) :: cp2k_start_time = 0.0_dp
       REAL(KIND=dp) :: cp2k_target_time = HUGE(0.0_dp) ! Maximum run time in seconds

--- a/src/input_cp2k_global.F
+++ b/src/input_cp2k_global.F
@@ -141,6 +141,13 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create(keyword, __LOCATION__, name="CUSOLVER_GENERALIZED", &
+                          description="Use cuSOLVERMp to solve the generalized eigenvalue problem directly on the GPU", &
+                          usage="CUSOLVER_GENERALIZED", &
+                          default_l_val=.TRUE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
       CALL keyword_create(keyword, __LOCATION__, name="PREFERRED_CHOLESKY_LIBRARY", &
                           description="Specifies Cholesky decomposition library to be used. If not available, "// &
                           "the ScaLAPACK library is used", &

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -39,9 +39,12 @@ MODULE qs_scf_diagonalization
                                               cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_reduce,&
                                               cp_fm_cholesky_restore
-   USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
+   USE cp_fm_diag,                      ONLY: FM_DIAG_TYPE_CUSOLVER,&
+                                              choose_eigv_solver,&
                                               cp_fm_geeig,&
-                                              cp_fm_geeig_canon
+                                              cp_fm_geeig_canon,&
+                                              cusolver_generalized,&
+                                              diag_type
    USE cp_fm_pool_types,                ONLY: cp_fm_pool_p_type,&
                                               fm_pool_create_fm,&
                                               fm_pool_give_back_fm
@@ -115,6 +118,7 @@ MODULE qs_scf_diagonalization
    USE qs_scf_methods,                  ONLY: combine_ks_matrices,&
                                               eigensolver,&
                                               eigensolver_dbcsr,&
+                                              eigensolver_generalized,&
                                               eigensolver_simple,&
                                               eigensolver_symm,&
                                               scf_env_density_mixing
@@ -247,25 +251,32 @@ CONTAINS
          END IF
 
          DO ispin = 1, nspin
-            IF (do_level_shift) THEN
-               CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin), &
-                                mo_set=mos(ispin), &
-                                ortho=ortho, &
-                                work=scf_env%scf_work2, &
-                                cholesky_method=scf_env%cholesky_method, &
-                                do_level_shift=do_level_shift, &
-                                level_shift=scf_control%level_shift, &
-                                matrix_u_fm=scf_env%ortho, &
-                                use_jacobi=use_jacobi)
+            IF (diag_type == FM_DIAG_TYPE_CUSOLVER .AND. cusolver_generalized .AND. .NOT. do_level_shift) THEN
+               CALL eigensolver_generalized(matrix_ks_fm=scf_env%scf_work1(ispin), &
+                                            matrix_s=matrix_s(ispin)%matrix, &
+                                            mo_set=mos(ispin), &
+                                            work=scf_env%scf_work2)
             ELSE
-               CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin), &
-                                mo_set=mos(ispin), &
-                                ortho=ortho, &
-                                work=scf_env%scf_work2, &
-                                cholesky_method=scf_env%cholesky_method, &
-                                do_level_shift=do_level_shift, &
-                                level_shift=scf_control%level_shift, &
-                                use_jacobi=use_jacobi)
+               IF (do_level_shift) THEN
+                  CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin), &
+                                   mo_set=mos(ispin), &
+                                   ortho=ortho, &
+                                   work=scf_env%scf_work2, &
+                                   cholesky_method=scf_env%cholesky_method, &
+                                   do_level_shift=do_level_shift, &
+                                   level_shift=scf_control%level_shift, &
+                                   matrix_u_fm=scf_env%ortho, &
+                                   use_jacobi=use_jacobi)
+               ELSE
+                  CALL eigensolver(matrix_ks_fm=scf_env%scf_work1(ispin), &
+                                   mo_set=mos(ispin), &
+                                   ortho=ortho, &
+                                   work=scf_env%scf_work2, &
+                                   cholesky_method=scf_env%cholesky_method, &
+                                   do_level_shift=do_level_shift, &
+                                   level_shift=scf_control%level_shift, &
+                                   use_jacobi=use_jacobi)
+               END IF
             END IF
          END DO
 

--- a/src/qs_scf_initialization.F
+++ b/src/qs_scf_initialization.F
@@ -26,8 +26,11 @@ MODULE qs_scf_initialization
                                               cp_fm_transpose,&
                                               cp_fm_triangular_invert
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_decompose
-   USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
-                                              cp_fm_power
+   USE cp_fm_diag,                      ONLY: FM_DIAG_TYPE_CUSOLVER,&
+                                              choose_eigv_solver,&
+                                              cp_fm_power,&
+                                              cusolver_generalized,&
+                                              diag_type
    USE cp_fm_pool_types,                ONLY: cp_fm_pool_p_type,&
                                               fm_pool_get_el_struct
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
@@ -803,6 +806,12 @@ CONTAINS
          CASE (diag_standard)
             scf_env%method = general_diag_method_nr
             scf_env%needs_ortho = (.NOT. has_unit_metric) .AND. (.NOT. do_kpoints)
+            IF (diag_type == FM_DIAG_TYPE_CUSOLVER .AND. &
+                cusolver_generalized .AND. &
+                scf_control%level_shift == 0.0_dp .AND. &
+                scf_env%cholesky_method /= cholesky_off) THEN
+               scf_env%needs_ortho = .FALSE.
+            END IF
             IF (has_unit_metric) THEN
                scf_env%method = special_diag_method_nr
             END IF

--- a/src/qs_scf_methods.F
+++ b/src/qs_scf_methods.F
@@ -29,6 +29,7 @@ MODULE qs_scf_methods
                                               cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_reduce,&
                                               cp_fm_cholesky_restore
+   USE cp_fm_cusolver_api,              ONLY: cp_fm_general_cusolver
    USE cp_fm_diag,                      ONLY: choose_eigv_solver,&
                                               cp_fm_block_jacobi
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
@@ -62,6 +63,7 @@ MODULE qs_scf_methods
    PUBLIC :: combine_ks_matrices, &
              cp_sm_mix, &
              eigensolver, &
+             eigensolver_generalized, &
              eigensolver_dbcsr, &
              eigensolver_symm, &
              eigensolver_simple, &
@@ -251,6 +253,51 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE eigensolver
+
+! **************************************************************************************************
+!> \brief Solve the generalized eigenvalue problem using cusolverMpSygvd
+!> \param matrix_ks_fm Kohn-Sham matrix in FM format
+!> \param matrix_s     Overlap matrix (DBCSR)
+!> \param mo_set       Molecular orbital set
+!> \param work         Work matrix (used as eigenvector buffer)
+! **************************************************************************************************
+   SUBROUTINE eigensolver_generalized(matrix_ks_fm, matrix_s, mo_set, work)
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: matrix_ks_fm
+      TYPE(dbcsr_type), INTENT(IN)                       :: matrix_s
+      TYPE(mo_set_type), INTENT(IN)                      :: mo_set
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: work
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'eigensolver_generalized'
+
+      INTEGER                                            :: handle, nmo
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
+      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct
+      TYPE(cp_fm_type)                                   :: s_fm
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (mo_coeff)
+      NULLIFY (mo_eigenvalues)
+
+      CALL get_mo_set(mo_set=mo_set, nmo=nmo, eigenvalues=mo_eigenvalues, mo_coeff=mo_coeff)
+      CALL cp_fm_get_info(matrix_ks_fm, matrix_struct=fm_struct)
+
+      ! Convert S matrix from DBCSR to FM (required for cuSOLVERMp)
+      CALL cp_fm_create(s_fm, fm_struct)
+      CALL copy_dbcsr_to_fm(matrix_s, s_fm)
+
+      ! Solve generalized eigenvalue problem - eigenvectors output to work buffer
+      CALL cp_fm_general_cusolver(matrix_ks_fm, s_fm, work, mo_eigenvalues)
+
+      ! Copy only the occupied MOs to mo_coeff
+      CALL cp_fm_to_fm(work, mo_coeff, nmo)
+
+      CALL cp_fm_release(s_fm)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE eigensolver_generalized
 
 ! **************************************************************************************************
 !> \brief ...


### PR DESCRIPTION
This PR introduces support for solving the generalized eigenvalue problem directly on GPU via [cusolverMpSygvd](https://docs.nvidia.com/cuda/cusolvermp/usage/functions.html#cusolvermpsygvd).

A new CUSOLVER_GENERALIZED input file option (default true) can be used to execute the original code path with Cholesky on CPU and [Syevd](https://docs.nvidia.com/cuda/cusolvermp/usage/functions.html#cusolvermpsyevd) on GPU.

Benchmark on a single Nvidia A40, based on `diag_cu144_broy.inp`: At 144 atoms, the generalized solver shows no net speedup (~0-5%). I think this is due to the eigensolver overhead being masked by data movement costs. At 288 atoms it delivers a ~25% total walltime speedup with the eigensolver itself 2.8x faster. I'm preparing a more thorough benchmark for larger sizes on (multiple) Nvidia H100, but as of now I'd say the implementation is already usable. 

The dispatch is done early when `diag_type` is set to cusolver, it is not disabled via the option, and a `do_level_shift` is _not_ being performed. I suppose level shift could be implemented too, but it would require a rewrite of the actual level shifting.

I also fixed a buffer overflow error I made in the earlier Sygvd implementation #3787 affecting also the k-point code path in the cp_fm_general_cusolver call where the eigenvector output buffer was too small (nao x nmo instead of nao x nao).