### PR TITLE
CMake: Make "require out-of-source builds" valid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,16 +11,6 @@ cmake_minimum_required(VERSION 3.24)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # =================================================================================================
-# REQUIRE OUT-OF-SOURCE BUILDS
-file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
-if(EXISTS "${LOC_PATH}")
-  message(
-    FATAL_ERROR
-      "You cannot build in a source directory (or any directory with a CMakeLists.txt file). Please make a build subdirectory."
-  )
-endif()
-
-# =================================================================================================
 # PROJECT AND VERSION
 include(CMakeDependentOption)
 include(CustomTargets)
@@ -40,6 +30,15 @@ project(
   LANGUAGES Fortran C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
+
+# Require out-of-source builds
+file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
+if(EXISTS "${LOC_PATH}")
+  message(
+    FATAL_ERROR
+      "You cannot build in a source directory (or any directory with a CMakeLists.txt file). Please make a build subdirectory."
+  )
+endif()
 
 # set language and standard.
 #

--- a/tools/docker/scripts/test_misc.sh
+++ b/tools/docker/scripts/test_misc.sh
@@ -72,7 +72,7 @@ run_test mypy --strict ./tools/vibronic_spec/
 #     /workspace/artifacts/dashboard/
 # done
 
-run_test cmake -DCP2K_ENABLE_CONSISTENCY_CHECKS=ON .
+run_test cmake -S . -B build -DCP2K_ENABLE_CONSISTENCY_CHECKS=ON
 
 echo ""
 echo "Summary: Miscellaneous tests passed"


### PR DESCRIPTION
Original behavior uses `${PROJECT_BINARY_DIR}` before project is clarified, which makes this command invalid, as pointed out in discussion #4317. This PR fixes the issue.