### PR TITLE
remove projMO REFERENCE_TYPE

### DIFF
--- a/src/emd/rt_projection_mo_utils.F
+++ b/src/emd/rt_projection_mo_utils.F
@@ -35,8 +35,6 @@ MODULE rt_projection_mo_utils
                                               cp_print_key_generate_filename,&
                                               cp_print_key_should_output,&
                                               cp_print_key_unit_nr
-   USE input_constants,                 ONLY: proj_mo_ref_scf,&
-                                              proj_mo_ref_xas_tdp
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
@@ -75,7 +73,7 @@ CONTAINS
       TYPE(rtp_control_type), POINTER                    :: rtp_control
 
       INTEGER                                            :: i_rep, j_td, n_rep_val, nbr_mo_td_max, &
-                                                            nrep, reftype
+                                                            nrep
       INTEGER, DIMENSION(:), POINTER                     :: tmp_ints
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
@@ -98,9 +96,6 @@ CONTAINS
          ALLOCATE (rtp_control%proj_mo_list(i_rep)%proj_mo)
          proj_mo => rtp_control%proj_mo_list(i_rep)%proj_mo
 
-         CALL section_vals_val_get(proj_mo_section, "REFERENCE_TYPE", i_rep_section=i_rep, &
-                                   i_val=reftype)
-
          CALL section_vals_val_get(proj_mo_section, "REF_MO_FILE_NAME", i_rep_section=i_rep, &
                                    c_val=proj_mo%ref_mo_file_name)
 
@@ -112,45 +107,28 @@ CONTAINS
             CALL section_vals_val_get(proj_mo_section, "PROPAGATE_REF", i_rep_section=i_rep, &
                                       l_val=proj_mo%propagate_ref)
 
-         IF (reftype == proj_mo_ref_scf) THEN
-            ! If no reference .wfn is provided, using the restart SCF file:
-            IF (proj_mo%ref_mo_file_name == "DEFAULT") THEN
-               CALL section_vals_val_get(input, "DFT%WFN_RESTART_FILE_NAME", n_rep_val=n_rep_val)
-               IF (n_rep_val > 0) THEN
-                  CALL section_vals_val_get(input, "DFT%WFN_RESTART_FILE_NAME", c_val=proj_mo%ref_mo_file_name)
-               ELSE
-                  !try to read from the filename that is generated automatically from the printkey
-                  print_key => section_vals_get_subs_vals(input, "DFT%SCF%PRINT%RESTART")
-                  logger => cp_get_default_logger()
-                  proj_mo%ref_mo_file_name = cp_print_key_generate_filename(logger, print_key, &
-                                                                            extension=".wfn", my_local=.FALSE.)
-               END IF
+         ! If no reference .wfn is provided, using the restart SCF file:
+         IF (proj_mo%ref_mo_file_name == "DEFAULT") THEN
+            CALL section_vals_val_get(input, "DFT%WFN_RESTART_FILE_NAME", n_rep_val=n_rep_val)
+            IF (n_rep_val > 0) THEN
+               CALL section_vals_val_get(input, "DFT%WFN_RESTART_FILE_NAME", c_val=proj_mo%ref_mo_file_name)
+            ELSE
+               !try to read from the filename that is generated automatically from the printkey
+               print_key => section_vals_get_subs_vals(input, "DFT%SCF%PRINT%RESTART")
+               logger => cp_get_default_logger()
+               proj_mo%ref_mo_file_name = cp_print_key_generate_filename(logger, print_key, &
+                                                                         extension=".wfn", my_local=.FALSE.)
             END IF
-
-            CALL section_vals_val_get(proj_mo_section, "REF_MO_INDEX", i_rep_section=i_rep, &
-                                      i_vals=tmp_ints)
-            ALLOCATE (proj_mo%ref_mo_index, SOURCE=tmp_ints(:))
-            CALL section_vals_val_get(proj_mo_section, "REF_MO_SPIN", i_rep_section=i_rep, &
-                                      i_val=proj_mo%ref_mo_spin)
-
-            ! Read the SCF mos and store the one required
-            CALL read_reference_mo_from_wfn(qs_env, proj_mo)
-
-         ELSE IF (reftype == proj_mo_ref_xas_tdp) THEN
-            IF (proj_mo%ref_mo_file_name == "DEFAULT") THEN
-               CALL cp_abort(__LOCATION__, &
-                             "Input error in DFT%REAL_TIME_PROPAGATION%PRINT%PROJECTION_MO. "// &
-                             "For REFERENCE_TYPE XAS_TDP one must define the name "// &
-                             "of the .wfn file to read the reference MO from. Please define REF_MO_FILE_NAME.")
-            END IF
-            ALLOCATE (proj_mo%ref_mo_index(1))
-            ! XAS restart files contain only one excited state
-            proj_mo%ref_mo_index(1) = 1
-            proj_mo%ref_mo_spin = 1
-            ! Read XAS TDP mos
-            CALL read_reference_mo_from_wfn(qs_env, proj_mo, xas_ref=.TRUE.)
-
          END IF
+
+         CALL section_vals_val_get(proj_mo_section, "REF_MO_INDEX", i_rep_section=i_rep, &
+                                   i_vals=tmp_ints)
+         ALLOCATE (proj_mo%ref_mo_index, SOURCE=tmp_ints(:))
+         CALL section_vals_val_get(proj_mo_section, "REF_MO_SPIN", i_rep_section=i_rep, &
+                                   i_val=proj_mo%ref_mo_spin)
+
+         ! Read the SCF mos and store the one required
+         CALL read_reference_mo_from_wfn(qs_env, proj_mo)
 
          ! Initialize the other parameters related to the TD mos.
          CALL section_vals_val_get(proj_mo_section, "SUM_ON_ALL_REF", i_rep_section=i_rep, &
@@ -198,21 +176,19 @@ CONTAINS
    END SUBROUTINE init_mo_projection
 
 ! **************************************************************************************************
-!> \brief Read the MO from .wfn file and store the required mos for TD projections
+!> \brief Read the MO from .wfn file and store the required MOs for TD projections
 !> \param qs_env ...
 !> \param proj_mo ...
-!> \param xas_ref ...
 !> \author Guillaume Le Breton (04.2023)
 ! **************************************************************************************************
-   SUBROUTINE read_reference_mo_from_wfn(qs_env, proj_mo, xas_ref)
+   SUBROUTINE read_reference_mo_from_wfn(qs_env, proj_mo)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(proj_mo_type), POINTER                        :: proj_mo
-      LOGICAL, OPTIONAL                                  :: xas_ref
 
       INTEGER                                            :: i_ref, ispin, mo_index, natom, &
                                                             nbr_mo_max, nbr_ref_mo, nspins, &
                                                             real_mo_index, restart_unit
-      LOGICAL                                            :: is_file, my_xasref
+      LOGICAL                                            :: is_file
       TYPE(cp_fm_struct_type), POINTER                   :: mo_ref_fmstruct
       TYPE(cp_fm_type)                                   :: mo_coeff_temp
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s
@@ -226,9 +202,6 @@ CONTAINS
       NULLIFY (mo_qs, mo_ref_temp, mo_set, qs_kind_set, particle_set, para_env, dft_control, &
                mo_ref_fmstruct, matrix_s)
 
-      my_xasref = .FALSE.
-      IF (PRESENT(xas_ref)) my_xasref = xas_ref
-
       CALL get_qs_env(qs_env, &
                       qs_kind_set=qs_kind_set, &
                       particle_set=particle_set, &
@@ -240,18 +213,11 @@ CONTAINS
       natom = SIZE(particle_set, 1)
 
       nspins = SIZE(mo_qs)
-      ! If the restart comes from DFT%XAS_TDP%PRINT%RESTART_WFN, then always 2 spins are saved
-      IF (my_xasref .AND. nspins < 2) THEN
-         nspins = 2
-      END IF
+
       ALLOCATE (mo_ref_temp(nspins))
 
       DO ispin = 1, nspins
-         IF (my_xasref) THEN
-            mo_set => mo_qs(1)
-         ELSE
-            mo_set => mo_qs(ispin)
-         END IF
+         mo_set => mo_qs(ispin)
          mo_ref_temp(ispin)%nmo = mo_set%nmo + proj_mo%ref_nlumo
          NULLIFY (mo_ref_fmstruct)
          CALL cp_fm_struct_create(mo_ref_fmstruct, nrow_global=mo_set%nao, &
@@ -268,15 +234,6 @@ CONTAINS
          ALLOCATE (mo_ref_temp(ispin)%occupation_numbers(mo_ref_temp(ispin)%nmo))
          NULLIFY (mo_set)
       END DO
-
-!         DO ispin = 1, nspins
-!            CALL duplicate_mo_set(mo_ref_temp(ispin), mo_qs(1))
-!         END DO
-!      ELSE
-!         DO ispin = 1, nspins
-!            CALL duplicate_mo_set(mo_ref_temp(ispin), mo_qs(ispin))
-!         END DO
-!      END IF
 
       IF (para_env%is_source()) THEN
          INQUIRE (FILE=TRIM(proj_mo%ref_mo_file_name), exist=is_file)
@@ -299,9 +256,8 @@ CONTAINS
 
       IF (proj_mo%ref_mo_spin > SIZE(mo_ref_temp)) &
          CALL cp_abort(__LOCATION__, &
-                       "You asked as reference spin the BETA one while the "// &
-                       "reference .wfn file has only one spin. Use a reference .wfn "// &
-                       "with 2 spins separated or set REF_MO_SPIN to 1")
+                       "Projection on spin BETA is not possible as the reference wavefunction "// &
+                       "only has one spin channel. Use a reference .wfn calculated with UKS/LSD, or set REF_MO_SPIN to 1")
 
       ! Store only the mos required
       nbr_mo_max = mo_ref_temp(proj_mo%ref_mo_spin)%mo_coeff%matrix_struct%ncol_global
@@ -315,15 +271,17 @@ CONTAINS
          DO i_ref = 1, SIZE(proj_mo%ref_mo_index)
             IF (proj_mo%ref_mo_index(i_ref) > nbr_mo_max) &
                CALL cp_abort(__LOCATION__, &
-                             "The MO number available in the Reference SCF "// &
-                             "is smaller than the MO number you have required in REF_MO_INDEX.")
+                             "The number of MOs available in the reference wavefunction "// &
+                             "is smaller than the MO number you have requested in REF_MO_INDEX.")
          END DO
       END IF
       nbr_ref_mo = SIZE(proj_mo%ref_mo_index)
 
       IF (nbr_ref_mo > nbr_mo_max) &
          CALL cp_abort(__LOCATION__, &
-                       "The number of reference mo is larger then the total number of available one in the .wfn file.")
+                       "The total number of requested MOs is larger than what is available in the reference wavefunction. "// &
+                       "If you are trying to project onto virtual states, make sure they are included in the .wfn file "// &
+                       "e.g., by the ADDED_MOS keyword in the SCF section of the input when calculating your reference.")
 
       ! Store
       ALLOCATE (proj_mo%mo_ref(nbr_ref_mo))
@@ -558,7 +516,7 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Write in one file the projection of (all) the time-dependent MO coefficients
-!>        on one reference ones
+!>        onto reference ones
 !> \param qs_env ...
 !> \param print_mo_section ...
 !> \param proj_mo ...
@@ -592,7 +550,7 @@ CONTAINS
       IF (proj_mo%sum_on_all_ref) THEN
          ext = "-"//TRIM(ADJUSTL(cp_to_string(n_proj)))//"-ALL_REF.dat"
       ELSE
-         ! Filename is update wrt the reference MO number
+         ! Filename is updated wrt the reference MO number
          ext = "-"//TRIM(ADJUSTL(cp_to_string(n_proj)))// &
                "-REF-"// &
                TRIM(ADJUSTL(cp_to_string(proj_mo%ref_mo_index(i_ref))))// &
@@ -604,9 +562,6 @@ CONTAINS
 
       IF (print_unit /= output_unit) THEN
          INQUIRE (UNIT=print_unit, NAME=filename)
-!         WRITE (UNIT=output_unit, FMT="(/,T2,A,2(/,T3,A),/)") &
-!            "PROJECTION MO", "The projection of the TD MOs is done in the file:", &
-!            TRIM(filename)
          WRITE (UNIT=print_unit, FMT="(/,(T2,A,T40,I6))") &
             "Real time propagation step:", qs_env%sim_step
       ELSE
@@ -652,7 +607,7 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Propagate the reference MO in case of EMD: since the nuclei moves, the MO coeff can be
-!>        propagate to represent the same MO (because the AO move with the nuclei).
+!>        propagated to represent the same MO (because the AO move with the nuclei).
 !>        To do so, we use the same formula as for the electrons of the system, but without the
 !>        Hamiltonian:
 !>        dc^j_alpha/dt = - sum_{beta, gamma} S^{-1}_{alpha, beta} B_{beta,gamma} c^j_gamma

--- a/src/input_constants.F
+++ b/src/input_constants.F
@@ -957,10 +957,6 @@ MODULE input_constants
    INTEGER, PARAMETER, PUBLIC               :: rtp_bse_ham_ks = 1, &
                                                rtp_bse_ham_g0w0 = 2
 
-   ! type of reference for RTP%PRINT%PROJECTION_MO
-   INTEGER, PARAMETER, PUBLIC               :: proj_mo_ref_scf = 1, &
-                                               proj_mo_ref_xas_tdp = 2
-
    ! how to solve polarizable force fields
    INTEGER, PARAMETER, PUBLIC               :: do_fist_pol_none = 1, &
                                                do_fist_pol_sc = 2, &

--- a/src/input_cp2k_projection_rtp.F
+++ b/src/input_cp2k_projection_rtp.F
@@ -10,9 +10,8 @@
 !> \author Guillaume Le Breton 04.2023
 ! **************************************************************************************************
 MODULE input_cp2k_projection_rtp
+
    USE cp_output_handling,              ONLY: cp_print_key_section_create
-   USE input_constants,                 ONLY: proj_mo_ref_scf,&
-                                              proj_mo_ref_xas_tdp
    USE input_keyword_types,             ONLY: keyword_create,&
                                               keyword_release,&
                                               keyword_type
@@ -22,7 +21,6 @@ MODULE input_cp2k_projection_rtp
                                               section_release,&
                                               section_type
    USE input_val_types,                 ONLY: integer_t
-   USE string_utilities,                ONLY: s2a
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -72,24 +70,13 @@ CONTAINS
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
-      CALL keyword_create(keyword, __LOCATION__, name="REFERENCE_TYPE", &
-                          description="Type of the reference MO file provided in REF_MO_FILE_NAME.", &
-                          enum_c_vals=s2a("SCF", "XAS_TDP"), &
-                          usage="REFERENCE_TYPE SCF", &
-                          default_i_val=proj_mo_ref_scf, &
-                          enum_desc=s2a("The reference MO is from an SCF calculation.", &
-                                        "The reference MO is from an XAS_TDP analysis."), &
-                          enum_i_vals=[proj_mo_ref_scf, proj_mo_ref_xas_tdp])
-      CALL section_add_keyword(section, keyword)
-      CALL keyword_release(keyword)
-
       CALL keyword_create(keyword, __LOCATION__, name="REF_MO_FILE_NAME", &
                           description="Name of the wavefunction file to read the reference MO from. "// &
-                          "For instance, a restart wfn file from SCF calculation or an excited state from XAS_TDP calculation. "// &
                           "If no file is specified, the default is to use DFT%WFN_RESTART_FILE_NAME. "// &
                           "Currently, a RTP restart file (.rtpwfn) cannot be used as reference. "// &
-                          "Currently, this file SHALL have the same number of spin as the propagated one "// &
-                          "(eventhough you use only the first spin from this reference).", &
+                          "It is important that the number of spin channels of the reference matches the "// &
+                          "type of propagation calculation you are performing (1 for restricted KS, and 2 "// &
+                          "for UKS/LSD.", &
                           usage="REF_MO_FILE_NAME <FILENAME>", &
                           default_lc_val="DEFAULT")
       CALL section_add_keyword(section, keyword)
@@ -97,7 +84,6 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="REF_MO_INDEX", &
                           description="Indexes of the reference MO read from the .wfn reference file (see REF_MO_FILE_NAME). "// &
-                          "Use this keyword if REFERENCE_TYPE=SCF. "// &
                           "Set to -1 to project on all the MO available. "// &
                           "One file will be generated per index defined.", &
                           usage="REF_MO_INDEX 1 2", &

--- a/tests/QS/regtest-xastdp/H2O-projection-mo-emd.inp
+++ b/tests/QS/regtest-xastdp/H2O-projection-mo-emd.inp
@@ -35,7 +35,6 @@
       MAX_ITER 10
       &PRINT
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX -1
           REF_MO_SPIN 1
           SUM_ON_ALL_REF .FALSE.
@@ -49,7 +48,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX -1
           REF_MO_SPIN 2
           SUM_ON_ALL_REF .TRUE.
@@ -63,7 +61,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX -1
           REF_MO_SPIN 1
           SUM_ON_ALL_REF .TRUE.
@@ -77,7 +74,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           &PRINT
             &EACH
               MD 1
@@ -85,7 +81,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_FILE_NAME H2O-projection-mo-RESTART.wfn
           &PRINT
             &EACH
@@ -94,29 +89,14 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE XAS_TDP
-          REF_MO_FILE_NAME H2O-B3LYP-full-xasat1_1s_singlet_idx1-1.wfn
-          SUM_ON_ALL_TD .TRUE.
-          TD_MO_INDEX -1
-          TD_MO_SPIN 1
           &PRINT
             &EACH
               MD 1
             &END EACH
           &END PRINT
         &END PROJECTION_MO
-        &PROJECTION_MO
-          REFERENCE_TYPE SCF
-          &PRINT
-            &EACH
-              MD 1
-            &END EACH
-          &END PRINT
-        &END PROJECTION_MO
-        ! PROPAGATE_REF .TRUE.
         &PROJECTION_MO
           PROPAGATE_REF .TRUE.
-          REFERENCE_TYPE SCF
           REF_MO_INDEX -1
           REF_MO_SPIN 1
           SUM_ON_ALL_REF .FALSE.
@@ -131,7 +111,6 @@
         &END PROJECTION_MO
         &PROJECTION_MO
           PROPAGATE_REF .TRUE.
-          REFERENCE_TYPE SCF
           REF_MO_INDEX -1
           REF_MO_SPIN 2
           SUM_ON_ALL_REF .TRUE.
@@ -146,7 +125,6 @@
         &END PROJECTION_MO
         &PROJECTION_MO
           PROPAGATE_REF .TRUE.
-          REFERENCE_TYPE SCF
           REF_MO_INDEX -1
           REF_MO_SPIN 1
           SUM_ON_ALL_REF .TRUE.
@@ -161,7 +139,6 @@
         &END PROJECTION_MO
         &PROJECTION_MO
           PROPAGATE_REF .TRUE.
-          REFERENCE_TYPE SCF
           &PRINT
             &EACH
               MD 1
@@ -170,7 +147,6 @@
         &END PROJECTION_MO
         &PROJECTION_MO
           PROPAGATE_REF .TRUE.
-          REFERENCE_TYPE SCF
           REF_MO_FILE_NAME H2O-projection-mo-RESTART.wfn
           &PRINT
             &EACH
@@ -180,20 +156,6 @@
         &END PROJECTION_MO
         &PROJECTION_MO
           PROPAGATE_REF .TRUE.
-          REFERENCE_TYPE XAS_TDP
-          REF_MO_FILE_NAME H2O-B3LYP-full-xasat1_1s_singlet_idx1-1.wfn
-          SUM_ON_ALL_TD .TRUE.
-          TD_MO_INDEX -1
-          TD_MO_SPIN 1
-          &PRINT
-            &EACH
-              MD 1
-            &END EACH
-          &END PRINT
-        &END PROJECTION_MO
-        &PROJECTION_MO
-          PROPAGATE_REF .TRUE.
-          REFERENCE_TYPE SCF
           &PRINT
             &EACH
               MD 1

--- a/tests/QS/regtest-xastdp/H2O-projection-mo.inp
+++ b/tests/QS/regtest-xastdp/H2O-projection-mo.inp
@@ -35,7 +35,6 @@
       MAX_ITER 10
       &PRINT
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX 4 5
           REF_MO_SPIN 1
           SUM_ON_ALL_REF .FALSE.
@@ -49,7 +48,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX 4 5
           REF_MO_SPIN 2
           SUM_ON_ALL_REF .FALSE.
@@ -63,7 +61,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX 4 5
           REF_MO_SPIN 1
           SUM_ON_ALL_REF .FALSE.
@@ -77,7 +74,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX 4 5 6
           REF_MO_SPIN 2
           SUM_ON_ALL_REF .FALSE.
@@ -91,7 +87,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX -1
           REF_MO_SPIN 1
           SUM_ON_ALL_REF .FALSE.
@@ -105,7 +100,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX -1
           REF_MO_SPIN 2
           SUM_ON_ALL_REF .TRUE.
@@ -119,7 +113,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_INDEX -1
           REF_MO_SPIN 1
           SUM_ON_ALL_REF .TRUE.
@@ -133,7 +126,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           &PRINT
             &EACH
               MD 1
@@ -141,7 +133,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE SCF
           REF_MO_FILE_NAME H2O-projection-mo-RESTART.wfn
           &PRINT
             &EACH
@@ -150,19 +141,6 @@
           &END PRINT
         &END PROJECTION_MO
         &PROJECTION_MO
-          REFERENCE_TYPE XAS_TDP
-          REF_MO_FILE_NAME H2O-B3LYP-full-xasat1_1s_singlet_idx1-1.wfn
-          SUM_ON_ALL_TD .TRUE.
-          TD_MO_INDEX -1
-          TD_MO_SPIN 1
-          &PRINT
-            &EACH
-              MD 1
-            &END EACH
-          &END PRINT
-        &END PROJECTION_MO
-        &PROJECTION_MO
-          REFERENCE_TYPE SCF
           &PRINT
             &EACH
               MD 1
@@ -171,7 +149,6 @@
         &END PROJECTION_MO
         &PROJECTION_MO
           PROPAGATE_REF .TRUE.  ! Should do nothing for RTP
-          REFERENCE_TYPE SCF
           REF_MO_FILE_NAME H2O-projection-mo-RESTART.wfn
           &PRINT
             &EACH


### PR DESCRIPTION
Removes `REAL_TIME_PROPAGATION % PRINT % PROJECTION_MO % REFERENCE_TYPE` as an option. This is because one of the two options (`REFRERENCE_TYPE XAS_TDP`) is (1) superfluous; one can achieve the same results by using the `REFERENCE_TYPE SCF` option instead, and (2) it was not working properly if the reference .wfn was obtained from an XAS_TDP calculation where the source electron was not from the lowest MO of the system.

The only reason to keep the `REFERENCE_TYPE` option is to expand the types of MOs to project onto, e.g., an .rtpwfn file. But there does not seem to be a demand for this functionality at the moment.