### PR TITLE
Molden: Replace [Nval] with [Pseudo] and enable marking ghost atoms

### DIFF
--- a/src/input_cp2k_print_dft.F
+++ b/src/input_cp2k_print_dft.F
@@ -622,6 +622,13 @@ CONTAINS
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="MARK_GHOST", &
+                          description="Controls whether ghost atoms are marked in the [Atoms] block by "// &
+                          "setting their atomic number to zero.", &
+                          usage="MARK_GHOST T", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="NDIGITS", &
                           description="Specifies the number of significant digits retained. 3 is OK for visualization.", &
                           usage="NDIGITS {int}", &
@@ -1497,6 +1504,13 @@ CONTAINS
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(sub_print_key, keyword)
       CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="MARK_GHOST", &
+                          description="Controls whether ghost atoms are marked in the [Atoms] block by "// &
+                          "setting their atomic number to zero.", &
+                          usage="MARK_GHOST T", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(sub_print_key, keyword)
+      CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="NDIGITS", &
                           description="Specifies the number of significant digits retained. 3 is OK for visualization.", &
                           usage="NDIGITS {int}", &
@@ -1601,6 +1615,13 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="WRITE_PSEUDO", &
                           description="Controls whether the [Pseudo] block is written to the MOLDEN file.", &
                           usage="WRITE_PSEUDO T", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(sub_print_key, keyword)
+      CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="MARK_GHOST", &
+                          description="Controls whether ghost atoms are marked in the [Atoms] block by "// &
+                          "setting their atomic number to zero.", &
+                          usage="MARK_GHOST T", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(sub_print_key, keyword)
       CALL keyword_release(keyword)
@@ -1746,6 +1767,13 @@ CONTAINS
       CALL keyword_create(keyword, __LOCATION__, name="WRITE_PSEUDO", &
                           description="Controls whether the [Pseudo] block is written to the MOLDEN file.", &
                           usage="WRITE_PSEUDO T", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="MARK_GHOST", &
+                          description="Controls whether ghost atoms are marked in the [Atoms] block by "// &
+                          "setting their atomic number to zero.", &
+                          usage="MARK_GHOST T", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_print_dft.F
+++ b/src/input_cp2k_print_dft.F
@@ -616,9 +616,9 @@ CONTAINS
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
-      CALL keyword_create(keyword, __LOCATION__, name="WRITE_NVAL", &
-                          description="Controls whether the [Nval] block is written to the MOLDEN file.", &
-                          usage="WRITE_NVAL T", &
+      CALL keyword_create(keyword, __LOCATION__, name="WRITE_PSEUDO", &
+                          description="Controls whether the [Pseudo] block is written to the MOLDEN file.", &
+                          usage="WRITE_PSEUDO T", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
@@ -1491,9 +1491,9 @@ CONTAINS
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(sub_print_key, keyword)
       CALL keyword_release(keyword)
-      CALL keyword_create(keyword, __LOCATION__, name="WRITE_NVAL", &
-                          description="Controls whether the [Nval] block is written to the MOLDEN file.", &
-                          usage="WRITE_NVAL T", &
+      CALL keyword_create(keyword, __LOCATION__, name="WRITE_PSEUDO", &
+                          description="Controls whether the [Pseudo] block is written to the MOLDEN file.", &
+                          usage="WRITE_PSEUDO T", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(sub_print_key, keyword)
       CALL keyword_release(keyword)
@@ -1598,9 +1598,9 @@ CONTAINS
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(sub_print_key, keyword)
       CALL keyword_release(keyword)
-      CALL keyword_create(keyword, __LOCATION__, name="WRITE_NVAL", &
-                          description="Controls whether the [Nval] block is written to the MOLDEN file.", &
-                          usage="WRITE_NVAL T", &
+      CALL keyword_create(keyword, __LOCATION__, name="WRITE_PSEUDO", &
+                          description="Controls whether the [Pseudo] block is written to the MOLDEN file.", &
+                          usage="WRITE_PSEUDO T", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(sub_print_key, keyword)
       CALL keyword_release(keyword)
@@ -1743,9 +1743,9 @@ CONTAINS
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
-      CALL keyword_create(keyword, __LOCATION__, name="WRITE_NVAL", &
-                          description="Controls whether the [Nval] block is written to the MOLDEN file.", &
-                          usage="WRITE_NVAL T", &
+      CALL keyword_create(keyword, __LOCATION__, name="WRITE_PSEUDO", &
+                          description="Controls whether the [Pseudo] block is written to the MOLDEN file.", &
+                          usage="WRITE_PSEUDO T", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_properties_dft.F
+++ b/src/input_cp2k_properties_dft.F
@@ -2087,6 +2087,13 @@ CONTAINS
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="MARK_GHOST", &
+                          description="Controls whether ghost atoms are marked in the [Atoms] block by "// &
+                          "setting their atomic number to zero.", &
+                          usage="MARK_GHOST T", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="NDIGITS", &
                           description="Specifies the number of significant digits retained. 3 is OK for visualization.", &
                           usage="NDIGITS {int}", &

--- a/src/input_cp2k_properties_dft.F
+++ b/src/input_cp2k_properties_dft.F
@@ -2081,9 +2081,9 @@ CONTAINS
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
-      CALL keyword_create(keyword, __LOCATION__, name="WRITE_NVAL", &
-                          description="Controls whether the [Nval] block is written to the MOLDEN file.", &
-                          usage="WRITE_NVAL TRUE", &
+      CALL keyword_create(keyword, __LOCATION__, name="WRITE_PSEUDO", &
+                          description="Controls whether the [Pseudo] block is written to the MOLDEN file.", &
+                          usage="WRITE_PSEUDO TRUE", &
                           default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)

--- a/src/molden_utils.F
+++ b/src/molden_utils.F
@@ -106,7 +106,7 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: l
       INTEGER, DIMENSION(molden_ncomax, 0:molden_lmax)   :: orbmap
       LOGICAL                                            :: do_calc_energies, print_warn, &
-                                                            write_cell, write_nval
+                                                            write_cell, write_pseudo
       REAL(KIND=dp)                                      :: expzet, prefac, scale_factor, zeff
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: cmatrix, smatrix
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
@@ -144,7 +144,7 @@ CONTAINS
 
          CALL section_vals_val_get(print_section, "GTO_KIND", i_val=gto_kind)
          CALL section_vals_val_get(print_section, "WRITE_CELL", l_val=write_cell)
-         CALL section_vals_val_get(print_section, "WRITE_NVAL", l_val=write_nval)
+         CALL section_vals_val_get(print_section, "WRITE_PSEUDO", l_val=write_pseudo)
 
          IF (mos(1)%use_mo_coeff_b) THEN
             ! we are using the dbcsr mo_coeff
@@ -186,12 +186,14 @@ CONTAINS
                WRITE (iw, '(T2,A2,I6,I6,3X,3(F12.6,3X))') &
                   element_symbol, i, z, particle_set(i)%r(:)*scale_factor
             END DO
-            IF (write_nval) THEN
-               WRITE (iw, '(T2,A)') "[Nval]"
-               DO i = 1, SIZE(qs_kind_set)
-                  CALL get_qs_kind(qs_kind_set(i), zeff=zeff)
-                  WRITE (iw, '(T2,A,1X,I6)') &
-                     TRIM(ADJUSTL(qs_kind_set(i)%element_symbol)), NINT(zeff)
+            IF (write_pseudo) THEN
+               WRITE (iw, '(T2,A)') "[Pseudo]"
+               DO i = 1, SIZE(particle_set)
+                  CALL get_atomic_kind(atomic_kind=particle_set(i)%atomic_kind, kind_number=ikind, &
+                                       element_symbol=element_symbol)
+                  CALL get_qs_kind(qs_kind_set(ikind), zeff=zeff)
+                  WRITE (iw, '(T2,A2,I6,I6)') &
+                     element_symbol, i, NINT(zeff)
                END DO
             END IF
 

--- a/src/molden_utils.F
+++ b/src/molden_utils.F
@@ -105,8 +105,9 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: npgf, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: l
       INTEGER, DIMENSION(molden_ncomax, 0:molden_lmax)   :: orbmap
-      LOGICAL                                            :: do_calc_energies, print_warn, &
-                                                            write_cell, write_pseudo
+      LOGICAL                                            :: do_calc_energies, ghost_atom, &
+                                                            mark_ghost, print_warn, write_cell, &
+                                                            write_pseudo
       REAL(KIND=dp)                                      :: expzet, prefac, scale_factor, zeff
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: cmatrix, smatrix
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues
@@ -145,6 +146,7 @@ CONTAINS
          CALL section_vals_val_get(print_section, "GTO_KIND", i_val=gto_kind)
          CALL section_vals_val_get(print_section, "WRITE_CELL", l_val=write_cell)
          CALL section_vals_val_get(print_section, "WRITE_PSEUDO", l_val=write_pseudo)
+         CALL section_vals_val_get(print_section, "MARK_GHOST", l_val=mark_ghost)
 
          IF (mos(1)%use_mo_coeff_b) THEN
             ! we are using the dbcsr mo_coeff
@@ -179,9 +181,13 @@ CONTAINS
                WRITE (iw, '(T2,A)') "[Atoms] AU"
             END IF
             DO i = 1, SIZE(particle_set)
-               CALL get_atomic_kind(atomic_kind=particle_set(i)%atomic_kind, &
+               CALL get_atomic_kind(atomic_kind=particle_set(i)%atomic_kind, kind_number=ikind, &
                                     element_symbol=element_symbol)
                CALL get_ptable_info(element_symbol, number=z)
+               IF (mark_ghost) THEN
+                  CALL get_qs_kind(qs_kind_set(ikind), ghost=ghost_atom)
+                  IF (ghost_atom) z = 0
+               END IF
 
                WRITE (iw, '(T2,A2,I6,I6,3X,3(F12.6,3X))') &
                   element_symbol, i, z, particle_set(i)%r(:)*scale_factor


### PR DESCRIPTION
Finally resolves #4353.

Note: The ghost atoms are marked by setting their atomic number to zero.