### PR TITLE
MD: prepare for adapting thermostat region temperatures to thermal region temperatures

### DIFF
--- a/src/input_constants.F
+++ b/src/input_constants.F
@@ -421,6 +421,7 @@ MODULE input_constants
                                                do_region_massive = 2, &
                                                do_region_none = 3, &
                                                do_region_defined = 4, &
+                                               do_region_thermal = 5, &
                                                do_bondparm_covalent = 0, &
                                                do_bondparm_vdw = 1, &
                                                do_skip_11 = 0, &

--- a/src/input_cp2k_thermostats.F
+++ b/src/input_cp2k_thermostats.F
@@ -23,8 +23,8 @@ MODULE input_cp2k_thermostats
    USE cp_units,                        ONLY: cp_unit_to_cp2k
    USE input_constants,                 ONLY: &
         do_constr_atomic, do_constr_molec, do_constr_none, do_region_defined, do_region_global, &
-        do_region_massive, do_region_molecule, do_region_none, do_thermo_al, do_thermo_csvr, &
-        do_thermo_gle, do_thermo_nose, do_thermo_same_as_part
+        do_region_massive, do_region_molecule, do_region_none, do_region_thermal, do_thermo_al, &
+        do_thermo_csvr, do_thermo_gle, do_thermo_nose, do_thermo_same_as_part
    USE input_cp2k_subsys,               ONLY: create_rng_section
    USE input_keyword_types,             ONLY: keyword_create,&
                                               keyword_release,&
@@ -247,10 +247,16 @@ CONTAINS
 
          CALL keyword_create(keyword, __LOCATION__, name="REGION", &
                              description="Determines the region each thermostat is attached to.", &
-                             usage="REGION (GLOBAL||MOLECULE||MASSIVE||DEFINED||NONE)", &
-                             enum_c_vals=s2a("GLOBAL", "MOLECULE", "MASSIVE", "DEFINED", "NONE"), &
-                             enum_i_vals=[do_region_global, do_region_molecule, &
-                                          do_region_massive, do_region_defined, do_region_none], &
+                             usage="REGION (GLOBAL|MOLECULE|MASSIVE|DEFINED|THERMAL|NONE)", &
+                             enum_c_vals=s2a("GLOBAL", "MOLECULE", "MASSIVE", "DEFINED", "THERMAL", "NONE"), &
+                             enum_i_vals=[do_region_global, do_region_molecule, do_region_massive, &
+                                          do_region_defined, do_region_thermal, do_region_none], &
+                             enum_desc=s2a("Apply one thermostat to the whole system (default)", &
+                                           "Apply one thermostat to each molecule kind", &
+                                           "Apply one thermostat to each degree of freedom", &
+                                           "Apply one thermostat to each defined region from THERMOSTAT/DEFINE_REGION", &
+                                           "Apply one thermostat to each defined region from THERMAL_REGION/DEFINE_REGION", &
+                                           "No thermostat is applied"), &
                              default_i_val=do_region_global)
          CALL section_add_keyword(section, keyword)
          CALL keyword_release(keyword)

--- a/src/motion/input_cp2k_md.F
+++ b/src/motion/input_cp2k_md.F
@@ -1005,7 +1005,8 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="MM_SUBSYS", &
                           variants=["PROTEIN"], &
-                          description="In a QM/MM run all MM atoms are specified as a whole region", &
+                          description="Not yet implemented: In a QM/MM run all "// &
+                          "MM atoms are specified as a whole region", &
                           usage="MM_SUBSYS (NONE|ATOMIC|MOLECULAR)", &
                           enum_c_vals=s2a("NONE", "ATOMIC", "MOLECULAR"), &
                           enum_i_vals=[do_constr_none, do_constr_atomic, do_constr_molec], &
@@ -1017,7 +1018,8 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="QM_SUBSYS", &
-                          description="In a QM/MM run all QM atoms are specified as a whole region", &
+                          description="Not yet implemented: In a QM/MM run all "// &
+                          "QM atoms are specified as a whole region", &
                           usage="QM_SUBSYS (NONE|ATOMIC|MOLECULAR)", &
                           enum_c_vals=s2a("NONE", "ATOMIC", "MOLECULAR"), &
                           enum_desc=s2a("Nothing in the region", &

--- a/src/motion/input_cp2k_md.F
+++ b/src/motion/input_cp2k_md.F
@@ -24,10 +24,10 @@ MODULE input_cp2k_md
    USE cp_units,                        ONLY: cp_unit_to_cp2k
    USE fparser,                         ONLY: docf
    USE input_constants,                 ONLY: &
-        isokin_ensemble, langevin_ensemble, md_init_default, md_init_vib, npe_f_ensemble, &
-        npe_i_ensemble, nph_ensemble, nph_uniaxial_damped_ensemble, nph_uniaxial_ensemble, &
-        npt_f_ensemble, npt_i_ensemble, npt_ia_ensemble, nve_ensemble, nvt_adiabatic_ensemble, &
-        nvt_ensemble, reftraj_ensemble
+        do_constr_atomic, do_constr_molec, do_constr_none, isokin_ensemble, langevin_ensemble, &
+        md_init_default, md_init_vib, npe_f_ensemble, npe_i_ensemble, nph_ensemble, &
+        nph_uniaxial_damped_ensemble, nph_uniaxial_ensemble, npt_f_ensemble, npt_i_ensemble, &
+        npt_ia_ensemble, nve_ensemble, nvt_adiabatic_ensemble, nvt_ensemble, reftraj_ensemble
    USE input_cp2k_barostats,            ONLY: create_barostat_section
    USE input_cp2k_thermostats,          ONLY: create_region_section,&
                                               create_thermo_fast_section,&
@@ -981,8 +981,10 @@ CONTAINS
       CALL section_create(region_section, __LOCATION__, name="DEFINE_REGION", &
                           description="Define arbitrary thermal region with distinct "// &
                           "temperature controls. For thermostat regions, see section "// &
-                          "MOTION%MD%THERMOSTAT%DEFINE_REGION. Typically the settings "// &
-                          "should be the same.", &
+                          "MOTION%MD%THERMOSTAT%DEFINE_REGION; when the keyword "// &
+                          "MOTION%MD%THERMOSTAT%REGION is set to THERMAL, the "// &
+                          "definition of thermostat regions will be the same as "// &
+                          "that of thermal regions.", &
                           n_keywords=3, n_subsections=1, repeats=.TRUE.)
 
       NULLIFY (keyword)
@@ -990,6 +992,39 @@ CONTAINS
                           description="Specifies a list of atoms belonging to the region.", &
                           usage="LIST {integer} {integer} .. {integer}", &
                           repeats=.TRUE., n_var=-1, type_of_var=integer_t)
+      CALL section_add_keyword(region_section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="MOLNAME", &
+                          variants=["SEGNAME"], &
+                          description="Specifies the name of the molecules belonging to the region.", &
+                          usage="MOLNAME WAT MEOH", repeats=.TRUE., &
+                          n_var=-1, type_of_var=char_t)
+      CALL section_add_keyword(region_section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="MM_SUBSYS", &
+                          variants=["PROTEIN"], &
+                          description="In a QM/MM run all MM atoms are specified as a whole region", &
+                          usage="MM_SUBSYS (NONE|ATOMIC|MOLECULAR)", &
+                          enum_c_vals=s2a("NONE", "ATOMIC", "MOLECULAR"), &
+                          enum_i_vals=[do_constr_none, do_constr_atomic, do_constr_molec], &
+                          enum_desc=s2a("Nothing in the region", &
+                                        "Only the MM atoms itself", &
+                                        "The full molecule/residue that contains a MM atom"), &
+                          default_i_val=do_constr_none, repeats=.FALSE.)
+      CALL section_add_keyword(region_section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="QM_SUBSYS", &
+                          description="In a QM/MM run all QM atoms are specified as a whole region", &
+                          usage="QM_SUBSYS (NONE|ATOMIC|MOLECULAR)", &
+                          enum_c_vals=s2a("NONE", "ATOMIC", "MOLECULAR"), &
+                          enum_desc=s2a("Nothing in the region", &
+                                        "Only the QM atoms itself", &
+                                        "The full molecule/residue that contains a QM atom"), &
+                          enum_i_vals=[do_constr_none, do_constr_atomic, do_constr_molec], &
+                          default_i_val=do_constr_none, repeats=.FALSE.)
       CALL section_add_keyword(region_section, keyword)
       CALL keyword_release(keyword)
 
@@ -1045,7 +1080,7 @@ CONTAINS
                           "and a small restrictive TEMP_TOL together with a rapidly varying "// &
                           "target temperature function leaves little time for the system to "// &
                           "adjust itself, possibly showing unphysical relaxation behaviors. "// &
-                          newline//"Further notes about temperature. "//docf(), &
+                          newline//newline//"Further notes about temperature. "//docf(), &
                           n_keywords=4, n_subsections=0, repeats=.FALSE.)
 
       NULLIFY (keyword)

--- a/src/motion/md_run.F
+++ b/src/motion/md_run.F
@@ -61,7 +61,8 @@ MODULE md_run
                                               md_environment_type,&
                                               need_per_atom_wiener_process,&
                                               set_md_env
-   USE md_util,                         ONLY: md_output
+   USE md_util,                         ONLY: md_output,&
+                                              update_expected_temperature
    USE md_vel_utils,                    ONLY: angvel_control,&
                                               comvel_control,&
                                               setup_velocities,&
@@ -87,8 +88,7 @@ MODULE md_run
                                               simpar_type
    USE thermal_region_types,            ONLY: thermal_regions_type
    USE thermal_region_utils,            ONLY: create_thermal_regions,&
-                                              print_thermal_regions_langevin,&
-                                              update_thermal_regions_temp_expected
+                                              print_thermal_regions_langevin
    USE thermostat_methods,              ONLY: create_thermostats
    USE thermostat_types,                ONLY: thermostats_type
    USE velocity_verlet_control,         ONLY: velocity_verlet
@@ -473,6 +473,10 @@ CONTAINS
          simpar%dump_lm = BTEST(cp_print_key_should_output(logger%iter_info, constraint_section, &
                                                            "LAGRANGE_MULTIPLIERS"), cp_p_file)
 
+         ! Update temperature for thermal regions and thermostat regions
+         !deb CALL set_md_env(md_env, itimes=itimes)
+         CALL update_expected_temperature(md_env)
+
          ! Velocity Verlet Integrator
          CALL velocity_verlet(md_env, globenv)
 
@@ -520,10 +524,6 @@ CONTAINS
 
          IF (simpar%ensemble /= reftraj_ensemble) THEN
             CALL md_energy(md_env, md_ener)
-            IF (simpar%do_thermal_region) THEN ! Optionally update expected temperature for each region
-               CALL get_md_env(md_env, thermal_regions=thermal_regions)
-               CALL update_thermal_regions_temp_expected(itimes, thermal_regions)
-            END IF
             CALL temperature_control(simpar, md_env, md_ener, force_env, logger)
             CALL comvel_control(md_ener, force_env, md_section, logger)
             CALL angvel_control(md_ener, force_env, md_section, logger)

--- a/src/motion/md_run.F
+++ b/src/motion/md_run.F
@@ -474,7 +474,6 @@ CONTAINS
                                                            "LAGRANGE_MULTIPLIERS"), cp_p_file)
 
          ! Update temperature for thermal regions and thermostat regions
-         !deb CALL set_md_env(md_env, itimes=itimes)
          CALL update_expected_temperature(md_env)
 
          ! Velocity Verlet Integrator

--- a/src/motion/md_util.F
+++ b/src/motion/md_util.F
@@ -14,17 +14,31 @@ MODULE md_util
    USE cp_files,                        ONLY: close_file,&
                                               open_file
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
-                                              cp_logger_type
+                                              cp_logger_type, &
+                                              cp_to_string
    USE cp_output_handling,              ONLY: cp_print_key_generate_filename
+   USE cp_units,                        ONLY: cp_unit_from_cp2k,&
+                                              cp_unit_to_cp2k
+   USE fparser,                         ONLY: EvalErrType,&
+                                              evalf,&
+                                              finalizef,&
+                                              initf,&
+                                              parsef
    USE input_cp2k_restarts,             ONLY: write_restart
    USE input_section_types,             ONLY: section_vals_get_subs_vals,&
                                               section_vals_type,&
                                               section_vals_val_get
    USE kinds,                           ONLY: default_path_length,&
+                                              default_string_length,&
                                               dp
    USE md_energies,                     ONLY: md_write_output
-   USE md_environment_types,            ONLY: md_environment_type
+   USE md_environment_types,            ONLY: get_md_env,&
+                                              md_environment_type
    USE message_passing,                 ONLY: mp_para_env_type
+   USE simpar_types,                    ONLY: simpar_type
+   USE string_utilities,                ONLY: integer_to_string
+   USE thermal_region_types,            ONLY: thermal_region_type,&
+                                              thermal_regions_type
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
@@ -36,9 +50,67 @@ MODULE md_util
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'md_util'
 
    PUBLIC :: md_output, &
-             read_vib_eigs_unformatted
+             read_vib_eigs_unformatted, &
+             update_expected_temperature
 
 CONTAINS
+
+! **************************************************************************************************
+!> \brief update_expected_temperature
+!> \param md_env ...
+!> \date   03.2026
+!> \par    Note on units: t_region%temperature is updated by
+!>         SUBROUTINE scale_velocity_region in md_vel_utils.F
+!>         which is in Kelvin, but t_region%temp_expected is
+!>         in cp2k internal units. See "Note the unit conversion
+!>         here" in SUBROUTINE print_thermal_regions_temperature
+!>         in thermal_region_utils.F for output processing.
+!> \author HE Zilong
+! **************************************************************************************************
+   SUBROUTINE update_expected_temperature(md_env)
+      TYPE(md_environment_type), POINTER                 :: md_env
+
+      CHARACTER(LEN=default_string_length)               :: my_itimes, my_region
+      INTEGER                                            :: ireg
+      INTEGER, POINTER                                   :: itimes
+      TYPE(simpar_type), POINTER                         :: simpar
+      TYPE(thermal_region_type), POINTER                 :: t_region
+      TYPE(thermal_regions_type), POINTER                :: thermal_regions
+
+      NULLIFY (itimes, simpar)
+      CALL get_md_env(md_env, itimes=itimes, simpar=simpar)
+
+      ! Update thermal regions
+      IF (simpar%do_thermal_region) THEN
+         NULLIFY (thermal_regions)
+         CALL get_md_env(md_env, thermal_regions=thermal_regions)
+         DO ireg = 1, thermal_regions%nregions
+            NULLIFY (t_region)
+            t_region => thermal_regions%thermal_region(ireg)
+            IF (LEN_TRIM(t_region%temperature_function) > 0) THEN
+               CALL initf(1)
+               CALL parsef(1, TRIM(t_region%temperature_function), t_region%temperature_function_parameters)
+               t_region%temperature_function_values(1) = itimes*1.0_dp
+               t_region%temperature_function_values(2) = t_region%temperature
+               t_region%temp_expected = cp_unit_to_cp2k(evalf(1, t_region%temperature_function_values), "K")
+               CPASSERT(EvalErrType <= 0)
+               CALL finalizef()
+               IF (t_region%temp_expected < 0.0_dp) THEN
+                  CALL integer_to_string(ireg, my_region)
+                  CALL integer_to_string(itimes, my_itimes)
+                  CALL cp_abort(__LOCATION__, &
+                                "At step "//TRIM(my_itimes)//" , the temperature "// &
+                                "evaluated for thermal region "//TRIM(my_region)//" is "// &
+                                TRIM(ADJUSTL(cp_to_string(cp_unit_from_cp2k(t_region%temp_expected, "K"))))// &
+                                " K, which is negative and unphysical!")
+               END IF
+            END IF
+         END DO
+      END IF
+
+      ! Update thermostat regions: WIP
+
+   END SUBROUTINE update_expected_temperature
 
 ! **************************************************************************************************
 !> \brief collects the part of the MD that, basically, does the output

--- a/src/motion/md_util.F
+++ b/src/motion/md_util.F
@@ -14,7 +14,7 @@ MODULE md_util
    USE cp_files,                        ONLY: close_file,&
                                               open_file
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
-                                              cp_logger_type, &
+                                              cp_logger_type,&
                                               cp_to_string
    USE cp_output_handling,              ONLY: cp_print_key_generate_filename
    USE cp_units,                        ONLY: cp_unit_from_cp2k,&

--- a/src/motion/thermal_region_types.F
+++ b/src/motion/thermal_region_types.F
@@ -73,7 +73,9 @@ CONTAINS
 
       IF (ASSOCIATED(thermal_regions%thermal_region)) THEN
          DO ireg = 1, SIZE(thermal_regions%thermal_region)
-            DEALLOCATE (thermal_regions%thermal_region(ireg)%part_index)
+            IF (ASSOCIATED(thermal_regions%thermal_region(ireg)%part_index)) THEN
+               DEALLOCATE (thermal_regions%thermal_region(ireg)%part_index)
+            END IF
          END DO
          DEALLOCATE (thermal_regions%thermal_region)
       END IF

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -140,14 +140,7 @@ CONTAINS
             ALLOCATE (thermal_regions%thermal_region(nregions))
             CALL force_env_get(force_env, subsys=subsys)
             CALL cp_subsys_get(subsys, particles=particles)
-            IF (simpar%ensemble == langevin_ensemble) THEN
-               CALL cite_reference(Kantorovich2008)
-               CALL cite_reference(Kantorovich2008a)
-               CALL section_vals_val_get(thermal_region_section, "DO_LANGEVIN_DEFAULT", &
-                                         l_val=do_langevin_default)
-               ALLOCATE (thermal_regions%do_langevin(particles%n_els))
-               thermal_regions%do_langevin = do_langevin_default
-            END IF
+
             ! TODO: parsing logic of thermal region should be aligned
             ! with thermostat region as in SUBROUTINE get_defined_region_info,
             ! src/motion/thermostat/thermostat_utils.F, so that MOLNAME,
@@ -163,10 +156,6 @@ CONTAINS
                                          i_rep_section=ireg, n_rep_val=nlist)
                NULLIFY (t_region%part_index)
                t_region%npart = 0
-               IF (simpar%ensemble == langevin_ensemble) THEN
-                  CALL section_vals_val_get(region_sections, "DO_LANGEVIN", &
-                                            i_rep_section=ireg, l_val=do_langevin)
-               END IF
                DO il = 1, nlist
                   CALL section_vals_val_get(region_sections, "LIST", i_rep_section=ireg, &
                                             i_rep_val=il, i_vals=tmplist)
@@ -177,9 +166,6 @@ CONTAINS
                      t_region%npart = t_region%npart + 1
                      t_region%part_index(t_region%npart) = ipart
                      particles%els(ipart)%t_region_index = ireg
-                     IF (simpar%ensemble == langevin_ensemble) THEN
-                        thermal_regions%do_langevin(ipart) = do_langevin
-                     END IF
                   END DO
                END DO
 
@@ -218,11 +204,37 @@ CONTAINS
                CALL section_vals_val_get(region_sections, "TEMP_TOL", i_rep_section=ireg, &
                                          r_val=temp_tol)
                t_region%temp_tol = temp_tol
-               CALL section_vals_val_get(region_sections, "NOISY_GAMMA_REGION", i_rep_section=ireg, explicit=do_read_ngr)
-               IF (do_read_ngr) THEN
-                  CALL section_vals_val_get(region_sections, "NOISY_GAMMA_REGION", i_rep_section=ireg, &
-                                            r_val=t_region%noisy_gamma_region)
-                  IF (simpar%ensemble == langevin_ensemble) THEN
+            END DO
+
+            ! For Langevin ensemble, determine thermal_regions%do_langevin
+            ! and t_region%noisy_gamma_region
+            IF (simpar%ensemble == langevin_ensemble) THEN
+               CALL cite_reference(Kantorovich2008)
+               CALL cite_reference(Kantorovich2008a)
+               CALL section_vals_val_get(thermal_region_section, "DO_LANGEVIN_DEFAULT", &
+                                         l_val=do_langevin_default)
+               ALLOCATE (thermal_regions%do_langevin(particles%n_els))
+               thermal_regions%do_langevin = do_langevin_default
+               DO ireg = 1, nregions
+                  NULLIFY (t_region)
+                  t_region => thermal_regions%thermal_region(ireg)
+                  CALL integer_to_string(ireg, my_region)
+                  CALL section_vals_val_get(region_sections, "DO_LANGEVIN", &
+                                            i_rep_section=ireg, l_val=do_langevin)
+                  CALL section_vals_val_get(region_sections, "LIST", &
+                                            i_rep_section=ireg, n_rep_val=nlist)
+                  DO il = 1, nlist
+                     CALL section_vals_val_get(region_sections, "LIST", i_rep_section=ireg, &
+                                               i_rep_val=il, i_vals=tmplist)
+                     DO i = 1, SIZE(tmplist)
+                        ipart = tmplist(i)
+                        thermal_regions%do_langevin(ipart) = do_langevin
+                     END DO
+                  END DO
+                  CALL section_vals_val_get(region_sections, "NOISY_GAMMA_REGION", i_rep_section=ireg, explicit=do_read_ngr)
+                  IF (do_read_ngr) THEN
+                     CALL section_vals_val_get(region_sections, "NOISY_GAMMA_REGION", i_rep_section=ireg, &
+                                               r_val=t_region%noisy_gamma_region)
                      IF (.NOT. do_langevin) THEN
                         CALL cp_warn(__LOCATION__, &
                                      "You provided NOISY_GAMMA_REGION but atoms in thermal region "//TRIM(my_region)// &
@@ -230,14 +242,11 @@ CONTAINS
                                      "NOISY_GAMMA_REGION will be ignored and its value discarded!")
                      END IF
                   ELSE
-                     CALL cp_warn(__LOCATION__, &
-                                  "You provided NOISY_GAMMA_REGION but the Langevin Ensamble is not selected "// &
-                                  "NOISY_GAMMA_REGION will be ignored and its value discarded!")
+                     t_region%noisy_gamma_region = simpar%noisy_gamma
                   END IF
-               ELSE
-                  t_region%noisy_gamma_region = simpar%noisy_gamma
-               END IF
-            END DO
+               END DO
+            END IF
+            ! End of Langevin treatment
             simpar%do_thermal_region = .TRUE.
          ELSE
             CALL release_thermal_regions(thermal_regions)

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -51,7 +51,6 @@ MODULE thermal_region_utils
                                               section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
-   USE memory_utilities,                ONLY: reallocate
    USE particle_list_types,             ONLY: particle_list_type
    USE physcon,                         ONLY: femtoseconds,&
                                               kelvin
@@ -92,7 +91,7 @@ CONTAINS
 
       CHARACTER(LEN=default_string_length)               :: my_region
       INTEGER                                            :: i, il, ipart, ireg, itimes, nlist, &
-                                                            nregions, output_unit, region
+                                                            nnpart, nregions, output_unit, region
       INTEGER, DIMENSION(:), POINTER                     :: tmplist
       LOGICAL                                            :: apply_thermostat, do_langevin, &
                                                             do_langevin_default, do_read_ngr, &
@@ -146,30 +145,25 @@ CONTAINS
             CALL force_env_get(force_env, subsys=subsys)
             CALL cp_subsys_get(subsys, particles=particles)
 
-            ! TODO: parsing logic of thermal region should be aligned
-            ! with thermostat region as in SUBROUTINE get_defined_region_info,
-            ! src/motion/thermostat/thermostat_utils.F, so that MOLNAME,
-            ! MM_SUBSYS and QM_SUBSYS keywords work for thermal regions
             DO ireg = 1, nregions
                NULLIFY (t_region)
                CALL integer_to_string(ireg, my_region)
                t_region => thermal_regions%thermal_region(ireg)
                t_region%region_index = ireg
+               NULLIFY (t_region%part_index)
 
-               ! Determine t_region%npart
+               ! TODO: parsing logic of thermal region should be aligned
+               ! with thermostat region as in SUBROUTINE get_defined_region_info,
+               ! src/motion/thermostat/thermostat_utils.F, so that MOLNAME,
+               ! MM_SUBSYS and QM_SUBSYS keywords work for thermal regions
                CALL section_vals_val_get(region_sections, "LIST", &
                                          i_rep_section=ireg, n_rep_val=nlist)
-               NULLIFY (t_region%part_index)
-               t_region%npart = 0
                DO il = 1, nlist
                   CALL section_vals_val_get(region_sections, "LIST", i_rep_section=ireg, &
                                             i_rep_val=il, i_vals=tmplist)
-                  CALL reallocate(t_region%part_index, 1, t_region%npart + SIZE(tmplist))
                   DO i = 1, SIZE(tmplist)
                      ipart = tmplist(i)
                      CPASSERT(((ipart > 0) .AND. (ipart <= particles%n_els)))
-                     t_region%npart = t_region%npart + 1
-                     t_region%part_index(t_region%npart) = ipart
                      particles%els(ipart)%t_region_index = ireg
                   END DO
                END DO
@@ -212,7 +206,7 @@ CONTAINS
             END DO
 
             ! For Langevin ensemble, determine thermal_regions%do_langevin
-            ! and t_region%noisy_gamma_region
+            ! and t_region%npart, t_region%part_index, t_region%noisy_gamma_region
             IF (simpar%ensemble == langevin_ensemble) THEN
                CALL cite_reference(Kantorovich2008)
                CALL cite_reference(Kantorovich2008a)
@@ -224,17 +218,20 @@ CONTAINS
                   NULLIFY (t_region)
                   t_region => thermal_regions%thermal_region(ireg)
                   CALL integer_to_string(ireg, my_region)
+                  nnpart = 0
+                  DO ipart = 1, particles%n_els
+                     IF (particles%els(ipart)%t_region_index == ireg) nnpart = nnpart + 1
+                  END DO
+                  ALLOCATE (t_region%part_index(nnpart))
+                  t_region%npart = 0
                   CALL section_vals_val_get(region_sections, "DO_LANGEVIN", &
                                             i_rep_section=ireg, l_val=do_langevin)
-                  CALL section_vals_val_get(region_sections, "LIST", &
-                                            i_rep_section=ireg, n_rep_val=nlist)
-                  DO il = 1, nlist
-                     CALL section_vals_val_get(region_sections, "LIST", i_rep_section=ireg, &
-                                               i_rep_val=il, i_vals=tmplist)
-                     DO i = 1, SIZE(tmplist)
-                        ipart = tmplist(i)
+                  DO ipart = 1, particles%n_els
+                     IF (particles%els(ipart)%t_region_index == ireg) THEN
+                        t_region%npart = t_region%npart + 1
+                        t_region%part_index(t_region%npart) = ipart
                         thermal_regions%do_langevin(ipart) = do_langevin
-                     END DO
+                     END IF
                   END DO
                   CALL section_vals_val_get(region_sections, "NOISY_GAMMA_REGION", i_rep_section=ireg, explicit=do_read_ngr)
                   IF (do_read_ngr) THEN

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -20,6 +20,7 @@ MODULE thermal_region_utils
                                               Kantorovich2008a,&
                                               cite_reference
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
+                                              cp_logger_get_default_io_unit,&
                                               cp_logger_type,&
                                               cp_to_string
    USE cp_output_handling,              ONLY: cp_p_file,&
@@ -91,19 +92,23 @@ CONTAINS
 
       CHARACTER(LEN=default_string_length)               :: my_region
       INTEGER                                            :: i, il, ipart, ireg, itimes, nlist, &
-                                                            nregions, region
+                                                            nregions, output_unit, region
       INTEGER, DIMENSION(:), POINTER                     :: tmplist
       LOGICAL                                            :: apply_thermostat, do_langevin, &
                                                             do_langevin_default, do_read_ngr, &
                                                             explicit, use_t, use_tfunc
       REAL(KIND=dp)                                      :: temp, temp_tol
+      TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(section_vals_type), POINTER                   :: region_sections, tfunc_section, &
                                                             thermal_region_section
       TYPE(thermal_region_type), POINTER                 :: t_region
 
-      NULLIFY (region_sections, t_region, tfunc_section, thermal_region_section, particles, subsys, tmplist)
+      NULLIFY (logger, region_sections, t_region, tfunc_section, &
+               thermal_region_section, particles, subsys, tmplist)
+      logger => cp_get_default_logger()
+      output_unit = cp_logger_get_default_io_unit(logger)
       ALLOCATE (thermal_regions)
       CALL allocate_thermal_regions(thermal_regions)
       thermal_region_section => section_vals_get_subs_vals(md_section, "THERMAL_REGION")
@@ -248,6 +253,16 @@ CONTAINS
             END IF
             ! End of Langevin treatment
             simpar%do_thermal_region = .TRUE.
+
+            ! Output thermal region mapping to particles
+            IF (output_unit > 0) THEN
+               WRITE (output_unit, '(/,T2,A)') &
+                  "THERMAL_REGION| Mapping of thermal region indices to particles"
+               DO ipart = 1, particles%n_els, 8
+                  WRITE (output_unit, '(T2,A,T17,8I8)') &
+                     "THERMAL_REGION|", particles%els(ipart:MIN(ipart + 7, particles%n_els))%t_region_index
+               END DO
+            END IF
          ELSE
             CALL release_thermal_regions(thermal_regions)
             DEALLOCATE (thermal_regions)

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -38,7 +38,8 @@ MODULE thermal_region_utils
                                               finalizef,&
                                               initf,&
                                               parsef
-   USE input_constants,                 ONLY: langevin_ensemble,&
+   USE input_constants,                 ONLY: do_region_thermal,&
+                                              langevin_ensemble,&
                                               npt_f_ensemble,&
                                               npt_i_ensemble,&
                                               npt_ia_ensemble,&
@@ -90,7 +91,7 @@ CONTAINS
 
       CHARACTER(LEN=default_string_length)               :: my_region
       INTEGER                                            :: i, il, ipart, ireg, itimes, nlist, &
-                                                            nregions
+                                                            nregions, region
       INTEGER, DIMENSION(:), POINTER                     :: tmplist
       LOGICAL                                            :: apply_thermostat, do_langevin, &
                                                             do_langevin_default, do_read_ngr, &
@@ -113,10 +114,14 @@ CONTAINS
                             (simpar%ensemble == npt_ia_ensemble) .OR. &
                             (simpar%ensemble == npt_i_ensemble)
          IF (apply_thermostat) THEN
-            CALL cp_warn(__LOCATION__, &
-                         "With the chosen ensemble the temperature is "// &
-                         "controlled by thermostats. The definition of different thermal "// &
-                         "regions might result inconsistent with the presence of thermostats.")
+            CALL section_vals_val_get(md_section, "THERMOSTAT%REGION", i_val=region)
+            IF (region /= do_region_thermal) THEN
+               CALL cp_warn(__LOCATION__, &
+                            "An ensemble has been chosen where one or more thermostats are "// &
+                            "used to control temperature, and one or more thermal regions "// &
+                            "are also defined. To ensure consistency between thermostat "// &
+                            "regions and thermal regions, set THERMOSTAT/REGION to THERMAL.")
+            END IF
          END IF
          IF (simpar%temp_tol > 0.0_dp) THEN
             CALL cp_warn(__LOCATION__, &
@@ -143,6 +148,10 @@ CONTAINS
                ALLOCATE (thermal_regions%do_langevin(particles%n_els))
                thermal_regions%do_langevin = do_langevin_default
             END IF
+            ! TODO: parsing logic of thermal region should be aligned
+            ! with thermostat region as in SUBROUTINE get_defined_region_info,
+            ! src/motion/thermostat/thermostat_utils.F, so that MOLNAME,
+            ! MM_SUBSYS and QM_SUBSYS keywords work for thermal regions
             DO ireg = 1, nregions
                NULLIFY (t_region)
                CALL integer_to_string(ireg, my_region)

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -97,8 +97,8 @@ CONTAINS
       CHARACTER(LEN=default_string_length)               :: my_region
       CHARACTER(LEN=default_string_length), &
          DIMENSION(:), POINTER                           :: tmpstringlist
-      INTEGER                                            :: first_atom, i, ikind, il, imol, ipart, &
-                                                            ireg, itimes, last_atom, nlist, &
+      INTEGER                                            :: first_atom, flen, i, ikind, il, imol, &
+                                                            ipart, ireg, itimes, last_atom, nlist, &
                                                             nnpart, nregions, output_unit, region
       INTEGER, DIMENSION(:), POINTER                     :: tmplist
       LOGICAL                                            :: apply_thermostat, do_langevin, &
@@ -347,12 +347,34 @@ CONTAINS
             END IF
             ! End of Langevin treatment
 
-            ! Output thermal region mapping to particles
+            ! Output thermal region temperature and mapping to particles
+            ! The region indices are assumed to be 0-999
             IF (output_unit > 0) THEN
+               WRITE (output_unit, '(/,T2,A)') &
+                  "THERMAL_REGION| Temperature value and function for each region [K]"
+               DO ireg = 1, nregions
+                  NULLIFY (t_region)
+                  t_region => thermal_regions%thermal_region(ireg)
+                  WRITE (output_unit, '(T2,A,T25,I3,T29,A,T34,I6,T41,A,T66,F15.6)') &
+                     "THERMAL_REGION| Region", t_region%region_index, &
+                     "with", t_region%npart, &
+                     "particles initialized at", &
+                     cp_unit_from_cp2k(t_region%temp_expected, "K")
+                  flen = LEN(TRIM(t_region%temperature_function))
+                  IF (flen > 0) THEN
+                     DO i = 1, flen, 64
+                        WRITE (output_unit, '(T2,A,T17,A64)') &
+                           "THERMAL_REGION|", t_region%temperature_function(i:MIN(i + 64, flen))
+                     END DO
+                  ELSE
+                     WRITE (output_unit, '(T2,A,T66,F15.6)') &
+                        "THERMAL_REGION|", cp_unit_from_cp2k(t_region%temp_expected, "K")
+                  END IF
+               END DO
                WRITE (output_unit, '(/,T2,A)') &
                   "THERMAL_REGION| Mapping of thermal region indices to particles"
                DO ipart = 1, particles%n_els, 16
-                  WRITE (output_unit, '(T2,A,T17,16I4)') &
+                  WRITE (output_unit, '(T2,A,T17,16(" ",I3))') &
                      "THERMAL_REGION|", particles%els(ipart:MIN(ipart + 15, particles%n_els))%t_region_index
                END DO
             END IF

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -51,6 +51,11 @@ MODULE thermal_region_utils
                                               section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
+   USE molecule_kind_list_types,        ONLY: molecule_kind_list_type
+   USE molecule_kind_types,             ONLY: molecule_kind_type
+   USE molecule_list_types,             ONLY: molecule_list_type
+   USE molecule_types,                  ONLY: get_molecule,&
+                                              molecule_type
    USE particle_list_types,             ONLY: particle_list_type
    USE physcon,                         ONLY: femtoseconds,&
                                               kelvin
@@ -64,7 +69,7 @@ MODULE thermal_region_utils
 
    IMPLICIT NONE
 
-   PRIVATE
+   PRIVATE :: set_t_region_index
    PUBLIC :: create_thermal_regions, &
              print_thermal_regions_temperature, &
              print_thermal_regions_langevin
@@ -90,7 +95,10 @@ CONTAINS
       TYPE(force_env_type), POINTER                      :: force_env
 
       CHARACTER(LEN=default_string_length)               :: my_region
-      INTEGER                                            :: i, il, ipart, ireg, itimes, nlist, &
+      CHARACTER(LEN=default_string_length), &
+         DIMENSION(:), POINTER                           :: tmpstringlist
+      INTEGER                                            :: first_atom, i, ikind, il, imol, ipart, &
+                                                            ireg, itimes, last_atom, nlist, &
                                                             nnpart, nregions, output_unit, region
       INTEGER, DIMENSION(:), POINTER                     :: tmplist
       LOGICAL                                            :: apply_thermostat, do_langevin, &
@@ -99,12 +107,18 @@ CONTAINS
       REAL(KIND=dp)                                      :: temp, temp_tol
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_subsys_type), POINTER                      :: subsys
+      TYPE(molecule_kind_list_type), POINTER             :: molecule_kinds
+      TYPE(molecule_kind_type), POINTER                  :: molecule_kind, molecule_kind_set(:)
+      TYPE(molecule_list_type), POINTER                  :: molecules
+      TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
+      TYPE(molecule_type), POINTER                       :: molecule
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(section_vals_type), POINTER                   :: region_sections, tfunc_section, &
                                                             thermal_region_section
       TYPE(thermal_region_type), POINTER                 :: t_region
 
-      NULLIFY (logger, region_sections, t_region, tfunc_section, &
+      NULLIFY (logger, molecule, molecule_kind, molecule_kind_set, molecule_kinds, &
+               region_sections, t_region, tfunc_section, &
                thermal_region_section, particles, subsys, tmplist)
       logger => cp_get_default_logger()
       output_unit = cp_logger_get_default_io_unit(logger)
@@ -142,8 +156,13 @@ CONTAINS
             thermal_regions%nregions = nregions
             thermal_regions%section => thermal_region_section
             ALLOCATE (thermal_regions%thermal_region(nregions))
+            simpar%do_thermal_region = .TRUE.
             CALL force_env_get(force_env, subsys=subsys)
-            CALL cp_subsys_get(subsys, particles=particles)
+            CALL cp_subsys_get(subsys, molecules=molecules, &
+                               molecule_kinds=molecule_kinds, &
+                               particles=particles)
+            molecule_kind_set => molecule_kinds%els
+            molecule_set => molecules%els
 
             DO ireg = 1, nregions
                NULLIFY (t_region)
@@ -154,21 +173,44 @@ CONTAINS
 
                ! TODO: parsing logic of thermal region should be aligned
                ! with thermostat region as in SUBROUTINE get_defined_region_info,
-               ! src/motion/thermostat/thermostat_utils.F, so that MOLNAME,
+               ! src/motion/thermostat/thermostat_utils.F, so that
                ! MM_SUBSYS and QM_SUBSYS keywords work for thermal regions
                CALL section_vals_val_get(region_sections, "LIST", &
                                          i_rep_section=ireg, n_rep_val=nlist)
-               DO il = 1, nlist
-                  CALL section_vals_val_get(region_sections, "LIST", i_rep_section=ireg, &
-                                            i_rep_val=il, i_vals=tmplist)
-                  DO i = 1, SIZE(tmplist)
-                     ipart = tmplist(i)
-                     CPASSERT(((ipart > 0) .AND. (ipart <= particles%n_els)))
-                     particles%els(ipart)%t_region_index = ireg
+               IF (nlist > 0) THEN
+                  DO il = 1, nlist
+                     CALL section_vals_val_get(region_sections, "LIST", i_rep_section=ireg, &
+                                               i_rep_val=il, i_vals=tmplist)
+                     DO i = 1, SIZE(tmplist)
+                        ipart = tmplist(i)
+                        CALL set_t_region_index(particles, ipart, ireg)
+                     END DO
                   END DO
-               END DO
+               END IF
+               CALL section_vals_val_get(region_sections, "MOLNAME", &
+                                         i_rep_section=ireg, n_rep_val=nlist)
+               IF (nlist > 0) THEN
+                  DO il = 1, nlist
+                     CALL section_vals_val_get(region_sections, "MOLNAME", i_rep_section=ireg, &
+                                               i_rep_val=il, c_vals=tmpstringlist)
+                     DO i = 1, SIZE(tmpstringlist)
+                        DO ikind = 1, SIZE(molecule_kind_set)
+                           molecule_kind => molecule_kind_set(ikind)
+                           IF (molecule_kind%name == tmpstringlist(i)) THEN
+                              DO imol = 1, SIZE(molecule_kind%molecule_list)
+                                 molecule => molecule_set(molecule_kind%molecule_list(imol))
+                                 CALL get_molecule(molecule, first_atom=first_atom, last_atom=last_atom)
+                                 DO ipart = first_atom, last_atom
+                                    CALL set_t_region_index(particles, ipart, ireg)
+                                 END DO
+                              END DO
+                           END IF
+                        END DO
+                     END DO
+                  END DO
+               END IF
 
-               ! Set up t_region%part_index
+               ! Set up t_region%part_index after parsing input
                nnpart = 0
                t_region%npart = 0
                DO ipart = 1, particles%n_els
@@ -255,7 +297,6 @@ CONTAINS
                END DO
             END IF
             ! End of Langevin treatment
-            simpar%do_thermal_region = .TRUE.
 
             ! Output thermal region mapping to particles
             IF (output_unit > 0) THEN
@@ -278,6 +319,49 @@ CONTAINS
       END IF
 
    END SUBROUTINE create_thermal_regions
+
+! **************************************************************************************************
+!> \brief set particles%els(ipart)%t_region_index to ireg
+!> \param particles ...
+!> \param ipart ...
+!> \param ireg ...
+!> \par History
+!>   - Created (04/2026)
+!> \author
+! **************************************************************************************************
+   SUBROUTINE set_t_region_index(particles, ipart, ireg)
+      TYPE(particle_list_type), POINTER                  :: particles
+      INTEGER, INTENT(IN)                                :: ipart, ireg
+
+      CHARACTER(LEN=default_string_length)               :: my_part, my_reg, my_region
+      INTEGER                                            :: iregion
+
+      CALL integer_to_string(ipart, my_part)
+      IF ((ipart > 0) .AND. (ipart <= particles%n_els)) THEN
+         CALL integer_to_string(ireg, my_reg)
+         iregion = particles%els(ipart)%t_region_index
+         IF ((iregion == 0) .OR. (iregion == ireg)) THEN
+            ! No thermal region has been assigned, or
+            ! the same one has already been assigned
+            particles%els(ipart)%t_region_index = ireg
+         ELSE
+            CALL integer_to_string(iregion, my_region)
+            CALL cp_abort(__LOCATION__, &
+                          "Atom "//TRIM(my_part)//" has been "// &
+                          "assigned to two different thermal "// &
+                          "regions "//TRIM(my_region)//" and "// &
+                          TRIM(my_reg)//" which is not allowed!")
+         END IF
+      ELSE
+         IF (.NOT. ipart > 0) &
+            CALL cp_abort(__LOCATION__, &
+                          "Input atom index "//TRIM(my_part)//" is non-positive!")
+         IF (.NOT. ipart <= particles%n_els) &
+            CALL cp_abort(__LOCATION__, &
+                          "Input atom index "//TRIM(my_part)//" is out of bounds!")
+      END IF
+
+   END SUBROUTINE set_t_region_index
 
 ! **************************************************************************************************
 !> \brief print_thermal_regions_temperature
@@ -330,7 +414,7 @@ CONTAINS
                   temp(ireg) = thermal_regions%thermal_region(ireg)%temperature
                   temp_tfunc(ireg) = cp_unit_from_cp2k(thermal_regions%thermal_region(ireg)%temp_expected, "K")
                END DO
-               fmd = "(I10,F20.3,"//TRIM(ADJUSTL(cp_to_string(2*nregions + 1)))//"F20.8)"
+               fmd = "(I10,F20.3,"//TRIM(ADJUSTL(cp_to_string(2*nregions + 1)))//"F20.10)"
                fmd = TRIM(fmd)
                WRITE (UNIT=unit, FMT=fmd) itimes, time, temp(0), (temp_tfunc(ireg), temp(ireg), ireg=1, nregions)
                DEALLOCATE (temp)

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -168,6 +168,20 @@ CONTAINS
                   END DO
                END DO
 
+               ! Set up t_region%part_index
+               nnpart = 0
+               t_region%npart = 0
+               DO ipart = 1, particles%n_els
+                  IF (particles%els(ipart)%t_region_index == ireg) nnpart = nnpart + 1
+               END DO
+               ALLOCATE (t_region%part_index(nnpart))
+               DO ipart = 1, particles%n_els
+                  IF (particles%els(ipart)%t_region_index == ireg) THEN
+                     t_region%npart = t_region%npart + 1
+                     t_region%part_index(t_region%npart) = ipart
+                  END IF
+               END DO
+
                ! Determine t_region%temp_expected
                tfunc_section => section_vals_get_subs_vals(region_sections, "TFUNC", i_rep_section=ireg)
                CALL section_vals_val_get(region_sections, "TEMPERATURE", i_rep_section=ireg, explicit=use_t)
@@ -206,7 +220,7 @@ CONTAINS
             END DO
 
             ! For Langevin ensemble, determine thermal_regions%do_langevin
-            ! and t_region%npart, t_region%part_index, t_region%noisy_gamma_region
+            ! and t_region%noisy_gamma_region
             IF (simpar%ensemble == langevin_ensemble) THEN
                CALL cite_reference(Kantorovich2008)
                CALL cite_reference(Kantorovich2008a)
@@ -218,18 +232,10 @@ CONTAINS
                   NULLIFY (t_region)
                   t_region => thermal_regions%thermal_region(ireg)
                   CALL integer_to_string(ireg, my_region)
-                  nnpart = 0
-                  DO ipart = 1, particles%n_els
-                     IF (particles%els(ipart)%t_region_index == ireg) nnpart = nnpart + 1
-                  END DO
-                  ALLOCATE (t_region%part_index(nnpart))
-                  t_region%npart = 0
                   CALL section_vals_val_get(region_sections, "DO_LANGEVIN", &
                                             i_rep_section=ireg, l_val=do_langevin)
                   DO ipart = 1, particles%n_els
                      IF (particles%els(ipart)%t_region_index == ireg) THEN
-                        t_region%npart = t_region%npart + 1
-                        t_region%part_index(t_region%npart) = ipart
                         thermal_regions%do_langevin(ipart) = do_langevin
                      END IF
                   END DO

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -66,8 +66,7 @@ MODULE thermal_region_utils
    PRIVATE
    PUBLIC :: create_thermal_regions, &
              print_thermal_regions_temperature, &
-             print_thermal_regions_langevin, &
-             update_thermal_regions_temp_expected
+             print_thermal_regions_langevin
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'thermal_region_utils'
 
@@ -243,50 +242,6 @@ CONTAINS
       END IF
 
    END SUBROUTINE create_thermal_regions
-
-! **************************************************************************************************
-!> \brief update_thermal_regions_temp_expected
-!> \param itimes          : iteration number of the time step
-!> \param thermal_regions : thermal regions type contains information
-!>                          about the regions
-!> \date   03.2026
-!> \par    Note on units: t_region%temperature is updated by
-!>         SUBROUTINE scale_velocity_region in md_vel_utils.F
-!>         which is in Kelvin, but t_region%temp_expected is
-!>         in cp2k internal units. See "Note the unit conversion
-!>         here" in print_thermal_regions_temperature below.
-!> \author HE Zilong
-! **************************************************************************************************
-   SUBROUTINE update_thermal_regions_temp_expected(itimes, thermal_regions)
-      INTEGER, INTENT(IN)                                :: itimes
-      TYPE(thermal_regions_type), POINTER                :: thermal_regions
-
-      CHARACTER(LEN=default_string_length)               :: my_region
-      INTEGER                                            :: ireg
-      TYPE(thermal_region_type), POINTER                 :: t_region
-
-      DO ireg = 1, thermal_regions%nregions
-         NULLIFY (t_region)
-         t_region => thermal_regions%thermal_region(ireg)
-         IF (LEN_TRIM(t_region%temperature_function) > 0) THEN
-            CALL initf(1)
-            CALL parsef(1, TRIM(t_region%temperature_function), t_region%temperature_function_parameters)
-            t_region%temperature_function_values(1) = itimes*1.0_dp
-            t_region%temperature_function_values(2) = t_region%temperature
-            t_region%temp_expected = cp_unit_to_cp2k(evalf(1, t_region%temperature_function_values), "K")
-            CPASSERT(EvalErrType <= 0)
-            CALL finalizef()
-            IF (t_region%temp_expected < 0.0_dp) THEN
-               CALL integer_to_string(ireg, my_region)
-               CALL cp_abort(__LOCATION__, &
-                             "The temperature evaluated for region "//TRIM(my_region)//" is "// &
-                             TRIM(ADJUSTL(cp_to_string(cp_unit_from_cp2k(t_region%temp_expected, "K"))))// &
-                             " K, which is negative and unphysical!")
-            END IF
-         END IF
-      END DO
-
-   END SUBROUTINE update_thermal_regions_temp_expected
 
 ! **************************************************************************************************
 !> \brief print_thermal_regions_temperature

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -166,10 +166,7 @@ CONTAINS
                t_region%region_index = ireg
                NULLIFY (t_region%part_index)
 
-               ! TODO: parsing logic of thermal region should be aligned
-               ! with thermostat region as in SUBROUTINE get_defined_region_info,
-               ! src/motion/thermostat/thermostat_utils.F, so that
-               ! MM_SUBSYS and QM_SUBSYS keywords work for thermal regions
+               ! Set up thermal region mapping to particles
                CALL section_vals_val_get(region_sections, "LIST", &
                                          i_rep_section=ireg, n_rep_val=nlist)
                IF (nlist > 0) THEN
@@ -203,6 +200,20 @@ CONTAINS
                         END DO
                      END DO
                   END DO
+               END IF
+               ! TODO: parsing logic of thermal region should be aligned
+               ! with thermostat region as in SUBROUTINE get_defined_region_info,
+               ! src/motion/thermostat/thermostat_utils.F, so that
+               ! MM_SUBSYS and QM_SUBSYS keywords work for thermal regions
+               CALL section_vals_val_get(region_sections, "QM_SUBSYS", &
+                                         i_rep_section=ireg, n_rep_val=nlist, explicit=explicit)
+               IF (explicit) THEN
+                  CPABORT("QM_SUBSYS not yet implemented for thermal regions")
+               END IF
+               CALL section_vals_val_get(region_sections, "MM_SUBSYS", &
+                                         i_rep_section=ireg, n_rep_val=nlist, explicit=explicit)
+               IF (explicit) THEN
+                  CPABORT("MM_SUBSYS not yet implemented for thermal regions")
                END IF
 
                ! Set up t_region%part_index after parsing input
@@ -265,9 +276,10 @@ CONTAINS
                         t_region%temp_expected = temp
                      ELSE
                         CALL cp_warn(__LOCATION__, &
-                                     "The initial temperature for the region "//TRIM(my_region)// &
-                                     "cannot be assigned to a positive value in K from input. "// &
-                                     "A value of zero will be used instead.")
+                                     "For thermal region "//TRIM(my_region)//" , none of the "// &
+                                     "input values for the initial temperature, nor the result "// &
+                                     "of evaluating temperature function at STEP_START_VAL, is "// &
+                                     "positive in Kelvin. A value of zero will be used instead.")
                         t_region%temp_expected = 0.0_dp
                      END IF
                   END IF

--- a/src/motion/thermal_region_utils.F
+++ b/src/motion/thermal_region_utils.F
@@ -103,7 +103,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: tmplist
       LOGICAL                                            :: apply_thermostat, do_langevin, &
                                                             do_langevin_default, do_read_ngr, &
-                                                            explicit, use_t, use_tfunc
+                                                            explicit, use_t, use_temp_tol, &
+                                                            use_tfunc
       REAL(KIND=dp)                                      :: temp, temp_tol
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_subsys_type), POINTER                      :: subsys
@@ -140,12 +141,6 @@ CONTAINS
                             "are also defined. To ensure consistency between thermostat "// &
                             "regions and thermal regions, set THERMOSTAT/REGION to THERMAL.")
             END IF
-         END IF
-         IF (simpar%temp_tol > 0.0_dp) THEN
-            CALL cp_warn(__LOCATION__, &
-                         "Control of the global temperature by rescaling of the velocity "// &
-                         "is not consistent with the presence of different thermal regions. "// &
-                         "The temperature of different regions is rescaled separatedly.")
          END IF
          CALL section_vals_val_get(thermal_region_section, "FORCE_RESCALING", &
                                    l_val=thermal_regions%force_rescaling)
@@ -224,10 +219,8 @@ CONTAINS
                   END IF
                END DO
 
-               ! Determine t_region%temp_expected
+               ! Set up temperature function, if any
                tfunc_section => section_vals_get_subs_vals(region_sections, "TFUNC", i_rep_section=ireg)
-               CALL section_vals_val_get(region_sections, "TEMPERATURE", i_rep_section=ireg, explicit=use_t)
-               IF (use_t) CALL section_vals_val_get(region_sections, "TEMPERATURE", i_rep_section=ireg, r_val=temp)
                CALL section_vals_get(tfunc_section, explicit=use_tfunc)
                IF (use_tfunc) THEN
                   CALL get_generic_info(tfunc_section, "FUNCTION", &
@@ -235,30 +228,74 @@ CONTAINS
                                         t_region%temperature_function_parameters, &
                                         t_region%temperature_function_values, &
                                         input_variables=["S", "T"], i_rep_sec=1)
-                  CALL initf(1)
-                  CALL parsef(1, TRIM(t_region%temperature_function), &
-                              t_region%temperature_function_parameters)
-                  IF (.NOT. use_t) THEN ! Evaluate function for initial temperature
+               END IF
+
+               ! Set up t_region%temp_expected
+               ! Precedence of temperature setting: the first positive value in
+               ! 1. MD/THERMAL_REGION/DEFINE_REGION/TEMPERATURE
+               ! 2. The temperature function evaluated at S = STEP_START_VAL and T = 0
+               ! 3. MD/TEMPERATURE
+               ! Otherwise it will be set to 0
+               temp = 0.0_dp
+               CALL section_vals_val_get(region_sections, "TEMPERATURE", &
+                                         i_rep_section=ireg, explicit=use_t)
+               IF (use_t) THEN
+                  CALL section_vals_val_get(region_sections, "TEMPERATURE", &
+                                            i_rep_section=ireg, r_val=temp)
+               END IF
+               IF (temp > 0.0_dp) THEN
+                  t_region%temp_expected = temp
+               ELSE
+                  IF (use_tfunc) THEN
+                     CALL initf(1)
+                     CALL parsef(1, TRIM(t_region%temperature_function), &
+                                 t_region%temperature_function_parameters)
                      CALL section_vals_val_get(md_section, "STEP_START_VAL", i_val=itimes)
                      t_region%temperature_function_values(1) = itimes*1.0_dp
                      t_region%temperature_function_values(2) = 0.0_dp
                      temp = cp_unit_to_cp2k(evalf(1, t_region%temperature_function_values), "K")
                      CPASSERT(EvalErrType <= 0)
+                     CALL finalizef()
                   END IF
-                  CALL finalizef()
-               END IF
-               IF (temp >= 0.0_dp) THEN ! Check for negative temperature in Kelvin
-                  t_region%temp_expected = temp
-               ELSE
-                  CALL cp_abort(__LOCATION__, &
-                                "The initial temperature for region "//TRIM(my_region)//" is "// &
-                                TRIM(ADJUSTL(cp_to_string(cp_unit_from_cp2k(temp, "K"))))// &
-                                " K, which is negative and unphysical!")
+                  IF (temp > 0.0_dp) THEN
+                     t_region%temp_expected = temp
+                  ELSE
+                     temp = simpar%temp_ext
+                     IF (temp > 0.0_dp) THEN
+                        t_region%temp_expected = temp
+                     ELSE
+                        CALL cp_warn(__LOCATION__, &
+                                     "The initial temperature for the region "//TRIM(my_region)// &
+                                     "cannot be assigned to a positive value in K from input. "// &
+                                     "A value of zero will be used instead.")
+                        t_region%temp_expected = 0.0_dp
+                     END IF
+                  END IF
                END IF
 
-               CALL section_vals_val_get(region_sections, "TEMP_TOL", i_rep_section=ireg, &
-                                         r_val=temp_tol)
-               t_region%temp_tol = temp_tol
+               ! Set up t_region%temp_tol
+               ! Precedence of tolerance setting: the first positive value in
+               ! 1. MD/THERMAL_REGION/DEFINE_REGION/TEMP_TOL
+               ! 2. MD/TEMP_TOL
+               ! Otherwise it will be set to 0 (i.e. not used)
+               temp_tol = 0.0_dp
+               CALL section_vals_val_get(region_sections, "TEMP_TOL", &
+                                         i_rep_section=ireg, explicit=use_temp_tol)
+               IF (use_temp_tol) THEN
+                  CALL section_vals_val_get(region_sections, "TEMP_TOL", &
+                                            i_rep_section=ireg, r_val=temp_tol)
+               END IF
+               IF (temp_tol > 0.0_dp) THEN
+                  t_region%temp_tol = temp_tol
+               ELSE
+                  temp_tol = simpar%temp_tol
+                  IF (temp_tol > 0.0_dp) THEN
+                     t_region%temp_tol = temp_tol
+                  ELSE
+                     t_region%temp_tol = 0.0_dp
+                  END IF
+               END IF
+               ! End of one thermal region in the loop
             END DO
 
             ! For Langevin ensemble, determine thermal_regions%do_langevin
@@ -302,9 +339,9 @@ CONTAINS
             IF (output_unit > 0) THEN
                WRITE (output_unit, '(/,T2,A)') &
                   "THERMAL_REGION| Mapping of thermal region indices to particles"
-               DO ipart = 1, particles%n_els, 8
-                  WRITE (output_unit, '(T2,A,T17,8I8)') &
-                     "THERMAL_REGION|", particles%els(ipart:MIN(ipart + 7, particles%n_els))%t_region_index
+               DO ipart = 1, particles%n_els, 16
+                  WRITE (output_unit, '(T2,A,T17,16I4)') &
+                     "THERMAL_REGION|", particles%els(ipart:MIN(ipart + 15, particles%n_els))%t_region_index
                END DO
             END IF
          ELSE

--- a/src/motion/thermostat/thermostat_mapping.F
+++ b/src/motion/thermostat/thermostat_mapping.F
@@ -23,6 +23,7 @@ MODULE thermostat_mapping
                                               do_region_global,&
                                               do_region_massive,&
                                               do_region_molecule,&
+                                              do_region_thermal,&
                                               do_thermo_communication,&
                                               do_thermo_no_communication
    USE kinds,                           ONLY: dp
@@ -567,7 +568,7 @@ CONTAINS
       SELECT CASE (region)
       CASE (do_region_global, do_region_molecule, do_region_massive)
          nsize = number
-      CASE (do_region_defined)
+      CASE (do_region_defined, do_region_thermal)
          nsize = sum_of_thermostats
       END SELECT
       ALLOCATE (map_info%s_kin(nsize))
@@ -665,7 +666,7 @@ CONTAINS
             number = 1
          END DO
          deg_of_freedom(1) = deg_of_freedom(1) + nglob_cns
-      ELSE IF (region == do_region_defined) THEN
+      ELSE IF ((region == do_region_defined) .OR. (region == do_region_thermal)) THEN
          ! User defined Region to thermostat
          check = (map_info%dis_type == do_thermo_communication)
          CPASSERT(check)
@@ -909,7 +910,7 @@ CONTAINS
             END DO
          END DO
       ELSE IF (dis_type == do_thermo_communication) THEN
-         IF (region == do_region_defined) THEN
+         IF ((region == do_region_defined) .OR. (region == do_region_thermal)) THEN
             ! Setup of the arbitrary region
             ALLOCATE (tot_const(sum_of_thermostats))
             ALLOCATE (point(2, 0))

--- a/src/motion/thermostat/thermostat_methods.F
+++ b/src/motion/thermostat/thermostat_methods.F
@@ -47,9 +47,9 @@ MODULE thermostat_methods
                                               initialize_gle_part
    USE global_types,                    ONLY: global_environment_type
    USE input_constants,                 ONLY: &
-        do_region_global, do_thermo_al, do_thermo_csvr, do_thermo_gle, do_thermo_nose, &
-        do_thermo_same_as_part, npe_f_ensemble, npe_i_ensemble, npt_f_ensemble, npt_i_ensemble, &
-        npt_ia_ensemble, nve_ensemble, nvt_adiabatic_ensemble, nvt_ensemble
+        do_region_global, do_region_thermal, do_thermo_al, do_thermo_csvr, do_thermo_gle, &
+        do_thermo_nose, do_thermo_same_as_part, npe_f_ensemble, npe_i_ensemble, npt_f_ensemble, &
+        npt_i_ensemble, npt_ia_ensemble, nve_ensemble, nvt_adiabatic_ensemble, nvt_ensemble
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_remove_values,&
@@ -122,8 +122,8 @@ CONTAINS
       INTEGER                                            :: n_rep, region, thermostat_type
       LOGICAL :: apply_general_thermo, apply_thermo_adiabatic, apply_thermo_baro, &
          apply_thermo_shell, explicit_adiabatic_fast, explicit_adiabatic_slow, explicit_baro, &
-         explicit_barostat_section, explicit_part, explicit_shell, save_mem, shell_adiabatic, &
-         shell_present
+         explicit_barostat_section, explicit_part, explicit_shell, explicit_thermal, save_mem, &
+         shell_adiabatic, shell_present
       TYPE(atomic_kind_list_type), POINTER               :: atomic_kinds
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_subsys_type), POINTER                      :: subsys
@@ -135,14 +135,15 @@ CONTAINS
       TYPE(qmmm_env_type), POINTER                       :: qmmm_env
       TYPE(section_vals_type), POINTER :: adiabatic_fast_section, adiabatic_slow_section, &
          barostat_section, print_section, region_section_fast, region_section_slow, &
-         region_sections, thermo_baro_section, thermo_part_section, thermo_shell_section, &
-         work_section
+         region_sections, thermal_region_section, thermo_baro_section, thermo_part_section, &
+         thermo_shell_section, work_section
 
       NULLIFY (qmmm_env, cell)
       ALLOCATE (thermostats)
       CALL allocate_thermostats(thermostats)
       adiabatic_fast_section => section_vals_get_subs_vals(md_section, "ADIABATIC_DYNAMICS%THERMOSTAT_FAST")
       adiabatic_slow_section => section_vals_get_subs_vals(md_section, "ADIABATIC_DYNAMICS%THERMOSTAT_SLOW")
+      thermal_region_section => section_vals_get_subs_vals(md_section, "THERMAL_REGION")
       thermo_part_section => section_vals_get_subs_vals(md_section, "THERMOSTAT")
       thermo_shell_section => section_vals_get_subs_vals(md_section, "SHELL%THERMOSTAT")
       thermo_baro_section => section_vals_get_subs_vals(md_section, "BAROSTAT%THERMOSTAT")
@@ -152,6 +153,7 @@ CONTAINS
       CALL force_env_get(force_env, qmmm_env=qmmm_env, subsys=subsys, cell=cell)
       CALL section_vals_get(barostat_section, explicit=explicit_barostat_section)
       CALL section_vals_val_get(global_section, "SAVE_MEM", l_val=save_mem)
+      CALL section_vals_get(thermal_region_section, explicit=explicit_thermal)
       CALL section_vals_get(thermo_part_section, explicit=explicit_part)
       CALL section_vals_get(thermo_shell_section, explicit=explicit_shell)
       CALL section_vals_get(thermo_baro_section, explicit=explicit_baro)
@@ -233,9 +235,25 @@ CONTAINS
          CALL release_thermostat_info(thermostats%thermostat_info_slow)
          DEALLOCATE (thermostats%thermostat_info_fast)
       ELSE
-         region = do_region_global
-         region_sections => section_vals_get_subs_vals(thermo_part_section, "DEFINE_REGION")
-         IF (explicit_part) CALL section_vals_val_get(thermo_part_section, "REGION", i_val=region)
+         IF (explicit_part) THEN
+            CALL section_vals_val_get(thermo_part_section, "REGION", i_val=region)
+         ELSE
+            region = do_region_global
+         END IF
+         ! Pass region and region_sections to compute_degrees_of_freedom()
+         ! which calls setup_thermostat_info() which calls get_defined_region_info()
+         ! in thermostat_utils.F
+         IF (region == do_region_thermal) THEN
+            IF (explicit_thermal) THEN
+               region_sections => section_vals_get_subs_vals(thermal_region_section, "DEFINE_REGION")
+            ELSE
+               CALL cp_abort(__LOCATION__, &
+                             "Thermostat region THERMAL must be used with explicitly defined "// &
+                             "thermal regions in MD/THERMAL_REGION section, but none is found!")
+            END IF
+         ELSE
+            region_sections => section_vals_get_subs_vals(thermo_part_section, "DEFINE_REGION")
+         END IF
          CALL cp_subsys_get(subsys, molecule_kinds=molecule_kinds, local_molecules=local_molecules, &
                             molecules=molecules, gci=gci, particles=particles)
          CALL compute_degrees_of_freedom(thermostats, cell, simpar, molecule_kinds%els, &

--- a/src/motion/thermostat/thermostat_utils.F
+++ b/src/motion/thermostat/thermostat_utils.F
@@ -771,10 +771,14 @@ CONTAINS
                DO i = 1, SIZE(tmplist)
                   ipart = tmplist(i)
                   CPASSERT(((ipart > 0) .AND. (ipart <= particles%n_els)))
-                  IF (thermolist(ipart) == HUGE(0)) THEN
+                  IF (thermolist(ipart) == HUGE(0) .OR. thermolist(ipart) == ig) THEN
                      thermolist(ipart) = ig
                   ELSE
-                     CPABORT("")
+                     CALL cp_abort(__LOCATION__, &
+                                   "The atom "//cp_to_string(ipart)//" has been "// &
+                                   "assigned to different thermostat regions "// &
+                                   cp_to_string(thermolist(ipart))//" and "// &
+                                   cp_to_string(ig)//" which is not allowed!")
                   END IF
                END DO
             END DO
@@ -791,10 +795,14 @@ CONTAINS
                            molecule => molecule_set(molecule_kind%molecule_list(imol))
                            CALL get_molecule(molecule, first_atom=first_atom, last_atom=last_atom)
                            DO ipart = first_atom, last_atom
-                              IF (thermolist(ipart) == HUGE(0)) THEN
+                              IF (thermolist(ipart) == HUGE(0) .OR. thermolist(ipart) == ig) THEN
                                  thermolist(ipart) = ig
                               ELSE
-                                 CPABORT("")
+                                 CALL cp_abort(__LOCATION__, &
+                                               "The atom "//cp_to_string(ipart)//" has been "// &
+                                               "assigned to different thermostat regions "// &
+                                               cp_to_string(thermolist(ipart))//" and "// &
+                                               cp_to_string(ig)//" which is not allowed!")
                               END IF
                            END DO
                         END DO

--- a/src/motion/thermostat/thermostat_utils.F
+++ b/src/motion/thermostat/thermostat_utils.F
@@ -838,11 +838,12 @@ CONTAINS
       CPASSERT(ALL(thermolist /= HUGE(0)))
 
       ! Output thermostat region mapping to particles
+      ! The region indices are assumed to be 0-999
       IF (output_unit > 0) THEN
          WRITE (output_unit, '(/,T2,A)') &
             "THERMOSTAT| Mapping of thermostat region indices to particles"
          DO ipart = 1, particles%n_els, 16
-            WRITE (output_unit, '(T2,A,T17,16I4)') &
+            WRITE (output_unit, '(T2,A,T17,16(" ",I3))') &
                "THERMOSTAT|", thermolist(ipart:MIN(ipart + 15, particles%n_els))
          END DO
       END IF

--- a/src/motion/thermostat/thermostat_utils.F
+++ b/src/motion/thermostat/thermostat_utils.F
@@ -841,9 +841,9 @@ CONTAINS
       IF (output_unit > 0) THEN
          WRITE (output_unit, '(/,T2,A)') &
             "THERMOSTAT| Mapping of thermostat region indices to particles"
-         DO ipart = 1, particles%n_els, 8
-            WRITE (output_unit, '(T2,A,T17,8I8)') &
-               "THERMOSTAT|", thermolist(ipart:MIN(ipart + 7, particles%n_els))
+         DO ipart = 1, particles%n_els, 16
+            WRITE (output_unit, '(T2,A,T17,16I4)') &
+               "THERMOSTAT|", thermolist(ipart:MIN(ipart + 15, particles%n_els))
          END DO
       END IF
 

--- a/src/motion/thermostat/thermostat_utils.F
+++ b/src/motion/thermostat/thermostat_utils.F
@@ -822,14 +822,30 @@ CONTAINS
                thermolist(i) = nregions
             END IF
          END DO
-         IF (output_unit > 0) THEN
-            WRITE (output_unit, '(A)') "THERMOSTAT| Warning: No thermostats defined for the following atoms:"
-            IF (ilist > 0) WRITE (output_unit, '("THERMOSTAT|",9I8)') tmp
-            WRITE (output_unit, '(A)') "THERMOSTAT| They will be included in a further unique thermostat!"
+         IF (ilist > 0) THEN
+            IF (output_unit > 0) THEN
+               WRITE (output_unit, '(/,T2,A)') &
+                  "THERMOSTAT| Warning: No thermostats defined for the following atoms:"
+               DO i = 1, ilist, 8
+                  WRITE (output_unit, '(T2,A,T17,8I8)') "THERMOSTAT|", tmp(i:MIN(i + 7, ilist))
+               END DO
+               WRITE (output_unit, '(T2,A)') &
+                  "THERMOSTAT| They will be included in a further unique thermostat!"
+            END IF
          END IF
          DEALLOCATE (tmp)
       END IF
       CPASSERT(ALL(thermolist /= HUGE(0)))
+
+      ! Output thermostat region mapping to particles
+      IF (output_unit > 0) THEN
+         WRITE (output_unit, '(/,T2,A)') &
+            "THERMOSTAT| Mapping of thermostat region indices to particles"
+         DO ipart = 1, particles%n_els, 8
+            WRITE (output_unit, '(T2,A,T17,8I8)') &
+               "THERMOSTAT|", thermolist(ipart:MIN(ipart + 7, particles%n_els))
+         END DO
+      END IF
 
       ! Now identify the local number of thermostats
       ALLOCATE (tmp(nregions))

--- a/src/motion/thermostat/thermostat_utils.F
+++ b/src/motion/thermostat/thermostat_utils.F
@@ -28,11 +28,11 @@ MODULE thermostat_utils
                                               npt_info_type
    USE input_constants,                 ONLY: &
         do_constr_atomic, do_constr_molec, do_region_defined, do_region_global, do_region_massive, &
-        do_region_molecule, do_thermo_al, do_thermo_communication, do_thermo_csvr, do_thermo_gle, &
-        do_thermo_no_communication, do_thermo_nose, isokin_ensemble, langevin_ensemble, &
-        npe_f_ensemble, npe_i_ensemble, nph_uniaxial_damped_ensemble, nph_uniaxial_ensemble, &
-        npt_f_ensemble, npt_i_ensemble, npt_ia_ensemble, nve_ensemble, nvt_adiabatic_ensemble, &
-        nvt_ensemble, reftraj_ensemble
+        do_region_molecule, do_region_thermal, do_thermo_al, do_thermo_communication, &
+        do_thermo_csvr, do_thermo_gle, do_thermo_no_communication, do_thermo_nose, &
+        isokin_ensemble, langevin_ensemble, npe_f_ensemble, npe_i_ensemble, &
+        nph_uniaxial_damped_ensemble, nph_uniaxial_ensemble, npt_f_ensemble, npt_i_ensemble, &
+        npt_ia_ensemble, nve_ensemble, nvt_adiabatic_ensemble, nvt_ensemble, reftraj_ensemble
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
@@ -650,7 +650,17 @@ CONTAINS
                CALL section_vals_get(region_sections, n_repetition=sum_of_thermostats)
                IF (sum_of_thermostats < 1) &
                   CALL cp_abort(__LOCATION__, &
-                                "Provide at least 1 region (&DEFINE_REGION) when using the thermostat type DEFINED")
+                                "A thermostat type DEFINED is requested but no thermostat "// &
+                                "regions are defined in THERMOSTAT/DEFINE_REGION.")
+            CASE (do_region_thermal)
+               ! Similar to defined region above, but in THERMAL_REGION%DEFINE_REGION
+               nointer = .FALSE.
+               ! Determine the number of thermostats defined in the input
+               CALL section_vals_get(region_sections, n_repetition=sum_of_thermostats)
+               IF (sum_of_thermostats < 1) &
+                  CALL cp_abort(__LOCATION__, &
+                                "A thermostat type THERMAL is requested but no thermal "// &
+                                "regions are defined in THERMAL_REGION/DEFINE_REGION.")
             END SELECT
 
             ! Here we decide which parallel algorithm to use.
@@ -684,7 +694,7 @@ CONTAINS
                dis_type = do_thermo_communication
                IF ((region == do_region_global) .OR. (region == do_region_molecule)) THEN
                   number = 1
-               ELSE IF (region == do_region_defined) THEN
+               ELSE IF ((region == do_region_defined) .OR. (region == do_region_thermal)) THEN
                   CALL get_defined_region_info(region_sections, number, sum_of_thermostats, &
                                                map_loc_thermo_gen=thermostat_info%map_loc_thermo_gen, &
                                                local_molecules=local_molecules, molecule_kind_set=molecule_kind_set, &
@@ -755,40 +765,44 @@ CONTAINS
       mregions = nregions
       DO ig = 1, mregions
          CALL section_vals_val_get(region_sections, "LIST", i_rep_section=ig, n_rep_val=n_rep)
-         DO jg = 1, n_rep
-            CALL section_vals_val_get(region_sections, "LIST", i_rep_section=ig, i_rep_val=jg, i_vals=tmplist)
-            DO i = 1, SIZE(tmplist)
-               ipart = tmplist(i)
-               CPASSERT(((ipart > 0) .AND. (ipart <= particles%n_els)))
-               IF (thermolist(ipart) == HUGE(0)) THEN
-                  thermolist(ipart) = ig
-               ELSE
-                  CPABORT("")
-               END IF
-            END DO
-         END DO
-         CALL section_vals_val_get(region_sections, "MOLNAME", i_rep_section=ig, n_rep_val=n_rep)
-         DO jg = 1, n_rep
-            CALL section_vals_val_get(region_sections, "MOLNAME", i_rep_section=ig, i_rep_val=jg, c_vals=tmpstringlist)
-            DO ilist = 1, SIZE(tmpstringlist)
-               DO ikind = 1, SIZE(molecule_kind_set)
-                  molecule_kind => molecule_kind_set(ikind)
-                  IF (molecule_kind%name == tmpstringlist(ilist)) THEN
-                     DO imol = 1, SIZE(molecule_kind%molecule_list)
-                        molecule => molecule_set(molecule_kind%molecule_list(imol))
-                        CALL get_molecule(molecule, first_atom=first_atom, last_atom=last_atom)
-                        DO ipart = first_atom, last_atom
-                           IF (thermolist(ipart) == HUGE(0)) THEN
-                              thermolist(ipart) = ig
-                           ELSE
-                              CPABORT("")
-                           END IF
-                        END DO
-                     END DO
+         IF (n_rep > 0) THEN
+            DO jg = 1, n_rep
+               CALL section_vals_val_get(region_sections, "LIST", i_rep_section=ig, i_rep_val=jg, i_vals=tmplist)
+               DO i = 1, SIZE(tmplist)
+                  ipart = tmplist(i)
+                  CPASSERT(((ipart > 0) .AND. (ipart <= particles%n_els)))
+                  IF (thermolist(ipart) == HUGE(0)) THEN
+                     thermolist(ipart) = ig
+                  ELSE
+                     CPABORT("")
                   END IF
                END DO
             END DO
-         END DO
+         END IF
+         CALL section_vals_val_get(region_sections, "MOLNAME", i_rep_section=ig, n_rep_val=n_rep)
+         IF (n_rep > 0) THEN
+            DO jg = 1, n_rep
+               CALL section_vals_val_get(region_sections, "MOLNAME", i_rep_section=ig, i_rep_val=jg, c_vals=tmpstringlist)
+               DO ilist = 1, SIZE(tmpstringlist)
+                  DO ikind = 1, SIZE(molecule_kind_set)
+                     molecule_kind => molecule_kind_set(ikind)
+                     IF (molecule_kind%name == tmpstringlist(ilist)) THEN
+                        DO imol = 1, SIZE(molecule_kind%molecule_list)
+                           molecule => molecule_set(molecule_kind%molecule_list(imol))
+                           CALL get_molecule(molecule, first_atom=first_atom, last_atom=last_atom)
+                           DO ipart = first_atom, last_atom
+                              IF (thermolist(ipart) == HUGE(0)) THEN
+                                 thermolist(ipart) = ig
+                              ELSE
+                                 CPABORT("")
+                              END IF
+                           END DO
+                        END DO
+                     END IF
+                  END DO
+               END DO
+            END DO
+         END IF
          CALL setup_thermostat_subsys(region_sections, qmmm_env, thermolist, molecule_set, &
                                       subsys_qm=.FALSE., ig=ig, sum_of_thermostats=sum_of_thermostats, nregions=nregions)
          CALL setup_thermostat_subsys(region_sections, qmmm_env, thermolist, molecule_set, &
@@ -809,9 +823,9 @@ CONTAINS
             END IF
          END DO
          IF (output_unit > 0) THEN
-            WRITE (output_unit, '(A)') " WARNING| No thermostats defined for the following atoms:"
-            IF (ilist > 0) WRITE (output_unit, '(" WARNING|",9I8)') tmp
-            WRITE (output_unit, '(A)') " WARNING| They will be included in a further unique thermostat!"
+            WRITE (output_unit, '(A)') "THERMOSTAT| Warning: No thermostats defined for the following atoms:"
+            IF (ilist > 0) WRITE (output_unit, '("THERMOSTAT|",9I8)') tmp
+            WRITE (output_unit, '(A)') "THERMOSTAT| They will be included in a further unique thermostat!"
          END IF
          DEALLOCATE (tmp)
       END IF


### PR DESCRIPTION
As a follow-up to #5002, this PR introduces a new option `THERMAL`
for `&MOTION/&MD/&THERMOSTAT/REGION`; similar to the
existing `DEFINE` option that already reads definition from the section
`&THERMOSTAT/&DEFINE_REGION`, the `THERMAL` option takes
definition of thermostat regions from thermal regions in
`&THERMAL_REGION/&DEFINE_REGION`.

A side effect is that the keywords for thermostat regions
`MOLNAME`, `MM_SUBSYS` and `QM_SUBSYS` have to be added to
`&THERMAL_REGION/&DEFINE_REGION`, but `MM_SUBSYS` and `QM_SUBSYS`
are not yet parsed for thermal regions due to the different
implementation between `thermostat_methods.F`, `SUBROUTINE create_thermostats` (which
takes region definition from `thermostat_utils.F`, `SUBROUTINE get_defined_region_info`)
and `thermal_region_utils.F`, `SUBROUTINE create_thermal_regions`.

The regions mapped to each particle is now dumped to output file like this:
```
 THERMAL_REGION| Mapping of thermal region indices to particles
 THERMAL_REGION|   1   1   1   1   1   1   1   1   1   1   2   2   2   2   2   2
 THERMAL_REGION|   2   2   2   2   2   2   2   2   3   3   3   3   0   0
```
