### PR TITLE
Fix behavior of `-ef/-df dlaf` and allow running as root with OpenMPI by default

### DIFF
--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1228,10 +1228,8 @@ ln -sf cp2k."${VERSION}" cp2k_shell
 cd "${CP2K_ROOT}" || ${EXIT_CMD} 1
 
 # Allow to run as root within a container with OpenMPI
-if [[ "${MPI_MODE}" == "openmpi" ]] && [[ "${IN_CONTAINER}" == "yes" ]]; then
+if [[ "${MPI_MODE}" == "openmpi" ]]; then
   OMPI_VARS="export OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 OMPI_MCA_plm_rsh_agent=/bin/false"
-else
-  OMPI_VARS="export OMPI_MCA_plm_rsh_agent=/bin/false"
 fi
 export OMPI_VARS
 

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -256,7 +256,7 @@ while [[ $# -gt 0 ]]; do
                 SED_PATTERN_LIST+=" -e '/\s*-\s+\"py-torch@/ ${SUBST}"
                 ;;
               dlaf)
-                SED_PATTERN_LIST+=" -e '/\s*-\s+\"dla-future*@/ ${SUBST}"
+                SED_PATTERN_LIST+=" -e '/\s*-\s+\"dla-future.*@/ ${SUBST}"
                 ;;
               fftw3)
                 SED_PATTERN_LIST+=" -e '/\s*-\s+\"fftw@/ ${SUBST}"


### PR DESCRIPTION
Original command `SED_PATTERN_LIST+=" -e '/\s*-\s+\"dla-future*@/ ${SUBST}"` is not completely valid because `*` here in `sed` actually males it detect things like "dla-future@", "dla-futur@", "dla-futureee@", etc. in the configuration file, but "dla-future-fortran@" cannot be detected (not the same with common bash script). It is therefore replaced with `.*`.