### PR TITLE
Toolchain: Download dftd4 from cp2k.org

### DIFF
--- a/tools/toolchain/scripts/stage8/install_dftd4.sh
+++ b/tools/toolchain/scripts/stage8/install_dftd4.sh
@@ -34,21 +34,7 @@ case "$with_dftd4" in
     if verify_checksums "${install_lock_file}"; then
       echo "dftd4-${dftd4_ver} is already installed, skipping it."
     else
-      if ! [ -f "dftd4-${dftd4_ver}.tar.xz" ]; then
-        if ! download_pkg_from_cp2k_org "${dftd4_sha256}" "dftd4-${dftd4_ver}.tar.xz"; then
-          download_pkg_from_urlpath "${dftd4_sha256}" "dftd4-${dftd4_ver}.tar.xz" \
-            "https://github.com/dftd4/dftd4/releases/download/v${dftd4_ver}"
-        fi
-      elif ! checksum "${dftd4_sha256}" "dftd4-${dftd4_ver}.tar.xz"; then
-        echo "dftd4-${dftd4_ver}.tar.xz is found but checksum is wrong; delete and re-download"
-        rm -vf "dftd4-${dftd4_ver}.tar.xz"
-        if ! download_pkg_from_cp2k_org "${dftd4_sha256}" "dftd4-${dftd4_ver}.tar.xz"; then
-          download_pkg_from_urlpath "${dftd4_sha256}" "dftd4-${dftd4_ver}.tar.xz" \
-            "https://github.com/dftd4/dftd4/releases/download/v${dftd4_ver}"
-        fi
-      else
-        echo "dftd4-${dftd4_ver}.tar.xz is found and checksum is right"
-      fi
+      retrieve_package "${dftd4_sha256}" dftd4-${dftd4_ver}.tar.gz
       echo "Installing from scratch into ${pkg_install_dir}"
       [ -d dftd4-${dftd4_ver} ] && rm -rf dftd4-${dftd4_ver}
       tar -xJf dftd4-${dftd4_ver}.tar.xz
@@ -61,19 +47,13 @@ case "$with_dftd4" in
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
-        -Ddftd4-dependency-method=subproject \
-        -DMCTC-LIB_FIND_METHOD=subproject \
-        -DMULTICHARGE_FIND_METHOD=subproject \
         .. \
         > cmake.log 2>&1 || tail_excerpt cmake.log
-      cmake --build . --target mctc-convert mstore-fortranize mstore-info multicharge-exe dftd4-exe \
-        -- -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-      cmake --install . >> make.log 2>&1 || tail_excerpt make.log
-
+      make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
       cd ..
+      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})" \
+        "${SCRIPT_DIR}/stage8/dftd4-${dftd4_ver}-gradient-fixes.patch"
     fi
-    write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})" \
-      "${SCRIPT_DIR}/stage8/dftd4-${dftd4_ver}-gradient-fixes.patch"
     ;;
 
   __SYSTEM__)


### PR DESCRIPTION
* Download dftd4 from cp2k.org.
* Remove `-D{pkg}-dependency-method=subproject` flag because CMake in dftd4 check subproject folder at first by default.
* Remove specific targets because the default target is `all` which contains those targets and I don't see the reason to specifically build them only.
* Move `write_checksums` to the right place.