### PR TITLE
lsGW: minor bugfix for read of restart files

### DIFF
--- a/src/gw_large_cell_gamma.F
+++ b/src/gw_large_cell_gamma.F
@@ -66,8 +66,7 @@ MODULE gw_large_cell_gamma
                                               time_to_freq
    USE input_constants,                 ONLY: rtp_method_bse
    USE input_section_types,             ONLY: section_vals_type
-   USE kinds,                           ONLY: default_string_length,&
-                                              default_path_length,&
+   USE kinds,                           ONLY: default_path_length,&
                                               dp,&
                                               int_8
    USE kpoint_coulomb_2c,               ONLY: build_2c_coulomb_matrix_kp
@@ -348,7 +347,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'fm_read'
 
-      CHARACTER(LEN=default_string_length)               :: f_chi
+      CHARACTER(LEN=default_path_length)                 :: f_chi
       INTEGER                                            :: handle, unit_nr
 
       CALL timeset(routineN, handle)
@@ -501,7 +500,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: key = 'PROPERTIES%BANDSTRUCTURE%GW%PRINT%RESTART', &
          routineN = 'fm_write'
 
-      CHARACTER(LEN=default_string_length)               :: filename
+      CHARACTER(LEN=default_path_length)                 :: filename
       INTEGER                                            :: handle, unit_nr
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(section_vals_type), POINTER                   :: input
@@ -2369,7 +2368,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'delete_unnecessary_files'
 
-      CHARACTER(LEN=default_path_length)               :: f_chi, f_W_t, prefix
+      CHARACTER(LEN=default_path_length)                 :: f_chi, f_W_t, prefix
       INTEGER                                            :: handle, i_t
 
       CALL timeset(routineN, handle)

--- a/src/gw_large_cell_gamma.F
+++ b/src/gw_large_cell_gamma.F
@@ -67,6 +67,7 @@ MODULE gw_large_cell_gamma
    USE input_constants,                 ONLY: rtp_method_bse
    USE input_section_types,             ONLY: section_vals_type
    USE kinds,                           ONLY: default_string_length,&
+                                              default_path_length,&
                                               dp,&
                                               int_8
    USE kpoint_coulomb_2c,               ONLY: build_2c_coulomb_matrix_kp
@@ -2368,7 +2369,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'delete_unnecessary_files'
 
-      CHARACTER(LEN=default_string_length)               :: f_chi, f_W_t, prefix
+      CHARACTER(LEN=default_path_length)               :: f_chi, f_W_t, prefix
       INTEGER                                            :: handle, i_t
 
       CALL timeset(routineN, handle)

--- a/src/gw_utils.F
+++ b/src/gw_utils.F
@@ -1252,8 +1252,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'check_for_restart_files'
 
       CHARACTER(LEN=9)                                   :: frmt
-      CHARACTER(len=default_path_length)                 :: project_name
-      CHARACTER(len=default_string_length)               :: f_chi, f_s_n, f_s_p, f_s_x, f_w_t, prefix
+      CHARACTER(len=default_path_length)                 :: project_name, f_chi, f_s_n, f_s_p, &
+                                                            f_s_x, f_w_t, prefix
       INTEGER                                            :: handle, i_spin, i_t_or_w, ind, n_spin, &
                                                             num_time_freq_points
       LOGICAL                                            :: chi_exists, Sigma_neg_time_exists, &

--- a/src/gw_utils.F
+++ b/src/gw_utils.F
@@ -72,7 +72,6 @@ MODULE gw_utils
                                               section_vals_val_get,&
                                               section_vals_val_set
    USE kinds,                           ONLY: default_path_length,&
-                                              default_string_length,&
                                               dp,&
                                               int_8
    USE kpoint_k_r_trafo_simple,         ONLY: rs_to_kp
@@ -1252,8 +1251,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'check_for_restart_files'
 
       CHARACTER(LEN=9)                                   :: frmt
-      CHARACTER(len=default_path_length)                 :: project_name, f_chi, f_s_n, f_s_p, &
-                                                            f_s_x, f_w_t, prefix
+      CHARACTER(len=default_path_length)                 :: f_chi, f_s_n, f_s_p, f_s_x, f_w_t, &
+                                                            prefix, project_name
       INTEGER                                            :: handle, i_spin, i_t_or_w, ind, n_spin, &
                                                             num_time_freq_points
       LOGICAL                                            :: chi_exists, Sigma_neg_time_exists, &
@@ -3258,7 +3257,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'analyt_conti_and_print'
 
       CHARACTER(len=3)                                   :: occ_vir
-      CHARACTER(len=default_string_length)               :: fname
+      CHARACTER(len=default_path_length)                 :: fname
       INTEGER                                            :: handle, i_mo, ikp_for_print, iunit, &
                                                             n_mo, nkp
       LOGICAL                                            :: is_bandstruc_kpoint, print_DOS_kpoints, &

--- a/src/post_scf_bandstructure_types.F
+++ b/src/post_scf_bandstructure_types.F
@@ -23,7 +23,7 @@ MODULE post_scf_bandstructure_types
                                               dbt_type
    USE input_constants,                 ONLY: rtp_method_bse,&
                                               small_cell_full_kp
-   USE kinds,                           ONLY: default_string_length,&
+   USE kinds,                           ONLY: default_path_length,&
                                               dp
    USE kpoint_types,                    ONLY: kpoint_release,&
                                               kpoint_type
@@ -244,7 +244,7 @@ MODULE post_scf_bandstructure_types
       CHARACTER(LEN=7)                             :: Sigma_x_name = "Sigma_x"
       CHARACTER(LEN=13)                            :: Sigma_p_name = "Sigma_pos_tau", &
                                                       Sigma_n_name = "Sigma_neg_tau"
-      CHARACTER(LEN=default_string_length)         :: prefix = ""
+      CHARACTER(LEN=default_path_length)           :: prefix = ""
       INTEGER                                      :: unit_nr = -1, &
                                                       unit_nr_contract = -1
 


### PR DESCRIPTION
Fix buffer overflow in check_for_restart_files causing runtime abort with long path names

Filename strings (f_chi, f_S_p, f_S_n, f_S_x, f_W_t, prefix) were declared as
default_string_length (80 chars) while project_name is default_path_length (240 chars),
causing a Fortran "End of record" abort when the path exceeds the buffer.