### PR TITLE
Libint required for regtest-hybrid-ace-gs

### DIFF
--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -427,4 +427,4 @@ QS/regtest-rtbse-gxac                                       libint greenx !ifx
 QS/regtest-cneo
 QS/regtest-tddfpt-bse                                       libint libxc
 QS/regtest-tdwf
-QS/regtest-hybrid-ace-gs
+QS/regtest-hybrid-ace-gs                                    libint


### PR DESCRIPTION
Follow up to #5238.