### PR TITLE
Prefer include directories from the selected Libint package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,6 +754,9 @@ endif()
 # Libint
 if(CP2K_USE_LIBINT2)
   find_package(Libint2 REQUIRED)
+  # Prefer the headers and Fortran module that match the selected libint
+  # library. System include paths can otherwise shadow a locally built libint.
+  include_directories(BEFORE ${CP2K_LIBINT2_INCLUDE_DIRS})
 endif()
 
 # Spglib


### PR DESCRIPTION
When CP2K is configured with a non-system Libint installation, system include paths can still shadow the selected Libint headers and Fortran module. This can lead to a build that links one Libint library but compiles against a different libint_f.mod.

Put CP2K_LIBINT2_INCLUDE_DIRS before existing include directories after find_package(Libint2), so the selected Libint package is used consistently.

Tested locally as part of a CP2K 2026.1 CP2K-GROMACS build on Apple Silicon with a locally built Libint lmax=5 installation; the full CP2K regtest suite passed: 4129 / 4129 correct.