### PR TITLE
Toolchain: Avoid additional dependencies of libint

### DIFF
--- a/tools/libint/README.md
+++ b/tools/libint/README.md
@@ -13,26 +13,20 @@ docker run -v "$(pwd)":/mnt bundles_img cp -rv  /opt/libint-bundles /mnt/
 
 ## Use pre-built libint-cp2k source to build and install libint
 
-1. First, ensure `boost` and `eigen3` are installed on your system. For Ubuntu/Debian users, run:
-
-```
-sudo apt install libboost-dev libeigen3-dev
-```
-
-For Fedora or RHEL (CRB repo required) users:
-
-```
-sudo dnf install boost-devel eigen3-devel
-```
-
-2. Build libint-cp2k with below cmake commands:
+Build libint-cp2k with below cmake commands:
 
 ```
 cd /path/to/libint-cp2k
 mkdir build && cd build
-CXXFLAGS="-g1" cmake .. \
+CXXFLAGS="-g1" FCFLAGS="-g1" cmake .. \
   -DCMAKE_INSTALL_PREFIX=/path/to/your/installation \
   -DLIBINT2_INSTALL_LIBDIR=/path/to/your/installation/lib \
-  -DLIBINT2_ENABLE_FORTRAN=ON
+  -DLIBINT2_ENABLE_FORTRAN=ON \
+  -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON \
+  -DLIBINT2_REQUIRE_CXX_API=OFF
+tar -xzf ../external/boost.tar.gz -C ./include/libint2
 make install -j N
 ```
+
+If you have boost and eigen3 installed on your host system, you may not need
+`-DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON` and `-DLIBINT2_REQUIRE_CXX_API=OFF`.

--- a/tools/toolchain/install_requirements_fedora.sh
+++ b/tools/toolchain/install_requirements_fedora.sh
@@ -10,11 +10,9 @@ dnf -qy install \
   autoconf \
   autogen \
   automake \
-  boost-devel \
   bzip2 \
   ca-certificates \
   diffutils \
-  eigen3-devel \
   g++ \
   gcc \
   gfortran \

--- a/tools/toolchain/install_requirements_ubuntu.sh
+++ b/tools/toolchain/install_requirements_ubuntu.sh
@@ -23,8 +23,6 @@ apt-get install -qq --no-install-recommends \
   gfortran \
   git \
   less \
-  libboost-dev \
-  libeigen3-dev \
   libtool \
   libtool-bin \
   make \

--- a/tools/toolchain/scripts/stage3/install_libint.sh
+++ b/tools/toolchain/scripts/stage3/install_libint.sh
@@ -66,7 +66,10 @@ case "$with_libint" in
         -DCMAKE_CXX_COMPILER="$CXX" \
         -DLIBINT2_INSTALL_LIBDIR="${pkg_install_dir}/lib" \
         -DLIBINT2_ENABLE_FORTRAN=ON \
+        -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON \
+        -DLIBINT2_REQUIRE_CXX_API=OFF \
         > configure.log 2>&1 || tail_excerpt configure.log
+      tar -xzf ../external/boost.tar.gz -C ./include/libint2
       make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
 
       cd ..

--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -6,10 +6,10 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-cosma_ver="2.8.3"
-cosma_sha256="fbd53b3b399ae521b1c632c02970560c78e0ae7733aa4a52d1426183336a1f75"
-costa_ver="2.3.1"
-costa_sha256="ab3a30165a821c77d34013ef8d01a9be5fefcc804e85c1e338ac970122ae938b"
+cosma_ver="2.8.2"
+cosma_sha256="bcf42558c1cdc35e91f662a9e87ae606f22d0c1aaf0cb763a6e4385c412c8f6b"
+costa_ver="2.3.0"
+costa_sha256="0413311a2821d4cd1f3f026672a75a5b5a2956f61305c07d7fc14565a126b517"
 tiled_mm_ver="2.3.2"
 tiled_mm_sha256="1f91ca02f6ee8e400835fa90630618baf86a7b425b4bbbb4151068f72658b858"
 
@@ -36,12 +36,9 @@ case "$with_cosma" in
     if verify_checksums "${install_lock_file}"; then
       echo "COSMA-${cosma_ver} is already installed, skipping it."
     else
-      #retrieve_package "${cosma_sha256}" "COSMA-v${cosma_ver}.tar.gz"
-      #retrieve_package "${costa_sha256}" "COSTA-v${costa_ver}.tar.gz"
-      #retrieve_package "${tiled_mm_sha256}" "Tiled-MM-v${tiled_mm_ver}.tar.gz"
-      download_pkg_from_urlpath "${cosma_sha256}" "v${cosma_ver}.tar.gz" https://github.com/eth-cscs/COSMA/archive/refs/tags "COSMA-v${cosma_ver}.tar.gz"
-      download_pkg_from_urlpath "${costa_sha256}" "v${costa_ver}.tar.gz" https://github.com/eth-cscs/COSTA/archive/refs/tags "COSTA-v${costa_ver}.tar.gz"
-      download_pkg_from_urlpath "${tiled_mm_sha256}" "v${tiled_mm_ver}.tar.gz" https://github.com/eth-cscs/Tiled-MM/archive/refs/tags "Tiled-MM-v${tiled_mm_ver}.tar.gz"
+      retrieve_package "${cosma_sha256}" "COSMA-v${cosma_ver}.tar.gz"
+      retrieve_package "${costa_sha256}" "COSTA-v${costa_ver}.tar.gz"
+      retrieve_package "${tiled_mm_sha256}" "Tiled-MM-v${tiled_mm_ver}.tar.gz"
       echo "Installing from scratch into ${pkg_install_dir}"
       [ -d COSMA-${cosma_ver} ] && rm -rf COSMA-${cosma_ver}
       tar -xzf COSMA-v${cosma_ver}.tar.gz


### PR DESCRIPTION
* Avoid additional dependencies of libint: Using bundled Boost brought by libint bundles themselves; not using Eigen3
* Revert COSMA and COSTA update due to dashboard issues