### PR TITLE
Vibrational analysis: extend width of data field

### DIFF
--- a/src/motion/vibrational_analysis.F
+++ b/src/motion/vibrational_analysis.F
@@ -864,23 +864,23 @@ CONTAINS
          to = MIN(from + 2, nvib)
          WRITE (UNIT=iw, FMT="(T2,'VIB|',13X,3(8X,I5,8X))") &
             (icol, icol=from, to)
-         WRITE (UNIT=iw, FMT="(T2,'VIB|Frequency (cm^-1)',3(1X,ES18.6E3,2X))") &
+         WRITE (UNIT=iw, FMT="(T2,'VIB|Frequency (cm^-1)',3(1X,ES18.10E3,2X))") &
             (freq(icol), icol=from, to)
          IF (ASSOCIATED(intensities_d)) THEN
-            WRITE (UNIT=iw, FMT="(T2,'VIB|IR int (KM/Mole) ',3(1X,ES18.6E3,2X))") &
+            WRITE (UNIT=iw, FMT="(T2,'VIB|IR int (KM/Mole) ',3(1X,ES18.10E3,2X))") &
                (fint*intensities_d(icol)**2, icol=from, to)
          END IF
          IF (ASSOCIATED(intensities_p)) THEN
-            WRITE (UNIT=iw, FMT="(T2,'VIB|Raman (A^4/amu)  ',3(1X,ES18.6E3,2X))") &
+            WRITE (UNIT=iw, FMT="(T2,'VIB|Raman (A^4/amu)  ',3(1X,ES18.10E3,2X))") &
                (pint*intensities_p(icol), icol=from, to)
-            WRITE (UNIT=iw, FMT="(T2,'VIB|Depol Ratio (P)  ',3(1X,ES18.6E3,2X))") &
+            WRITE (UNIT=iw, FMT="(T2,'VIB|Depol Ratio (P)  ',3(1X,ES18.10E3,2X))") &
                (depol_p(icol), icol=from, to)
-            WRITE (UNIT=iw, FMT="(T2,'VIB|Depol Ratio (U)  ',3(1X,ES18.6E3,2X))") &
+            WRITE (UNIT=iw, FMT="(T2,'VIB|Depol Ratio (U)  ',3(1X,ES18.10E3,2X))") &
                (depol_u(icol), icol=from, to)
          END IF
-         WRITE (UNIT=iw, FMT="(T2,'VIB|Red.Masses (a.u.)',3(1X,ES18.6E3,2X))") &
+         WRITE (UNIT=iw, FMT="(T2,'VIB|Red.Masses (a.u.)',3(1X,ES18.10E3,2X))") &
             (m(icol), icol=from, to)
-         WRITE (UNIT=iw, FMT="(T2,'VIB|Frc consts (a.u.)',3(1X,ES18.6E3,2X))") &
+         WRITE (UNIT=iw, FMT="(T2,'VIB|Frc consts (a.u.)',3(1X,ES18.10E3,2X))") &
             (k(icol), icol=from, to)
          WRITE (UNIT=iw, FMT="(T2,' ATOM',2X,'EL',7X,3(4X,'  X  ',1X,'  Y  ',1X,'  Z  '))")
          DO iatom = 1, natom, 3

--- a/src/motion/vibrational_analysis.F
+++ b/src/motion/vibrational_analysis.F
@@ -864,23 +864,23 @@ CONTAINS
          to = MIN(from + 2, nvib)
          WRITE (UNIT=iw, FMT="(T2,'VIB|',13X,3(8X,I5,8X))") &
             (icol, icol=from, to)
-         WRITE (UNIT=iw, FMT="(T2,'VIB|Frequency (cm^-1)',3(1X,F12.6,8X))") &
+         WRITE (UNIT=iw, FMT="(T2,'VIB|Frequency (cm^-1)',3(1X,ES18.6E3,2X))") &
             (freq(icol), icol=from, to)
          IF (ASSOCIATED(intensities_d)) THEN
-            WRITE (UNIT=iw, FMT="(T2,'VIB|IR int (KM/Mole) ',3(1X,F12.6,8X))") &
+            WRITE (UNIT=iw, FMT="(T2,'VIB|IR int (KM/Mole) ',3(1X,ES18.6E3,2X))") &
                (fint*intensities_d(icol)**2, icol=from, to)
          END IF
          IF (ASSOCIATED(intensities_p)) THEN
-            WRITE (UNIT=iw, FMT="(T2,'VIB|Raman (A^4/amu)  ',3(1X,F12.6,8X))") &
+            WRITE (UNIT=iw, FMT="(T2,'VIB|Raman (A^4/amu)  ',3(1X,ES18.6E3,2X))") &
                (pint*intensities_p(icol), icol=from, to)
-            WRITE (UNIT=iw, FMT="(T2,'VIB|Depol Ratio (P)  ',3(1X,F12.6,8X))") &
+            WRITE (UNIT=iw, FMT="(T2,'VIB|Depol Ratio (P)  ',3(1X,ES18.6E3,2X))") &
                (depol_p(icol), icol=from, to)
-            WRITE (UNIT=iw, FMT="(T2,'VIB|Depol Ratio (U)  ',3(1X,F12.6,8X))") &
+            WRITE (UNIT=iw, FMT="(T2,'VIB|Depol Ratio (U)  ',3(1X,ES18.6E3,2X))") &
                (depol_u(icol), icol=from, to)
          END IF
-         WRITE (UNIT=iw, FMT="(T2,'VIB|Red.Masses (a.u.)',3(1X,F12.6,8X))") &
+         WRITE (UNIT=iw, FMT="(T2,'VIB|Red.Masses (a.u.)',3(1X,ES18.6E3,2X))") &
             (m(icol), icol=from, to)
-         WRITE (UNIT=iw, FMT="(T2,'VIB|Frc consts (a.u.)',3(1X,F12.6,8X))") &
+         WRITE (UNIT=iw, FMT="(T2,'VIB|Frc consts (a.u.)',3(1X,ES18.6E3,2X))") &
             (k(icol), icol=from, to)
          WRITE (UNIT=iw, FMT="(T2,' ATOM',2X,'EL',7X,3(4X,'  X  ',1X,'  Y  ',1X,'  Z  '))")
          DO iatom = 1, natom, 3

--- a/tests/Fist/regtest-5-vib/TEST_FILES.toml
+++ b/tests/Fist/regtest-5-vib/TEST_FILES.toml
@@ -1,8 +1,8 @@
 #vibrational analysis
-"wat_freq.inp"                          = [{matcher="Vib_freq", tol=1.0E-14, ref=1736.710173},
+"wat_freq.inp"                          = [{matcher="Vib_freq", tol=1.0E-14, ref=1736.7101734},
                                            {matcher="Vib_frc_const", tol=1.0E-04, ref=0.122443}]
-"wat_freq_norot.inp"                    = [{matcher="Vib_freq", tol=1.0E-14, ref=1736.710173}]
-"wat_freq_freeze.inp"                   = [{matcher="Vib_freq", tol=1.0E-14, ref=-37.593284}]
+"wat_freq_norot.inp"                    = [{matcher="Vib_freq", tol=1.0E-14, ref=1736.7101734}]
+"wat_freq_freeze.inp"                   = [{matcher="Vib_freq", tol=1.0E-14, ref=-37.593283504}]
 "wat_mode_sel.inp"                      = []
 "wat_mode_sel_range.inp"                = []
 # MD inititalization with velocities from vibrational analysis

--- a/tests/QS/regtest-ot-1-vib/TEST_FILES.toml
+++ b/tests/QS/regtest-ot-1-vib/TEST_FILES.toml
@@ -6,9 +6,9 @@
 # Mode selectiv vibrational analysis and intensities
 "H2O-VIB-MS-INT-1.inp"                  = [{matcher="M021", tol=1.0E-14, ref=180.498851}]
 "H2O-VIB-MS-INT-2.inp"                  = [{matcher="M021", tol=1.0E-14, ref=180.498851}]
-"vib-mixed.inp"                         = [{matcher="Vib_freq", tol=1e-14, ref=2160.693948},
+"vib-mixed.inp"                         = [{matcher="Vib_freq", tol=1e-14, ref=2160.6939476},
                                            {matcher="Vib_frc_const", tol=1e-05, ref=0.184127}]
 "dip-mixed.inp"                         = [{matcher="M011", tol=2e-14, ref=-17.248506334913024}]
-"vib-int-mixed.inp"                     = [{matcher="Vib_freq", tol=1e-14, ref=2284.489403},
+"vib-int-mixed.inp"                     = [{matcher="Vib_freq", tol=1e-14, ref=2284.4894031},
                                            {matcher="Vib_frc_const", tol=1e-05, ref=0.206952}]
 #EOF

--- a/tests/QS/regtest-stda-force-4/TEST_FILES.toml
+++ b/tests/QS/regtest-stda-force-4/TEST_FILES.toml
@@ -5,5 +5,5 @@
 #      for details see cp2k/tools/do_regtest
 #
 "h2o_v01.inp"                           = [{matcher="Vib_freq", tol=1.0E-07, ref=402.001443},
-                                           {matcher="Vib_frc_const", tol=1.0E-05, ref=0.00655602027954}]
+                                           {matcher="Vib_frc_const", tol=1.0E-05, ref=0.0065562027954}]
 #EOF

--- a/tests/QS/regtest-stda-force-4/TEST_FILES.toml
+++ b/tests/QS/regtest-stda-force-4/TEST_FILES.toml
@@ -5,5 +5,5 @@
 #      for details see cp2k/tools/do_regtest
 #
 "h2o_v01.inp"                           = [{matcher="Vib_freq", tol=1.0E-07, ref=402.001443},
-                                           {matcher="Vib_frc_const", tol=1.0E-05, ref=0.006556}]
+                                           {matcher="Vib_frc_const", tol=1.0E-05, ref=0.00655602027954}]
 #EOF


### PR DESCRIPTION
The old format for printing out IR and Raman intensities from a vibrational
analysis job is `3(1X,F12.6,8X)`, whose fixed 12-character width for float
type data may be faced with overflow in practice; this PR proposes sacrificing
width of trailing blank and extending width of data field with a new format
`3(1X,ES18.6E3,2X)` that is less likely to become a string of asterisks (****)
and obscure the data result. Note that this does not imply that an abnormally
high intensity from vibrational analysis is free from numeric error and/or
chemically sensible; the user is still responsible of verifying data.

For downstream output file parsers, this should be fine unless a restriction
of data type `F12.6` is expected.

Closes #4219.