### PR TITLE
Activate Fedora rawhide tester (spack)

### DIFF
--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -351,6 +351,13 @@ timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-4x2_report.txt
 
+[spack-psmp-rawhide]
+sortkey:     1041
+name:        Spack (psmp, rawhide)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-rawhide_report.txt
+
 [spack-psmp-fedora]
 sortkey:     1042
 name:        Spack (psmp, fedora)

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -416,6 +416,14 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-4x2
 
+[spack-psmp-rawhide]
+display_name: Spack (psmp, rawhide)
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-rawhide
+
 [spack-psmp-fedora]
 display_name: Spack (psmp, fedora)
 tags:         weekly-afternoon

--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -181,7 +181,7 @@ spack:
     - "python@3.11:"
     # CP2K
     - "adios2@2.11.0"
-    - "cosma@2.8.1"
+    - "cosma@master"
     - "dbcsr@2.9.1"
     - "deepmdkit@3.1.2"
     - "dftd4@3.7.0"


### PR DESCRIPTION
This tester is supposed to detect problems with the latest GCC version early and is therefore likely to fail in most cases.