### PR TITLE
Restart-backup races under MPI + slow filesystems: two fixes + one open question

### DIFF
--- a/src/base/machine.F
+++ b/src/base/machine.F
@@ -708,6 +708,7 @@ CONTAINS
       CHARACTER(LEN=*), INTENT(IN)             :: source, TARGET
 
       INTEGER                                  :: istat
+      LOGICAL                                  :: src_exists
 
       INTERFACE
          FUNCTION rename(src, dest) BIND(C, name="rename") RESULT(errno)
@@ -729,6 +730,9 @@ CONTAINS
       ! now move
       istat = rename(TRIM(source)//c_null_char, TRIM(TARGET)//c_null_char)
       IF (istat /= 0) THEN
+         ! Source already moved by a concurrent rank: benign, nothing to back up.
+         INQUIRE (FILE=source, EXIST=src_exists)
+         IF (.NOT. src_exists) RETURN
          WRITE (*, *) "Trying to move "//TRIM(source)//" to "//TRIM(TARGET)//"."
          WRITE (*, *) "rename returned status: ", istat
          WRITE (*, *) "Problem moving file"

--- a/src/input/cp_output_handling.F
+++ b/src/input/cp_output_handling.F
@@ -993,7 +993,10 @@ CONTAINS
                                  WRITE (unit_nr, *) "File "//TRIM(filename_bak_2)//" not existing.."
                            END IF
                         ELSE
-                           CALL m_mov(TRIM(filename_bak_2), TRIM(filename_bak_1))
+                           ! Shared file: rotate on the source rank only; per-task
+                           ! (my_local) files are per-rank, rotated by their owner.
+                           IF (my_local .OR. logger%para_env%is_source()) &
+                              CALL m_mov(TRIM(filename_bak_2), TRIM(filename_bak_1))
                         END IF
                      END DO
                      ! The last backup is always the one with index 1
@@ -1003,7 +1006,8 @@ CONTAINS
                         IF (unit_nr > 0) &
                            WRITE (unit_nr, *) "Moving file "//TRIM(filename)//" into file "//TRIM(filename_bak)//"."
                      END IF
-                     CALL m_mov(TRIM(filename), TRIM(filename_bak))
+                     IF (my_local .OR. logger%para_env%is_source()) &
+                        CALL m_mov(TRIM(filename), TRIM(filename_bak))
                   ELSE
                      ! Zero the backup history for this new iteration level..
                      print_key%ibackup(my_backup_level) = 0


### PR DESCRIPTION
Here, I propose a small pair of fixes for races in the restart-file backup path that bite under MPI + heavy filesystem load.

I encountered that when running regtests with 2 MPI ranks and 2 OMP threads on WSL2 with MPICH-based toolchain.
Worth noting: serial single-rank is always clean, it only goes wrong with ≥2 ranks under filesystem pressure. 
So it seems like a real race; however, i am not 100% sure why the CI doesnt show this. Maybe due to the higher latency of WSL?

The two fixes are

1. **m_mov: don't abort when a concurrent rank already moved the file**
m_mov treats any non-zero rename(2) as fatal and calls m_abort(). When several ranks rotate the same shared backup file, one rank wins the rename and another finds the source already gone → rename returns ENOENT → the whole run dies with "Problem moving file". 
**Fix**: if the rename failed and the source no longer exists, that's benign (nothing left to back up) — return quietly; any other failure stays fatal  exactly as before.

2. **Only the source rank rotates a shared backup**
  The main reason multiple ranks were in m_mov at all: in cp_print_key_unit_nr, when a restart is written via collective MPI-IO, my_mpi_io is true on every rank, so every rank entered the backup-rotation block and ran the serial unlink/rename on the same shared path — racing each other and (even with fix 1) leaving the rotated backup inconsistent. 
**Fix**: only the source rank rotates backups of a shared file; genuine per-task (my_local) files are per-rank and still rotated by their owner. The following collective open synchronises the ranks, so no extra barrier is needed — and it's actually slightly fewer syscalls.

However, while digging I also found a third, deeper bug that I've deliberately left out of this PR because the clean fix is bigger than a quick patch.

3. **Binary-restart reader races the job's own restart rotation (not fixed here)**
Same WSL+MPICH setup, same kind of symptom but on the read side: a binary-restart run that continues under the same project name intermittently aborts at startup with things like An error occurred reading data object <nhc_size (IOSTAT = 5016)> or a VELOCITIES … (IOSTAT = -1) EOF. It's non-deterministic — which section/test fails moves around between runs, and serial single-rank is always clean.
The suspected cause: the binary restart is read by four separate routines (coordinates / cs-coordinates / velocities / nose-thermostats) called from four different modules at different init phases. They don't read one open stream — each re-opens the file by name and relies on the cp_files preconnection cache + file_position="ASIS" + close_file(keep_preconnection=.TRUE.) to continue sequentially. Because PROJECT+counter regenerate the same filename, the running job writes and rotates (rename → .bak-1, recreate) that very path during the run; if a by-name reopen binds to the freshly-recreated, still-incomplete file, a later section is parsed from the wrong offset → EOF/IOSTAT abort.
I tried a contained fix with claude: take a hard-link snapshot of the original restart on first read (frozen inode) and point all four readers at that, so the job rotating the path underneath no longer matters. It works and is accuracy-safe, but it leaves a stray *.rdsnap link in the run directory that can't be cleaned up cleanly — there's no single "restart reading is done" hook (it's spread across four modules/phases), and open_file re-INQUIREs the name on every call so it can't be early-unlinked either. A module-cached open unit instead of a snapshot would avoid the artifact, but it breaks the sequential ASIS/preconnection protocol and risks silently wrong restart data. So rather than bolt on a workaround that leaves droppings or risks accuracy, the proper fix is a small refactor of the read path (open once, thread the unit through the four readers). 
I don't think this is WSL-specific as such. Not sure what the preferred fix shape is here, so I'd rather ask than bolt something on - suggestions are very welcome.

The first two fixes (+the 3rd stopgap locally) allow me to run the regtests successfully on my local WSL. The behaviour change to be aware of: for other m_mov callers, a failed rename whose source has already vanished is now a quiet no-op instead of an abort — every other failure still aborts exactly as before. I did check whether fix 2 alone is enough and it isn't: reverting fix 1 brings the crash straight back (metadynamics / ASPC / BSSE / tddfpt), so it's load-bearing, not just defensive. Still, a second pair of eyes on that trade-off would be welcome.

I would be happy about any feedback/ideas on this (and also the unfixed no 3).

Best,
Max