### PR TITLE
Libint-cp2k: adjust build procedure

### DIFF
--- a/tools/libint/Dockerfile
+++ b/tools/libint/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get install -qq --no-install-recommends \
     libgmp-dev \
     libboost-dev \
     make \
-    wget
+    wget \
+    xz-utils
 
 WORKDIR /opt
 COPY ./build_bundles.sh .

--- a/tools/libint/build_bundles.sh
+++ b/tools/libint/build_bundles.sh
@@ -32,7 +32,8 @@ for lmax in 4 5 6 7; do
     -DLIBINT2_ENABLE_FORTRAN=ON \
     -DLIBINT2_ENABLE_UNROLLING=0 &> cmake.log
   make export -j 32 &> build.log
-  cp -v ./libint-2.13.1-post999.tgz "/opt/libint-bundles/libint-v${libint_ver}-cp2k-lmax-${lmax}.tgz"
+  mv -f ./libint-2.13.1-post999 ./libint-v${libint_ver}-cp2k-lmax-${lmax}
+  tar -cJf "/opt/libint-bundles/libint-v${libint_ver}-cp2k-lmax-${lmax}.tar.xz" ./libint-v${libint_ver}-cp2k-lmax-${lmax}
   cd ..
 done
 


### PR DESCRIPTION
Directly renaming the tarball will cause it to extract into a directory still with the original name, which does not meet the original expectation.

Since there would be a directory `libint-${libint_ver}-post999` whose contents are identical to those in the generated tarball, here we directly rename this directory and re-compress it to better handle this situation. The `.tar.xz` is used because it provides a higher compression ratio, thereby substantially reducing upload and download overhead.