### PR TITLE
Spack docker tester: Use a dedicated cache network instead of host

### DIFF
--- a/tools/docker/Dockerfile.test_spack_openmpi-pdbg
+++ b/tools/docker/Dockerfile.test_spack_openmpi-pdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_openmpi-pdbg -f ./Dockerfile.test_spack_openmpi-pdbg ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_openmpi-pdbg -f ./Dockerfile.test_spack_openmpi-pdbg ../../
 #
 
 ARG BASE_IMAGE="ubuntu:26.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_openmpi-pdbg}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_spack_openmpi-psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_openmpi-psmp -f ./Dockerfile.test_spack_openmpi-psmp ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_openmpi-psmp -f ./Dockerfile.test_spack_openmpi-psmp ../../
 #
 
 ARG BASE_IMAGE="ubuntu:26.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_openmpi-psmp}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_pdbg
+++ b/tools/docker/Dockerfile.test_spack_pdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_pdbg -f ./Dockerfile.test_spack_pdbg ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_pdbg -f ./Dockerfile.test_spack_pdbg ../../
 #
 
 ARG BASE_IMAGE="ubuntu:26.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_pdbg}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp
+++ b/tools/docker/Dockerfile.test_spack_psmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp -f ./Dockerfile.test_spack_psmp ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp -f ./Dockerfile.test_spack_psmp ../../
 #
 
 ARG BASE_IMAGE="ubuntu:26.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-4x2
+++ b/tools/docker/Dockerfile.test_spack_psmp-4x2
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-4x2 -f ./Dockerfile.test_spack_psmp-4x2 ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-4x2 -f ./Dockerfile.test_spack_psmp-4x2 ../../
 #
 
 ARG BASE_IMAGE="ubuntu:26.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-4x2}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-P100
+++ b/tools/docker/Dockerfile.test_spack_psmp-P100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-P100 -f ./Dockerfile.test_spack_psmp-P100 ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-P100 -f ./Dockerfile.test_spack_psmp-P100 ../../
 #
 
 ARG BASE_IMAGE="docker.io/nvidia/cuda:12.9.1-devel-ubuntu24.04"
@@ -48,7 +48,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-P100}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-fedora
+++ b/tools/docker/Dockerfile.test_spack_psmp-fedora
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-fedora -f ./Dockerfile.test_spack_psmp-fedora ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-fedora -f ./Dockerfile.test_spack_psmp-fedora ../../
 #
 
 ARG BASE_IMAGE="fedora:latest"
@@ -30,7 +30,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-fedora}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc10
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc10
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-gcc10 -f ./Dockerfile.test_spack_psmp-gcc10 ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-gcc10 -f ./Dockerfile.test_spack_psmp-gcc10 ../../
 #
 
 ARG BASE_IMAGE="ubuntu:24.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc10}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc11
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc11
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-gcc11 -f ./Dockerfile.test_spack_psmp-gcc11 ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-gcc11 -f ./Dockerfile.test_spack_psmp-gcc11 ../../
 #
 
 ARG BASE_IMAGE="ubuntu:24.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc11}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc12
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc12
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-gcc12 -f ./Dockerfile.test_spack_psmp-gcc12 ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-gcc12 -f ./Dockerfile.test_spack_psmp-gcc12 ../../
 #
 
 ARG BASE_IMAGE="ubuntu:24.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc12}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc14
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc14
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-gcc14 -f ./Dockerfile.test_spack_psmp-gcc14 ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-gcc14 -f ./Dockerfile.test_spack_psmp-gcc14 ../../
 #
 
 ARG BASE_IMAGE="ubuntu:26.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc14}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc15
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc15
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-gcc15 -f ./Dockerfile.test_spack_psmp-gcc15 ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-gcc15 -f ./Dockerfile.test_spack_psmp-gcc15 ../../
 #
 
 ARG BASE_IMAGE="ubuntu:26.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc15}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-opensuse
+++ b/tools/docker/Dockerfile.test_spack_psmp-opensuse
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-opensuse -f ./Dockerfile.test_spack_psmp-opensuse ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-opensuse -f ./Dockerfile.test_spack_psmp-opensuse ../../
 #
 
 ARG BASE_IMAGE="opensuse/leap:15.6"
@@ -38,7 +38,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-opensuse}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-rawhide
+++ b/tools/docker/Dockerfile.test_spack_psmp-rawhide
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-rawhide -f ./Dockerfile.test_spack_psmp-rawhide ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-rawhide -f ./Dockerfile.test_spack_psmp-rawhide ../../
 #
 
 ARG BASE_IMAGE="fedora:rawhide"
@@ -30,7 +30,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-rawhide}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_psmp-rockylinux
+++ b/tools/docker/Dockerfile.test_spack_psmp-rockylinux
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_psmp-rockylinux -f ./Dockerfile.test_spack_psmp-rockylinux ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_psmp-rockylinux -f ./Dockerfile.test_spack_psmp-rockylinux ../../
 #
 
 ARG BASE_IMAGE="docker.io/rockylinux/rockylinux:10"
@@ -32,7 +32,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-rockylinux}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_sdbg
+++ b/tools/docker/Dockerfile.test_spack_sdbg
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_sdbg -f ./Dockerfile.test_spack_sdbg ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_sdbg -f ./Dockerfile.test_spack_sdbg ../../
 #
 
 ARG BASE_IMAGE="ubuntu:26.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_ssmp
+++ b/tools/docker/Dockerfile.test_spack_ssmp
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_ssmp -f ./Dockerfile.test_spack_ssmp ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_ssmp -f ./Dockerfile.test_spack_ssmp ../../
 #
 
 ARG BASE_IMAGE="ubuntu:26.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_ssmp}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_ssmp-P100
+++ b/tools/docker/Dockerfile.test_spack_ssmp-P100
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_ssmp-P100 -f ./Dockerfile.test_spack_ssmp-P100 ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_ssmp-P100 -f ./Dockerfile.test_spack_ssmp-P100 ../../
 #
 
 ARG BASE_IMAGE="docker.io/nvidia/cuda:12.9.1-devel-ubuntu24.04"
@@ -48,7 +48,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_ssmp-P100}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_ssmp-rawhide
+++ b/tools/docker/Dockerfile.test_spack_ssmp-rawhide
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_ssmp-rawhide -f ./Dockerfile.test_spack_ssmp-rawhide ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_ssmp-rawhide -f ./Dockerfile.test_spack_ssmp-rawhide ../../
 #
 
 ARG BASE_IMAGE="fedora:rawhide"
@@ -30,7 +30,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_ssmp-rawhide}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/Dockerfile.test_spack_ssmp-static
+++ b/tools/docker/Dockerfile.test_spack_ssmp-static
@@ -1,6 +1,6 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --network=host --shm-size=1g -t spack_ssmp-static -f ./Dockerfile.test_spack_ssmp-static ../../
+# Usage: ./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t spack_ssmp-static -f ./Dockerfile.test_spack_ssmp-static ../../
 #
 
 ARG BASE_IMAGE="ubuntu:24.04"
@@ -41,7 +41,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${IMAGE_TAG:-spack_ssmp-static}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}"
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}"
 
 # Copy CP2K repository into container
 WORKDIR /opt

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -10,7 +10,7 @@ To run a test one simply has to build the image:
 
 ```shell
 ./spack_cache_start.sh
-podman build --network=host --shm-size=1g -f Dockerfile.test_sdbg -t cp2k_test_sdbg ../../
+podman build --network=cp2k-spack-cache-net --shm-size=1g -f Dockerfile.test_sdbg -t cp2k_test_sdbg ../../
 ```
 
 To retrieve the cached report of an old image simply run it:

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -750,7 +750,7 @@ ARG IMAGE_TAG
 ENV IMAGE_TAG=${{IMAGE_TAG:-{image_tag}}}
 
 ARG SPACK_CACHE
-ENV SPACK_CACHE="${{SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://localhost:9000}}"
+ENV SPACK_CACHE="${{SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://spack-cache:9000}}"
 
 # Copy CP2K repository into container
 WORKDIR /opt
@@ -991,7 +991,7 @@ class OutputFile:
         self.content.write(f"# This file was created by generate_dockerfiles.py.\n")
         if "_spack_" in filename:
             self.image_tag = filename.removeprefix("Dockerfile.test_")
-            usage = f"./spack_cache_start.sh; podman build --network=host --shm-size=1g -t {self.image_tag} -f ./{filename} ../../"
+            usage = f"./spack_cache_start.sh; podman build --network=cp2k-spack-cache-net --shm-size=1g -t {self.image_tag} -f ./{filename} ../../"
         else:
             self.image_tag = ""
             usage = f"podman build --shm-size=1g -f ./{filename} ../../"

--- a/tools/docker/scripts/setup_spack_cache.sh
+++ b/tools/docker/scripts/setup_spack_cache.sh
@@ -3,11 +3,11 @@
 # author: Ole Schuett
 
 if [[ -n "${SPACK_CACHE}" ]]; then
-  if [[ "${SPACK_CACHE}" == *"http://localhost:9000"* ]]; then
-    if ! wget -q --tries=1 "http://localhost:9000/spack-cache"; then
+  if [[ "${SPACK_CACHE}" == *"http://spack-cache:9000"* ]]; then
+    if ! wget -q --tries=1 "http://spack-cache:9000/spack-cache"; then
       echo ""
       echo "ERROR: Could not connect to local Spack cache."
-      echo "       Start the cache by running ./spack_cache_start.sh and then pass --network=host to podman."
+      echo "       Start the cache by running ./spack_cache_start.sh and then pass --network=cp2k-spack-cache-net to podman."
       echo "       Alternatively, disable the cache by passing --build-arg SPACK_CACHE=\"\" to podman."
       echo "       See also: https://manual.cp2k.org/trunk/getting-started/build-with-spack.html"
       echo ""

--- a/tools/docker/spack_cache_start.sh
+++ b/tools/docker/spack_cache_start.sh
@@ -2,12 +2,22 @@
 
 # author: Ole Schuett
 
+SPACK_CACHE_NETWORK="${SPACK_CACHE_NETWORK:-cp2k-spack-cache-net}"
+
+if ! podman network exists "${SPACK_CACHE_NETWORK}"; then
+  podman network create "${SPACK_CACHE_NETWORK}"
+fi
+
 if podman start spack-cache; then
   echo "Re-started existing spack cache."
+  podman network connect "${SPACK_CACHE_NETWORK}" spack-cache 2> /dev/null || true
 
 else
   # Start MinIO server.
-  podman run --name spack-cache --detach -p 9000:9000 -p 9001:9001 \
+  podman run --name spack-cache --detach \
+    --network "${SPACK_CACHE_NETWORK}" \
+    --network-alias spack-cache \
+    -p 9000:9000 -p 9001:9001 \
     quay.io/minio/minio server /data --console-address ":9001"
 
   sleep 3


### PR DESCRIPTION
This avoids exposing local Spack Docker regtests to host networking when using a local MinIO cache, causing `mpirun`/`mpiexec` in the container take a very slow startup path on some machines. It fixes the local reproducer from #5055 according to my tests, but does not by itself address the slow official CP2K-CI Spack pdbg jobs, where the cache is `gs://cp2k-spack-cache` and docker build is not run with `--network=host`.