### PR TITLE
spack* added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ build-*
 .spack_patched
 /spack
 /spack_cache
+spack*
 
 ### CMake Patch ###
 # External projects


### PR DESCRIPTION
Many spack folders are necessary, and files started with spack!