### PR TITLE
Revamp cell parser and allow for fallback to parse from coordinate file

### DIFF
--- a/src/cell_methods.F
+++ b/src/cell_methods.F
@@ -32,15 +32,9 @@ MODULE cell_methods
                                               parser_release
    USE cp_units,                        ONLY: cp_unit_from_cp2k,&
                                               cp_unit_to_cp2k
-   USE input_constants,                 ONLY: do_cell_cif,&
-                                              do_cell_cp2k,&
-                                              do_cell_extxyz,&
-                                              do_cell_pdb,&
-                                              do_cell_xsc,&
-                                              do_coord_cif,&
-                                              do_coord_cp2k,&
-                                              do_coord_pdb,&
-                                              do_coord_xyz
+   USE input_constants,                 ONLY: &
+        do_cell_cif, do_cell_cp2k, do_cell_extxyz, do_cell_pdb, do_cell_xsc, do_coord_cif, &
+        do_coord_cp2k, do_coord_pdb, do_coord_xyz
    USE input_cp2k_subsys,               ONLY: create_cell_section
    USE input_enumeration_types,         ONLY: enum_i2c,&
                                               enumeration_type
@@ -73,8 +67,10 @@ MODULE cell_methods
              init_cell, &
              read_cell, &
              read_cell_cif, &
+             read_cell_cp2k, &
              read_cell_extxyz, &
              read_cell_pdb, &
+             read_cell_xsc, &
              set_cell_param, &
              write_cell, &
              write_cell_low
@@ -271,6 +267,7 @@ CONTAINS
 !> \param cell_ref ...
 !> \param use_ref_cell ...
 !> \param cell_section ...
+!> \param topology_section ...
 !> \param check_for_ref ...
 !> \param para_env ...
 !> \par History
@@ -287,29 +284,26 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                      :: check_for_ref
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
-      CHARACTER(LEN=default_path_length)                 :: ang_unit,&
-                                                            cell_file_name,&
-                                                            coord_file_name,&
-                                                            cryst,&
-                                                            len_unit
-      INTEGER                                            :: cell_file_format,&
-                                                            coord_file_format,&
-                                                            i, id1, id2, idum,&
-                                                            j, my_per
+      REAL(KIND=dp), PARAMETER                           :: eps = EPSILON(0.0_dp)
+
+      CHARACTER(LEN=default_path_length)                 :: cell_file_name, coord_file_name
+      INTEGER                                            :: cell_file_format, coord_file_format, &
+                                                            my_per
       INTEGER, DIMENSION(:), POINTER                     :: multiple_unit_cell
       LOGICAL :: cell_read_a, cell_read_abc, cell_read_alpha_beta_gamma, cell_read_b, cell_read_c, &
-         cell_read_file, cif_cell, my_check_ref, my_end, pdb_cryst, tmp_comb_abc, tmp_comb_cell, &
-         tmp_comb_top, topo_read_coord
-      REAL(KIND=dp)                                      :: xdum
-      REAL(KIND=dp), DIMENSION(3, 3)                     :: read_mat
+         cell_read_file, my_check_ref, tmp_comb_abc, tmp_comb_cell, tmp_comb_top, topo_read_coord
       REAL(KIND=dp), DIMENSION(3)                        :: read_ang, read_len
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: read_mat
       REAL(KIND=dp), DIMENSION(:), POINTER               :: cell_par
-      REAL(KIND=dp), PARAMETER                           :: eps = EPSILON(0.0_dp)
-      TYPE(cp_parser_type)                               :: parser
+      TYPE(cell_type), POINTER                           :: cell_tmp
       TYPE(section_vals_type), POINTER                   :: cell_ref_section
 
       my_check_ref = .TRUE.
-      NULLIFY (cell_ref_section, cell_par, multiple_unit_cell)
+      NULLIFY (cell_ref_section, cell_par, cell_tmp, multiple_unit_cell)
+      ! cell_tmp is only for transferring matrix of cell vectors from
+      ! individual file parser subroutines to read_mat here, assuming
+      ! that unit conversion has been done in those subroutines.
+      CALL cell_create(cell_tmp)
       IF (.NOT. ASSOCIATED(cell)) CALL cell_create(cell, tag="CELL")
       IF (.NOT. ASSOCIATED(cell_ref)) CALL cell_create(cell_ref, tag="CELL_REF")
       IF (PRESENT(check_for_ref)) my_check_ref = check_for_ref
@@ -338,7 +332,7 @@ CONTAINS
       ! The actual order of processing is 4 -> 1 -> 2 -> 3, with
       ! case 4 merged to case 1 (if file format permits) first.
       ! Store data into either read_mat or read_ang and read_len
-      ! in CP2K units, which will be converted to cell%hamt and A, B, C.
+      ! in CP2K units, which will be converted to cell%hmat and A, B, C.
       CALL section_vals_val_get(cell_section, "A", explicit=cell_read_a)
       CALL section_vals_val_get(cell_section, "B", explicit=cell_read_b)
       CALL section_vals_val_get(cell_section, "C", explicit=cell_read_c)
@@ -354,7 +348,7 @@ CONTAINS
       IF (tmp_comb_top) THEN
          CALL cp_warn(__LOCATION__, &
                       "None of the keywords CELL_FILE_NAME, ABC, or A, B, C "// &
-                      "are specified in CELL section. Will now attempt to read "// &
+                      "are specified in CELL section. CP2K will now attempt to read "// &
                       "TOPOLOGY/COORD_FILE_NAME if its format can be parsed for "// &
                       "cell information.")
          IF (ASSOCIATED(topology_section)) THEN
@@ -377,12 +371,12 @@ CONTAINS
                   CALL section_vals_val_set(cell_section, "CELL_FILE_FORMAT", i_val=do_cell_extxyz)
                CASE DEFAULT
                   CALL cp_abort(__LOCATION__, &
-                               "COORD_FILE_FORMAT is not set to one of implemented CELL_FILE_FORMAT "// &
-                               "and cannot be parsed for cell information!" )
+                                "COORD_FILE_FORMAT is not set to one of the implemented "// &
+                                "CELL_FILE_FORMAT options and cannot be parsed for cell information!")
                END SELECT
             ELSE
                CALL cp_abort(__LOCATION__, &
-                            "COORD_FILE_NAME is not set, so no cell information available!")
+                             "COORD_FILE_NAME is not set, so no cell information is available!")
             END IF
          ELSE
             CALL cp_warn(__LOCATION__, &
@@ -393,126 +387,31 @@ CONTAINS
       ! Former logic in SUBROUTINE read_cell_from_external_file is moved here
       CALL section_vals_val_get(cell_section, "CELL_FILE_NAME", explicit=cell_read_file)
       IF (cell_read_file) THEN ! Case 1
-         len_unit = "angstrom" ! Initialize default units; when adding new cell format
-         ang_unit = "deg"      ! parser, units should be set for specific case
          tmp_comb_cell = (cell_read_abc .OR. (cell_read_a .OR. (cell_read_b .OR. cell_read_c)))
          IF (tmp_comb_cell) &
             CALL cp_warn(__LOCATION__, &
-                        "Cell Information provided through A, B, C, or ABC in conjunction "// &
-                        "with CELL_FILE_NAME. The definition in external file will override "// &
-                        "other ones.")
+                         "Cell Information provided through A, B, C, or ABC in conjunction "// &
+                         "with CELL_FILE_NAME. The definition in external file will override "// &
+                         "other ones.")
          CALL section_vals_val_get(cell_section, "CELL_FILE_NAME", c_val=cell_file_name)
          CALL section_vals_val_get(cell_section, "CELL_FILE_FORMAT", i_val=cell_file_format)
          SELECT CASE (cell_file_format)
          CASE (do_cell_cp2k)
-            len_unit = "angstrom"
-            CALL parser_create(parser, cell_file_name, para_env=para_env)
-            CALL parser_get_next_line(parser, 1)
-            my_end = .FALSE.
-            DO WHILE (.NOT. my_end)
-               READ (parser%input_line, *) idum, xdum, read_mat(:, 1), read_mat(:, 2), read_mat(:, 3)
-               CALL parser_get_next_line(parser, 1, at_end=my_end)
-            END DO
-            CALL parser_release(parser)
+            CALL read_cell_cp2k(cell_file_name, cell_tmp, para_env)
          CASE (do_cell_xsc)
-            len_unit = "angstrom"
-            CALL parser_create(parser, cell_file_name, para_env=para_env)
-            CALL parser_get_next_line(parser, 1)
-            READ (parser%input_line, *) idum, read_mat(:, 1), read_mat(:, 2), read_mat(:, 3)
-            CALL parser_release(parser)
+            CALL read_cell_xsc(cell_file_name, cell_tmp, para_env)
          CASE (do_cell_extxyz)
-            len_unit = "angstrom"
-            CALL parser_create(parser, cell_file_name, para_env=para_env)
-            CALL parser_get_next_line(parser, 2)
-            CALL uppercase(parser%input_line)
-            id1 = INDEX(parser%input_line, "LATTICE=")
-            IF (id1 > 0) THEN
-               id2 = INDEX(parser%input_line(id1 + 9:), '"')
-               READ (parser%input_line(id1 + 9:id1 + id2 + 7), *) read_mat(:, 1), read_mat(:, 2), read_mat(:, 3)
-               CALL parser_release(parser)
-            ELSE
-               CALL parser_release(parser)
-               CALL cp_abort(__LOCATION__, &
-                            "The field lattice= was not found on comment line "// &
-                            "of XYZ file, so cell information cannot be set via "// &
-                            "extended XYZ specification!")
-            END IF
+            CALL read_cell_extxyz(cell_file_name, cell_tmp, para_env)
          CASE (do_cell_pdb)
-            len_unit = "angstrom"
-            ang_unit = "deg"
-            CALL parser_create(parser, cell_file_name, para_env=para_env)
-            CALL parser_search_string(parser, "CRYST1", ignore_case=.FALSE., found=pdb_cryst, &
-                                begin_line=.TRUE., search_from_begin_of_file=.TRUE.)
-            IF (pdb_cryst) THEN
-               READ (parser%input_line, *) cryst, read_len(:), read_ang(:)
-               CALL parser_release(parser)
-            ELSE
-               CALL parser_release(parser)
-               CALL cp_abort(__LOCATION__, &
-                            "The field CRYST1 was not found in PDB file, so cell "// &
-                            "information cannot be set!")
-            END IF
+            CALL read_cell_pdb(cell_file_name, cell_tmp, para_env)
          CASE (do_cell_cif)
-            len_unit = "angstrom"
-            ang_unit = "deg"
-            CALL parser_create(parser, cell_file_name, para_env=para_env)
-            cif_cell = .FALSE.
-            ! _cell_length_a
-            CALL parser_search_string(parser, "_cell_length_a", ignore_case=.FALSE., &
-                                      found=cif_cell, begin_line=.FALSE., &
-                                      search_from_begin_of_file=.TRUE.)
-            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
-                                                            "_cell_length_a was not found in CIF file!")
-            CALL cif_get_real(parser, read_len(1))
-            ! _cell_length_b
-            CALL parser_search_string(parser, "_cell_length_b", ignore_case=.FALSE., &
-                                      found=cif_cell, begin_line=.FALSE., &
-                                      search_from_begin_of_file=.TRUE.)
-            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
-                                                            "_cell_length_b was not found in CIF file!")
-            CALL cif_get_real(parser, read_len(2))
-            ! _cell_length_c
-            CALL parser_search_string(parser, "_cell_length_c", ignore_case=.FALSE., &
-                                      found=cif_cell, begin_line=.FALSE., &
-                                      search_from_begin_of_file=.TRUE.)
-            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
-                                                            "_cell_length_c was not found in CIF file!")
-            CALL cif_get_real(parser, read_len(3))
-            ! _cell_angle_alpha
-            CALL parser_search_string(parser, "_cell_angle_alpha", ignore_case=.FALSE., &
-                                      found=cif_cell, begin_line=.FALSE., &
-                                      search_from_begin_of_file=.TRUE.)
-            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
-                                                            "_cell_angle_alpha was not found in CIF file!")
-            CALL cif_get_real(parser, read_ang(1))
-            ! _cell_angle_beta
-            CALL parser_search_string(parser, "_cell_angle_beta", ignore_case=.FALSE., &
-                                      found=cif_cell, begin_line=.FALSE., &
-                                      search_from_begin_of_file=.TRUE.)
-            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
-                                                            "_cell_angle_beta was not found in CIF file!")
-            CALL cif_get_real(parser, read_ang(2))
-            ! _cell_angle_gamma
-            CALL parser_search_string(parser, "_cell_angle_gamma", ignore_case=.FALSE., &
-                                      found=cif_cell, begin_line=.FALSE., &
-                                      search_from_begin_of_file=.TRUE.)
-            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
-                                                            "_cell_angle_gamma was not found in CIF file!")
-            CALL cif_get_real(parser, read_ang(3))
-            CALL parser_release(parser)
+            CALL read_cell_cif(cell_file_name, cell_tmp, para_env)
          CASE DEFAULT
             CALL cp_abort(__LOCATION__, &
-                          "CELL_FILE_FORMAT is not set to one of implemented options "// &
-                          "and cannot be parsed for cell information!" )
+                          "CELL_FILE_FORMAT is not set to one of the implemented "// &
+                          "options and cannot be parsed for cell information!")
          END SELECT
-         ! Unit conversion
-         DO i = 1, 3
-            read_len(i) = cp_unit_to_cp2k(read_len(i), TRIM(len_unit))
-            read_ang(i) = cp_unit_to_cp2k(read_ang(i), TRIM(ang_unit))
-            DO j = 1, 3
-               read_mat(j, i) = cp_unit_to_cp2k(read_mat(j, i), TRIM(len_unit))
-            END DO
-         END DO
+         read_mat = cell_tmp%hmat
       ELSE
          IF (cell_read_abc) THEN ! Case 2
             CALL section_vals_val_get(cell_section, "ABC", r_vals=cell_par)
@@ -543,20 +442,8 @@ CONTAINS
             END IF
          END IF
       END IF
-      ! Unset other cell options
-      IF (cell_read_file) &
-         CALL section_vals_val_unset(cell_section, "CELL_FILE_NAME")
-         CALL section_vals_val_unset(cell_section, "CELL_FILE_FORMAT")
-      IF (cell_read_abc) &
-         CALL section_vals_val_unset(cell_section, "ABC")
-      IF (cell_read_alpha_beta_gamma) &
-      CALL section_vals_val_unset(cell_section, "ALPHA_BETA_GAMMA")
-      IF (cell_read_a) &
-         CALL section_vals_val_unset(cell_section, "A")
-      IF (cell_read_b) &
-         CALL section_vals_val_unset(cell_section, "B")
-      IF (cell_read_c) &
-         CALL section_vals_val_unset(cell_section, "C")
+      CALL cell_release(cell_tmp)
+
       ! Convert read_mat or read_len and read_ang to actual cell%hmat
       IF (ANY(read_mat(:, :) > eps)) THEN
          ! Make a warning before storing cell vectors that
@@ -564,7 +451,7 @@ CONTAINS
          IF ((ABS(read_mat(2, 1)) > eps) .OR. &
              (ABS(read_mat(3, 1)) > eps) .OR. &
              (ABS(read_mat(3, 2)) > eps)) &
-             CALL cp_warn(__LOCATION__, &
+            CALL cp_warn(__LOCATION__, &
                          "Cell vectors are read but cell matrix is not "// &
                          "a lower triangle, not conforming to the program "// &
                          "convention that A lies along the X-axis and "// &
@@ -579,16 +466,8 @@ CONTAINS
                           "No meaningful cell information is read from parser!")
          END IF
       END IF
-      ! Modify CELL section to use A, B, C keywords for future reuse.
-      ALLOCATE (cell_par(3))
-      cell_par = cell%hmat(:, 1)
-      CALL section_vals_val_set(cell_section, "A", r_vals_ptr=cell_par)
-      ALLOCATE (cell_par(3))
-      cell_par = cell%hmat(:, 2)
-      CALL section_vals_val_set(cell_section, "B", r_vals_ptr=cell_par)
-      ALLOCATE (cell_par(3))
-      cell_par = cell%hmat(:, 3)
-      CALL section_vals_val_set(cell_section, "C", r_vals_ptr=cell_par)
+      ! Reset cell section so that only A, B, C are kept
+      CALL reset_cell_section_by_cell_mat(cell, cell_section)
 
       ! Multiple unit cell
       CALL section_vals_val_get(cell_section, "MULTIPLE_UNIT_CELL", i_vals=multiple_unit_cell)
@@ -982,6 +861,124 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE read_cell_pdb
+
+! **************************************************************************************************
+!> \brief  Reads cell information from cp2k file
+!> \param cp2k_file_name ...
+!> \param cell ...
+!> \param para_env ...
+!> \date   03.2026
+!> \par    Isolated from former read_cell_from_external_file
+! **************************************************************************************************
+   SUBROUTINE read_cell_cp2k(cp2k_file_name, cell, para_env)
+
+      CHARACTER(len=*)                                   :: cp2k_file_name
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'read_cell_cp2k'
+
+      INTEGER                                            :: handle, i, idum, j
+      LOGICAL                                            :: my_end
+      REAL(KIND=dp)                                      :: xdum
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
+      TYPE(cp_parser_type)                               :: parser
+
+      CALL timeset(routineN, handle)
+
+      CALL parser_create(parser, cp2k_file_name, &
+                         para_env=para_env, apply_preprocessing=.FALSE.)
+
+      CALL parser_get_next_line(parser, 1)
+      my_end = .FALSE.
+      DO WHILE (.NOT. my_end)
+         READ (parser%input_line, *) idum, xdum, hmat(:, 1), hmat(:, 2), hmat(:, 3)
+         CALL parser_get_next_line(parser, 1, at_end=my_end)
+      END DO
+      DO i = 1, 3
+         DO j = 1, 3
+            cell%hmat(j, i) = cp_unit_to_cp2k(hmat(j, i), "angstrom")
+         END DO
+      END DO
+
+      CALL parser_release(parser)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE read_cell_cp2k
+
+! **************************************************************************************************
+!> \brief  Reads cell information from xsc file
+!> \param xsc_file_name ...
+!> \param cell ...
+!> \param para_env ...
+!> \date   03.2026
+!> \par    Isolated from former read_cell_from_external_file
+! **************************************************************************************************
+   SUBROUTINE read_cell_xsc(xsc_file_name, cell, para_env)
+
+      CHARACTER(len=*)                                   :: xsc_file_name
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'read_cell_xsc'
+
+      INTEGER                                            :: handle, i, idum, j
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
+      TYPE(cp_parser_type)                               :: parser
+
+      CALL timeset(routineN, handle)
+
+      CALL parser_create(parser, xsc_file_name, &
+                         para_env=para_env, apply_preprocessing=.FALSE.)
+
+      CALL parser_get_next_line(parser, 1)
+      READ (parser%input_line, *) idum, hmat(:, 1), hmat(:, 2), hmat(:, 3)
+      DO i = 1, 3
+         DO j = 1, 3
+            cell%hmat(j, i) = cp_unit_to_cp2k(hmat(j, i), "angstrom")
+         END DO
+      END DO
+
+      CALL parser_release(parser)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE read_cell_xsc
+
+! **************************************************************************************************
+!> \brief   Reset cell section by matrix in cell-type pointer
+!> \param cell ...
+!> \param cell_section ...
+!> \date    03.2026
+!> \par     Alternative keywords for cell settings will be unset
+!>          except MULTIPLE_UNIT_CELL, PERIODIC and SYMMETRY.
+! **************************************************************************************************
+   SUBROUTINE reset_cell_section_by_cell_mat(cell, cell_section)
+
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(section_vals_type), POINTER                   :: cell_section
+
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: cell_par
+
+      CALL section_vals_val_unset(cell_section, "CELL_FILE_NAME")
+      CALL section_vals_val_unset(cell_section, "CELL_FILE_FORMAT")
+      CALL section_vals_val_unset(cell_section, "ABC")
+      CALL section_vals_val_unset(cell_section, "ALPHA_BETA_GAMMA")
+      CALL section_vals_val_unset(cell_section, "A")
+      CALL section_vals_val_unset(cell_section, "B")
+      CALL section_vals_val_unset(cell_section, "C")
+      ALLOCATE (cell_par(3))
+      cell_par = cell%hmat(:, 1)
+      CALL section_vals_val_set(cell_section, "A", r_vals_ptr=cell_par)
+      ALLOCATE (cell_par(3))
+      cell_par = cell%hmat(:, 2)
+      CALL section_vals_val_set(cell_section, "B", r_vals_ptr=cell_par)
+      ALLOCATE (cell_par(3))
+      cell_par = cell%hmat(:, 3)
+      CALL section_vals_val_set(cell_section, "C", r_vals_ptr=cell_par)
+
+   END SUBROUTINE reset_cell_section_by_cell_mat
 
 ! **************************************************************************************************
 !> \brief   Write the cell parameters to the output unit.

--- a/src/cell_methods.F
+++ b/src/cell_methods.F
@@ -36,7 +36,11 @@ MODULE cell_methods
                                               do_cell_cp2k,&
                                               do_cell_extxyz,&
                                               do_cell_pdb,&
-                                              do_cell_xsc
+                                              do_cell_xsc,&
+                                              do_coord_cif,&
+                                              do_coord_cp2k,&
+                                              do_coord_pdb,&
+                                              do_coord_xyz
    USE input_cp2k_subsys,               ONLY: create_cell_section
    USE input_enumeration_types,         ONLY: enum_i2c,&
                                               enumeration_type
@@ -69,6 +73,8 @@ MODULE cell_methods
              init_cell, &
              read_cell, &
              read_cell_cif, &
+             read_cell_extxyz, &
+             read_cell_pdb, &
              set_cell_param, &
              write_cell, &
              write_cell_low
@@ -269,29 +275,44 @@ CONTAINS
 !> \param para_env ...
 !> \par History
 !>      03.2005 created [teo]
+!>      03.2026 revamped logic with pdb and extxyz parsers
 !> \author Teodoro Laino
 ! **************************************************************************************************
    RECURSIVE SUBROUTINE read_cell(cell, cell_ref, use_ref_cell, cell_section, &
-                                  check_for_ref, para_env)
+                                  topology_section, check_for_ref, para_env)
 
       TYPE(cell_type), POINTER                           :: cell, cell_ref
       LOGICAL, INTENT(INOUT), OPTIONAL                   :: use_ref_cell
-      TYPE(section_vals_type), OPTIONAL, POINTER         :: cell_section
+      TYPE(section_vals_type), OPTIONAL, POINTER         :: cell_section, topology_section
       LOGICAL, INTENT(IN), OPTIONAL                      :: check_for_ref
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
-      INTEGER                                            :: my_per
+      CHARACTER(LEN=default_path_length)                 :: ang_unit,&
+                                                            cell_file_name,&
+                                                            coord_file_name,&
+                                                            cryst,&
+                                                            len_unit
+      INTEGER                                            :: cell_file_format,&
+                                                            coord_file_format,&
+                                                            i, id1, id2, idum,&
+                                                            j, my_per
       INTEGER, DIMENSION(:), POINTER                     :: multiple_unit_cell
       LOGICAL :: cell_read_a, cell_read_abc, cell_read_alpha_beta_gamma, cell_read_b, cell_read_c, &
-         cell_read_file, check_read_abc, my_check
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: cell_angles, cell_par
+         cell_read_file, cif_cell, my_check_ref, my_end, pdb_cryst, tmp_comb_abc, tmp_comb_cell, &
+         tmp_comb_top, topo_read_coord
+      REAL(KIND=dp)                                      :: xdum
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: read_mat
+      REAL(KIND=dp), DIMENSION(3)                        :: read_ang, read_len
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: cell_par
+      REAL(KIND=dp), PARAMETER                           :: eps = EPSILON(0.0_dp)
+      TYPE(cp_parser_type)                               :: parser
       TYPE(section_vals_type), POINTER                   :: cell_ref_section
 
-      my_check = .TRUE.
+      my_check_ref = .TRUE.
       NULLIFY (cell_ref_section, cell_par, multiple_unit_cell)
       IF (.NOT. ASSOCIATED(cell)) CALL cell_create(cell, tag="CELL")
       IF (.NOT. ASSOCIATED(cell_ref)) CALL cell_create(cell_ref, tag="CELL_REF")
-      IF (PRESENT(check_for_ref)) my_check = check_for_ref
+      IF (PRESENT(check_for_ref)) my_check_ref = check_for_ref
 
       cell%deth = 0.0_dp
       cell%orthorhombic = .FALSE.
@@ -305,46 +326,269 @@ CONTAINS
       cell_read_c = .FALSE.
       cell_read_abc = .FALSE.
       cell_read_alpha_beta_gamma = .FALSE.
+      read_mat(:, :) = 0.0_dp
+      read_ang(:) = 0.0_dp
+      read_len(:) = 0.0_dp
 
-      CALL section_vals_val_get(cell_section, "CELL_FILE_NAME", explicit=cell_read_file)
+      ! Precedence of retrieving cell information from input:
+      ! 1. CELL/CELL_FILE_NAME
+      ! 2. CELL/ABC and optionally CELL/ALPHA_BETA_GAMMA
+      ! 3. CELL/A, CELL/B, CELL/C
+      ! 4. TOPOLOGY/COORD_FILE_NAME, if topology_section is present
+      ! The actual order of processing is 4 -> 1 -> 2 -> 3, with
+      ! case 4 merged to case 1 (if file format permits) first.
+      ! Store data into either read_mat or read_ang and read_len
+      ! in CP2K units, which will be converted to cell%hamt and A, B, C.
       CALL section_vals_val_get(cell_section, "A", explicit=cell_read_a)
       CALL section_vals_val_get(cell_section, "B", explicit=cell_read_b)
       CALL section_vals_val_get(cell_section, "C", explicit=cell_read_c)
       CALL section_vals_val_get(cell_section, "ABC", explicit=cell_read_abc)
       CALL section_vals_val_get(cell_section, "ALPHA_BETA_GAMMA", explicit=cell_read_alpha_beta_gamma)
+      CALL section_vals_val_get(cell_section, "CELL_FILE_NAME", explicit=cell_read_file)
 
-      ! Trying to read cell info from file
-      ! It resets the respective keywords
-      IF (cell_read_file) &
-         CALL read_cell_from_external_file(cell_section, para_env)
-
-      IF (cell_read_abc) THEN ! Presence of ABC overrides A, B, C
-         IF (cell_read_a .OR. cell_read_b .OR. cell_read_c) &
-            CALL cp_warn(__LOCATION__, &
-                         "Cell Information provided through vectors A, B or C in conjunction with ABC."// &
-                         " The definition of the ABC keyword will override the one provided by A, B and C.")
-         CALL section_vals_val_get(cell_section, "ABC", r_vals=cell_par)
-         CALL section_vals_val_get(cell_section, "ALPHA_BETA_GAMMA", r_vals=cell_angles)
-         CALL set_cell_param(cell, cell_par, cell_angles, do_init_cell=.FALSE.)
-      ELSE ! With no ABC, try to read A, B, C
-         check_read_abc = ((cell_read_a .EQV. cell_read_b) .AND. (cell_read_b .EQV. cell_read_c))
-         IF (check_read_abc) THEN
-            CALL section_vals_val_get(cell_section, "A", r_vals=cell_par)
-            cell%hmat(:, 1) = cell_par(:)
-            CALL section_vals_val_get(cell_section, "B", r_vals=cell_par)
-            cell%hmat(:, 2) = cell_par(:)
-            CALL section_vals_val_get(cell_section, "C", r_vals=cell_par)
-            cell%hmat(:, 3) = cell_par(:)
-            IF (cell_read_alpha_beta_gamma) &
-               CALL cp_warn(__LOCATION__, &
-                            "The keyword ALPHA_BETA_GAMMA is ignored because it was used without the "// &
-                            "keyword ABC.")
+      ! Case 4
+      tmp_comb_top = (.NOT. (cell_read_file .OR. cell_read_abc))
+      tmp_comb_top = (tmp_comb_top .AND. (.NOT. cell_read_a))
+      tmp_comb_top = (tmp_comb_top .AND. (.NOT. cell_read_b))
+      tmp_comb_top = (tmp_comb_top .AND. (.NOT. cell_read_c))
+      IF (tmp_comb_top) THEN
+         CALL cp_warn(__LOCATION__, &
+                      "None of the keywords CELL_FILE_NAME, ABC, or A, B, C "// &
+                      "are specified in CELL section. Will now attempt to read "// &
+                      "TOPOLOGY/COORD_FILE_NAME if its format can be parsed for "// &
+                      "cell information.")
+         IF (ASSOCIATED(topology_section)) THEN
+            CALL section_vals_val_get(topology_section, "COORD_FILE_NAME", explicit=topo_read_coord)
+            IF (topo_read_coord) THEN
+               CALL section_vals_val_get(topology_section, "COORD_FILE_NAME", c_val=coord_file_name)
+               CALL section_vals_val_get(topology_section, "COORD_FILE_FORMAT", i_val=coord_file_format)
+               SELECT CASE (coord_file_format) ! Add formats with both cell and coord parser manually
+               CASE (do_coord_cif)
+                  CALL section_vals_val_set(cell_section, "CELL_FILE_NAME", c_val=coord_file_name)
+                  CALL section_vals_val_set(cell_section, "CELL_FILE_FORMAT", i_val=do_cell_cif)
+               CASE (do_coord_cp2k)
+                  CALL section_vals_val_set(cell_section, "CELL_FILE_NAME", c_val=coord_file_name)
+                  CALL section_vals_val_set(cell_section, "CELL_FILE_FORMAT", i_val=do_cell_cp2k)
+               CASE (do_coord_pdb)
+                  CALL section_vals_val_set(cell_section, "CELL_FILE_NAME", c_val=coord_file_name)
+                  CALL section_vals_val_set(cell_section, "CELL_FILE_FORMAT", i_val=do_cell_pdb)
+               CASE (do_coord_xyz)
+                  CALL section_vals_val_set(cell_section, "CELL_FILE_NAME", c_val=coord_file_name)
+                  CALL section_vals_val_set(cell_section, "CELL_FILE_FORMAT", i_val=do_cell_extxyz)
+               CASE DEFAULT
+                  CALL cp_abort(__LOCATION__, &
+                               "COORD_FILE_FORMAT is not set to one of implemented CELL_FILE_FORMAT "// &
+                               "and cannot be parsed for cell information!" )
+               END SELECT
+            ELSE
+               CALL cp_abort(__LOCATION__, &
+                            "COORD_FILE_NAME is not set, so no cell information available!")
+            END IF
          ELSE
-            CALL cp_abort(__LOCATION__, &
-                          "Cell Information provided through vectors A, B and C. Not all three "// &
-                          "vectors were provided! Cell setup may be incomplete!")
+            CALL cp_warn(__LOCATION__, &
+                         "TOPOLOGY section is not available, so COORD_FILE_NAME cannot "// &
+                         "be parsed for cell information in lieu of missing CELL settings.")
          END IF
       END IF
+      ! Former logic in SUBROUTINE read_cell_from_external_file is moved here
+      CALL section_vals_val_get(cell_section, "CELL_FILE_NAME", explicit=cell_read_file)
+      IF (cell_read_file) THEN ! Case 1
+         len_unit = "angstrom" ! Initialize default units; when adding new cell format
+         ang_unit = "deg"      ! parser, units should be set for specific case
+         tmp_comb_cell = (cell_read_abc .OR. (cell_read_a .OR. (cell_read_b .OR. cell_read_c)))
+         IF (tmp_comb_cell) &
+            CALL cp_warn(__LOCATION__, &
+                        "Cell Information provided through A, B, C, or ABC in conjunction "// &
+                        "with CELL_FILE_NAME. The definition in external file will override "// &
+                        "other ones.")
+         CALL section_vals_val_get(cell_section, "CELL_FILE_NAME", c_val=cell_file_name)
+         CALL section_vals_val_get(cell_section, "CELL_FILE_FORMAT", i_val=cell_file_format)
+         SELECT CASE (cell_file_format)
+         CASE (do_cell_cp2k)
+            len_unit = "angstrom"
+            CALL parser_create(parser, cell_file_name, para_env=para_env)
+            CALL parser_get_next_line(parser, 1)
+            my_end = .FALSE.
+            DO WHILE (.NOT. my_end)
+               READ (parser%input_line, *) idum, xdum, read_mat(:, 1), read_mat(:, 2), read_mat(:, 3)
+               CALL parser_get_next_line(parser, 1, at_end=my_end)
+            END DO
+            CALL parser_release(parser)
+         CASE (do_cell_xsc)
+            len_unit = "angstrom"
+            CALL parser_create(parser, cell_file_name, para_env=para_env)
+            CALL parser_get_next_line(parser, 1)
+            READ (parser%input_line, *) idum, read_mat(:, 1), read_mat(:, 2), read_mat(:, 3)
+            CALL parser_release(parser)
+         CASE (do_cell_extxyz)
+            len_unit = "angstrom"
+            CALL parser_create(parser, cell_file_name, para_env=para_env)
+            CALL parser_get_next_line(parser, 2)
+            CALL uppercase(parser%input_line)
+            id1 = INDEX(parser%input_line, "LATTICE=")
+            IF (id1 > 0) THEN
+               id2 = INDEX(parser%input_line(id1 + 9:), '"')
+               READ (parser%input_line(id1 + 9:id1 + id2 + 7), *) read_mat(:, 1), read_mat(:, 2), read_mat(:, 3)
+               CALL parser_release(parser)
+            ELSE
+               CALL parser_release(parser)
+               CALL cp_abort(__LOCATION__, &
+                            "The field lattice= was not found on comment line "// &
+                            "of XYZ file, so cell information cannot be set via "// &
+                            "extended XYZ specification!")
+            END IF
+         CASE (do_cell_pdb)
+            len_unit = "angstrom"
+            ang_unit = "deg"
+            CALL parser_create(parser, cell_file_name, para_env=para_env)
+            CALL parser_search_string(parser, "CRYST1", ignore_case=.FALSE., found=pdb_cryst, &
+                                begin_line=.TRUE., search_from_begin_of_file=.TRUE.)
+            IF (pdb_cryst) THEN
+               READ (parser%input_line, *) cryst, read_len(:), read_ang(:)
+               CALL parser_release(parser)
+            ELSE
+               CALL parser_release(parser)
+               CALL cp_abort(__LOCATION__, &
+                            "The field CRYST1 was not found in PDB file, so cell "// &
+                            "information cannot be set!")
+            END IF
+         CASE (do_cell_cif)
+            len_unit = "angstrom"
+            ang_unit = "deg"
+            CALL parser_create(parser, cell_file_name, para_env=para_env)
+            cif_cell = .FALSE.
+            ! _cell_length_a
+            CALL parser_search_string(parser, "_cell_length_a", ignore_case=.FALSE., &
+                                      found=cif_cell, begin_line=.FALSE., &
+                                      search_from_begin_of_file=.TRUE.)
+            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
+                                                            "_cell_length_a was not found in CIF file!")
+            CALL cif_get_real(parser, read_len(1))
+            ! _cell_length_b
+            CALL parser_search_string(parser, "_cell_length_b", ignore_case=.FALSE., &
+                                      found=cif_cell, begin_line=.FALSE., &
+                                      search_from_begin_of_file=.TRUE.)
+            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
+                                                            "_cell_length_b was not found in CIF file!")
+            CALL cif_get_real(parser, read_len(2))
+            ! _cell_length_c
+            CALL parser_search_string(parser, "_cell_length_c", ignore_case=.FALSE., &
+                                      found=cif_cell, begin_line=.FALSE., &
+                                      search_from_begin_of_file=.TRUE.)
+            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
+                                                            "_cell_length_c was not found in CIF file!")
+            CALL cif_get_real(parser, read_len(3))
+            ! _cell_angle_alpha
+            CALL parser_search_string(parser, "_cell_angle_alpha", ignore_case=.FALSE., &
+                                      found=cif_cell, begin_line=.FALSE., &
+                                      search_from_begin_of_file=.TRUE.)
+            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
+                                                            "_cell_angle_alpha was not found in CIF file!")
+            CALL cif_get_real(parser, read_ang(1))
+            ! _cell_angle_beta
+            CALL parser_search_string(parser, "_cell_angle_beta", ignore_case=.FALSE., &
+                                      found=cif_cell, begin_line=.FALSE., &
+                                      search_from_begin_of_file=.TRUE.)
+            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
+                                                            "_cell_angle_beta was not found in CIF file!")
+            CALL cif_get_real(parser, read_ang(2))
+            ! _cell_angle_gamma
+            CALL parser_search_string(parser, "_cell_angle_gamma", ignore_case=.FALSE., &
+                                      found=cif_cell, begin_line=.FALSE., &
+                                      search_from_begin_of_file=.TRUE.)
+            IF (.NOT. cif_cell) CALL cp_abort(__LOCATION__, "The field "// &
+                                                            "_cell_angle_gamma was not found in CIF file!")
+            CALL cif_get_real(parser, read_ang(3))
+            CALL parser_release(parser)
+         CASE DEFAULT
+            CALL cp_abort(__LOCATION__, &
+                          "CELL_FILE_FORMAT is not set to one of implemented options "// &
+                          "and cannot be parsed for cell information!" )
+         END SELECT
+         ! Unit conversion
+         DO i = 1, 3
+            read_len(i) = cp_unit_to_cp2k(read_len(i), TRIM(len_unit))
+            read_ang(i) = cp_unit_to_cp2k(read_ang(i), TRIM(ang_unit))
+            DO j = 1, 3
+               read_mat(j, i) = cp_unit_to_cp2k(read_mat(j, i), TRIM(len_unit))
+            END DO
+         END DO
+      ELSE
+         IF (cell_read_abc) THEN ! Case 2
+            CALL section_vals_val_get(cell_section, "ABC", r_vals=cell_par)
+            read_len = cell_par
+            CALL section_vals_val_get(cell_section, "ALPHA_BETA_GAMMA", r_vals=cell_par)
+            read_ang = cell_par
+            IF (cell_read_a .OR. cell_read_b .OR. cell_read_c) &
+               CALL cp_warn(__LOCATION__, &
+                            "Cell information provided through vectors A, B or C in conjunction with ABC. "// &
+                            "The definition of the ABC keyword will override the one provided by A, B and C.")
+         ELSE ! Case 3
+            tmp_comb_abc = ((cell_read_a .EQV. cell_read_b) .AND. (cell_read_b .EQV. cell_read_c))
+            IF (tmp_comb_abc) THEN
+               CALL section_vals_val_get(cell_section, "A", r_vals=cell_par)
+               read_mat(:, 1) = cell_par(:)
+               CALL section_vals_val_get(cell_section, "B", r_vals=cell_par)
+               read_mat(:, 2) = cell_par(:)
+               CALL section_vals_val_get(cell_section, "C", r_vals=cell_par)
+               read_mat(:, 3) = cell_par(:)
+               IF (cell_read_alpha_beta_gamma) &
+                  CALL cp_warn(__LOCATION__, &
+                               "The keyword ALPHA_BETA_GAMMA is ignored because it was used without the "// &
+                               "keyword ABC.")
+            ELSE
+               CALL cp_abort(__LOCATION__, &
+                             "Neither of the keywords CELL_FILE_NAME or ABC are specified, "// &
+                             "and cell vector settings in A, B, C are incomplete!")
+            END IF
+         END IF
+      END IF
+      ! Unset other cell options
+      IF (cell_read_file) &
+         CALL section_vals_val_unset(cell_section, "CELL_FILE_NAME")
+         CALL section_vals_val_unset(cell_section, "CELL_FILE_FORMAT")
+      IF (cell_read_abc) &
+         CALL section_vals_val_unset(cell_section, "ABC")
+      IF (cell_read_alpha_beta_gamma) &
+      CALL section_vals_val_unset(cell_section, "ALPHA_BETA_GAMMA")
+      IF (cell_read_a) &
+         CALL section_vals_val_unset(cell_section, "A")
+      IF (cell_read_b) &
+         CALL section_vals_val_unset(cell_section, "B")
+      IF (cell_read_c) &
+         CALL section_vals_val_unset(cell_section, "C")
+      ! Convert read_mat or read_len and read_ang to actual cell%hmat
+      IF (ANY(read_mat(:, :) > eps)) THEN
+         ! Make a warning before storing cell vectors that
+         ! do not form a triangular matrix.
+         IF ((ABS(read_mat(2, 1)) > eps) .OR. &
+             (ABS(read_mat(3, 1)) > eps) .OR. &
+             (ABS(read_mat(3, 2)) > eps)) &
+             CALL cp_warn(__LOCATION__, &
+                         "Cell vectors are read but cell matrix is not "// &
+                         "a lower triangle, not conforming to the program "// &
+                         "convention that A lies along the X-axis and "// &
+                         "B is in the XY plane.")
+         cell%hmat = read_mat
+      ELSE
+         IF (ANY(read_ang(:) > eps) .AND. ANY(read_len(:) > eps)) THEN
+            CALL set_cell_param(cell, cell_length=read_len, cell_angle=read_ang, &
+                                do_init_cell=.FALSE.)
+         ELSE
+            CALL cp_abort(__LOCATION__, &
+                          "No meaningful cell information is read from parser!")
+         END IF
+      END IF
+      ! Modify CELL section to use A, B, C keywords for future reuse.
+      ALLOCATE (cell_par(3))
+      cell_par = cell%hmat(:, 1)
+      CALL section_vals_val_set(cell_section, "A", r_vals_ptr=cell_par)
+      ALLOCATE (cell_par(3))
+      cell_par = cell%hmat(:, 2)
+      CALL section_vals_val_set(cell_section, "B", r_vals_ptr=cell_par)
+      ALLOCATE (cell_par(3))
+      cell_par = cell%hmat(:, 3)
+      CALL section_vals_val_set(cell_section, "C", r_vals_ptr=cell_par)
 
       ! Multiple unit cell
       CALL section_vals_val_get(cell_section, "MULTIPLE_UNIT_CELL", i_vals=multiple_unit_cell)
@@ -378,7 +622,7 @@ CONTAINS
       ! Initialize cell
       CALL init_cell(cell)
 
-      IF (my_check) THEN
+      IF (my_check_ref) THEN
          ! Recursive check for reference cell requested
          cell_ref_section => section_vals_get_subs_vals(cell_section, "CELL_REF")
          IF (parsed_cp2k_input(cell_ref_section, check_this_section=.TRUE.)) THEN
@@ -508,110 +752,6 @@ CONTAINS
       cell%hmat(:, 3) = cell%hmat(:, 3)*multiple_unit_cell(3)
 
    END SUBROUTINE set_multiple_unit_cell
-
-! **************************************************************************************************
-!> \brief   Read cell information from an external file
-!> \param cell_section ...
-!> \param para_env ...
-!> \date    02.2008
-!> \author  Teodoro Laino [tlaino] - University of Zurich
-!> \version 1.0
-! **************************************************************************************************
-   SUBROUTINE read_cell_from_external_file(cell_section, para_env)
-
-      TYPE(section_vals_type), POINTER                   :: cell_section
-      TYPE(mp_para_env_type), POINTER                    :: para_env
-
-      CHARACTER(LEN=default_path_length)                 :: cell_file_name
-      INTEGER                                            :: i, idum, j, my_format, n_rep
-      LOGICAL                                            :: explicit, my_end
-      REAL(KIND=dp)                                      :: xdum
-      REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: cell_par
-      TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_parser_type)                               :: parser
-
-      CALL section_vals_val_get(cell_section, "CELL_FILE_NAME", c_val=cell_file_name)
-      CALL section_vals_val_get(cell_section, "CELL_FILE_FORMAT", i_val=my_format)
-      SELECT CASE (my_format)
-      CASE (do_cell_cp2k)
-         CALL parser_create(parser, cell_file_name, para_env=para_env)
-         CALL parser_get_next_line(parser, 1)
-         my_end = .FALSE.
-         DO WHILE (.NOT. my_end)
-            READ (parser%input_line, *) idum, xdum, hmat(:, 1), hmat(:, 2), hmat(:, 3)
-            CALL parser_get_next_line(parser, 1, at_end=my_end)
-         END DO
-         CALL parser_release(parser)
-         ! Convert to CP2K units
-         DO i = 1, 3
-            DO j = 1, 3
-               hmat(j, i) = cp_unit_to_cp2k(hmat(j, i), "angstrom")
-            END DO
-         END DO
-      CASE (do_cell_xsc)
-         CALL parser_create(parser, cell_file_name, para_env=para_env)
-         CALL parser_get_next_line(parser, 1)
-         READ (parser%input_line, *) idum, hmat(:, 1), hmat(:, 2), hmat(:, 3)
-         CALL parser_release(parser)
-         ! Convert to CP2K units
-         DO i = 1, 3
-            DO j = 1, 3
-               hmat(j, i) = cp_unit_to_cp2k(hmat(j, i), "angstrom")
-            END DO
-         END DO
-      CASE (do_cell_extxyz)
-         NULLIFY (cell)
-         CALL cell_create(cell)
-         CALL read_cell_extxyz(cell_file_name, cell, para_env)
-         hmat = cell%hmat
-         CALL cell_release(cell)
-      CASE (do_cell_cif)
-         NULLIFY (cell)
-         CALL cell_create(cell)
-         CALL read_cell_cif(cell_file_name, cell, para_env)
-         hmat = cell%hmat
-         CALL cell_release(cell)
-      CASE (do_cell_pdb)
-         NULLIFY (cell)
-         CALL cell_create(cell)
-         CALL read_cell_pdb(cell_file_name, cell, para_env)
-         hmat = cell%hmat
-         CALL cell_release(cell)
-      END SELECT
-      CALL section_vals_val_unset(cell_section, "CELL_FILE_NAME")
-      CALL section_vals_val_unset(cell_section, "CELL_FILE_FORMAT")
-      ! Check if the cell was already defined
-      explicit = .FALSE.
-      CALL section_vals_val_get(cell_section, "A", n_rep_val=n_rep)
-      explicit = explicit .OR. (n_rep == 1)
-      CALL section_vals_val_get(cell_section, "B", n_rep_val=n_rep)
-      explicit = explicit .OR. (n_rep == 1)
-      CALL section_vals_val_get(cell_section, "C", n_rep_val=n_rep)
-      explicit = explicit .OR. (n_rep == 1)
-      CALL section_vals_val_get(cell_section, "ABC", n_rep_val=n_rep)
-      explicit = explicit .OR. (n_rep == 1)
-      ! Possibly print a warning
-      IF (explicit) &
-         CALL cp_warn(__LOCATION__, &
-                      "Cell specification (A,B,C or ABC) provided together with the external "// &
-                      "cell setup! Ignoring (A,B,C or ABC) and proceeding with info read from the "// &
-                      "external file! ")
-      ! Copy cell information in the A, B, C fields..(we may need them later on..)
-      ALLOCATE (cell_par(3))
-      cell_par = hmat(:, 1)
-      CALL section_vals_val_set(cell_section, "A", r_vals_ptr=cell_par)
-      ALLOCATE (cell_par(3))
-      cell_par = hmat(:, 2)
-      CALL section_vals_val_set(cell_section, "B", r_vals_ptr=cell_par)
-      ALLOCATE (cell_par(3))
-      cell_par = hmat(:, 3)
-      CALL section_vals_val_set(cell_section, "C", r_vals_ptr=cell_par)
-      ! Unset possible keywords
-      CALL section_vals_val_unset(cell_section, "ABC")
-      CALL section_vals_val_unset(cell_section, "ALPHA_BETA_GAMMA")
-
-   END SUBROUTINE read_cell_from_external_file
 
 ! **************************************************************************************************
 !> \brief  Reads cell information from CIF file

--- a/src/input_cp2k_subsys.F
+++ b/src/input_cp2k_subsys.F
@@ -88,7 +88,13 @@ CONTAINS
                           description="Input parameters needed to set up the simulation cell. "// &
                           "Simple products and fractions combined with functions of a single "// &
                           "number can be used like 2/3, 0.3*COS(60) or -SQRT(3)/2. The functions "// &
-                          "COS, EXP, LOG, LOG10, SIN, SQRT, and TAN are available.")
+                          "COS, EXP, LOG, LOG10, SIN, SQRT, and TAN are available."//newline//newline// &
+                          "Cell settings are parsed in the following precedence order:"//newline// &
+                          "1. The external file set by CELL_FILE_NAME with a CELL_FILE_FORMAT;"//newline// &
+                          "2. The lengths and angles of cell vectors set by ABC and ALPHA_BETA_GAMMA;"//newline// &
+                          "3. The vectors set by A, B, C together;"//newline// &
+                          "4. If none above exist, the external file set by TOPOLOGY/COORD_FILE_NAME with"// &
+                          "certain TOPOLOGY/COORD_FILE_FORMAT may also be parsed.")
       CALL create_cell_section_low(section, periodic)
 
       NULLIFY (subsection)
@@ -1670,7 +1676,10 @@ CONTAINS
       ! Character
       CALL keyword_create(keyword, __LOCATION__, name="COORD_FILE_NAME", &
                           variants=s2a("COORD_FILE"), &
-                          description="Specifies the filename that contains coordinates.", &
+                          description="Specifies the filename that contains coordinates. "// &
+                          "In case the CELL section is not set explicitly but this file "// &
+                          "contains cell information, including CIF, PDB and (Extended) XYZ "// &
+                          "formats, this file is also parsed for setting up the simulation cell.", &
                           usage="COORD_FILE_NAME <FILENAME>", type_of_var=lchar_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_subsys.F
+++ b/src/input_cp2k_subsys.F
@@ -93,7 +93,7 @@ CONTAINS
                           "1. The external file set by CELL_FILE_NAME with a CELL_FILE_FORMAT;"//newline// &
                           "2. The lengths and angles of cell vectors set by ABC and ALPHA_BETA_GAMMA;"//newline// &
                           "3. The vectors set by A, B, C together;"//newline// &
-                          "4. If none above exist, the external file set by TOPOLOGY/COORD_FILE_NAME with"// &
+                          "4. If none above exist, the external file set by TOPOLOGY/COORD_FILE_NAME with "// &
                           "certain TOPOLOGY/COORD_FILE_FORMAT may also be parsed.")
       CALL create_cell_section_low(section, periodic)
 


### PR DESCRIPTION
Following recent developments of cell-parsing logic in #4950 and #4960, this PR
drafts implementation of an idea in #4962 as follows:

> Furthermore, if the cell is not provided explicitly, then we should start to fall back to reading it from the [coordinate file](https://manual.cp2k.org/trunk/CP2K_INPUT/FORCE_EVAL/SUBSYS/TOPOLOGY.html#CP2K_INPUT.FORCE_EVAL.SUBSYS.TOPOLOGY.COORD_FILE_NAME).

With this in mind, a note about precedence order of cell parsing logic is added
to the manual: firstly `CELL_FILE_NAME` and `CELL_FILE_FORMAT`, secondly `ABC`
and `ALPHA_BETA_GAMMA`, thirdly `A`, `B`, `C`, and finally `COORD_FILE_NAME`
under the `TOPOLOGY` section.

A major consequence is that `SUBROUTINE read_cell` having access to the `CELL`
section in input file as before is not enough now: it has to know the contents
of `TOPOLOGY` section with an optional `topology_section` pointer as input
argument. As I noted in [this comment](https://github.com/cp2k/cp2k/issues/4962#issuecomment-4068402866), `SUBROUTINE read_cell` is called in
several different contexts; a task yet to be done is to verify that each of
them do have access to `topology_section` (e.g. if they are already working
with the upper-level `subsys_section`) and that fallback to parsing coordinate
file for cell information is desirable, before adjusting anything beyond the
`cell_methods.F` code to enable this behavior. The first commit has no such
adjustments yet.

Also, `SUBROUTINE read_cell` in this PR has undergone a major overhaul due to
the former logic using auxiliary `SUBROUTINE read_cell_from_external_file` a
bit contrived to work with. In the current proof-of-concept, all cell data are
read from external file into `read_mat` or `read_ang` and `read_len` and has
units converted before assigning to the cell setup. Whether this may introduce
numeric noise and leads to noticeable variation of computational results is to
be tested.