### PR TITLE
Test installed CP2K CMake package config

### DIFF
--- a/cmake/cp2kConfig.cmake.in
+++ b/cmake/cp2kConfig.cmake.in
@@ -61,17 +61,22 @@ if(NOT TARGET cp2k::cp2k)
 
   if(@CP2K_USE_DLAF@)
     set(CP2K_USE_DLAF @CP2K_USE_DLAF@)
-    find_dependency(DLAF REQUIRED)
+    find_dependency(DLAFFortran 0.4.0 REQUIRED)
   endif()
 
   if(@CP2K_USE_LIBXC@)
     set(CP2K_USE_LIBXC @CP2K_USE_LIBXC@)
-    find_dependency(LibXC 7 REQUIRED CONFIG)
+    find_dependency(Libxc 7 REQUIRED CONFIG)
   endif()
 
   if(@CP2K_USE_COSMA@)
     set(CP2K_USE_COSMA @CP2K_USE_COSMA@)
     find_dependency(cosma REQUIRED)
+    if(NOT TARGET cp2k::cosma)
+      add_library(cp2k::cosma INTERFACE IMPORTED)
+      target_link_libraries(cp2k::cosma INTERFACE cosma::cosma_prefixed_pxgemm
+                                                  cosma::cosma)
+    endif()
   endif()
 
   if(@CP2K_USE_MPI@)
@@ -96,17 +101,17 @@ if(NOT TARGET cp2k::cp2k)
 
   if(@CP2K_USE_SPGLIB@)
     set(CP2K_USE_SPGLIB @CP2K_USE_SPGLIB@)
-    find_dependency(LibSPG REQUIRED)
+    find_dependency(Spglib REQUIRED CONFIG)
   endif()
 
   if(@CP2K_USE_SPLA@)
     set(CP2K_USE_SPLA @CP2K_USE_SPLA@)
-    find_dependency(SPLA REQUIRED)
+    find_dependency(SPLA REQUIRED CONFIG)
   endif()
 
   if(@CP2K_USE_SIRIUS@)
     set(CP2K_USE_SIRIUS @CP2K_USE_SIRIUS@)
-    find_dependency(sirius REQUIRED)
+    find_dependency(sirius 7.7.0 REQUIRED)
   endif()
 
   if(@CP2K_USE_PLUMED@)
@@ -115,7 +120,7 @@ if(NOT TARGET cp2k::cp2k)
   endif()
 
   if(@CP2K_USE_LIBTORCH@)
-    set(CP2K_USE_TORCH @CP2K_USE_TORCH@)
+    set(CP2K_USE_LIBTORCH @CP2K_USE_LIBTORCH@)
     find_dependency(Torch REQUIRED)
   endif()
 
@@ -131,12 +136,12 @@ if(NOT TARGET cp2k::cp2k)
 
   if(@CP2K_USE_DEEPMD@)
     set(CP2K_USE_DEEPMD @CP2K_USE_DEEPMD@)
-    find_dependency(DeepMD REQUIRED)
+    find_dependency(DeePMD REQUIRED CONFIG)
   endif()
 
   if(@CP2K_USE_PEXSI@)
     set(CP2K_USE_PEXSI @CP2K_USE_PEXSI@)
-    find_dependency(PEXSI REQUIRED)
+    find_dependency(PEXSI REQUIRED CONFIG)
   endif()
 
   if(@CP2K_USE_ACE@)
@@ -145,18 +150,54 @@ if(NOT TARGET cp2k::cp2k)
   endif()
 
   if(@CP2K_USE_LIBSMEAGOL@)
-    set(CP2K_USE_ACE @CP2K_USE_LIBSMEAGOL@)
+    set(CP2K_USE_LIBSMEAGOL @CP2K_USE_LIBSMEAGOL@)
     find_dependency(libsmeagol REQUIRED)
   endif()
 
+  if(@CP2K_USE_MIMIC@)
+    set(CP2K_USE_MIMIC @CP2K_USE_MIMIC@)
+    find_dependency(MiMiC REQUIRED)
+  endif()
+
+  if(@CP2K_USE_OPENPMD@)
+    set(CP2K_USE_OPENPMD @CP2K_USE_OPENPMD@)
+    find_dependency(openPMD 0.16.1 REQUIRED)
+  endif()
+
   if(@CP2K_USE_VORI@)
-    set(CP2K_USE_VORI @CP2K_USE_LIBVORI@)
+    set(CP2K_USE_VORI @CP2K_USE_VORI@)
     find_dependency(LibVORI REQUIRED)
   endif()
 
   if(@CP2K_USE_GREENX@)
     set(CP2K_USE_GREENX @CP2K_USE_GREENX@)
-    find_dependency(greenX REQUIRED)
+    find_dependency(greenX REQUIRED CONFIG)
+    if(NOT TARGET cp2k::greenx)
+      add_library(cp2k::greenx INTERFACE IMPORTED)
+      target_link_libraries(cp2k::greenx INTERFACE greenX::GXCommon
+                                                   greenX::LibGXAC
+                                                   greenX::LibGXMiniMax)
+    endif()
+  endif()
+
+  if(@CP2K_USE_TBLITE@)
+    set(CP2K_USE_TBLITE @CP2K_USE_TBLITE@)
+    find_dependency(mctc-lib REQUIRED)
+    find_dependency(toml-f REQUIRED)
+    find_dependency(dftd4 REQUIRED)
+    find_dependency(s-dftd3 REQUIRED)
+    find_dependency(tblite REQUIRED)
+    if(NOT TARGET cp2k::tblite)
+      add_library(cp2k::tblite INTERFACE IMPORTED)
+      target_link_libraries(
+        cp2k::tblite INTERFACE tblite::tblite mctc-lib::mctc-lib dftd4::dftd4
+                               toml-f::toml-f s-dftd3::s-dftd3)
+    endif()
+  endif()
+
+  if(@CP2K_USE_TREXIO@)
+    set(CP2K_USE_TREXIO @CP2K_USE_TREXIO@)
+    find_dependency(TrexIO REQUIRED)
   endif()
 
   include("${CMAKE_CURRENT_LIST_DIR}/cp2kTargets.cmake")

--- a/tools/docker/scripts/test_gromacs.sh
+++ b/tools/docker/scripts/test_gromacs.sh
@@ -8,6 +8,9 @@ source /opt/cp2k-toolchain/install/setup
 cd build
 ninja install &> install.log
 
+# shellcheck disable=SC1091
+source /opt/cp2k/cp2k_env
+
 echo -e "\n========== Testing CP2K CMake package config =========="
 mkdir -p /tmp/cp2k_config_smoke
 cat > /tmp/cp2k_config_smoke/CMakeLists.txt << 'EOF'
@@ -29,7 +32,7 @@ if(NOT EXISTS "${CP2K_IMPORTED_LOCATION}")
 endif()
 EOF
 if cmake -S /tmp/cp2k_config_smoke -B /tmp/cp2k_config_smoke/build \
-  -DCMAKE_PREFIX_PATH="/opt/cp2k" &> cp2k_config_cmake.out; then
+  &> cp2k_config_cmake.out; then
   echo "CP2K CMake package config works."
 else
   echo -e "failed.\n\n"

--- a/tools/docker/scripts/test_gromacs.sh
+++ b/tools/docker/scripts/test_gromacs.sh
@@ -8,9 +8,6 @@ source /opt/cp2k-toolchain/install/setup
 cd build
 ninja install &> install.log
 
-# shellcheck disable=SC1091
-source /opt/cp2k/cp2k_env
-
 echo -e "\n========== Testing CP2K CMake package config =========="
 mkdir -p /tmp/cp2k_config_smoke
 cat > /tmp/cp2k_config_smoke/CMakeLists.txt << 'EOF'
@@ -32,7 +29,7 @@ if(NOT EXISTS "${CP2K_IMPORTED_LOCATION}")
 endif()
 EOF
 if cmake -S /tmp/cp2k_config_smoke -B /tmp/cp2k_config_smoke/build \
-  &> cp2k_config_cmake.out; then
+  -DCMAKE_PREFIX_PATH="/opt/cp2k" &> cp2k_config_cmake.out; then
   echo "CP2K CMake package config works."
 else
   echo -e "failed.\n\n"

--- a/tools/docker/scripts/test_gromacs.sh
+++ b/tools/docker/scripts/test_gromacs.sh
@@ -8,6 +8,39 @@ source /opt/cp2k-toolchain/install/setup
 cd build
 ninja install &> install.log
 
+echo -e "\n========== Testing CP2K CMake package config =========="
+mkdir -p /tmp/cp2k_config_smoke
+cat > /tmp/cp2k_config_smoke/CMakeLists.txt << 'EOF'
+cmake_minimum_required(VERSION 3.22)
+project(cp2k_config_smoke LANGUAGES C Fortran)
+
+find_package(cp2k CONFIG REQUIRED)
+
+if(NOT TARGET cp2k::cp2k)
+  message(FATAL_ERROR "cp2k::cp2k target missing after find_package(cp2k)")
+endif()
+
+get_target_property(CP2K_IMPORTED_LOCATION cp2k::cp2k IMPORTED_LOCATION_NOCONFIG)
+if(NOT CP2K_IMPORTED_LOCATION)
+  get_target_property(CP2K_IMPORTED_LOCATION cp2k::cp2k IMPORTED_LOCATION_RELEASE)
+endif()
+if(NOT EXISTS "${CP2K_IMPORTED_LOCATION}")
+  message(FATAL_ERROR "cp2k::cp2k imported location does not exist: ${CP2K_IMPORTED_LOCATION}")
+endif()
+EOF
+if cmake -S /tmp/cp2k_config_smoke -B /tmp/cp2k_config_smoke/build \
+  -DCMAKE_PREFIX_PATH="/opt/cp2k" &> cp2k_config_cmake.out; then
+  echo "CP2K CMake package config works."
+else
+  echo -e "failed.\n\n"
+  tail -n 100 cp2k_config_cmake.out
+  mkdir -p /workspace/artifacts/
+  cp cp2k_config_cmake.out /workspace/artifacts/
+  echo -e "\nSummary: Testing CP2K CMake package config failed."
+  echo -e "Status: FAILED\n"
+  exit 0
+fi
+
 echo -e "\n========== Installing Dependencies =========="
 apt-get update -qq
 apt-get install -qq --no-install-recommends git


### PR DESCRIPTION
Closes #5059.

This adds explicit coverage for the installed `cp2kConfig.cmake` package file in the existing GROMACS Docker test. That test already installs CP2K before configuring GROMACS, so it is a natural place to validate the downstream CMake package interface and to prepare the planned GROMACS-side migration from `gmxManageCP2K.cmake` to CP2K's installed package config.

The smoke test:

- creates a tiny downstream CMake project
- calls `find_package(cp2k CONFIG REQUIRED)` with `CMAKE_PREFIX_PATH=/opt/cp2k`
- verifies that the imported target `cp2k::cp2k` exists
- verifies that the imported CP2K library location exists on disk
- stores `cp2k_config_cmake.out` as an artifact if configuration fails

The PR also fixes issues exposed by the new test in the installed package config:

- uses the same dependency package names as the main CP2K build (`Libxc`, `Spglib`, `DeePMD`, etc.)
- restores missing downstream dependencies for enabled features such as TBLITE, TREXIO, MiMiC, and openPMD
- recreates generated interface targets needed by exported link interfaces, e.g. `cp2k::tblite`, `cp2k::greenx`, and `cp2k::cosma`

## Testing

- `bash -n tools/docker/scripts/test_gromacs.sh`
- `./make_pretty.sh cmake/cp2kConfig.cmake.in tools/docker/scripts/test_gromacs.sh`
- `git diff --check origin/master...HEAD`
- `git diff --check`
- CP2K pre-push hook checked 2 files successfully
