### PR TITLE
Toolchain: improve `generate_cmake_options.sh`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ find_package(PkgConfig)
 # Define the paths for static libraries and executables
 # ##############################################################################
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY
-    ${cp2k_BINARY_DIR}/lib
+    ${PROJECT_BINARY_DIR}/lib
     CACHE PATH "Single output directory for building all libraries.")
 
 # Search for rocm in common locations
@@ -356,7 +356,7 @@ if(CP2K_ENABLE_CONSISTENCY_CHECKS)
 endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
-    ${cp2k_BINARY_DIR}/bin
+    ${PROJECT_BINARY_DIR}/bin
     CACHE PATH "Single output directory for building all executables.")
 
 # Python
@@ -1241,7 +1241,7 @@ endif()
 message(
   "\n\n" # let below line separate
   "After building CP2K the regtests can be run with the following command:\n"
-  "   ./tests/do_regtest.py ${cp2k_BINARY_DIR}/bin ${__cp2k_ext}\n\n")
+  "   ./tests/do_regtest.py ${CMAKE_INSTALL_PREFIX}/bin ${__cp2k_ext}\n\n")
 
 # files needed for cmake
 

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi100
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi100
@@ -46,7 +46,8 @@ RUN ./install_cp2k_toolchain.sh \
     --enable-hip=yes \
     --gpu-ver=Mi100 \
     --with-dbcsr \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.build_hip_rocm_Mi50
+++ b/tools/docker/Dockerfile.build_hip_rocm_Mi50
@@ -46,7 +46,8 @@ RUN ./install_cp2k_toolchain.sh \
     --enable-hip=yes \
     --gpu-ver=Mi50 \
     --with-dbcsr \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_aiida
+++ b/tools/docker/Dockerfile.test_aiida
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_arm64-psmp
+++ b/tools/docker/Dockerfile.test_arm64-psmp
@@ -28,7 +28,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-gcc=system \
     --with-libtorch=no \
     --with-deepmd=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_asan-psmp
+++ b/tools/docker/Dockerfile.test_asan-psmp
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_ase
+++ b/tools/docker/Dockerfile.test_ase
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_conventions
+++ b/tools/docker/Dockerfile.test_conventions
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_coverage
+++ b/tools/docker/Dockerfile.test_coverage
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_cuda_A100
+++ b/tools/docker/Dockerfile.test_cuda_A100
@@ -39,7 +39,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=A100 \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_cuda_P100
+++ b/tools/docker/Dockerfile.test_cuda_P100
@@ -39,7 +39,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=P100 \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_cuda_V100
+++ b/tools/docker/Dockerfile.test_cuda_V100
@@ -39,7 +39,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=V100 \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_fedora-psmp
+++ b/tools/docker/Dockerfile.test_fedora-psmp
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_gcc10
+++ b/tools/docker/Dockerfile.test_gcc10
@@ -63,7 +63,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libxsmm=no \
     --with-spglib=no \
     --with-libvori=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_gcc11
+++ b/tools/docker/Dockerfile.test_gcc11
@@ -63,7 +63,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libxsmm=no \
     --with-spglib=no \
     --with-libvori=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_gcc12
+++ b/tools/docker/Dockerfile.test_gcc12
@@ -63,7 +63,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libxsmm=no \
     --with-spglib=no \
     --with-libvori=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_gcc13
+++ b/tools/docker/Dockerfile.test_gcc13
@@ -63,7 +63,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libxsmm=no \
     --with-spglib=no \
     --with-libvori=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_gcc14
+++ b/tools/docker/Dockerfile.test_gcc14
@@ -67,7 +67,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libxsmm=no \
     --with-spglib=no \
     --with-libvori=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_gcc8
+++ b/tools/docker/Dockerfile.test_gcc8
@@ -63,7 +63,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libxsmm=no \
     --with-spglib=no \
     --with-libvori=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_gcc9
+++ b/tools/docker/Dockerfile.test_gcc9
@@ -63,7 +63,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libxsmm=no \
     --with-spglib=no \
     --with-libvori=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -27,7 +27,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-dbcsr \
     --with-gcc=system \
     --target-cpu=generic \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_gromacs
+++ b/tools/docker/Dockerfile.test_gromacs
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_i-pi
+++ b/tools/docker/Dockerfile.test_i-pi
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_intel-ifort-psmp
+++ b/tools/docker/Dockerfile.test_intel-ifort-psmp
@@ -29,7 +29,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libsmeagol \
     --with-libtorch=no \
     --with-deepmd=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_intel-ifort-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ifort-ssmp
@@ -29,7 +29,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libsmeagol \
     --with-libtorch=no \
     --with-deepmd=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_intel-ifx-psmp
+++ b/tools/docker/Dockerfile.test_intel-ifx-psmp
@@ -29,7 +29,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libsmeagol \
     --with-libtorch=no \
     --with-deepmd=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_intel-ifx-ssmp
+++ b/tools/docker/Dockerfile.test_intel-ifx-ssmp
@@ -29,7 +29,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libsmeagol \
     --with-libtorch=no \
     --with-deepmd=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_manual
+++ b/tools/docker/Dockerfile.test_manual
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_minimal
+++ b/tools/docker/Dockerfile.test_minimal
@@ -63,7 +63,8 @@ RUN ./install_cp2k_toolchain.sh \
     --with-libxsmm=no \
     --with-spglib=no \
     --with-libvori=no \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_openmpi-psmp
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=openmpi \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_pdbg
+++ b/tools/docker/Dockerfile.test_pdbg
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_performance
+++ b/tools/docker/Dockerfile.test_performance
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_performance_cuda_A100
+++ b/tools/docker/Dockerfile.test_performance_cuda_A100
@@ -39,7 +39,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=A100 \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_performance_cuda_P100
+++ b/tools/docker/Dockerfile.test_performance_cuda_P100
@@ -39,7 +39,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=P100 \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_performance_cuda_V100
+++ b/tools/docker/Dockerfile.test_performance_cuda_V100
@@ -39,7 +39,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --enable-cuda=yes \
     --gpu-ver=V100 \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_phonopy
+++ b/tools/docker/Dockerfile.test_phonopy
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_psmp
+++ b/tools/docker/Dockerfile.test_psmp
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_psmp_4ranks
+++ b/tools/docker/Dockerfile.test_psmp_4ranks
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=mpich \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_sdbg
+++ b/tools/docker/Dockerfile.test_sdbg
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/Dockerfile.test_ssmp
+++ b/tools/docker/Dockerfile.test_ssmp
@@ -26,7 +26,8 @@ RUN ./install_cp2k_toolchain.sh \
     --mpi-mode=no \
     --with-dbcsr \
     --with-gcc=system \
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -601,7 +601,8 @@ COPY ./tools/toolchain/scripts/VERSION \
 COPY ./tools/toolchain/install_cp2k_toolchain.sh .
 RUN ./install_cp2k_toolchain.sh \
 {install_args_str}
-    --dry-run
+    --dry-run \
+    --list-cmake-options=no
 
 # Dry-run leaves behind config files for the followup install scripts.
 # This breaks up the lengthy installation into smaller build steps.

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -1292,17 +1292,17 @@ else
   echo "Options have been parsed successfully."
   echo "Compiling with ${NPROCS_OVERWRITE} processes for target ${TARGET_CPU}."
   echo "# Leak suppressions" > "${INSTALLDIR}"/lsan.supp
-  ./scripts/stage0/install_stage0.sh
-  ./scripts/stage1/install_stage1.sh
-  ./scripts/stage2/install_stage2.sh
-  ./scripts/stage3/install_stage3.sh
-  ./scripts/stage4/install_stage4.sh
-  ./scripts/stage5/install_stage5.sh
-  ./scripts/stage6/install_stage6.sh
-  ./scripts/stage7/install_stage7.sh
-  ./scripts/stage8/install_stage8.sh
-  ./scripts/stage9/install_stage9.sh
+  "${SCRIPTDIR}"/stage0/install_stage0.sh
+  "${SCRIPTDIR}"/stage1/install_stage1.sh
+  "${SCRIPTDIR}"/stage2/install_stage2.sh
+  "${SCRIPTDIR}"/stage3/install_stage3.sh
+  "${SCRIPTDIR}"/stage4/install_stage4.sh
+  "${SCRIPTDIR}"/stage5/install_stage5.sh
+  "${SCRIPTDIR}"/stage6/install_stage6.sh
+  "${SCRIPTDIR}"/stage7/install_stage7.sh
+  "${SCRIPTDIR}"/stage8/install_stage8.sh
+  "${SCRIPTDIR}"/stage9/install_stage9.sh
 fi
 
 # Generate CMake options
-./scripts/generate_cmake_options.sh
+"${SCRIPTDIR}"/generate_cmake_options.sh

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -79,83 +79,87 @@ $(basename "$SCRIPT_NAME") [options]
 
 OPTIONS:
 
-  -h, --help                Show this message and exit.
-  --help-hpc                Show additional hints for HPC users and exit.
-  -j <n>                    Number of processors for parallel compiling.
-                            If omitted, the script will automatically try to
-                            determine the number of available processors and use
-                            all of them by default.
-  --no-check-certificate    Bypass verification of server's certificate while
-                            downloading anything from internet via wget command.
-                            In case wget errors about "certificate verification"
-                            or "common name doesn't match requested host name"
-                            occur while downloading tarballs, the recommended
-                            solution is to install the latest wget release;
-                            alternatively, this script can be rerun with this
-                            option in command line.
-                            Security wise this should still be okay as sha256
-                            checksums are validated after every tarball
-                            download. Nevertheless, use this option at your own
-                            risk.
-  --install-all             Set value of all --with-PKG options to "install"
-                            (except --with-intel, --with-intelmpi, --with-amd).
-                            By default, GNU compiler and MPICH are installed.
-                            AFTER this option on the command line, you can set
-                            specific --with-PKG options to another value again
-                            for selective fine controls (see below).
-  --mpi-mode                Select which MPI flavour to use. Available options
-                            are: mpich, openmpi, intelmpi, and no.
-                            If omitted, the script will automatically try to
-                            determine the flavour based on the MPI library
-                            available in system path; alternatively, if any of
-                            --with-mpich, --with-openmpi or --with-intelmpi
-                            options (see below) is explicitly set to values
-                            other than no, the script will follow.
-                            For CRAY (CLE) systems and the case that you use
-                            "--with-mpi" but no MPI installation is detected,
-                            the default flavour is mpich.
-                            By selecting "no", MPI is unsupported and disabled.
-  --math-mode               Select which core math library to use. Available
-                            options are: acml, cray, mkl, and openblas.
-                            If omitted, for non-CRAY systems, mkl is the default
-                            when environment variable \$MKLROOT exists, otherwise
-                            openblas is the drefault; for CRAY (CLE) systems,
-                            cray is the default, corresponding to cray libsci.
-                            Alternatively, if any of --with-acml, --with-mkl,
-                            or --with-openblas options (see below) is explicitly
-                            set to values other than no, the script will follow.
-  --target-cpu              Select the target CPU architecture for compiling.
-                            This option determines the value of -mtune flag in
-                            CFLAGS for compilers. If omitted or set to "native",
-                            compiling will be tuned/optimized for the native
-                            host system, and some instruction sets will be
-                            detected including AVX, AVX2, AVX512,etc.
-                            Alternatively this option can be set depending on
-                            actual target CPU microarchitecture, e.g. "haswell",
-                            "skylake", or just "generic".
-                            Default = native
-  --gpu-ver                 Select the target GPU architecture for compiling.
-                            Available options are: K20X, K40, K80, P100, V100,
-                            A100, H100, A40, Mi50, Mi100, Mi250, and no.
-                            This option determines the value of nvcc -arch flag.
-                            Default = no
-  --libint-lmax             Maximum supported angular momentum by libint if the
-                            "--with-libint" option is set to "install".
-                            Available options are: 4, 5, 6, 7. Higher value will
-                            result in more build time and larger library size.
-                            Default = 5
-  --log-lines               The number of final lines from the log file in the
-                            corresponding directory that will be dumped to the
-                            command line in case a package build returns a non-
-                            zero exit code. Due to limited length, this snippet
-                            may not contain the very first warning or error
-                            message.
-                            Default = 200
-  --dry-run                 After writing toolchain config and env files to the
-                            install directory, just print a list of effective
-                            settings after resolving known conflicts, then exit
-                            without actually downloading tarballs or building
-                            packages.
+  -h, --help              Show this message and exit.
+  --help-hpc              Show additional hints for HPC users and exit.
+  -j <n>                  Number of processors for parallel compiling.
+                          If omitted, the script will automatically try to
+                          determine the number of available processors and use
+                          all of them by default.
+  --no-check-certificate  Bypass verification of server's certificate while
+                          downloading anything from internet via wget command.
+                          In case wget errors about "certificate verification"
+                          or "common name doesn't match requested host name"
+                          occur while downloading tarballs, the recommended
+                          solution is to install the latest wget release;
+                          alternatively, this script can be rerun with this
+                          option in command line.
+                          Security wise this should still be okay as sha256
+                          checksums are validated after every tarball
+                          download. Nevertheless, use this option at your own
+                          risk.
+  --install-all           Set value of all --with-PKG options to "install"
+                          (except --with-intel, --with-intelmpi, --with-amd).
+                          By default, GNU compiler and MPICH are installed.
+                          AFTER this option on the command line, you can set
+                          specific --with-PKG options to another value again
+                          for selective fine controls (see below).
+  --mpi-mode              Select which MPI flavour to use. Available options
+                          are: mpich, openmpi, intelmpi, and no.
+                          If omitted, the script will automatically try to
+                          determine the flavour based on the MPI library
+                          available in system path; alternatively, if any of
+                          --with-mpich, --with-openmpi or --with-intelmpi
+                          options (see below) is explicitly set to values
+                          other than no, the script will follow.
+                          For CRAY (CLE) systems and the case that you use
+                          "--with-mpi" but no MPI installation is detected,
+                          the default flavour is mpich.
+                          By selecting "no", MPI is unsupported and disabled.
+  --math-mode             Select which core math library to use. Available
+                          options are: acml, cray, mkl, and openblas.
+                          If omitted, for non-CRAY systems, mkl is the default
+                          when environment variable \$MKLROOT exists, otherwise
+                          openblas is the drefault; for CRAY (CLE) systems,
+                          cray is the default, corresponding to cray libsci.
+                          Alternatively, if any of --with-acml, --with-mkl,
+                          or --with-openblas options (see below) is explicitly
+                          set to values other than no, the script will follow.
+  --target-cpu            Select the target CPU architecture for compiling.
+                          This option determines the value of -mtune flag in
+                          CFLAGS for compilers. If omitted or set to "native",
+                          compiling will be tuned/optimized for the native
+                          host system, and some instruction sets will be
+                          detected including AVX, AVX2, AVX512,etc.
+                          Alternatively this option can be set depending on
+                          actual target CPU microarchitecture, e.g. "haswell",
+                          "skylake", or just "generic".
+                          Default = native
+  --gpu-ver               Select the target GPU architecture for compiling.
+                          Available options are: K20X, K40, K80, P100, V100,
+                          A100, H100, A40, Mi50, Mi100, Mi250, and no.
+                          This option determines the value of nvcc -arch flag.
+                          Default = no
+  --libint-lmax           Maximum supported angular momentum by libint if the
+                          "--with-libint" option is set to "install".
+                          Available options are: 4, 5, 6, 7. Higher value will
+                          result in more build time and larger library size.
+                          Default = 5
+  --log-lines             The number of final lines from the log file in the
+                          corresponding directory that will be dumped to the
+                          command line in case a package build returns a non-
+                          zero exit code. Due to limited length, this snippet
+                          may not contain the very first warning or error
+                          message.
+                          Default = 200
+  --dry-run               After writing toolchain config and env files to the
+                          install directory, just print a list of effective
+                          settings after resolving known conflicts, then exit
+                          without actually downloading tarballs or building
+                          packages.
+  --list-cmake-options    If yes, generate a list of CMake options for building
+                          CP2K with the toolchain configuration as well as some
+                          further instructions at the end of toolchain.
+                          Default = yes
 
 The --enable-FEATURE options follow the rules:
   --enable-FEATURE=yes    Enable this particular feature.
@@ -549,6 +553,7 @@ else
 fi
 
 # default enable options
+list_cmake_options="__TRUE__"
 dry_run="__FALSE__"
 enable_tsan="__FALSE__"
 enable_opencl="__FALSE__"
@@ -713,6 +718,13 @@ Otherwise use option no."
       ;;
     --dry-run)
       dry_run="__TRUE__"
+      ;;
+    --list-cmake-options)
+      list_cmake_options=$(read_enable "${1}")
+      if [ "${list_cmake_options}" = "__INVALID__" ]; then
+        report_error "invalid value for --list-cmake-options, please use yes or no"
+        exit 1
+      fi
       ;;
     --enable-tsan*)
       enable_tsan=$(read_enable "${1}")
@@ -1305,4 +1317,6 @@ else
 fi
 
 # Generate CMake options
-"${SCRIPTDIR}"/generate_cmake_options.sh
+if [ "${list_cmake_options}" = "__TRUE__" ]; then
+  "${SCRIPTDIR}"/generate_cmake_options.sh
+fi

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -719,7 +719,7 @@ Otherwise use option no."
     --dry-run)
       dry_run="__TRUE__"
       ;;
-    --list-cmake-options=*)
+    --list-cmake-options*)
       list_cmake_options=$(read_enable "${1}")
       if [ "${list_cmake_options}" = "__INVALID__" ]; then
         report_error "invalid value for --list-cmake-options, please use yes or no"

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -719,7 +719,7 @@ Otherwise use option no."
     --dry-run)
       dry_run="__TRUE__"
       ;;
-    --list-cmake-options)
+    --list-cmake-options=*)
       list_cmake_options=$(read_enable "${1}")
       if [ "${list_cmake_options}" = "__INVALID__" ]; then
         report_error "invalid value for --list-cmake-options, please use yes or no"

--- a/tools/toolchain/scripts/generate_cmake_options.sh
+++ b/tools/toolchain/scripts/generate_cmake_options.sh
@@ -33,15 +33,15 @@ source "${INSTALLDIR}"/toolchain.env
 #
 # First, validate existence of relevant upper-level directory and file
 printf "\n========================== %s =========================\n" \
-"Generating CMake options for building CP2K"
-export CP2K_ROOT=$(real_path "${ROOTDIR}/../..")
+  "Generating CMake options for building CP2K"
+export CP2K_ROOT=$(cd "${ROOTDIR}/../.." && pwd)
 cat << EOF
 Root directory of CP2K is assumed to be ${CP2K_ROOT} (variable \${CP2K_ROOT}).
 Build directory will be ${CP2K_ROOT}/build for executing CMake.
 Install directory will be ${CP2K_ROOT}/install for CP2K binaries, libraries etc.
 EOF
 CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${CP2K_ROOT}/install"
-if [ -d "${CP2K_ROOT}/data" ] ; then
+if [ -d "${CP2K_ROOT}/data" ]; then
   echo "Data directory ${CP2K_ROOT}/data is found and set as -DCP2K_DATA_DIR."
   CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_DATA_DIR=${CP2K_ROOT}/data"
 else
@@ -111,8 +111,12 @@ fi
 
 # Export variable for CMake options to setup file
 echo "export CP2K_CMAKE_OPTIONS=\"${CMAKE_OPTIONS}\"" >> "${SETUPFILE}"
-echo "CMake options from parsing files are now collected in the variable
-\${CP2K_CMAKE_OPTIONS} that is exported at the end of ${SETUPFILE}."
+cat << EOF
+
+CMake options from parsing files are now collected in the variable
+\${CP2K_CMAKE_OPTIONS}, which is exported at the end of setup file:
+${SETUPFILE}
+EOF
 
 # -------------------------
 # print out user instructions

--- a/tools/toolchain/scripts/generate_cmake_options.sh
+++ b/tools/toolchain/scripts/generate_cmake_options.sh
@@ -46,7 +46,6 @@ EOF
   CMAKE_OPTIONS="-S ${CP2K_ROOT} -B ${CP2K_ROOT}/build"
   CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=${CP2K_ROOT}/install"
   CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_INSTALL_LIBDIR=lib"
-  CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_SKIP_RPATH=ON"
 else
   report_error ${LINENO} "\${CP2K_ROOT} does not have subdirectory src, so it
 cannot be set as source path for CMake options."
@@ -121,8 +120,17 @@ else
 fi
 
 # Export variable for CMake options to setup file
-printf "# ==================== Setup for CP2K ==================== #" >> "${SETUPFILE}"
-printf 'export CP2K_CMAKE_OPTIONS="%s"\n' "${CMAKE_OPTIONS}" >> "${SETUPFILE}"
+cat << EOF  >> "${SETUPFILE}"
+# ==================== Setup for CP2K ==================== #
+export CP2K_ROOT="${CP2K_ROOT}"
+export CP2K_CMAKE_OPTIONS="${CMAKE_OPTIONS}"
+prepend_path PATH "${CP2K_ROOT}/install/bin"
+prepend_path LD_LIBRARY_PATH "${CP2K_ROOT}/install/lib"
+prepend_path LD_RUN_PATH "${CP2K_ROOT}/install/lib"
+prepend_path LIBRARY_PATH "${CP2K_ROOT}/install/lib"
+prepend_path PKG_CONFIG_PATH "${CP2K_ROOT}/install/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${CP2K_ROOT}"
+EOF
 cat << EOF
 Suggested cmake command if toolchain is built with your options:
 
@@ -155,7 +163,9 @@ Toolchain is now ready for building CP2K! Instructions for next steps:
     suggested above:
       cd ${CP2K_ROOT}
       cmake ${CMAKE_OPTIONS}
-    Other commands from ${CP2K_ROOT}/CMakeLists.txt can also be added.
+    Other commands from ${CP2K_ROOT}/CMakeLists.txt can also be added. For more
+    information about available build options, see documentation:
+    https://manual.cp2k.org/trunk/getting-started/build-from-source.html.
     Alternative to copy-paste long lines in terminal is to use a variable from
     setup file for CMake options, which is not to be quoted so that whitespace
     delimiters allow it to expand to command options in shell:
@@ -172,15 +182,6 @@ Toolchain is now ready for building CP2K! Instructions for next steps:
 
 (6) Recommended - perform regtest as is suggested at the end of (3).
 
-(7) Recommended - append CP2K directory to paths:
-      export PATH="${CP2K_ROOT}/install/bin:\$PATH"
-      export LD_LIBRARY_PATH="${CP2K_ROOT}/install/lib:\${LD_LIBRARY_PATH}"
-      export LD_RUN_PATH="${CP2K_ROOT}/install/lib:\${LD_RUN_PATH}"
-      export LIBRARY_PATH="${CP2K_ROOT}/install/lib:\${LIBRARY_PATH}"
-      export CMAKE_PREFIX_PATH="${CP2K_ROOT}:\${CMAKE_PREFIX_PATH}"
-
-For more information about available build options, see:
-https://manual.cp2k.org/trunk/getting-started/build-from-source.html.
 This message is saved to "${INSTALLDIR}/cp2k_installation_guide.txt".
 EOF
 fi

--- a/tools/toolchain/scripts/generate_cmake_options.sh
+++ b/tools/toolchain/scripts/generate_cmake_options.sh
@@ -40,7 +40,10 @@ Root directory of CP2K is assumed to be ${CP2K_ROOT} (variable \${CP2K_ROOT}).
 Build directory will be ${CP2K_ROOT}/build for executing CMake.
 Install directory will be ${CP2K_ROOT}/install for CP2K binaries, libraries etc.
 EOF
-CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${CP2K_ROOT}/install"
+CMAKE_OPTIONS="-S ${CP2K_ROOT} -B ${CP2K_ROOT}/build"
+CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=${CP2K_ROOT}/install"
+CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_INSTALL_LIBDIR=lib"
+CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_SKIP_RPATH=ON"
 if [ -d "${CP2K_ROOT}/data" ]; then
   echo "Data directory ${CP2K_ROOT}/data is found and set as -DCP2K_DATA_DIR."
   CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_DATA_DIR=${CP2K_ROOT}/data"
@@ -110,7 +113,7 @@ else
 fi
 
 # Export variable for CMake options to setup file
-echo "export CP2K_CMAKE_OPTIONS=\"${CMAKE_OPTIONS}\"" >> "${SETUPFILE}"
+printf 'export CP2K_CMAKE_OPTIONS="%s"\n' "${CMAKE_OPTIONS}" >> "${SETUPFILE}"
 cat << EOF
 
 CMake options from parsing files are now collected in the variable
@@ -124,7 +127,7 @@ EOF
 if [ "${dry_run}" = "__TRUE__" ]; then
   cat << EOF
 Suggested cmake command if toolchain is built with your options:
-  cmake .. ${CMAKE_OPTIONS}
+  cmake ${CMAKE_OPTIONS}
 EOF
 else
   echo
@@ -145,13 +148,15 @@ Toolchain is now ready for building CP2K! Instructions for next steps:
 (3) Recommended - go to root directory of CP2K and build executable:
       cd ${CP2K_ROOT}
       mkdir build && cd build
-      cmake .. ${CMAKE_OPTIONS}
+      cmake ${CMAKE_OPTIONS}
       make install -j $(get_nprocs)
+    The CMake command shows the options from generate_cmake_options.sh. For more
+    CMake options, see ${CP2K_ROOT}/CMakeLists.txt.
     Alternatively the CMake command may take the same options from a variable as
     exported in the setup file, no need to copy-paste long lines in terminal:
-      cmake .. "\${CP2K_CMAKE_OPTIONS}"
+      cmake "\${CP2K_CMAKE_OPTIONS}"
     It may be helpful to also save a copy of command line messages to log files:
-      cmake .. "\${CP2K_CMAKE_OPTIONS}" 2>&1 | tee make.log
+      cmake "\${CP2K_CMAKE_OPTIONS}" 2>&1 | tee make.log
       make install -j $(get_nprocs) 2>&1 | tee install.log
 
 (4) Optional - once build is completed, remove ./build directory like in (1):

--- a/tools/toolchain/scripts/generate_cmake_options.sh
+++ b/tools/toolchain/scripts/generate_cmake_options.sh
@@ -120,7 +120,7 @@ else
 fi
 
 # Export variable for CMake options to setup file
-cat << EOF  >> "${SETUPFILE}"
+cat << EOF >> "${SETUPFILE}"
 # ==================== Setup for CP2K ==================== #
 export CP2K_ROOT="${CP2K_ROOT}"
 export CP2K_CMAKE_OPTIONS="${CMAKE_OPTIONS}"
@@ -159,7 +159,7 @@ Toolchain is now ready for building CP2K! Instructions for next steps:
     is executed. If modules have been used to estabilish environment variables
     and paths, remember to load these modules prior to sourcing setup file.
 
-(3) Recommended - go to root directory of CP2K and configure CMake with options
+(3) Required - go to root directory of CP2K and configure CMake with options
     suggested above:
       cd ${CP2K_ROOT}
       cmake ${CMAKE_OPTIONS}
@@ -171,7 +171,7 @@ Toolchain is now ready for building CP2K! Instructions for next steps:
     delimiters allow it to expand to command options in shell:
       cmake \${CP2K_CMAKE_OPTIONS}
 
-(4) Build CP2K with command:
+(4) Required - build CP2K with command:
       cmake --build ${CP2K_ROOT}/build --target install -j $(get_nprocs)
     It may be helpful to also save a copy of command line messages to log files:
       cmake --build ${CP2K_ROOT}/build --target install -j $(get_nprocs) 2>&1 | tee install.log

--- a/tools/toolchain/scripts/generate_cmake_options.sh
+++ b/tools/toolchain/scripts/generate_cmake_options.sh
@@ -13,11 +13,11 @@ source "${INSTALLDIR}"/toolchain.conf
 source "${INSTALLDIR}"/toolchain.env
 
 # This script assumes a working environment as follows:
-# cp2k                                  <- variable ${CP2K_ROOT}
+# cp2k                                  <- variable ${CP2K_ROOT}; CMake option -S
 # ├── CMakeLists.txt                    <- * file to be parsed in this script
-# ├── data                              <- CMake option -DCP2K_DATA_DIR
-# ├── build                             <- to-be-created CP2K CMake build directory
-# ├── install                           <- to-be-created CP2K install directory
+# ├── data                              <- CP2K data directory; CMake option -DCP2K_DATA_DIR
+# ├── build                             <- to-be-created; CMake option -B
+# ├── install                           <- to-be-created; CMake option -DCMAKE_INSTALL_PREFIX
 # ├── src                               <- CP2K source code directory
 # └── tools
 #     └── toolchain                     <- working directory; variable ${ROOTDIR}
@@ -34,22 +34,23 @@ source "${INSTALLDIR}"/toolchain.env
 # First, validate existence of relevant upper-level directory and file
 printf "\n========================== %s =========================\n" \
   "Generating CMake options for building CP2K"
-export CP2K_ROOT=$(cd "${ROOTDIR}/../.." && pwd)
-cat << EOF
-Root directory of CP2K is assumed to be ${CP2K_ROOT} (variable \${CP2K_ROOT}).
-Build directory will be ${CP2K_ROOT}/build for executing CMake.
-Install directory will be ${CP2K_ROOT}/install for CP2K binaries, libraries etc.
+CP2K_ROOT=$(cd "${ROOTDIR}/../.." && pwd)
+if [ -d "${CP2K_ROOT}/src" ]; then
+  cat << EOF
+Root directory of CP2K with source code is found as ${CP2K_ROOT}
+(path is exported to variable \${CP2K_ROOT}).
+Build directory will be \${CP2K_ROOT}/build.
+Install directory will be \${CP2K_ROOT}/install.
 EOF
-CMAKE_OPTIONS="-S ${CP2K_ROOT} -B ${CP2K_ROOT}/build"
-CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=${CP2K_ROOT}/install"
-CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_INSTALL_LIBDIR=lib"
-CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_SKIP_RPATH=ON"
-if [ -d "${CP2K_ROOT}/data" ]; then
-  echo "Data directory ${CP2K_ROOT}/data is found and set as -DCP2K_DATA_DIR."
-  CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_DATA_DIR=${CP2K_ROOT}/data"
+  export CP2K_ROOT
+  CMAKE_OPTIONS="-S ${CP2K_ROOT} -B ${CP2K_ROOT}/build"
+  CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_INSTALL_PREFIX=${CP2K_ROOT}/install"
+  CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_INSTALL_LIBDIR=lib"
+  CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCMAKE_SKIP_RPATH=ON"
 else
-  report_warning ${LINENO} "Data directory ${CP2K_ROOT}/data cannot be found;
-please set -DCP2K_DATA_DIR to actual path manually."
+  report_error ${LINENO} "\${CP2K_ROOT} does not have subdirectory src, so it
+cannot be set as source path for CMake options."
+  return 1
 fi
 if [ -f "${CP2K_ROOT}/CMakeLists.txt" ] && [ -r "${CP2K_ROOT}/CMakeLists.txt" ]; then
   echo "${CP2K_ROOT}/CMakeLists.txt exists; will be parsed for CMake options."
@@ -57,6 +58,13 @@ else
   report_error ${LINENO} "${CP2K_ROOT}/CMakeLists.txt cannot be found or read;
 suggested CMake option will be incomplete and/or incorrect."
   return 1
+fi
+if [ -d "${CP2K_ROOT}/data" ]; then
+  echo "Data directory ${CP2K_ROOT}/data is found and set as -DCP2K_DATA_DIR."
+  CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_DATA_DIR=${CP2K_ROOT}/data"
+else
+  report_warning ${LINENO} "Data directory ${CP2K_ROOT}/data cannot be found;
+please set -DCP2K_DATA_DIR to actual path manually."
 fi
 
 # ------------------------------------------------------------------------
@@ -115,21 +123,16 @@ fi
 # Export variable for CMake options to setup file
 printf 'export CP2K_CMAKE_OPTIONS="%s"\n' "${CMAKE_OPTIONS}" >> "${SETUPFILE}"
 cat << EOF
-
-CMake options from parsing files are now collected in the variable
-\${CP2K_CMAKE_OPTIONS}, which is exported at the end of setup file:
-${SETUPFILE}
+Suggested cmake command if toolchain is built with your options:
+  cmake ${CMAKE_OPTIONS}
+These options are also collected in the variable \${CP2K_CMAKE_OPTIONS} that is
+exported at the end of setup file ${SETUPFILE}.
 EOF
 
 # -------------------------
 # print out user instructions
 # -------------------------
-if [ "${dry_run}" = "__TRUE__" ]; then
-  cat << EOF
-Suggested cmake command if toolchain is built with your options:
-  cmake ${CMAKE_OPTIONS}
-EOF
-else
+if [ ! "${dry_run}" = "__TRUE__" ]; then
   echo
   cat << EOF | tee ${INSTALLDIR}/cp2k_installation_guide.txt
 ========================== Epilogue =========================
@@ -145,23 +148,27 @@ Toolchain is now ready for building CP2K! Instructions for next steps:
     is executed. If modules have been used to estabilish environment variables
     and paths, remember to load these modules prior to sourcing setup file.
 
-(3) Recommended - go to root directory of CP2K and build executable:
+(3) Recommended - go to root directory of CP2K and configure CMake with options
+    suggested above:
       cd ${CP2K_ROOT}
-      mkdir build && cd build
       cmake ${CMAKE_OPTIONS}
-      make install -j $(get_nprocs)
-    The CMake command shows the options from generate_cmake_options.sh. For more
-    CMake options, see ${CP2K_ROOT}/CMakeLists.txt.
-    Alternatively the CMake command may take the same options from a variable as
-    exported in the setup file, no need to copy-paste long lines in terminal:
+    Other commands from ${CP2K_ROOT}/CMakeLists.txt can also be added.
+    Alternative to copy-paste long lines in terminal is to use a variable from
+    setup file for CMake options:
       cmake "\${CP2K_CMAKE_OPTIONS}"
+
+(4) Build CP2K with command:
+      cmake --build ${CP2K_ROOT}/build --target install -j $(get_nprocs)
     It may be helpful to also save a copy of command line messages to log files:
-      cmake "\${CP2K_CMAKE_OPTIONS}" 2>&1 | tee make.log
-      make install -j $(get_nprocs) 2>&1 | tee install.log
+      cmake --build ${CP2K_ROOT}/build --target install -j $(get_nprocs) 2>&1 | tee install.log
 
 (4) Optional - once build is completed, remove ./build directory like in (1):
-      make clean
+      cmake --build ${CP2K_ROOT}/build --target clean
     Again, do not move the ./install directory from now on.
+
+(5) Recommended - edit ${SETUPFILE} and append paths:
+      export PATH="${CP2K_ROOT}/install:\$PATH"
+      export LD_LIBRARY_PATH="${CP2K_ROOT}/install/lib:\${LD_LIBRARY_PATH}"
 
 For more information about available build options, see:
 https://manual.cp2k.org/trunk/getting-started/build-from-source.html.

--- a/tools/toolchain/scripts/generate_cmake_options.sh
+++ b/tools/toolchain/scripts/generate_cmake_options.sh
@@ -167,7 +167,7 @@ Toolchain is now ready for building CP2K! Instructions for next steps:
     Again, do not move the ./install directory from now on.
 
 (5) Recommended - edit ${SETUPFILE} and append paths:
-      export PATH="${CP2K_ROOT}/install:\$PATH"
+      export PATH="${CP2K_ROOT}/install/bin:\$PATH"
       export LD_LIBRARY_PATH="${CP2K_ROOT}/install/lib:\${LD_LIBRARY_PATH}"
 
 For more information about available build options, see:

--- a/tools/toolchain/scripts/generate_cmake_options.sh
+++ b/tools/toolchain/scripts/generate_cmake_options.sh
@@ -12,13 +12,54 @@ source "${SCRIPT_DIR}"/signal_trap.sh
 source "${INSTALLDIR}"/toolchain.conf
 source "${INSTALLDIR}"/toolchain.env
 
-export CP2K_ROOT=$(cd ${ROOTDIR}/../.. && pwd)
+# This script assumes a working environment as follows:
+# cp2k                                  <- variable ${CP2K_ROOT}
+# ├── CMakeLists.txt                    <- * file to be parsed in this script
+# ├── data                              <- CMake option -DCP2K_DATA_DIR
+# ├── build                             <- to-be-created CP2K CMake build directory
+# ├── install                           <- to-be-created CP2K install directory
+# ├── src                               <- CP2K source code directory
+# └── tools
+#     └── toolchain                     <- working directory; variable ${ROOTDIR}
+#         ├── install_cp2k_toolchain.sh <- script being executed calling this script
+#         ├── scripts                   <- variable ${SCRIPT_DIR}
+#         │   ├── common_vars.sh
+#         │   ├── tool_kit.sh
+#         │   └── generate_cmake_options.sh <- this script
+#         └── install                   <- variable ${INSTALLDIR}
+#             ├── setup                 <- * file to be parsed in this script
+#             ├── toolchain.conf        <- * file to be parsed in this script
+#             └── toolchain.env         <- * file to be parsed in this script
+#
+# First, validate existence of relevant upper-level directory and file
+printf "\n========================== %s =========================\n" \
+"Generating CMake options for building CP2K"
+export CP2K_ROOT=$(real_path "${ROOTDIR}/../..")
+cat << EOF
+Root directory of CP2K is assumed to be ${CP2K_ROOT} (variable \${CP2K_ROOT}).
+Build directory will be ${CP2K_ROOT}/build for executing CMake.
+Install directory will be ${CP2K_ROOT}/install for CP2K binaries, libraries etc.
+EOF
+CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${CP2K_ROOT}/install"
+if [ -d "${CP2K_ROOT}/data" ] ; then
+  echo "Data directory ${CP2K_ROOT}/data is found and set as -DCP2K_DATA_DIR."
+  CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_DATA_DIR=${CP2K_ROOT}/data"
+else
+  report_warning ${LINENO} "Data directory ${CP2K_ROOT}/data cannot be found;
+please set -DCP2K_DATA_DIR to actual path manually."
+fi
+if [ -f "${CP2K_ROOT}/CMakeLists.txt" ] && [ -r "${CP2K_ROOT}/CMakeLists.txt" ]; then
+  echo "${CP2K_ROOT}/CMakeLists.txt exists; will be parsed for CMake options."
+else
+  report_error ${LINENO} "${CP2K_ROOT}/CMakeLists.txt cannot be found or read;
+suggested CMake option will be incomplete and/or incorrect."
+  return 1
+fi
 
 # ------------------------------------------------------------------------
 # generate cmake options for compiling cp2k
 # ------------------------------------------------------------------------
 # Build the program in source tree for convenience
-CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=../install -DCP2K_DATA_DIR=${CP2K_ROOT}/data"
 if [ -n "$(grep -- "--install-all" ${INSTALLDIR}/setup)" ]; then
   CMAKE_OPTIONS="${CMAKE_OPTIONS} -DCP2K_USE_EVERYTHING=ON -DCP2K_USE_DLAF=OFF -DCP2K_USE_PEXSI=OFF"
   # Since "--install-all" can be used together with "--with-PKG=no", an extra safeguard is added here
@@ -68,6 +109,11 @@ else
   done
 fi
 
+# Export variable for CMake options to setup file
+echo "export CP2K_CMAKE_OPTIONS=\"${CMAKE_OPTIONS}\"" >> "${SETUPFILE}"
+echo "CMake options from parsing files are now collected in the variable
+\${CP2K_CMAKE_OPTIONS} that is exported at the end of ${SETUPFILE}."
+
 # -------------------------
 # print out user instructions
 # -------------------------
@@ -79,21 +125,37 @@ EOF
 else
   echo
   cat << EOF | tee ${INSTALLDIR}/cp2k_installation_guide.txt
-========================== usage =========================
-Done! The "build" directory can now be removed.
+========================== Epilogue =========================
+Toolchain is now ready for building CP2K! Instructions for next steps:
 
-To use the installed tools and libraries and cp2k version compiled with it you will first need to execute at the prompt:
-  source ${SETUPFILE}
+(1) Optional - remove packages in ./build directory to free up disk space:
+      rm -rf ${BUILDDIR}
+    However, do NOT delete or move the ./install directory from now on.
 
-It's recommended for you to build CP2K like this after executing above command:
-  cd ${CP2K_ROOT}
-  mkdir build && cd build
-  cmake .. ${CMAKE_OPTIONS}
-  make install -j $(get_nprocs)
+(2) Required - source setup file to activate toolchain-configured dependencies:
+      source ${SETUPFILE}
+    This setup file MUST also be sourced whenever CP2K built with this toolchain
+    is executed. If modules have been used to estabilish environment variables
+    and paths, remember to load these modules prior to sourcing setup file.
 
-When completed, you can run "make clean" or delete this build directory to free up some space.
+(3) Recommended - go to root directory of CP2K and build executable:
+      cd ${CP2K_ROOT}
+      mkdir build && cd build
+      cmake .. ${CMAKE_OPTIONS}
+      make install -j $(get_nprocs)
+    Alternatively the CMake command may take the same options from a variable as
+    exported in the setup file, no need to copy-paste long lines in terminal:
+      cmake .. "\${CP2K_CMAKE_OPTIONS}"
+    It may be helpful to also save a copy of command line messages to log files:
+      cmake .. "\${CP2K_CMAKE_OPTIONS}" 2>&1 | tee make.log
+      make install -j $(get_nprocs) 2>&1 | tee install.log
 
-For more information about available build options, see: https://manual.cp2k.org/trunk/getting-started/build-from-source.html.
+(4) Optional - once build is completed, remove ./build directory like in (1):
+      make clean
+    Again, do not move the ./install directory from now on.
+
+For more information about available build options, see:
+https://manual.cp2k.org/trunk/getting-started/build-from-source.html.
 This message is saved to "${INSTALLDIR}/cp2k_installation_guide.txt".
 EOF
 fi

--- a/tools/toolchain/scripts/generate_cmake_options.sh
+++ b/tools/toolchain/scripts/generate_cmake_options.sh
@@ -121,10 +121,13 @@ else
 fi
 
 # Export variable for CMake options to setup file
+printf "# ==================== Setup for CP2K ==================== #" >> "${SETUPFILE}"
 printf 'export CP2K_CMAKE_OPTIONS="%s"\n' "${CMAKE_OPTIONS}" >> "${SETUPFILE}"
 cat << EOF
 Suggested cmake command if toolchain is built with your options:
+
   cmake ${CMAKE_OPTIONS}
+
 These options are also collected in the variable \${CP2K_CMAKE_OPTIONS} that is
 exported at the end of setup file ${SETUPFILE}.
 EOF
@@ -154,21 +157,27 @@ Toolchain is now ready for building CP2K! Instructions for next steps:
       cmake ${CMAKE_OPTIONS}
     Other commands from ${CP2K_ROOT}/CMakeLists.txt can also be added.
     Alternative to copy-paste long lines in terminal is to use a variable from
-    setup file for CMake options:
-      cmake "\${CP2K_CMAKE_OPTIONS}"
+    setup file for CMake options, which is not to be quoted so that whitespace
+    delimiters allow it to expand to command options in shell:
+      cmake \${CP2K_CMAKE_OPTIONS}
 
 (4) Build CP2K with command:
       cmake --build ${CP2K_ROOT}/build --target install -j $(get_nprocs)
     It may be helpful to also save a copy of command line messages to log files:
       cmake --build ${CP2K_ROOT}/build --target install -j $(get_nprocs) 2>&1 | tee install.log
 
-(4) Optional - once build is completed, remove ./build directory like in (1):
+(5) Optional - once build is completed, remove ./build directory like in (1):
       cmake --build ${CP2K_ROOT}/build --target clean
     Again, do not move the ./install directory from now on.
 
-(5) Recommended - edit ${SETUPFILE} and append paths:
+(6) Recommended - perform regtest as is suggested at the end of (3).
+
+(7) Recommended - append CP2K directory to paths:
       export PATH="${CP2K_ROOT}/install/bin:\$PATH"
       export LD_LIBRARY_PATH="${CP2K_ROOT}/install/lib:\${LD_LIBRARY_PATH}"
+      export LD_RUN_PATH="${CP2K_ROOT}/install/lib:\${LD_RUN_PATH}"
+      export LIBRARY_PATH="${CP2K_ROOT}/install/lib:\${LIBRARY_PATH}"
+      export CMAKE_PREFIX_PATH="${CP2K_ROOT}:\${CMAKE_PREFIX_PATH}"
 
 For more information about available build options, see:
 https://manual.cp2k.org/trunk/getting-started/build-from-source.html.

--- a/tools/toolchain/scripts/stage2/install_openblas.sh
+++ b/tools/toolchain/scripts/stage2/install_openblas.sh
@@ -137,10 +137,7 @@ if [ "$with_openblas" != "__DONTUSE__" ]; then
 prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 prepend_path CPATH "$pkg_install_dir/include"
-export OPENBLAS_ROOT=${pkg_install_dir}
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_openblas"

--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -250,8 +250,6 @@ prepend_path LD_LIBRARY_PATH "${COSMA_LIBDIR}"
 prepend_path LD_RUN_PATH "${COSMA_LIBDIR}"
 prepend_path LIBRARY_PATH "${COSMA_LIBDIR}"
 prepend_path CPATH "$pkg_install_dir/include"
-export COSMA_INCLUDE_DIR="$pkg_install_dir/include"
-export COSMA_ROOT="${pkg_install_dir}"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF

--- a/tools/toolchain/scripts/stage4/install_scalapack.sh
+++ b/tools/toolchain/scripts/stage4/install_scalapack.sh
@@ -96,7 +96,6 @@ prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
-export SCALAPACK_ROOT="${pkg_install_dir}"
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_scalapack"

--- a/tools/toolchain/scripts/stage7/install_libvori.sh
+++ b/tools/toolchain/scripts/stage7/install_libvori.sh
@@ -80,7 +80,6 @@ prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
 export LIBVORI_LIBS="${LIBVORI_LIBS}"
-export LIBVORI_ROOT="${pkg_install_dir}"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF


### PR DESCRIPTION
Because `generate_cmake_options.sh` involves files and directories outside of
the `tools/toolchain` folder, it is necessary to validate their existence.
For instance, this problem may arise from the "regtest pdbg" pipeline where
toolchain scripts are copied elsewhere before executing:
https://github.com/cp2k/cp2k/blob/9782edaafd29042022628e50587f5e43aa572e14/tools/docker/Dockerfile.test_pdbg#L14-L29
Due to `--dry-run` option, regtest is not aborted but error message is present:
```shell
 [91msed: can't read //CMakeLists.txt: No such file or directory
 [0m [91msed: can't read //CMakeLists.txt: No such file or directory
 [0m [91msed: can't read //CMakeLists.txt: No such file or directory
 [0m [91msed: can't read //CMakeLists.txt: No such file or directory
 [0m [91msed: can't read //CMakeLists.txt: No such file or directory
 [0mSuggested cmake command if toolchain is built with your options: 
  cmake .. -DCMAKE_INSTALL_PREFIX=../install -DCP2K_DATA_DIR=//data -DCP2K_USE_EVERYTHING=ON -DCP2K_USE_DLAF=OFF -DCP2K_USE_PEXSI=OFF
```
This is now captured by validating existence and printing messages properly.

Meanwhile, analogues to the existing shell variable `CP2K_TOOLCHAIN_OPTIONS`
that is exported in the setup file, a new variable `CP2K_CMAKE_OPTIONS` has
been added to setup file to simplify command; in addition to the old way
```shell
cmake .. {a very long chain of cmake options copy-pasted from CLI message}
```
it is now easier to simply enter the command as
```shell
cmake .. ${CP2K_CMAKE_OPTIONS}
```
Finally, the message at the end of `generate_cmake_options.sh` (which should
conclude execution of `install_cp2k_toolchain.sh`) is redrafted.