### PR TITLE
openPMD output: Fix hangup of parallel HDF5 in versions >= 2.0

### DIFF
--- a/src/openpmd_api.F
+++ b/src/openpmd_api.F
@@ -105,6 +105,7 @@ MODULE openpmd_api
       PROCEDURE, PUBLIC :: get_mesh => openpmd_iteration_get_mesh
       PROCEDURE, PUBLIC :: get_particle_species => openpmd_iteration_get_particle_species
       PROCEDURE, PUBLIC :: close => openpmd_iteration_close
+      PROCEDURE, PUBLIC :: open => openpmd_iteration_open
       PROCEDURE, PUBLIC :: closed => openpmd_iteration_closed
    END TYPE openpmd_iteration_type
 
@@ -689,6 +690,25 @@ MODULE openpmd_api
 !> \brief ...
 !> \param iteration ...
 ! **************************************************************************************************
+      SUBROUTINE openpmd_iteration_open(iteration)
+         CLASS(openpmd_iteration_type), INTENT(INOUT)           :: iteration
+
+         INTERFACE
+! **************************************************************************************************
+!> \brief ...
+!> \param iteration ...
+! **************************************************************************************************
+            SUBROUTINE openpmd_c_iteration_open(iteration) &
+               BIND(C, name="openPMD_Iteration_open")
+               IMPORT :: C_PTR
+               TYPE(C_PTR), VALUE :: iteration
+            END SUBROUTINE openpmd_c_iteration_open
+         END INTERFACE
+
+         CPASSERT(C_ASSOCIATED(iteration%c_ptr))
+         CALL openpmd_c_iteration_open(iteration=iteration%c_ptr)
+      END SUBROUTINE openpmd_iteration_open
+
       SUBROUTINE openpmd_iteration_close(iteration)
          CLASS(openpmd_iteration_type), INTENT(INOUT)           :: iteration
 

--- a/src/openpmd_c_api.cpp
+++ b/src/openpmd_c_api.cpp
@@ -171,6 +171,10 @@ int openPMD_Iteration_get_particle_species(
     // out
     openPMD_ParticleSpecies *particle_species);
 
+int openPMD_Iteration_open(
+    // in
+    openPMD_Iteration iteration);
+
 int openPMD_Iteration_close(
     // in
     openPMD_Iteration iteration);
@@ -713,6 +717,13 @@ int openPMD_Iteration_get_particle_species(
   auto iteration = reinterpret_cast<openPMD::Iteration *>(iteration_param);
   auto &res = iteration->particles[name];
   *reinterpret_cast<openPMD::ParticleSpecies **>(particle_species) = &res;
+  return 0;
+}
+
+int openPMD_Iteration_open(openPMD_Iteration iteration_param) {
+  auto iteration = reinterpret_cast<openPMD::Iteration *>(iteration_param);
+  std::cout << "OPENING ITERATION" << std::endl;
+  iteration->open();
   return 0;
 }
 

--- a/src/pw/realspace_grid_openpmd.F
+++ b/src/pw/realspace_grid_openpmd.F
@@ -176,31 +176,27 @@ CONTAINS
          CALL position_offset_component%make_constant_zero(openpmd_type_int, global_extent)
          position_component = position%get_component(dims(k))
          CALL position_component%reset_dataset(openpmd_type_double, global_extent)
-         IF (do_write_data) THEN
-            unresolved_write_buffers(k) = &
-               position_component%store_chunk_span_1d_double(global_offset, local_extent)
-            write_buffers(k)%buffer => unresolved_write_buffers(k)%resolve_double(DEALLOCATE=.FALSE.)
-         END IF
+         unresolved_write_buffers(k) = &
+            position_component%store_chunk_span_1d_double(global_offset, local_extent)
+         write_buffers(k)%buffer => unresolved_write_buffers(k)%resolve_double(DEALLOCATE=.FALSE.)
       END DO
 
       IF (PRESENT(particles_zeff)) THEN
          charge = species%get_record("charge")
          charge_component = charge%as_record_component()
          CALL charge_component%reset_dataset(openpmd_type_double, global_extent)
-         IF (do_write_data) THEN
-            unresolved_charge_write_buffer = charge_component%store_chunk_span_1d_double(global_offset, local_extent)
-            charge_write_buffer%buffer => unresolved_charge_write_buffer%resolve_double(DEALLOCATE=.FALSE.)
-         END IF
+         unresolved_charge_write_buffer = charge_component%store_chunk_span_1d_double(global_offset, local_extent)
+         charge_write_buffer%buffer => unresolved_charge_write_buffer%resolve_double(DEALLOCATE=.FALSE.)
       END IF
 
+      ! Resolve Spans for a second time to allow for internal reallocations in BP4 engine of ADIOS2
+      DO k = 1, SIZE(dims)
+         write_buffers(k)%buffer = unresolved_write_buffers(k)%resolve_double(DEALLOCATE=.TRUE.)
+      END DO
+      IF (PRESENT(particles_zeff)) THEN
+         charge_write_buffer%buffer = unresolved_charge_write_buffer%resolve_double(DEALLOCATE=.TRUE.)
+      END IF
       IF (do_write_data) THEN
-         ! Resolve Spans for a second time to allow for internal reallocations in BP4 engine of ADIOS2
-         DO k = 1, SIZE(dims)
-            write_buffers(k)%buffer = unresolved_write_buffers(k)%resolve_double(DEALLOCATE=.TRUE.)
-         END DO
-         IF (PRESENT(particles_zeff)) THEN
-            charge_write_buffer%buffer = unresolved_charge_write_buffer%resolve_double(DEALLOCATE=.TRUE.)
-         END IF
          j = 1
          DO i = 1, SIZE(particles_z)
             IF (particles_z(i) == atom_type) THEN

--- a/src/pw/realspace_grid_openpmd.F
+++ b/src/pw/realspace_grid_openpmd.F
@@ -167,6 +167,7 @@ CONTAINS
       WRITE (atom_type_as_string, '(I3)') atom_type
       species_name = TRIM(openpmd_data%name_prefix)//"-"//ADJUSTL(atom_type_as_string)
 
+      CALL openpmd_data%iteration%open()
       species = openpmd_data%iteration%get_particle_species(TRIM(species_name))
 
       position_offset = species%get_record("positionOffset")


### PR DESCRIPTION
HDF5 seems to have become a lot stricter about collective parallel metadata handling as of version 2.0, leading to hanging file close operations. Ultimately, I need to fix this inside the openPMD-api (https://github.com/openPMD/openPMD-api/pull/1862), but this PR includes a workaround that at least makes parallel HDF5 output from CP2K to openPMD work again.

Also adds a call to explicitly open Iterations, good practise in parallel setups.

What the workaround does: `store_chunk` operations in the openPMD-api are intended to be non-collective. However, CP2K uses one kind of `store_chunk` operation that allocates memory in the backend, requiring some minimal structural setup of groups / datasets. 
Earlier, these setup operations had to be defined consistently, but not in the same order across MPI ranks. Now, the ordering has become decisive. 
As a workaround, this PR issues zero-sized `store_chunk` operations on ranks that do not contribute data. This runs the structural setup, while ignoring any actual data write.