### PR TITLE
Refactor: when calling `cp_subsys_create()` do not call `read_cell()` again

### DIFF
--- a/src/cp_subsys_methods.F
+++ b/src/cp_subsys_methods.F
@@ -157,7 +157,8 @@ CONTAINS
                             subsys%colvar_p, subsys%gci, root_section, para_env, &
                             force_env_section=my_force_env_section, &
                             subsys_section=my_subsys_section, use_motion_section=my_use_motion_section, &
-                            qmmm=qmmm, qmmm_env=qmmm_env, exclusions=exclusions, elkind=elkind)
+                            qmmm=qmmm, qmmm_env=qmmm_env, exclusions=exclusions, elkind=elkind, &
+                            subsys=subsys)
 
       CALL particle_list_create(particles, els_ptr=particle_set)
       CALL atomic_kind_list_create(atomic_kinds, els_ptr=atomic_kind_set)

--- a/src/eip_environment.F
+++ b/src/eip_environment.F
@@ -14,14 +14,9 @@
 MODULE eip_environment
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind
-   USE cell_methods,                    ONLY: read_cell,&
-                                              write_cell
-   USE cell_types,                      ONLY: cell_release,&
-                                              cell_type,&
-                                              get_cell
+   USE cell_types,                      ONLY: cell_type
    USE cp_subsys_methods,               ONLY: cp_subsys_create
-   USE cp_subsys_types,                 ONLY: cp_subsys_set,&
-                                              cp_subsys_type
+   USE cp_subsys_types,                 ONLY: cp_subsys_type
    USE distribution_1d_types,           ONLY: distribution_1d_release,&
                                               distribution_1d_type
    USE distribution_methods,            ONLY: distribute_molecules_1d
@@ -77,43 +72,29 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'eip_init'
 
       INTEGER                                            :: handle
-      LOGICAL                                            :: use_ref_cell
-      REAL(KIND=dp), DIMENSION(3)                        :: abc
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(section_vals_type), POINTER                   :: cell_section, colvar_section, eip_section
+      TYPE(section_vals_type), POINTER                   :: colvar_section, eip_section
 
       CALL timeset(routineN, handle)
 
       CPASSERT(ASSOCIATED(eip_env))
 
       ! nullifying  pointers
-      NULLIFY (cell_section, colvar_section, eip_section, cell, cell_ref, &
-               subsys)
+      NULLIFY (colvar_section, eip_section, subsys)
 
       IF (.NOT. ASSOCIATED(subsys_section)) THEN
          subsys_section => section_vals_get_subs_vals(force_env_section, "SUBSYS")
       END IF
-      cell_section => section_vals_get_subs_vals(subsys_section, "CELL")
       colvar_section => section_vals_get_subs_vals(subsys_section, "COLVAR")
       eip_section => section_vals_get_subs_vals(force_env_section, "EIP")
 
       CALL eip_env_set(eip_env=eip_env, eip_input=eip_section, &
                        force_env_input=force_env_section)
 
-      CALL read_cell(cell=cell, cell_ref=cell_ref, use_ref_cell=use_ref_cell, cell_section=cell_section, &
-                     para_env=para_env)
-      CALL get_cell(cell=cell, abc=abc)
-      CALL write_cell(cell=cell, subsys_section=subsys_section)
-
       CALL cp_subsys_create(subsys, para_env, root_section)
 
-      CALL eip_init_subsys(eip_env=eip_env, subsys=subsys, cell=cell, &
-                           cell_ref=cell_ref, use_ref_cell=use_ref_cell, &
+      CALL eip_init_subsys(eip_env=eip_env, subsys=subsys, &
                            subsys_section=subsys_section)
-
-      CALL cell_release(cell)
-      CALL cell_release(cell_ref)
 
       CALL timestop(handle)
 
@@ -123,25 +104,21 @@ CONTAINS
 !> \brief Initialize the eip environment
 !> \param eip_env The eip environment of matter
 !> \param subsys the subsys
-!> \param cell Pointer to the actual simulation cell
-!> \param cell_ref Pointer to the reference cell, used e.g. in NPT simulations
-!> \param use_ref_cell Logical which indicates if cell_ref is in use
 !> \param subsys_section ...
 !> \par History
 !>      03.2006 initial create [tdk]
 !> \author Thomas D. Kuehne (tkuehne@phys.chem.ethz.ch)
 ! **************************************************************************************************
-   SUBROUTINE eip_init_subsys(eip_env, subsys, cell, cell_ref, use_ref_cell, subsys_section)
+   SUBROUTINE eip_init_subsys(eip_env, subsys, subsys_section)
       TYPE(eip_environment_type), POINTER                :: eip_env
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
-      LOGICAL, INTENT(in)                                :: use_ref_cell
       TYPE(section_vals_type), POINTER                   :: subsys_section
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'eip_init_subsys'
 
       INTEGER                                            :: handle, natom
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: my_cell, my_cell_ref
       TYPE(distribution_1d_type), POINTER                :: local_molecules, local_particles
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
@@ -152,21 +129,28 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (atomic_kind_set, molecule_kind_set, particle_set, molecule_set, &
-               local_molecules, local_particles)
+               my_cell, my_cell_ref, local_molecules, local_particles)
 
       particle_set => subsys%particles%els
       atomic_kind_set => subsys%atomic_kinds%els
       molecule_kind_set => subsys%molecule_kinds%els
       molecule_set => subsys%molecules%els
+      my_cell => subsys%cell
+      my_cell_ref => subsys%cell_ref
+
+!   *** Set up cell ***
+      CALL eip_env_set(eip_env=eip_env, subsys=subsys, &
+                       cell_ref=my_cell_ref, &
+                       use_ref_cell=subsys%use_ref_cell)
 
 !   *** Print the molecule kind set ***
       CALL write_molecule_kind_set(molecule_kind_set, subsys_section)
 
 !   *** Print the atomic coordinates
       CALL write_fist_particle_coordinates(particle_set, subsys_section)
-      CALL write_particle_distances(particle_set, cell=cell, &
+      CALL write_particle_distances(particle_set, cell=my_cell, &
                                     subsys_section=subsys_section)
-      CALL write_structure_data(particle_set, cell=cell, &
+      CALL write_structure_data(particle_set, cell=my_cell, &
                                 input_section=subsys_section)
 
 !   *** Distribute molecules and atoms using the new data structures ***
@@ -184,9 +168,7 @@ CONTAINS
 
       eip_env%eip_forces(:, :) = 0.0_dp
 
-      CALL cp_subsys_set(subsys, cell=cell)
-      CALL eip_env_set(eip_env=eip_env, subsys=subsys, &
-                       cell_ref=cell_ref, use_ref_cell=use_ref_cell, &
+      CALL eip_env_set(eip_env=eip_env, &
                        local_molecules=local_molecules, &
                        local_particles=local_particles)
 

--- a/src/embed_environment.F
+++ b/src/embed_environment.F
@@ -11,14 +11,9 @@
 ! **************************************************************************************************
 MODULE embed_environment
    USE atomic_kind_types,               ONLY: atomic_kind_type
-   USE cell_methods,                    ONLY: read_cell,&
-                                              write_cell
-   USE cell_types,                      ONLY: cell_release,&
-                                              cell_type,&
-                                              get_cell
+   USE cell_types,                      ONLY: cell_type
    USE cp_subsys_methods,               ONLY: cp_subsys_create
-   USE cp_subsys_types,                 ONLY: cp_subsys_set,&
-                                              cp_subsys_type
+   USE cp_subsys_types,                 ONLY: cp_subsys_type
    USE distribution_1d_types,           ONLY: distribution_1d_release,&
                                               distribution_1d_type
    USE distribution_methods,            ONLY: distribute_molecules_1d
@@ -26,7 +21,6 @@ MODULE embed_environment
                                               set_embed_env
    USE input_section_types,             ONLY: section_vals_get_subs_vals,&
                                               section_vals_type
-   USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_para_env_type
    USE molecule_kind_types,             ONLY: molecule_kind_type,&
                                               write_molecule_kind_set
@@ -66,38 +60,22 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'embed_init'
 
       INTEGER                                            :: handle
-      LOGICAL                                            :: use_ref_cell
-      REAL(KIND=dp), DIMENSION(3)                        :: abc
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(section_vals_type), POINTER                   :: cell_section, subsys_section
+      TYPE(section_vals_type), POINTER                   :: subsys_section
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (subsys, cell, cell_ref)
-      NULLIFY (cell_section)
+      NULLIFY (subsys)
 
       subsys_section => section_vals_get_subs_vals(force_env_section, "SUBSYS")
-      cell_section => section_vals_get_subs_vals(subsys_section, "CELL")
 
       CALL set_embed_env(embed_env, input=force_env_section)
       CALL cp_subsys_create(subsys, para_env, root_section, &
                             force_env_section=force_env_section, &
                             use_motion_section=use_motion_section)
 
-      CALL read_cell(cell, cell_ref, use_ref_cell=use_ref_cell, &
-                     cell_section=cell_section, para_env=para_env)
-      CALL get_cell(cell, abc=abc)
-
-      ! Print the cell parameters ***
-      CALL write_cell(cell, subsys_section)
-      CALL write_cell(cell_ref, subsys_section)
-
-      CALL embed_init_subsys(embed_env, subsys, cell, cell_ref, &
+      CALL embed_init_subsys(embed_env, subsys, &
                              force_env_section, subsys_section)
-
-      CALL cell_release(cell)
-      CALL cell_release(cell_ref)
 
       CALL timestop(handle)
 
@@ -108,36 +86,35 @@ CONTAINS
 !>          embed environment.
 !> \param embed_env ...
 !> \param subsys ...
-!> \param cell ...
-!> \param cell_ref ...
 !> \param force_env_section ...
 !> \param subsys_section ...
 !> \date    02.2018
 !> \author  Vladimir Rybkin
 ! **************************************************************************************************
-   SUBROUTINE embed_init_subsys(embed_env, subsys, cell, cell_ref, &
-                                force_env_section, subsys_section)
+   SUBROUTINE embed_init_subsys(embed_env, subsys, force_env_section, &
+                                subsys_section)
 
       TYPE(embed_env_type), INTENT(INOUT)                :: embed_env
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(section_vals_type), POINTER                   :: force_env_section, subsys_section
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'embed_init_subsys'
 
       INTEGER                                            :: handle
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: my_cell_ref
       TYPE(distribution_1d_type), POINTER                :: local_molecules, local_particles
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       CALL timeset(routineN, handle)
-      NULLIFY (local_molecules, local_particles)
+      NULLIFY (local_molecules, local_particles, my_cell_ref)
       particle_set => subsys%particles%els
       atomic_kind_set => subsys%atomic_kinds%els
       molecule_set => subsys%molecules%els
       molecule_kind_set => subsys%molecule_kinds%els
+      my_cell_ref => subsys%cell_ref
 
       ! Print the molecule kind set
       CALL write_molecule_kind_set(molecule_kind_set, subsys_section)
@@ -151,12 +128,10 @@ CONTAINS
                                    local_molecules=local_molecules, &
                                    force_env_section=force_env_section)
 
-      CALL cp_subsys_set(subsys, cell=cell)
-
       ! set the embed_env
       CALL set_embed_env(embed_env=embed_env, subsys=subsys)
       CALL set_embed_env(embed_env=embed_env, &
-                         cell_ref=cell_ref, &
+                         cell_ref=my_cell_ref, &
                          local_molecules=local_molecules, &
                          local_particles=local_particles)
 

--- a/src/fist_environment.F
+++ b/src/fist_environment.F
@@ -16,11 +16,7 @@ MODULE fist_environment
                                               Dick1958,&
                                               Mitchell1993,&
                                               cite_reference
-   USE cell_methods,                    ONLY: read_cell,&
-                                              write_cell
-   USE cell_types,                      ONLY: cell_release,&
-                                              cell_type,&
-                                              get_cell
+   USE cell_types,                      ONLY: cell_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type
    USE cp_output_handling,              ONLY: cp_print_key_finished_output,&
@@ -53,7 +49,6 @@ MODULE fist_environment
    USE header,                          ONLY: fist_header
    USE input_section_types,             ONLY: section_vals_get_subs_vals,&
                                               section_vals_type
-   USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_para_env_type
    USE molecule_kind_types,             ONLY: molecule_kind_type,&
                                               write_molecule_kind_set
@@ -104,8 +99,6 @@ CONTAINS
 
       INTEGER                                            :: handle, iw
       LOGICAL                                            :: qmmm, shell_adiabatic, shell_present
-      REAL(KIND=dp), DIMENSION(3)                        :: abc
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(ewald_environment_type), POINTER              :: ewald_env
@@ -115,21 +108,19 @@ CONTAINS
       TYPE(particle_list_type), POINTER                  :: core_particles, shell_particles
       TYPE(particle_type), DIMENSION(:), POINTER         :: core_particle_set, shell_particle_set
       TYPE(qmmm_env_mm_type), POINTER                    :: qmmm_env
-      TYPE(section_vals_type), POINTER                   :: cell_section, ewald_section, mm_section, &
+      TYPE(section_vals_type), POINTER                   :: ewald_section, mm_section, &
                                                             poisson_section
 
       CALL timeset(routineN, handle)
       logger => cp_get_default_logger()
 
-      NULLIFY (subsys, cell, cell_ref)
-      NULLIFY (ewald_env, fist_nonbond_env, qmmm_env, cell_section, &
+      NULLIFY (ewald_env, fist_nonbond_env, qmmm_env, subsys, &
                poisson_section, shell_particle_set, shell_particles, &
                core_particle_set, core_particles, exclusions)
       IF (.NOT. ASSOCIATED(subsys_section)) THEN
          subsys_section => section_vals_get_subs_vals(force_env_section, "SUBSYS")
       END IF
       mm_section => section_vals_get_subs_vals(force_env_section, "MM")
-      cell_section => section_vals_get_subs_vals(subsys_section, "CELL")
       poisson_section => section_vals_get_subs_vals(mm_section, "POISSON")
       ewald_section => section_vals_get_subs_vals(poisson_section, "EWALD")
 
@@ -139,13 +130,6 @@ CONTAINS
                                 extension=".mmLog")
       CALL fist_header(iw)
       CALL cp_print_key_finished_output(iw, logger, mm_section, "PRINT%PROGRAM_BANNER")
-
-      CALL read_cell(cell, cell_ref, cell_section=cell_section, para_env=para_env)
-      CALL get_cell(cell, abc=abc)
-
-      ! Print the cell parameters
-      CALL write_cell(cell, subsys_section)
-      CALL write_cell(cell_ref, subsys_section)
 
       ! Create the ewald environment
       ALLOCATE (ewald_env)
@@ -173,7 +157,7 @@ CONTAINS
                                ewald_env, fist_nonbond_env, root_section, para_env, qmmm=qmmm, &
                                qmmm_env=qmmm_env, subsys_section=subsys_section, &
                                mm_section=mm_section, shell_particle_set=shell_particle_set, &
-                               core_particle_set=core_particle_set, cell=cell)
+                               core_particle_set=core_particle_set, cell=subsys%cell)
 
       NULLIFY (shell_particles, core_particles)
       IF (ASSOCIATED(shell_particle_set)) THEN
@@ -194,11 +178,8 @@ CONTAINS
       CALL particle_list_release(shell_particles)
       CALL particle_list_release(core_particles)
 
-      CALL fist_init_subsys(fist_env, subsys, cell, cell_ref, fist_nonbond_env, ewald_env, &
+      CALL fist_init_subsys(fist_env, subsys, fist_nonbond_env, ewald_env, &
                             force_env_section, subsys_section, prev_subsys)
-
-      CALL cell_release(cell)
-      CALL cell_release(cell_ref)
 
       CALL timestop(handle)
 
@@ -209,8 +190,6 @@ CONTAINS
 !>          FIST environment.
 !> \param fist_env ...
 !> \param subsys ...
-!> \param cell ...
-!> \param cell_ref ...
 !> \param fist_nonbond_env ...
 !> \param ewald_env ...
 !> \param force_env_section ...
@@ -220,13 +199,12 @@ CONTAINS
 !> \author  MK
 !> \version 1.0
 ! **************************************************************************************************
-   SUBROUTINE fist_init_subsys(fist_env, subsys, cell, cell_ref, fist_nonbond_env, &
+   SUBROUTINE fist_init_subsys(fist_env, subsys, fist_nonbond_env, &
                                ewald_env, force_env_section, subsys_section, &
                                prev_subsys)
 
       TYPE(fist_environment_type), POINTER               :: fist_env
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(fist_nonbond_env_type), POINTER               :: fist_nonbond_env
       TYPE(ewald_environment_type), POINTER              :: ewald_env
       TYPE(section_vals_type), POINTER                   :: force_env_section, subsys_section
@@ -237,6 +215,7 @@ CONTAINS
       INTEGER                                            :: handle, max_multipole
       LOGICAL                                            :: do_multipoles
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: my_cell, my_cell_ref
       TYPE(distribution_1d_type), POINTER                :: local_molecules, local_particles, &
                                                             prev_local_molecules
       TYPE(ewald_pw_type), POINTER                       :: ewald_pw
@@ -248,11 +227,14 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: grid_print_section
 
       CALL timeset(routineN, handle)
-      NULLIFY (thermo, ewald_pw, local_molecules, local_particles, multipoles)
+      NULLIFY (thermo, ewald_pw, local_molecules, local_particles, &
+               multipoles, my_cell, my_cell_ref)
       particle_set => subsys%particles%els
       atomic_kind_set => subsys%atomic_kinds%els
       molecule_set => subsys%molecules%els
       molecule_kind_set => subsys%molecule_kinds%els
+      my_cell => subsys%cell
+      my_cell_ref => subsys%cell_ref
 
       IF (PRESENT(prev_subsys)) THEN
          prev_molecule_kind_set => prev_subsys%molecule_kinds%els
@@ -271,11 +253,11 @@ CONTAINS
       ! Print the atomic coordinates
       CALL write_fist_particle_coordinates(particle_set, subsys_section, &
                                            fist_nonbond_env%charges)
-      CALL write_particle_distances(particle_set, cell, subsys_section)
-      CALL write_structure_data(particle_set, cell=cell, input_section=subsys_section)
+      CALL write_particle_distances(particle_set, my_cell, subsys_section)
+      CALL write_structure_data(particle_set, cell=my_cell, input_section=subsys_section)
 
       ! Print symmetry information
-      CALL write_symmetry(particle_set, cell, subsys_section)
+      CALL write_symmetry(particle_set, my_cell, subsys_section)
 
       ! Distribute molecules and atoms using the new data structures ***
       CALL distribute_molecules_1d(atomic_kind_set=atomic_kind_set, &
@@ -292,10 +274,10 @@ CONTAINS
       grid_print_section => section_vals_get_subs_vals(force_env_section, &
                                                        "PRINT%GRID_INFORMATION")
       ALLOCATE (ewald_pw)
-      CALL ewald_pw_create(ewald_pw, ewald_env, cell, cell_ref, grid_print_section)
+      CALL ewald_pw_create(ewald_pw, ewald_env, my_cell, my_cell_ref, grid_print_section)
 
       ! Initialize ewald grids
-      CALL ewald_pw_grid_update(ewald_pw, ewald_env, cell%hmat)
+      CALL ewald_pw_grid_update(ewald_pw, ewald_env, my_cell%hmat)
 
       ! Possibly Initialize the multipole environment
       CALL ewald_env_get(ewald_env, do_multipoles=do_multipoles, &
@@ -304,11 +286,11 @@ CONTAINS
          ALLOCATE (multipoles)
          CALL create_multipole_type(multipoles, particle_set, subsys_section, max_multipole)
       END IF
-      CALL cp_subsys_set(subsys, multipoles=multipoles, cell=cell)
+      CALL cp_subsys_set(subsys, multipoles=multipoles)
 
       ! Set the fist_env
       CALL fist_env_set(fist_env=fist_env, &
-                        cell_ref=cell_ref, &
+                        cell_ref=my_cell_ref, &
                         local_molecules=local_molecules, &
                         local_particles=local_particles, &
                         ewald_env=ewald_env, ewald_pw=ewald_pw, &

--- a/src/input_cp2k_subsys.F
+++ b/src/input_cp2k_subsys.F
@@ -87,7 +87,8 @@ CONTAINS
                           "2. The lengths and angles of cell vectors set by ABC and ALPHA_BETA_GAMMA;"//newline// &
                           "3. The vectors set by A, B, C together;"//newline// &
                           "4. If none above exist, the external file set by TOPOLOGY/COORD_FILE_NAME with "// &
-                          "certain TOPOLOGY/COORD_FILE_FORMAT may also be parsed.")
+                          "certain TOPOLOGY/COORD_FILE_FORMAT may also be parsed. This behavior has NOT "// &
+                          "been fully tested for BSSE as well as QM/MM calculations.")
       CALL create_cell_section_low(section, periodic)
 
       NULLIFY (subsection)

--- a/src/ipi_environment.F
+++ b/src/ipi_environment.F
@@ -13,14 +13,9 @@
 ! **************************************************************************************************
 MODULE ipi_environment
    USE atomic_kind_types,               ONLY: atomic_kind_type
-   USE cell_methods,                    ONLY: read_cell,&
-                                              write_cell
-   USE cell_types,                      ONLY: cell_release,&
-                                              cell_type,&
-                                              get_cell
+   USE cell_types,                      ONLY: cell_type
    USE cp_subsys_methods,               ONLY: cp_subsys_create
-   USE cp_subsys_types,                 ONLY: cp_subsys_set,&
-                                              cp_subsys_type
+   USE cp_subsys_types,                 ONLY: cp_subsys_type
    USE distribution_1d_types,           ONLY: distribution_1d_release,&
                                               distribution_1d_type
    USE distribution_methods,            ONLY: distribute_molecules_1d
@@ -75,38 +70,25 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'ipi_init'
 
       INTEGER                                            :: handle
-      REAL(KIND=dp), DIMENSION(3)                        :: abc
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(section_vals_type), POINTER                   :: cell_section, driver_section, &
-                                                            motion_section
+      TYPE(section_vals_type), POINTER                   :: driver_section, motion_section
 
       CALL timeset(routineN, handle)
 
       CPASSERT(ASSOCIATED(ipi_env))
 
       ! nullifying  pointers
-      NULLIFY (cell_section, cell, cell_ref, subsys)
+      NULLIFY (subsys)
 
       IF (.NOT. ASSOCIATED(subsys_section)) THEN
          subsys_section => section_vals_get_subs_vals(force_env_section, "SUBSYS")
       END IF
-      cell_section => section_vals_get_subs_vals(subsys_section, "CELL")
 
       CALL ipi_env_set(ipi_env=ipi_env, force_env_input=force_env_section)
 
-      CALL read_cell(cell=cell, cell_ref=cell_ref, &
-                     cell_section=cell_section, para_env=para_env)
-      CALL get_cell(cell=cell, abc=abc)
-      CALL write_cell(cell=cell, subsys_section=subsys_section)
-
       CALL cp_subsys_create(subsys, para_env, root_section)
 
-      CALL ipi_init_subsys(ipi_env=ipi_env, subsys=subsys, cell=cell, &
-                           cell_ref=cell_ref, subsys_section=subsys_section)
-
-      CALL cell_release(cell)
-      CALL cell_release(cell_ref)
+      CALL ipi_init_subsys(ipi_env=ipi_env, subsys=subsys, subsys_section=subsys_section)
 
       motion_section => section_vals_get_subs_vals(root_section, "MOTION")
       driver_section => section_vals_get_subs_vals(motion_section, "DRIVER")
@@ -120,23 +102,21 @@ CONTAINS
 !> \brief Initialize the ipi environment
 !> \param ipi_env The ipi environment
 !> \param subsys the subsys
-!> \param cell Pointer to the actual simulation cell
-!> \param cell_ref Pointer to the reference cell, used e.g. in NPT simulations
 !> \param subsys_section ...
 !> \par History
 !>      03.2024 initial create
 !> \author Sebastian Seidenath (sebastian.seidenath@uni-jena.de)
 ! **************************************************************************************************
-   SUBROUTINE ipi_init_subsys(ipi_env, subsys, cell, cell_ref, subsys_section)
+   SUBROUTINE ipi_init_subsys(ipi_env, subsys, subsys_section)
       TYPE(ipi_environment_type), POINTER                :: ipi_env
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(section_vals_type), POINTER                   :: subsys_section
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'ipi_init_subsys'
 
       INTEGER                                            :: handle, natom
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: my_cell, my_cell_ref
       TYPE(distribution_1d_type), POINTER                :: local_molecules, local_particles
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
@@ -145,21 +125,23 @@ CONTAINS
       CALL timeset(routineN, handle)
 
       NULLIFY (atomic_kind_set, molecule_kind_set, particle_set, molecule_set, &
-               local_molecules, local_particles)
+               local_molecules, local_particles, my_cell, my_cell_ref)
 
       particle_set => subsys%particles%els
       atomic_kind_set => subsys%atomic_kinds%els
       molecule_kind_set => subsys%molecule_kinds%els
       molecule_set => subsys%molecules%els
+      my_cell => subsys%cell
+      my_cell_ref => subsys%cell_ref
 
 !   *** Print the molecule kind set ***
       CALL write_molecule_kind_set(molecule_kind_set, subsys_section)
 
 !   *** Print the atomic coordinates ***
       CALL write_fist_particle_coordinates(particle_set, subsys_section)
-      CALL write_particle_distances(particle_set, cell=cell, &
+      CALL write_particle_distances(particle_set, cell=my_cell, &
                                     subsys_section=subsys_section)
-      CALL write_structure_data(particle_set, cell=cell, &
+      CALL write_structure_data(particle_set, cell=my_cell, &
                                 input_section=subsys_section)
 
 !   *** Distribute molecules and atoms using the new data structures ***
@@ -176,9 +158,8 @@ CONTAINS
       ALLOCATE (ipi_env%ipi_forces(3, natom))
       ipi_env%ipi_forces(:, :) = 0.0_dp
 
-      CALL cp_subsys_set(subsys, cell=cell)
       CALL ipi_env_set(ipi_env=ipi_env, subsys=subsys, &
-                       cell_ref=cell_ref, &
+                       cell_ref=my_cell_ref, &
                        local_molecules=local_molecules, &
                        local_particles=local_particles)
 

--- a/src/mixed_environment.F
+++ b/src/mixed_environment.F
@@ -11,20 +11,14 @@
 ! **************************************************************************************************
 MODULE mixed_environment
    USE atomic_kind_types,               ONLY: atomic_kind_type
-   USE cell_methods,                    ONLY: read_cell,&
-                                              write_cell
-   USE cell_types,                      ONLY: cell_release,&
-                                              cell_type,&
-                                              get_cell
+   USE cell_types,                      ONLY: cell_type
    USE cp_subsys_methods,               ONLY: cp_subsys_create
-   USE cp_subsys_types,                 ONLY: cp_subsys_set,&
-                                              cp_subsys_type
+   USE cp_subsys_types,                 ONLY: cp_subsys_type
    USE distribution_1d_types,           ONLY: distribution_1d_release,&
                                               distribution_1d_type
    USE distribution_methods,            ONLY: distribute_molecules_1d
    USE input_section_types,             ONLY: section_vals_get_subs_vals,&
                                               section_vals_type
-   USE kinds,                           ONLY: dp
    USE message_passing,                 ONLY: mp_para_env_type
    USE mixed_energy_types,              ONLY: allocate_mixed_energy,&
                                               mixed_energy_type
@@ -68,38 +62,22 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'mixed_init'
 
       INTEGER                                            :: handle
-      LOGICAL                                            :: use_ref_cell
-      REAL(KIND=dp), DIMENSION(3)                        :: abc
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(section_vals_type), POINTER                   :: cell_section, subsys_section
+      TYPE(section_vals_type), POINTER                   :: subsys_section
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (subsys, cell, cell_ref)
-      NULLIFY (cell_section)
+      NULLIFY (subsys)
 
       subsys_section => section_vals_get_subs_vals(force_env_section, "SUBSYS")
-      cell_section => section_vals_get_subs_vals(subsys_section, "CELL")
 
       CALL set_mixed_env(mixed_env, input=force_env_section)
       CALL cp_subsys_create(subsys, para_env, root_section, &
                             force_env_section=force_env_section, &
                             use_motion_section=use_motion_section)
 
-      CALL read_cell(cell, cell_ref, use_ref_cell=use_ref_cell, &
-                     cell_section=cell_section, para_env=para_env)
-      CALL get_cell(cell, abc=abc)
-
-      ! Print the cell parameters ***
-      CALL write_cell(cell, subsys_section)
-      CALL write_cell(cell_ref, subsys_section)
-
-      CALL mixed_init_subsys(mixed_env, subsys, cell, cell_ref, &
+      CALL mixed_init_subsys(mixed_env, subsys, &
                              force_env_section, subsys_section)
-
-      CALL cell_release(cell)
-      CALL cell_release(cell_ref)
 
       CALL timestop(handle)
 
@@ -110,26 +88,24 @@ CONTAINS
 !>          mixed environment.
 !> \param mixed_env ...
 !> \param subsys ...
-!> \param cell ...
-!> \param cell_ref ...
 !> \param force_env_section ...
 !> \param subsys_section ...
 !> \date    11.06
 !> \author  fschiff
 !> \version 1.0
 ! **************************************************************************************************
-   SUBROUTINE mixed_init_subsys(mixed_env, subsys, cell, cell_ref, &
-                                force_env_section, subsys_section)
+   SUBROUTINE mixed_init_subsys(mixed_env, subsys, force_env_section, &
+                                subsys_section)
 
       TYPE(mixed_environment_type), INTENT(INOUT)        :: mixed_env
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(section_vals_type), POINTER                   :: force_env_section, subsys_section
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'mixed_init_subsys'
 
       INTEGER                                            :: handle
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: my_cell_ref
       TYPE(distribution_1d_type), POINTER                :: local_molecules, local_particles
       TYPE(mixed_energy_type), POINTER                   :: mixed_energy
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
@@ -137,11 +113,12 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       CALL timeset(routineN, handle)
-      NULLIFY (mixed_energy, local_molecules, local_particles)
+      NULLIFY (mixed_energy, local_molecules, local_particles, my_cell_ref)
       particle_set => subsys%particles%els
       atomic_kind_set => subsys%atomic_kinds%els
       molecule_set => subsys%molecules%els
       molecule_kind_set => subsys%molecule_kinds%els
+      my_cell_ref => subsys%cell_ref
 
       ! Create the mixed_energy_type
       CALL allocate_mixed_energy(mixed_energy)
@@ -158,12 +135,10 @@ CONTAINS
                                    local_molecules=local_molecules, &
                                    force_env_section=force_env_section)
 
-      CALL cp_subsys_set(subsys, cell=cell)
-
       ! set the mixed_env
       CALL set_mixed_env(mixed_env=mixed_env, subsys=subsys)
       CALL set_mixed_env(mixed_env=mixed_env, &
-                         cell_ref=cell_ref, &
+                         cell_ref=my_cell_ref, &
                          local_molecules=local_molecules, &
                          local_particles=local_particles, &
                          mixed_energy=mixed_energy)

--- a/src/nnp_environment.F
+++ b/src/nnp_environment.F
@@ -18,6 +18,11 @@ MODULE nnp_environment
                                               Schran2020a,&
                                               Schran2020b,&
                                               cite_reference
+   USE cell_methods,                    ONLY: read_cell,&
+                                              write_cell
+   USE cell_types,                      ONLY: cell_release,&
+                                              cell_type,&
+                                              get_cell
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_unit_nr,&
                                               cp_logger_type
@@ -28,7 +33,8 @@ MODULE nnp_environment
                                               parser_release,&
                                               parser_reset
    USE cp_subsys_methods,               ONLY: cp_subsys_create
-   USE cp_subsys_types,                 ONLY: cp_subsys_type
+   USE cp_subsys_types,                 ONLY: cp_subsys_set,&
+                                              cp_subsys_type
    USE distribution_1d_types,           ONLY: distribution_1d_release,&
                                               distribution_1d_type
    USE distribution_methods,            ONLY: distribute_molecules_1d
@@ -92,9 +98,11 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'nnp_init'
 
       INTEGER                                            :: handle
-      LOGICAL                                            :: explicit
+      LOGICAL                                            :: explicit, use_ref_cell
+      REAL(KIND=dp), DIMENSION(3)                        :: abc
+      TYPE(cell_type), POINTER                           :: cell, cell_ref
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(section_vals_type), POINTER                   :: nnp_section
+      TYPE(section_vals_type), POINTER                   :: cell_section, nnp_section
 
       CALL timeset(routineN, handle)
       CALL cite_reference(Behler2007)
@@ -104,11 +112,12 @@ CONTAINS
 
       CPASSERT(ASSOCIATED(nnp_env))
 
-      NULLIFY (nnp_section, subsys)
+      NULLIFY (cell_section, nnp_section, cell, cell_ref, subsys)
 
       IF (.NOT. ASSOCIATED(subsys_section)) THEN
          subsys_section => section_vals_get_subs_vals(force_env_section, "SUBSYS")
       END IF
+      cell_section => section_vals_get_subs_vals(subsys_section, "CELL")
       nnp_section => section_vals_get_subs_vals(force_env_section, "NNP")
       CALL section_vals_get(nnp_section, explicit=explicit)
       IF (.NOT. explicit) THEN
@@ -118,12 +127,21 @@ CONTAINS
       CALL nnp_env_set(nnp_env=nnp_env, nnp_input=nnp_section, &
                        force_env_input=force_env_section)
 
+      CALL read_cell(cell=cell, cell_ref=cell_ref, use_ref_cell=use_ref_cell, cell_section=cell_section, &
+                     para_env=para_env)
+      CALL get_cell(cell=cell, abc=abc)
+      CALL write_cell(cell=cell, subsys_section=subsys_section)
+
       CALL cp_subsys_create(subsys, para_env, root_section, &
                             force_env_section=force_env_section, subsys_section=subsys_section, &
                             use_motion_section=use_motion_section)
 
-      CALL nnp_init_subsys(nnp_env=nnp_env, subsys=subsys, &
+      CALL nnp_init_subsys(nnp_env=nnp_env, subsys=subsys, cell=cell, &
+                           cell_ref=cell_ref, use_ref_cell=use_ref_cell, &
                            subsys_section=subsys_section)
+
+      CALL cell_release(cell)
+      CALL cell_release(cell_ref)
 
       CALL timestop(handle)
 
@@ -133,13 +151,18 @@ CONTAINS
 !> \brief Read and initialize all the information for neural network potentials
 !> \param nnp_env ...
 !> \param subsys ...
+!> \param cell ...
+!> \param cell_ref ...
+!> \param use_ref_cell ...
 !> \param subsys_section ...
 !> \date   2020-10-10
 !> \author Christoph Schran (christoph.schran@rub.de)
 ! **************************************************************************************************
-   SUBROUTINE nnp_init_subsys(nnp_env, subsys, subsys_section)
+   SUBROUTINE nnp_init_subsys(nnp_env, subsys, cell, cell_ref, use_ref_cell, subsys_section)
       TYPE(nnp_type), INTENT(INOUT), POINTER             :: nnp_env
       TYPE(cp_subsys_type), INTENT(IN), POINTER          :: subsys
+      TYPE(cell_type), INTENT(INOUT), POINTER            :: cell, cell_ref
+      LOGICAL, INTENT(IN)                                :: use_ref_cell
       TYPE(section_vals_type), INTENT(IN), POINTER       :: subsys_section
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'nnp_init_subsys'
@@ -164,16 +187,11 @@ CONTAINS
       !Print the molecule kind set
       CALL write_molecule_kind_set(molecule_kind_set, subsys_section)
 
-      !Set up cell
-      CALL nnp_env_set(nnp_env=nnp_env, subsys=subsys, &
-                       cell=subsys%cell, cell_ref=subsys%cell_ref, &
-                       use_ref_cell=subsys%use_ref_cell)
-
       !Print the atomic coordinates
       CALL write_fist_particle_coordinates(particle_set, subsys_section)
-      CALL write_particle_distances(particle_set, cell=nnp_env%cell, &
+      CALL write_particle_distances(particle_set, cell=cell, &
                                     subsys_section=subsys_section)
-      CALL write_structure_data(particle_set, cell=nnp_env%cell, &
+      CALL write_structure_data(particle_set, cell=cell, &
                                 input_section=subsys_section)
 
       !Distribute molecules and atoms using the new data structures
@@ -202,7 +220,10 @@ CONTAINS
       ALLOCATE (nnp_env%sort(natom))
       ALLOCATE (nnp_env%sort_inv(natom))
 
-      CALL nnp_env_set(nnp_env=nnp_env, &
+      CALL cp_subsys_set(subsys, cell=cell)
+
+      CALL nnp_env_set(nnp_env=nnp_env, subsys=subsys, &
+                       cell_ref=cell_ref, use_ref_cell=use_ref_cell, &
                        local_molecules=local_molecules, &
                        local_particles=local_particles)
 

--- a/src/nnp_environment.F
+++ b/src/nnp_environment.F
@@ -18,11 +18,6 @@ MODULE nnp_environment
                                               Schran2020a,&
                                               Schran2020b,&
                                               cite_reference
-   USE cell_methods,                    ONLY: read_cell,&
-                                              write_cell
-   USE cell_types,                      ONLY: cell_release,&
-                                              cell_type,&
-                                              get_cell
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_unit_nr,&
                                               cp_logger_type
@@ -33,8 +28,7 @@ MODULE nnp_environment
                                               parser_release,&
                                               parser_reset
    USE cp_subsys_methods,               ONLY: cp_subsys_create
-   USE cp_subsys_types,                 ONLY: cp_subsys_set,&
-                                              cp_subsys_type
+   USE cp_subsys_types,                 ONLY: cp_subsys_type
    USE distribution_1d_types,           ONLY: distribution_1d_release,&
                                               distribution_1d_type
    USE distribution_methods,            ONLY: distribute_molecules_1d
@@ -98,11 +92,9 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'nnp_init'
 
       INTEGER                                            :: handle
-      LOGICAL                                            :: explicit, use_ref_cell
-      REAL(KIND=dp), DIMENSION(3)                        :: abc
-      TYPE(cell_type), POINTER                           :: cell, cell_ref
+      LOGICAL                                            :: explicit
       TYPE(cp_subsys_type), POINTER                      :: subsys
-      TYPE(section_vals_type), POINTER                   :: cell_section, nnp_section
+      TYPE(section_vals_type), POINTER                   :: nnp_section
 
       CALL timeset(routineN, handle)
       CALL cite_reference(Behler2007)
@@ -112,12 +104,11 @@ CONTAINS
 
       CPASSERT(ASSOCIATED(nnp_env))
 
-      NULLIFY (cell_section, nnp_section, cell, cell_ref, subsys)
+      NULLIFY (nnp_section, subsys)
 
       IF (.NOT. ASSOCIATED(subsys_section)) THEN
          subsys_section => section_vals_get_subs_vals(force_env_section, "SUBSYS")
       END IF
-      cell_section => section_vals_get_subs_vals(subsys_section, "CELL")
       nnp_section => section_vals_get_subs_vals(force_env_section, "NNP")
       CALL section_vals_get(nnp_section, explicit=explicit)
       IF (.NOT. explicit) THEN
@@ -127,21 +118,12 @@ CONTAINS
       CALL nnp_env_set(nnp_env=nnp_env, nnp_input=nnp_section, &
                        force_env_input=force_env_section)
 
-      CALL read_cell(cell=cell, cell_ref=cell_ref, use_ref_cell=use_ref_cell, cell_section=cell_section, &
-                     para_env=para_env)
-      CALL get_cell(cell=cell, abc=abc)
-      CALL write_cell(cell=cell, subsys_section=subsys_section)
-
       CALL cp_subsys_create(subsys, para_env, root_section, &
                             force_env_section=force_env_section, subsys_section=subsys_section, &
                             use_motion_section=use_motion_section)
 
-      CALL nnp_init_subsys(nnp_env=nnp_env, subsys=subsys, cell=cell, &
-                           cell_ref=cell_ref, use_ref_cell=use_ref_cell, &
+      CALL nnp_init_subsys(nnp_env=nnp_env, subsys=subsys, &
                            subsys_section=subsys_section)
-
-      CALL cell_release(cell)
-      CALL cell_release(cell_ref)
 
       CALL timestop(handle)
 
@@ -151,18 +133,13 @@ CONTAINS
 !> \brief Read and initialize all the information for neural network potentials
 !> \param nnp_env ...
 !> \param subsys ...
-!> \param cell ...
-!> \param cell_ref ...
-!> \param use_ref_cell ...
 !> \param subsys_section ...
 !> \date   2020-10-10
 !> \author Christoph Schran (christoph.schran@rub.de)
 ! **************************************************************************************************
-   SUBROUTINE nnp_init_subsys(nnp_env, subsys, cell, cell_ref, use_ref_cell, subsys_section)
+   SUBROUTINE nnp_init_subsys(nnp_env, subsys, subsys_section)
       TYPE(nnp_type), INTENT(INOUT), POINTER             :: nnp_env
       TYPE(cp_subsys_type), INTENT(IN), POINTER          :: subsys
-      TYPE(cell_type), INTENT(INOUT), POINTER            :: cell, cell_ref
-      LOGICAL, INTENT(IN)                                :: use_ref_cell
       TYPE(section_vals_type), INTENT(IN), POINTER       :: subsys_section
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'nnp_init_subsys'
@@ -187,11 +164,16 @@ CONTAINS
       !Print the molecule kind set
       CALL write_molecule_kind_set(molecule_kind_set, subsys_section)
 
+      !Set up cell
+      CALL nnp_env_set(nnp_env=nnp_env, subsys=subsys, &
+                       cell=subsys%cell, cell_ref=subsys%cell_ref, &
+                       use_ref_cell=subsys%use_ref_cell)
+
       !Print the atomic coordinates
       CALL write_fist_particle_coordinates(particle_set, subsys_section)
-      CALL write_particle_distances(particle_set, cell=cell, &
+      CALL write_particle_distances(particle_set, cell=nnp_env%cell, &
                                     subsys_section=subsys_section)
-      CALL write_structure_data(particle_set, cell=cell, &
+      CALL write_structure_data(particle_set, cell=nnp_env%cell, &
                                 input_section=subsys_section)
 
       !Distribute molecules and atoms using the new data structures
@@ -220,10 +202,7 @@ CONTAINS
       ALLOCATE (nnp_env%sort(natom))
       ALLOCATE (nnp_env%sort_inv(natom))
 
-      CALL cp_subsys_set(subsys, cell=cell)
-
-      CALL nnp_env_set(nnp_env=nnp_env, subsys=subsys, &
-                       cell_ref=cell_ref, use_ref_cell=use_ref_cell, &
+      CALL nnp_env_set(nnp_env=nnp_env, &
                        local_molecules=local_molecules, &
                        local_particles=local_particles)
 

--- a/src/nnp_environment.F
+++ b/src/nnp_environment.F
@@ -18,6 +18,7 @@ MODULE nnp_environment
                                               Schran2020a,&
                                               Schran2020b,&
                                               cite_reference
+   USE cell_types,                      ONLY: cell_type
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_unit_nr,&
                                               cp_logger_type
@@ -146,6 +147,7 @@ CONTAINS
 
       INTEGER                                            :: handle, natom
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(cell_type), POINTER                           :: my_cell, my_cell_ref
       TYPE(distribution_1d_type), POINTER                :: local_molecules, local_particles
       TYPE(molecule_kind_type), DIMENSION(:), POINTER    :: molecule_kind_set
       TYPE(molecule_type), DIMENSION(:), POINTER         :: molecule_set
@@ -153,27 +155,29 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (atomic_kind_set, molecule_kind_set, particle_set, molecule_set, &
-               local_molecules, local_particles)
+      NULLIFY (atomic_kind_set, molecule_kind_set, my_cell, my_cell_ref, &
+               particle_set, molecule_set, local_molecules, local_particles)
 
       particle_set => subsys%particles%els
       atomic_kind_set => subsys%atomic_kinds%els
       molecule_kind_set => subsys%molecule_kinds%els
       molecule_set => subsys%molecules%els
+      my_cell => subsys%cell
+      my_cell_ref => subsys%cell_ref
 
       !Print the molecule kind set
       CALL write_molecule_kind_set(molecule_kind_set, subsys_section)
 
       !Set up cell
       CALL nnp_env_set(nnp_env=nnp_env, subsys=subsys, &
-                       cell=subsys%cell, cell_ref=subsys%cell_ref, &
+                       cell=my_cell, cell_ref=my_cell_ref, &
                        use_ref_cell=subsys%use_ref_cell)
 
       !Print the atomic coordinates
       CALL write_fist_particle_coordinates(particle_set, subsys_section)
-      CALL write_particle_distances(particle_set, cell=nnp_env%cell, &
+      CALL write_particle_distances(particle_set, cell=my_cell, &
                                     subsys_section=subsys_section)
-      CALL write_structure_data(particle_set, cell=nnp_env%cell, &
+      CALL write_structure_data(particle_set, cell=my_cell, &
                                 input_section=subsys_section)
 
       !Distribute molecules and atoms using the new data structures

--- a/src/qs_subsys_methods.F
+++ b/src/qs_subsys_methods.F
@@ -15,10 +15,16 @@ MODULE qs_subsys_methods
                                               get_atomic_kind
    USE basis_set_types,                 ONLY: get_gto_basis_set,&
                                               gto_basis_set_type
-   USE cell_types,                      ONLY: cell_type
+   USE cell_methods,                    ONLY: cell_create,&
+                                              read_cell,&
+                                              write_cell
+   USE cell_types,                      ONLY: cell_clone,&
+                                              cell_release,&
+                                              cell_type
    USE cp_subsys_methods,               ONLY: cp_subsys_create
    USE cp_subsys_types,                 ONLY: cp_subsys_get,&
                                               cp_subsys_release,&
+                                              cp_subsys_set,&
                                               cp_subsys_type
    USE external_potential_types,        ONLY: all_potential_type,&
                                               get_potential,&
@@ -80,10 +86,9 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: my_cell, my_cell_ref
       TYPE(cp_subsys_type), POINTER                      :: my_cp_subsys
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(section_vals_type), POINTER                   :: kind_section
+      TYPE(section_vals_type), POINTER                   :: cell_section, kind_section
 
-      NULLIFY (atomic_kind_set, qs_kind_set, kind_section, my_cell, &
-               my_cell_ref, my_cp_subsys)
+      NULLIFY (atomic_kind_set, qs_kind_set, cell_section, kind_section, my_cell, my_cell_ref, my_cp_subsys)
 
       be_silent = .FALSE.
       IF (PRESENT(silent)) be_silent = silent
@@ -100,23 +105,36 @@ CONTAINS
          CPABORT("qs_subsys_create: cp_subsys or root_section needed")
       END IF
 
-      ! Note: the input cell and cell_ref seems to be not removable as qs_init() and
-      ! qs_init_subsys() pass them, and qs_init() is called in qmmm_env_create()
-      ! where distinction between qm_cell_small and mm_cell is important.
+      ! create cp_subsys%cell
+      !TODO: moved to cp_subsys_create(), needs further disentanglement of cell_ref.
+      ![NB] subroutines qs_init() and qs_init_subsys() may pass cell and cell_ref to
+      ! qs_subsys_create() here, and two places where qs_init() is called are tricky:
+      ! 1. For QM/MM calculation, qmmm_env_create() passes "qm_cell_small" from
+      !    setup_qmmm_vars_qm() to qs_init() and subsequently to my_cell here;
+      ! 2. For BSSE calculation, eval_bsse_energy_low() calls create_small_subsys()
+      !    to create cp_subsys_type "subsys_loc" and then calls qs_init() with
+      !    subsys_loc, but create_small_subsys() does not set subsys_loc%cell.
+      ! If not for these, it would have been easy to set my_cell => my_cp_subsys%cell
+      ! and my_cell_ref => my_cp_subsys%cell_ref so as to avoid re-read the cell_section
+      ! when cell and cell_ref are not passed as input here.
       use_ref_cell = .FALSE.
       IF (PRESENT(cell)) THEN
          my_cell => cell
+         IF (PRESENT(cell_ref)) THEN
+            my_cell_ref => cell_ref
+            use_ref_cell = .TRUE.
+         ELSE
+            CALL cell_create(my_cell_ref)
+            CALL cell_clone(my_cell, my_cell_ref, tag="CELL_REF")
+         END IF
       ELSE
-         CPASSERT(ASSOCIATED(my_cp_subsys%cell))
-         my_cell => my_cp_subsys%cell
+         cell_section => section_vals_get_subs_vals(subsys_section, "CELL")
+         CALL read_cell(my_cell, my_cell_ref, use_ref_cell=use_ref_cell, &
+                        cell_section=cell_section, para_env=para_env)
       END IF
-      IF (PRESENT(cell_ref)) THEN
-         my_cell_ref => cell_ref
-      ELSE
-         CPASSERT(ASSOCIATED(my_cp_subsys%cell_ref))
-         my_cell_ref => my_cp_subsys%cell_ref
-      END IF
-      IF (PRESENT(cell) .AND. PRESENT(cell_ref)) use_ref_cell = .TRUE.
+      CALL cp_subsys_set(my_cp_subsys, cell=my_cell)
+      CALL write_cell(my_cell, subsys_section)
+      CALL write_cell(my_cell_ref, subsys_section)
 
       ! setup qs_kinds
       CALL cp_subsys_get(my_cp_subsys, atomic_kind_set=atomic_kind_set)
@@ -133,6 +151,8 @@ CONTAINS
                          use_ref_cell=use_ref_cell, &
                          qs_kind_set=qs_kind_set)
 
+      IF (.NOT. PRESENT(cell)) CALL cell_release(my_cell)
+      IF (.NOT. PRESENT(cell_ref)) CALL cell_release(my_cell_ref)
       IF (.NOT. PRESENT(cp_subsys)) CALL cp_subsys_release(my_cp_subsys)
 
    END SUBROUTINE qs_subsys_create

--- a/src/qs_subsys_methods.F
+++ b/src/qs_subsys_methods.F
@@ -15,16 +15,10 @@ MODULE qs_subsys_methods
                                               get_atomic_kind
    USE basis_set_types,                 ONLY: get_gto_basis_set,&
                                               gto_basis_set_type
-   USE cell_methods,                    ONLY: cell_create,&
-                                              read_cell,&
-                                              write_cell
-   USE cell_types,                      ONLY: cell_clone,&
-                                              cell_release,&
-                                              cell_type
+   USE cell_types,                      ONLY: cell_type
    USE cp_subsys_methods,               ONLY: cp_subsys_create
    USE cp_subsys_types,                 ONLY: cp_subsys_get,&
                                               cp_subsys_release,&
-                                              cp_subsys_set,&
                                               cp_subsys_type
    USE external_potential_types,        ONLY: all_potential_type,&
                                               get_potential,&
@@ -86,9 +80,10 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: my_cell, my_cell_ref
       TYPE(cp_subsys_type), POINTER                      :: my_cp_subsys
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(section_vals_type), POINTER                   :: cell_section, kind_section
+      TYPE(section_vals_type), POINTER                   :: kind_section
 
-      NULLIFY (atomic_kind_set, qs_kind_set, cell_section, kind_section, my_cell, my_cell_ref, my_cp_subsys)
+      NULLIFY (atomic_kind_set, qs_kind_set, kind_section, my_cell, &
+               my_cell_ref, my_cp_subsys)
 
       be_silent = .FALSE.
       IF (PRESENT(silent)) be_silent = silent
@@ -105,26 +100,23 @@ CONTAINS
          CPABORT("qs_subsys_create: cp_subsys or root_section needed")
       END IF
 
-      ! create cp_subsys%cell
-      !TODO: moved to cp_subsys_create(), needs further disentanglement of cell_ref.
+      ! Note: the input cell and cell_ref seems to be not removable as qs_init() and
+      ! qs_init_subsys() pass them, and qs_init() is called in qmmm_env_create()
+      ! where distinction between qm_cell_small and mm_cell is important.
       use_ref_cell = .FALSE.
       IF (PRESENT(cell)) THEN
          my_cell => cell
-         IF (PRESENT(cell_ref)) THEN
-            my_cell_ref => cell_ref
-            use_ref_cell = .TRUE.
-         ELSE
-            CALL cell_create(my_cell_ref)
-            CALL cell_clone(my_cell, my_cell_ref, tag="CELL_REF")
-         END IF
       ELSE
-         cell_section => section_vals_get_subs_vals(subsys_section, "CELL")
-         CALL read_cell(my_cell, my_cell_ref, use_ref_cell=use_ref_cell, &
-                        cell_section=cell_section, para_env=para_env)
+         CPASSERT(ASSOCIATED(my_cp_subsys%cell))
+         my_cell => my_cp_subsys%cell
       END IF
-      CALL cp_subsys_set(my_cp_subsys, cell=my_cell)
-      CALL write_cell(my_cell, subsys_section)
-      CALL write_cell(my_cell_ref, subsys_section)
+      IF (PRESENT(cell_ref)) THEN
+         my_cell_ref => cell_ref
+      ELSE
+         CPASSERT(ASSOCIATED(my_cp_subsys%cell_ref))
+         my_cell_ref => my_cp_subsys%cell_ref
+      END IF
+      IF (PRESENT(cell) .AND. PRESENT(cell_ref)) use_ref_cell = .TRUE.
 
       ! setup qs_kinds
       CALL cp_subsys_get(my_cp_subsys, atomic_kind_set=atomic_kind_set)
@@ -141,8 +133,6 @@ CONTAINS
                          use_ref_cell=use_ref_cell, &
                          qs_kind_set=qs_kind_set)
 
-      IF (.NOT. PRESENT(cell)) CALL cell_release(my_cell)
-      IF (.NOT. PRESENT(cell_ref)) CALL cell_release(my_cell_ref)
       IF (.NOT. PRESENT(cp_subsys)) CALL cp_subsys_release(my_cp_subsys)
 
    END SUBROUTINE qs_subsys_create

--- a/src/subsys/cp_subsys_types.F
+++ b/src/subsys/cp_subsys_types.F
@@ -108,7 +108,8 @@ MODULE cp_subsys_types
       TYPE(atprop_type), POINTER                 :: atprop => Null()
       TYPE(virial_type), POINTER                 :: virial => Null()
       TYPE(cp_result_type), POINTER              :: results => Null()
-      TYPE(cell_type), POINTER                   :: cell => Null()
+      TYPE(cell_type), POINTER                   :: cell => Null(), cell_ref => Null()
+      LOGICAL                                    :: use_ref_cell = .FALSE.
    END TYPE cp_subsys_type
 
 ! **************************************************************************************************
@@ -172,6 +173,7 @@ CONTAINS
             IF (ASSOCIATED(subsys%virial)) DEALLOCATE (subsys%virial)
             CALL cp_result_release(subsys%results)
             CALL cell_release(subsys%cell)
+            CALL cell_release(subsys%cell_ref)
             DEALLOCATE (subsys)
          END IF
          NULLIFY (subsys)
@@ -195,13 +197,16 @@ CONTAINS
 !> \param multipoles ...
 !> \param results ...
 !> \param cell ...
+!> \param cell_ref ...
+!> \param use_ref_cell ...
 !> \par History
 !>      08.2003 created [fawzi]
 !> \author Fawzi Mohamed
 ! **************************************************************************************************
    SUBROUTINE cp_subsys_set(subsys, atomic_kinds, particles, local_particles, &
                             molecules, molecule_kinds, local_molecules, para_env, &
-                            colvar_p, shell_particles, core_particles, gci, multipoles, results, cell)
+                            colvar_p, shell_particles, core_particles, gci, multipoles, &
+                            results, cell, cell_ref, use_ref_cell)
       TYPE(cp_subsys_type), INTENT(INOUT)                :: subsys
       TYPE(atomic_kind_list_type), OPTIONAL, POINTER     :: atomic_kinds
       TYPE(particle_list_type), OPTIONAL, POINTER        :: particles
@@ -216,7 +221,8 @@ CONTAINS
       TYPE(global_constraint_type), OPTIONAL, POINTER    :: gci
       TYPE(multipole_type), OPTIONAL, POINTER            :: multipoles
       TYPE(cp_result_type), OPTIONAL, POINTER            :: results
-      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
+      TYPE(cell_type), OPTIONAL, POINTER                 :: cell, cell_ref
+      LOGICAL, OPTIONAL                                  :: use_ref_cell
 
       CPASSERT(subsys%ref_count > 0)
       IF (PRESENT(multipoles)) THEN
@@ -299,6 +305,17 @@ CONTAINS
             subsys%cell => cell
          END IF
       END IF
+      IF (PRESENT(cell_ref)) THEN
+         IF (ASSOCIATED(cell_ref)) THEN
+            CALL cell_retain(cell_ref)
+            CALL cell_release(subsys%cell_ref)
+            subsys%cell_ref => cell_ref
+            subsys%use_ref_cell = .TRUE.
+         END IF
+      END IF
+      IF (PRESENT(use_ref_cell)) THEN
+         subsys%use_ref_cell = use_ref_cell
+      END IF
    END SUBROUTINE cp_subsys_set
 
 ! **************************************************************************************************
@@ -330,6 +347,8 @@ CONTAINS
 !> \param virial ...
 !> \param results ...
 !> \param cell ...
+!> \param cell_ref ...
+!> \param use_ref_cell ...
 !> \par History
 !>      08.2003 created [fawzi]
 !>      22.11.2010 (MK)
@@ -341,7 +360,7 @@ CONTAINS
                             molecule_kind_set, local_molecules, para_env, colvar_p, &
                             shell_particles, core_particles, gci, multipoles, &
                             natom, nparticle, ncore, nshell, nkind, atprop, virial, &
-                            results, cell)
+                            results, cell, cell_ref, use_ref_cell)
       TYPE(cp_subsys_type), INTENT(IN)                   :: subsys
       INTEGER, INTENT(out), OPTIONAL                     :: ref_count
       TYPE(atomic_kind_list_type), OPTIONAL, POINTER     :: atomic_kinds
@@ -368,7 +387,8 @@ CONTAINS
       TYPE(atprop_type), OPTIONAL, POINTER               :: atprop
       TYPE(virial_type), OPTIONAL, POINTER               :: virial
       TYPE(cp_result_type), OPTIONAL, POINTER            :: results
-      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
+      TYPE(cell_type), OPTIONAL, POINTER                 :: cell, cell_ref
+      LOGICAL, OPTIONAL                                  :: use_ref_cell
 
       INTEGER                                            :: n_atom, n_core, n_shell
 
@@ -399,6 +419,8 @@ CONTAINS
       IF (PRESENT(atprop)) atprop => subsys%atprop
       IF (PRESENT(results)) results => subsys%results
       IF (PRESENT(cell)) cell => subsys%cell
+      IF (PRESENT(cell_ref)) cell_ref => subsys%cell_ref
+      IF (PRESENT(use_ref_cell)) use_ref_cell = subsys%use_ref_cell
       IF (PRESENT(nkind)) nkind = SIZE(subsys%atomic_kinds%els)
 
       IF (PRESENT(natom) .OR. PRESENT(nparticle) .OR. PRESENT(nshell)) THEN

--- a/src/topology.F
+++ b/src/topology.F
@@ -197,7 +197,7 @@ CONTAINS
       CALL cell_clone(my_cell, topology%cell)
       CALL cell_clone(my_cell_ref, topology%cell_ref)
       CALL setup_cell_muc(topology%cell_muc, topology%cell, subsys_section)
-      IF (PRESENT(subsys) .AND. (.NOT. my_qmmm)) THEN
+      IF (PRESENT(subsys)) THEN ! subsys is passed from cp_subsys_create
          CALL cp_subsys_set(subsys, cell=my_cell, cell_ref=my_cell_ref)
       END IF
       CALL cell_release(my_cell)

--- a/src/topology.F
+++ b/src/topology.F
@@ -16,7 +16,8 @@ MODULE topology
    USE cell_methods,                    ONLY: cell_create,&
                                               read_cell,&
                                               write_cell
-   USE cell_types,                      ONLY: cell_retain,&
+   USE cell_types,                      ONLY: cell_clone,&
+                                              cell_retain,&
                                               cell_type
    USE colvar_types,                    ONLY: colvar_p_type,&
                                               colvar_setup,&
@@ -151,6 +152,7 @@ CONTAINS
       INTEGER                                            :: handle, iw, iw2
       LOGICAL                                            :: binary_coord_read, el_as_kind, explicit, &
                                                             my_qmmm
+      TYPE(cell_type), POINTER                           :: my_cell, my_cell_ref
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(section_vals_type), POINTER                   :: cell_section, constraint_section, &
                                                             topology_section
@@ -186,11 +188,16 @@ CONTAINS
       CALL init_topology(topology)
 
       ! 2. Get the cell info
-      CALL read_cell(topology%cell, topology%cell_ref, cell_section=cell_section, &
+      NULLIFY (my_cell, my_cell_ref)
+      CALL read_cell(my_cell, my_cell_ref, cell_section=cell_section, &
                      topology_section=topology_section, para_env=para_env)
+      IF (.NOT. ASSOCIATED(topology%cell)) CALL cell_create(topology%cell)
+      IF (.NOT. ASSOCIATED(topology%cell_ref)) CALL cell_create(topology%cell_ref)
+      CALL cell_clone(my_cell, topology%cell)
+      CALL cell_clone(my_cell_ref, topology%cell_ref)
       CALL setup_cell_muc(topology%cell_muc, topology%cell, subsys_section)
       IF (PRESENT(subsys) .AND. (.NOT. my_qmmm)) THEN
-         CALL cp_subsys_set(subsys, cell=topology%cell, cell_ref=topology%cell_ref)
+         CALL cp_subsys_set(subsys, cell=my_cell, cell_ref=my_cell_ref)
       END IF
 
       ! 3. Read in the topology section in the input file if any

--- a/src/topology.F
+++ b/src/topology.F
@@ -26,6 +26,8 @@ MODULE topology
                                               cp_logger_type
    USE cp_output_handling,              ONLY: cp_print_key_finished_output,&
                                               cp_print_key_unit_nr
+   USE cp_subsys_types,                 ONLY: cp_subsys_set,&
+                                              cp_subsys_type
    USE exclusion_types,                 ONLY: exclusion_type
    USE input_constants,                 ONLY: &
         do_conn_amb7, do_conn_g87, do_conn_g96, do_conn_generate, do_conn_mol_set, do_conn_off, &
@@ -120,10 +122,12 @@ CONTAINS
 !> \param use_motion_section ...
 !> \param exclusions ...
 !> \param elkind ...
+!> \param subsys ...
 ! **************************************************************************************************
    SUBROUTINE topology_control(atomic_kind_set, particle_set, molecule_kind_set, &
                                molecule_set, colvar_p, gci, root_section, para_env, qmmm, qmmm_env, &
-                               force_env_section, subsys_section, use_motion_section, exclusions, elkind)
+                               force_env_section, subsys_section, use_motion_section, &
+                               exclusions, elkind, subsys)
 
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -140,6 +144,7 @@ CONTAINS
       TYPE(exclusion_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: exclusions
       LOGICAL, INTENT(IN), OPTIONAL                      :: elkind
+      TYPE(cp_subsys_type), OPTIONAL, POINTER            :: subsys
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'topology_control'
 
@@ -182,9 +187,11 @@ CONTAINS
 
       ! 2. Get the cell info
       CALL read_cell(topology%cell, topology%cell_ref, cell_section=cell_section, &
-                     para_env=para_env)
-      CALL write_cell(topology%cell, subsys_section, tag="CELL_TOP")
+                     topology_section=topology_section, para_env=para_env)
       CALL setup_cell_muc(topology%cell_muc, topology%cell, subsys_section)
+      IF (PRESENT(subsys) .AND. (.NOT. my_qmmm)) THEN
+         CALL cp_subsys_set(subsys, cell=topology%cell, cell_ref=topology%cell_ref)
+      END IF
 
       ! 3. Read in the topology section in the input file if any
       CALL read_topology_section(topology, topology_section)

--- a/src/topology.F
+++ b/src/topology.F
@@ -17,6 +17,7 @@ MODULE topology
                                               read_cell,&
                                               write_cell
    USE cell_types,                      ONLY: cell_clone,&
+                                              cell_release,&
                                               cell_retain,&
                                               cell_type
    USE colvar_types,                    ONLY: colvar_p_type,&
@@ -199,6 +200,8 @@ CONTAINS
       IF (PRESENT(subsys) .AND. (.NOT. my_qmmm)) THEN
          CALL cp_subsys_set(subsys, cell=my_cell, cell_ref=my_cell_ref)
       END IF
+      CALL cell_release(my_cell)
+      CALL cell_release(my_cell_ref)
 
       ! 3. Read in the topology section in the input file if any
       CALL read_topology_section(topology, topology_section)

--- a/src/topology.F
+++ b/src/topology.F
@@ -200,6 +200,8 @@ CONTAINS
       IF (PRESENT(subsys)) THEN ! subsys is passed from cp_subsys_create
          CALL cp_subsys_set(subsys, cell=my_cell, cell_ref=my_cell_ref)
       END IF
+      CALL write_cell(my_cell, subsys_section, tag="CELL")
+      CALL write_cell(my_cell_ref, subsys_section, tag="CELL_REF")
       CALL cell_release(my_cell)
       CALL cell_release(my_cell_ref)
 


### PR DESCRIPTION
While working on the proposal in #4962 to parse cell information from topology file, I discovered that many environment initialization routines use `read_cell()` and `cp_subsys_create()` together.
https://github.com/cp2k/cp2k/blob/7a2a2325688a604b8fabcf9d9fe03426e2037a48/src/eip_environment.F#L104-L116
https://github.com/cp2k/cp2k/blob/7a2a2325688a604b8fabcf9d9fe03426e2037a48/src/embed_environment.F#L84-L100
https://github.com/cp2k/cp2k/blob/7a2a2325688a604b8fabcf9d9fe03426e2037a48/src/ipi_environment.F#L98-L109
https://github.com/cp2k/cp2k/blob/7a2a2325688a604b8fabcf9d9fe03426e2037a48/src/mixed_environment.F#L86-L102
https://github.com/cp2k/cp2k/blob/7a2a2325688a604b8fabcf9d9fe03426e2037a48/src/nnp_environment.F#L130-L144
This is even the case for long-estabilished modules like FIST...
https://github.com/cp2k/cp2k/blob/7a2a2325688a604b8fabcf9d9fe03426e2037a48/src/fist_environment.F#L143-L165
https://github.com/cp2k/cp2k/blob/7a2a2325688a604b8fabcf9d9fe03426e2037a48/src/fist_environment.F#L197-L201
and QS, lampshaded by a TODO remark.
https://github.com/cp2k/cp2k/blob/7a2a2325688a604b8fabcf9d9fe03426e2037a48/src/qs_subsys_methods.F#L99-L125
https://github.com/cp2k/cp2k/blob/7a2a2325688a604b8fabcf9d9fe03426e2037a48/src/qs_subsys_methods.F#L138-L145
Due to the fact that `cp_subsys_create()` calls `topology_control()` which calls `read_cell()` which already parses input for cell and cell_ref information, a separate call of `read_cell()` before or after calling `cp_subsys_create()` seems like a piece of tech debt that makes maintenance of `read_cell()` harder. In addition, this seems to result in outputs containing `CELL|`, `CELL_REF|` and `CELL_TOP|` printouts which can be confusing.

This PR would like to address this problem by taking cell and cell_ref information from the subsys as treated by `cp_subsys_create()`. This may be a risky move since behaviors in periodic boudary condition (PBC) setup vary from module to module, so substantial behavior-affecting edits are yet to be included in the first commit.