### PR TITLE
add cmake_policy_version_minimum in install_libxc.sh

### DIFF
--- a/tools/toolchain/scripts/stage3/install_libxc.sh
+++ b/tools/toolchain/scripts/stage3/install_libxc.sh
@@ -60,6 +60,7 @@ case "$with_libxc" in
         -DBUILD_TESTING=OFF \
         -DENABLE_FORTRAN=ON \
         -DDISABLE_KXC=OFF \
+	-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         .. > configure.log 2>&1 || tail_excerpt configure.log
       make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
       make install > install.log 2>&1 || tail_excerpt install.log

--- a/tools/toolchain/scripts/stage3/install_libxc.sh
+++ b/tools/toolchain/scripts/stage3/install_libxc.sh
@@ -60,7 +60,7 @@ case "$with_libxc" in
         -DBUILD_TESTING=OFF \
         -DENABLE_FORTRAN=ON \
         -DDISABLE_KXC=OFF \
-	-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         .. > configure.log 2>&1 || tail_excerpt configure.log
       make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
       make install > install.log 2>&1 || tail_excerpt install.log

--- a/tools/toolchain/scripts/stage3/install_libxc.sh
+++ b/tools/toolchain/scripts/stage3/install_libxc.sh
@@ -60,7 +60,7 @@ case "$with_libxc" in
         -DBUILD_TESTING=OFF \
         -DENABLE_FORTRAN=ON \
         -DDISABLE_KXC=OFF \
-        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        #-DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         .. > configure.log 2>&1 || tail_excerpt configure.log
       make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
       make install > install.log 2>&1 || tail_excerpt install.log


### PR DESCRIPTION
when using toolchain to install libxc, it raises the error for cmake version

here, I tested that the adding of -DCMAKE_POLICY_VERSION_MINIMUM=3.5 is ok for installing