### PR TITLE
HFX: respect `CUTOFF_RADIUS` input with shortrange potential

### DIFF
--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -731,10 +731,10 @@ CONTAINS
                                 actual_x_data%potential_parameter%omega, &
                                 actual_x_data%potential_parameter%cutoff_radius)
                CALL section_vals_val_get(hf_sub_section, "CUTOFF_RADIUS", explicit=explicit)
-               IF (explicit) then
+               IF (explicit) THEN
                   CALL section_vals_val_get(hf_sub_section, "CUTOFF_RADIUS", r_val=real_val)
                   IF (real_val < actual_x_data%potential_parameter%cutoff_radius .AND. &
-                     i_thread == 1 .AND. irep == 1) THEN
+                      i_thread == 1 .AND. irep == 1) THEN
                      WRITE (error_msg, '(A,F6.3,A,ES8.1,A,F6.3,A,F6.3,A)') &
                         "Periodic Hartree Fock calculation requested with the use "// &
                         "of a shortrange potential erfc(omega*r)/r. Given omega = ", &

--- a/src/hfx_types.F
+++ b/src/hfx_types.F
@@ -730,6 +730,25 @@ CONTAINS
                CALL erfc_cutoff(actual_x_data%screening_parameter%eps_schwarz, &
                                 actual_x_data%potential_parameter%omega, &
                                 actual_x_data%potential_parameter%cutoff_radius)
+               CALL section_vals_val_get(hf_sub_section, "CUTOFF_RADIUS", explicit=explicit)
+               IF (explicit) then
+                  CALL section_vals_val_get(hf_sub_section, "CUTOFF_RADIUS", r_val=real_val)
+                  IF (real_val < actual_x_data%potential_parameter%cutoff_radius .AND. &
+                     i_thread == 1 .AND. irep == 1) THEN
+                     WRITE (error_msg, '(A,F6.3,A,ES8.1,A,F6.3,A,F6.3,A)') &
+                        "Periodic Hartree Fock calculation requested with the use "// &
+                        "of a shortrange potential erfc(omega*r)/r. Given omega = ", &
+                        actual_x_data%potential_parameter%omega, " and EPS_SCHWARZ = ", &
+                        actual_x_data%screening_parameter%eps_schwarz, ", the requested "// &
+                        "cutoff radius ", real_val*a_bohr*1e+10_dp, " A is smaller than "// &
+                        "what is necessary to satisfy erfc(omega*r)/r = EPS_SCHWARZ at r = ", &
+                        actual_x_data%potential_parameter%cutoff_radius*a_bohr*1e+10_dp, &
+                        " A. Increase input value (or omit keyword to use program default) "// &
+                        "to ensure accuracy."
+                     CPWARN(error_msg)
+                  END IF
+                  actual_x_data%potential_parameter%cutoff_radius = real_val
+               END IF
             END IF
             IF (actual_x_data%potential_parameter%potential_type == do_potential_id) THEN
                actual_x_data%potential_parameter%cutoff_radius = 0.0_dp
@@ -2097,18 +2116,18 @@ CONTAINS
                   WRITE (error_msg, "(A,F6.3,A,F6.3,A)") &
                      "Periodic Hartree Fock calculation requested with the use "// &
                      "of a truncated or shortrange potential. "// &
-                     "The cutoff radius (", x_data%potential_parameter%cutoff_radius/a_bohr*1e-10_dp, &
+                     "The cutoff radius (", x_data%potential_parameter%cutoff_radius*a_bohr*1e+10_dp, &
                      " A) is larger than half the minimal cell dimension (", &
-                     l_min/a_bohr*1e-10_dp, " A). This may lead to unphysical "// &
+                     l_min*a_bohr*1e+10_dp, " A). This may lead to unphysical "// &
                      "total energies. Reduce the cutoff radius in order to avoid "// &
                      "possible problems."
                ELSE
                   WRITE (error_msg, "(A,F6.3,A,F6.3,A)") &
                      "K-point Hartree-Fock calculation requested with the use of a "// &
                      "truncated or shortrange potential. The cutoff radius (", &
-                     x_data%potential_parameter%cutoff_radius/a_bohr*1e-10_dp, &
+                     x_data%potential_parameter%cutoff_radius*a_bohr*1e+10_dp, &
                      " A) is larger than half the minimal Born-von Karman supercell dimension (", &
-                     l_min/a_bohr*1e-10_dp, " A). This may lead "// &
+                     l_min*a_bohr*1e+10_dp, " A). This may lead "// &
                      "to unphysical total energies. Reduce the cutoff radius or increase "// &
                      "the number of K-points in order to avoid possible problems."
                END IF

--- a/src/input_cp2k_hfx.F
+++ b/src/input_cp2k_hfx.F
@@ -274,8 +274,10 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="CUTOFF_RADIUS", &
-                          description="Determines cutoff radius (in Angstroms) for the truncated 1/r potential. "// &
-                          "Only valid when doing truncated calculation", &
+                          description="Determines cutoff radius (in Angstroms) for the truncated 1/r "// &
+                          "potential or the shortrange erfc(omega*r)/r potential. Default value "// &
+                          "for shortrange potential is solved from erfc(omega*r)/r = EPS_SCHWARZ "// &
+                          "by Newton-Raphson method with SCREENING/EPS_SCHWARZ", &
                           usage="CUTOFF_RADIUS 10.0", type_of_var=real_t, & ! default_r_val=10.0_dp,&
                           unit_str="angstrom")
       CALL section_add_keyword(section, keyword)


### PR DESCRIPTION
For Hartree-Fock and hybrid DFT calculations, the input section for setting
interaction potential at `&FORCE_EVAL/&DFT/&XC/&HF/&INTERACTION_POTENTIAL`
contains a keyword `CUTOFF_RADIUS` with no default values and a default unit
of angstrom. It sets the cutoff radius for the truncated potential so that it
switches between operators 1/r and 0. Meanwhile, for the different shortrange
potential erfc(omega\*r)/r, a cutoff radius is implicitly determined by using
Newton-Raphson method to solve erfc(omega*r)/r=EPS_SCHWARZ, as can be seen
from `SUBROUTINE erfc_cutoff()` that was moved to `src/common/mathlib.F` in
commit d37ed58. For instance, with HSE06 hybrid functional where omega = 0.11,
`EPS_SCHWARZ 1.0E-6` gives a cutoff radius of 14.28 angstrom and `1.0E-4` gives
10.52 angstrom. However, these values are rather large such that the warning
`The cutoff radius is larger than half the minimal cell dimension` (see at
e.g. PR #4754) is easily triggered, and computational cost may be quite high.

This PR proposes that, in case `CUTOFF_RADIUS` has been specified alongside
shortrange potential via `POTENTIAL_TYPE SHORTRANGE`, the value will be taken
as the cutoff radius in place of the result of `erfc_cutoff()`. If the explicit
input value is smaller than the result of `erfc_cutoff()`, a warning is printed
```
 *** WARNING in hfx_types.F:748 :: Periodic Hartree Fock calculation       ***
 *** requested with the use of a shortrange potential erfc(omega*r)/r.     ***
 *** Given omega =  0.110 and EPS_SCHWARZ =  1.0E-06, the requested cutoff ***
 *** radius 10.000 A is smaller than what is necessary to satisfy          ***
 *** erfc(omega*r)/r = EPS_SCHWARZ at r = 14.279 A. Increase input value   ***
 *** (or omit keyword to use program default) to ensure accuracy.          ***
```
This way, a user may perform convergence test for energy and other properties
on the cutoff radius so as to reach balance between accuracy and cost.

(Also, in PR #4754 the unit conversion for length data is incorrect and does
not match the stated unit angstrom in message. Here it is fixed as well.)