### PR TITLE
Fix test-farm failure of RPM build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -41,11 +41,9 @@ jobs:
     tmt_plan: .*/smoke
   - job: copr_build
     trigger: pull_request
-    manual_trigger: true
   - <<: *tests
     identifier: smoke
     trigger: pull_request
-    manual_trigger: true
   - <<: *tests
     identifier: full
     trigger: pull_request

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -41,9 +41,11 @@ jobs:
     tmt_plan: .*/smoke
   - job: copr_build
     trigger: pull_request
+    manual_trigger: true
   - <<: *tests
     identifier: smoke
     trigger: pull_request
+    manual_trigger: true
   - <<: *tests
     identifier: full
     trigger: pull_request

--- a/tools/fedora/cp2k.spec
+++ b/tools/fedora/cp2k.spec
@@ -157,6 +157,7 @@ for mpi in '' mpich openmpi; do
       "-DCMAKE_INSTALL_Fortran_MODULES:PATH=${MPI_FORTRAN_MOD_DIR}/cp2k"
       "-DCP2K_DATA_DIR:PATH=%{_datadir}/cp2k/data"
       "-DCP2K_USE_MPI:BOOL=ON"
+      "-DCP2K_USE_MPI_F08:BOOL=ON"
     )
   else
     cmake_mpi_args=(
@@ -236,7 +237,7 @@ done
 %{_bindir}/graph.ssmp
 %{_bindir}/grid_miniapp.ssmp
 %{_bindir}/xyz2dcd.ssmp
-%{_libdir}/libcp2k.so*
+%{_libdir}/libcp2k.so.*
 
 %files devel
 %{_fmoddir}/cp2k/
@@ -252,7 +253,7 @@ done
 %{_libdir}/openmpi/bin/graph.psmp
 %{_libdir}/openmpi/bin/grid_miniapp.psmp
 %{_libdir}/openmpi/bin/xyz2dcd.psmp
-%{_libdir}/openmpi/lib/libcp2k.so*
+%{_libdir}/openmpi/lib/libcp2k.so.*
 
 %files openmpi-devel
 %{_fmoddir}/openmpi/cp2k/
@@ -268,7 +269,7 @@ done
 %{_libdir}/mpich/bin/graph.psmp
 %{_libdir}/mpich/bin/grid_miniapp.psmp
 %{_libdir}/mpich/bin/xyz2dcd.psmp
-%{_libdir}/mpich/lib/libcp2k.so*
+%{_libdir}/mpich/lib/libcp2k.so.*
 
 %files mpich-devel
 %{_fmoddir}/mpich/cp2k/

--- a/tools/fedora/tests/do_regtest.sh
+++ b/tools/fedora/tests/do_regtest.sh
@@ -32,10 +32,18 @@ rlJournalStart
       rlRun "ls /usr/bin/cp2k.ssmp" 0 "Verify CP2K serial binary exists"
     fi
 
+    # Temporary change to try looking for why performance issue happen
+    if [[ "${CP2K_VARIANT}" == "openmpi" ]]; then
+      rlRun "cat /proc/sys/kernel/yama/ptrace_scope" 0 "Check ptrace scope (0=CMA works, 1+=CMA blocked)"
+      rlRun "df -h /dev/shm" 0 "Check shared memory size"
+    fi
+
     rlRun "./do_regtest.py $args" 0 "Run regression tests"
 
     if [[ -d "${workdir}" ]]; then
-      rlFileSubmit "${workdir}/TEST-"*/status.txt "regtest-${CP2K_VARIANT}-status.txt" 2>/dev/null || true
+      for file in ${workdir}/TEST-*/status.txt regtest-${CP2K_VARIANT}-status.txt; do
+        rlFileSubmit $file
+      done
     fi
 
     rlRun "popd"

--- a/tools/fedora/tests/do_regtest.sh
+++ b/tools/fedora/tests/do_regtest.sh
@@ -28,11 +28,6 @@ rlJournalStart
 
     if [[ "${CP2K_VARIANT}" != "serial" ]]; then
       rlRun "ls ${MPI_BIN}/cp2k.psmp" 0 "Verify CP2K MPI binary exists"
-      if [[ "${CP2K_VARIANT}" == "openmpi" ]]; then
-        rlRun "time mpiexec -n 2 cp2k.psmp --version > /dev/null" 0 "Check the PRTE startup overhead in OpenMPI 5.x."
-      else
-        rlRun "time mpiexec -n 2 cp2k.psmp --version > /dev/null"
-      fi
     else
       rlRun "ls /usr/bin/cp2k.ssmp" 0 "Verify CP2K serial binary exists"
     fi

--- a/tools/fedora/tests/do_regtest.sh
+++ b/tools/fedora/tests/do_regtest.sh
@@ -28,15 +28,15 @@ rlJournalStart
 
     if [[ "${CP2K_VARIANT}" != "serial" ]]; then
       rlRun "ls ${MPI_BIN}/cp2k.psmp" 0 "Verify CP2K MPI binary exists"
+      if [[ "${CP2K_VARIANT}" == "openmpi" ]]; then
+        rlRun "time mpiexec -n 2 cp2k.psmp --version > /dev/null" 0 "Check the PRTE startup overhead in OpenMPI 5.x."
+      else
+        rlRun "time mpiexec -n 2 cp2k.psmp --version > /dev/null"
+      fi
     else
       rlRun "ls /usr/bin/cp2k.ssmp" 0 "Verify CP2K serial binary exists"
     fi
 
-    # Temporary change to try looking for why performance issue happen
-    if [[ "${CP2K_VARIANT}" == "openmpi" ]]; then
-      rlRun "cat /proc/sys/kernel/yama/ptrace_scope" 0 "Check ptrace scope (0=CMA works, 1+=CMA blocked)"
-      rlRun "df -h /dev/shm" 0 "Check shared memory size"
-    fi
 
     rlRun "./do_regtest.py $args" 0 "Run regression tests"
 

--- a/tools/fedora/tests/do_regtest.sh
+++ b/tools/fedora/tests/do_regtest.sh
@@ -9,7 +9,10 @@ rlJournalStart
 
     rlRun "pushd tests" 0 "cd to cp2k tests folder"
 
-    rlRun "args=\"--maxtasks $(nproc) --ompthreads 2\"" 0 "Set base arguments"
+    workdir="/tmp/cp2k-regtest-${CP2K_VARIANT}"
+    rlRun "rm -rf ${workdir}" 0 "Clean previous workdir"
+    rlRun "args=\"--workbasedir ${workdir} --maxtasks $(nproc) --ompthreads 2\"" 0 "Set base arguments"
+
     [[ "${CP2K_SKIP_UNITTEST,,}" == "true" ]] && rlRun "args=\"\$args --skip_unittests\"" 0 "Skip unit tests"
     [[ "${CP2K_SKIP_REGTEST,,}" == "true" ]] && rlRun "args=\"\$args --skip_regtests\"" 0 "Skip regression tests"
     [[ "${CP2K_SMOKE_ONLY,,}" == "true" ]] && rlRun "args=\"\$args --smoketest\"" 0 "Set smoketest flag"
@@ -22,7 +25,18 @@ rlJournalStart
     else
       rlRun "args=\"\$args /usr/bin ssmp\"" 0 "Set run specific arguments"
     fi
+
+    if [[ "${CP2K_VARIANT}" != "serial" ]]; then
+      rlRun "ls ${MPI_BIN}/cp2k.psmp" 0 "Verify CP2K MPI binary exists"
+    else
+      rlRun "ls /usr/bin/cp2k.ssmp" 0 "Verify CP2K serial binary exists"
+    fi
+
     rlRun "./do_regtest.py $args" 0 "Run regression tests"
+
+    if [[ -d "${workdir}" ]]; then
+      rlFileSubmit "${workdir}/TEST-"*/status.txt "regtest-${CP2K_VARIANT}-status.txt" 2>/dev/null || true
+    fi
 
     rlRun "popd"
   rlPhaseEnd

--- a/tools/fedora/tests/regression.fmf
+++ b/tools/fedora/tests/regression.fmf
@@ -3,7 +3,7 @@ framework: beakerlib
 path: /
 test: ./tools/fedora/tests/do_regtest.sh
 # TODO: Reduce the tests duration
-duration: 3h
+duration: 2h
 environment+:
   # Cannot run unittest outside of the build environment
   CP2K_SKIP_UNITTEST: true
@@ -19,6 +19,9 @@ environment+:
     # prterun blocks running mpiexec as root. Set some environment variables to workaround it
     OMPI_ALLOW_RUN_AS_ROOT: 1
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
+    OMPI_MCA_mpi_yield_when_idle: 1
+    OMPI_MCA_pml: ob1
+    OMPI_MCA_btl: self,sm
 /mpich:
   summary+: (mpich)
   environment+:

--- a/tools/fedora/tests/regression.fmf
+++ b/tools/fedora/tests/regression.fmf
@@ -19,8 +19,6 @@ environment+:
     # prterun blocks running mpiexec as root. Set some environment variables to workaround it
     OMPI_ALLOW_RUN_AS_ROOT: 1
     OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-  # TODO: Investigate why openmpi tests are significantly slower
-  duration: 6h
 /mpich:
   summary+: (mpich)
   environment+:

--- a/tools/fedora/tests/regression.fmf
+++ b/tools/fedora/tests/regression.fmf
@@ -3,7 +3,7 @@ framework: beakerlib
 path: /
 test: ./tools/fedora/tests/do_regtest.sh
 # TODO: Reduce the tests duration
-duration: 2h
+duration: 3h
 environment+:
   # Cannot run unittest outside of the build environment
   CP2K_SKIP_UNITTEST: true


### PR DESCRIPTION
The original `do_regtests.sh` script contains a critical flaw: if a regtesting directory already exists from a previous run, the script will repeatedly create new subdirectories within it, leading to infinite recursion and nesting, eventually causing the testing farm to crash. This PR should fix this issue. Also dealt with some (probable) regressions in spec file.

The testing farm on Fedora Rawhide is currently not able to work, because LMod and its dependencies are not yet compatible with the Lua 5.5 version shipped in Rawhide. For robustness, I’m hesitating whether we should replace the extremely aggressive Rawhide with the latest **stable** release (`latest-stable` flag; currently Fedora 43, vs Fedora 44 as `latest` flag actually in development or beta status) in the configuration file; or, we can use `fedora-branched` instead.