### PR TITLE
openPMD output routines: Fix indexing

### DIFF
--- a/src/pw/realspace_grid_openpmd.F
+++ b/src/pw/realspace_grid_openpmd.F
@@ -394,8 +394,9 @@ CONTAINS
 
       DO iat = 1, 3
          global_extent(iat) = (pw%pw_grid%npts(iat) + my_stride(iat) - 1)/my_stride(iat)
-         ! '+ 1' because upper end is inclusive, '- 1' for upper gaussian bracket
+         ! '- 1' for upper gaussian bracket
          offset(iat) = ((pw%pw_grid%bounds_local(1, iat) - pw%pw_grid%bounds(1, iat) + my_stride(iat) - 1)/my_stride(iat))
+         ! '+ 1' because upper end is inclusive, '- 1' for upper gaussian bracket
          ! refer local_extent to the global offset first in order to have consistent rounding
          local_extent(iat) = ((pw%pw_grid%bounds_local(2, iat) + 1 - pw%pw_grid%bounds(1, iat) + my_stride(iat) - 1)/my_stride(iat))
       END DO
@@ -414,13 +415,12 @@ CONTAINS
       ! (when working with a stride, we might have to skip the first n values)
       ! so keep this consistent with the offset and local_extent computed above
       ! L1 = pw%pw_grid%bounds_local(1, 1)
-      L1 = offset(1)*my_stride(1)
+      L1 = pw%pw_grid%bounds(1, 1) + offset(1)*my_stride(1)
       L2 = pw%pw_grid%bounds_local(1, 2)
       L3 = pw%pw_grid%bounds_local(1, 3)
-      ! U1 = pw%pw_grid%bounds_local(2, 1)
       ! offset + local_extent is the start index for the next rank already
       ! since the indexes are inclusive, subtract 1 from the boundary index
-      U1 = (offset(1) + local_extent(1) - 1)*my_stride(1)
+      U1 = pw%pw_grid%bounds(1, 1) + (offset(1) + local_extent(1) - 1)*my_stride(1)
       U2 = pw%pw_grid%bounds_local(2, 2)
       U3 = pw%pw_grid%bounds_local(2, 3)
 

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -2610,9 +2610,19 @@ CONTAINS
                ELSE
                   filename = mpi_filename
                END IF
-               WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                  "The total electron density is written in "//e_density_section%format_name//" file format to the file:", &
-                  TRIM(filename)
+               IF (e_density_section%grid_output == grid_output_openpmd) THEN
+                  WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
+                     "The total electron density is written in " &
+                     //e_density_section%format_name &
+                     //" file format to the file / file pattern:", &
+                     TRIM(filename)
+               ELSE
+                  WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
+                     "The total electron density is written in " &
+                     //e_density_section%format_name &
+                     //" file format to the file:", &
+                     TRIM(filename)
+               END IF
                WRITE (UNIT=output_unit, FMT="(/,(T2,A,F20.10))") &
                   "q(max) [1/Angstrom]              :", q_max/angstrom, &
                   "Soft electronic charge (G-space) :", rho_soft, &
@@ -2656,9 +2666,19 @@ CONTAINS
                   ELSE
                      filename = mpi_filename
                   END IF
-                  WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                     "The total spin density is written in "//e_density_section%format_name//" file format to the file:", &
-                     TRIM(filename)
+                  IF (e_density_section%grid_output == grid_output_openpmd) THEN
+                     WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
+                        "The total spin density is written in " &
+                        //e_density_section%format_name &
+                        //" file format to the file / file pattern:", &
+                        TRIM(filename)
+                  ELSE
+                     WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
+                        "The total spin density is written in " &
+                        //e_density_section%format_name &
+                        //" file format to the file:", &
+                        TRIM(filename)
+                  END IF
                   WRITE (UNIT=output_unit, FMT="(/,(T2,A,F20.10))") &
                      "q(max) [1/Angstrom]                    :", q_max/angstrom, &
                      "Soft part of the spin density (G-space):", rho_soft, &
@@ -2697,9 +2717,19 @@ CONTAINS
                   ELSE
                      filename = mpi_filename
                   END IF
-                  WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                   "The sum of alpha and beta density is written in "//e_density_section%format_name//" file format to the file:", &
-                     TRIM(filename)
+                  IF (e_density_section%grid_output == grid_output_openpmd) THEN
+                     WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
+                        "The sum of alpha and beta density is written in " &
+                        //e_density_section%format_name &
+                        //" file format to the file / file pattern:", &
+                        TRIM(filename)
+                  ELSE
+                     WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
+                        "The sum of alpha and beta density is written in " &
+                        //e_density_section%format_name &
+                        //" file format to the file:", &
+                        TRIM(filename)
+                  END IF
                END IF
                CALL e_density_section%write_pw(rho_elec_rspace, unit_nr, "SUM OF ALPHA AND BETA DENSITY", &
         particles=particles, zeff=zcharge, stride=section_get_ivals(dft_section, e_density_section%concat_to_relative("%STRIDE")), &
@@ -2720,9 +2750,19 @@ CONTAINS
                   ELSE
                      filename = mpi_filename
                   END IF
-                  WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                     "The spin density is written in "//e_density_section%format_name//" file format to the file:", &
-                     TRIM(filename)
+                  IF (e_density_section%grid_output == grid_output_openpmd) THEN
+                     WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
+                        "The spin density is written in " &
+                        //e_density_section%format_name &
+                        //" file format to the file / file pattern:", &
+                        TRIM(filename)
+                  ELSE
+                     WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
+                        "The spin density is written in " &
+                        //e_density_section%format_name &
+                        //" file format to the file:", &
+                        TRIM(filename)
+                  END IF
                END IF
                CALL e_density_section%write_pw(rho_elec_rspace, unit_nr, "SPIN DENSITY", &
                                                particles=particles, zeff=zcharge, &
@@ -2743,9 +2783,19 @@ CONTAINS
                   ELSE
                      filename = mpi_filename
                   END IF
-                  WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                     "The electron density is written in "//e_density_section%format_name//" file format to the file:", &
-                     TRIM(filename)
+                  IF (e_density_section%grid_output == grid_output_openpmd) THEN
+                     WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
+                        "The electron density is written in " &
+                        //e_density_section%format_name &
+                        //" file format to the file / file pattern:", &
+                        TRIM(filename)
+                  ELSE
+                     WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
+                        "The electron density is written in " &
+                        //e_density_section%format_name &
+                        //" file format to the file:", &
+                        TRIM(filename)
+                  END IF
                END IF
                CALL e_density_section%write_pw(rho_r(1), unit_nr, "ELECTRON DENSITY", &
                                                particles=particles, zeff=zcharge, &
@@ -2795,9 +2845,19 @@ CONTAINS
                ELSE
                   filename = mpi_filename
                END IF
-               WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                  "The electron density is written in "//e_density_section%format_name//" file format to the file:", &
-                  TRIM(filename)
+               IF (e_density_section%grid_output == grid_output_openpmd) THEN
+                  WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
+                     "The electron density is written in " &
+                     //e_density_section%format_name &
+                     //" file format to the file / file pattern:", &
+                     TRIM(filename)
+               ELSE
+                  WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
+                     "The electron density is written in " &
+                     //e_density_section%format_name &
+                     //" file format to the file:", &
+                     TRIM(filename)
+               END IF
                WRITE (UNIT=output_unit, FMT="(/,(T2,A,F20.10))") &
                   "Soft electronic charge (R-space) :", rho_soft, &
                   "Hard electronic charge (R-space) :", rho_hard, &
@@ -2838,7 +2898,9 @@ CONTAINS
                   filename = mpi_filename
                END IF
                WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                  "The spin density is written in "//e_density_section%format_name//" file format to the file:", &
+                  "The spin density is written in " &
+                  //e_density_section%format_name &
+                  //" file format to the file:", &
                   TRIM(filename)
                WRITE (UNIT=output_unit, FMT="(/,(T2,A,F20.10))") &
                   "Soft part of the spin density          :", rho_soft, &

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -521,7 +521,37 @@ CONTAINS
    END FUNCTION section_key_do_write
 
 ! **************************************************************************************************
-!> \brief collects possible post - scf calculations and prints info / computes properties.
+!> \brief Prints the output message for density file writing
+!> \param output_unit Unit number for output
+!> \param prefix The message prefix (e.g., "The total electron density")
+!> \param e_density_section Section key containing grid_output and format_name
+!> \param filename The actual filename or pattern used
+! **************************************************************************************************
+   SUBROUTINE print_density_output_message(output_unit, prefix, e_density_section, filename)
+      INTEGER, INTENT(IN)                                :: output_unit
+      CHARACTER(len=*), INTENT(IN)                       :: prefix
+      TYPE(cp_section_key), INTENT(IN)                   :: e_density_section
+      CHARACTER(len=*), INTENT(IN)                       :: filename
+
+      IF (e_density_section%grid_output == grid_output_openpmd) THEN
+         WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
+            TRIM(prefix)//" is written in " &
+            //e_density_section%format_name &
+            //" file format to the file / file pattern:", &
+            TRIM(filename)
+      ELSE
+         WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
+            TRIM(prefix)//" is written in " &
+            //e_density_section%format_name &
+            //" file format to the file:", &
+            TRIM(filename)
+      END IF
+   END SUBROUTINE print_density_output_message
+
+   ! **************************************************************************************************
+   !> \brief collects possible post - scf calculations and prints info / computes properties.
+! **************************************************************************************************
+!> \brief ...
 !> \param qs_env the qs_env in which the qs_env lives
 !> \param wf_type ...
 !> \param do_mp2 ...
@@ -2610,19 +2640,8 @@ CONTAINS
                ELSE
                   filename = mpi_filename
                END IF
-               IF (e_density_section%grid_output == grid_output_openpmd) THEN
-                  WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
-                     "The total electron density is written in " &
-                     //e_density_section%format_name &
-                     //" file format to the file / file pattern:", &
-                     TRIM(filename)
-               ELSE
-                  WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                     "The total electron density is written in " &
-                     //e_density_section%format_name &
-                     //" file format to the file:", &
-                     TRIM(filename)
-               END IF
+               CALL print_density_output_message(output_unit, "The total electron density", &
+                                                 e_density_section, filename)
                WRITE (UNIT=output_unit, FMT="(/,(T2,A,F20.10))") &
                   "q(max) [1/Angstrom]              :", q_max/angstrom, &
                   "Soft electronic charge (G-space) :", rho_soft, &
@@ -2666,19 +2685,8 @@ CONTAINS
                   ELSE
                      filename = mpi_filename
                   END IF
-                  IF (e_density_section%grid_output == grid_output_openpmd) THEN
-                     WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
-                        "The total spin density is written in " &
-                        //e_density_section%format_name &
-                        //" file format to the file / file pattern:", &
-                        TRIM(filename)
-                  ELSE
-                     WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                        "The total spin density is written in " &
-                        //e_density_section%format_name &
-                        //" file format to the file:", &
-                        TRIM(filename)
-                  END IF
+                  CALL print_density_output_message(output_unit, "The total spin density", &
+                                                    e_density_section, filename)
                   WRITE (UNIT=output_unit, FMT="(/,(T2,A,F20.10))") &
                      "q(max) [1/Angstrom]                    :", q_max/angstrom, &
                      "Soft part of the spin density (G-space):", rho_soft, &
@@ -2717,19 +2725,8 @@ CONTAINS
                   ELSE
                      filename = mpi_filename
                   END IF
-                  IF (e_density_section%grid_output == grid_output_openpmd) THEN
-                     WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
-                        "The sum of alpha and beta density is written in " &
-                        //e_density_section%format_name &
-                        //" file format to the file / file pattern:", &
-                        TRIM(filename)
-                  ELSE
-                     WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                        "The sum of alpha and beta density is written in " &
-                        //e_density_section%format_name &
-                        //" file format to the file:", &
-                        TRIM(filename)
-                  END IF
+                  CALL print_density_output_message(output_unit, "The sum of alpha and beta density", &
+                                                    e_density_section, filename)
                END IF
                CALL e_density_section%write_pw(rho_elec_rspace, unit_nr, "SUM OF ALPHA AND BETA DENSITY", &
         particles=particles, zeff=zcharge, stride=section_get_ivals(dft_section, e_density_section%concat_to_relative("%STRIDE")), &
@@ -2750,19 +2747,8 @@ CONTAINS
                   ELSE
                      filename = mpi_filename
                   END IF
-                  IF (e_density_section%grid_output == grid_output_openpmd) THEN
-                     WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
-                        "The spin density is written in " &
-                        //e_density_section%format_name &
-                        //" file format to the file / file pattern:", &
-                        TRIM(filename)
-                  ELSE
-                     WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                        "The spin density is written in " &
-                        //e_density_section%format_name &
-                        //" file format to the file:", &
-                        TRIM(filename)
-                  END IF
+                  CALL print_density_output_message(output_unit, "The spin density", &
+                                                    e_density_section, filename)
                END IF
                CALL e_density_section%write_pw(rho_elec_rspace, unit_nr, "SPIN DENSITY", &
                                                particles=particles, zeff=zcharge, &
@@ -2783,19 +2769,8 @@ CONTAINS
                   ELSE
                      filename = mpi_filename
                   END IF
-                  IF (e_density_section%grid_output == grid_output_openpmd) THEN
-                     WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
-                        "The electron density is written in " &
-                        //e_density_section%format_name &
-                        //" file format to the file / file pattern:", &
-                        TRIM(filename)
-                  ELSE
-                     WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                        "The electron density is written in " &
-                        //e_density_section%format_name &
-                        //" file format to the file:", &
-                        TRIM(filename)
-                  END IF
+                  CALL print_density_output_message(output_unit, "The electron density", &
+                                                    e_density_section, filename)
                END IF
                CALL e_density_section%write_pw(rho_r(1), unit_nr, "ELECTRON DENSITY", &
                                                particles=particles, zeff=zcharge, &
@@ -2845,19 +2820,8 @@ CONTAINS
                ELSE
                   filename = mpi_filename
                END IF
-               IF (e_density_section%grid_output == grid_output_openpmd) THEN
-                  WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
-                     "The electron density is written in " &
-                     //e_density_section%format_name &
-                     //" file format to the file / file pattern:", &
-                     TRIM(filename)
-               ELSE
-                  WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                     "The electron density is written in " &
-                     //e_density_section%format_name &
-                     //" file format to the file:", &
-                     TRIM(filename)
-               END IF
+               CALL print_density_output_message(output_unit, "The electron density", &
+                                                 e_density_section, filename)
                WRITE (UNIT=output_unit, FMT="(/,(T2,A,F20.10))") &
                   "Soft electronic charge (R-space) :", rho_soft, &
                   "Hard electronic charge (R-space) :", rho_hard, &
@@ -2897,11 +2861,8 @@ CONTAINS
                ELSE
                   filename = mpi_filename
                END IF
-               WRITE (UNIT=output_unit, FMT="(/,T2,A,/,/,T2,A)") &
-                  "The spin density is written in " &
-                  //e_density_section%format_name &
-                  //" file format to the file:", &
-                  TRIM(filename)
+               CALL print_density_output_message(output_unit, "The spin density", &
+                                                 e_density_section, filename)
                WRITE (UNIT=output_unit, FMT="(/,(T2,A,F20.10))") &
                   "Soft part of the spin density          :", rho_soft, &
                   "Hard part of the spin density          :", rho_hard, &


### PR DESCRIPTION
Since the first dimension of the output array is distributed among MPI processes, I had to adjust for uneven parallel decompositions, leading to slightly offset definitions for the array bounds along the first dimension.
While doing that, I apparently forgot adjusting the bounds back to the lower corner of the array (not at (0,0,0)). This fixes that.

TODO:

- [x] While testing this, I get a hangup in HDF5. Unsure yet if this is related to the issue at hand, need to look further.
    UPDATE: This issue seems to have come with HDF5 2.0, HDF5 1.14.3 works fine. Need to check what causes it.
    UPDATE \# 2: The error is unrelated, will be fixed separately
- [x] Use the chance to clarify some status outputs 