### PR TITLE
Fix Spack-test failure

### DIFF
--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1227,9 +1227,11 @@ ln -sf cp2k."${VERSION}" cp2k."${VERSION/smp/opt}"
 ln -sf cp2k."${VERSION}" cp2k_shell
 cd "${CP2K_ROOT}" || ${EXIT_CMD} 1
 
-# Allow to run as root within a container with OpenMPI
+# Allow to run as root with OpenMPI
 if [[ "${MPI_MODE}" == "openmpi" ]]; then
   OMPI_VARS="export OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 OMPI_MCA_plm_rsh_agent=/bin/false"
+else
+  OMPI_VARS=""
 fi
 export OMPI_VARS
 


### PR DESCRIPTION
`make.sh` try to export `OMPI_VARS` that shouldn't here if not using OpenMPI. This PR initialize it to a blank value in case OpenMPI is not used, though there maybe a better solution.