### PR TITLE
Revise build instructions for CP2K from source

### DIFF
--- a/docs/getting-started/build-from-source.md
+++ b/docs/getting-started/build-from-source.md
@@ -3,13 +3,136 @@
 CP2K uses the [CMake](https://cmake.org) build system, which detects dependencies and controls the
 compilation process. The dependencies have to be installed in advance.
 
-Currently, CP2K offers three convenient methods for building CP2K from source with its dependencies.
+Currently, CP2K offers two convenient ways for building CP2K from source with its dependencies.
 One is to use the classic toolchain scripts to customize and install the required dependencies in a
-single step, thereby preparing the environment for compiling CP2K. A more modern and automated
-approach is via `make_cp2k.sh`, which leverages [Spack](https://spack.readthedocs.io) to install the
-dependencies and subsequently build CP2K. Alternatively, one can use Spack directly to install all
-the dependencies and setup the build environment, as described in
-[](./build-with-spack.md#developer-workflow).
+single step, thereby preparing the environment for compiling CP2K.
+
+A more modern and automated approach is via the `make_cp2k.sh` script, which
+leverages [Spack](https://spack.readthedocs.io) to install the dependencies and
+subsequently build CP2K. The latter approach is only available for the current
+[CP2K master branch](https://github.com/cp2k/cp2k) and CP2K release versions `2026.02`
+and newer.
+
+## make_cp2k.sh
+
+The `make_cp2k.sh` script supports and facilitates the build of CP2K and its dependencies from scratch
+using [Spack](https://spack.readthedocs.io) and [CMake](https://cmake.org/cmake/help/latest/index.html).
+The build is performed locally within the folder `CP2K_ROOT` which defaults to the current working directory.
+This should be a `cp2k` folder containing the CP2K source tree which can be download with
+
+```
+> git clone https://github.com/cp2k/cp2k.git cp2k
+```
+
+and after
+
+```  
+> cd cp2k
+```
+
+this script can be run using the default options with
+
+```
+> ./make_cp2k.sh
+```
+
+The flags `-h` or `--help` print the available options.
+<details>
+
+  <summary>Click to see all options (of version 1.6)</summary>
+
+```
+Usage: make_cp2k.sh [-bd | --build_deps]
+                    [-bd_only | --build_deps_only]
+                    [-bt | --build_type (Debug | Release | RelWithDebInfo)]
+                    [-cray]
+                    [-cv | --cp2k_version (pdbg | psmp | sdbg | ssmp | ssmp-static)]
+                    [-df | --disable | --disable_feature (all | FEATURE | PACKAGE | none)
+                    [-dlc | --disable_local_cache]
+                    [-ef | --enable | --enable_feature (all | FEATURE | PACKAGE | none)
+                    [-gm | -gpu  | --gpu_model (<CUDA SM code> | P100 | V100 | T400 | A100 | H100 | H200 | GH200 | none)]
+                    [-gv | --gcc_version (10 | 11 | 12 | 13 | 14 | 15 | 16)]
+                    [-h | --help]
+                    [-ip | --install_path PATH]
+                    [-j #PROCESSES]
+                    [-mpi | --mpi_mode (mpich | no | openmpi)]
+                    [-np | --num_packages #PACKAGES]
+                    [-rc | --rebuild_cp2k]
+                    [-t | -test "TESTOPTS"]
+                    [-ue | --use_externals]
+                    [-v | --verbose]
+
+Flags:
+ --build_deps         : Force a rebuild of all CP2K dependencies from scratch (removes the spack folder)
+ --build_deps_only    : Rebuild ONLY the CP2K dependencies from scratch (removes the spack folder)
+ --build_type         : Set preferred CMake build type for CP2K (default: Release)
+ --cp2k_version       : CP2K version to be built (default: psmp)
+ -cray                : Use Cray specific spack configuration
+ --disable_local_cache: Don't add local spack cache
+ --enable_feature     : Enable feature or package (default: all)
+ --disable_feature    : Disable feature or package
+ --help               : Print this help information
+ --gcc_version        : Use the specified GCC version (default: automatically decided by spack)
+ --gpu_model          : Select GPU model (default: none)
+ --install_path       : Define the CP2K installation path (default: ./install)
+ -j                   : Maximum number of processes used in parallel
+ --mpi_mode           : Set preferred MPI mode (default: mpich)
+ --num_packages       : Maximum number of packages built by spack in parallel (default: 4)
+ --rebuild_cp2k       : Rebuild CP2K: removes the build folder (default: no)
+ --test               : Perform a regression test run after a successful build
+ --use_externals      : Use external packages installed on the host system. This results in much
+                        faster build times, but it can also cause conflicts with outdated packages
+                        pulled in from the host system, e.g. old python or gcc versions
+ --verbose            : Write verbose output
+
+Hints:
+ - Remove the folder ${CP2K_ROOT}/build to (re)build CP2K from scratch
+   (see also --rebuild_cp2k flag)
+ - Remove the folder ${CP2K_ROOT}/spack to (re)build CP2K and all its dependencies from scratch
+   (see also --build_deps flag)
+ - The folder ${CP2K_ROOT}/install is updated after each successful run
+
+Packages: all | ace | cosma | deepmd | dftd4 | dlaf | elpa | fftw3 | greenx | hdf5 | libint2 |
+          libsmeagol | libtorch | libvdwxc | libxsmm | mimic | openpmd | pexsi | plumed | sirius |
+          spfft | spglib | spla | tblite | trexio | vori
+
+Features: cray_pm_accel_energy | cusolver_mp | dbm_gpu | elpa_gpu | grid_gpu | pw_gpu |
+          spla_gemm_offloading | unified_memory
+```
+
+</details>
+
+The first run will take longer as it will build all CP2K dependencies with Spack. The Spack installation
+is kept fully local in the subfolder `cp2k/spack` which corresponds to the `tools/toolchain/install` folder
+created by the CP2K toolchain.
+
+Subsequent runs of the `make_cp2k.sh` script will use the software stack from that `cp2k/spack` folder.
+A rebuild of all CP2K dependencies can be enforced simply by removing or renaming the folder `cp2k/spack`.
+The latter allows for keeping different software stacks (see also `-bd` and `-bd_only` flags).
+
+It is recommended to install podman to take advantage of a local cache. This will accelerate the
+(re)build of the CP2K dependencies with Spack significantly.
+
+After the CP2K dependencies are built with Spack, CP2K itself is built and installed using `CMake`
+in the subfolders `cp2k/build` and `cp2k/install`, respectively.
+
+Subsequent runs of the script will use the CMake configuration in the subfolder `cp2k/build`.
+A rebuild of CP2K from scratch can be enforced by removing or renaming that subfolder.
+  
+A CP2K regression run can be launched automatically by adding the flag `-t ""` (or `--test ""`).
+This flag expects a string with the `TESTOPTS`, e.g.
+```
+> ./make_cp2k.sh -t "--maxtasks 8 --restrictdir QS/regtest-gpw-1"
+```
+Alternatively, the script `cp2k/install/bin/run_tests` can be launched after a successful CP2K build.
+Usage examples are printed at the end of a (successful) `make_cp2k.sh` run.
+
+### Docker containers
+
+Check the folder [`cp2k/tools/docker`](https://github.com/cp2k/cp2k/tree/master/tools/docker) for Docker files
+with the name pattern `Dockerfile.test_spack_*` like `Dockerfile.test_spack_psmp` to build Docker containers
+using `make_cp2k.sh`. Each Docker file provides a usage example in its header
+which employs [`podman`](https://docs.podman.io/en/latest/) for building the the CP2K docker containers.
 
 ## Dependencies and build options
 


### PR DESCRIPTION
Updated the documentation to reflect the removal of one build method and added detailed instructions for using the make_cp2k.sh script.