### PR TITLE
Initialize matrices before parallel_gemm in make_basis_lowdin

### DIFF
--- a/src/qs_mo_methods.F
+++ b/src/qs_mo_methods.F
@@ -43,6 +43,7 @@ MODULE qs_mo_methods
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
                                               cp_fm_release,&
+                                              cp_fm_set_all,&
                                               cp_fm_to_fm,&
                                               cp_fm_type
    USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit

--- a/src/qs_mo_methods.F
+++ b/src/qs_mo_methods.F
@@ -325,7 +325,9 @@ CONTAINS
                                para_env=vmatrix%matrix_struct%para_env, &
                                context=vmatrix%matrix_struct%context)
       CALL cp_fm_create(csc, fm_struct_tmp, "csc")
+      CALL cp_fm_set_all(csc, 0.0_dp)
       CALL cp_fm_create(work, fm_struct_tmp, "work")
+      CALL cp_fm_set_all(work, 0.0_dp)
       CALL cp_fm_struct_release(fm_struct_tmp)
 
       CALL parallel_gemm('T', 'N', ncol, ncol, n, rone, vmatrix, sc, rzero, csc)


### PR DESCRIPTION
## Summary

Initialize `csc` and `work` matrices to zero before passing them to `parallel_gemm` in `make_basis_lowdin` (`qs_mo_methods.F`). When COSMA is built with CUDA support, uninitialized matrix data causes segfaults in the GPU pdgemm kernel during MPI+GPU runs.

This is the same class of bug as 52a73339f4 (`bfgs_optimizer.F`, @mkrack, 2026-02-26), now applied to `qs_mo_methods.F`.

## Bug details

- **Crash path:** `wfi_extrapolate` → `reorthogonalize_vectors` → `make_basis_lowdin` → `parallel_gemm` → COSMA GPU `pdgemm` → SIGSEGV
- **When:** AIMD step 1+ (step 0 has no WF history, so ASPC extrapolation is skipped)
- **Condition:** MPI >= 2, COSMA with CUDA, any GPU (tested A100, RTX 4070S, RTX 5070 Ti)
- **Single-rank:** no crash (COSMA uses local CPU path)
- **Root cause:** `cp_fm_create` allocates but does not zero-initialize. `parallel_gemm` with `beta=zero` should overwrite, but COSMA GPU kernel reads uninitialized data before writing, triggering segfault

## Test plan

- [x] CP2K 2025.2, COSMA 2.8.2+CUDA, A100-PCIE-40GB, MPI=4, OMP=4
- [x] 73-atom mackinawite+water AIMD (NVT 300K, PBE-D3, Broyden/DIAG)
- [x] 5 MD steps completed without crash (previously SIGSEGV at step 1)
- [x] Step timing consistent with pre-fix CPU-only runs (~28-33 s/step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)