### PR TITLE
Install GauXC Skala with spack

### DIFF
--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -287,7 +287,7 @@ while [[ $# -gt 0 ]]; do
               ace)
                 SED_PATTERN_LIST+=" -e '/\s*-\s+\"p${2,,}@/ ${SUBST}"
                 ;;
-              cosma | elpa | gauxc | greenx | hdf5 | libfci | libsmeagol | libxc | pexsi | plumed | spglib | trexio)
+              cosma | elpa | greenx | hdf5 | libfci | libsmeagol | libxc | pexsi | plumed | spglib | trexio)
                 SED_PATTERN_LIST+=" -e '/\s*-\s+\"${2,,}@/ ${SUBST}"
                 ;;
               deepmd)
@@ -312,15 +312,25 @@ while [[ $# -gt 0 ]]; do
               fftw3)
                 SED_PATTERN_LIST+=" -e '/\s*-\s+\"fftw@/ ${SUBST}"
                 ;;
+              gauxc)
+                SED_PATTERN_LIST+=" -e '/\s*-\s+\"${2,,}@/ ${SUBST}"
+                if [[ "${ON_OFF}" == "ON" ]]; then
+                  # GauXC requires libtorch
+                  CMAKE_FEATURE_FLAGS+=" -DCP2K_USE_LIBTORCH=${ON_OFF}"
+                  SED_PATTERN_LIST+=" -e '/\s*-\s+\"py-torch@/ ${SUBST}"
+                fi
+                ;;
               libint2)
                 SED_PATTERN_LIST+=" -e '/\s*-\s+\"libint@/ ${SUBST}"
                 ;;
               libtorch)
                 SED_PATTERN_LIST+=" -e '/\s*-\s+\"py-torch@/ ${SUBST}"
                 if [[ "${ON_OFF}" == "OFF" ]]; then
-                  # DeePMD-kit requires libtorch
+                  # DeePMD-kit and GauXC require libtorch
                   CMAKE_FEATURE_FLAGS+=" -DCP2K_USE_DEEPMD=${ON_OFF}"
                   SED_PATTERN_LIST+=" -e '/\s*-\s+\"deepmdkit@/ ${SUBST}"
+                  CMAKE_FEATURE_FLAGS+=" -DCP2K_USE_GAUXC=${ON_OFF}"
+                  SED_PATTERN_LIST+=" -e '/\s*-\s+\"gauxc@/ ${SUBST}"
                 fi
                 ;;
               libxsmm)
@@ -1363,6 +1373,35 @@ if ((EXIT_CODE != 0)); then
   ${EXIT_CMD} "${EXIT_CODE}"
 fi
 
+# Install Skala resource files if needed
+export GAUXC_SKALA_MODEL="GauXC Skala model not available"
+if [[ "${CMAKE_FEATURE_FLAGS}" == *" -DCP2K_USE_GAUXC=ON"* ]]; then
+  GAUXC_PREFIX="$(spack location -i gauxc)"
+  GAUXC_PATH="share/gauxc/onedft_models"
+  GAUXC_MODEL_SOURCE_PATH="${GAUXC_PREFIX%/}/${GAUXC_PATH}"
+  GAUXC_MODEL_TARGET_PATH="${INSTALL_PREFIX%/}/${GAUXC_PATH}"
+  if [[ -d "${GAUXC_MODEL_SOURCE_PATH}" ]]; then
+    mkdir -p "${GAUXC_MODEL_TARGET_PATH}"
+    if compgen -G "${GAUXC_MODEL_SOURCE_PATH}/*.fun" > /dev/null; then
+      cp "${GAUXC_MODEL_SOURCE_PATH}"/*.fun "${GAUXC_MODEL_TARGET_PATH}/"
+    else
+      echo -e "\nERROR: No GauXC model files found in source folder ${GAUXC_MODEL_SOURCE_PATH}"
+      ${EXIT_CMD} 1
+    fi
+  else
+    echo -e "\nERROR: The GauXC model source folder ${GAUXC_MODEL_SOURCE_PATH} does not exist"
+    ${EXIT_CMD} 1
+  fi
+  MATCHES=("${GAUXC_MODEL_TARGET_PATH}"/skala*)
+  if [[ -e "${MATCHES[0]}" ]]; then
+    export GAUXC_SKALA_MODEL="${MATCHES[-1]}"
+    echo -e "\nGAUXC_SKALA_MODEL = ${GAUXC_SKALA_MODEL}"
+  else
+    echo -e "\nERROR: Failed to resolve GAUXC_SKALA_MODEL in target path ${GAUXC_MODEL_TARGET_PATH}"
+    ${EXIT_CMD} 1
+  fi
+fi
+
 # Collect and compress all log files when building within a container
 if [[ "${IN_CONTAINER}" == "yes" ]]; then
   if ! cat "${CMAKE_BUILD_PATH}"/cmake.log \
@@ -1474,6 +1513,7 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
 export OMP_NUM_THREADS=\${OMP_NUM_THREADS:-2}
 export OMP_STACKSIZE=256M
 ${OMPI_VARS}
+export GAUXC_SKALA_MODEL=${GAUXC_SKALA_MODEL}
 exec "\$@"
 ***
 chmod 750 "${LAUNCH_SCRIPT}"
@@ -1486,6 +1526,7 @@ if [[ "${VERSION}" =~ ^(s|p)dbg$ ]]; then
   echo "LSAN_OPTIONS = \${LSAN_OPTIONS}"
 fi
 ldd -- ${INSTALL_PREFIX}/bin/cp2k.${VERSION} 2>&1 | grep -E 'not ' | sort | uniq
+export GAUXC_SKALA_MODEL=${GAUXC_SKALA_MODEL}
 ${CP2K_ROOT}/tests/do_regtest.py ${TESTOPTS} \$* ${INSTALL_PREFIX}/bin ${VERSION}
 ***
 chmod 750 "${INSTALL_PREFIX}"/bin/run_tests

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1374,33 +1374,30 @@ if ((EXIT_CODE != 0)); then
 fi
 
 # Install Skala resource files if needed
-export GAUXC_SKALA_MODEL="GauXC Skala model not available"
-if [[ "${CMAKE_FEATURE_FLAGS}" == *" -DCP2K_USE_GAUXC=ON"* ]]; then
-  GAUXC_PREFIX="$(spack location -i gauxc)"
-  GAUXC_PATH="share/gauxc/onedft_models"
-  GAUXC_MODEL_SOURCE_PATH="${GAUXC_PREFIX%/}/${GAUXC_PATH}"
+export GAUXC_SKALA_MODEL="(not available)"
+GAUXC_PATH="share/gauxc/onedft_models"
+GAUXC_PREFIX="$(spack location -i gauxc)"
+GAUXC_MODEL_SOURCE_PATH="${GAUXC_PREFIX%/}/${GAUXC_PATH}"
+if [[ -d "${GAUXC_MODEL_SOURCE_PATH}" ]]; then
   GAUXC_MODEL_TARGET_PATH="${INSTALL_PREFIX%/}/${GAUXC_PATH}"
-  if [[ -d "${GAUXC_MODEL_SOURCE_PATH}" ]]; then
-    mkdir -p "${GAUXC_MODEL_TARGET_PATH}"
-    if compgen -G "${GAUXC_MODEL_SOURCE_PATH}/*.fun" > /dev/null; then
-      cp "${GAUXC_MODEL_SOURCE_PATH}"/*.fun "${GAUXC_MODEL_TARGET_PATH}/"
-    else
-      echo -e "\nERROR: No GauXC model files found in source folder ${GAUXC_MODEL_SOURCE_PATH}"
-      ${EXIT_CMD} 1
-    fi
+  mkdir -p "${GAUXC_MODEL_TARGET_PATH}"
+  if compgen -G "${GAUXC_MODEL_SOURCE_PATH}/*.fun" > /dev/null; then
+    cp "${GAUXC_MODEL_SOURCE_PATH}"/*.fun "${GAUXC_MODEL_TARGET_PATH}/"
   else
-    echo -e "\nERROR: The GauXC model source folder ${GAUXC_MODEL_SOURCE_PATH} does not exist"
+    echo -e "\nERROR: No GauXC model files found in source folder ${GAUXC_MODEL_SOURCE_PATH}"
     ${EXIT_CMD} 1
   fi
+  shopt -s nullglob
   MATCHES=("${GAUXC_MODEL_TARGET_PATH}"/skala*)
-  if [[ -e "${MATCHES[0]}" ]]; then
-    export GAUXC_SKALA_MODEL="${MATCHES[-1]}"
-    echo -e "\nGAUXC_SKALA_MODEL = ${GAUXC_SKALA_MODEL}"
+  shopt -u nullglob
+  if ((${#MATCHES[@]} > 0)); then
+    export GAUXC_SKALA_MODEL="${MATCHES[${#MATCHES[@]} - 1]}"
   else
     echo -e "\nERROR: Failed to resolve GAUXC_SKALA_MODEL in target path ${GAUXC_MODEL_TARGET_PATH}"
     ${EXIT_CMD} 1
   fi
 fi
+echo -e "\nGAUXC_SKALA_MODEL = ${GAUXC_SKALA_MODEL}"
 
 # Collect and compress all log files when building within a container
 if [[ "${IN_CONTAINER}" == "yes" ]]; then

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -234,7 +234,7 @@ while [[ $# -gt 0 ]]; do
                 for package in libfci libint2 libxc libxsmm spglib vori tblite; do
                   CMAKE_FEATURE_FLAGS+=" -DCP2K_USE_${package^^}=ON"
                 done
-                for package in ace deepmd greenx hdf5 libtorch pexsi trexio; do
+                for package in ace deepmd gauxc greenx hdf5 libtorch pexsi trexio; do
                   CMAKE_FEATURE_FLAGS+=" -DCP2K_USE_${package^^}=OFF"
                 done
                 ;;
@@ -268,7 +268,7 @@ while [[ $# -gt 0 ]]; do
             # Enable or disable all features
             CMAKE_FEATURE_FLAG_ALL="-DCP2K_USE_EVERYTHING=${ON_OFF}"
             for package in adios2 cosma deepmdkit dla-future dla-future-fortran elpa \
-              greenx hdf5 libfci libfabric libint libvdwxc libsmeagol libvori libxc \
+              gauxc greenx hdf5 libfci libfabric libint libvdwxc libsmeagol libvori libxc \
               libxsmm mimic-mcl openpmd-api pace pexsi plumed py-torch sirius spfft \
               spglib spla tblite trexio; do
               SED_PATTERN_LIST+=" -e '/\s*-\s+\"${package}@/ ${SUBST}"
@@ -278,7 +278,7 @@ while [[ $# -gt 0 ]]; do
               SED_PATTERN_LIST+=" -e '/\s*-\s+\"smm=libxsmm\"/ s/libxsmm/blas/'"
             fi
             ;;
-          ace | cosma | deepmd | dftd4 | dlaf | elpa | fftw3 | greenx | hdf5 | libfci | libint2 | \
+          ace | cosma | deepmd | dftd4 | dlaf | elpa | fftw3 | gauxc | greenx | hdf5 | libfci | libint2 | \
             libsmeagol | libtorch | libxc | libxsmm | mimic | openpmd | pexsi | plumed | spglib | \
             tblite | trexio | vori)
             CMAKE_FEATURE_FLAGS+=" -DCP2K_USE_${2^^}=${ON_OFF}"
@@ -287,7 +287,7 @@ while [[ $# -gt 0 ]]; do
               ace)
                 SED_PATTERN_LIST+=" -e '/\s*-\s+\"p${2,,}@/ ${SUBST}"
                 ;;
-              cosma | elpa | greenx | hdf5 | libfci | libsmeagol | libxc | pexsi | plumed | spglib | trexio)
+              cosma | elpa | gauxc | greenx | hdf5 | libfci | libsmeagol | libxc | pexsi | plumed | spglib | trexio)
                 SED_PATTERN_LIST+=" -e '/\s*-\s+\"${2,,}@/ ${SUBST}"
                 ;;
               deepmd)
@@ -583,7 +583,7 @@ NUM_PROCS=$(awk '{print $1+0}' <<< "${NUM_PROCS}")
 [[ -f /.dockerenv || -f /run/.containerenv ]] && IN_CONTAINER="yes" || IN_CONTAINER="no"
 
 # Assemble CMake feature flag list
-CMAKE_FEATURE_FLAGS="${CMAKE_FEATURE_FLAG_ALL} ${CMAKE_FEATURE_FLAG_MPI} ${CMAKE_FEATURE_FLAGS} -DCP2K_USE_GAUXC=OFF"
+CMAKE_FEATURE_FLAGS="${CMAKE_FEATURE_FLAG_ALL} ${CMAKE_FEATURE_FLAG_MPI} ${CMAKE_FEATURE_FLAGS}"
 
 # Clean CMake feature flag list from repeated entries and keep only the last definition
 declare -A last=()
@@ -667,9 +667,9 @@ if [[ "${HELP}" == "yes" ]]; then
   echo "   (see also --build_deps flag)"
   echo " - The folder ${CP2K_ROOT}/install is updated after each successful run"
   echo ""
-  echo "Packages: all | ace | cosma | deepmd | dftd4 | dlaf | elpa | fftw3 | greenx | hdf5 | libfci | libint2 |"
-  echo "          libsmeagol | libtorch | libvdwxc | libxsmm | mimic | openpmd | pexsi | plumed | sirius |"
-  echo "          spfft | spglib | spla | tblite | trexio | vori "
+  echo "Packages: all | ace | cosma | deepmd | dftd4 | dlaf | elpa | fftw3 | gauxc | greenx | hdf5 | libfci |"
+  echo "          libint | libsmeagol | libtorch | libvdwxc | libxsmm | mimic | openpmd | pexsi | plumed |"
+  echo "          sirius | spfft | spglib | spla | tblite | trexio | vori "
   echo ""
   echo "Features: cray_pm_accel_energy | cusolver_mp | dbm_gpu | elpa_gpu | grid_gpu | pw_gpu |"
   echo "          spla_gemm_offloading | unified_memory"

--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -197,7 +197,7 @@ spack:
     - "dla-future-fortran@0.5.0"
     - "elpa@2026.02.001"
     - "fftw@3.3.11"
-    - "gauxc@1.2.dev2"
+    - "gauxc@dev20260522"
     - "greenx@2.2"
     - "hdf5@2.1.0"
     - "libfabric@2.5.1"

--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -26,6 +26,7 @@ spack:
       buildable: true
       prefer:
         - "~cuda"
+        - "+fortran"
         - "+mpi"
         - "+mpi_f08"
         - "+openmp"
@@ -69,7 +70,6 @@ spack:
 
     openblas:
       require:
-        - "+fortran"
         - "threads=openmp"
         - "build_system=makefile"
 
@@ -108,6 +108,13 @@ spack:
     fftw:
       require:
         - "+openmp"
+
+    gauxc:
+      require:
+        - "+c"
+        - "+fortran"
+        - "+openmp"
+        - "+skala"
 
     hdf5:
       require:
@@ -190,6 +197,7 @@ spack:
     - "dla-future-fortran@0.5.0"
     - "elpa@2026.02.001"
     - "fftw@3.3.11"
+    - "gauxc@1.2.dev2"
     - "greenx@2.2"
     - "hdf5@2.1.0"
     - "libfabric@2.5.1"

--- a/tools/spack/cp2k_deps_s.yaml
+++ b/tools/spack/cp2k_deps_s.yaml
@@ -26,6 +26,7 @@ spack:
       buildable: true
       prefer:
         - "~cuda"
+        - "+fortran"
         - "~mpi"
         - "~mpi_f08"
         - "+openmp"
@@ -73,6 +74,13 @@ spack:
       require:
         - "+openmp"
 
+    gauxc:
+      require:
+        - "+c"
+        - "+fortran"
+        - "+openmp"
+        - "+skala"
+
     hdf5:
       require:
         - "+fortran"
@@ -115,6 +123,7 @@ spack:
     - "deepmdkit@3.1.3"
 #   - "dftd4@4.0.2"
     - "fftw@3.3.11"
+    - "gauxc@dev20260522"
     - "greenx@2.2"
     - "hdf5@2.1.0"
     - "libfci@0.1.0"

--- a/tools/spack/spack_repo/cp2k_dev/packages/exchcxx/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/exchcxx/package.py
@@ -34,9 +34,10 @@ class Exchcxx(CMakePackage, CudaPackage):
     generator("ninja")
 
     variant("cuda", default=False, description="Build with CUDA support")
+    variant("pic", default=True, description="Build position independent code")
 
     def cmake_args(self):
-        args = []
+        args = [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
         if "+cuda" in self.spec:
             args.append(self.define("EXCHCXX_ENABLE_CUDA", True))
         return args

--- a/tools/spack/spack_repo/cp2k_dev/packages/exchcxx/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/exchcxx/package.py
@@ -1,0 +1,42 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+
+from spack.package import *
+
+
+class Exchcxx(CMakePackage, CudaPackage):
+    """Exchange correlation (XC) library for density functional theory (DFT)
+    calculations in modern C++."""
+
+    homepage = "https://github.com/wavefunction91/ExchCXX"
+    git = "https://github.com/wavefunction91/ExchCXX.git"
+    url = "https://github.com/wavefunction91/ExchCXX/archive/refs/tags/v1.0.0.tar.gz"
+
+    maintainers("awvwgk")
+
+    license("BSD-3-Clause")
+
+    version("master", branch="master")
+    version("1.0.0", sha256="0ea38aab563ea5d11a03d80dc1bf909821091d903eb852c5cb350484753a847a")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.20:", type="build")
+    depends_on("ninja@1.10:", type="build")
+    depends_on("libxc@7.0.0:")
+    depends_on("cuda", when="+cuda")
+
+    generator("ninja")
+
+    variant("cuda", default=False, description="Build with CUDA support")
+
+    def cmake_args(self):
+        args = []
+        if "+cuda" in self.spec:
+            args.append(self.define("EXCHCXX_ENABLE_CUDA", True))
+        return args

--- a/tools/spack/spack_repo/cp2k_dev/packages/exchcxx/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/exchcxx/package.py
@@ -17,7 +17,7 @@ class Exchcxx(CMakePackage, CudaPackage):
     git = "https://github.com/wavefunction91/ExchCXX.git"
     url = "https://github.com/wavefunction91/ExchCXX/archive/refs/tags/v1.0.0.tar.gz"
 
-    maintainers("awvwgk")
+    maintainers("awvwgk", "mkrack")
 
     license("BSD-3-Clause")
 

--- a/tools/spack/spack_repo/cp2k_dev/packages/gau2grid/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/gau2grid/package.py
@@ -16,11 +16,12 @@ class Gau2grid(CMakePackage):
     git = "https://github.com/psi4/gau2grid.git"
     url = "https://github.com/psi4/gau2grid/archive/refs/tags/v2.0.8.tar.gz"
 
-    maintainers("awvwgk")
+    maintainers("awvwgk", "mkrack")
 
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("2.0.9", sha256="7879bdddf3a52cd2a051086215977822bbe8d1af927fcf5b4fb0256a38b8a76c")
     version("2.0.8", sha256="c5f445344a465c1d9afc6516544dc4a2fba588af7ba0f1ac1a6b538260f0cd96")
 
     depends_on("cmake@3.12:", type="build")

--- a/tools/spack/spack_repo/cp2k_dev/packages/gau2grid/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/gau2grid/package.py
@@ -1,0 +1,39 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+
+from spack.package import *
+
+
+class Gau2grid(CMakePackage):
+    """Gau2Grid is a library for efficient evaluation of Gaussian
+    basis functions on grids."""
+
+    homepage = "https://gau2grid.readthedocs.io"
+    git = "https://github.com/psi4/gau2grid.git"
+    url = "https://github.com/psi4/gau2grid/archive/refs/tags/v2.0.8.tar.gz"
+
+    maintainers("awvwgk")
+
+    license("BSD-3-Clause")
+
+    version("master", branch="master")
+    version("2.0.8", sha256="c5f445344a465c1d9afc6516544dc4a2fba588af7ba0f1ac1a6b538260f0cd96")
+
+    depends_on("cmake@3.12:", type="build")
+    depends_on("ninja@1.10:", type="build")
+    depends_on("python@2.12:", type="build")
+    depends_on("py-numpy", type="build")
+
+    generator("ninja")
+
+    def cmake_args(self):
+        args = [
+            self.define("MAX_AM", 8),
+            self.define("ENABLE_XHOST", False),
+            self.define("INSTALL_PYMOD", False),
+        ]
+        return args

--- a/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
@@ -18,7 +18,7 @@ class Gauxc(CMakePackage, CudaPackage):
     git = "https://github.com/wavefunction91/GauXC.git"
     url = "https://github.com/wavefunction91/GauXC/archive/refs/tags/v1.1.tar.gz"
 
-    maintainers("awvwgk")
+    maintainers("awvwgk", "mkrack")
 
     license("BSD-3-Clause")
 
@@ -30,6 +30,18 @@ class Gauxc(CMakePackage, CudaPackage):
         url="https://github.com/microsoft/skala/releases/download/v1.1.1/gauxc-skala-r2.tar.gz",
     )
     version("1.1", sha256="17de077fb23e44d03b0ed14dcd8117c01e5b3431fbefa2352d751639ada7f91c")
+
+    # Skala resource file
+    skala_version = "1.1"
+    skala_file = f"skala-{skala_version}.fun"
+    resource(
+        name="skala_fun",
+        url=f"https://huggingface.co/microsoft/skala-{skala_version}/resolve/main/{skala_file}",
+        sha256="0c8432ac3f03c8f1276372df9aca5b7ee7f8939d47a8789eb158976e89aa0606",
+        expand=False,
+        placement=skala_file,
+        when="+skala",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -76,3 +88,11 @@ class Gauxc(CMakePackage, CudaPackage):
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
         return args
+
+    def install(self, spec, prefix):
+        super().install(spec, prefix)
+        if self.spec.satisfies("+skala"):
+            target_dir = self.prefix.share.gauxc.join("onedft_models")
+            mkdirp(target_dir)
+            print(target_dir)
+            install(join_path(self.skala_file, self.skala_file), target_dir)

--- a/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
@@ -1,0 +1,75 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+from spack_repo.builtin.build_systems.cuda import CudaPackage
+
+from spack.package import *
+
+
+class Gauxc(CMakePackage, CudaPackage):
+    """GauXC is a modern, modular C++ library for the evaluation of quantities related to
+    the exchange-correlation (XC) energy (e.g. potential, etc) in the Gaussian basis set
+    discretization of Kohn-Sham density function theory (KS-DFT) on heterogenous architectures."""
+
+    homepage = "https://github.com/wavefunction91/GauXC"
+    git = "https://github.com/wavefunction91/GauXC.git"
+    url = "https://github.com/wavefunction91/GauXC/archive/refs/tags/v1.1.tar.gz"
+
+    maintainers("awvwgk")
+
+    license("BSD-3-Clause")
+
+    version("master", branch="master")
+    version(
+        "1.2.dev2",
+        sha256="6659d00522b443f2557a960a9ba0217449d2ee25df809634d6becca23eb0f1ff",
+        url="https://github.com/microsoft/skala/releases/download/v1.1.1/gauxc-skala-r2.tar.gz",
+    )
+    version("1.1", sha256="17de077fb23e44d03b0ed14dcd8117c01e5b3431fbefa2352d751639ada7f91c")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", when="+fortran", type="build")
+    depends_on("cmake@3.20:", type="build")
+    depends_on("ninja@1.10:", type="build")
+    depends_on("exchcxx ~cuda", when="~cuda")
+    depends_on("exchcxx +cuda", when="+cuda")
+    depends_on("integratorxx")
+    depends_on("hdf5", when="+hdf5")
+    depends_on("mpi", when="+mpi")
+    depends_on("cuda", when="+cuda")
+    depends_on("highfive@:2.10.1", when="+hdf5")
+    depends_on("gau2grid")
+    depends_on("blas")
+    depends_on("nlohmann-json", when="+skala")
+    depends_on("py-torch@2:", when="+skala")
+    depends_on("py-torch@2: +cuda", when="+skala+cuda")
+
+    generator("ninja")
+
+    variant("openmp", default=True, description="Build with OpenMP support")
+    variant("mpi", default=False, description="Build with MPI support")
+    variant("cuda", default=False, description="Build with CUDA support")
+    variant("hdf5", default=False, description="Build with HDF5 support")
+    variant("c", default=False, description="Build with C support", when="@1.2.dev2")
+    variant("fortran", default=False, description="Build with Fortran support", when="@1.2.dev2")
+    variant("skala", default=False, description="Build with Skala support", when="@1.2.dev2")
+    variant("host", default=True, description="Build with host integrators")
+    variant("tests", default=False, description="Build with testing framework (Catch2)")
+
+    def cmake_args(self):
+        args = [
+            self.define("GAUXC_ENABLE_OPENMP", self.spec.satisfies("+openmp")),
+            self.define("GAUXC_ENABLE_MPI", self.spec.satisfies("+mpi")),
+            self.define("GAUXC_ENABLE_CUDA", self.spec.satisfies("+cuda")),
+            self.define("GAUXC_ENABLE_HDF5", self.spec.satisfies("+hdf5")),
+            self.define("GAUXC_ENABLE_C", self.spec.satisfies("+c")),
+            self.define("GAUXC_ENABLE_FORTRAN", self.spec.satisfies("+fortran")),
+            self.define("GAUXC_ENABLE_ONEDFT", self.spec.satisfies("+skala")),
+            self.define("GAUXC_ENABLE_HOST", self.spec.satisfies("+host")),
+            self.define("GAUXC_ENABLE_TESTS", self.spec.satisfies("+tests")),
+        ]
+        return args

--- a/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
@@ -23,6 +23,7 @@ class Gauxc(CMakePackage, CudaPackage):
     license("BSD-3-Clause")
 
     version("master", branch="master")
+    version("dev20260522", branch="skala", commit="69ee054054c642bce0d9b5e8c9c0c13afa97b774")
     version(
         "1.2.dev2",
         sha256="6659d00522b443f2557a960a9ba0217449d2ee25df809634d6becca23eb0f1ff",
@@ -54,11 +55,12 @@ class Gauxc(CMakePackage, CudaPackage):
     variant("mpi", default=False, description="Build with MPI support")
     variant("cuda", default=False, description="Build with CUDA support")
     variant("hdf5", default=False, description="Build with HDF5 support")
-    variant("c", default=False, description="Build with C support", when="@1.2.dev2")
-    variant("fortran", default=False, description="Build with Fortran support", when="@1.2.dev2")
-    variant("skala", default=False, description="Build with Skala support", when="@1.2.dev2")
+    variant("c", default=False, description="Build with C support")
+    variant("fortran", default=False, description="Build with Fortran support")
+    variant("skala", default=False, description="Build with Skala support")
     variant("host", default=True, description="Build with host integrators")
     variant("tests", default=False, description="Build with testing framework (Catch2)")
+    variant("pic", default=True, description="Build position independent code")
 
     def cmake_args(self):
         args = [
@@ -71,5 +73,6 @@ class Gauxc(CMakePackage, CudaPackage):
             self.define("GAUXC_ENABLE_ONEDFT", self.spec.satisfies("+skala")),
             self.define("GAUXC_ENABLE_HOST", self.spec.satisfies("+host")),
             self.define("GAUXC_ENABLE_TESTS", self.spec.satisfies("+tests")),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
         return args

--- a/tools/spack/spack_repo/cp2k_dev/packages/integratorxx/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/integratorxx/package.py
@@ -1,0 +1,29 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+
+from spack.package import *
+
+
+class Integratorxx(CMakePackage):
+    """Reuseable density functional theory (DFT) grid library."""
+
+    homepage = "https://github.com/wavefunction91/IntegratorXX"
+    git = "https://github.com/wavefunction91/IntegratorXX.git"
+    url = "https://github.com/wavefunction91/IntegratorXX/archive/refs/tags/v1.0.0.tar.gz"
+
+    maintainers("awvwgk")
+
+    license("BSD-3-Clause")
+
+    version("master", branch="master")
+    version("1.0.0", sha256="d2826439d14b3f716ffd57a07d1d407de029a80c0e0446998b8f1339d5085b9c")
+
+    depends_on("cxx", type="build")
+    depends_on("cmake@3.20:", type="build")
+    depends_on("ninja@1.10:", type="build")
+
+    generator("ninja")

--- a/tools/spack/spack_repo/cp2k_dev/packages/integratorxx/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/integratorxx/package.py
@@ -27,3 +27,9 @@ class Integratorxx(CMakePackage):
     depends_on("ninja@1.10:", type="build")
 
     generator("ninja")
+
+    variant("pic", default=True, description="Build position independent code")
+
+    def cmake_args(self):
+        args = [self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic")]
+        return args

--- a/tools/spack/spack_repo/cp2k_dev/packages/integratorxx/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/integratorxx/package.py
@@ -15,7 +15,7 @@ class Integratorxx(CMakePackage):
     git = "https://github.com/wavefunction91/IntegratorXX.git"
     url = "https://github.com/wavefunction91/IntegratorXX/archive/refs/tags/v1.0.0.tar.gz"
 
-    maintainers("awvwgk")
+    maintainers("awvwgk", "mkrack")
 
     license("BSD-3-Clause")
 


### PR DESCRIPTION
This is a dependency build check using spack. The compilation of CP2K with GauXC is still failing. The new spack recipes were retrieve from a (currently) open pull request [4814](https://github.com/spack/spack-packages/pull/4814) and slightly modified.