### PR TITLE
GW: Fix RI metric eigenvalue printing

### DIFF
--- a/src/gw_utils.F
+++ b/src/gw_utils.F
@@ -3025,6 +3025,8 @@ CONTAINS
       END DO ! ikp
 
       CALL bs_env%para_env%max(cond_nr_max)
+      CALL bs_env%para_env%min(min_ev)
+      CALL bs_env%para_env%max(max_ev)
 
       u = bs_env%unit_nr
       IF (u > 0) THEN


### PR DESCRIPTION
Reduce the minimum and maximum absolute eigenvalues of the RI metric matrix M(k) across all parallel environments. This ensures the correct global extremes are printed to the output file during parallel GW small cell calculations.

Previously, in src/gw_utils.F:3022, the min_ev and max_ev variables were not reduced after the mpi-parallel loop. This bug only concerned the printing to the outfile ("Min. abs. eigenvalue of RI metric matrix M(k) 1.8E-05 Max. abs. eigenvalue of RI metric matrix M(k) 2.0E+02").