### PR TITLE
Toolchain: Lower optimization level of KXC functionals of libxc for GCC

### DIFF
--- a/tools/toolchain/scripts/stage3/install_libxc.sh
+++ b/tools/toolchain/scripts/stage3/install_libxc.sh
@@ -38,8 +38,26 @@ case "$with_libxc" in
       cd libxc-${libxc_ver}
       mkdir build
       cd build
+
+      # Lower the optimization level of KXC functionals for GCC to reduce time cost
+      # LXC functionals are not used so ignore them
+      if [ "${with_gcc}" != "__DONTUSE__" ]; then
+        if [ "${with_intel}" = "__DONTUSE__" ] && [ "${with_amd}" = "__DONTUSE__" ]; then
+          MAPLE2C_DIR="../src/maple2c"
+          for f in "$MAPLE2C_DIR"/gga_exc/*.c "$MAPLE2C_DIR"/mgga_exc/*.c "$MAPLE2C_DIR"/lda_exc/*.c; do
+            [ -f "$f" ] || continue
+            if grep -q "^func_kxc_" "$f" && ! grep -q "__attribute__((optimize" "$f"; then
+              sed -i 's/^func_kxc_/__attribute__((optimize("O1"))) func_kxc_/' "$f"
+            fi
+          done
+          LIBXC_CFLAGS="${CFLAGS} -fno-var-tracking"
+        else
+          LIBXC_CFLAGS="${CFLAGS}"
+        fi
+      fi
+
       # CP2K does not make use of fourth derivatives, so skip their compilation with -DDISABLE_KXC=OFF
-      cmake \
+      CFLAGS="${LIBXC_CFLAGS}" cmake \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_VERBOSE_MAKEFILE=ON \


### PR DESCRIPTION
Part of the code in Libxc is automatically generated. The higher-order derivative routines often contain tens of thousands of lines consisting purely of variable assignments and floating-point operations, without any complex control structures. When GCC’s optimizer processes a single function of this scale, the compilation time can grow exponentially, thus slowing down the build process (at least for some machines). 

Therefore, for the KXC part of the code, the optimization level is intentionally reduced to significantly shorten the compilation time. The LXC part is not enabled during compilation, so no similar adjustment is applied there.

Considering that KXC is rarely used in CP2K, and when used it is not a primary computational bottleneck, I think this change would not have noticeable impact on CP2K’s runtime performance.