### PR TITLE
Add Fedora Rawhide toolchain tester

### DIFF
--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -343,15 +343,22 @@ timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_fedora-psmp_report.txt
 
-[generic-psmp]
+[rawhide-psmp]
 sortkey:     1035
+name:        Rawhide Toolchain (psmp)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_rawhide-psmp_report.txt
+
+[generic-psmp]
+sortkey:     1036
 name:        Generic Toolchain (psmp)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_generic-psmp_report.txt
 
 [psmp-4ranks]
-sortkey:     1036
+sortkey:     1037
 name:        4 MPI ranks (psmp)
 timeout:     170
 host:        GCP

--- a/tools/docker/Dockerfile.test_rawhide-psmp
+++ b/tools/docker/Dockerfile.test_rawhide-psmp
@@ -1,0 +1,87 @@
+#
+# This file was created by generate_dockerfiles.py.
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_rawhide-psmp ../../
+#
+
+FROM fedora:rawhide
+
+# Install requirements for the toolchain.
+WORKDIR /opt/cp2k-toolchain
+COPY ./tools/toolchain/install_requirements*.sh ./
+RUN ./install_requirements.sh fedora:rawhide
+
+# Install the toolchain.
+RUN mkdir scripts
+COPY ./tools/toolchain/scripts/VERSION \
+     ./tools/toolchain/scripts/parse_if.py \
+     ./tools/toolchain/scripts/tool_kit.sh \
+     ./tools/toolchain/scripts/common_vars.sh \
+     ./tools/toolchain/scripts/signal_trap.sh \
+     ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./scripts/
+COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+RUN ./install_cp2k_toolchain.sh \
+    --install-all \
+    --mpi-mode=mpich \
+    --with-dbcsr \
+    --with-gcc=system \
+    --dry-run
+
+# Dry-run leaves behind config files for the followup install scripts.
+# This breaks up the lengthy installation into smaller build steps.
+COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
+RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage1/ ./scripts/stage1/
+RUN  ./scripts/stage1/install_stage1.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage2/ ./scripts/stage2/
+RUN  ./scripts/stage2/install_stage2.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage3/ ./scripts/stage3/
+RUN  ./scripts/stage3/install_stage3.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage4/ ./scripts/stage4/
+RUN  ./scripts/stage4/install_stage4.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage5/ ./scripts/stage5/
+RUN  ./scripts/stage5/install_stage5.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage6/ ./scripts/stage6/
+RUN  ./scripts/stage6/install_stage6.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage7/ ./scripts/stage7/
+RUN  ./scripts/stage7/install_stage7.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage8/ ./scripts/stage8/
+RUN  ./scripts/stage8/install_stage8.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage9/ ./scripts/stage9/
+RUN  ./scripts/stage9/install_stage9.sh && rm -rf ./build
+
+# Install CP2K sources.
+WORKDIR /opt/cp2k
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
+
+# Compile CP2K.
+COPY ./tools/docker/scripts/build_cp2k.sh .
+RUN ./build_cp2k.sh toolchain psmp
+
+# Run regression tests.
+ARG TESTOPTS=""
+COPY ./tests ./tests
+COPY ./tools/docker/scripts/test_regtest.sh ./
+RUN /bin/bash -o pipefail -c " \
+    TESTOPTS='${TESTOPTS}' \
+    ./test_regtest.sh toolchain psmp |& tee report.log && \
+    rm -rf regtesting"
+
+# Output the report if the image is old and was therefore pulled from the build cache.
+CMD cat $(find ./report.log -mmin +10) | sed '/^Summary:/ s/$/ (cached)/'
+ENTRYPOINT []
+
+#EOF

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -371,6 +371,14 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_fedora-psmp
 
+[rawhide-psmp]
+display_name: Fedora Rawhide
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_rawhide-psmp
+
 [generic-psmp]
 display_name: Generic
 tags:         weekly-afternoon

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -37,6 +37,10 @@ def main() -> None:
         f.write(install_deps_toolchain(base_image="fedora:44"))
         f.write(regtest("toolchain", "psmp"))
 
+    with OutputFile(f"Dockerfile.test_rawhide-psmp", args.check) as f:
+        f.write(install_deps_toolchain(base_image="fedora:rawhide"))
+        f.write(regtest("toolchain", "psmp"))
+
     for version in "ssmp", "psmp":
         mpi_mode = "intelmpi" if version.startswith("p") else "no"
         f.write(install_deps_toolchain(mpi_mode=mpi_mode))


### PR DESCRIPTION
This tester is supposed to detect problems with the latest GCC version and system environment early and is therefore likely to fail in most cases.