### PR TITLE
Add spin-channel-specific mixing parameters

### DIFF
--- a/src/qs_density_mixing_types.F
+++ b/src/qs_density_mixing_types.F
@@ -63,8 +63,11 @@ MODULE qs_density_mixing_types
                                                            max_g2 = -1.0_dp, max_gvec_exp = -1.0_dp, pulay_alpha = -1.0_dp, &
                                                            pulay_beta = -1.0_dp, r_step = -1.0_dp, reg_par = -1.0_dp, &
                                                            sigma_max = -1.0_dp, wc = -1.0_dp, wmax = -1.0_dp
+      ! Spin-channel-specific mixing parameters (for nspin==2, ispin=2 is the magnetization channel)
+      REAL(KIND=dp)                                     :: alpha_mag = -1.0_dp, beta_mag = -1.0_dp
       REAL(KIND=dp), DIMENSION(:), POINTER              :: p_metric => NULL()
       REAL(KIND=dp), DIMENSION(:), POINTER              :: kerker_factor => NULL()
+      REAL(KIND=dp), DIMENSION(:), POINTER              :: kerker_factor_mag => NULL()
       REAL(KIND=dp), DIMENSION(:), POINTER              :: special_metric => NULL()
       REAL(KIND=dp), DIMENSION(:, :), POINTER           :: weight => NULL()
       REAL(KIND=dp), DIMENSION(:, :), POINTER           :: norm_res_buffer => NULL()
@@ -118,12 +121,15 @@ CONTAINS
       mixing_store%alpha = 1.0_dp
       mixing_store%pulay_beta = 1.0_dp
       mixing_store%beta = 1.0_dp
+      mixing_store%alpha_mag = -1.0_dp
+      mixing_store%beta_mag = -1.0_dp
       mixing_store%iter_method = "NoMix"
       mixing_store%max_g2 = 2._dp*ecut
       mixing_store%gmix_p = .FALSE.
 
       NULLIFY (mixing_store%p_metric)
       NULLIFY (mixing_store%kerker_factor)
+      NULLIFY (mixing_store%kerker_factor_mag)
       NULLIFY (mixing_store%special_metric)
       NULLIFY (mixing_store%pulay_matrix)
       NULLIFY (mixing_store%weight)
@@ -164,6 +170,11 @@ CONTAINS
 
       CALL section_vals_val_get(mixing_section, "ALPHA", r_val=mixing_store%alpha)
       CALL section_vals_val_get(mixing_section, "BETA", r_val=mixing_store%beta)
+      CALL section_vals_val_get(mixing_section, "ALPHA_MAG", r_val=mixing_store%alpha_mag)
+      CALL section_vals_val_get(mixing_section, "BETA_MAG", r_val=mixing_store%beta_mag)
+      ! Fall back to charge-channel values if magnetization parameters are not set
+      IF (mixing_store%alpha_mag < 0.0_dp) mixing_store%alpha_mag = mixing_store%alpha
+      IF (mixing_store%beta_mag < 0.0_dp) mixing_store%beta_mag = mixing_store%beta
       CALL section_vals_val_get(mixing_section, "N_SIMPLE_MIX", i_val=mixing_store%n_simple_mix)
       CALL section_vals_val_get(mixing_section, "NBUFFER", i_val=mixing_store%nbuffer)
       CALL section_vals_val_get(mixing_section, "NSKIP", i_val=mixing_store%nskip_mixing)
@@ -208,6 +219,10 @@ CONTAINS
 
       IF (ASSOCIATED(mixing_store%kerker_factor)) THEN
          DEALLOCATE (mixing_store%kerker_factor)
+      END IF
+
+      IF (ASSOCIATED(mixing_store%kerker_factor_mag)) THEN
+         DEALLOCATE (mixing_store%kerker_factor_mag)
       END IF
 
       IF (ASSOCIATED(mixing_store%special_metric)) THEN
@@ -524,6 +539,21 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, &
+                          name="ALPHA_MAG", &
+                          description="Fraction of new magnetization density to be included "// &
+                          "(for spin-polarized calculations, ispin=2 channel after rho_total/m transform). "// &
+                          "A negative value (default) means: use the same value as ALPHA. "// &
+                          "For magnetic transition-metal systems, a larger value (e.g. 0.8-1.6) "// &
+                          "than ALPHA often improves convergence.", &
+                          repeats=.FALSE., &
+                          n_var=1, &
+                          type_of_var=real_t, &
+                          default_r_val=-1.0_dp, &
+                          usage="ALPHA_MAG 0.8")
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, &
                           name="BETA", &
                           description="Denominator parameter in Kerker damping "// &
                           "introduced to suppress charge sloshing: "// &
@@ -534,6 +564,22 @@ CONTAINS
                           default_r_val=0.5_dp, &
                           unit_str="bohr^-1", &
                           usage="BETA 1.5")
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, &
+                          name="BETA_MAG", &
+                          description="Kerker damping parameter for the magnetization channel "// &
+                          "(for spin-polarized calculations). A negative value (default) means: "// &
+                          "use the same value as BETA. Set to 0.0 to disable Kerker screening "// &
+                          "on the magnetization density, which avoids suppression of long-range "// &
+                          "magnetic order formation in transition-metal systems.", &
+                          repeats=.FALSE., &
+                          n_var=1, &
+                          type_of_var=real_t, &
+                          default_r_val=-1.0_dp, &
+                          unit_str="bohr^-1", &
+                          usage="BETA_MAG 0.0")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -204,7 +204,8 @@ CONTAINS
       INTEGER                                            :: handle, iatom, ig, ispin, natom, ng, &
                                                             nspin
       LOGICAL                                            :: gapw
-      REAL(dp)                                           :: alpha, f_mix
+      REAL(dp)                                           :: alpha, alpha_eff, f_mix
+      REAL(dp), DIMENSION(:), POINTER                    :: kerker_eff
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_c1d_gs_type), DIMENSION(:), POINTER        :: rho_g
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom
@@ -213,7 +214,7 @@ CONTAINS
       CPASSERT(ASSOCIATED(mixing_store%kerker_factor))
 
       CALL timeset(routineN, handle)
-      NULLIFY (cc_new, dft_control, rho_atom, rho_g)
+      NULLIFY (cc_new, dft_control, rho_atom, rho_g, kerker_eff)
 
       CALL get_qs_env(qs_env, dft_control=dft_control)
       CALL qs_rho_get(rho, rho_g=rho_g)
@@ -225,14 +226,22 @@ CONTAINS
       alpha = mixing_store%alpha
 
       DO ispin = 1, nspin
+         ! Select spin-channel-specific mixing parameters
+         IF (ispin >= 2 .AND. nspin >= 2) THEN
+            alpha_eff = mixing_store%alpha_mag
+            kerker_eff => mixing_store%kerker_factor_mag
+         ELSE
+            alpha_eff = mixing_store%alpha
+            kerker_eff => mixing_store%kerker_factor
+         END IF
          cc_new => rho_g(ispin)%array
          DO ig = 1, mixing_store%ig_max ! ng
-            f_mix = mixing_store%alpha*mixing_store%kerker_factor(ig)
+            f_mix = alpha_eff*kerker_eff(ig)
             cc_new(ig) = (1.0_dp - f_mix)*mixing_store%rhoin(ispin)%cc(ig) + f_mix*cc_new(ig)
             mixing_store%rhoin(ispin)%cc(ig) = cc_new(ig)
          END DO
          DO ig = mixing_store%ig_max + 1, ng
-            f_mix = mixing_store%alpha
+            f_mix = alpha_eff
             cc_new(ig) = (1.0_dp - f_mix)*mixing_store%rhoin(ispin)%cc(ig) + f_mix*cc_new(ig)
             mixing_store%rhoin(ispin)%cc(ig) = cc_new(ig)
          END DO
@@ -244,12 +253,17 @@ CONTAINS
                          rho_atom_set=rho_atom)
          natom = SIZE(rho_atom)
          DO ispin = 1, nspin
+            IF (ispin >= 2 .AND. nspin >= 2) THEN
+               alpha_eff = mixing_store%alpha_mag
+            ELSE
+               alpha_eff = mixing_store%alpha
+            END IF
             DO iatom = 1, natom
                IF (mixing_store%paw(iatom)) THEN
-                  rho_atom(iatom)%cpc_h(ispin)%r_coef = alpha*rho_atom(iatom)%cpc_h(ispin)%r_coef + &
-                                                        mixing_store%cpc_h_in(iatom, ispin)%r_coef*(1._dp - alpha)
-                  rho_atom(iatom)%cpc_s(ispin)%r_coef = alpha*rho_atom(iatom)%cpc_s(ispin)%r_coef + &
-                                                        mixing_store%cpc_s_in(iatom, ispin)%r_coef*(1._dp - alpha)
+                  rho_atom(iatom)%cpc_h(ispin)%r_coef = alpha_eff*rho_atom(iatom)%cpc_h(ispin)%r_coef + &
+                                                        mixing_store%cpc_h_in(iatom, ispin)%r_coef*(1._dp - alpha_eff)
+                  rho_atom(iatom)%cpc_s(ispin)%r_coef = alpha_eff*rho_atom(iatom)%cpc_s(ispin)%r_coef + &
+                                                        mixing_store%cpc_s_in(iatom, ispin)%r_coef*(1._dp - alpha_eff)
                   mixing_store%cpc_h_in(iatom, ispin)%r_coef = rho_atom(iatom)%cpc_h(ispin)%r_coef
                   mixing_store%cpc_s_in(iatom, ispin)%r_coef = rho_atom(iatom)%cpc_s(ispin)%r_coef
                END IF
@@ -289,18 +303,19 @@ CONTAINS
                                                             jb, n1, n2, natom, nb, nb1, nbuffer, &
                                                             ng, nspin
       LOGICAL                                            :: gapw
-      REAL(dp)                                           :: alpha_kerker, alpha_pulay, beta, f_mix, &
-                                                            inv_err, norm, norm_c_inv, res_norm, &
-                                                            vol
+      REAL(dp)                                           :: alpha_eff, alpha_kerker, alpha_pulay, &
+                                                            beta, f_mix, inv_err, norm, &
+                                                            norm_c_inv, res_norm, vol
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: alpha_c, ev
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: b, c, c_inv, cpc_h_mix, cpc_s_mix
+      REAL(dp), DIMENSION(:), POINTER                    :: kerker_eff
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_c1d_gs_type), DIMENSION(:), POINTER        :: rho_g
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom
 
       CPASSERT(ASSOCIATED(mixing_store%res_buffer))
       CPASSERT(ASSOCIATED(mixing_store%rhoin_buffer))
-      NULLIFY (dft_control, rho_atom, rho_g)
+      NULLIFY (dft_control, rho_atom, rho_g, kerker_eff)
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, dft_control=dft_control)
@@ -309,7 +324,7 @@ CONTAINS
       ng = SIZE(mixing_store%res_buffer(1, 1)%cc)
       vol = rho_g(1)%pw_grid%vol
 
-      alpha_kerker = mixing_store%alpha
+      alpha_kerker = mixing_store%alpha  ! default, overridden per spin in loop
       beta = mixing_store%pulay_beta
       alpha_pulay = mixing_store%pulay_alpha
       nbuffer = mixing_store%nbuffer
@@ -341,6 +356,15 @@ CONTAINS
       END IF
 
       DO ispin = 1, nspin
+         ! Select spin-channel-specific mixing parameters
+         IF (ispin >= 2 .AND. nspin >= 2) THEN
+            alpha_eff = mixing_store%alpha_mag
+            kerker_eff => mixing_store%kerker_factor_mag
+         ELSE
+            alpha_eff = mixing_store%alpha
+            kerker_eff => mixing_store%kerker_factor
+         END IF
+         alpha_kerker = alpha_eff
          ib = MODULO(mixing_store%ncall_p(ispin), nbuffer) + 1
 
          mixing_store%ncall_p(ispin) = mixing_store%ncall_p(ispin) + 1
@@ -352,7 +376,7 @@ CONTAINS
          IF (nb == 1) mixing_store%rhoin_buffer(1, ispin)%cc = mixing_store%rhoin(ispin)%cc
          res_norm = 0.0_dp
          DO ig = 1, ng
-            f_mix = mixing_store%kerker_factor(ig)
+            f_mix = kerker_eff(ig)
             mixing_store%res_buffer(ib, ispin)%cc(ig) = f_mix*(rho_g(ispin)%array(ig) - &
                                                                mixing_store%rhoin_buffer(ib, ispin)%cc(ig))
             res_norm = res_norm + &
@@ -403,7 +427,7 @@ CONTAINS
 
          IF (nb == 1 .OR. res_norm < 1.E-14_dp) THEN
             DO ig = 1, ng
-               f_mix = alpha_kerker*mixing_store%kerker_factor(ig)
+               f_mix = alpha_kerker*kerker_eff(ig)
                cc_mix(ig) = rho_g(ispin)%array(ig) - &
                             mixing_store%rhoin_buffer(ib, ispin)%cc(ig)
                rho_g(ispin)%array(ig) = f_mix*cc_mix(ig) + &
@@ -461,7 +485,7 @@ CONTAINS
             mixing_store%rhoin_buffer(ibb, ispin)%cc = CMPLX(0._dp, 0._dp, KIND=dp)
             IF (alpha_pulay > 0.0_dp) THEN
                DO ig = 1, ng
-                  f_mix = alpha_pulay*mixing_store%kerker_factor(ig)
+                  f_mix = alpha_pulay*kerker_eff(ig)
                   rho_g(ispin)%array(ig) = f_mix*rho_g(ispin)%array(ig) + &
                                            (1.0_dp - f_mix)*cc_mix(ig)
                   mixing_store%rhoin_buffer(ibb, ispin)%cc(ig) = rho_g(ispin)%array(ig)
@@ -570,11 +594,13 @@ CONTAINS
                                                             kb, n1, n2, natom, nb, nbuffer, ng, &
                                                             nspin
       LOGICAL                                            :: gapw, only_kerker
-      REAL(dp)                                           :: alpha, dcpc_h_res, dcpc_s_res, &
-                                                            delta_norm, f_mix, inv_err, res_norm, &
-                                                            rho_norm, valh, vals, w0
+      REAL(dp)                                           :: alpha, alpha_eff, dcpc_h_res, &
+                                                            dcpc_s_res, delta_norm, f_mix, &
+                                                            inv_err, res_norm, rho_norm, valh, &
+                                                            vals, w0
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: c, g
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: a, b
+      REAL(dp), DIMENSION(:), POINTER                    :: kerker_eff
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(pw_c1d_gs_type), DIMENSION(:), POINTER        :: rho_g
       TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom
@@ -583,7 +609,7 @@ CONTAINS
       CPASSERT(ASSOCIATED(mixing_store%rhoin))
       CPASSERT(ASSOCIATED(mixing_store%rhoin_old))
       CPASSERT(ASSOCIATED(mixing_store%drho_buffer))
-      NULLIFY (dft_control, rho_atom, rho_g)
+      NULLIFY (dft_control, rho_atom, rho_g, kerker_eff)
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, dft_control=dft_control)
@@ -635,6 +661,14 @@ CONTAINS
       END IF
 
       DO ispin = 1, nspin
+         ! Select spin-channel-specific mixing parameters
+         IF (ispin >= 2 .AND. nspin >= 2) THEN
+            alpha_eff = mixing_store%alpha_mag
+            kerker_eff => mixing_store%kerker_factor_mag
+         ELSE
+            alpha_eff = mixing_store%alpha
+            kerker_eff => mixing_store%kerker_factor
+         END IF
          res_rho = z_zero
          DO ig = 1, ng
             res_rho(ig) = rho_g(ispin)%array(ig) - mixing_store%rhoin(ispin)%cc(ig)
@@ -643,7 +677,7 @@ CONTAINS
          IF (only_kerker) THEN
             DO ig = 1, ng
                mixing_store%last_res(ispin)%cc(ig) = res_rho(ig)
-               f_mix = alpha*mixing_store%kerker_factor(ig)
+               f_mix = alpha_eff*kerker_eff(ig)
                rho_g(ispin)%array(ig) = mixing_store%rhoin(ispin)%cc(ig) + f_mix*res_rho(ig)
                mixing_store%rhoin_old(ispin)%cc(ig) = mixing_store%rhoin(ispin)%cc(ig)
                mixing_store%rhoin(ispin)%cc(ig) = rho_g(ispin)%array(ig)
@@ -658,10 +692,10 @@ CONTAINS
                         mixing_store%cpc_s_lastres(iatom, ispin)%r_coef = rho_atom(iatom)%cpc_s(ispin)%r_coef - &
                                                                           mixing_store%cpc_s_in(iatom, ispin)%r_coef
 
-                        rho_atom(iatom)%cpc_h(ispin)%r_coef = alpha*rho_atom(iatom)%cpc_h(ispin)%r_coef + &
-                                                              mixing_store%cpc_h_in(iatom, ispin)%r_coef*(1._dp - alpha)
-                        rho_atom(iatom)%cpc_s(ispin)%r_coef = alpha*rho_atom(iatom)%cpc_s(ispin)%r_coef + &
-                                                              mixing_store%cpc_s_in(iatom, ispin)%r_coef*(1._dp - alpha)
+                        rho_atom(iatom)%cpc_h(ispin)%r_coef = alpha_eff*rho_atom(iatom)%cpc_h(ispin)%r_coef + &
+                                                              mixing_store%cpc_h_in(iatom, ispin)%r_coef*(1._dp - alpha_eff)
+                        rho_atom(iatom)%cpc_s(ispin)%r_coef = alpha_eff*rho_atom(iatom)%cpc_s(ispin)%r_coef + &
+                                                              mixing_store%cpc_s_in(iatom, ispin)%r_coef*(1._dp - alpha_eff)
 
                         mixing_store%cpc_h_old(iatom, ispin)%r_coef = mixing_store%cpc_h_in(iatom, ispin)%r_coef
                         mixing_store%cpc_s_old(iatom, ispin)%r_coef = mixing_store%cpc_s_in(iatom, ispin)%r_coef
@@ -742,10 +776,10 @@ CONTAINS
                                                                                     mixing_store%cpc_s_in(iatom, ispin)%r_coef(j, i)
 
                               mixing_store%dcpc_h_in(ib, iatom, ispin)%r_coef(j, i) = &
-                                 alpha*dcpc_h_res + &
+                                 alpha_eff*dcpc_h_res + &
                                  mixing_store%dcpc_h_in(ib, iatom, ispin)%r_coef(j, i)
                               mixing_store%dcpc_s_in(ib, iatom, ispin)%r_coef(j, i) = &
-                                 alpha*dcpc_s_res + &
+                                 alpha_eff*dcpc_s_res + &
                                  mixing_store%dcpc_s_in(ib, iatom, ispin)%r_coef(j, i)
                            END DO
                         END DO
@@ -755,7 +789,7 @@ CONTAINS
 
                a(:, :) = 0.0_dp
                DO ig = 1, ng
-                  f_mix = alpha*mixing_store%kerker_factor(ig)
+                  f_mix = alpha_eff*kerker_eff(ig)
                   mixing_store%drho_buffer(ib, ispin)%cc(ig) = &
                      f_mix*mixing_store%res_buffer(ib, ispin)%cc(ig) + &
                      mixing_store%drho_buffer(ib, ispin)%cc(ig)
@@ -796,7 +830,7 @@ CONTAINS
                DO jb = 1, nb
                   cc_mix = cc_mix - G(jb)*mixing_store%drho_buffer(jb, ispin)%cc(ig)
                END DO
-               f_mix = alpha*mixing_store%kerker_factor(ig)
+               f_mix = alpha_eff*kerker_eff(ig)
 
                IF (res_norm > 1.E-14_dp) rho_g(ispin)%array(ig) = mixing_store%rhoin(ispin)%cc(ig) + &
                                                                   f_mix*res_rho(ig) + cc_mix
@@ -820,11 +854,11 @@ CONTAINS
                               END DO
                               IF (res_norm > 1.E-14_dp) THEN
                                  rho_atom(iatom)%cpc_h(ispin)%r_coef(j, i) = &
-                                    alpha*rho_atom(iatom)%cpc_h(ispin)%r_coef(j, i) + &
-                                    mixing_store%cpc_h_in(iatom, ispin)%r_coef(j, i)*(1._dp - alpha) + valh
+                                    alpha_eff*rho_atom(iatom)%cpc_h(ispin)%r_coef(j, i) + &
+                                    mixing_store%cpc_h_in(iatom, ispin)%r_coef(j, i)*(1._dp - alpha_eff) + valh
                                  rho_atom(iatom)%cpc_s(ispin)%r_coef(j, i) = &
-                                    alpha*rho_atom(iatom)%cpc_s(ispin)%r_coef(j, i) + &
-                                    mixing_store%cpc_s_in(iatom, ispin)%r_coef(j, i)*(1._dp - alpha) + vals
+                                    alpha_eff*rho_atom(iatom)%cpc_s(ispin)%r_coef(j, i) + &
+                                    mixing_store%cpc_s_in(iatom, ispin)%r_coef(j, i)*(1._dp - alpha_eff) + vals
                               END IF
                            END DO
                         END DO
@@ -901,11 +935,11 @@ CONTAINS
                                                             ig_global, iig, ispin, jb, kb, nb, &
                                                             nbuffer, ng, ng_global, nspin
       LOGICAL                                            :: use_zgemm, use_zgemm_rev
-      REAL(dp) :: alpha, f_mix, gn_norm, gn_norm_old, inv_err, n_low, n_up, pgn_norm, prec, &
-         r_step, reg_par, sigma_max, sigma_tilde, step_size
+      REAL(dp) :: alpha, alpha_eff, f_mix, gn_norm, gn_norm_old, inv_err, n_low, n_up, pgn_norm, &
+         prec, r_step, reg_par, sigma_max, sigma_tilde, step_size
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: norm_res, norm_res_low, norm_res_up
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: b_matrix, binv_matrix
-      REAL(dp), DIMENSION(:), POINTER                    :: g2
+      REAL(dp), DIMENSION(:), POINTER                    :: g2, kerker_eff
       REAL(dp), SAVE                                     :: sigma_old = 1.0_dp
       TYPE(pw_c1d_gs_type), DIMENSION(:), POINTER        :: rho_g
 
@@ -961,8 +995,15 @@ CONTAINS
       IF (nb == 0) THEN
          !simple mixing
          DO ispin = 1, nspin
+            IF (ispin >= 2 .AND. nspin >= 2) THEN
+               alpha_eff = mixing_store%alpha_mag
+               kerker_eff => mixing_store%kerker_factor_mag
+            ELSE
+               alpha_eff = mixing_store%alpha
+               kerker_eff => mixing_store%kerker_factor
+            END IF
             DO ig = 1, ng
-               f_mix = alpha*mixing_store%kerker_factor(ig)
+               f_mix = alpha_eff*kerker_eff(ig)
                rho_g(ispin)%array(ig) = mixing_store%rhoin_buffer(1, ispin)%cc(ig) + &
                                         f_mix*mixing_store%res_buffer(1, ispin)%cc(ig)
                mixing_store%rhoin_buffer(ib_next, ispin)%cc(ig) = rho_g(ispin)%array(ig)
@@ -1002,6 +1043,14 @@ CONTAINS
       ALLOCATE (ugn(ng))
 
       DO ispin = 1, nspin
+         ! Select spin-channel-specific mixing parameters
+         IF (ispin >= 2 .AND. nspin >= 2) THEN
+            alpha_eff = mixing_store%alpha_mag
+            kerker_eff => mixing_store%kerker_factor_mag
+         ELSE
+            alpha_eff = mixing_store%alpha
+            kerker_eff => mixing_store%kerker_factor
+         END IF
          ! generate the global vector with the present residual
          gn => mixing_store%res_buffer(ib, ispin)%cc
          gn_global = z_zero
@@ -1197,7 +1246,7 @@ CONTAINS
 
          ! update the density
          DO ig = 1, ng
-            prec = mixing_store%kerker_factor(ig)
+            prec = kerker_eff(ig)
             rho_g(ispin)%array(ig) = mixing_store%rhoin_buffer(ib, ispin)%cc(ig) &
                                      - prec*step_size*ugn(ig) + prec*pgn(ig) ! - 0.1_dp * prec* gn(ig)
             mixing_store%rhoin_buffer(ib_next, ispin)%cc(ig) = rho_g(ispin)%array(ig)

--- a/src/qs_mixing_utils.F
+++ b/src/qs_mixing_utils.F
@@ -436,17 +436,27 @@ CONTAINS
       IF (.NOT. ASSOCIATED(mixing_store%kerker_factor)) THEN
          ALLOCATE (mixing_store%kerker_factor(ng))
       END IF
+      IF (.NOT. ASSOCIATED(mixing_store%kerker_factor_mag)) THEN
+         ALLOCATE (mixing_store%kerker_factor_mag(ng))
+      END IF
       IF (.NOT. ASSOCIATED(mixing_store%special_metric)) THEN
          ALLOCATE (mixing_store%special_metric(ng))
       END IF
       beta = mixing_store%beta
       kmin = 0.1_dp
       mixing_store%kerker_factor = 1.0_dp
+      mixing_store%kerker_factor_mag = 1.0_dp
       mixing_store%special_metric = 1.0_dp
       ig1 = 1
       IF (rho_g(1)%pw_grid%have_g0) ig1 = 2
       DO ig = ig1, mixing_store%ig_max
          mixing_store%kerker_factor(ig) = MAX(g2(ig)/(g2(ig) + beta*beta), kmin)
+         IF (mixing_store%beta_mag > 1.0E-10_dp) THEN
+            mixing_store%kerker_factor_mag(ig) = MAX(g2(ig)/(g2(ig) + mixing_store%beta_mag*mixing_store%beta_mag), kmin)
+         ELSE
+            ! beta_mag ~ 0 means no Kerker screening on the magnetization channel
+            mixing_store%kerker_factor_mag(ig) = 1.0_dp
+         END IF
          mixing_store%special_metric(ig) = &
             1.0_dp + 50.0_dp/8.0_dp*( &
             1.0_dp + COS(g_vec(1, ig)) + COS(g_vec(2, ig)) + COS(g_vec(3, ig)) + &

--- a/tests/QS/regtest-gpw-3/O2-UKS-mixing.inp
+++ b/tests/QS/regtest-gpw-3/O2-UKS-mixing.inp
@@ -1,0 +1,61 @@
+&GLOBAL
+  PRINT_LEVEL low
+  PROJECT O2-UKS-GPW-relax_multip
+  RUN_TYPE energy
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_SET
+    MULTIPLICITY 3
+    POTENTIAL_FILE_NAME POTENTIAL
+    RELAX_MULTIP 1.0E-5
+    UKS
+    &MGRID
+      CUTOFF 200
+    &END MGRID
+    &QS
+      EPS_DEFAULT 1.0E-8
+    &END QS
+    &SCF
+      ADDED_MOS 2 1
+      SCF_GUESS atomic
+      &MIXING
+        ALPHA 0.4
+        ALPHA_MAG 1.6
+        BETA 1.0
+        BETA_MAG 0.0
+        METHOD BROYDEN_MIXING
+        NBROYDEN 8
+      &END MIXING
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PADE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 4.0 4.0 6.0
+      PERIODIC none
+    &END CELL
+    &COORD
+      O  0.000000  0.000000  0.608000
+      O  0.000000  0.000000 -0.608000
+    &END COORD
+    &KIND O
+      BASIS_SET DZVP-GTH-PADE
+      POTENTIAL GTH-PADE-q6
+    &END KIND
+    &PRINT
+      &KINDS
+        BASIS_SET
+        POTENTIAL
+      &END KINDS
+      &STRUCTURE_DATA
+        DISTANCE 1 2
+      &END STRUCTURE_DATA
+    &END PRINT
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-gpw-3/TEST_FILES.toml
+++ b/tests/QS/regtest-gpw-3/TEST_FILES.toml
@@ -68,4 +68,6 @@
 "O2-UKS-OTdiag-relax_multip.inp"        = [{matcher="E_total", tol=5e-14, ref=-31.86509209577858}]
 # Test reading LnPP2 
 "CeO2.inp"                              = [{matcher="E_total", tol=1e-12, ref=-64.41562845141048}]
+# Spin-channel-specific mixing parameters
+"O2-UKS-mixing.inp"                     = [{matcher="E_total", tol=5.0E-14, ref=-31.86511812037723}]
 #EOF


### PR DESCRIPTION
For (potentially) better convergence for some magnetic systems.

For example, users can set:
```
&MIXING
  METHOD BROYDEN_MIXING
  ALPHA 0.4
  ALPHA_MAG 1.6
  BETA 1.0
  BETA_MAG 0.0
  NBUFFER 8
&END MIXING
```