### PR TITLE
Write `CIF` after optimization

### DIFF
--- a/src/input_cp2k_motion_print.F
+++ b/src/input_cp2k_motion_print.F
@@ -144,6 +144,16 @@ CONTAINS
       CALL section_add_subsection(section, print_key)
       CALL section_release(print_key)
 
+      CALL cp_print_key_section_create(print_key, __LOCATION__, "FINAL_CIF", &
+                                       description="Controls the dumping of a CIF containing "// &
+                                       "the final geometry and cell for optimization tasks. "// &
+                                       "Currently the structure will always be dumped with "// &
+                                       "the space group `P 1` and a single symmetry-equivalent "// &
+                                       "position `x, y, z` for all of the atoms.", &
+                                       print_level=low_print_level, filename="FINAL")
+      CALL section_add_subsection(section, print_key)
+      CALL section_release(print_key)
+
       CALL cp_print_key_section_create( &
          print_key, __LOCATION__, "FORCE_MIXING_LABELS", &
          description="Controls the output of the force mixing (FORCE_EVAL&QMMM&FORCE_MIXING) labels", &

--- a/src/motion/gopt_f_methods.F
+++ b/src/motion/gopt_f_methods.F
@@ -47,7 +47,13 @@ MODULE gopt_f_methods
                               default_minimization_method_id, &
                               default_shellcore_method_id, &
                               default_ts_method_id, &
-                              fix_none
+                              fix_none, &
+                              fix_x, &
+                              fix_xy, &
+                              fix_xz, &
+                              fix_y, &
+                              fix_yz, &
+                              fix_z
    USE input_cp2k_restarts, ONLY: write_restart
    USE input_section_types, ONLY: section_vals_type, &
                                   section_vals_val_get
@@ -61,7 +67,8 @@ MODULE gopt_f_methods
                            write_stress_tensor_to_file, &
                            write_trajectory
    USE particle_list_types, ONLY: particle_list_type
-   USE particle_methods, ONLY: write_structure_data
+   USE particle_methods, ONLY: write_final_cif, &
+                               write_structure_data
    USE particle_types, ONLY: particle_type
    USE qmmm_util, ONLY: apply_qmmm_translate
    USE qmmmx_util, ONLY: apply_qmmmx_translate
@@ -857,6 +864,9 @@ CONTAINS
       TYPE(force_env_type), POINTER                      :: force_env
       TYPE(section_vals_type), POINTER                   :: motion_section, root_section
 
+      CHARACTER(LEN=4)                                   :: constraint_label
+      LOGICAL                                            :: keep_angles, keep_symmetry, &
+                                                            keep_volume
       REAL(KIND=dp)                                      :: etot
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_subsys_type), POINTER                      :: subsys
@@ -866,6 +876,39 @@ CONTAINS
       CALL force_env_get(force_env, cell=cell, subsys=subsys)
       CALL cp_subsys_get(subsys=subsys, particles=particles)
       particle_set => particles%els
+
+      ! Passing gopt_f_type pointer gopt_env to particle_methods where
+      ! write_final_cif is defined causes a circular dependency, so it
+      ! is necessary to get some flags by preprocessing...
+      keep_angles = .TRUE.
+      keep_symmetry = .TRUE.
+      keep_volume = .TRUE.
+      constraint_label = "NONE"
+      IF (gopt_env%type_id == default_cell_method_id) THEN
+         keep_angles = gopt_env%cell_env%keep_angles
+         keep_symmetry = gopt_env%cell_env%keep_symmetry
+         keep_volume = gopt_env%cell_env%keep_volume
+         SELECT CASE (gopt_env%cell_env%constraint_id)
+         CASE (fix_x)
+            constraint_label = "   X"
+         CASE (fix_y)
+            constraint_label = "   Y"
+         CASE (fix_z)
+            constraint_label = "   Z"
+         CASE (fix_xy)
+            constraint_label = "  XY"
+         CASE (fix_xz)
+            constraint_label = "  XZ"
+         CASE (fix_yz)
+            constraint_label = "  YZ"
+         CASE (fix_none)
+            constraint_label = "NONE"
+         END SELECT
+      END IF
+      CALL write_final_cif(particle_set, cell, motion_section, conv, &
+                           keep_angles, keep_symmetry, keep_volume, &
+                           gopt_env%label, constraint_label)
+
       IF (conv) THEN
          it = it + 1
          CALL write_structure_data(particle_set, cell, motion_section)

--- a/src/particle_methods.F
+++ b/src/particle_methods.F
@@ -23,10 +23,17 @@ MODULE particle_methods
                                               get_cell,&
                                               pbc,&
                                               real_to_scaled
+   USE cp2k_info,                       ONLY: compile_revision,&
+                                              cp2k_version,&
+                                              r_cwd,&
+                                              r_host_name,&
+                                              r_user_name
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
+                                              cp_logger_get_default_io_unit,&
                                               cp_logger_type,&
                                               cp_to_string
    USE cp_output_handling,              ONLY: cp_print_key_finished_output,&
+                                              cp_print_key_generate_filename,&
                                               cp_print_key_unit_nr
    USE cp_units,                        ONLY: cp_unit_from_cp2k
    USE external_potential_types,        ONLY: fist_potential_type,&
@@ -37,18 +44,31 @@ MODULE particle_methods
                                               dump_extxyz,&
                                               dump_pdb,&
                                               dump_xmol
-   USE input_section_types,             ONLY: section_vals_get_subs_vals,&
+   USE input_cp2k_subsys,               ONLY: create_cell_section
+   USE input_enumeration_types,         ONLY: enum_i2c,&
+                                              enumeration_type
+   USE input_keyword_types,             ONLY: keyword_get,&
+                                              keyword_type
+   USE input_section_types,             ONLY: section_get_keyword,&
+                                              section_release,&
+                                              section_type,&
+                                              section_vals_get_subs_vals,&
                                               section_vals_type,&
                                               section_vals_val_get
-   USE kinds,                           ONLY: default_string_length,&
+   USE kinds,                           ONLY: default_path_length,&
+                                              default_string_length,&
                                               dp,&
                                               sp
+   USE machine,                         ONLY: m_timestamp,&
+                                              timestamp_length
    USE mathconstants,                   ONLY: degree
    USE mathlib,                         ONLY: angle,&
-                                              dihedral_angle
+                                              dihedral_angle,&
+                                              gcd
    USE memory_utilities,                ONLY: reallocate
    USE particle_types,                  ONLY: get_particle_pos_or_vel,&
                                               particle_type
+   USE periodic_table,                  ONLY: nelem
    USE physcon,                         ONLY: massunit
    USE qmmm_ff_fist,                    ONLY: qmmm_ff_precond_only_qm
    USE qs_kind_types,                   ONLY: get_qs_kind,&
@@ -72,7 +92,8 @@ MODULE particle_methods
              write_particle_coordinates, &
              write_structure_data, &
              get_particle_set, &
-             write_particle_matrix
+             write_particle_matrix, &
+             write_final_cif
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'particle_methods'
 
@@ -1009,5 +1030,320 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE write_structure_data
+
+! **************************************************************************************************
+!> \brief   Write the final geometry and cell information to a CIF file
+!> \param particle_set pointer to particles with atm_name, element_symbol and position
+!> \param cell pointer to cell with abc, angle_alpha, angle_beta, angle_gamma and deth
+!> \param input_section pointer to motion_section which has PRINT%FINAL_CIF
+!> \param conv flag for whether convergence is achieved or not in optimization
+!> \param keep_angles flag for whether cell optimization keeps initial angles
+!> \param keep_symmetry flag for whether cell optimization keeps initial symmetry
+!> \param keep_volume flag for whether cell optimization keeps initial volume
+!> \param gopt_env_label the geometry optimization label "GEO_OPT", "CELL_OPT", ...
+!> \param constraint_label label for directions with constraint in cell optimization
+!> \par     Intended to be invoked in gopt_f_methods:write_final_info.
+!>          This implementation does not consider higher space groups even if
+!>          one is detected, and the chemical formulae are neither written in
+!>          the sorted "Hill notation" nor expressed in groups of molecules.
+!>          Other potentially useful but yet to be written information includes:
+!>          the external pressure from CELL_OPT/EXTERNAL_POTENTIAL and the
+!>          stress tensor (virial) for CELL_OPT;
+!>          the fixed atoms from MOTION/CONSTRAINT/FIXED_ATOMS for all.
+!>
+!>          History
+!>          04.2026 - Created
+!> \author  HE Zilong
+!> \version 1.0
+! **************************************************************************************************
+   SUBROUTINE write_final_cif(particle_set, cell, input_section, conv, &
+                              keep_angles, keep_symmetry, keep_volume, &
+                              gopt_env_label, constraint_label)
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(cell_type), INTENT(IN), POINTER               :: cell
+      TYPE(section_vals_type), INTENT(IN), POINTER       :: input_section
+      LOGICAL, INTENT(IN)                                :: conv, keep_angles, keep_symmetry, &
+                                                            keep_volume
+      CHARACTER(LEN=default_string_length), INTENT(IN)   :: gopt_env_label
+      CHARACTER(LEN=4), INTENT(IN)                       :: constraint_label
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'write_final_cif'
+
+      CHARACTER(LEN=2)                                   :: element_symbol
+      CHARACTER(LEN=2), ALLOCATABLE                      :: element_list(:)
+      CHARACTER(LEN=4)                                   :: perd_str
+      CHARACTER(LEN=:), ALLOCATABLE                      :: formula_structural, formula_sum
+      CHARACTER(LEN=default_path_length)                 :: record
+      CHARACTER(LEN=default_string_length)               :: atm_name, f_cif, f_label, f_type_symbol
+      CHARACTER(LEN=default_string_length), ALLOCATABLE  :: label(:), type_symbol(:)
+      CHARACTER(LEN=timestamp_length)                    :: timestamp
+      INTEGER                                            :: elem_seen, file_unit, gcd_all, handle, &
+                                                            i, iatom, ielem, natom, output_unit, &
+                                                            symmetry_id, w_label, w_type_symbol
+      INTEGER, ALLOCATABLE                               :: count_list(:)
+      INTEGER, DIMENSION(3)                              :: periodic
+      LOGICAL                                            :: dummy, elem_in_list, orthorhombic
+      REAL(KIND=dp)                                      :: angle_alpha, angle_beta, angle_gamma, &
+                                                            deth
+      REAL(KIND=dp), DIMENSION(3)                        :: abc, r, s
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
+      TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(enumeration_type), POINTER                    :: enum
+      TYPE(keyword_type), POINTER                        :: symmetry_keyword
+      TYPE(section_type), POINTER                        :: tmp_cell_section
+      TYPE(section_vals_type), POINTER                   :: print_key
+
+      CALL timeset(routineN, handle)
+
+      NULLIFY (enum, logger, symmetry_keyword, print_key, tmp_cell_section)
+      logger => cp_get_default_logger()
+      output_unit = cp_logger_get_default_io_unit(logger)
+      print_key => section_vals_get_subs_vals(input_section, "PRINT%FINAL_CIF")
+
+      ! Collect cell information
+      perd_str = "NONE"
+      CALL get_cell(cell, alpha=angle_alpha, beta=angle_beta, gamma=angle_gamma, &
+                    deth=deth, orthorhombic=orthorhombic, abc=abc, periodic=periodic, &
+                    h=hmat, symmetry_id=symmetry_id)
+      IF (SUM(periodic(1:3)) /= 0) THEN
+         perd_str = ""
+         IF (periodic(1) == 1) perd_str = TRIM(perd_str)//"X"
+         IF (periodic(2) == 1) perd_str = TRIM(perd_str)//"Y"
+         IF (periodic(3) == 1) perd_str = TRIM(perd_str)//"Z"
+      END IF
+      CALL create_cell_section(tmp_cell_section)
+      symmetry_keyword => section_get_keyword(tmp_cell_section, "SYMMETRY")
+      CALL keyword_get(symmetry_keyword, enum=enum)
+
+      ! Collect atom information
+      natom = SIZE(particle_set)
+      ALLOCATE (element_list(nelem + 1), count_list(nelem + 1))
+      count_list(:) = 0
+      ALLOCATE (label(natom), type_symbol(natom))
+      elem_seen = 0
+      w_type_symbol = 0
+      w_label = 0
+      atom_loop: DO iatom = 1, natom
+         elem_in_list = .FALSE.
+         CALL get_atomic_kind(atomic_kind=particle_set(iatom)%atomic_kind, &
+                              name=atm_name, element_symbol=element_symbol)
+         type_symbol(iatom) = TRIM(atm_name)
+         ! From write_particle_coordinates above it seems possible
+         ! for some atoms to have empty element symbols; whatever
+         ! these are, do not count them in the chemical formula
+         IF (LEN_TRIM(element_symbol) == 0) THEN
+            dummy = qmmm_ff_precond_only_qm(id1=atm_name)
+            label(iatom) = TRIM(atm_name)//TRIM(ADJUSTL(cp_to_string(iatom)))
+         ELSE
+            label(iatom) = TRIM(element_symbol)//TRIM(ADJUSTL(cp_to_string(iatom)))
+            elem_loop: DO ielem = 1, nelem + 1
+               IF (element_list(ielem) == element_symbol) THEN
+                  elem_in_list = .TRUE.
+                  count_list(ielem) = count_list(ielem) + 1
+                  EXIT elem_loop
+               END IF
+            END DO elem_loop
+            IF (.NOT. elem_in_list) THEN
+               elem_seen = elem_seen + 1
+               element_list(elem_seen) = element_symbol
+               count_list(elem_seen) = 1
+            END IF
+         END IF
+         IF (LEN_TRIM(type_symbol(iatom)) > w_type_symbol) &
+            w_type_symbol = LEN_TRIM(type_symbol(iatom))
+         IF (LEN_TRIM(label(iatom)) > w_label) &
+            w_label = LEN_TRIM(label(iatom))
+      END DO atom_loop
+
+      ! Determine the format of each line in cif considering width of type_symbol and label
+      ! The fields are, in order:
+      !  _atom_site_type_symbol, _atom_site_label, _atom_site_symmetry_multiplicity,
+      !  _atom_site_fract_x, _atom_site_fract_y, _atom_site_fract_z, _atom_site_occupancy
+      ! in which:
+      !  _atom_site_type_symbol is taken as atm_name
+      !  _atom_site_label is taken as element_symbol//iatom
+      !  _atom_site_symmetry_multiplicity and _atom_site_occupancy are always 1
+      f_type_symbol = "A"//TRIM(ADJUSTL(cp_to_string(w_type_symbol + 4)))
+      f_label = "A"//TRIM(ADJUSTL(cp_to_string(w_label + 4)))
+      f_cif = "(T3,"//TRIM(f_type_symbol)//","//TRIM(f_label)//",I4,3F14.8,F8.2)"
+
+      ! Determine formula_sum
+      CPASSERT(elem_seen > 0)
+      CPASSERT(count_list(1) > 0)
+      formula_sum = "'"
+      DO ielem = 1, elem_seen
+         formula_sum = formula_sum//TRIM(ADJUSTL(element_list(ielem)))
+         formula_sum = formula_sum//TRIM(ADJUSTL(cp_to_string(count_list(ielem))))
+         formula_sum = formula_sum//" "
+      END DO
+      formula_sum = TRIM(ADJUSTL(formula_sum))//"'"
+
+      ! Determine formula_structural and Z
+      gcd_all = count_list(1)
+      DO ielem = 1, elem_seen
+         IF (count_list(ielem) /= 0) THEN
+            gcd_all = gcd(gcd_all, count_list(ielem))
+         END IF
+      END DO
+      IF (gcd_all > 1) count_list = count_list/gcd_all
+      formula_structural = "'"
+      DO ielem = 1, elem_seen
+         formula_structural = formula_structural//TRIM(ADJUSTL(element_list(ielem)))
+         formula_structural = formula_structural//TRIM(ADJUSTL(cp_to_string(count_list(ielem))))
+         formula_structural = formula_structural//" "
+      END DO
+      formula_structural = TRIM(ADJUSTL(formula_structural))//"'"
+
+      ! Print a message to log
+      record = cp_print_key_generate_filename(logger, print_key, &
+                                              extension=".cif", &
+                                              my_local=.FALSE.)
+      IF (output_unit > 0) THEN
+         IF (conv) THEN
+            WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
+               routineN//": Optimization converged, writing CIF file gladly:"
+         ELSE
+            WRITE (UNIT=output_unit, FMT="(/,T2,A)") &
+               routineN//": Optimization not yet converged, writing CIF file anyway:"
+         END IF
+         WRITE (UNIT=output_unit, FMT="(T3,A)") TRIM(record)
+      END IF
+
+      ! Make timestamp for the file
+      CALL m_timestamp(timestamp)
+
+      ! Prepare file unit and write to it
+      file_unit = cp_print_key_unit_nr(logger, input_section, "PRINT%FINAL_CIF", &
+                                       file_status="REPLACE", extension=".cif")
+      IF (file_unit > 0) THEN
+         ! Generic information
+         WRITE (UNIT=file_unit, FMT="(A)") &
+            "# CIF file created by CP2K "//TRIM(moduleN)//":"//TRIM(routineN)
+         WRITE (UNIT=file_unit, FMT="(A)") &
+            "data_"//TRIM(logger%iter_info%project_name)
+         WRITE (UNIT=file_unit, FMT="(A,T39,A)") &
+            "_audit_creation_date", timestamp(:10)
+         WRITE (UNIT=file_unit, FMT="(A,/,A,/,A)") &
+            "_audit_creation_method", ";", &
+            TRIM(cp2k_version)//" (revision "//TRIM(compile_revision)//")"
+         WRITE (UNIT=file_unit, FMT="(A,/,A,/,A,/,A)") &
+            "Project name "//TRIM(logger%iter_info%project_name), &
+            "submitted by "//TRIM(r_user_name)//"@"//TRIM(r_host_name), &
+            "processed in "//TRIM(r_cwd), &
+            "generated at "//TRIM(timestamp)
+         WRITE (UNIT=file_unit, FMT="(T2,A)") &
+            "- Optimization type: "//TRIM(gopt_env_label)
+         IF (conv) THEN
+            WRITE (UNIT=file_unit, FMT="(T2,A)") &
+               "- Optimization converged: TRUE"
+         ELSE
+            WRITE (UNIT=file_unit, FMT="(T2,A)") &
+               "- Optimization converged: FALSE"
+         END IF
+         WRITE (UNIT=file_unit, FMT="(T2,A)") &
+            "- Requested initial cell symmetry: "//TRIM(enum_i2c(enum, symmetry_id))
+         IF (orthorhombic) THEN
+            WRITE (UNIT=file_unit, FMT="(T2,A)") &
+               "- Cell is numerically orthorhombic: TRUE"
+         ELSE
+            WRITE (UNIT=file_unit, FMT="(T2,A)") &
+               "- Cell is numerically orthorhombic: FALSE"
+         END IF
+         WRITE (UNIT=file_unit, FMT="(T2,A)") &
+            "- Periodicity of cell: "//TRIM(perd_str)
+         IF (gopt_env_label == "CELL_OPT") THEN
+            WRITE (UNIT=file_unit, FMT="(T2,A)") &
+               "- Cell is subject to optimization: TRUE"
+            WRITE (UNIT=file_unit, FMT="(T2,A)") &
+               "- Cell has constraint on direction: "//TRIM(ADJUSTL(constraint_label))
+            IF (keep_angles) THEN
+               WRITE (UNIT=file_unit, FMT="(T2,A)") &
+                  "- Keep angles between the cell vectors during optimization: TRUE"
+            ELSE
+               WRITE (UNIT=file_unit, FMT="(T2,A)") &
+                  "- Keep angles between the cell vectors during optimization: FALSE"
+            END IF
+            IF (keep_symmetry) THEN
+               WRITE (UNIT=file_unit, FMT="(T2,A)") &
+                  "- Keep initial cell symmetry during optimization: TRUE"
+            ELSE
+               WRITE (UNIT=file_unit, FMT="(T2,A)") &
+                  "- Keep initial cell symmetry during optimization: FALSE"
+            END IF
+            IF (keep_volume) THEN
+               WRITE (UNIT=file_unit, FMT="(T2,A)") &
+                  "- Keep initial cell volume during optimization: TRUE"
+            ELSE
+               WRITE (UNIT=file_unit, FMT="(T2,A)") &
+                  "- Keep initial cell volume during optimization: FALSE"
+            END IF
+         ELSE
+            WRITE (UNIT=file_unit, FMT="(T2,A)") &
+               "- Cell is subject to optimization: FALSE"
+         END IF
+         WRITE (UNIT=file_unit, FMT="(T2,A)") &
+            "- Final cell vectors A, B, C by rows [angstrom]:"
+         DO i = 1, 3
+            WRITE (UNIT=file_unit, FMT="(T3,3(1X,F19.10))") &
+               cp_unit_from_cp2k(hmat(1, i), "angstrom"), &
+               cp_unit_from_cp2k(hmat(2, i), "angstrom"), &
+               cp_unit_from_cp2k(hmat(3, i), "angstrom")
+         END DO
+         WRITE (UNIT=file_unit, FMT="(A)") ";"
+         ! Data of cell and geometry
+         WRITE (UNIT=file_unit, FMT="(/,A,T44,A)") &
+            "_symmetry_space_group_name_H-M", "'P 1'"
+         WRITE (UNIT=file_unit, FMT="(A,T31,F18.8)") &
+            "_cell_length_a", cp_unit_from_cp2k(abc(1), "angstrom")
+         WRITE (UNIT=file_unit, FMT="(A,T31,F18.8)") &
+            "_cell_length_b", cp_unit_from_cp2k(abc(2), "angstrom")
+         WRITE (UNIT=file_unit, FMT="(A,T31,F18.8)") &
+            "_cell_length_c", cp_unit_from_cp2k(abc(3), "angstrom")
+         WRITE (UNIT=file_unit, FMT="(A,T31,F18.8)") &
+            "_cell_angle_alpha", angle_alpha
+         WRITE (UNIT=file_unit, FMT="(A,T31,F18.8)") &
+            "_cell_angle_beta", angle_beta
+         WRITE (UNIT=file_unit, FMT="(A,T31,F18.8)") &
+            "_cell_angle_gamma", angle_gamma
+         WRITE (UNIT=file_unit, FMT="(A,T48,A)") &
+            "_symmetry_Int_Tables_number", "1"
+         WRITE (UNIT=file_unit, FMT="(A,T36,A)") &
+            "_chemical_formula_structural", formula_structural
+         WRITE (UNIT=file_unit, FMT="(A,T36,A)") &
+            "_chemical_formula_sum", formula_sum
+         WRITE (UNIT=file_unit, FMT="(A,T31,F18.8)") &
+            "_cell_volume", cp_unit_from_cp2k(ABS(deth), "angstrom^3")
+         WRITE (UNIT=file_unit, FMT="(A,T41,I8)") &
+            "_cell_formula_units_Z", gcd_all
+         WRITE (UNIT=file_unit, FMT="(A,/,T2,A,/,T2,A,/,T3,A)") &
+            "loop_", "_symmetry_equiv_pos_site_id", &
+            "_symmetry_equiv_pos_as_xyz", "1  'x, y, z'"
+         WRITE (UNIT=file_unit, FMT="(A,/,T2,A,/,T2,A,/,T2,A,/,T2,A,/,T2,A,/,T2,A,/,T2,A)") &
+            "loop_", "_atom_site_type_symbol", "_atom_site_label", &
+            "_atom_site_symmetry_multiplicity", "_atom_site_fract_x", &
+            "_atom_site_fract_y", "_atom_site_fract_z", "_atom_site_occupancy"
+         DO iatom = 1, natom
+            r(1:3) = pbc(particle_set(iatom)%r(1:3), cell)
+            CALL real_to_scaled(s, r, cell)
+            DO i = 1, 3
+               s(i) = MODULO(s(i), 1.0_dp)
+            END DO
+            WRITE (UNIT=file_unit, FMT=TRIM(f_cif)) &
+               type_symbol(iatom), label(iatom), 1, s(1:3), 1.0_dp
+         END DO
+      END IF
+
+      ! Finish
+      DEALLOCATE (element_list, count_list, formula_structural, formula_sum, label, type_symbol)
+      CALL section_release(tmp_cell_section)
+      CALL cp_print_key_finished_output(file_unit, logger, input_section, &
+                                        "PRINT%FINAL_CIF")
+      IF (output_unit > 0) &
+         WRITE (UNIT=output_unit, FMT='(/,T2,A)') &
+         routineN//": Done!"
+
+      CALL timestop(handle)
+
+   END SUBROUTINE write_final_cif
 
 END MODULE particle_methods


### PR DESCRIPTION
This PR enables the output of a simple `CIF` which should resolve #177 as a response to one of the frequent user requests. Setting `PRINT_LEVEL` to `LOW` or higher in an optimization job will create a `{project_name}-FINAL-1_{iterations}.cif` containing the final geometry and cell information after converging (or exceeding maximum number of iterations `MAX_ITER`).

The current implementation simply treats the structure as space group `P 1` with every atom on an equivalent position not undergone symmetry reduction. No higher cell symmetry or space group is determined and there is no dependency on `spglib`.

An excerpt from the result of running the regtest `Fist/regtest-opt/cell_sym_hexagonal_gamma_120.inp`:

<details>
<summary>Click to expand</summary>

```
# CIF file created by CP2K particle_methods:write_final_cif
data_cell_sym_hexagonal_gamma_120
_audit_creation_date                  2026-04-30
_audit_creation_method
;
CP2K version 2026.1 (Development Version) (revision e704af8e31)
Project name cell_sym_hexagonal_gamma_120
submitted by user@host
processed in /home/user/test/cp2k-dev/regtesting/TEST-2026-04-30_21-01-38/Fist/regtest-opt
generated at 2026-04-30 21:01:59.378
 - Optimization type: CELL_OPT
 - Optimization converged: TRUE
 - Requested initial cell symmetry: HEXAGONAL_GAMMA_120
 - Cell is numerically orthorhombic: FALSE
 - Periodicity of cell: XYZ
 - Cell is subject to optimization: TRUE
 - Cell has constraint on direction: NONE
 - Keep angles between the cell vectors during optimization: FALSE
 - Keep initial cell symmetry during optimization: TRUE
 - Keep initial cell volume during optimization: FALSE
 - Final cell vectors A, B, C by rows [angstrom]:
         12.1198078086        0.0000000000        0.0000000000
         -6.0599039043       10.4960614512        0.0000000000
          0.0000000000        0.0000000000       10.3485681700
;

_symmetry_space_group_name_H-M             'P 1'
_cell_length_a                       12.11980781
_cell_length_b                       12.11980781
_cell_length_c                       10.34856817
_cell_angle_alpha                    90.00000000
_cell_angle_beta                     90.00000000
_cell_angle_gamma                   120.00000000
_symmetry_Int_Tables_number                    1
_chemical_formula_structural       'Zr1 O2'
_chemical_formula_sum              'Zr32 O64'
_cell_volume                       1316.44391854
_cell_formula_units_Z                         32
loop_
 _symmetry_equiv_pos_site_id
 _symmetry_equiv_pos_as_xyz
  1  'x, y, z'
loop_
 _atom_site_type_symbol
 _atom_site_label
 _atom_site_symmetry_multiplicity
 _atom_site_fract_x
 _atom_site_fract_y
 _atom_site_fract_z
 _atom_site_occupancy
  Zr    Zr1        1    0.12501061    0.00001821    0.06247261    1.00
  Zr    Zr2        1    0.12499843    0.24997034    0.31248073    1.00
  Zr    Zr3        1    0.37500157    0.25002966    0.18751927    1.00
  Zr    Zr4        1    0.37498939    0.49998179    0.43752739    1.00
  O     O5         1    0.93126466    0.15311777    0.31250565    1.00
  O     O6         1    0.06876140    0.09687426    0.43746424    1.00
  O     O7         1    0.43123860    0.40312574    0.06253576    1.00
  O     O8         1    0.56873534    0.34688223    0.18749435    1.00
[truncated]
```
</details>
