### PR TITLE
Omit COORD_FILE_NAME from restart file

### DIFF
--- a/src/input_restart_force_eval.F
+++ b/src/input_restart_force_eval.F
@@ -376,6 +376,9 @@ CONTAINS
                CALL close_file(unit_number=output_unit)
             END IF
          ELSE
+            ! Remove COORD_FILE_NAME and COORD_FILE_FORMAT keywords from restart
+            CALL section_vals_val_unset(subsys_section, "TOPOLOGY%COORD_FILE_NAME")
+            CALL section_vals_val_unset(subsys_section, "TOPOLOGY%COORD_FILE_FORMAT")
             CALL section_coord_val_set(work_section, particles, molecules, conv_factor, scale, &
                                        cell)
          END IF


### PR DESCRIPTION
`&COORD` and `&CELL` contain up-to-date coordinates and cell information, and
restart file is intended to be rerun from current system rather than the very
beginning as specified by `&TOPOLOGY/COORD_FILE_NAME` and `COORD_FILE_FORMAT`.

Closes #227 