### PR TITLE
grid: improve OpenMP use in task setup and memory loops

### DIFF
--- a/src/grid/common/grid_common.h
+++ b/src/grid/common/grid_common.h
@@ -13,14 +13,19 @@
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) &&                         \
     !defined(__INTEL_LLVM_COMPILER) && __GNUC__ < 6
 #define GRID_PRAGMA_SIMD(OBJS, N)
+#define GRID_PRAGMA_SIMD_LOOP
 // Intel added the simd pragma with version 19.00.
 #elif defined(__INTEL_COMPILER) && __INTEL_COMPILER < 1900
 #define GRID_PRAGMA_SIMD(OBJS, N)
+#define GRID_PRAGMA_SIMD_LOOP
 // All compilers support the same syntax defined by the OpenMP standard.
 #else
 #define GRID_PRAGMA_SIMD(OBJS, N)                                              \
   _Pragma(GRID_STRINGIFY(omp simd linear OBJS simdlen(N)))
+#define GRID_PRAGMA_SIMD_LOOP _Pragma(GRID_STRINGIFY(omp simd))
 #endif
+
+#define GRID_OMP_MIN_ITERATIONS 1024
 
 // GCC added the unroll pragma with version 8 and...
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER) &&                         \

--- a/src/grid/cpu/grid_cpu_task_list.c
+++ b/src/grid/cpu/grid_cpu_task_list.c
@@ -100,6 +100,7 @@ void grid_cpu_create_task_list(
   size = ntasks * sizeof(grid_cpu_task);
   task_list->tasks = malloc(size);
   assert(task_list->tasks != NULL || size == 0);
+#pragma omp parallel for schedule(static) if (ntasks > GRID_OMP_MIN_ITERATIONS)
   for (int i = 0; i < ntasks; i++) {
     task_list->tasks[i].level = level_list[i];
     task_list->tasks[i].iatom = iatom_list[i];
@@ -142,7 +143,10 @@ void grid_cpu_create_task_list(
   assert(task_list->first_level_block_task != NULL || size == 0);
   task_list->last_level_block_task = malloc(size);
   assert(task_list->last_level_block_task != NULL || size == 0);
-  for (int i = 0; i < nlevels * nblocks; i++) {
+  const int nlevel_blocks = nlevels * nblocks;
+#pragma omp parallel for schedule(static) if (nlevel_blocks >                  \
+                                                  GRID_OMP_MIN_ITERATIONS)
+  for (int i = 0; i < nlevel_blocks; i++) {
     task_list->first_level_block_task[i] = 0;
     task_list->last_level_block_task[i] = -1; // last < first means no tasks
   }
@@ -391,6 +395,7 @@ static void collocate_one_grid_level(
       const int64_t ub =
           ((int64_t)npts_local_total * (rank + 1)) / actual_group_size;
       if (src_thread < nthreads) {
+        GRID_PRAGMA_SIMD_LOOP
         for (int i = (int)lb; i < (int)ub; i++) {
           task_list->threadlocals[dest_thread][i] +=
               task_list->threadlocals[src_thread][i];
@@ -402,6 +407,7 @@ static void collocate_one_grid_level(
     // Copy final result from first thread into shared grid.
     const int64_t lb = ((int64_t)npts_local_total * ithread) / nthreads;
     const int64_t ub = ((int64_t)npts_local_total * (ithread + 1)) / nthreads;
+    GRID_PRAGMA_SIMD_LOOP
     for (int i = (int)lb; i < (int)ub; i++) {
       grid->host_buffer[i] = task_list->threadlocals[0][i];
     }

--- a/src/grid/dgemm/grid_dgemm_context.c
+++ b/src/grid/dgemm/grid_dgemm_context.c
@@ -220,18 +220,10 @@ void update_task_lists(const int nlevels, const int ntasks,
     ctx->tasks[i] = ctx->tasks[i - 1] + ctx->tasks_per_level[i - 1];
   }
 
-  int prev_block_num = -1;
-  int prev_iset = -1;
-  int prev_jset = -1;
-  int prev_level = -1;
-  _task *task = ctx->tasks[0];
+  _task *const tasks = ctx->tasks[0];
+#pragma omp parallel for schedule(static) if (ntasks > GRID_OMP_MIN_ITERATIONS)
   for (int i = 0; i < ntasks; i++) {
-    if (prev_level != (level_list[i] - 1)) {
-      prev_level = level_list[i] - 1;
-      prev_block_num = -1;
-      prev_iset = -1;
-      prev_jset = -1;
-    }
+    _task *const task = &tasks[i];
     task->level = level_list[i] - 1;
     task->iatom = iatom_list[i] - 1;
     task->jatom = jatom_list[i] - 1;
@@ -271,8 +263,6 @@ void update_task_lists(const int nlevels, const int ntasks,
     task->prefactor = exp(-task->zeta[0] * f * rab2);
     task->zetp = zetp;
 
-    const int block_num = task->block_num;
-
     for (int i = 0; i < 3; i++) {
       task->ra[i] = ra[i];
       task->rp[i] = ra[i] + f * task->rab[i];
@@ -284,19 +274,13 @@ void update_task_lists(const int nlevels, const int ntasks,
     task->lmin[0] = ibasis->lmin[iset];
     task->lmin[1] = jbasis->lmin[jset];
 
-    if ((block_num != prev_block_num) || (iset != prev_iset) ||
-        (jset != prev_jset)) {
-      task->update_block_ = true;
-      prev_block_num = block_num;
-      prev_iset = iset;
-      prev_jset = jset;
-    } else {
-      task->update_block_ = false;
-    }
+    task->update_block_ = i == 0 || level_list[i] != level_list[i - 1] ||
+                          block_num_list[i] != block_num_list[i - 1] ||
+                          iset_list[i] != iset_list[i - 1] ||
+                          jset_list[i] != jset_list[i - 1];
 
     task->offset[0] = ipgf * ncoseta;
     task->offset[1] = jpgf * ncosetb;
-    task++;
   }
 
   // Find largest Cartesian subblock size.

--- a/src/grid/ref/grid_ref_task_list.c
+++ b/src/grid/ref/grid_ref_task_list.c
@@ -100,6 +100,7 @@ void grid_ref_create_task_list(
   size = ntasks * sizeof(grid_ref_task);
   task_list->tasks = malloc(size);
   assert(task_list->tasks != NULL || size == 0);
+#pragma omp parallel for schedule(static) if (ntasks > GRID_OMP_MIN_ITERATIONS)
   for (int i = 0; i < ntasks; i++) {
     task_list->tasks[i].level = level_list[i];
     task_list->tasks[i].iatom = iatom_list[i];
@@ -142,7 +143,10 @@ void grid_ref_create_task_list(
   assert(task_list->first_level_block_task != NULL || size == 0);
   task_list->last_level_block_task = malloc(size);
   assert(task_list->last_level_block_task != NULL || size == 0);
-  for (int i = 0; i < nlevels * nblocks; i++) {
+  const int nlevel_blocks = nlevels * nblocks;
+#pragma omp parallel for schedule(static) if (nlevel_blocks >                  \
+                                                  GRID_OMP_MIN_ITERATIONS)
+  for (int i = 0; i < nlevel_blocks; i++) {
     task_list->first_level_block_task[i] = 0;
     task_list->last_level_block_task[i] = -1; // last < first means no tasks
   }
@@ -390,6 +394,7 @@ static void collocate_one_grid_level(
       const int lb = (npts_local_total * rank) / actual_group_size;
       const int ub = (npts_local_total * (rank + 1)) / actual_group_size;
       if (src_thread < nthreads) {
+        GRID_PRAGMA_SIMD_LOOP
         for (int i = lb; i < ub; i++) {
           task_list->threadlocals[dest_thread][i] +=
               task_list->threadlocals[src_thread][i];
@@ -401,6 +406,7 @@ static void collocate_one_grid_level(
     // Copy final result from first thread into shared grid.
     const int lb = (npts_local_total * ithread) / nthreads;
     const int ub = (npts_local_total * (ithread + 1)) / nthreads;
+    GRID_PRAGMA_SIMD_LOOP
     for (int i = lb; i < ub; i++) {
       grid->host_buffer[i] = task_list->threadlocals[0][i];
     }


### PR DESCRIPTION
This PR adds conservative OpenMP/SIMD improvements to the grid CPU, REF, and DGEMM task-list setup paths.

The changes are intentionally limited to independent writes and element-wise memory loops:

- add `GRID_PRAGMA_SIMD_LOOP` as an architecture-neutral `omp simd` helper
- add `GRID_OMP_MIN_ITERATIONS` to avoid OpenMP overhead on small loops
- parallelize CPU/REF task-array initialization
- parallelize CPU/REF first/last level-block task initialization
- add SIMD hints to CPU/REF thread-local grid reduction and final grid copy loops
- parallelize DGEMM task-structure initialization by computing `update_block_` directly from adjacent input entries instead of carrying serial loop state

The PR does not change the grid kernel math or the reduction order of the main physical accumulations. The SIMD helper deliberately does not specify a fixed `simdlen`, so the compiler can choose an appropriate vector width for the target architecture.

Testing:

- built `cp2k` with the psmp toolchain
- built `grid_unittest`
- ran `QS/regtest-grid` with `1 MPI rank x 2 OpenMP threads`: `16 / 16` correct
- ran `QS/regtest-gapw` with `1 MPI rank x 2 OpenMP threads`: `26 / 26` correct
- ran short DGEMM H2O-32 and H2O-64 comparisons with `1 MPI rank x 4 OpenMP threads`, `OPENBLAS_NUM_THREADS=1`
  - energies matched to printed precision
  - H2O-32 showed a small improvement
  - H2O-64 was within timing noise

Performance note:

The benchmark results show no regression and small improvements in some runs, but this PR should be viewed as a conservative cleanup/improvement rather than a major performance change.