### PR TITLE
Make spin-channel representation consistent in reciprocal-space mixing

### DIFF
--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -73,7 +73,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'gspace_mixing'
 
       INTEGER                                            :: handle, iatom, ig, ispin, natom, ng, &
-                                                            nimg, nspin
+                                                            nspin
       LOGICAL                                            :: gapw
       REAL(dp)                                           :: alpha
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tot_rho_r
@@ -96,12 +96,17 @@ CONTAINS
          CALL qs_rho_get(rho, rho_g=rho_g, rho_r=rho_r, tot_rho_r=tot_rho_r)
 
          nspin = SIZE(rho_g, 1)
-         nimg = dft_control%nimages
          ng = SIZE(rho_g(1)%pw_grid%gsq)
          CPASSERT(ng == SIZE(mixing_store%rhoin(1)%cc))
 
          alpha = mixing_store%alpha
          gapw = dft_control%qs_control%gapw
+         natom = 0
+
+         IF (mixing_store%gmix_p .AND. gapw) THEN
+            CALL get_qs_env(qs_env=qs_env, rho_atom_set=rho_atom)
+            natom = SIZE(rho_atom)
+         END IF
 
          IF (nspin == 2) THEN
             CALL pw_env_get(pw_env=pw_env, auxbas_pw_pool=auxbas_pw_pool)
@@ -111,6 +116,9 @@ CONTAINS
             CALL pw_axpy(rho_g(2), rho_g(1), 1.0_dp)
             CALL pw_axpy(rho_tmp, rho_g(2), -1.0_dp)
             CALL pw_scale(rho_g(2), -1.0_dp)
+            IF (mixing_store%gmix_p .AND. gapw) THEN
+               CALL gapw_cpc_spin_to_charge_mag(rho_atom, mixing_store)
+            END IF
          END IF
 
          IF (iter_count + 1 <= mixing_store%nskip_mixing) THEN
@@ -121,8 +129,6 @@ CONTAINS
                END DO
             END DO
             IF (mixing_store%gmix_p .AND. gapw) THEN
-               CALL get_qs_env(qs_env=qs_env, rho_atom_set=rho_atom)
-               natom = SIZE(rho_atom)
                DO ispin = 1, nspin
                   DO iatom = 1, natom
                      IF (mixing_store%paw(iatom)) THEN
@@ -135,6 +141,9 @@ CONTAINS
 
             mixing_store%iter_method = "NoMix"
             IF (nspin == 2) THEN
+               IF (mixing_store%gmix_p .AND. gapw) THEN
+                  CALL gapw_cpc_charge_mag_to_spin(rho_atom, mixing_store)
+               END IF
                CALL pw_axpy(rho_g(2), rho_g(1), 1.0_dp)
                CALL pw_scale(rho_g(1), 0.5_dp)
                CALL pw_axpy(rho_g(1), rho_g(2), -1.0_dp)
@@ -164,6 +173,9 @@ CONTAINS
          END IF
 
          IF (nspin == 2) THEN
+            IF (mixing_store%gmix_p .AND. gapw) THEN
+               CALL gapw_cpc_charge_mag_to_spin(rho_atom, mixing_store)
+            END IF
             CALL pw_axpy(rho_g(2), rho_g(1), 1.0_dp)
             CALL pw_scale(rho_g(1), 0.5_dp)
             CALL pw_axpy(rho_g(1), rho_g(2), -1.0_dp)
@@ -180,6 +192,118 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE gspace_mixing
+
+! **************************************************************************************************
+!> \brief Convert GAPW compensation charge coefficients from spin-up/spin-down
+!>        representation to total-charge/magnetization representation.
+!> \param rho_atom ...
+!> \param mixing_store ...
+! **************************************************************************************************
+   SUBROUTINE gapw_cpc_spin_to_charge_mag(rho_atom, mixing_store)
+      TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom
+      TYPE(mixing_storage_type), POINTER                 :: mixing_store
+
+      INTEGER                                            :: iatom, icoef1, icoef2, ncoef_h1, &
+                                                            ncoef_h2, ncoef_s1, ncoef_s2
+      REAL(dp)                                           :: cpc_h_tmp, cpc_s_tmp
+
+      CPASSERT(ASSOCIATED(rho_atom))
+      CPASSERT(ASSOCIATED(mixing_store%paw))
+
+      DO iatom = 1, SIZE(rho_atom)
+         IF (mixing_store%paw(iatom)) THEN
+            CPASSERT(ASSOCIATED(rho_atom(iatom)%cpc_h(1)%r_coef))
+            CPASSERT(ASSOCIATED(rho_atom(iatom)%cpc_h(2)%r_coef))
+            CPASSERT(ASSOCIATED(rho_atom(iatom)%cpc_s(1)%r_coef))
+            CPASSERT(ASSOCIATED(rho_atom(iatom)%cpc_s(2)%r_coef))
+            ncoef_h1 = SIZE(rho_atom(iatom)%cpc_h(1)%r_coef, 1)
+            ncoef_h2 = SIZE(rho_atom(iatom)%cpc_h(1)%r_coef, 2)
+            ncoef_s1 = SIZE(rho_atom(iatom)%cpc_s(1)%r_coef, 1)
+            ncoef_s2 = SIZE(rho_atom(iatom)%cpc_s(1)%r_coef, 2)
+            CPASSERT(ncoef_h1 == SIZE(rho_atom(iatom)%cpc_h(2)%r_coef, 1))
+            CPASSERT(ncoef_h2 == SIZE(rho_atom(iatom)%cpc_h(2)%r_coef, 2))
+            CPASSERT(ncoef_s1 == SIZE(rho_atom(iatom)%cpc_s(2)%r_coef, 1))
+            CPASSERT(ncoef_s2 == SIZE(rho_atom(iatom)%cpc_s(2)%r_coef, 2))
+
+            DO icoef2 = 1, ncoef_h2
+               DO icoef1 = 1, ncoef_h1
+                  cpc_h_tmp = rho_atom(iatom)%cpc_h(1)%r_coef(icoef1, icoef2)
+                  rho_atom(iatom)%cpc_h(1)%r_coef(icoef1, icoef2) = &
+                     cpc_h_tmp + rho_atom(iatom)%cpc_h(2)%r_coef(icoef1, icoef2)
+                  rho_atom(iatom)%cpc_h(2)%r_coef(icoef1, icoef2) = &
+                     cpc_h_tmp - rho_atom(iatom)%cpc_h(2)%r_coef(icoef1, icoef2)
+               END DO
+            END DO
+
+            DO icoef2 = 1, ncoef_s2
+               DO icoef1 = 1, ncoef_s1
+                  cpc_s_tmp = rho_atom(iatom)%cpc_s(1)%r_coef(icoef1, icoef2)
+                  rho_atom(iatom)%cpc_s(1)%r_coef(icoef1, icoef2) = &
+                     cpc_s_tmp + rho_atom(iatom)%cpc_s(2)%r_coef(icoef1, icoef2)
+                  rho_atom(iatom)%cpc_s(2)%r_coef(icoef1, icoef2) = &
+                     cpc_s_tmp - rho_atom(iatom)%cpc_s(2)%r_coef(icoef1, icoef2)
+               END DO
+            END DO
+         END IF
+      END DO
+
+   END SUBROUTINE gapw_cpc_spin_to_charge_mag
+
+! **************************************************************************************************
+!> \brief Convert GAPW compensation charge coefficients from total-charge/magnetization
+!>        representation back to spin-up/spin-down representation.
+!> \param rho_atom ...
+!> \param mixing_store ...
+! **************************************************************************************************
+   SUBROUTINE gapw_cpc_charge_mag_to_spin(rho_atom, mixing_store)
+      TYPE(rho_atom_type), DIMENSION(:), POINTER         :: rho_atom
+      TYPE(mixing_storage_type), POINTER                 :: mixing_store
+
+      INTEGER                                            :: iatom, icoef1, icoef2, ncoef_h1, &
+                                                            ncoef_h2, ncoef_s1, ncoef_s2
+      REAL(dp)                                           :: cpc_h_tmp, cpc_s_tmp
+
+      CPASSERT(ASSOCIATED(rho_atom))
+      CPASSERT(ASSOCIATED(mixing_store%paw))
+
+      DO iatom = 1, SIZE(rho_atom)
+         IF (mixing_store%paw(iatom)) THEN
+            CPASSERT(ASSOCIATED(rho_atom(iatom)%cpc_h(1)%r_coef))
+            CPASSERT(ASSOCIATED(rho_atom(iatom)%cpc_h(2)%r_coef))
+            CPASSERT(ASSOCIATED(rho_atom(iatom)%cpc_s(1)%r_coef))
+            CPASSERT(ASSOCIATED(rho_atom(iatom)%cpc_s(2)%r_coef))
+            ncoef_h1 = SIZE(rho_atom(iatom)%cpc_h(1)%r_coef, 1)
+            ncoef_h2 = SIZE(rho_atom(iatom)%cpc_h(1)%r_coef, 2)
+            ncoef_s1 = SIZE(rho_atom(iatom)%cpc_s(1)%r_coef, 1)
+            ncoef_s2 = SIZE(rho_atom(iatom)%cpc_s(1)%r_coef, 2)
+            CPASSERT(ncoef_h1 == SIZE(rho_atom(iatom)%cpc_h(2)%r_coef, 1))
+            CPASSERT(ncoef_h2 == SIZE(rho_atom(iatom)%cpc_h(2)%r_coef, 2))
+            CPASSERT(ncoef_s1 == SIZE(rho_atom(iatom)%cpc_s(2)%r_coef, 1))
+            CPASSERT(ncoef_s2 == SIZE(rho_atom(iatom)%cpc_s(2)%r_coef, 2))
+
+            DO icoef2 = 1, ncoef_h2
+               DO icoef1 = 1, ncoef_h1
+                  cpc_h_tmp = rho_atom(iatom)%cpc_h(1)%r_coef(icoef1, icoef2)
+                  rho_atom(iatom)%cpc_h(1)%r_coef(icoef1, icoef2) = &
+                     0.5_dp*(cpc_h_tmp + rho_atom(iatom)%cpc_h(2)%r_coef(icoef1, icoef2))
+                  rho_atom(iatom)%cpc_h(2)%r_coef(icoef1, icoef2) = &
+                     0.5_dp*(cpc_h_tmp - rho_atom(iatom)%cpc_h(2)%r_coef(icoef1, icoef2))
+               END DO
+            END DO
+
+            DO icoef2 = 1, ncoef_s2
+               DO icoef1 = 1, ncoef_s1
+                  cpc_s_tmp = rho_atom(iatom)%cpc_s(1)%r_coef(icoef1, icoef2)
+                  rho_atom(iatom)%cpc_s(1)%r_coef(icoef1, icoef2) = &
+                     0.5_dp*(cpc_s_tmp + rho_atom(iatom)%cpc_s(2)%r_coef(icoef1, icoef2))
+                  rho_atom(iatom)%cpc_s(2)%r_coef(icoef1, icoef2) = &
+                     0.5_dp*(cpc_s_tmp - rho_atom(iatom)%cpc_s(2)%r_coef(icoef1, icoef2))
+               END DO
+            END DO
+         END IF
+      END DO
+
+   END SUBROUTINE gapw_cpc_charge_mag_to_spin
 
 ! **************************************************************************************************
 !> \brief G-space mixing performed via the Kerker damping on the density on the grid

--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -336,25 +336,6 @@ CONTAINS
 
       ALLOCATE (cc_mix(ng))
 
-      IF (nspin == 2) THEN
-         CALL pw_axpy(rho_g(1), rho_g(2), 1.0_dp, -1.0_dp)
-         DO ig = 1, ng
-            mixing_store%rhoin(2)%cc(ig) = mixing_store%rhoin(1)%cc(ig) - mixing_store%rhoin(2)%cc(ig)
-         END DO
-         IF (gapw .AND. mixing_store%gmix_p) THEN
-            DO iatom = 1, natom
-               IF (mixing_store%paw(iatom)) THEN
-                  rho_atom(iatom)%cpc_h(2)%r_coef = rho_atom(iatom)%cpc_h(1)%r_coef - rho_atom(iatom)%cpc_h(2)%r_coef
-                  rho_atom(iatom)%cpc_s(2)%r_coef = rho_atom(iatom)%cpc_s(1)%r_coef - rho_atom(iatom)%cpc_s(2)%r_coef
-                  mixing_store%cpc_h_in(iatom, 2)%r_coef = mixing_store%cpc_h_in(iatom, 1)%r_coef - &
-                                                           mixing_store%cpc_h_in(iatom, 2)%r_coef
-                  mixing_store%cpc_s_in(iatom, 2)%r_coef = mixing_store%cpc_s_in(iatom, 1)%r_coef - &
-                                                           mixing_store%cpc_s_in(iatom, 2)%r_coef
-               END IF
-            END DO
-         END IF
-      END IF
-
       DO ispin = 1, nspin
          ! Select spin-channel-specific mixing parameters
          IF (ispin >= 2 .AND. nspin >= 2) THEN
@@ -543,26 +524,6 @@ CONTAINS
 
       DEALLOCATE (cc_mix)
 
-      IF (nspin == 2) THEN
-         CALL pw_axpy(rho_g(1), rho_g(2), 1.0_dp, -1.0_dp)
-         DO ig = 1, ng
-            mixing_store%rhoin(2)%cc(ig) = mixing_store%rhoin(1)%cc(ig) - mixing_store%rhoin(2)%cc(ig)
-         END DO
-         IF (gapw .AND. mixing_store%gmix_p) THEN
-            DO iatom = 1, natom
-               IF (mixing_store%paw(iatom)) THEN
-                  rho_atom(iatom)%cpc_h(2)%r_coef = rho_atom(iatom)%cpc_h(1)%r_coef - rho_atom(iatom)%cpc_h(2)%r_coef
-                  rho_atom(iatom)%cpc_s(2)%r_coef = rho_atom(iatom)%cpc_s(1)%r_coef - rho_atom(iatom)%cpc_s(2)%r_coef
-                  mixing_store%cpc_h_in(iatom, 2)%r_coef = mixing_store%cpc_h_in(iatom, 1)%r_coef - &
-                                                           mixing_store%cpc_h_in(iatom, 2)%r_coef
-                  mixing_store%cpc_s_in(iatom, 2)%r_coef = mixing_store%cpc_s_in(iatom, 1)%r_coef - &
-                                                           mixing_store%cpc_s_in(iatom, 2)%r_coef
-               END IF
-            END DO
-         END IF
-
-      END IF
-
       CALL timestop(handle)
 
    END SUBROUTINE pulay_mixing
@@ -639,25 +600,6 @@ CONTAINS
          natom = SIZE(rho_atom)
       ELSE
          natom = 0
-      END IF
-
-      IF (nspin == 2) THEN
-         CALL pw_axpy(rho_g(1), rho_g(2), 1.0_dp, -1.0_dp)
-         DO ig = 1, ng
-            mixing_store%rhoin(2)%cc(ig) = mixing_store%rhoin(1)%cc(ig) - mixing_store%rhoin(2)%cc(ig)
-         END DO
-         IF (gapw .AND. mixing_store%gmix_p) THEN
-            DO iatom = 1, natom
-               IF (mixing_store%paw(iatom)) THEN
-                  rho_atom(iatom)%cpc_h(2)%r_coef = rho_atom(iatom)%cpc_h(1)%r_coef - rho_atom(iatom)%cpc_h(2)%r_coef
-                  rho_atom(iatom)%cpc_s(2)%r_coef = rho_atom(iatom)%cpc_s(1)%r_coef - rho_atom(iatom)%cpc_s(2)%r_coef
-                  mixing_store%cpc_h_in(iatom, 2)%r_coef = mixing_store%cpc_h_in(iatom, 1)%r_coef - &
-                                                           mixing_store%cpc_h_in(iatom, 2)%r_coef
-                  mixing_store%cpc_s_in(iatom, 2)%r_coef = mixing_store%cpc_s_in(iatom, 1)%r_coef - &
-                                                           mixing_store%cpc_s_in(iatom, 2)%r_coef
-               END IF
-            END DO
-         END IF
       END IF
 
       DO ispin = 1, nspin
@@ -876,25 +818,6 @@ CONTAINS
          END IF
 
       END DO ! ispin
-      IF (nspin == 2) THEN
-         CALL pw_axpy(rho_g(1), rho_g(2), 1.0_dp, -1.0_dp)
-         DO ig = 1, ng
-            mixing_store%rhoin(2)%cc(ig) = mixing_store%rhoin(1)%cc(ig) - mixing_store%rhoin(2)%cc(ig)
-         END DO
-         IF (gapw .AND. mixing_store%gmix_p) THEN
-            DO iatom = 1, natom
-               IF (mixing_store%paw(iatom)) THEN
-                  rho_atom(iatom)%cpc_h(2)%r_coef = rho_atom(iatom)%cpc_h(1)%r_coef - rho_atom(iatom)%cpc_h(2)%r_coef
-                  rho_atom(iatom)%cpc_s(2)%r_coef = rho_atom(iatom)%cpc_s(1)%r_coef - rho_atom(iatom)%cpc_s(2)%r_coef
-                  mixing_store%cpc_h_in(iatom, 2)%r_coef = mixing_store%cpc_h_in(iatom, 1)%r_coef - &
-                                                           mixing_store%cpc_h_in(iatom, 2)%r_coef
-                  mixing_store%cpc_s_in(iatom, 2)%r_coef = mixing_store%cpc_s_in(iatom, 1)%r_coef - &
-                                                           mixing_store%cpc_s_in(iatom, 2)%r_coef
-               END IF
-            END DO
-         END IF
-
-      END IF
 
       DEALLOCATE (res_rho)
 

--- a/src/qs_mixing_utils.F
+++ b/src/qs_mixing_utils.F
@@ -405,10 +405,10 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'mixing_init'
 
-      INTEGER                                            :: handle, iat, ib, ig, ig1, ig_count, &
-                                                            iproc, ispin, n1, n2, natom, nbuffer, &
-                                                            ng, nimg, nspin
-      REAL(dp)                                           :: bconst, beta, fdamp, g2max, g2min, kmin
+      INTEGER :: handle, iat, ib, icoef1, icoef2, ig, ig1, ig_count, iproc, ispin, n1, n2, natom, &
+         nbuffer, ncoef_h1, ncoef_h2, ncoef_s1, ncoef_s2, ng, nimg, nspin
+      REAL(dp)                                           :: bconst, beta, cpc_h_tmp, cpc_s_tmp, &
+                                                            fdamp, g2max, g2min, kmin
       REAL(dp), DIMENSION(:), POINTER                    :: g2
       REAL(dp), DIMENSION(:, :), POINTER                 :: g_vec
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rho_ao_kp
@@ -522,6 +522,45 @@ CONTAINS
                   END IF
                END DO
             END DO
+            IF (nspin == 2 .AND. ASSOCIATED(mixing_store%cpc_s_in)) THEN
+               DO iat = 1, natom
+                  IF (mixing_store%paw(iat)) THEN
+                     CPASSERT(ASSOCIATED(mixing_store%cpc_h_in(iat, 1)%r_coef))
+                     CPASSERT(ASSOCIATED(mixing_store%cpc_h_in(iat, 2)%r_coef))
+                     CPASSERT(ASSOCIATED(mixing_store%cpc_s_in(iat, 1)%r_coef))
+                     CPASSERT(ASSOCIATED(mixing_store%cpc_s_in(iat, 2)%r_coef))
+
+                     ncoef_h1 = SIZE(mixing_store%cpc_h_in(iat, 1)%r_coef, 1)
+                     ncoef_h2 = SIZE(mixing_store%cpc_h_in(iat, 1)%r_coef, 2)
+                     ncoef_s1 = SIZE(mixing_store%cpc_s_in(iat, 1)%r_coef, 1)
+                     ncoef_s2 = SIZE(mixing_store%cpc_s_in(iat, 1)%r_coef, 2)
+                     CPASSERT(ncoef_h1 == SIZE(mixing_store%cpc_h_in(iat, 2)%r_coef, 1))
+                     CPASSERT(ncoef_h2 == SIZE(mixing_store%cpc_h_in(iat, 2)%r_coef, 2))
+                     CPASSERT(ncoef_s1 == SIZE(mixing_store%cpc_s_in(iat, 2)%r_coef, 1))
+                     CPASSERT(ncoef_s2 == SIZE(mixing_store%cpc_s_in(iat, 2)%r_coef, 2))
+
+                     DO icoef2 = 1, ncoef_h2
+                        DO icoef1 = 1, ncoef_h1
+                           cpc_h_tmp = mixing_store%cpc_h_in(iat, 1)%r_coef(icoef1, icoef2)
+                           mixing_store%cpc_h_in(iat, 1)%r_coef(icoef1, icoef2) = &
+                              cpc_h_tmp + mixing_store%cpc_h_in(iat, 2)%r_coef(icoef1, icoef2)
+                           mixing_store%cpc_h_in(iat, 2)%r_coef(icoef1, icoef2) = &
+                              cpc_h_tmp - mixing_store%cpc_h_in(iat, 2)%r_coef(icoef1, icoef2)
+                        END DO
+                     END DO
+
+                     DO icoef2 = 1, ncoef_s2
+                        DO icoef1 = 1, ncoef_s1
+                           cpc_s_tmp = mixing_store%cpc_s_in(iat, 1)%r_coef(icoef1, icoef2)
+                           mixing_store%cpc_s_in(iat, 1)%r_coef(icoef1, icoef2) = &
+                              cpc_s_tmp + mixing_store%cpc_s_in(iat, 2)%r_coef(icoef1, icoef2)
+                           mixing_store%cpc_s_in(iat, 2)%r_coef(icoef1, icoef2) = &
+                              cpc_s_tmp - mixing_store%cpc_s_in(iat, 2)%r_coef(icoef1, icoef2)
+                        END DO
+                     END DO
+                  END IF
+               END DO
+            END IF
          END IF
       END IF
 

--- a/tests/QS/regtest-gpw-3/TEST_FILES.toml
+++ b/tests/QS/regtest-gpw-3/TEST_FILES.toml
@@ -69,5 +69,5 @@
 # Test reading LnPP2 
 "CeO2.inp"                              = [{matcher="E_total", tol=1e-12, ref=-64.41562845141048}]
 # Spin-channel-specific mixing parameters
-"O2-UKS-mixing.inp"                     = [{matcher="E_total", tol=5.0E-14, ref=-31.86511812037723}]
+"O2-UKS-mixing.inp"                     = [{matcher="E_total", tol=5.0E-14, ref=-31.86541677222950}]
 #EOF

--- a/tests/QS/regtest-gpw-4/TEST_FILES.toml
+++ b/tests/QS/regtest-gpw-4/TEST_FILES.toml
@@ -59,8 +59,8 @@
 #multiple ddapc restraints
 "He3_multi_ddapc.inp"                   = [{matcher="E_total", tol=3e-09, ref=-7.58374882585469}]
 #many added MOS with LSD
-"N.inp"                                 = [{matcher="E_total", tol=2e-13, ref=-9.73920135929005}]
-"N_notfixedMM.inp"                      = [{matcher="E_total", tol=2e-13, ref=-9.73920135929005}]
+"N.inp"                                 = [{matcher="E_total", tol=2e-13, ref=-9.73919798338060}]
+"N_notfixedMM.inp"                      = [{matcher="E_total", tol=2e-13, ref=-9.73919798338060}]
 #new diagonalization
 "h2o-otdiag.inp"                        = [{matcher="E_total", tol=8e-13, ref=-17.09951347030604}]
 "h2o-diag.inp"                          = [{matcher="E_total", tol=6e-14, ref=-16.10105776251690}]

--- a/tests/QS/regtest-gpw-6-3/TEST_FILES.toml
+++ b/tests/QS/regtest-gpw-6-3/TEST_FILES.toml
@@ -1,7 +1,7 @@
 "si8_lsd_broy_wc_rst.inp"               = [{matcher="M023", tol=2e-09, ref=2111.2137083255}]
 "si8_lsd_broy_wc_list.inp"              = [{matcher="M023", tol=4e-10, ref=992.1693045962}]
 "si8_lsd_broy_wc_list_rst.inp"          = [{matcher="M023", tol=4e-10, ref=991.9475824044}]
-"si8_lsd_broy_fm0.2.inp"                = [{matcher="M048", tol=1.0E-14, ref=-0.050162}]
+"si8_lsd_broy_fm0.2.inp"                = [{matcher="M048", tol=1.0E-14, ref=-0.049499}]
 #
 "c8_kerker.inp"                         = [{matcher="E_total", tol=1e-13, ref=-44.11857062837854}]
 "c8_pmix.inp"                           = [{matcher="E_total", tol=2e-13, ref=-43.56688833744322}]

--- a/tests/QS/regtest-kp-1/TEST_FILES.toml
+++ b/tests/QS/regtest-kp-1/TEST_FILES.toml
@@ -21,7 +21,7 @@
                                            {matcher="N_special_kpoints", tol=0.0, ref=1}]
 "c_gapwxc_spglib_backend.inp"           = [{matcher="E_total", tol=1e-8, ref=-45.66746891467081},
                                            {matcher="N_special_kpoints", tol=0.0, ref=1}]
-"cn_1.inp"                              = [{matcher="E_total", tol=5e-12, ref=-49.26750485181102}]
+"cn_1.inp"                              = [{matcher="E_total", tol=5e-12, ref=-49.26750298571628}]
 "c_dos.inp"                             = [{matcher="E_total", tol=2e-14, ref=-45.65703654036614}]
 "h_sym_red.inp"                         = [{matcher="E_total", tol=1e-13, ref=-4.34916646889997}]
 "h_sym_red_restart.inp"                 = [{matcher="E_total", tol=1e-8, ref=-4.34916647312477}]


### PR DESCRIPTION
Follow up to #5061.

In the current implementation, `gspace_mixing` already transforms the two spin densities from the spin-up/spin-down representation to the charge/magnetization representation before calling the individual mixing routines. However, the Pulay and Broyden mixers then performed an additional internal spin-channel transformation, changing the second channel from the intended magnetization density into a different linear combination of the spin densities. As a result, `ALPHA_MAG` and `BETA_MAG` might not have acted on the magnetization channel as intended.

This PR removes the redundant spin-channel transformations inside `pulay_mixing` and `broyden_mixing`, and makes the spin-channel representation in reciprocal-space mixing explicit and consistent across grid densities, GAPW compensation charges, and mixing history.