### PR TITLE
Exclude curl and readline from spack view

### DIFF
--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -219,5 +219,6 @@ spack:
     default:
       root: /opt/spack/view
       exclude:
-        # Exclude gcc-runtime to avoid adding a copy of libgomp.so to the view
+        - curl
         - gcc-runtime
+        - readline

--- a/tools/spack/cp2k_deps_s-static.yaml
+++ b/tools/spack/cp2k_deps_s-static.yaml
@@ -116,5 +116,6 @@ spack:
     default:
       root: /opt/spack/view
       exclude:
-        # Exclude gcc-runtime to avoid adding a copy of libgomp.so to the view
+        - curl
         - gcc-runtime
+        - readline

--- a/tools/spack/cp2k_deps_s.yaml
+++ b/tools/spack/cp2k_deps_s.yaml
@@ -133,5 +133,6 @@ spack:
     default:
       root: /opt/spack/view
       exclude:
-        # Exclude gcc-runtime to avoid adding a copy of libgomp.so to the view
+        - curl
         - gcc-runtime
+        - readline


### PR DESCRIPTION
This should fix the CMake warnings "no version information available"