### PR TITLE
Make .gitignore less general

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,8 @@ build*/
 # Spack
 build-*
 .spack_patched
-spack*
+/spack
+/spack_cache
 
 ### CMake Patch ###
 # External projects


### PR DESCRIPTION
Do not ignore all folders in the source tree  with the name spack, just the folder  spack and spack_cache in the CP2K root folder.