### PR TITLE
CI: Increase cpu/ram limit for misc test

### DIFF
--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -39,7 +39,7 @@ dockerfile:   /tools/docker/Dockerfile.test_precommit
 [misc]
 display_name: Misc
 tags:         daily
-cpu:          1
+cpu:          8
 nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_misc


### PR DESCRIPTION
~Follow up to #5015.~
It seems, the misc test has been using too much memory for a while, but we got lucky most of the time.