### PR TITLE
Toolchain: check sha256sum for local packages

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -401,12 +401,13 @@ some hints and observations that may be useful:
     recommended to check for available modules (with "module avail", "module
     show" or similar commands) beforehand, and activate desired packages when
     running the toolchain script with "--with-PKG=system" options so as to
-    avoid repeated labour. However, actual compatibility between modules and
+    avoid repeated labour. That said, actual compatibility between modules and
     CP2K to be built may still take rounds of trial-and-error to confirm, and
     resorting to "--with-PKG=install" can sometimes resolve problems if modules
     turn out to be outdated, or compiled inconsistently, or not registering
     complete variables and paths, or not built with GPU support on GPU machine,
-    etc. Please forward these complaints to whoever responsible for the server.
+    etc. Please forward complaints about faulty modules to whoever responsible
+    for the server first before submitting any bug report to program developer.
 
 (4) If no internet connection is available for downloading packages from public
     resources on the server, an offline installation of toolchain and CP2K may
@@ -430,10 +431,16 @@ some hints and observations that may be useful:
 
 (6) Again, be careful about the environment if CP2K is to be executed with job
     submission scripts to the job queue system handling resource allocation.
-    Active environment variables and paths on the login node (by loading
-    modules, sourcing scripts, editing ~/.bashrc or /etc/profile files, etc.)
-    may NOT be active on the compute node where CP2K actually runs, unless all
-    appropriate commands are explicitly written in the job submission script.
+    Active environment variables and paths on the login node seen by user (by
+    loading modules, sourcing scripts, editing ~/.bashrc or /etc/profile files,
+    or entering commands interactively in general) may NOT be effective on the
+    compute node where CP2K actually runs, unless all appropriate commands are
+    written explicitly in the batch job submission script. For example, a
+    frequently encountered scenario with corrupted, interleaved output messages
+    stems from incorrect MPI library configuration launching multiple instances
+    of CP2K simultaneously instead of multi-process parallel execution of one
+    single instance; it is likely that the ./install/setup file is not sourced
+    or the wrong module for MPI library is loaded at runtime.
 
 EOF
 }

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -358,9 +358,6 @@ It should be safe to terminate running of this script in the middle of a build
 process. The script will know if a package has been successfully installed and
 will just carry on and recompile and install the last package it is working on.
 This is true even if you lose the content of the entire ./build directory.
-However, if you terminate when downloading packages, you will have to delete the
-incomplete tarball as toolchain don't check existing ones and will give error
-due to failing to uncompress an incomplete tarball.
 
 Some packages are sensitive to the environment variables of their dependencies.
 Therefore, if you use --with-PKG_A=system but encounter an error indicating that
@@ -402,29 +399,34 @@ some hints and observations that may be useful:
     LMod and Environment Modules. Users can load or unload modules to control
     active environment variables and paths in runtime without conflicts. It is
     recommended to check for available modules (with "module avail", "module
-    show" or similar commands) beforehand, and activate desired compatible 
-    packages when running the toolchain script with "--with-PKG=system" options
-    to avoid repeated labour.
+    show" or similar commands) beforehand, and activate desired packages when
+    running the toolchain script with "--with-PKG=system" options so as to
+    avoid repeated labour. However, actual compatibility between modules and
+    CP2K to be built may still take rounds of trial-and-error to confirm, and
+    resorting to "--with-PKG=install" can sometimes resolve problems if modules
+    turn out to be outdated, or compiled inconsistently, or not registering
+    complete variables and paths, or not built with GPU support on GPU machine,
+    etc. Please forward these complaints to whoever responsible for the server.
 
 (4) If no internet connection is available for downloading packages from public
     resources on the server, an offline installation of toolchain and CP2K may
     be carried out by downloading all packages elsewhere, transferring them to
     server and placing them under the ./build directory. The toolchain script
     will not attempt to download packages if they are already present in the
-    build directory with filenames reflecting the correct versions.
+    build directory, with filenames and sha256sum strings matching the records.
 
 (5) An important common feature of clusters is the distinction of node types:
     "login node", where users log in and perform tasks with low workload; and
     "compute node", where resource-intensive computation jobs are carried out.
     They may be hosted on separate machines, and their hardware specifications
     (CPU, RAM, disk space, etc.) may be similar or different. Therefore, care
-    must be taken especially for the latter case; for instance, running
-    toolchain scripts on login node with "--target-cpu=native" (which is
-    default too if omitted) and executing CP2K on compute node afterwards may
-    result in poor performance or illegal instruction errors due to
-    discrepancies in CPU architectures and supported instruction sets, In this
-    case, the option with best portability for compiling programs at the cost
-    of reduced (non-optimal) performance is "--target-cpu=generic".
+    must be taken especially for the latter case. For instance, discrepancies
+    in CPU architectures and supported instruction sets may cause poor program
+    performance or illegal instruction errors if toolchain script is executed
+    on login node with "--target-cpu=native" (which is default too if omitted)
+    but CP2K is executed on compute node afterwards. In this case, the option
+    "--target-cpu=generic" with best portability for compiling programs at the
+    cost of reduced (non-optimized) performance may be necessary.
 
 (6) Again, be careful about the environment if CP2K is to be executed with job
     submission scripts to the job queue system handling resource allocation.

--- a/tools/toolchain/scripts/get_openblas_arch.sh
+++ b/tools/toolchain/scripts/get_openblas_arch.sh
@@ -35,7 +35,7 @@ echo "==================== Getting proc arch info using OpenBLAS tools =========
 openblas_dir="$(find_openblas_dir)"
 # if cannot find openblas source dir, try download one
 if ! [ "$openblas_dir" ]; then
-  if [ -f ${openblas_pkg} ]; then
+  if [ -f ${openblas_pkg} ] && checksum "${openblas_sha256}" "${openblas_pkg}"; then
     echo "${openblas_pkg} is found"
   else
     download_pkg_from_cp2k_org "${openblas_sha256}" "${openblas_pkg}"

--- a/tools/toolchain/scripts/stage0/install_cmake.sh
+++ b/tools/toolchain/scripts/stage0/install_cmake.sh
@@ -47,7 +47,7 @@ case "${with_cmake}" in
     if verify_checksums "${install_lock_file}"; then
       echo "cmake-${cmake_ver} is already installed, skipping it."
     else
-      if [ -f cmake-${cmake_ver}-${cmake_arch}.${cmake_ext} ]; then
+      if [ -f cmake-${cmake_ver}-${cmake_arch}.${cmake_ext} ] && checksum "${cmake_sha256}" "cmake-${cmake_ver}-${cmake_arch}.${cmake_ext}"; then
         echo "cmake-${cmake_ver}-${cmake_arch}.${cmake_ext} is found"
       else
         download_pkg_from_cp2k_org "${cmake_sha256}" "cmake-${cmake_ver}-${cmake_arch}.${cmake_ext}"

--- a/tools/toolchain/scripts/stage0/install_gcc.sh
+++ b/tools/toolchain/scripts/stage0/install_gcc.sh
@@ -30,7 +30,7 @@ case "${with_gcc}" in
     if verify_checksums "${install_lock_file}"; then
       echo "gcc-${gcc_ver} is already installed, skipping it."
     else
-      if [ -f gcc-${gcc_ver}.tar.gz ]; then
+      if [ -f gcc-${gcc_ver}.tar.gz ] && checksum "${gcc_sha256}" "gcc-${gcc_ver}.tar.gz"; then
         echo "gcc-${gcc_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${gcc_sha256}" "gcc-${gcc_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage0/install_ninja.sh
+++ b/tools/toolchain/scripts/stage0/install_ninja.sh
@@ -29,7 +29,7 @@ case "${with_ninja}" in
     if verify_checksums "${install_lock_file}"; then
       echo "ninja-v${ninja_ver} is already installed, skipping it."
     else
-      if [ -f ninja-v${ninja_ver}.tar.gz ]; then
+      if [ -f ninja-v${ninja_ver}.tar.gz ] && checksum "${ninja_sha256}" "ninja-v${ninja_ver}.tar.gz"; then
         echo "ninja-v${ninja_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${ninja_sha256}" "ninja-v${ninja_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage1/install_mpich.sh
+++ b/tools/toolchain/scripts/stage1/install_mpich.sh
@@ -30,7 +30,7 @@ case "${with_mpich}" in
     if verify_checksums "${install_lock_file}"; then
       echo "mpich-${mpich_ver} is already installed, skipping it."
     else
-      if [ -f ${mpich_pkg} ]; then
+      if [ -f ${mpich_pkg} ] && checksum "${mpich_sha256}" "${mpich_pkg}"; then
         echo "${mpich_pkg} is found"
       else
         download_pkg_from_cp2k_org "${mpich_sha256}" "${mpich_pkg}"

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -30,7 +30,7 @@ case "${with_openmpi}" in
     if verify_checksums "${install_lock_file}"; then
       echo "openmpi-${openmpi_ver} is already installed, skipping it."
     else
-      if [ -f ${openmpi_pkg} ]; then
+      if [ -f ${openmpi_pkg} ] && checksum "${openmpi_sha256}" "${openmpi_pkg}"; then
         echo "${openmpi_pkg} is found"
       else
         download_pkg_from_cp2k_org "${openmpi_sha256}" "${openmpi_pkg}"

--- a/tools/toolchain/scripts/stage2/install_gmp.sh
+++ b/tools/toolchain/scripts/stage2/install_gmp.sh
@@ -29,7 +29,7 @@ case "$with_gmp" in
     if verify_checksums "${install_lock_file}"; then
       echo "gmp-${gmp_ver} is already installed, skipping it."
     else
-      if [ -f gmp-${gmp_ver}.tar.gz ]; then
+      if [ -f gmp-${gmp_ver}.tar.gz ] && checksum "${gmp_sha256}" "gmp-${gmp_ver}.tar.gz"; then
         echo "gmp-${gmp_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${gmp_sha256}" "gmp-${gmp_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage2/install_openblas.sh
+++ b/tools/toolchain/scripts/stage2/install_openblas.sh
@@ -29,7 +29,7 @@ case "${with_openblas}" in
     if verify_checksums "${install_lock_file}"; then
       echo "openblas-${openblas_ver} is already installed, skipping it."
     else
-      if [ -f ${openblas_pkg} ]; then
+      if [ -f ${openblas_pkg} ] && checksum "${openblas_sha256}" "${openblas_pkg}"; then
         echo "${openblas_pkg} is found"
       else
         download_pkg_from_cp2k_org "${openblas_sha256}" "${openblas_pkg}"

--- a/tools/toolchain/scripts/stage3/install_fftw.sh
+++ b/tools/toolchain/scripts/stage3/install_fftw.sh
@@ -31,7 +31,7 @@ case "$with_fftw" in
     if verify_checksums "${install_lock_file}"; then
       echo "fftw-${fftw_ver} is already installed, skipping it."
     else
-      if [ -f ${fftw_pkg} ]; then
+      if [ -f ${fftw_pkg} ] && checksum "${fftw_sha256}" "${fftw_pkg}"; then
         echo "${fftw_pkg} is found"
       else
         download_pkg_from_cp2k_org "${fftw_sha256}" "${fftw_pkg}"

--- a/tools/toolchain/scripts/stage3/install_greenx.sh
+++ b/tools/toolchain/scripts/stage3/install_greenx.sh
@@ -31,7 +31,7 @@ case "$with_greenx" in
     if verify_checksums "${install_lock_file}"; then
       echo "greenX-${greenx_ver} is already installed, skipping it."
     else
-      if [ -f greenX-${greenx_ver}.tar.gz ]; then
+      if [ -f greenX-${greenx_ver}.tar.gz ] && checksum "${greenx_sha256}" "greenX-${greenx_ver}.tar.gz"; then
         echo "greenX-${greenx_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${greenx_sha256}" "greenX-${greenx_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -47,7 +47,7 @@ case "$with_libint" in
     if verify_checksums "${install_lock_file}"; then
       echo "libint-${libint_ver} is already installed, skipping it."
     else
-      if [ -f ${libint_pkg} ]; then
+      if [ -f ${libint_pkg} ] && checksum "${libint_sha256}" "${libint_pkg}"; then
         echo "${libint_pkg} is found"
       else
         download_pkg_from_cp2k_org "${libint_sha256}" "${libint_pkg}"

--- a/tools/toolchain/scripts/stage3/install_libxc.sh
+++ b/tools/toolchain/scripts/stage3/install_libxc.sh
@@ -27,7 +27,7 @@ case "$with_libxc" in
     if verify_checksums "${install_lock_file}"; then
       echo "libxc-${libxc_ver} is already installed, skipping it."
     else
-      if [ -f libxc-${libxc_ver}.tar.bz2 ]; then
+      if [ -f libxc-${libxc_ver}.tar.bz2 ] && checksum "${libxc_sha256}" "libxc-${libxc_ver}.tar.bz2"; then
         echo "libxc-${libxc_ver}.tar.bz2 is found"
       else
         download_pkg_from_cp2k_org "${libxc_sha256}" "libxc-${libxc_ver}.tar.bz2"

--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -36,11 +36,19 @@ case "$with_cosma" in
     if verify_checksums "${install_lock_file}"; then
       echo "COSMA-${cosma_ver} is already installed, skipping it."
     else
-      if [ -f COSMA-v${cosma_ver}.tar.gz ]; then
+      if [ -f COSMA-v${cosma_ver}.tar.gz ] && checksum "${cosma_sha256}" "COSMA-v${cosma_ver}.tar.gz"; then
         echo "COSMA-v${cosma_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${cosma_sha256}" "COSMA-v${cosma_ver}.tar.gz"
+      fi
+      if [ -f COSTA-v${costa_ver}.tar.gz ] && checksum "${costa_sha256}" "COSTA-v${costa_ver}.tar.gz"; then
+        echo "COSTA-v${costa_ver}.tar.gz is found"
+      else
         download_pkg_from_cp2k_org "${costa_sha256}" "COSTA-v${costa_ver}.tar.gz"
+      fi
+      if [ -f Tiled-MM-v${tiled_mm_ver}.tar.gz ] && checksum "${tiled_mm_sha256}" "Tiled-MM-v${tiled_mm_ver}.tar.gz"; then
+        echo "Tiled-MM-v${tiled_mm_ver}.tar.gz is found"
+      else
         download_pkg_from_cp2k_org "${tiled_mm_sha256}" "Tiled-MM-v${tiled_mm_ver}.tar.gz"
       fi
       echo "Installing from scratch into ${pkg_install_dir}"

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -34,7 +34,7 @@ EOF
     if verify_checksums "${install_lock_file}"; then
       echo "libxsmm-${libxsmm_ver} is already installed, skipping it."
     else
-      if [ -f libxsmm-${libxsmm_ver}.tar.gz ]; then
+      if [ -f libxsmm-${libxsmm_ver}.tar.gz ] && checksum "${libxsmm_sha256}" "libxsmm-${libxsmm_ver}.tar.gz"; then
         echo "libxsmm-${libxsmm_ver}.tar.gz is found"
       else
         if ! download_pkg_from_cp2k_org "${libxsmm_sha256}" "libxsmm-${libxsmm_ver}.tar.gz"; then

--- a/tools/toolchain/scripts/stage4/install_scalapack.sh
+++ b/tools/toolchain/scripts/stage4/install_scalapack.sh
@@ -30,7 +30,7 @@ case "$with_scalapack" in
       echo "scalapack-${scalapack_ver} is already installed, skipping it."
     else
       require_env MATH_LIBS
-      if [ -f ${scalapack_pkg} ]; then
+      if [ -f ${scalapack_pkg} ] && checksum "${scalapack_sha256}" "${scalapack_pkg}"; then
         echo "${scalapack_pkg} is found"
       else
         download_pkg_from_cp2k_org "${scalapack_sha256}" "${scalapack_pkg}"

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -49,7 +49,7 @@ case "${with_elpa}" in
       echo "elpa-${elpa_ver} is already installed, skipping it."
     else
       require_env MATH_LIBS
-      if [ -f elpa-${elpa_ver}.tar.gz ]; then
+      if [ -f elpa-${elpa_ver}.tar.gz ] && checksum "${elpa_sha256}" "elpa-${elpa_ver}.tar.gz"; then
         echo "elpa-${elpa_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${elpa_sha256}" "elpa-${elpa_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage6/install_ace.sh
+++ b/tools/toolchain/scripts/stage6/install_ace.sh
@@ -35,7 +35,7 @@ case "$with_ace" in
     if verify_checksums "${install_lock_file}"; then
       echo "${ace_dir} aka Ace is already installed, skipping it."
     else
-      if [ -f ${ace_pkg} ]; then
+      if [ -f ${ace_pkg} ] && checksum "${ace_sha256}" "${ace_pkg}"; then
         echo "${ace_pkg} is found"
       else
         download_pkg_from_cp2k_org "${ace_sha256}" "${ace_pkg}"

--- a/tools/toolchain/scripts/stage6/install_deepmd.sh
+++ b/tools/toolchain/scripts/stage6/install_deepmd.sh
@@ -34,7 +34,7 @@ case "$with_deepmd" in
     if verify_checksums "${install_lock_file}"; then
       echo "libdeepmd_c-${deepmd_ver} is already installed, skipping it."
     else
-      if [ -f ${deepmd_pkg} ]; then
+      if [ -f ${deepmd_pkg} ] && checksum "${deepmd_sha256}" "${deepmd_pkg}"; then
         echo "${deepmd_pkg} is found"
       else
         download_pkg_from_cp2k_org "${deepmd_sha256}" "${deepmd_pkg}"

--- a/tools/toolchain/scripts/stage6/install_gsl.sh
+++ b/tools/toolchain/scripts/stage6/install_gsl.sh
@@ -27,7 +27,7 @@ case "$with_gsl" in
     if verify_checksums "${install_lock_file}"; then
       echo "gsl-${gsl_ver} is already installed, skipping it."
     else
-      if [ -f gsl-${gsl_ver}.tar.gz ]; then
+      if [ -f gsl-${gsl_ver}.tar.gz ] && checksum "${gls_sha256}" "gsl-${gsl_ver}.tar.gz"; then
         echo "gsl-${gsl_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${gls_sha256}" "gsl-${gsl_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage6/install_libtorch.sh
+++ b/tools/toolchain/scripts/stage6/install_libtorch.sh
@@ -33,7 +33,7 @@ case "${with_libtorch}" in
     if verify_checksums "${install_lock_file}"; then
       echo "libtorch-${libtorch_ver} is already installed, skipping it."
     else
-      if [ -f ${archive_file} ]; then
+      if [ -f ${archive_file} ] && checksum "${libtorch_sha256}" "${archive_file}"; then
         echo "${archive_file} is found"
       else
         download_pkg_from_cp2k_org "${libtorch_sha256}" "${archive_file}"

--- a/tools/toolchain/scripts/stage6/install_plumed.sh
+++ b/tools/toolchain/scripts/stage6/install_plumed.sh
@@ -38,7 +38,7 @@ case "$with_plumed" in
     if verify_checksums "${install_lock_file}"; then
       echo "plumed-${plumed_ver} is already installed, skipping it."
     else
-      if [ -f ${plumed_pkg} ]; then
+      if [ -f ${plumed_pkg} ] && checksum "${plumed_sha256}" "${plumed_pkg}"; then
         echo "${plumed_pkg} is found"
       else
         download_pkg_from_cp2k_org "${plumed_sha256}" "${plumed_pkg}"

--- a/tools/toolchain/scripts/stage7/install_hdf5.sh
+++ b/tools/toolchain/scripts/stage7/install_hdf5.sh
@@ -28,7 +28,7 @@ case "$with_hdf5" in
     if verify_checksums "${install_lock_file}"; then
       echo "hdf5-${hdf5_ver} is already installed, skipping it."
     else
-      if [ -f hdf5-${hdf5_ver}.tar.gz ]; then
+      if [ -f hdf5-${hdf5_ver}.tar.gz ] && checksum "${hdf5_sha256}" "hdf5-${hdf5_ver}.tar.gz"; then
         echo "hdf5-${hdf5_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${hdf5_sha256}" "hdf5-${hdf5_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage7/install_libsmeagol.sh
+++ b/tools/toolchain/scripts/stage7/install_libsmeagol.sh
@@ -32,7 +32,7 @@ case "${with_libsmeagol}" in
     if verify_checksums "${install_lock_file}"; then
       echo "libsmeagol-${libsmeagol_ver} is already installed, skipping it."
     else
-      if [ -f libsmeagol-${libsmeagol_ver}.tar.gz ]; then
+      if [ -f libsmeagol-${libsmeagol_ver}.tar.gz ] && checksum "${libsmeagol_sha256}" "libsmeagol-${libsmeagol_ver}.tar.gz"; then
         echo "libsmeagol-${libsmeagol_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${libsmeagol_sha256}" "libsmeagol-${libsmeagol_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage7/install_libvdwxc.sh
+++ b/tools/toolchain/scripts/stage7/install_libvdwxc.sh
@@ -35,7 +35,7 @@ case "$with_libvdwxc" in
     if verify_checksums "${install_lock_file}"; then
       echo "libvdwxc-${libvdwxc_ver} is already installed, skipping it."
     else
-      if [ -f libvdwxc-${libvdwxc_ver}.tar.gz ]; then
+      if [ -f libvdwxc-${libvdwxc_ver}.tar.gz ] && checksum "${libvdwxc_sha256}" "libvdwxc-${libvdwxc_ver}.tar.gz"; then
         echo "libvdwxc-${libvdwxc_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${libvdwxc_sha256}" "libvdwxc-${libvdwxc_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage7/install_libvori.sh
+++ b/tools/toolchain/scripts/stage7/install_libvori.sh
@@ -30,7 +30,7 @@ case "${with_libvori:=__INSTALL__}" in
     if verify_checksums "${install_lock_file}"; then
       echo "libvori-${libvori_ver} is already installed, skipping it."
     else
-      if [ -f libvori-${libvori_ver}.tar.gz ]; then
+      if [ -f libvori-${libvori_ver}.tar.gz ] && checksum "${libvori_sha256}" "libvori-${libvori_ver}.tar.gz"; then
         echo "libvori-${libvori_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${libvori_sha256}" "libvori-${libvori_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage7/install_spglib.sh
+++ b/tools/toolchain/scripts/stage7/install_spglib.sh
@@ -27,7 +27,7 @@ case "$with_spglib" in
     if verify_checksums "${install_lock_file}"; then
       echo "spglib-${spglib_ver} is already installed, skipping it."
     else
-      if [ -f spglib-${spglib_ver}.tar.gz ]; then
+      if [ -f spglib-${spglib_ver}.tar.gz ] && checksum "${spglib_sha256}" "spglib-${spglib_ver}.tar.gz"; then
         echo "spglib-${spglib_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${spglib_sha256}" "spglib-${spglib_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage8/install_dftd4.sh
+++ b/tools/toolchain/scripts/stage8/install_dftd4.sh
@@ -34,7 +34,7 @@ case "$with_dftd4" in
     if verify_checksums "${install_lock_file}"; then
       echo "dftd4_dist-${dftd4_ver} is already installed, skipping it."
     else
-      if [ -f dftd4-${dftd4_ver}.tar.gz ]; then
+      if [ -f dftd4-${dftd4_ver}.tar.gz ] && checksum "${dftd4_sha256}" "dftd4-${dftd4_ver}.tar.gz"; then
         echo " dftd4-${dftd4_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${dftd4_sha256}" "dftd4-${dftd4_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage8/install_mcl.sh
+++ b/tools/toolchain/scripts/stage8/install_mcl.sh
@@ -30,7 +30,7 @@ case "${with_mcl:=__INSTALL__}" in
     if verify_checksums "${install_lock_file}"; then
       echo "libmcl-${mcl_ver} is already installed, skipping it."
     else
-      if [ -f mcl-${mcl_ver}.tar.gz ]; then
+      if [ -f mcl-${mcl_ver}.tar.gz ] && checksum "${mcl_sha256}" mcl-${mcl_ver}.tar.gz; then
         echo "mcl-${mcl_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${mcl_sha256}" mcl-${mcl_ver}.tar.gz

--- a/tools/toolchain/scripts/stage8/install_pugixml.sh
+++ b/tools/toolchain/scripts/stage8/install_pugixml.sh
@@ -27,7 +27,7 @@ case "${with_pugixml}" in
     if verify_checksums "${install_lock_file}"; then
       echo "pugixml-${pugixml_ver} is already installed, skipping it."
     else
-      if [ -f pugixml-${pugixml_ver}.tar.gz ]; then
+      if [ -f pugixml-${pugixml_ver}.tar.gz ] && checksum "${pugixml_sha256}" "pugixml-${pugixml_ver}.tar.gz"; then
         echo "pugixml-${pugixml_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${pugixml_sha256}" "pugixml-${pugixml_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage8/install_sirius.sh
+++ b/tools/toolchain/scripts/stage8/install_sirius.sh
@@ -101,7 +101,7 @@ case "$with_sirius" in
     if verify_checksums "${install_lock_file}"; then
       echo "sirius_dist-${sirius_ver} is already installed, skipping it."
     else
-      if [ -f SIRIUS-${sirius_ver}.tar.gz ]; then
+      if [ -f SIRIUS-${sirius_ver}.tar.gz ] && checksum "${sirius_sha256}" "SIRIUS-${sirius_ver}.tar.gz"; then
         echo "sirius_${sirius_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${sirius_sha256}" "SIRIUS-${sirius_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage8/install_spfft.sh
+++ b/tools/toolchain/scripts/stage8/install_spfft.sh
@@ -27,7 +27,7 @@ case "${with_spfft}" in
     if verify_checksums "${install_lock_file}"; then
       echo "SpFFT-${spfft_ver} is already installed, skipping it."
     else
-      if [ -f SpFFT-${spfft_ver}.tar.gz ]; then
+      if [ -f SpFFT-${spfft_ver}.tar.gz ] && checksum "${spfft_sha256}" "SpFFT-${spfft_ver}.tar.gz"; then
         echo "SpFFT-${spfft_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${spfft_sha256}" "SpFFT-${spfft_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -27,7 +27,7 @@ case "${with_spla}" in
     if verify_checksums "${install_lock_file}"; then
       echo "SpLA-${spla_ver} is already installed, skipping it."
     else
-      if [ -f SpLA-${spla_ver}.tar.gz ]; then
+      if [ -f SpLA-${spla_ver}.tar.gz ] && checksum "${spla_sha256}" "SpLA-${spla_ver}.tar.gz"; then
         echo "SpLA-${spla_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${spla_sha256}" "SpLA-${spla_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage8/install_tblite.sh
+++ b/tools/toolchain/scripts/stage8/install_tblite.sh
@@ -34,7 +34,7 @@ case "$with_tblite" in
     if verify_checksums "${install_lock_file}"; then
       echo "tblite-${tblite_ver} is already installed, skipping it."
     else
-      if [ -f tblite-${tblite_ver}.tar.xz ]; then
+      if [ -f tblite-${tblite_ver}.tar.xz ] && checksum "${tblite_sha256}" "tblite-${tblite_ver}.tar.xz"; then
         echo "tblite-${tblite_ver}.tar.xz is found"
       else
         download_pkg_from_cp2k_org "${tblite_sha256}" "tblite-${tblite_ver}.tar.xz"

--- a/tools/toolchain/scripts/stage8/install_trexio.sh
+++ b/tools/toolchain/scripts/stage8/install_trexio.sh
@@ -37,7 +37,7 @@ case "$with_trexio" in
       echo "Installing from scratch into ${pkg_install_dir}"
       [ -d trexio-${trexio_ver} ] && rm -rf trexio-${trexio_ver}
 
-      if [ -f trexio-${trexio_ver}.tar.gz ]; then
+      if [ -f trexio-${trexio_ver}.tar.gz ] && checksum "${trexio_sha256}" "trexio-${trexio_ver}.tar.gz"; then
         echo "trexio_${trexio_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${trexio_sha256}" "trexio-${trexio_ver}.tar.gz"

--- a/tools/toolchain/scripts/stage9/install_dbcsr.sh
+++ b/tools/toolchain/scripts/stage9/install_dbcsr.sh
@@ -27,7 +27,7 @@ case "${with_dbcsr}" in
     if verify_checksums "${install_lock_file}"; then
       echo "dbcsr-${dbcsr_ver} is already installed, skipping it."
     else
-      if [ -f dbcsr-${dbcsr_ver}.tar.gz ]; then
+      if [ -f dbcsr-${dbcsr_ver}.tar.gz ] && checksum "${dbcsr_sha256}" "dbcsr-${dbcsr_ver}.tar.gz"; then
         echo "dbcsr-${dbcsr_ver}.tar.gz is found"
       else
         download_pkg_from_cp2k_org "${dbcsr_sha256}" "dbcsr-${dbcsr_ver}.tar.gz"

--- a/tools/toolchain/scripts/tool_kit.sh
+++ b/tools/toolchain/scripts/tool_kit.sh
@@ -615,25 +615,25 @@ read_with() {
   esac
 }
 
-# helper routine to check integrity of downloaded files
-checksum() {
-  local __filename=$1
-  local __sha256=$2
+# check if we have sha256sum command, Mac OS X does not have
+# sha256sum, but has an equivalent with shasum -a 256
+get_checksum_cmd() {
   local __shasum_command='sha256sum'
-  # check if we have sha256sum command, Mac OS X does not have
-  # sha256sum, but has an equivalent with shasum -a 256
   if command -v "$__shasum_command" > /dev/null 2>&1 && ! ${__shasum_command} --version 2>&1 | grep -q 'Darwin'; then
     __shasum_command='sha256sum'
   else
     __shasum_command="shasum -a 256"
   fi
-  if echo "$__sha256  $__filename" | ${__shasum_command} --check; then
-    echo "Checksum of $__filename Ok"
-  else
-    rm -v ${__filename}
-    report_error "Checksum of $__filename could not be verified, abort."
-    return 1
-  fi
+  echo "$__shasum_command"
+}
+
+# helper routine to check integrity of files
+# usage: checksum sha256 filename
+checksum() {
+  local __sha256="$1"
+  local __filename="$2"
+  local __shasum_command=$(get_checksum_cmd)
+  echo "$__sha256  $__filename" | ${__shasum_command} --check
 }
 
 # downloader for the package tars, includes checksum
@@ -651,7 +651,12 @@ download_pkg_from_urlpath() {
     return 1
   fi
   # checksum
-  checksum "${__outfile}" "${__sha256}"
+  if checksum "${__sha256}" "${__outfile}"; then
+    echo "Checksum of $__filename Ok"
+  else
+    report_error "Checksum of $__filename could not be verified, abort."
+    return 1
+  fi
 }
 
 # download from CP2K.org
@@ -663,15 +668,7 @@ download_pkg_from_cp2k_org() {
 # verify the checksums inside the given checksum file
 verify_checksums() {
   local __checksum_file=$1
-  local __shasum_command='sha256sum'
-
-  # check if we have sha256sum command, Mac OS X does not have
-  # sha256sum, but has an equivalent with shasum -a 256
-  if command -v "$__shasum_command" > /dev/null 2>&1 && ! ${__shasum_command} --version 2>&1 | grep -q 'Darwin'; then
-    __shasum_command='sha256sum'
-  else
-    __shasum_command="shasum -a 256"
-  fi
+  local __shasum_command=$(get_checksum_cmd)
 
   ${__shasum_command} --check "${__checksum_file}" > /dev/null 2>&1
 }
@@ -680,15 +677,7 @@ verify_checksums() {
 write_checksums() {
   local __checksum_file=$1
   shift # remove output file from arguments to be able to pass them along properly quoted
-  local __shasum_command='sha256sum'
-
-  # check if we have sha256sum command, Mac OS X does not have
-  # sha256sum, but has an equivalent with shasum -a 256
-  if command -v "$__shasum_command" > /dev/null 2>&1 && ! ${__shasum_command} --version 2>&1 | grep -q 'Darwin'; then
-    __shasum_command='sha256sum'
-  else
-    __shasum_command="shasum -a 256"
-  fi
+  local __shasum_command=$(get_checksum_cmd)
 
   ${__shasum_command} "${VERSION_FILE}" "$@" > "${__checksum_file}"
 }


### PR DESCRIPTION
**This issue is obsolete**

Attempt to address #1807 by explicitly checking whether sha256sum matches record in
addition to whether file exists for each package. The `checksum` wrapper
in `tool_kit.sh` is slightly rewritten with (1) the functionality of finding
sha256sum command refactored to `get_checksum_cmd` and (2) the positional
arguments swapped place for convenience.