### PR TITLE
Make MO_MOLDEN pick up `mo_set` even if MO output is not triggered on

### DIFF
--- a/src/iao_analysis.F
+++ b/src/iao_analysis.F
@@ -488,7 +488,7 @@ CONTAINS
             mo_iao(ispin)%occupation_numbers = 1.0_dp
          END DO
          ! Print IAO basis functions: molden format
-         CALL write_mos_molden(mo_iao, qs_kind_set, particle_set, iao_molden_section, cell=cell)
+         CALL write_mos_molden(mo_iao, qs_kind_set, particle_set, iao_molden_section, cell=cell, qs_env=qs_env)
          DO ispin = 1, nspin
             CALL deallocate_mo_set(mo_iao(ispin))
          END DO
@@ -662,7 +662,7 @@ CONTAINS
                mo_loc(ispin)%occupation_numbers = 1.0_dp
             END DO
             ! Print IBO functions: molden format
-            CALL write_mos_molden(mo_loc, qs_kind_set, particle_set, ibo_molden_section, cell=cell)
+            CALL write_mos_molden(mo_loc, qs_kind_set, particle_set, ibo_molden_section, cell=cell, qs_env=qs_env)
             DO ispin = 1, nspin
                CALL deallocate_mo_set(mo_loc(ispin))
             END DO

--- a/src/minbas_wfn_analysis.F
+++ b/src/minbas_wfn_analysis.F
@@ -367,7 +367,7 @@ CONTAINS
          ! Print basis functions: molden format
          CALL get_qs_env(qs_env, cell=cell)
          molden_section => section_vals_get_subs_vals(input_section, "MINBAS_MOLDEN")
-         CALL write_mos_molden(mbas, qs_kind_set, particle_set, molden_section, cell=cell)
+         CALL write_mos_molden(mbas, qs_kind_set, particle_set, molden_section, cell=cell, qs_env=qs_env)
          DO ispin = 1, nspin
             CALL deallocate_mo_set(mbas(ispin))
          END DO

--- a/src/molden_utils.F
+++ b/src/molden_utils.F
@@ -10,11 +10,17 @@
 !> \author Teodoro Laino, 03.2009
 ! **************************************************************************************************
 MODULE molden_utils
+   USE admm_types,                      ONLY: admm_type
+   USE admm_utils,                      ONLY: admm_correct_for_eigenvalues,&
+                                              admm_uncorrect_for_eigenvalues
    USE atomic_kind_types,               ONLY: get_atomic_kind
    USE basis_set_types,                 ONLY: get_gto_basis_set,&
                                               gto_basis_set_type
    USE cell_types,                      ONLY: cell_type
    USE cp_array_utils,                  ONLY: cp_1d_r_p_type
+   USE cp_control_types,                ONLY: dft_control_type
+   USE cp_dbcsr_api,                    ONLY: dbcsr_p_type,&
+                                              dbcsr_type
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm
    USE cp_fm_types,                     ONLY: cp_fm_get_info,&
                                               cp_fm_get_submatrix,&
@@ -38,10 +44,14 @@ MODULE molden_utils
    USE periodic_table,                  ONLY: get_ptable_info
    USE physcon,                         ONLY: angstrom,&
                                               massunit
+   USE qs_environment_types,            ONLY: get_qs_env,&
+                                              qs_environment_type
    USE qs_kind_types,                   ONLY: get_qs_kind,&
                                               get_qs_kind_set,&
                                               qs_kind_type
-   USE qs_mo_types,                     ONLY: mo_set_type
+   USE qs_mo_methods,                   ONLY: calculate_subspace_eigenvalues
+   USE qs_mo_types,                     ONLY: get_mo_set,&
+                                              mo_set_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -66,10 +76,12 @@ CONTAINS
 !> \param cell ...
 !> \param unoccupied_orbs optional: unoccupied orbital coefficients from make_lumo_gpw
 !> \param unoccupied_evals optional: unoccupied orbital eigenvalues
+!> \param qs_env ...
+!> \param calc_energies ...
 !> \author MattW, IainB
 ! **************************************************************************************************
    SUBROUTINE write_mos_molden(mos, qs_kind_set, particle_set, print_section, cell, &
-                               unoccupied_orbs, unoccupied_evals)
+                               unoccupied_orbs, unoccupied_evals, qs_env, calc_energies)
       TYPE(mo_set_type), DIMENSION(:), INTENT(IN)        :: mos
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -79,6 +91,8 @@ CONTAINS
          OPTIONAL                                        :: unoccupied_orbs
       TYPE(cp_1d_r_p_type), DIMENSION(:), INTENT(IN), &
          OPTIONAL                                        :: unoccupied_evals
+      TYPE(qs_environment_type), OPTIONAL, POINTER       :: qs_env
+      LOGICAL, INTENT(IN), OPTIONAL                      :: calc_energies
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'write_mos_molden'
       CHARACTER(LEN=molden_lmax+1), PARAMETER            :: angmom = "spdfg"
@@ -91,12 +105,19 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: npgf, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: l
       INTEGER, DIMENSION(molden_ncomax, 0:molden_lmax)   :: orbmap
-      LOGICAL                                            :: print_warn, write_cell, write_nval
+      LOGICAL                                            :: do_calc_energies, print_warn, &
+                                                            write_cell, write_nval
       REAL(KIND=dp)                                      :: expzet, prefac, scale_factor, zeff
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: cmatrix, smatrix
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: zet
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: gcc
+      TYPE(admm_type), POINTER                           :: admm_env
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks
+      TYPE(dbcsr_type), POINTER                          :: matrix_ks, mo_coeff_deriv
+      TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(gto_basis_set_type), POINTER                  :: orb_basis_set
 
       CALL timeset(routineN, handle)
@@ -274,6 +295,40 @@ CONTAINS
          END IF
 
          DO ispin = 1, SIZE(mos)
+            do_calc_energies = .FALSE.
+            IF (PRESENT(calc_energies)) do_calc_energies = calc_energies
+
+            IF (PRESENT(qs_env) .AND. do_calc_energies) THEN
+               CALL get_qs_env(qs_env, matrix_ks=ks, dft_control=dft_control)
+
+               matrix_ks => ks(ispin)%matrix
+
+               ! With ADMM, we have to modify the Kohn-Sham matrix
+               IF (dft_control%do_admm) THEN
+                  CALL get_qs_env(qs_env, admm_env=admm_env)
+                  CALL admm_correct_for_eigenvalues(ispin, admm_env, matrix_ks)
+               END IF
+
+               CALL get_mo_set(mo_set=mos(ispin), mo_coeff=mo_coeff, eigenvalues=mo_eigenvalues)
+
+               IF (ASSOCIATED(qs_env%mo_derivs)) THEN
+                  mo_coeff_deriv => qs_env%mo_derivs(ispin)%matrix
+               ELSE
+                  mo_coeff_deriv => NULL()
+               END IF
+
+               ! Update the eigenvalues of the occupied orbitals
+               CALL calculate_subspace_eigenvalues(orbitals=mo_coeff, &
+                                                   ks_matrix=matrix_ks, &
+                                                   evals_arg=mo_eigenvalues, &
+                                                   co_rotate_dbcsr=mo_coeff_deriv)
+
+               ! With ADMM, we have to undo the modification of the Kohn-Sham matrix
+               IF (dft_control%do_admm) THEN
+                  CALL admm_uncorrect_for_eigenvalues(ispin, admm_env, matrix_ks)
+               END IF
+            END IF
+
             CALL cp_fm_get_info(mos(ispin)%mo_coeff, &
                                 nrow_global=nrow_global, &
                                 ncol_global=ncol_global)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -1145,7 +1145,8 @@ CONTAINS
             END IF
             CALL write_mos_molden(mos, qs_kind_set, particle_set, sprint_section, cell=cell, &
                                   unoccupied_orbs=unoccupied_orbs, &
-                                  unoccupied_evals=unoccupied_evals)
+                                  unoccupied_evals=unoccupied_evals, &
+                                  qs_env=qs_env, calc_energies=.TRUE.)
             DO ispin = 1, dft_control%nspins
                DEALLOCATE (unoccupied_evals(ispin)%array)
                CALL cp_fm_release(unoccupied_orbs(ispin))
@@ -2164,7 +2165,8 @@ CONTAINS
                IF (scf_env%method == ot_method_nr) defer_molden = .TRUE.
             END IF
             IF (.NOT. defer_molden) THEN
-               CALL write_mos_molden(mos, qs_kind_set, particle_set, sprint_section, cell=cell)
+               CALL write_mos_molden(mos, qs_kind_set, particle_set, sprint_section, cell=cell, &
+                                     qs_env=qs_env, calc_energies=.TRUE.)
             END IF
             ! Write Chargemol .wfx
             IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, "PRINT%CHARGEMOL"), &

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -426,7 +426,8 @@ CONTAINS
                CASE ("xTB")
                   sprint_section => section_vals_get_subs_vals(dft_section, "PRINT%MO_MOLDEN")
                   CALL get_qs_env(qs_env, mos=mos, cell=cell)
-                  CALL write_mos_molden(mos, qs_kind_set, particle_set, sprint_section, cell=cell)
+                  CALL write_mos_molden(mos, qs_kind_set, particle_set, sprint_section, cell=cell, &
+                                        qs_env=qs_env, calc_energies=.TRUE.)
                CASE DEFAULT
                   CPABORT("Unknown TB type")
                END SELECT

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -1184,7 +1184,7 @@ CONTAINS
             END IF
             CALL get_qs_env(qs_env, qs_kind_set=qs_kind_set, particle_set=particle_set, cell=cell)
             molden_section => section_vals_get_subs_vals(print_section, "MOS_MOLDEN")
-            CALL write_mos_molden(nto_set, qs_kind_set, particle_set, molden_section, cell=cell)
+            CALL write_mos_molden(nto_set, qs_kind_set, particle_set, molden_section, cell=cell, qs_env=qs_env)
             !
             DEALLOCATE (eigenvalues)
             CALL cp_fm_release(teig)


### PR DESCRIPTION
This should resolve the problem that `&MO_MOLDEN` with OT calculations write out occupied orbital eigenvalues to `*.molden` file only when `&MO` is on, as described in #4927.