### PR TITLE
Improve GAPW one-center atom-grid performance

### DIFF
--- a/src/hartree_local_methods.F
+++ b/src/hartree_local_methods.F
@@ -116,7 +116,7 @@ CONTAINS
       INTEGER                                            :: handle, ir, iso, ispin, l_ang, &
                                                             max_s_harm, nchannels, nr, nspins
       REAL(dp)                                           :: I1_down, I1_up, I2_down, I2_up, prefactor
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: rho_1, rho_2
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: rho_1, rho_2
       REAL(dp), DIMENSION(:), POINTER                    :: wr
       REAL(dp), DIMENSION(:, :), POINTER                 :: oor2l, r2l
 
@@ -131,41 +131,35 @@ CONTAINS
       oor2l => grid_atom%oorad2l
       wr => grid_atom%wr
 
-      ALLOCATE (rho_1(nr, max_s_harm), rho_2(nr, max_s_harm))
-      rho_1 = 0.0_dp
-      rho_2 = 0.0_dp
-
-      !   Case lm = 0
-      rho_1(:, 1) = rrad_z(:)
-      rho_2(:, 1) = rrad_0(:, 1)
-
-      DO iso = 2, nchannels
-         rho_2(:, iso) = rrad_0(:, iso)
-      END DO
+      ALLOCATE (rho_1(nr), rho_2(nr))
 
       DO iso = 1, max_s_harm
+         rho_1(:) = 0.0_dp
+         rho_2(:) = 0.0_dp
+         IF (iso == 1) rho_1(:) = rrad_z(:)
+         IF (iso <= nchannels) rho_2(:) = rrad_0(:, iso)
          DO ispin = 1, nspins
-            rho_1(:, iso) = rho_1(:, iso) + rrad_h(ispin)%r_coef(:, iso)
-            rho_2(:, iso) = rho_2(:, iso) + rrad_s(ispin)%r_coef(:, iso)
+            rho_1(:) = rho_1(:) + rrad_h(ispin)%r_coef(:, iso)
+            rho_2(:) = rho_2(:) + rrad_s(ispin)%r_coef(:, iso)
          END DO
 
          l_ang = indso(1, iso)
          prefactor = fourpi/(2._dp*l_ang + 1._dp)
 
-         rho_1(:, iso) = rho_1(:, iso)*wr(:)
-         rho_2(:, iso) = rho_2(:, iso)*wr(:)
+         rho_1(:) = rho_1(:)*wr(:)
+         rho_2(:) = rho_2(:)*wr(:)
 
          I1_up = 0.0_dp
          I1_down = 0.0_dp
          I2_up = 0.0_dp
          I2_down = 0.0_dp
 
-         I1_up = r2l(nr, l_ang)*rho_1(nr, iso)
-         I2_up = r2l(nr, l_ang)*rho_2(nr, iso)
+         I1_up = r2l(nr, l_ang)*rho_1(nr)
+         I2_up = r2l(nr, l_ang)*rho_2(nr)
 
          DO ir = nr - 1, 1, -1
-            I1_down = I1_down + oor2l(ir, l_ang + 1)*rho_1(ir, iso)
-            I2_down = I2_down + oor2l(ir, l_ang + 1)*rho_2(ir, iso)
+            I1_down = I1_down + oor2l(ir, l_ang + 1)*rho_1(ir)
+            I2_down = I2_down + oor2l(ir, l_ang + 1)*rho_2(ir)
          END DO
 
          vrad_h(nr, iso) = vrad_h(nr, iso) + prefactor* &
@@ -174,10 +168,10 @@ CONTAINS
                            (oor2l(nr, l_ang + 1)*I2_up + r2l(nr, l_ang)*I2_down)
 
          DO ir = nr - 1, 1, -1
-            I1_up = I1_up + r2l(ir, l_ang)*rho_1(ir, iso)
-            I1_down = I1_down - oor2l(ir, l_ang + 1)*rho_1(ir, iso)
-            I2_up = I2_up + r2l(ir, l_ang)*rho_2(ir, iso)
-            I2_down = I2_down - oor2l(ir, l_ang + 1)*rho_2(ir, iso)
+            I1_up = I1_up + r2l(ir, l_ang)*rho_1(ir)
+            I1_down = I1_down - oor2l(ir, l_ang + 1)*rho_1(ir)
+            I2_up = I2_up + r2l(ir, l_ang)*rho_2(ir)
+            I2_down = I2_down - oor2l(ir, l_ang + 1)*rho_2(ir)
 
             vrad_h(ir, iso) = vrad_h(ir, iso) + prefactor* &
                               (oor2l(ir, l_ang + 1)*I1_up + r2l(ir, l_ang)*I1_down)

--- a/src/qs_grid_atom.F
+++ b/src/qs_grid_atom.F
@@ -44,12 +44,13 @@ MODULE qs_grid_atom
    TYPE grid_atom_type
       INTEGER                         :: quadrature = -1
       INTEGER                         :: nr = -1, ng_sphere = -1
+      REAL(dp)                        :: gapw_weight_alpha = -1.0_dp
       REAL(dp), DIMENSION(:), POINTER :: rad => NULL(), rad2 => NULL(), &
                                          wr => NULL(), wa => NULL(), &
                                          azi => NULL(), cos_azi => NULL(), sin_azi => NULL(), &
                                          pol => NULL(), cos_pol => NULL(), sin_pol => NULL(), usin_azi => NULL()
       REAL(dp), DIMENSION(:, :), &
-         POINTER :: rad2l => NULL(), oorad2l => NULL(), weight => NULL()
+         POINTER :: rad2l => NULL(), oorad2l => NULL(), weight => NULL(), gapw_weight_s => NULL()
    END TYPE grid_atom_type
 
    PUBLIC :: allocate_grid_atom, create_grid_atom, deallocate_grid_atom
@@ -82,6 +83,7 @@ CONTAINS
       NULLIFY (grid_atom%wr)
       NULLIFY (grid_atom%wa)
       NULLIFY (grid_atom%weight)
+      NULLIFY (grid_atom%gapw_weight_s)
       NULLIFY (grid_atom%azi)
       NULLIFY (grid_atom%cos_azi)
       NULLIFY (grid_atom%sin_azi)
@@ -124,6 +126,10 @@ CONTAINS
 
          IF (ASSOCIATED(grid_atom%weight)) THEN
             DEALLOCATE (grid_atom%weight)
+         END IF
+
+         IF (ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+            DEALLOCATE (grid_atom%gapw_weight_s)
          END IF
 
          IF (ASSOCIATED(grid_atom%azi)) THEN

--- a/src/qs_integrate_potential_single.F
+++ b/src/qs_integrate_potential_single.F
@@ -773,8 +773,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'integrate_v_rspace_one_center'
 
-      INTEGER :: atom_a, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, m1, maxco, &
-         maxsgf_set, my_pos, na1, natom_of_kind, ncoa, nkind, nseta, offset, sgfa
+      INTEGER :: atom_a, group_size, handle, i, iatom, igrid_level, ikind, ipgf, iset, m1, &
+         max_npgf, maxco, maxsgf_set, my_pos, na1, natom_of_kind, ncoa, nkind, nseta, offset, sgfa
       INTEGER, DIMENSION(:), POINTER                     :: atom_list, la_max, la_min, npgfa, &
                                                             nsgf_seta
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
@@ -856,6 +856,10 @@ CONTAINS
          ALLOCATE (hab(maxco, 1), pab(maxco, 1))
          hab = 0._dp
          pab(:, 1) = 0._dp
+         max_npgf = MAXVAL(npgfa(1:nseta))
+         ALLOCATE (map_it(max_npgf))
+         ALLOCATE (work_i(maxsgf_set, 1))
+         IF (calculate_forces) ALLOCATE (work_f(maxsgf_set, 1))
 
          DO iatom = 1, natom_of_kind
 
@@ -868,9 +872,6 @@ CONTAINS
             force_b(:) = 0._dp
             my_virial_a(:, :) = 0._dp
             my_virial_b(:, :) = 0._dp
-
-            m1 = MAXVAL(npgfa(1:nseta))
-            ALLOCATE (map_it(m1))
 
             DO iset = 1, nseta
                !
@@ -886,18 +887,15 @@ CONTAINS
                   sgfa = first_sgfa(1, iset)
                   ncoa = npgfa(iset)*ncoset(la_max(iset))
                   hab(:, 1) = 0._dp
-                  ALLOCATE (work_i(nsgf_seta(iset), 1))
-                  work_i = 0.0_dp
+                  work_i(1:nsgf_seta(iset), 1) = 0.0_dp
 
                   ! get fit coefficients for forces
                   IF (calculate_forces) THEN
                      m1 = sgfa + nsgf_seta(iset) - 1
-                     ALLOCATE (work_f(nsgf_seta(iset), 1))
                      work_f(1:nsgf_seta(iset), 1) = int_res(ikind)%acoef(iatom, sgfa:m1)
                      CALL dgemm("N", "N", ncoa, 1, nsgf_seta(iset), 1.0_dp, sphi_a(1, sgfa), &
                                 SIZE(sphi_a, 1), work_f(1, 1), SIZE(work_f, 1), 0.0_dp, pab(1, 1), &
                                 SIZE(pab, 1))
-                     DEALLOCATE (work_f)
                   END IF
 
                   DO ipgf = 1, npgfa(iset)
@@ -939,7 +937,6 @@ CONTAINS
 
                   int_res(ikind)%v_int(iatom, sgfa:sgfa - 1 + nsgf_seta(iset)) = &
                      int_res(ikind)%v_int(iatom, sgfa:sgfa - 1 + nsgf_seta(iset)) + work_i(1:nsgf_seta(iset), 1)
-                  DEALLOCATE (work_i)
                END IF
             END DO
             !
@@ -951,10 +948,10 @@ CONTAINS
                END IF
             END IF
 
-            DEALLOCATE (map_it)
-
          END DO
 
+         IF (calculate_forces) DEALLOCATE (work_f)
+         DEALLOCATE (work_i, map_it)
          DEALLOCATE (hab, pab)
       END DO
 

--- a/src/qs_ks_atom.F
+++ b/src/qs_ks_atom.F
@@ -135,6 +135,7 @@ CONTAINS
       LOGICAL                                            :: dista, distb, found, is_entry_null, &
                                                             is_task_valid, my_tddft, paw_atom, &
                                                             use_virial
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: has_intac, paw_kind
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: a_matrix, p_matrix
       REAL(dp), DIMENSION(3)                             :: rac, rbc
       REAL(dp), DIMENSION(3, 3)                          :: force_tmp
@@ -271,13 +272,19 @@ CONTAINS
       END ASSOCIATE
 
       ALLOCATE (basis_set_list(nkind))
+      ALLOCATE (paw_kind(nkind), has_intac(nkind*nkind))
+      paw_kind(:) = .FALSE.
+      has_intac(:) = .FALSE.
       DO ikind = 1, nkind
-         CALL get_qs_kind(my_kind_set(ikind), basis_set=basis_set_a)
+         CALL get_qs_kind(my_kind_set(ikind), basis_set=basis_set_a, paw_atom=paw_kind(ikind))
          IF (ASSOCIATED(basis_set_a)) THEN
             basis_set_list(ikind)%gto_basis_set => basis_set_a
          ELSE
             NULLIFY (basis_set_list(ikind)%gto_basis_set)
          END IF
+      END DO
+      DO ikind = 1, nkind*nkind
+         has_intac(ikind) = ASSOCIATED(my_oce%intac(ikind)%alist)
       END DO
 
       ! build the hash table in serial...
@@ -309,6 +316,7 @@ CONTAINS
 !$OMP                 , ksmat, pmat, natom, nkind, my_kind_set, my_oce &
 !$OMP                 , my_rho_atom, factor1, factor2, use_virial    &
 !$OMP                 , atom_of_kind, ldCPC, force, locks, force_fac &
+!$OMP                 , paw_kind, has_intac                          &
 !$OMP                 )                                              &
 !$OMP          PRIVATE( slot_num, is_entry_null, TASK, is_task_valid &
 !$OMP                 , C_int_h, C_int_s, coc, a_matrix, p_matrix    &
@@ -317,7 +325,7 @@ CONTAINS
 !$OMP                 , ikind, jkind, iatom, jatom, cell_b           &
 !$OMP                 , basis_set_a, basis_set_b, img                &
 !$OMP                 , found, next_task                             &
-!$OMP                 , kkind, paw_atom, lock_num                    &
+!$OMP                 , kkind, lock_num                              &
 !$OMP                 , iac, alist_ac, kac, n_cont_a, list_a         &
 !$OMP                 , ibc, alist_bc, kbc, n_cont_b, list_b         &
 !$OMP                 , katom, rho_at, nsoctot                       &
@@ -411,14 +419,12 @@ CONTAINS
                END DO
 
                DO kkind = 1, nkind
-                  CALL get_qs_kind(my_kind_set(kkind), paw_atom=paw_atom)
-
-                  IF (.NOT. paw_atom) CYCLE
+                  IF (.NOT. paw_kind(kkind)) CYCLE
 
                   iac = ikind + nkind*(kkind - 1)
                   ibc = jkind + nkind*(kkind - 1)
-                  IF (.NOT. ASSOCIATED(my_oce%intac(iac)%alist)) CYCLE
-                  IF (.NOT. ASSOCIATED(my_oce%intac(ibc)%alist)) CYCLE
+                  IF (.NOT. has_intac(iac)) CYCLE
+                  IF (.NOT. has_intac(ibc)) CYCLE
 
                   CALL get_alist(my_oce%intac(iac), alist_ac, iatom)
                   CALL get_alist(my_oce%intac(ibc), alist_bc, jatom)
@@ -570,7 +576,7 @@ CONTAINS
 
       CALL nl_hash_table_release(nl_hash_table)
 
-      DEALLOCATE (basis_set_list)
+      DEALLOCATE (basis_set_list, paw_kind, has_intac)
 
       CALL timestop(handle)
 

--- a/src/qs_oce_methods.F
+++ b/src/qs_oce_methods.F
@@ -524,6 +524,7 @@ CONTAINS
                                                             nprjla, nsgf_seta
       INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa
       LOGICAL                                            :: local, paw_atom_b, sgf_soft_only
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: has_1c_basis, has_orb_basis, paw_kind
       REAL(KIND=dp)                                      :: dab, rcprj
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: sab, work
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: ai_work
@@ -564,6 +565,21 @@ CONTAINS
             intac(i)%nalist = 0
          END DO
 
+         ALLOCATE (has_orb_basis(nkind), paw_kind(nkind), has_1c_basis(nkind))
+         has_orb_basis(:) = .FALSE.
+         paw_kind(:) = .FALSE.
+         has_1c_basis(:) = .FALSE.
+         DO ikind = 1, nkind
+            NULLIFY (orb_basis_set)
+            CALL get_qs_kind(qs_kind=qs_kind_set(ikind), basis_set=orb_basis_set)
+            has_orb_basis(ikind) = ASSOCIATED(orb_basis_set)
+            NULLIFY (paw_proj_b)
+            CALL get_qs_kind(qs_kind=qs_kind_set(ikind), paw_proj_set=paw_proj_b, paw_atom=paw_kind(ikind))
+            NULLIFY (orb_basis_paw)
+            CALL get_qs_kind(qs_kind=qs_kind_set(ikind), basis_set=orb_basis_paw, basis_type="GAPW_1C")
+            has_1c_basis(ikind) = ASSOCIATED(orb_basis_paw)
+         END DO
+
          ! Allocate memory list
          DO slot = 1, sap_oce(1)%nl_size
             ikind = sap_oce(1)%nlist_task(slot)%ikind
@@ -575,15 +591,9 @@ CONTAINS
 
             iac = ikind + nkind*(jkind - 1)
 
-            qs_kind => qs_kind_set(ikind)
-            CALL get_qs_kind(qs_kind=qs_kind, basis_set=orb_basis_set)
-            IF (.NOT. ASSOCIATED(orb_basis_set)) CYCLE
-            qs_kind => qs_kind_set(jkind)
-            NULLIFY (paw_proj_b)
-            CALL get_qs_kind(qs_kind=qs_kind, paw_proj_set=paw_proj_b, paw_atom=paw_atom_b)
-            IF (.NOT. paw_atom_b) CYCLE
-            CALL get_qs_kind(qs_kind=qs_kind, basis_set=orb_basis_paw, basis_type="GAPW_1C")
-            IF (.NOT. ASSOCIATED(orb_basis_paw)) CYCLE
+            IF (.NOT. has_orb_basis(ikind)) CYCLE
+            IF (.NOT. paw_kind(jkind)) CYCLE
+            IF (.NOT. has_1c_basis(jkind)) CYCLE
             IF (.NOT. ASSOCIATED(intac(iac)%alist)) THEN
                intac(iac)%a_kind = ikind
                intac(iac)%p_kind = jkind
@@ -607,7 +617,8 @@ CONTAINS
 
          !calculate the overlap integrals <a|p>
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP SHARED (intac, ldsab, ldai, nder, nkind, maxder, ncoset, sap_oce, qs_kind_set, eps_fit) &
+!$OMP SHARED (intac, ldsab, ldai, nder, nkind, maxder, ncoset, sap_oce, qs_kind_set, eps_fit, &
+!$OMP         has_orb_basis, paw_kind, has_1c_basis, maxsgf) &
 !$OMP PRIVATE (sab, work, ai_work, oceh, oces, slot, ikind, jkind, atom_a, atom_b, ilist, jneighbor, rab, cell_b, &
 !$OMP          iac, dab, qs_kind, orb_basis_set, first_sgfa, la_max, la_min, ncoa_sum, maxsoa, npgfa, nseta, &
 !$OMP          nsgfa, nsgf_seta, rpgfa, set_radius_a, sphi_a, zeta, paw_proj_b, paw_atom_b, orb_basis_paw, &
@@ -619,6 +630,7 @@ CONTAINS
          ALLOCATE (ai_work(ldai, ldai, ncoset(nder + 1)))
          ai_work = 0.0_dp
          ALLOCATE (oceh(maxder), oces(maxder))
+         ALLOCATE (sgf_list(maxsgf))
 
 !$OMP DO SCHEDULE(GUIDED)
          DO slot = 1, sap_oce(1)%nl_size
@@ -633,6 +645,10 @@ CONTAINS
 
             iac = ikind + nkind*(jkind - 1)
             dab = SQRT(SUM(rab*rab))
+
+            IF (.NOT. has_orb_basis(ikind)) CYCLE
+            IF (.NOT. paw_kind(jkind)) CYCLE
+            IF (.NOT. has_1c_basis(jkind)) CYCLE
 
             qs_kind => qs_kind_set(ikind)
             CALL get_qs_kind(qs_kind=qs_kind, basis_set=orb_basis_set)
@@ -683,8 +699,6 @@ CONTAINS
             clist%maxac = 0.0_dp
             clist%maxach = 0.0_dp
             NULLIFY (clist%acint, clist%achint, clist%sgf_list)
-
-            ALLOCATE (sgf_list(nsgfa))
 
             at_a => qs_kind_set(jkind)
             at_b => qs_kind_set(ikind)
@@ -741,16 +755,17 @@ CONTAINS
                END DO
             END IF
 
-            DEALLOCATE (sgf_list)
-
          END DO
 
          DEALLOCATE (sab, work, ai_work)
+         DEALLOCATE (sgf_list)
          DEALLOCATE (oceh, oces)
 !$OMP END PARALLEL
 
          ! Setup sort index
          CALL sap_sort(intac)
+
+         DEALLOCATE (has_orb_basis, paw_kind, has_1c_basis)
 
       END IF
 

--- a/src/qs_rho0_methods.F
+++ b/src/qs_rho0_methods.F
@@ -258,8 +258,16 @@ CONTAINS
                CALL get_rho_atom(rho_atom=rho_atom, cpc_h=cpc_h, cpc_s=cpc_s)
                nspins = SIZE(cpc_h)
                nsotot = SIZE(mpole_gau%Qlm_gg, 1)
+               IF (ALLOCATED(cpc_ah)) THEN
+                  IF (SIZE(cpc_ah, 1) /= nsotot .OR. SIZE(cpc_ah, 2) /= nsotot .OR. &
+                      SIZE(cpc_ah, 3) /= nspins) DEALLOCATE (cpc_ah)
+               END IF
                IF (.NOT. ALLOCATED(cpc_ah)) ALLOCATE (cpc_ah(nsotot, nsotot, nspins))
                cpc_ah = 0._dp
+               IF (ALLOCATED(cpc_as)) THEN
+                  IF (SIZE(cpc_as, 1) /= nsotot .OR. SIZE(cpc_as, 2) /= nsotot .OR. &
+                      SIZE(cpc_as, 3) /= nspins) DEALLOCATE (cpc_as)
+               END IF
                IF (.NOT. ALLOCATED(cpc_as)) ALLOCATE (cpc_as(nsotot, nsotot, nspins))
                cpc_as = 0._dp
                DO ispin = 1, nspins
@@ -270,10 +278,16 @@ CONTAINS
                IF (ASSOCIATED(cneo_potential)) THEN
                   IF (rhoz_cneo_set(iatom)%ready) THEN
                      nsotot_nuc = SIZE(cneo_potential%Qlm_gg, 1)
-                     IF (.NOT. ALLOCATED(cpc_h_nuc)) &
-                        ALLOCATE (cpc_h_nuc(nsotot_nuc, nsotot_nuc))
-                     IF (.NOT. ALLOCATED(cpc_s_nuc)) &
-                        ALLOCATE (cpc_s_nuc(nsotot_nuc, nsotot_nuc))
+                     IF (ALLOCATED(cpc_h_nuc)) THEN
+                        IF (SIZE(cpc_h_nuc, 1) /= nsotot_nuc .OR. &
+                            SIZE(cpc_h_nuc, 2) /= nsotot_nuc) DEALLOCATE (cpc_h_nuc)
+                     END IF
+                     IF (.NOT. ALLOCATED(cpc_h_nuc)) ALLOCATE (cpc_h_nuc(nsotot_nuc, nsotot_nuc))
+                     IF (ALLOCATED(cpc_s_nuc)) THEN
+                        IF (SIZE(cpc_s_nuc, 1) /= nsotot_nuc .OR. &
+                            SIZE(cpc_s_nuc, 2) /= nsotot_nuc) DEALLOCATE (cpc_s_nuc)
+                     END IF
+                     IF (.NOT. ALLOCATED(cpc_s_nuc)) ALLOCATE (cpc_s_nuc(nsotot_nuc, nsotot_nuc))
                      cpc_h_nuc = 0._dp
                      cpc_s_nuc = 0._dp
                      CALL cneo_scatter(rhoz_cneo_set(iatom)%cpc_h, cpc_h_nuc, cneo_potential%npsgf, &

--- a/src/qs_rho0_methods.F
+++ b/src/qs_rho0_methods.F
@@ -258,9 +258,9 @@ CONTAINS
                CALL get_rho_atom(rho_atom=rho_atom, cpc_h=cpc_h, cpc_s=cpc_s)
                nspins = SIZE(cpc_h)
                nsotot = SIZE(mpole_gau%Qlm_gg, 1)
-               ALLOCATE (cpc_ah(nsotot, nsotot, nspins))
+               IF (.NOT. ALLOCATED(cpc_ah)) ALLOCATE (cpc_ah(nsotot, nsotot, nspins))
                cpc_ah = 0._dp
-               ALLOCATE (cpc_as(nsotot, nsotot, nspins))
+               IF (.NOT. ALLOCATED(cpc_as)) ALLOCATE (cpc_as(nsotot, nsotot, nspins))
                cpc_as = 0._dp
                DO ispin = 1, nspins
                   CALL prj_scatter(cpc_h(ispin)%r_coef, cpc_ah(:, :, ispin), qs_kind)
@@ -270,7 +270,10 @@ CONTAINS
                IF (ASSOCIATED(cneo_potential)) THEN
                   IF (rhoz_cneo_set(iatom)%ready) THEN
                      nsotot_nuc = SIZE(cneo_potential%Qlm_gg, 1)
-                     ALLOCATE (cpc_h_nuc(nsotot_nuc, nsotot_nuc), cpc_s_nuc(nsotot_nuc, nsotot_nuc))
+                     IF (.NOT. ALLOCATED(cpc_h_nuc)) &
+                        ALLOCATE (cpc_h_nuc(nsotot_nuc, nsotot_nuc))
+                     IF (.NOT. ALLOCATED(cpc_s_nuc)) &
+                        ALLOCATE (cpc_s_nuc(nsotot_nuc, nsotot_nuc))
                      cpc_h_nuc = 0._dp
                      cpc_s_nuc = 0._dp
                      CALL cneo_scatter(rhoz_cneo_set(iatom)%cpc_h, cpc_h_nuc, cneo_potential%npsgf, &
@@ -320,10 +323,6 @@ CONTAINS
                      END DO ! iso
                   END IF
                END IF
-
-               DEALLOCATE (cpc_ah, cpc_as)
-               IF (ALLOCATED(cpc_h_nuc)) DEALLOCATE (cpc_h_nuc)
-               IF (ALLOCATED(cpc_s_nuc)) DEALLOCATE (cpc_s_nuc)
             END IF
 
             DO iso = 1, nsoset(lmax0)
@@ -348,6 +347,11 @@ CONTAINS
             END DO ! iso
          END DO ! iat
       END IF
+
+      IF (ALLOCATED(cpc_ah)) DEALLOCATE (cpc_ah)
+      IF (ALLOCATED(cpc_as)) DEALLOCATE (cpc_as)
+      IF (ALLOCATED(cpc_h_nuc)) DEALLOCATE (cpc_h_nuc)
+      IF (ALLOCATED(cpc_s_nuc)) DEALLOCATE (cpc_s_nuc)
 
       ! Transform the coefficinets from spherical to Cartesian
       IF (.NOT. paw_atom .AND. gapw_control%nopaw_as_gpw) THEN

--- a/src/qs_rho_atom_methods.F
+++ b/src/qs_rho_atom_methods.F
@@ -113,8 +113,8 @@ CONTAINS
       INTEGER :: damax_iso_not0_local, handle, i, i1, i2, iat, iatom, icg, ipgf1, ipgf2, ir, &
          iset1, iset2, iso, iso1, iso1_first, iso1_last, iso2, iso2_first, iso2_last, j, l, l1, &
          l2, l_iso, l_sub, l_sum, lmax12, lmax_expansion, lmin12, m1s, m2s, max_iso_not0, &
-         max_iso_not0_local, max_s_harm, maxl, maxso, mepos, n1s, n2s, nr, nset, num_pe, size1, &
-         size2
+         max_iso_not0_local, max_npgf, max_s_harm, maxl, maxso, mepos, n1s, n2s, nr, nset, num_pe, &
+         size1, size2
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cg_n_list, dacg_n_list
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: cg_list, dacg_list
       INTEGER, DIMENSION(2)                              :: bo
@@ -123,7 +123,7 @@ CONTAINS
       REAL(dp)                                           :: c1, c2, rho_h, rho_s, root_zet12, zet12
       REAL(dp), ALLOCATABLE, DIMENSION(:)                :: erf_zet12, g1, g2, gg0, int1, int2
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: CPCH_sphere, CPCS_sphere, dgg, gg, gg_lm1
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: vgg
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: g_rad, vgg
       REAL(dp), DIMENSION(:, :), POINTER                 :: coeff, zet
       REAL(dp), DIMENSION(:, :, :), POINTER              :: my_CG
       REAL(dp), DIMENSION(:, :, :, :), POINTER           :: my_CG_dxyz
@@ -152,6 +152,7 @@ CONTAINS
       max_s_harm = harmonics%max_s_harm
 
       nr = grid_atom%nr
+      max_npgf = MAXVAL(npgf(1:nset))
       lmax_expansion = indso(1, max_iso_not0)
       ! Distribute the atoms of this kind
       num_pe = para_env%num_pe
@@ -169,6 +170,13 @@ CONTAINS
       ALLOCATE (int1(nr), int2(nr))
       ALLOCATE (cg_list(2, nsoset(maxl)**2, max_s_harm), cg_n_list(max_s_harm), &
                 dacg_list(2, nsoset(maxl)**2, max_s_harm), dacg_n_list(max_s_harm))
+      ALLOCATE (g_rad(nr, max_npgf, nset))
+
+      DO iset1 = 1, nset
+         DO ipgf1 = 1, npgf(iset1)
+            g_rad(1:nr, ipgf1, iset1) = EXP(-zet(ipgf1, iset1)*grid_atom%rad2(1:nr))
+         END DO
+      END DO
 
       DO iat = bo(1), bo(2)
          iatom = atom_list(iat)
@@ -203,7 +211,7 @@ CONTAINS
                CPASSERT(size1 == i1)
                i1 = nsoset(lmin(iset1) - 1) + 1
 
-               g1(1:nr) = EXP(-zet(ipgf1, iset1)*grid_atom%rad2(1:nr))
+               g1(1:nr) = g_rad(1:nr, ipgf1, iset1)
 
                n2s = nsoset(lmax(iset2))
                DO ipgf2 = 1, npgf(iset2)
@@ -216,7 +224,7 @@ CONTAINS
                   CPASSERT(size2 == i2)
                   i2 = nsoset(lmin(iset2) - 1) + 1
 
-                  g2(1:nr) = EXP(-zet(ipgf2, iset2)*grid_atom%rad2(1:nr))
+                  g2(1:nr) = g_rad(1:nr, ipgf2, iset2)
                   lmin12 = lmin(iset1) + lmin(iset2)
                   lmax12 = lmax(iset1) + lmax(iset2)
 
@@ -390,7 +398,7 @@ CONTAINS
       END DO ! iat
 
       DEALLOCATE (CPCH_sphere, CPCS_sphere)
-      DEALLOCATE (g1, g2, gg0, gg, gg_lm1, dgg, vgg, done_vgg, erf_zet12, int1, int2)
+      DEALLOCATE (g1, g2, gg0, gg, gg_lm1, dgg, vgg, done_vgg, erf_zet12, int1, int2, g_rad)
       DEALLOCATE (cg_list, cg_n_list, dacg_list, dacg_n_list)
       DEALLOCATE (o2nindex)
 
@@ -431,12 +439,13 @@ CONTAINS
 
       INTEGER :: bo(2), handle, i, iac, iatom, ibc, icol, ikind, img, irow, ispin, jatom, jkind, &
          kac, katom, kbc, kkind, len_CPC, len_PC1, max_gau, max_nsgf, mepos, n_cont_a, n_cont_b, &
-         nat_kind, natom, nimages, nkind, nsatbas, nsoctot, nspins, num_pe
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of
+         nat_kind, natom, nimages, nkind, nsoctot, nspins, num_pe
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: kind_of, nsatbas_kind
       INTEGER, DIMENSION(3)                              :: cell_b
       INTEGER, DIMENSION(:), POINTER                     :: a_list, list_a, list_b
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: dista, distab, distb, found, paw_atom
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: has_intac, paw_kind
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: p_matrix
       REAL(KIND=dp)                                      :: eps_cpc, factor, pmax
       REAL(KIND=dp), DIMENSION(3)                        :: rab
@@ -509,6 +518,10 @@ CONTAINS
       END DO ! ikind
 
       ALLOCATE (basis_set_list(nkind))
+      ALLOCATE (paw_kind(nkind), nsatbas_kind(nkind), has_intac(nkind*nkind))
+      paw_kind(:) = .FALSE.
+      nsatbas_kind(:) = 0
+      has_intac(:) = .FALSE.
       DO ikind = 1, nkind
          CALL get_qs_kind(qs_kind_set(ikind), basis_set=basis_set_a)
          IF (ASSOCIATED(basis_set_a)) THEN
@@ -516,6 +529,12 @@ CONTAINS
          ELSE
             NULLIFY (basis_set_list(ikind)%gto_basis_set)
          END IF
+         CALL get_qs_kind(qs_kind_set(ikind), basis_set=basis_1c, basis_type="GAPW_1C", &
+                          paw_atom=paw_kind(ikind))
+         IF (paw_kind(ikind)) CALL get_paw_basis_info(basis_1c, nsatbas=nsatbas_kind(ikind))
+      END DO
+      DO ikind = 1, nkind*nkind
+         has_intac(ikind) = ASSOCIATED(oce%intac(ikind)%alist)
       END DO
 
       len_PC1 = max_nsgf*max_gau
@@ -535,16 +554,16 @@ CONTAINS
 !$OMP                 , oce, eps_cpc                      &
 !$OMP                 , rho_atom_set                      &
 !$OMP                 , natom, locks, number_of_locks     &
+!$OMP                 , paw_kind, nsatbas_kind, has_intac &
 !$OMP                 )                                   &
 !$OMP          PRIVATE( p_block_spin, ispin               &
 !$OMP                 , p_matrix, mepos                   &
 !$OMP                 , ikind, jkind, iatom, jatom        &
-!$OMP                 , cell_b, rab, basis_1c             &
+!$OMP                 , cell_b, rab                       &
 !$OMP                 , basis_set_a, basis_set_b          &
 !$OMP                 , pmax, irow, icol, img             &
 !$OMP                 , found                             &
 !$OMP                 , kkind                             &
-!$OMP                 , paw_atom, nsatbas                 &
 !$OMP                 , nsoctot, katom                    &
 !$OMP                 , iac , alist_ac, kac, n_cont_a, list_a     &
 !$OMP                 , ibc , alist_bc, kbc, n_cont_b, list_b     &
@@ -606,18 +625,14 @@ CONTAINS
          END DO
 
          DO kkind = 1, nkind
-            CALL get_qs_kind(qs_kind_set(kkind), basis_set=basis_1c, basis_type="GAPW_1C", &
-                             paw_atom=paw_atom)
+            IF (.NOT. paw_kind(kkind)) CYCLE
 
-            IF (.NOT. paw_atom) CYCLE
-
-            CALL get_paw_basis_info(basis_1c, nsatbas=nsatbas)
-            nsoctot = nsatbas
+            nsoctot = nsatbas_kind(kkind)
 
             iac = ikind + nkind*(kkind - 1)
             ibc = jkind + nkind*(kkind - 1)
-            IF (.NOT. ASSOCIATED(oce%intac(iac)%alist)) CYCLE
-            IF (.NOT. ASSOCIATED(oce%intac(ibc)%alist)) CYCLE
+            IF (.NOT. has_intac(iac)) CYCLE
+            IF (.NOT. has_intac(ibc)) CYCLE
 
             CALL get_alist(oce%intac(iac), alist_ac, iatom)
             CALL get_alist(oce%intac(ibc), alist_bc, jatom)
@@ -734,7 +749,7 @@ CONTAINS
 
       END DO
 
-      DEALLOCATE (kind_of, basis_set_list)
+      DEALLOCATE (kind_of, basis_set_list, paw_kind, nsatbas_kind, has_intac)
 
       CALL timestop(handle)
 

--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -2679,9 +2679,10 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'dgaVtaudgb'
 
       INTEGER                                            :: dir, handle, ipgf, iset, iso, ispin, &
-                                                            jpgf, jset, jso, l, maxso, na, nr, &
-                                                            nset, starti, startj
+                                                            iterm, jpgf, jset, jso, l, maxso, na, &
+                                                            nr, nset, nterm, starti, startj
       INTEGER, DIMENSION(:), POINTER                     :: lmax, lmin, npgf
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: gexp
       REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: fga, fgr, r1, r2, work
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: a1, a2, intso_h, intso_s
       REAL(dp), DIMENSION(:, :), POINTER                 :: slm, zet
@@ -2702,6 +2703,7 @@ CONTAINS
 
       ! Separate the functions into purely r and purely angular parts and precompute them all
       ! Not memory intensive since 1D arrays
+      ALLOCATE (gexp(nr))
       ALLOCATE (a1(na, nset*maxso, 3), a2(na, nset*maxso, 3))
       ALLOCATE (r1(nr, nset*maxso), r2(nr, nset*maxso))
       a1 = 0.0_dp; a2 = 0.0_dp
@@ -2710,6 +2712,7 @@ CONTAINS
       DO iset = 1, nset
          DO ipgf = 1, npgf(iset)
             starti = (iset - 1)*maxso + (ipgf - 1)*nsoset(lmax(iset))
+            gexp(1:nr) = EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
             DO iso = nsoset(lmin(iset) - 1) + 1, nsoset(lmax(iset))
                l = indso(1, iso)
 
@@ -2717,11 +2720,11 @@ CONTAINS
                ! Two of each are needed because d/dx(r^l Y_lm) * exp(-al*r^2) + r^l Y_lm *  d/dx(exp-al*r^2)
 
                ! the purely radial part of d/dx(r^l Y_lm) * exp(-al*r^2) (same for y,z)
-               r1(1:nr, starti + iso) = grid_atom%rad(1:nr)**(l - 1)*EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
+               r1(1:nr, starti + iso) = grid_atom%rad(1:nr)**(l - 1)*gexp(1:nr)
 
                ! the purely radial part of r^l Y_lm * d/dx(exp-al*r^2) (same for y,z)
-               r2(1:nr, starti + iso) = -2.0_dp*zet(ipgf, iset)*grid_atom%rad(1:nr)**(l + 1) &
-                                        *EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
+               r2(1:nr, starti + iso) = -2.0_dp*zet(ipgf, iset)*grid_atom%rad2(1:nr)* &
+                                        r1(1:nr, starti + iso)
 
                DO dir = 1, 3
                   ! the purely angular part of d/dx(r^l Y_lm) * exp(-al*r^2)
@@ -2735,14 +2738,13 @@ CONTAINS
          END DO !ipgf
       END DO !iset
 
-      !Do the integration in terms of matrix-matrix multiplications
       ALLOCATE (intso_h(nset*maxso, nset*maxso, nspins))
       ALLOCATE (intso_s(nset*maxso, nset*maxso, nspins))
       intso_h = 0.0_dp; intso_s = 0.0_dp
 
-      ALLOCATE (fga(na, 1))
-      ALLOCATE (fgr(nr, 1))
-      ALLOCATE (work(na, 1))
+      ALLOCATE (fga(na, 12))
+      ALLOCATE (fgr(nr, 12))
+      ALLOCATE (work(na, 12))
       fga = 0.0_dp; fgr = 0.0_dp; work = 0.0_dp
 
       DO iset = 1, nset
@@ -2755,79 +2757,48 @@ CONTAINS
                   DO iso = nsoset(lmin(iset) - 1) + 1, nsoset(lmax(iset))
                      DO jso = nsoset(lmin(jset) - 1) + 1, nsoset(lmax(jset))
 
-                        !Two component per function => 4 terms in total
-
-                        ! take 0.5*r1*a1(dir) * V * r1*a1(dir)
-                        fgr(1:nr, 1) = r1(1:nr, starti + iso)*r1(1:nr, startj + jso)
+                        nterm = 0
                         DO dir = 1, 3
-                           fga(1:na, 1) = a1(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
-
-                           DO ispin = 1, nspins
-                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_h(:, :, ispin), na, fgr, &
-                                         nr, 0.0_dp, work, na)
-                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
-                                         intso_h(starti + iso:, startj + jso, ispin), 1)
-
-                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_s(:, :, ispin), na, fgr, &
-                                         nr, 0.0_dp, work, na)
-                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
-                                         intso_s(starti + iso:, startj + jso, ispin), 1)
-                           END DO
+                           nterm = nterm + 1
+                           fgr(1:nr, nterm) = r1(1:nr, starti + iso)*r1(1:nr, startj + jso)
+                           fga(1:na, nterm) = a1(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
                         END DO !dir
 
-                        ! add 0.5*r1*a1(dir) * V * r2*a2(dir)
-                        fgr(1:nr, 1) = r1(1:nr, starti + iso)*r2(1:nr, startj + jso)
                         DO dir = 1, 3
-                           fga(1:na, 1) = a1(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
-
-                           DO ispin = 1, nspins
-                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_h(:, :, ispin), na, fgr, &
-                                         nr, 0.0_dp, work, na)
-                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
-                                         intso_h(starti + iso:, startj + jso, ispin), 1)
-
-                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_s(:, :, ispin), na, fgr, &
-                                         nr, 0.0_dp, work, na)
-                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
-                                         intso_s(starti + iso:, startj + jso, ispin), 1)
-                           END DO
+                           nterm = nterm + 1
+                           fgr(1:nr, nterm) = r1(1:nr, starti + iso)*r2(1:nr, startj + jso)
+                           fga(1:na, nterm) = a1(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
                         END DO !dir
 
-                        ! add 0.5*r2*a2(dir) * V * r1*a1(dir)
-                        fgr(1:nr, 1) = r2(1:nr, starti + iso)*r1(1:nr, startj + jso)
                         DO dir = 1, 3
-                           fga(1:na, 1) = a2(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
-
-                           DO ispin = 1, nspins
-                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_h(:, :, ispin), na, fgr, &
-                                         nr, 0.0_dp, work, na)
-                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
-                                         intso_h(starti + iso:, startj + jso, ispin), 1)
-
-                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_s(:, :, ispin), na, fgr, &
-                                         nr, 0.0_dp, work, na)
-                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
-                                         intso_s(starti + iso:, startj + jso, ispin), 1)
-                           END DO
+                           nterm = nterm + 1
+                           fgr(1:nr, nterm) = r2(1:nr, starti + iso)*r1(1:nr, startj + jso)
+                           fga(1:na, nterm) = a2(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
                         END DO !dir
 
-                        ! add the last term: 0.5*r2*a2(dir) * V * r2*a2(dir)
-                        fgr(1:nr, 1) = r2(1:nr, starti + iso)*r2(1:nr, startj + jso)
                         DO dir = 1, 3
-                           fga(1:na, 1) = a2(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
-
-                           DO ispin = 1, nspins
-                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_h(:, :, ispin), na, fgr, &
-                                         nr, 0.0_dp, work, na)
-                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
-                                         intso_h(starti + iso:, startj + jso, ispin), 1)
-
-                              CALL dgemm('N', 'N', na, 1, nr, 0.5_dp, vtau_s(:, :, ispin), na, fgr, &
-                                         nr, 0.0_dp, work, na)
-                              CALL dgemm('T', 'N', 1, 1, na, 1.0_dp, work, na, fga, na, 1.0_dp, &
-                                         intso_s(starti + iso:, startj + jso, ispin), 1)
-                           END DO
+                           nterm = nterm + 1
+                           fgr(1:nr, nterm) = r2(1:nr, starti + iso)*r2(1:nr, startj + jso)
+                           fga(1:na, nterm) = a2(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
                         END DO !dir
+
+                        DO ispin = 1, nspins
+                           CALL dgemm('N', 'N', na, nterm, nr, 0.5_dp, vtau_h(:, :, ispin), na, fgr, &
+                                      nr, 0.0_dp, work, na)
+                           DO iterm = 1, nterm
+                              intso_h(starti + iso, startj + jso, ispin) = &
+                                 intso_h(starti + iso, startj + jso, ispin) + &
+                                 SUM(work(1:na, iterm)*fga(1:na, iterm))
+                           END DO
+
+                           CALL dgemm('N', 'N', na, nterm, nr, 0.5_dp, vtau_s(:, :, ispin), na, fgr, &
+                                      nr, 0.0_dp, work, na)
+                           DO iterm = 1, nterm
+                              intso_s(starti + iso, startj + jso, ispin) = &
+                                 intso_s(starti + iso, startj + jso, ispin) + &
+                                 SUM(work(1:na, iterm)*fga(1:na, iterm))
+                           END DO
+                        END DO
 
                      END DO !jso
                   END DO !iso
@@ -2842,6 +2813,8 @@ CONTAINS
          int_hh(ispin)%r_coef(:, :) = int_hh(ispin)%r_coef(:, :) + intso_h(:, :, ispin)
          int_ss(ispin)%r_coef(:, :) = int_ss(ispin)%r_coef(:, :) + intso_s(:, :, ispin)
       END DO
+
+      DEALLOCATE (a1, a2, fga, fgr, gexp, intso_h, intso_s, r1, r2, work)
 
       CALL timestop(handle)
 

--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -225,12 +225,19 @@ CONTAINS
             ! set integration weights
             IF (accint) THEN
                weight_h => grid_atom%weight
-               ALLOCATE (weight_s(na, nr))
                alpha = dft_control%qs_control%gapw_control%aw(ikind)
-               DO ir = 1, nr
-                  agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ir))
-                  weight_s(:, ir) = grid_atom%weight(:, ir)*agr
-               END DO
+               IF (ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+                  IF (grid_atom%gapw_weight_alpha /= alpha) DEALLOCATE (grid_atom%gapw_weight_s)
+               END IF
+               IF (.NOT. ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+                  ALLOCATE (grid_atom%gapw_weight_s(na, nr))
+                  DO ir = 1, nr
+                     agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ir))
+                     grid_atom%gapw_weight_s(:, ir) = grid_atom%weight(:, ir)*agr
+                  END DO
+                  grid_atom%gapw_weight_alpha = alpha
+               END IF
+               weight_s => grid_atom%gapw_weight_s
             ELSE
                weight_h => grid_atom%weight
                weight_s => grid_atom%weight
@@ -318,6 +325,7 @@ CONTAINS
                                         ir, rho_nlcc(:, 1), rho_h, rho_s, rho_nlcc(:, 2), drho_h, drho_s)
                   END IF
                END DO
+
                DO ir = 1, nr
                   IF (tau_f) THEN
                      CALL fill_rho_set(rho_set_h, lsd, nspins, needs, rho_h, drho_h, tau_h, na, ir)
@@ -379,10 +387,6 @@ CONTAINS
             CALL xc_dset_release(deriv_set)
             CALL xc_rho_set_release(rho_set_h)
             CALL xc_rho_set_release(rho_set_s)
-            IF (accint) THEN
-               DEALLOCATE (weight_s)
-            END IF
-
          END DO ! ikind
 
          CALL para_env%sum(exc1)
@@ -547,12 +551,19 @@ CONTAINS
             ! set integration weights
             IF (accint) THEN
                weight_h => grid_atom%weight
-               ALLOCATE (weight_s(na, nr))
                alpha = dft_control%qs_control%gapw_control%aw(ikind)
-               DO ir = 1, nr
-                  agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ir))
-                  weight_s(:, ir) = grid_atom%weight(:, ir)*agr
-               END DO
+               IF (ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+                  IF (grid_atom%gapw_weight_alpha /= alpha) DEALLOCATE (grid_atom%gapw_weight_s)
+               END IF
+               IF (.NOT. ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+                  ALLOCATE (grid_atom%gapw_weight_s(na, nr))
+                  DO ir = 1, nr
+                     agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ir))
+                     grid_atom%gapw_weight_s(:, ir) = grid_atom%weight(:, ir)*agr
+                  END DO
+                  grid_atom%gapw_weight_alpha = alpha
+               END IF
+               weight_s => grid_atom%gapw_weight_s
             ELSE
                weight_h => grid_atom%weight
                weight_s => grid_atom%weight
@@ -712,10 +723,6 @@ CONTAINS
             CALL xc_dset_release(deriv_set)
             CALL xc_rho_set_release(rho_set_h)
             CALL xc_rho_set_release(rho_set_s)
-            IF (accint) THEN
-               DEALLOCATE (weight_s)
-            END IF
-
          END DO ! ikind
 
          CALL para_env%sum(exc1)
@@ -883,12 +890,19 @@ CONTAINS
          ! set integration weights
          IF (accint) THEN
             weight_h => grid_atom%weight
-            ALLOCATE (weight_s(na, nr))
             alpha = dft_control%qs_control%gapw_control%aw(ikind)
-            DO ir = 1, nr
-               agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ir))
-               weight_s(:, ir) = grid_atom%weight(:, ir)*agr
-            END DO
+            IF (ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+               IF (grid_atom%gapw_weight_alpha /= alpha) DEALLOCATE (grid_atom%gapw_weight_s)
+            END IF
+            IF (.NOT. ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+               ALLOCATE (grid_atom%gapw_weight_s(na, nr))
+               DO ir = 1, nr
+                  agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ir))
+                  grid_atom%gapw_weight_s(:, ir) = grid_atom%weight(:, ir)*agr
+               END DO
+               grid_atom%gapw_weight_alpha = alpha
+            END IF
+            weight_s => grid_atom%gapw_weight_s
          ELSE
             weight_h => grid_atom%weight
             weight_s => grid_atom%weight
@@ -1053,10 +1067,6 @@ CONTAINS
          CALL xc_rho_set_release(rho1_set_h)
          CALL xc_rho_set_release(rho_set_s)
          CALL xc_rho_set_release(rho1_set_s)
-         IF (accint) THEN
-            DEALLOCATE (weight_s)
-         END IF
-
       END DO
 
       CALL timestop(handle)
@@ -1191,12 +1201,19 @@ CONTAINS
             ! set integration weights
             IF (accint) THEN
                weight_h => grid_atom%weight
-               ALLOCATE (weight_s(na, nr))
                alpha = dft_control%qs_control%gapw_control%aw(ikind)
-               DO ir = 1, nr
-                  agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ikind))
-                  weight_s(:, ir) = grid_atom%weight(:, ir)*agr
-               END DO
+               IF (ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+                  IF (grid_atom%gapw_weight_alpha /= alpha) DEALLOCATE (grid_atom%gapw_weight_s)
+               END IF
+               IF (.NOT. ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+                  ALLOCATE (grid_atom%gapw_weight_s(na, nr))
+                  DO ir = 1, nr
+                     agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ir))
+                     grid_atom%gapw_weight_s(:, ir) = grid_atom%weight(:, ir)*agr
+                  END DO
+                  grid_atom%gapw_weight_alpha = alpha
+               END IF
+               weight_s => grid_atom%gapw_weight_s
             ELSE
                weight_h => grid_atom%weight
                weight_s => grid_atom%weight
@@ -1468,10 +1485,6 @@ CONTAINS
                DEALLOCATE (tau_h, tau_s, tau0_h, tau0_s, tau1_h, tau1_s)
                DEALLOCATE (vtau_h, vtau_s)
             END IF
-            IF (accint) THEN
-               DEALLOCATE (weight_s)
-            END IF
-
          END DO ! ikind
 
       END IF !xc_none
@@ -1607,12 +1620,19 @@ CONTAINS
             ! set integration weights
             IF (accint) THEN
                weight_h => grid_atom%weight
-               ALLOCATE (weight_s(na, nr))
                alpha = dft_control%qs_control%gapw_control%aw(ikind)
-               DO ir = 1, nr
-                  agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ir))
-                  weight_s(:, ir) = grid_atom%weight(:, ir)*agr
-               END DO
+               IF (ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+                  IF (grid_atom%gapw_weight_alpha /= alpha) DEALLOCATE (grid_atom%gapw_weight_s)
+               END IF
+               IF (.NOT. ASSOCIATED(grid_atom%gapw_weight_s)) THEN
+                  ALLOCATE (grid_atom%gapw_weight_s(na, nr))
+                  DO ir = 1, nr
+                     agr = 1.0_dp - EXP(-alpha*grid_atom%rad2(ir))
+                     grid_atom%gapw_weight_s(:, ir) = grid_atom%weight(:, ir)*agr
+                  END DO
+                  grid_atom%gapw_weight_alpha = alpha
+               END IF
+               weight_s => grid_atom%gapw_weight_s
             ELSE
                weight_h => grid_atom%weight
                weight_s => grid_atom%weight
@@ -1860,10 +1880,6 @@ CONTAINS
                DEALLOCATE (tau_h, tau_s, tau0_h, tau0_s, tau1_h, tau1_s)
                DEALLOCATE (vtau_h, vtau_s)
             END IF
-            IF (accint) THEN
-               DEALLOCATE (weight_s)
-            END IF
-
          END DO ! ikind
 
       END IF !xc_none
@@ -1978,18 +1994,19 @@ CONTAINS
                                              r_s_d(3, ispin)%r_coef(ir, iso)* &
                                              harmonics%slm(ia, iso)
 
-                  drho_h(4, ia, ir, ispin) = SQRT( &
-                                             drho_h(1, ia, ir, ispin)*drho_h(1, ia, ir, ispin) + &
-                                             drho_h(2, ia, ir, ispin)*drho_h(2, ia, ir, ispin) + &
-                                             drho_h(3, ia, ir, ispin)*drho_h(3, ia, ir, ispin))
-
-                  drho_s(4, ia, ir, ispin) = SQRT( &
-                                             drho_s(1, ia, ir, ispin)*drho_s(1, ia, ir, ispin) + &
-                                             drho_s(2, ia, ir, ispin)*drho_s(2, ia, ir, ispin) + &
-                                             drho_s(3, ia, ir, ispin)*drho_s(3, ia, ir, ispin))
-
                END DO ! ia
             END DO ! iso
+            DO ia = 1, na
+               drho_h(4, ia, ir, ispin) = SQRT( &
+                                          drho_h(1, ia, ir, ispin)*drho_h(1, ia, ir, ispin) + &
+                                          drho_h(2, ia, ir, ispin)*drho_h(2, ia, ir, ispin) + &
+                                          drho_h(3, ia, ir, ispin)*drho_h(3, ia, ir, ispin))
+
+               drho_s(4, ia, ir, ispin) = SQRT( &
+                                          drho_s(1, ia, ir, ispin)*drho_s(1, ia, ir, ispin) + &
+                                          drho_s(2, ia, ir, ispin)*drho_s(2, ia, ir, ispin) + &
+                                          drho_s(3, ia, ir, ispin)*drho_s(3, ia, ir, ispin))
+            END DO ! ia
          END DO ! ispin
       END IF
 
@@ -2019,8 +2036,9 @@ CONTAINS
                                                             iso, ispin, jp, jpgf, jset, jso, l, &
                                                             maxso, na, nr, nset, starti, startj
       INTEGER, DIMENSION(:), POINTER                     :: lmax, lmin, npgf, o2nindex
-      REAL(dp)                                           :: cpc_h, cpc_s
-      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: fga, fgr, r1, r2
+      REAL(dp)                                           :: cpc_h, cpc_s, grad_i, grad_j
+      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: gexp
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :)             :: r1, r2
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :)          :: a1, a2
       REAL(dp), DIMENSION(:, :), POINTER                 :: slm, zet
       REAL(dp), DIMENSION(:, :, :), POINTER              :: dslm_dxyz
@@ -2053,6 +2071,7 @@ CONTAINS
                              nset=nset, zet=zet, maxso=maxso)
 
       !Separate the functions into purely r and purely angular parts, precompute them all
+      ALLOCATE (gexp(nr))
       ALLOCATE (a1(na, nset*maxso, 3), a2(na, nset*maxso, 3))
       ALLOCATE (r1(nr, nset*maxso), r2(nr, nset*maxso))
       a1 = 0.0_dp; a2 = 0.0_dp
@@ -2061,6 +2080,7 @@ CONTAINS
       DO iset = 1, nset
          DO ipgf = 1, npgf(iset)
             starti = (iset - 1)*maxso + (ipgf - 1)*nsoset(lmax(iset))
+            gexp(1:nr) = EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
             DO iso = nsoset(lmin(iset) - 1) + 1, nsoset(lmax(iset))
                l = indso(1, iso)
 
@@ -2068,11 +2088,11 @@ CONTAINS
                ! Two of each are needed because d/dx(r^l Y_lm) * exp(-al*r^2) + r^l Y_lm * ! d/dx(exp-al*r^2)
 
                ! the purely radial part of d/dx(r^l Y_lm) * exp(-al*r^2) (same for y, z)
-               r1(1:nr, starti + iso) = grid_atom%rad(1:nr)**(l - 1)*EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
+               r1(1:nr, starti + iso) = grid_atom%rad(1:nr)**(l - 1)*gexp(1:nr)
 
                ! the purely radial part of r^l Y_lm * d/dx(exp-al*r^2) (same for y, z)
-               r2(1:nr, starti + iso) = -2.0_dp*zet(ipgf, iset)*grid_atom%rad(1:nr)**(l + 1) &
-                                        *EXP(-zet(ipgf, iset)*grid_atom%rad2(1:nr))
+               r2(1:nr, starti + iso) = -2.0_dp*zet(ipgf, iset)*grid_atom%rad2(1:nr)* &
+                                        r1(1:nr, starti + iso)
 
                DO dir = 1, 3
                   ! the purely angular part of d/dx(r^l Y_lm) * exp(-al*r^2)
@@ -2085,11 +2105,6 @@ CONTAINS
             END DO !iso
          END DO !ipgf
       END DO !iset
-
-      !Compute the matrix products
-      ALLOCATE (fga(na, 1))
-      ALLOCATE (fgr(nr, 1))
-      fga = 0.0_dp; fgr = 0.0_dp
 
       DO iset = 1, nset
          DO jset = 1, nset
@@ -2104,103 +2119,25 @@ CONTAINS
                         ip = o2nindex(starti + iso)
                         jp = o2nindex(startj + jso)
 
-                        !Two component per function => 4 terms in total
-
-                        ! take r1*a1(dir) *  r1*a1(dir)
-                        fgr(1:nr, 1) = r1(1:nr, starti + iso)*r1(1:nr, startj + jso)
-                        DO dir = 1, 3
-                           fga(1:na, 1) = a1(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
-
-                           DO ispin = 1, nspins
-                              !get the projectors
-                              cpc_h = rho_atom%cpc_h(ispin)%r_coef(ip, jp)
-                              cpc_s = rho_atom%cpc_s(ispin)%r_coef(ip, jp)
-
-                              !compute contribution to tau
+                        ! Two radial/angular components per basis function:
+                        ! dot(grad_i, grad_j) = sum_dir (r1_i*a1_i + r2_i*a2_i)*
+                        !                                (r1_j*a1_j + r2_j*a2_j)
+                        DO ispin = 1, nspins
+                           cpc_h = 0.5_dp*rho_atom%cpc_h(ispin)%r_coef(ip, jp)
+                           cpc_s = 0.5_dp*rho_atom%cpc_s(ispin)%r_coef(ip, jp)
+                           DO dir = 1, 3
                               DO ir = 1, nr
                                  DO ia = 1, na
-                                    tau_h(ia, ir, ispin) = tau_h(ia, ir, ispin) + 0.5_dp*cpc_h* &
-                                                           fgr(ir, 1)*fga(ia, 1)
-
-                                    tau_s(ia, ir, ispin) = tau_s(ia, ir, ispin) + 0.5_dp*cpc_s* &
-                                                           fgr(ir, 1)*fga(ia, 1)
+                                    grad_i = r1(ir, starti + iso)*a1(ia, starti + iso, dir) + &
+                                             r2(ir, starti + iso)*a2(ia, starti + iso, dir)
+                                    grad_j = r1(ir, startj + jso)*a1(ia, startj + jso, dir) + &
+                                             r2(ir, startj + jso)*a2(ia, startj + jso, dir)
+                                    tau_h(ia, ir, ispin) = tau_h(ia, ir, ispin) + cpc_h*grad_i*grad_j
+                                    tau_s(ia, ir, ispin) = tau_s(ia, ir, ispin) + cpc_s*grad_i*grad_j
                                  END DO
                               END DO
-
-                           END DO !ispin
-                        END DO !dir
-
-                        ! add r1*a1(dir) * r2*a2(dir)
-                        fgr(1:nr, 1) = r1(1:nr, starti + iso)*r2(1:nr, startj + jso)
-                        DO dir = 1, 3
-                           fga(1:na, 1) = a1(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
-
-                           DO ispin = 1, nspins
-                              !get the projectors
-                              cpc_h = rho_atom%cpc_h(ispin)%r_coef(ip, jp)
-                              cpc_s = rho_atom%cpc_s(ispin)%r_coef(ip, jp)
-
-                              !compute contribution to tau
-                              DO ir = 1, nr
-                                 DO ia = 1, na
-                                    tau_h(ia, ir, ispin) = tau_h(ia, ir, ispin) + 0.5_dp*cpc_h* &
-                                                           fgr(ir, 1)*fga(ia, 1)
-
-                                    tau_s(ia, ir, ispin) = tau_s(ia, ir, ispin) + 0.5_dp*cpc_s* &
-                                                           fgr(ir, 1)*fga(ia, 1)
-                                 END DO
-                              END DO
-
-                           END DO !ispin
-                        END DO !dir
-
-                        ! add r2*a2(dir) * V * r1*a1(dir)
-                        fgr(1:nr, 1) = r2(1:nr, starti + iso)*r1(1:nr, startj + jso)
-                        DO dir = 1, 3
-                           fga(1:na, 1) = a2(1:na, starti + iso, dir)*a1(1:na, startj + jso, dir)
-
-                           DO ispin = 1, nspins
-                              !get the projectors
-                              cpc_h = rho_atom%cpc_h(ispin)%r_coef(ip, jp)
-                              cpc_s = rho_atom%cpc_s(ispin)%r_coef(ip, jp)
-
-                              !compute contribution to tau
-                              DO ir = 1, nr
-                                 DO ia = 1, na
-                                    tau_h(ia, ir, ispin) = tau_h(ia, ir, ispin) + 0.5_dp*cpc_h* &
-                                                           fgr(ir, 1)*fga(ia, 1)
-
-                                    tau_s(ia, ir, ispin) = tau_s(ia, ir, ispin) + 0.5_dp*cpc_s* &
-                                                           fgr(ir, 1)*fga(ia, 1)
-                                 END DO
-                              END DO
-
-                           END DO !ispin
-                        END DO !dir
-
-                        ! add the last term: r2*a2(dir) * r2*a2(dir)
-                        fgr(1:nr, 1) = r2(1:nr, starti + iso)*r2(1:nr, startj + jso)
-                        DO dir = 1, 3
-                           fga(1:na, 1) = a2(1:na, starti + iso, dir)*a2(1:na, startj + jso, dir)
-
-                           DO ispin = 1, nspins
-                              !get the projectors
-                              cpc_h = rho_atom%cpc_h(ispin)%r_coef(ip, jp)
-                              cpc_s = rho_atom%cpc_s(ispin)%r_coef(ip, jp)
-
-                              !compute contribution to tau
-                              DO ir = 1, nr
-                                 DO ia = 1, na
-                                    tau_h(ia, ir, ispin) = tau_h(ia, ir, ispin) + 0.5_dp*cpc_h* &
-                                                           fgr(ir, 1)*fga(ia, 1)
-
-                                    tau_s(ia, ir, ispin) = tau_s(ia, ir, ispin) + 0.5_dp*cpc_s* &
-                                                           fgr(ir, 1)*fga(ia, 1)
-                                 END DO
-                              END DO
-
-                           END DO !ispin
-                        END DO !dir
+                           END DO !dir
+                        END DO !ispin
 
                      END DO !jso
                   END DO !iso
@@ -2210,6 +2147,7 @@ CONTAINS
          END DO !jset
       END DO !iset
 
+      DEALLOCATE (a1, a2, gexp, r1, r2)
       DEALLOCATE (o2nindex)
 
       CALL timestop(handle)


### PR DESCRIPTION
## Summary

This PR improves several GAPW one-center atom-grid hot paths by reducing repeated allocation, repeated radial work, and small per-iteration lookup overhead.

Main changes:
- Cache GAPW accurate-XC soft integration weights on `grid_atom_type`, guarded by the alpha value.
- Reuse radial Gaussian factors in GAPW atom-density and meta-GGA tau paths.
- Hoist/reuse one-center scratch arrays in density, rho0, Hartree, OCE, KS-atom, and single-center potential integration routines.
- Simplify GAPW meta-GGA tau density accumulation by evaluating the gradient dot product directly.
- Batch `dgaVtaudgb` tau-potential contractions into wider DGEMM calls.

The `dgaVtaudgb` batching is kept as a separate commit because its effect is most visible in the meta-GGA benchmark and is easier to review independently.

## Validation

Built successfully with:

```bash
OMPI_CC=/opt/homebrew/bin/gcc-15 \
OMPI_CXX=/opt/homebrew/bin/g++-15 \
OMPI_FC=/opt/homebrew/bin/gfortran-15 \
cmake --build build-psmp -j 8
```

Code hygiene:

```bash
git diff --check origin/master..HEAD
```

Regtests with fresh `build-psmp/bin/cp2k.psmp` and local runtime library path:

```text
QS/regtest-acc-1: 17 / 17 OK
QS/regtest-acc-5: 23 / 23 OK
```

The accurate-XC force tests cover the `GAPW_ACCURATE_XCINT T` force paths. A previous local failure was traced to loading a stale installed CP2K library rather than the freshly built one.

## Performance

Local GAPW benchmark suite, 10 runs each, median times, current branch vs the matching pre-GAPW baseline build on the same machine.

| case | metric | baseline | current | time reduction |
|---|---:|---:|---:|---:|
| `gapw_mgga` | wall time | 1.6610 s | 1.5615 s | 5.99% |
| `gapw_mgga` | CP2K total | 1.3755 s | 1.2635 s | 8.14% |
| `gapw_mgga` | `calculate_vxc_atom` | 0.2585 s | 0.1390 s | 46.23% |
| `gapw_mgga` | `calc_tau_atom` | 0.0690 s | 0.0290 s | 57.97% |
| `gapw_mgga` | `dgaVtaudgb` | 0.1220 s | 0.0440 s | 63.93% |

Across the three small GAPW benchmark cases, summed median CP2K total time improved from 1.6955 s to 1.5850 s, a 6.52% time reduction. The very small H2O/Be cases are mostly walltime-noise limited, while the meta-GGA case shows the intended hot-path improvement clearly.

Energies matched between baseline and current for all benchmark cases.