### PR TITLE
Correct author name in BASIS_MOLOPT_LnPP1

### DIFF
--- a/data/BASIS_MOLOPT_LnPP1
+++ b/data/BASIS_MOLOPT_LnPP1
@@ -1,12 +1,12 @@
 # Norm-Conserving Pseudopotentials and Basis Sets To Explore Lanthanide Chemistry in Complex Environments
-# Jun-Bo Lu, David C. Cantu, Manh-Thuong Nguyen, Jun Li, Vassiliki-Alexandra Glezakoui, Roger Rousseau
+# Jun-Bo Lu, David C. Cantu, Manh-Thuong Nguyen, Jun Li, Vassiliki-Alexandra Glezakou, Roger Rousseau
 # J. Chem. Theory Comput. 2019, 15, 11, 5987-5997
 # https://doi.org/10.1021/acs.jctc.9b00553
 
 # Supporting Information
 # Norm-conserving pseudopotentials and basis sets to explore
 # Lanthanide chemistry in complex environments
-# Jun-Bo Lu, David C. Cantub , Manh-Thuong Nguyen, Jun Li, Vassiliki-Alexandra Glezakou, Roger Rousseau
+# Jun-Bo Lu, David C. Cantu, Manh-Thuong Nguyen, Jun Li, Vassiliki-Alexandra Glezakou, Roger Rousseau
 #
 # Department of Chemistry and Key Laboratory of Organic Optoelectronics & Molecular Engineering
 # of the Ministry of Education, Tsinghua University, Beijing 100084, China

--- a/data/BASIS_MOLOPT_LnPP1
+++ b/data/BASIS_MOLOPT_LnPP1
@@ -6,7 +6,7 @@
 # Supporting Information
 # Norm-conserving pseudopotentials and basis sets to explore
 # Lanthanide chemistry in complex environments
-# Jun-Bo Lu, David C. Cantub , Manh-Thuong Nguyen, Jun Lia, Vassiliki-Alexandra Glezakou, Roger Rousseau
+# Jun-Bo Lu, David C. Cantub , Manh-Thuong Nguyen, Jun Li, Vassiliki-Alexandra Glezakou, Roger Rousseau
 #
 # Department of Chemistry and Key Laboratory of Organic Optoelectronics & Molecular Engineering
 # of the Ministry of Education, Tsinghua University, Beijing 100084, China


### PR DESCRIPTION
Dear CP2K developers,

I just found several small typos in the reference information of this file. 
After checking the original paper, I think the extra "a" and "b" might be superscripts. This PR will remove those superscripts.

Regards,
Yike