### PR TITLE
GauXC: HDF5 debug output

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1809,8 +1809,8 @@ target_compile_definitions(
     $<$<BOOL:${CP2K_USE_LIBVDWXC}>:__LIBVDWXC>
     $<$<BOOL:${CP2K_USE_GAUXC}>:__GAUXC>
     # GauXC feature flags GAUXC_HAS_MPI, GAUXC_HAS_ONEDFT, GAUXC_HAS_HOST,
-    # GAUXC_HAS_DEVICE, and GAUXC_HAS_CUDA are provided by gauxc/gauxc_config.f
-    # in the Fortran sources.
+    # GAUXC_HAS_DEVICE, GAUXC_HAS_CUDA, and GAUXC_HAS_HDF5 are provided by
+    # gauxc/gauxc_config.f in the Fortran sources.
     $<$<BOOL:${CP2K_USE_SPLA}>:__SPLA>
     $<$<BOOL:${CP2K_USE_SPLA_GEMM_OFFLOADING}>:__OFFLOAD_GEMM>
     $<$<BOOL:${CP2K_USE_ELPA}>:__ELPA>

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -129,6 +129,9 @@ CONTAINS
 #if defined(GAUXC_HAS_CUDA)
       flags = TRIM(flags)//" gauxc_cuda"
 #endif
+#if defined(GAUXC_HAS_HDF5)
+      flags = TRIM(flags)//" gauxc_hdf5"
+#endif
 #if defined(__PEXSI)
       flags = TRIM(flags)//" pexsi"
 #endif

--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -1301,7 +1301,7 @@ CONTAINS
       CPASSERT(.NOT. ASSOCIATED(section))
       CALL section_create(section, __LOCATION__, name="GAUXC", &
                           description="Use exchange-correlation functionals provided by GauXC", &
-                          n_keywords=12, n_subsections=0, repeats=.FALSE.)
+                          n_keywords=13, n_subsections=0, repeats=.FALSE.)
 
       NULLIFY (keyword)
 
@@ -1417,6 +1417,14 @@ CONTAINS
                           enum_desc=s2a("Run on host (default)", &
                                         "Run on device"), &
                           default_i_val=1)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="OUTPUT_PATH", &
+                          description="Optional path to an existing directory for GauXC HDF5 debug output. "// &
+                          "If set, molecule and basis set data are written as separate HDF5 files.", &
+                          usage="OUTPUT_PATH /path/to/output", &
+                          default_c_val="")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/xc/xc_gauxc_functional.F
+++ b/src/xc/xc_gauxc_functional.F
@@ -42,13 +42,15 @@ MODULE xc_gauxc_functional
                                               set_ks_env
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_type
+   USE qs_scf_types,                    ONLY: qs_scf_env_type
    USE string_utilities,                ONLY: uppercase
    USE xc_gauxc_interface,              ONLY: &
         cp_gauxc_basisset_type, cp_gauxc_grid_type, cp_gauxc_integrator_type, &
         cp_gauxc_molecule_type, cp_gauxc_status_type, cp_gauxc_xc_gradient_type, cp_gauxc_xc_type, &
         gauxc_check_status, gauxc_compute_xc, gauxc_compute_xc_gradient, gauxc_create_basisset, &
         gauxc_create_grid, gauxc_create_integrator, gauxc_create_molecule, gauxc_destroy_basisset, &
-        gauxc_destroy_grid, gauxc_destroy_integrator, gauxc_destroy_molecule
+        gauxc_destroy_grid, gauxc_destroy_integrator, gauxc_destroy_molecule, &
+        gauxc_write_basisset_hdf5, gauxc_write_molecule_hdf5
    USE xc_rho_cflags_types,             ONLY: xc_rho_cflags_type
 #include "../base/base_uses.f90"
 
@@ -780,13 +782,14 @@ CONTAINS
          "Use an additive PAIR_POTENTIAL dispersion correction or disable GauXC."
       REAL(KIND=dp), PARAMETER :: gapw_fd_gradient_dx = 1.0E-4_dp
 
-      CHARACTER(len=default_path_length)                 :: model_key, model_name
+      CHARACTER(len=default_path_length)                 :: model_key, model_name, output_path
       CHARACTER(len=default_string_length) :: grid_key, grid_type, int_exec_space, lb_exec_space, &
          pruning_key, pruning_scheme, radial_quadrature, xc_fun_name
       INTEGER                                            :: batch_size, img, ispin, natom, nimages, &
                                                             nspins
-      LOGICAL :: grid_explicit, molecular_virial, molecular_virial_debug, pruning_explicit, &
-         use_fd_gradient, use_gradient_self_runtime, use_onedft, use_self_runtime, use_skala_model
+      LOGICAL :: grid_explicit, hdf5_output, molecular_virial, molecular_virial_debug, &
+         pruning_explicit, use_fd_gradient, use_gradient_self_runtime, use_onedft, &
+         use_self_runtime, use_skala_model, write_hdf5_output
       REAL(KIND=dp)                                      :: molecular_virial_debug_dx
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: density_scalar, density_zeta
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
@@ -809,6 +812,7 @@ CONTAINS
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(qs_ks_env_type), POINTER                      :: ks_env
       TYPE(qs_rho_type), POINTER                         :: rho, rho_use, rho_xc
+      TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(section_vals_type), POINTER                   :: gauxc_functional_section
 
       NULLIFY ( &
@@ -824,7 +828,8 @@ CONTAINS
          rho, &
          rho_use, &
          rho_xc, &
-         rho_ao)
+         rho_ao, &
+         scf_env)
 
       CALL get_qs_env( &
          qs_env, &
@@ -839,7 +844,8 @@ CONTAINS
          particle_set=particle_set, &
          qs_kind_set=qs_kind_set, &
          rho=rho, &
-         rho_xc=rho_xc)
+         rho_xc=rho_xc, &
+         scf_env=scf_env)
 
       IF (dft_control%qs_control%gapw_xc) THEN
          CPABORT(gapw_xc_abort_message)
@@ -910,6 +916,10 @@ CONTAINS
          gauxc_functional_section, &
          "INT_EXECUTION_SPACE", &
          c_val=int_exec_space)
+      CALL section_vals_val_get( &
+         gauxc_functional_section, &
+         "OUTPUT_PATH", &
+         c_val=output_path)
 
       model_key = ADJUSTL(model_name)
       CALL uppercase(model_key)
@@ -956,6 +966,27 @@ CONTAINS
                     particle_set, &
                     gauxc_status)
       CALL gauxc_check_status(gauxc_status)
+      hdf5_output = (TRIM(output_path) /= "")
+      write_hdf5_output = hdf5_output .AND. para_env%mepos == 0
+      IF (write_hdf5_output .AND. ASSOCIATED(scf_env)) THEN
+         write_hdf5_output = scf_env%iter_count == 1
+      END IF
+      IF (write_hdf5_output) THEN
+         CALL gauxc_write_molecule_hdf5( &
+            gauxc_mol, &
+            output_path, &
+            "molecule.h5", &
+            "molecule", &
+            gauxc_status)
+         CALL gauxc_check_status(gauxc_status)
+         CALL gauxc_write_basisset_hdf5( &
+            gauxc_basis, &
+            output_path, &
+            "basisset.h5", &
+            "basisset", &
+            gauxc_status)
+         CALL gauxc_check_status(gauxc_status)
+      END IF
       use_fd_gradient = dft_control%qs_control%gapw .AND. calculate_forces .AND. &
                         (use_skala_model .OR. gauxc_basis%max_l > 3)
       IF (use_fd_gradient .AND. para_env%mepos == 0) THEN

--- a/src/xc/xc_gauxc_interface.F
+++ b/src/xc/xc_gauxc_interface.F
@@ -117,6 +117,10 @@ MODULE xc_gauxc_interface
       omp_get_max_threads, &
       omp_set_num_threads
 #endif
+#ifdef GAUXC_HAS_HDF5
+   USE gauxc_external_hdf5_write, ONLY: &
+      gauxc_write_hdf5_record
+#endif
    USE string_utilities, ONLY: &
       uppercase
 #endif
@@ -215,7 +219,9 @@ MODULE xc_gauxc_interface
       gauxc_destroy_integrator, &
       gauxc_destroy_molecule, &
       gauxc_finalize, &
-      gauxc_init
+      gauxc_init, &
+      gauxc_write_basisset_hdf5, &
+      gauxc_write_molecule_hdf5
 CONTAINS
 
 ! **************************************************************************************************
@@ -1083,5 +1089,61 @@ CONTAINS
    END FUNCTION read_pruning_scheme
 
 #endif
+
+! **************************************************************************************************
+!> \brief Write molecule data to HDF5 file for debugging
+!> \param molecule ...
+!> \param output_path ...
+!> \param filename ...
+!> \param dataset ...
+!> \param status ...
+! **************************************************************************************************
+   SUBROUTINE gauxc_write_molecule_hdf5(molecule, output_path, filename, dataset, status)
+      TYPE(cp_gauxc_molecule_type), INTENT(IN)           :: molecule
+      CHARACTER(len=*), INTENT(IN)                       :: output_path, filename, dataset
+      TYPE(cp_gauxc_status_type), INTENT(INOUT)          :: status
+
+#if defined(__GAUXC) && defined(GAUXC_HAS_HDF5)
+      CHARACTER(len=default_path_length)                 :: full_path
+
+      full_path = TRIM(output_path)//"/"//TRIM(filename)
+      CALL gauxc_write_hdf5_record(status%status, molecule%molecule, full_path, dataset)
+#else
+      MARK_USED(molecule)
+      MARK_USED(output_path)
+      MARK_USED(filename)
+      MARK_USED(dataset)
+      MARK_USED(status)
+      CPABORT("GauXC HDF5 output requires GauXC to be built with HDF5 support.")
+#endif
+   END SUBROUTINE gauxc_write_molecule_hdf5
+
+! **************************************************************************************************
+!> \brief Write basis set data to HDF5 file for debugging
+!> \param basis ...
+!> \param output_path ...
+!> \param filename ...
+!> \param dataset ...
+!> \param status ...
+! **************************************************************************************************
+   SUBROUTINE gauxc_write_basisset_hdf5(basis, output_path, filename, dataset, status)
+      TYPE(cp_gauxc_basisset_type), INTENT(IN)           :: basis
+      CHARACTER(len=*), INTENT(IN)                       :: output_path, filename, dataset
+      TYPE(cp_gauxc_status_type), INTENT(INOUT)          :: status
+
+#if defined(__GAUXC) && defined(GAUXC_HAS_HDF5)
+      CHARACTER(len=default_path_length)                 :: full_path
+
+      full_path = TRIM(output_path)//"/"//TRIM(filename)
+      CALL gauxc_write_hdf5_record(status%status, basis%basis, full_path, dataset)
+#else
+      MARK_USED(basis)
+      MARK_USED(output_path)
+      MARK_USED(filename)
+      MARK_USED(dataset)
+      MARK_USED(status)
+      CPABORT("GauXC HDF5 output requires GauXC to be built with HDF5 support.")
+#endif
+   END SUBROUTINE gauxc_write_basisset_hdf5
 
 END MODULE xc_gauxc_interface


### PR DESCRIPTION
Adds optional GauXC HDF5 debug output via DFT%XC%XC_FUNCTIONAL%GAUXC%OUTPUT_PATH. When set, CP2K writes the GauXC molecule and basis-set records through GauXC's native HDF5 writer. The output path is expected to point to an existing directory.

The HDF5 interface is guarded by GAUXC_HAS_HDF5 from gauxc/gauxc_config.f, so the default CP2K toolchain build with GauXC HDF5 disabled still compiles cleanly and aborts explicitly if OUTPUT_PATH is requested without HDF5 support.

Validation performed locally:
- make_pretty.sh -m src/CMakeLists.txt src/cp2k_info.F src/input_cp2k_xc.F src/xc/xc_gauxc_functional.F src/xc/xc_gauxc_interface.F
- git diff --check