### PR TITLE
Bug fix for TDDFPT oscillator strength for unrestricted calculations

### DIFF
--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -618,7 +618,7 @@ CONTAINS
          IF (nspins == 1) THEN
             trans_dipoles(:, :, 1) = SQRT(2.0_dp)*trans_dipoles(:, :, 1)
          ELSE
-            trans_dipoles(:, :, 1) = SQRT(trans_dipoles(:, :, 1)**2 + trans_dipoles(:, :, 2)**2)
+            trans_dipoles(:, :, 1) = trans_dipoles(:, :, 1) + trans_dipoles(:, :, 2)
          END IF
       END IF
 

--- a/tests/QS/regtest-rixs/TEST_FILES.toml
+++ b/tests/QS/regtest-rixs/TEST_FILES.toml
@@ -9,11 +9,11 @@
 
 "CH3-PBE-roks.inp"                             = [{matcher="XAS_excit_ener", tol=1e-07, ref=265.06592},
                                                   {matcher="TDDFPT_Check_Energy", tol=5.0E-06, ref=0.53118944},
-                                                  {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.2301125}]
+                                                  {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.024402234}]
 
 "CH3-PBE-uks.inp"                              = [{matcher="XAS_excit_ener", tol=1e-07, ref=265.236146},
                                                   {matcher="TDDFPT_Check_Energy", tol=5.0E-06, ref=0.57948051},
-                                                  {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.20993236}]
+                                                  {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.034065264}]
 
 "H2O-PBE0.inp"                                 = [{matcher="XAS_excit_ener", tol=1e-07, ref=519.371583},
                                                   {matcher="TDDFPT_Check_Energy", tol=5.0E-06, ref=0.63681532},
@@ -31,5 +31,4 @@
                                                   {matcher="TDDFPT_Check_Energy", tol=5.0E-06, ref=0.52370352},
                                                   {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.32678429}]
 #EOF
-
 

--- a/tests/QS/regtest-tddfpt-2/TEST_FILES.toml
+++ b/tests/QS/regtest-tddfpt-2/TEST_FILES.toml
@@ -32,7 +32,7 @@
 # Compute the lowest 3 doublet excited states of a nitrogen monooxyde molecule at PBE / aug-TZV2P-GTH level of theory.
 # Reference excitation energies (in eV): 0.13, 5.44, 6.14
 "no_pbe_uks_d_tddfpt.inp"               = [{matcher="TDDFPT_Check_Energy", tol=5.0E-06, ref=0.21062029},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.012585523}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.017924205}]
 "o2_pbe_uks_t_tddfpt.inp"               = [{matcher="TDDFPT_Check_Energy", tol=5.0E-06, ref=0.811288},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.028554365}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.040124936}]
 #EOF

--- a/tests/QS/regtest-tddfpt-3/TEST_FILES.toml
+++ b/tests/QS/regtest-tddfpt-3/TEST_FILES.toml
@@ -6,7 +6,7 @@
 #
 # test of new LSD KERNEL and finite differences
 "ch2o_t1.inp"                           = [{matcher="TDDFPT_Check_Energy", tol=5.0E-06, ref=0.181985E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=3.5891026E-06}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=1.4704668e-06}]
 "ch2o_t2.inp"                           = [{matcher="TDDFPT_Check_Energy", tol=5.0E-06, ref=0.241729E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.0000000E+00}]
 "ch2o_t3.inp"                           = [{matcher="TDDFPT_Check_Energy", tol=5.0E-06, ref=0.182932E+00},

--- a/tests/QS/regtest-tddfpt-os/TEST_FILES.toml
+++ b/tests/QS/regtest-tddfpt-os/TEST_FILES.toml
@@ -15,14 +15,15 @@
                                     {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.34970609E+00}]
 
 "NO_df0.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.31464224E+00},
-                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.28917150E+00}]
+                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00043376801}]
 "NO_df1.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.31464224E+00},
-                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.28917150E+00}]
+                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00043376801}]
 "NO_df2.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.31464224E+00},
-                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.37500099E+03}]
+                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.18406189}]
 "NO_df3.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.31464224E+00},
-                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.10204918E+02}]
+                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00043785886}]
 "NO_df4.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.31464224E+00},
-                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.16653282E+00}]
+                                    {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00020832769}]
 #
 #EOF
+

--- a/tests/QS/regtest-tddfpt-stda/TEST_FILES.toml
+++ b/tests/QS/regtest-tddfpt-stda/TEST_FILES.toml
@@ -6,7 +6,7 @@
 "CH2O_tddfpt_stda-s-1.inp"              = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.349885E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.087968314E+00}]
 "CH2Oplus_tddfpt_stda-lsd.inp"          = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.2121448E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.048696467E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.05544372}]
 "CH2O_tddfpt_stda-pbe-s.inp"            = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.125452E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=5.56619410E-07}]
 "CH2O_tddfpt_stda-pbe-s_doexchange.inp" = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.155105E+00},
@@ -20,7 +20,7 @@
 "H2O_tddfpt_stda-pbe-s.inp"             = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.599658E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.29153549E+00}]
 "H2Oplus_tddfpt_stda-pbe-lsd.inp"       = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.463329E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.49999918E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.49007769}]
 "H2O_tddfpt_stda-pbe-t.inp"             = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.595565E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00000000E+00}]
 "H2O_tddfpt_stda-pbe0-s.inp"            = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.637391E+00},
@@ -30,7 +30,7 @@
 "H2O_tddfpt_stda-s-1.inp"               = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.173147E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.13595821E+02}]
 "NO_tddfpt_stda-s-1.inp"                = [{matcher="TDDFPT_Check_Energy", tol=1.0E-05, ref=0.375613E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.43019506E-01}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.043014553}]
 "water_xTB.inp"                         = [{matcher="TDDFPT_Check_Energy", tol=2.0E-05, ref=0.125917E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.51465005E+00}]
 "water_xTBi_NTO.inp"                    = [{matcher="TDDFPT_Check_Energy", tol=2.0E-05, ref=0.125917E+00},

--- a/tests/QS/regtest-tddfpt/TEST_FILES.toml
+++ b/tests/QS/regtest-tddfpt/TEST_FILES.toml
@@ -8,31 +8,31 @@
 "H2O_tddfpt-t-1.inp"                    = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.289055E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00000000E+00}]
 "H2Oplus_tddfpt.inp"                    = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.505543E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.59644063E-01}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.066365983}]
 "NO_tddfpt-s-1.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.319837E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.29530847E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00056540661}]
 "NO_tddfpt-t-1.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=2.0E-04, ref=0.324319E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.29117391E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00061671143}]
 "H2O_tddfpt-s-2.inp"                    = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.543390E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.80526481E+00}]
 "H2O_tddfpt-t-2.inp"                    = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.548605E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00000000E+00}]
 "NO_tddfpt-t-2.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.340342E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.32381493E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00082370684}]
 "H2O_tddfpt-s-3.inp"                    = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.543390E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.80526481E+00}]
 "H2O_tddfpt-t-3.inp"                    = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.579030E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00000000E+00}]
 "NO_tddfpt-s-3.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.326331E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.35572424E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.0010064162}]
 "NO_tddfpt-t-3.inp"                     = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.340342E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.32381493E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.00082370684}]
 "H2O_tddfpt_NTO.inp"                    = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.542432E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.15673493E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.01674626}]
 "H2O_tddfpt_NTO_slist.inp"              = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.542432E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.15673493E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.01674626}]
 "H2O_tddfpt_NTO_restart.inp"            = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.542432E+00},
-                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.15673493E+00}]
+                                           {matcher="TDDFPT_Check_Osc_Strength", tol=1.0E-06, ref=0.01674626}]
 "H2_kp_tddfpt_none_mp.inp"              = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.658268E+00},
                                            {matcher="TDDFPT_Check_Osc_Strength", tol=4.0E-06, ref=0.36697616E+00}]
 "H2_kp_tddfpt_none_general.inp"         = [{matcher="TDDFPT_Check_Energy", tol=4.0E-06, ref=0.658268E+00},


### PR DESCRIPTION
This fixes a long standing bug in the calculation of oscillator strengths for unrestricted systems.
Transition dipoles were correct, but the calcullation of oscillator strengths used a wrong formula.