### PR TITLE
Grid improvements

### DIFF
--- a/src/grid/cpu/grid_cpu_task_list.c
+++ b/src/grid/cpu/grid_cpu_task_list.c
@@ -17,6 +17,7 @@
 #include "grid_cpu_collocate.h"
 #include "grid_cpu_integrate.h"
 #include "grid_cpu_task_list.h"
+#include "grid_cpu_task_list_internal.h"
 
 /*******************************************************************************
  * \brief Comperator passed to qsort to compare two tasks.
@@ -59,7 +60,8 @@ void grid_cpu_create_task_list(
     grid_cpu_free_task_list(*task_list_out);
   }
 
-  grid_cpu_task_list *task_list = malloc(sizeof(grid_cpu_task_list));
+  grid_cpu_task_list_internal *task_list =
+      malloc(sizeof(grid_cpu_task_list_internal));
   assert(task_list != NULL);
 
   task_list->orthorhombic = orthorhombic;
@@ -183,7 +185,12 @@ void grid_cpu_create_task_list(
  * \brief Deallocates given task list, basis_sets have to be freed separately.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_cpu_free_task_list(grid_cpu_task_list *task_list) {
+void grid_cpu_free_task_list(grid_cpu_task_list *ptr) {
+  if (ptr == NULL)
+    return;
+
+  grid_cpu_task_list_internal *task_list = (grid_cpu_task_list_internal *)ptr;
+
   free(task_list->block_offsets);
   free(task_list->atom_positions);
   free(task_list->atom_kinds);
@@ -268,11 +275,16 @@ static void load_pab(const grid_basis_set *ibasis, const grid_basis_set *jbasis,
  * \author Ole Schuett
  ******************************************************************************/
 static void collocate_one_grid_level(
-    const grid_cpu_task_list *task_list, const int *first_block_task,
+    const grid_cpu_task_list *ptr, const int *first_block_task,
     const int *last_block_task, const enum grid_func func,
     const int npts_global[3], const int npts_local[3], const int shift_local[3],
     const int border_width[3], const double dh[3][3], const double dh_inv[3][3],
     const double *pab_blocks, offload_buffer *grid) {
+
+  if (ptr == NULL)
+    return;
+
+  grid_cpu_task_list_internal *task_list = (grid_cpu_task_list_internal *)ptr;
 
 // Using default(shared) because with GCC 9 the behavior around const changed:
 // https://www.gnu.org/software/gcc/gcc-9/porting_to.html
@@ -420,11 +432,14 @@ static void collocate_one_grid_level(
  *        See grid_task_list.h for details.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_cpu_collocate_task_list(const grid_cpu_task_list *task_list,
+void grid_cpu_collocate_task_list(const grid_cpu_task_list *ptr,
                                   const enum grid_func func, const int nlevels,
                                   const offload_buffer *pab_blocks,
                                   offload_buffer *grids[nlevels]) {
+  if (ptr == NULL)
+    return;
 
+  grid_cpu_task_list_internal *task_list = (grid_cpu_task_list_internal *)ptr;
   assert(task_list->nlevels == nlevels);
 
   for (int level = 0; level < task_list->nlevels; level++) {
@@ -487,12 +502,17 @@ static inline void store_hab(const grid_basis_set *ibasis,
  * \author Ole Schuett
  ******************************************************************************/
 static void integrate_one_grid_level(
-    const grid_cpu_task_list *task_list, const int *first_block_task,
+    const grid_cpu_task_list *ptr, const int *first_block_task,
     const int *last_block_task, const bool compute_tau, const int natoms,
     const int npts_global[3], const int npts_local[3], const int shift_local[3],
     const int border_width[3], const double dh[3][3], const double dh_inv[3][3],
     const offload_buffer *pab_blocks, const offload_buffer *grid,
     offload_buffer *hab_blocks, double forces[natoms][3], double virial[3][3]) {
+
+  if (ptr == NULL)
+    return;
+
+  grid_cpu_task_list_internal *task_list = (grid_cpu_task_list_internal *)ptr;
 
 // Using default(shared) because with GCC 9 the behavior around const changed:
 // https://www.gnu.org/software/gcc/gcc-9/porting_to.html
@@ -636,10 +656,15 @@ static void integrate_one_grid_level(
  * \author Ole Schuett
  ******************************************************************************/
 void grid_cpu_integrate_task_list(
-    const grid_cpu_task_list *task_list, const bool compute_tau,
-    const int natoms, const int nlevels, const offload_buffer *pab_blocks,
+    const grid_cpu_task_list *ptr, const bool compute_tau, const int natoms,
+    const int nlevels, const offload_buffer *pab_blocks,
     const offload_buffer *grids[nlevels], offload_buffer *hab_blocks,
     double forces[natoms][3], double virial[3][3]) {
+
+  if (ptr == NULL)
+    return;
+
+  grid_cpu_task_list_internal *task_list = (grid_cpu_task_list_internal *)ptr;
 
   assert(task_list->nlevels == nlevels);
   assert(task_list->natoms == natoms);

--- a/src/grid/cpu/grid_cpu_task_list.h
+++ b/src/grid/cpu/grid_cpu_task_list.h
@@ -13,60 +13,7 @@
 #include "../common/grid_basis_set.h"
 #include "../common/grid_constants.h"
 
-/*******************************************************************************
- * \brief Internal representation of a task.
- * \author Ole Schuett
- ******************************************************************************/
-typedef struct {
-  int level;
-  int iatom;
-  int jatom;
-  int iset;
-  int jset;
-  int ipgf;
-  int jpgf;
-  int border_mask;
-  int block_num;
-  double radius;
-  double rab[3];
-} grid_cpu_task;
-
-/*******************************************************************************
- * \brief Internal representation of a grid layout.
- * \author Ole Schuett
- ******************************************************************************/
-typedef struct {
-  int npts_global[3];
-  int npts_local[3];
-  int shift_local[3];
-  int border_width[3];
-  double dh[3][3];
-  double dh_inv[3][3];
-} grid_cpu_layout;
-
-/*******************************************************************************
- * \brief Internal representation of a task list.
- * \author Ole Schuett
- ******************************************************************************/
-typedef struct {
-  bool orthorhombic;
-  int ntasks;
-  int nlevels;
-  int natoms;
-  int nkinds;
-  int nblocks;
-  int *block_offsets;
-  double *atom_positions;
-  int *atom_kinds;
-  grid_basis_set **basis_sets;
-  grid_cpu_task *tasks;
-  grid_cpu_layout *layouts;
-  int *first_level_block_task;
-  int *last_level_block_task;
-  int maxco;
-  double **threadlocals;
-  size_t *threadlocal_sizes;
-} grid_cpu_task_list;
+typedef void grid_cpu_task_list;
 
 /*******************************************************************************
  * \brief Allocates a task list for the cpu backend.

--- a/src/grid/cpu/grid_cpu_task_list_internal.h
+++ b/src/grid/cpu/grid_cpu_task_list_internal.h
@@ -1,0 +1,71 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2026 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: BSD-3-Clause                                     */
+/*----------------------------------------------------------------------------*/
+
+#ifndef GRID_CPU_TASK_LIST_INTERNAL_H
+#define GRID_CPU_TASK_LIST_INTERNAL_H
+
+#include "../../offload/offload_buffer.h"
+#include "../common/grid_basis_set.h"
+#include "../common/grid_constants.h"
+#include <stdbool.h>
+
+/*******************************************************************************
+ * \brief Internal representation of a task.
+ * \author Ole Schuett
+ ******************************************************************************/
+typedef struct {
+  int level;
+  int iatom;
+  int jatom;
+  int iset;
+  int jset;
+  int ipgf;
+  int jpgf;
+  int border_mask;
+  int block_num;
+  double radius;
+  double rab[3];
+} grid_cpu_task;
+
+/*******************************************************************************
+ * \brief Internal representation of a grid layout.
+ * \author Ole Schuett
+ ******************************************************************************/
+typedef struct {
+  int npts_global[3];
+  int npts_local[3];
+  int shift_local[3];
+  int border_width[3];
+  double dh[3][3];
+  double dh_inv[3][3];
+} grid_cpu_layout;
+
+/*******************************************************************************
+ * \brief Internal representation of a task list.
+ * \author Ole Schuett
+ ******************************************************************************/
+typedef struct {
+  bool orthorhombic;
+  int ntasks;
+  int nlevels;
+  int natoms;
+  int nkinds;
+  int nblocks;
+  int *block_offsets;
+  double *atom_positions;
+  int *atom_kinds;
+  grid_basis_set **basis_sets;
+  grid_cpu_task *tasks;
+  grid_cpu_layout *layouts;
+  int *first_level_block_task;
+  int *last_level_block_task;
+  int maxco;
+  double **threadlocals;
+  size_t *threadlocal_sizes;
+} grid_cpu_task_list_internal;
+
+#endif

--- a/src/grid/dgemm/grid_dgemm_task_list.h
+++ b/src/grid/dgemm/grid_dgemm_task_list.h
@@ -17,7 +17,7 @@
  * It is not needed to know what exact structure for the public interface.
  * Equivalent to private member in c++ class
  ******************************************************************************/
-typedef struct grid_context_ grid_dgemm_task_list;
+typedef void grid_dgemm_task_list;
 
 /*******************************************************************************
  * \brief Allocates a task list for the dgemm backend.

--- a/src/grid/gpu/grid_gpu_collocate.cu
+++ b/src/grid/gpu/grid_gpu_collocate.cu
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cuda/atomic>
 
 #include "grid_gpu_internal_header.h"
 #include "grid_gpu_prepare_pab.h"
@@ -59,14 +60,13 @@ __device__ __inline__ void block_to_cab(const kernel_params &params,
             block_val =
                 task.pab_block[i * task.nsgfa + j] * task.off_diag_twice;
           }
-          //          const T sphia = task.sphia[j * task.maxcoa + ico];
           tmp_val += block_val * task.sphia[j * task.maxcoa + ico];
         }
         pab_val += tmp_val * sphib;
       }
 
       if (IS_FUNC_AB) {
-        cab[jco * task.ncoseta + ico] += pab_val;
+        cab[jco * task.ncoseta + ico] = pab_val;
       } else {
         const auto a = coset_inv[ico];
         const auto b = coset_inv[jco];
@@ -81,29 +81,37 @@ __device__ __inline__ void block_to_cab(const kernel_params &params,
 template <typename T, bool IS_FUNC_AB>
 __global__
 __launch_bounds__(64) void calculate_coefficients(const kernel_params dev_) {
-  __shared__ smem_task<T> task;
-  if (dev_.tasks[dev_.first_task + blockIdx.x].skip_task)
+  // Copy task from global to shared memory and precompute some stuff.
+  extern __shared__ T shared_memory[];
+  const int number_of_tasks = dev_.num_tasks_per_block_dev[blockIdx.x];
+
+  if (number_of_tasks == 0)
     return;
 
+  T *smem_alpha = &shared_memory[0];
   const int tid =
       threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+  const int offset = dev_.sorted_blocks_offset_dev[blockIdx.x];
+  T *smem_cab = allocate_workspace<T>(dev_);
 
-  fill_smem_task_coef(dev_, dev_.first_task + blockIdx.x, task);
-  extern __shared__ T shared_memory[];
-  // T *smem_cab = &shared_memory[dev_.smem_cab_offset];
-  T *smem_alpha = &shared_memory[dev_.smem_alpha_offset];
-  T *coef_ =
-      &dev_.ptr_dev[2][dev_.tasks[dev_.first_task + blockIdx.x].coef_offset];
-  T *smem_cab =
-      &dev_.ptr_dev[6][dev_.tasks[dev_.first_task + blockIdx.x].cab_offset];
-  compute_alpha(task, smem_alpha);
-  for (int z = tid; z < task.n1 * task.n2;
-       z += blockDim.x * blockDim.y * blockDim.z)
-    smem_cab[z] = 0.0;
-  __syncthreads();
-  block_to_cab<T, IS_FUNC_AB>(dev_, task, smem_cab);
-  __syncthreads();
-  cab_to_cxyz(task, smem_alpha, smem_cab, coef_);
+  for (int tk = 0; tk < number_of_tasks; tk++) {
+    __shared__ smem_task<T> task;
+    const int task_id = dev_.task_sorted_by_blocks_dev[offset + tk];
+    if (dev_.tasks[task_id].skip_task)
+      continue;
+    fill_smem_task_coef(dev_, task_id, task);
+
+    T *coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
+
+    compute_alpha(task, smem_alpha);
+    for (int z = tid; z < task.n1 * task.n2;
+         z += blockDim.x * blockDim.y * blockDim.z)
+      smem_cab[z] = 0.0;
+    __syncthreads();
+    block_to_cab<T, IS_FUNC_AB>(dev_, task, smem_cab);
+    __syncthreads();
+    cab_to_cxyz(task, smem_alpha, smem_cab, coef_);
+  }
 }
 
 /*
@@ -396,7 +404,6 @@ __launch_bounds__(64) void collocate_kernel(const kernel_params dev_) {
 
           if (task.lp >= 7) {
             for (int ic = ncoset(6); ic < ncoset(task.lp); ic++) {
-              T tmp1 = coef_[ic];
               auto &co = coset_inv[ic];
               T tmp = 1.0;
               for (int po = 0; po < (co.l[2] >> 1); po++)
@@ -411,7 +418,7 @@ __launch_bounds__(64) void collocate_kernel(const kernel_params dev_) {
                 tmp *= r3x2;
               if (co.l[0] & 0x1)
                 tmp *= r3.x;
-              res += tmp * tmp1;
+              res += tmp * coef_[ic];
             }
           }
         }
@@ -424,6 +431,33 @@ __launch_bounds__(64) void collocate_kernel(const kernel_params dev_) {
                   res);
       }
     }
+  }
+}
+
+void context_info::calculate_all_coefficients(const enum grid_func func,
+                                              int *lp_diff) {
+  // Compute max angular momentum.
+  const ldiffs_value ldiffs = prepare_get_ldiffs(func);
+  smem_parameters smem_params(ldiffs, lmax());
+
+  *lp_diff = smem_params.lp_diff();
+  init_constant_memory();
+
+  // kernel parameters
+  kernel_params params = set_kernel_parameters(-1, smem_params);
+  params.func = func;
+
+  // Launch !
+  const dim3 threads_per_block(4, 4, 4);
+
+  if (func == GRID_FUNC_AB) {
+    calculate_coefficients<double, true>
+        <<<nblocks, threads_per_block, smem_params.smem_per_block(),
+           main_stream>>>(params);
+  } else {
+    calculate_coefficients<double, false>
+        <<<nblocks, threads_per_block, smem_params.smem_per_block(),
+           main_stream>>>(params);
   }
 }
 /*******************************************************************************
@@ -449,16 +483,6 @@ void context_info::collocate_one_grid_level(const int level,
 
   // Launch !
   const dim3 threads_per_block(4, 4, 4);
-
-  if (func == GRID_FUNC_AB) {
-    calculate_coefficients<double, true>
-        <<<number_of_tasks_per_level_[level], threads_per_block,
-           smem_params.smem_per_block(), level_streams[level]>>>(params);
-  } else {
-    calculate_coefficients<double, false>
-        <<<number_of_tasks_per_level_[level], threads_per_block,
-           smem_params.smem_per_block(), level_streams[level]>>>(params);
-  }
 
   if (grid_[level].is_distributed()) {
     if (grid_[level].is_orthorhombic())

--- a/src/grid/gpu/grid_gpu_collocate.cu
+++ b/src/grid/gpu/grid_gpu_collocate.cu
@@ -19,7 +19,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cuda/atomic>
 
 #include "grid_gpu_internal_header.h"
 #include "grid_gpu_prepare_pab.h"
@@ -66,7 +65,7 @@ __device__ __inline__ void block_to_cab(const kernel_params &params,
       }
 
       if (IS_FUNC_AB) {
-        cab[jco * task.ncoseta + ico] = pab_val;
+        cab[jco * task.ncoseta + ico] += pab_val;
       } else {
         const auto a = coset_inv[ico];
         const auto b = coset_inv[jco];

--- a/src/grid/gpu/grid_gpu_context.cu
+++ b/src/grid/gpu/grid_gpu_context.cu
@@ -34,6 +34,54 @@ extern "C" {
 #error "OpenMP should not be used in .cu files to accommodate HIP."
 #endif
 
+namespace rocm_backend {
+kernel_params
+context_info::set_kernel_parameters(const int level,
+                                    const smem_parameters &smem_params) {
+  kernel_params params;
+  params.cab_size_ = smem_params.cab_size();
+  params.first_task = 0;
+
+  params.la_min_diff = smem_params.ldiffs().la_min_diff;
+  params.lb_min_diff = smem_params.ldiffs().lb_min_diff;
+
+  params.la_max_diff = smem_params.ldiffs().la_max_diff;
+  params.lb_max_diff = smem_params.ldiffs().lb_max_diff;
+  params.tasks = this->tasks_dev.data();
+  params.task_sorted_by_blocks_dev = task_sorted_by_blocks_dev.data();
+  params.sorted_blocks_offset_dev = sorted_blocks_offset_dev.data();
+  params.num_tasks_per_block_dev = this->num_tasks_per_block_dev_.data();
+  params.block_offsets = this->block_offsets_dev.data();
+  params.la_min_diff = smem_params.ldiffs().la_min_diff;
+  params.lb_min_diff = smem_params.ldiffs().lb_min_diff;
+  params.la_max_diff = smem_params.ldiffs().la_max_diff;
+  params.lb_max_diff = smem_params.ldiffs().lb_max_diff;
+
+  params.ptr_dev[0] = pab_block_.data();
+
+  if (level >= 0) {
+    params.ptr_dev[1] = grid_[level].data();
+    for (int i = 0; i < 3; i++) {
+      memcpy(params.dh_, grid_[level].dh(), 9 * sizeof(double));
+      memcpy(params.dh_inv_, grid_[level].dh_inv(), 9 * sizeof(double));
+      params.grid_full_size_[i] = grid_[level].full_size(i);
+      params.grid_local_size_[i] = grid_[level].local_size(i);
+      params.grid_lower_corner_[i] = grid_[level].lower_corner(i);
+      params.grid_border_width_[i] = grid_[level].border_width(i);
+    }
+    params.first_task = first_task_per_level_[level];
+  }
+  params.ptr_dev[2] = this->coef_dev_.data();
+  params.ptr_dev[3] = hab_block_.data();
+  params.ptr_dev[4] = forces_.data();
+  params.ptr_dev[5] = virial_.data();
+  params.ptr_dev[6] = this->cab_dev_.data();
+  params.cab_block_offset_dev = this->cab_block_offset_dev.data();
+  params.sphi_dev = this->sphi_dev.data();
+  return params;
+}
+}; // namespace rocm_backend
+
 /*******************************************************************************
  * \brief Allocates a task list for the GPU backend.
  *        See grid_ctx.h for details.
@@ -51,6 +99,13 @@ extern "C" void grid_gpu_create_task_list(
     const double *dh, const double *dh_inv, grid_gpu_task_list **ptr) {
 
   rocm_backend::context_info **ctx_out = (rocm_backend::context_info **)ptr;
+
+  // Yes it makes no sense
+  if ((nblocks == 0) || (ntasks == 0)) {
+    *ptr = nullptr;
+    return;
+  }
+
   // Select GPU device.
   rocm_backend::context_info *ctx = nullptr;
   if (*ctx_out == nullptr) {
@@ -66,9 +121,10 @@ extern "C" void grid_gpu_create_task_list(
   ctx->nlevels = nlevels;
   ctx->natoms = natoms;
   ctx->nblocks = nblocks;
-
+  ctx->nkinds = nkinds;
   ctx->grid_.resize(nlevels);
   ctx->set_device();
+
   std::vector<double> dh_max(ctx->nlevels, 0);
 
   for (int level = 0; level < ctx->nlevels; level++) {
@@ -94,7 +150,8 @@ extern "C" void grid_gpu_create_task_list(
   std::vector<rocm_backend::task_info> tasks_host(ntasks);
 
   size_t coef_size = 0;
-  size_t cab_size_ = 0;
+  int lmax_ = 0;
+
   for (int i = 0; i < ntasks; i++) {
     const int level = level_list[i] - 1;
 
@@ -164,6 +221,9 @@ extern "C" void grid_gpu_create_task_list(
     tasks_host[i].la_min = la_min_basis;
     tasks_host[i].lb_min = lb_min_basis;
 
+    lmax_ = std::max(lmax_, tasks_host[i].la_max);
+    lmax_ = std::max(lmax_, tasks_host[i].lb_max);
+
     // start of decontracted set, ie. pab and hab
     tasks_host[i].first_coseta =
         (la_min_basis > 0) ? rocm_backend::ncoset(la_min_basis - 1) : 0;
@@ -173,6 +233,10 @@ extern "C" void grid_gpu_create_task_list(
     // size of decontracted set, ie. pab and hab
     tasks_host[i].ncoseta = rocm_backend::ncoset(la_max_basis);
     tasks_host[i].ncosetb = rocm_backend::ncoset(lb_max_basis);
+    // it should lmax + 3 because calculating forces+stress+compute_tau requires
+    // l + 3
+    tasks_host[i].max_cab_size = rocm_backend::ncoset(la_max_basis + 3) *
+                                 rocm_backend::ncoset(lb_max_basis + 3);
 
     // size of entire spherical basis
     tasks_host[i].nsgfa = ibasis->nsgf;
@@ -214,17 +278,6 @@ extern "C" void grid_gpu_create_task_list(
     }
     coef_size += rocm_backend::ncoset(tasks_host[i].lp_max);
 
-    if (i == 0)
-      tasks_host[i].cab_offset = 0;
-    else
-      tasks_host[i].cab_offset =
-          tasks_host[i - 1].cab_offset +
-          rocm_backend::ncoset(tasks_host[i - 1].la_max + 3) *
-              rocm_backend::ncoset(tasks_host[i - 1].lb_max + 3);
-
-    cab_size_ += rocm_backend::ncoset(tasks_host[i].la_max + 3) *
-                 rocm_backend::ncoset(tasks_host[i].lb_max + 3);
-
     auto &grid = ctx->grid_[tasks_host[i].level];
     // compute the cube properties
 
@@ -254,15 +307,6 @@ extern "C" void grid_gpu_create_task_list(
   }
 
   // we need to sort the task list although I expect it to be sorted already
-  /*
-   * sorting with this lambda does not work
-  std::sort(tasks_host.begin(), tasks_host.end(), [](rocm_backend::task_info a,
-  rocm_backend::task_info b) { if (a.level == b.level) { if (a.block_num <=
-  b.block_num) return true; else return false; } else { return (a.level <
-  b.level);
-      }
-    });
-  */
   // it is a exclusive scan actually
   for (int level = 1; level < (int)ctx->number_of_tasks_per_level_.size();
        level++) {
@@ -311,6 +355,9 @@ extern "C" void grid_gpu_create_task_list(
   ctx->task_sorted_by_blocks_dev.resize(sorted_blocks.size());
   ctx->task_sorted_by_blocks_dev.copy_to_gpu(sorted_blocks);
 
+  std::vector<int> cab_size_offset_tmp(nblocks, 0);
+  std::vector<int> cab_size_tmp(nblocks);
+
   for (int i = 0; i < (int)sorted_blocks_offset.size(); i++) {
     int num_tasks = 0;
     if (i == (int)sorted_blocks_offset.size() - 1)
@@ -318,15 +365,31 @@ extern "C" void grid_gpu_create_task_list(
     else
       num_tasks = sorted_blocks_offset[i + 1] - sorted_blocks_offset[i];
 
-    // pointless tests since they should be equal.
+    // invariants tests since they should be equal.
     assert(num_tasks == num_tasks_per_block[i]);
 
-    // check that all tasks point to the same block
-    for (int tk = 0; tk < num_tasks; tk++)
+    int tmp_cab_size = 0;
+    for (int tk = 0; tk < num_tasks; tk++) {
+      auto &task = tasks_host[sorted_blocks[tk + sorted_blocks_offset[i]]];
+      // check that all tasks point to the same block
       assert(
           tasks_host[sorted_blocks[tk + sorted_blocks_offset[i]]].block_num ==
           i);
+
+      // calculate the largest cab block needed for this block
+      tmp_cab_size = std::max(task.max_cab_size, tmp_cab_size);
+    }
+
+    // keep the size of the largest cab block
+    cab_size_tmp[i] = tmp_cab_size;
   }
+
+  cab_size_offset_tmp[0] = 0;
+
+  for (int i = 1; i < cab_size_tmp.size(); i++) {
+    cab_size_offset_tmp[i] = cab_size_offset_tmp[i - 1] + cab_size_tmp[i - 1];
+  }
+
   for (auto &block : task_sorted_by_block)
     block.clear();
   task_sorted_by_block.clear();
@@ -334,8 +397,30 @@ extern "C" void grid_gpu_create_task_list(
   sorted_blocks.clear();
   sorted_blocks_offset.clear();
 
+  ctx->cab_block_offset_dev.resize(cab_size_offset_tmp.size());
+  ctx->cab_block_offset_dev.copy_to_gpu(cab_size_offset_tmp);
+
   ctx->num_tasks_per_block_dev_.resize(num_tasks_per_block.size());
   ctx->num_tasks_per_block_dev_.copy_to_gpu(num_tasks_per_block);
+
+  // Calculate the total amount of workspace needed
+  size_t cab_size_total = 0;
+
+  for (auto &elem : cab_size_tmp)
+    cab_size_total += elem;
+
+  cab_size_offset_tmp.clear();
+  cab_size_tmp.clear();
+
+  // To avoid memory saturation, cab only depends on the number of blocks not
+  // the number of tasks. It forces us to compute all xyz coefficients before
+  // calling collocate. However it does not change the logic of the integrate
+  // counterpart.
+
+  ctx->cab_dev_.resize(cab_size_total);
+
+  // allocate workspace for the coefficients
+  ctx->coef_dev_.resize(coef_size);
 
   // collect stats
   memset(ctx->stats, 0, 2 * 20 * sizeof(int));
@@ -354,11 +439,11 @@ extern "C" void grid_gpu_create_task_list(
   }
 
   ctx->create_streams();
-
-  tasks_host.clear();
-  ctx->coef_dev_.resize(coef_size);
-  ctx->cab_dev_.resize(cab_size_);
   ctx->compute_checksum();
+
+  // cleanup
+  tasks_host.clear();
+
   // return newly created or updated context
   *ctx_out = ctx;
 }
@@ -391,6 +476,11 @@ extern "C" void grid_gpu_collocate_task_list(const grid_gpu_task_list *ptr,
     return;
 
   ctx->verify_checksum();
+
+  if ((ctx->nblocks == 0) || (ctx->ntasks == 0)) {
+    return;
+  }
+
   assert(ctx->nlevels == nlevels);
   ctx->set_device();
 
@@ -404,7 +494,10 @@ extern "C" void grid_gpu_collocate_task_list(const grid_gpu_task_list *ptr,
       explicit
         - no unified memory : Explicit copy will happen
     */
-  ctx->pab_block_.copy_to_gpu(ctx->main_stream);
+  int lp_diff = -1;
+  ctx->pab_block_.copy_associated_host_to_gpu(ctx->main_stream);
+  ctx->coef_dev_.zero(ctx->main_stream);
+  ctx->calculate_all_coefficients(func, &lp_diff);
 
   for (int level = 0; level < ctx->nlevels; level++) {
     ctx->grid_[level].associate(grids[level]->host_buffer,
@@ -412,8 +505,6 @@ extern "C" void grid_gpu_collocate_task_list(const grid_gpu_task_list *ptr,
                                 grids[level]->size / sizeof(double));
     ctx->grid_[level].zero(ctx->level_streams[level]);
   }
-
-  int lp_diff = -1;
 
   ctx->synchronize(ctx->main_stream);
 
@@ -485,7 +576,7 @@ extern "C" void grid_gpu_integrate_task_list(
     ctx->pab_block_.associate(pab_blocks->host_buffer,
                               pab_blocks->device_buffer,
                               pab_blocks->size / sizeof(double));
-    ctx->pab_block_.copy_to_gpu(ctx->main_stream);
+    ctx->pab_block_.copy_associated_host_to_gpu(ctx->main_stream);
   }
 
   // we do not need to wait for this to start the computations since the matrix
@@ -497,6 +588,7 @@ extern "C" void grid_gpu_integrate_task_list(
   ctx->calculate_forces = (forces != nullptr);
   ctx->calculate_virial = (virial != nullptr);
   ctx->compute_tau = compute_tau;
+
   if (forces != nullptr) {
     ctx->forces_.resize(3 * ctx->natoms);
     ctx->forces_.zero(ctx->main_stream);
@@ -539,7 +631,7 @@ extern "C" void grid_gpu_integrate_task_list(
   // computing the hab coefficients does not depend on the number of grids so we
   // can run these calculations on the main stream
   ctx->compute_hab_coefficients();
-  ctx->hab_block_.copy_from_gpu(ctx->main_stream);
+  ctx->hab_block_.copy_gpu_to_associated_host(ctx->main_stream);
 
   if (forces != NULL) {
     ctx->forces_.copy_from_gpu(forces, ctx->main_stream);

--- a/src/grid/gpu/grid_gpu_context.h
+++ b/src/grid/gpu/grid_gpu_context.h
@@ -185,8 +185,6 @@ public:
         offloadFree(device_ptr_);
       device_ptr_ = nullptr;
       allocated_size_ = (new_size__ < 16) ? 16 : round_up16(new_size__);
-      if (allocated_size_ == 0)
-        printf("new_size__ %d\n", new_size__);
       offloadMalloc((void **)&device_ptr_, sizeof(T) * allocated_size_);
       internal_allocation_ = true;
       host_ptr_ = nullptr;
@@ -531,8 +529,8 @@ public:
         tasks_dev{std::move(other.tasks_dev)},
         num_tasks_per_block_dev_{std::move(other.num_tasks_per_block_dev_)},
         grid_{std::move(other.grid_)},
-        number_of_tasks_per_level_{std::move(number_of_tasks_per_level_)},
-        first_task_per_level_{std::move(first_task_per_level_)},
+        number_of_tasks_per_level_{std::move(other.number_of_tasks_per_level_)},
+        first_task_per_level_{std::move(other.first_task_per_level_)},
         sphi_size{std::move(other.sphi_size)},
         sphi_dev{std::move(other.sphi_dev)},
         task_sorted_by_blocks_dev{std::move(other.task_sorted_by_blocks_dev)},

--- a/src/grid/gpu/grid_gpu_context.h
+++ b/src/grid/gpu/grid_gpu_context.h
@@ -7,8 +7,8 @@
 
 /*
  * Authors :
-   - Dr Mathieu Taillefumier (ETH Zurich / CSCS)
-   - Advanced Micro Devices, Inc.
+ - Dr Mathieu Taillefumier (ETH Zurich / CSCS)
+ - Advanced Micro Devices, Inc.
 */
 
 #ifndef GRID_GPU_CONTEXT_H
@@ -19,6 +19,7 @@
 #else
 #include <cuda_runtime.h>
 #endif
+#include <array>
 #include <vector>
 
 extern "C" {
@@ -34,86 +35,123 @@ namespace rocm_backend {
 // somewhere. Maybe possible to get the same thing with std::vector and
 // specific allocator.
 
+inline size_t round_up16(size_t n) { return (n + 15) & ~size_t(15); }
+
 class smem_parameters;
 template <typename T> class gpu_vector {
   size_t allocated_size_{0};
   size_t current_size_{0};
-  bool allocated_outside_{false};
-  bool internal_allocation_ = {false};
-  T *device_ptr_ = nullptr;
-  T *host_ptr_ = nullptr;
+  bool internal_allocation_{false};
+  T *device_ptr_{nullptr};
+  T *host_ptr_{nullptr};
+
+  void move_from(gpu_vector &&other) noexcept {
+    allocated_size_ = other.allocated_size_;
+    current_size_ = other.current_size_;
+    internal_allocation_ = other.internal_allocation_;
+    device_ptr_ = other.device_ptr_;
+    host_ptr_ = other.host_ptr_;
+
+    other.allocated_size_ = 0;
+    other.current_size_ = 0;
+    other.internal_allocation_ = false;
+    other.device_ptr_ = nullptr;
+    other.host_ptr_ = nullptr;
+  }
 
 public:
-  gpu_vector() {}
+  gpu_vector() = default;
+
+  gpu_vector(const gpu_vector &) = delete;
+  gpu_vector &operator=(const gpu_vector &) = delete;
+
+  gpu_vector(gpu_vector &&other) noexcept { move_from(std::move(other)); }
+
+  gpu_vector &operator=(gpu_vector &&other) noexcept {
+    if (this != &other) {
+      reset();
+      move_from(std::move(other));
+    }
+    return *this;
+  }
 
   // size is the number of elements not the memory size
-  gpu_vector(const size_t size__) {
-    if (size__ < 16) {
-      allocated_size_ = 16;
-    } else {
-      allocated_size_ = (size__ / 16 + 1) * 16;
-    }
+  explicit gpu_vector(const size_t size__) {
+    allocated_size_ = (size__ < 16) ? 16 : round_up16(size__);
     current_size_ = size__;
     internal_allocation_ = true;
+
 #ifndef __OFFLOAD_UNIFIED_MEMORY
     offloadMalloc((void **)&device_ptr_, sizeof(T) * allocated_size_);
 #else
     hipMallocManaged((void **)&device_ptr_, sizeof(T) * allocated_size_);
 #endif
+    assert(device_ptr_ != nullptr);
   }
 
-  gpu_vector(const size_t size__, const void *ptr__) {
+  gpu_vector(const size_t size__, void *ptr__) {
     allocated_size_ = size__;
     current_size_ = size__;
-    allocated_outside_ = true;
-    device_ptr_ = ptr__;
+    internal_allocation_ = false;
+    device_ptr_ = static_cast<T *>(ptr__);
   }
   ~gpu_vector() { reset(); }
 
-  inline size_t size() { return current_size_; }
+  inline size_t size() const { return current_size_; }
 
   inline void copy_to_gpu(const T *data__) {
+    assert(device_ptr_ != nullptr);
+    assert(data__ != nullptr);
     offloadMemcpyHtoD(device_ptr_, data__, sizeof(T) * current_size_);
   }
 
   inline void copy_to_gpu(const T *data__, offloadStream_t &stream__) {
+    assert(device_ptr_ != nullptr);
+    assert(data__ != nullptr);
     offloadMemcpyAsyncHtoD(device_ptr_, data__, sizeof(T) * current_size_,
                            stream__);
   }
 
-  inline void copy_to_gpu(offloadStream_t &stream__) {
+  inline void copy_associated_host_to_gpu(offloadStream_t &stream__) {
+    assert(device_ptr_ != nullptr);
+    assert(host_ptr_ != nullptr);
+    // If the second assert fails it means that the object was created without
+    // host buffer. It should not happen in the current scenario
+
     offloadMemcpyAsyncHtoD(device_ptr_, host_ptr_, sizeof(T) * current_size_,
                            stream__);
   }
 
   inline void copy_from_gpu(T *data__, offloadStream_t &stream__) {
+    assert(device_ptr_ != nullptr);
+    assert(data__ != nullptr);
     offloadMemcpyAsyncDtoH(data__, device_ptr_, sizeof(T) * current_size_,
                            stream__);
   }
 
-  inline void copy_from_gpu(offloadStream_t &stream__) {
+  inline void copy_gpu_to_associated_host(offloadStream_t &stream__) {
+    assert(device_ptr_ != nullptr);
+    assert(host_ptr_ != nullptr);
+    // If the second assert fails it means that the object was created without
+    // host buffer. It should not happen in the current scenario
+
     offloadMemcpyAsyncDtoH(host_ptr_, device_ptr_, sizeof(T) * current_size_,
                            stream__);
   }
 
   inline void zero(offloadStream_t &stream__) {
+    assert(device_ptr_ != nullptr);
     // zero device grid buffers
     offloadMemsetAsync(device_ptr_, 0, sizeof(T) * current_size_, stream__);
   }
 
   inline void associate(void *host_ptr__, void *device_ptr__,
                         const size_t size__) {
-
-    if (internal_allocation_) {
-      if (device_ptr_)
-        offloadFree(device_ptr_);
-      if (host_ptr_)
-        std::free(host_ptr_);
-      internal_allocation_ = false;
-    }
-
-    allocated_outside_ = true;
-    // size__ is the number of elements not the size of the memory block
+    assert(host_ptr__ != nullptr);
+    assert(device_ptr__ != nullptr);
+    reset();
+    internal_allocation_ = false;
+    allocated_size_ = size__;
     current_size_ = size__;
     device_ptr_ = static_cast<T *>(device_ptr__);
     host_ptr_ = static_cast<T *>(host_ptr__);
@@ -130,26 +168,31 @@ public:
     // size. two option then
     // - resize the gpu vector
     // - or the cpu vector and gpu vector are not representing the quantity.
-
+    assert(device_ptr_ != nullptr);
     offloadMemcpyHtoD(device_ptr_, data__.data(), sizeof(T) * data__.size());
   }
 
-  inline void resize(const size_t new_size_) {
-    if (allocated_outside_) {
-      allocated_outside_ = false;
+  inline void resize(const size_t new_size__) {
+    if (!internal_allocation_) {
       allocated_size_ = 0;
       device_ptr_ = nullptr;
       host_ptr_ = nullptr;
     }
 
-    if (allocated_size_ < new_size_) {
-      if (device_ptr_ != nullptr)
+    assert(new_size__ != 0);
+    if (allocated_size_ < new_size__) {
+      if (internal_allocation_ && device_ptr_ != nullptr)
         offloadFree(device_ptr_);
-      allocated_size_ = (new_size_ / 16 + (new_size_ % 16 != 0)) * 16;
+      device_ptr_ = nullptr;
+      allocated_size_ = (new_size__ < 16) ? 16 : round_up16(new_size__);
+      if (allocated_size_ == 0)
+        printf("new_size__ %d\n", new_size__);
       offloadMalloc((void **)&device_ptr_, sizeof(T) * allocated_size_);
       internal_allocation_ = true;
+      host_ptr_ = nullptr;
     }
-    current_size_ = new_size_;
+    assert(device_ptr_ != nullptr);
+    current_size_ = new_size__;
   }
 
   // does not invalidate the pointer. The memory is still allocated
@@ -157,12 +200,8 @@ public:
 
   // reset the class and free memory
   inline void reset() {
-    if (!allocated_outside_) {
-      if (device_ptr_ != nullptr)
-        offloadFree(device_ptr_);
-
-      if (host_ptr_ != nullptr)
-        std::free(device_ptr_);
+    if (internal_allocation_ && (device_ptr_ != nullptr)) {
+      offloadFree(device_ptr_);
     }
 
     allocated_size_ = 0;
@@ -173,38 +212,46 @@ public:
   }
 
   inline T *data() { return device_ptr_; }
+  inline const T *data() const { return device_ptr_; }
 };
 
 template <typename T> class grid_info {
-  int full_size_[3] = {0, 0, 0};
-  int local_size_[3] = {0, 0, 0};
+private:
+  std::array<int, 3> full_size_;
+  std::array<int, 3> local_size_;
   // origin of the local part of the grid in grid point
-  int lower_corner_[3] = {0, 0, 0};
-  int border_width_[3] = {0, 0, 0};
-  double dh_[9];
-  double dh_inv_[9];
+  std::array<int, 3> lower_corner_;
+  std::array<int, 3> border_width_;
+  std::array<T, 9> dh_;
+  std::array<T, 9> dh_inv_;
   bool orthorhombic_{false};
   bool is_distributed_{false};
   gpu_vector<T> grid_;
 
 public:
+  grid_info(const grid_info &) = delete;
+  grid_info &operator=(const grid_info &) = delete;
+
+  grid_info(grid_info &&) noexcept = default;
+  grid_info &operator=(grid_info &&) noexcept = default;
+
   grid_info(){};
 
   grid_info(const int *full_size__, const int *local_size__,
             const int *border_width__) {
-    initialize(full_size__, local_size__, border_width__);
+    int roffset__[3] = {0, 0, 0};
+    initialize(full_size__, local_size__, roffset__, border_width__);
   }
 
-  ~grid_info() { grid_.reset(); };
-
-  inline T *data() { return grid_.data(); }
+  ~grid_info() = default;
 
   inline void copy_to_gpu(const T *data, offloadStream_t &stream) {
+    assert(data != nullptr);
     grid_.copy_to_gpu(data, stream);
   }
 
   inline void copy_to_gpu(offloadStream_t &stream) {
-    grid_.copy_to_gpu(stream);
+    grid_.copy_associated_host_to_gpu(stream);
   }
 
   inline void reset() { grid_.reset(); }
@@ -222,17 +269,13 @@ public:
   inline size_t size() const { return grid_.size(); }
 
   inline void zero(offloadStream_t &stream) { grid_.zero(stream); }
-  inline gpu_vector<T> &grid() { return grid_; }
-  inline void set_lattice_vectors(const double *dh__, const double *dh_inv__) {
-    memcpy(dh_, dh__, sizeof(double) * 9);
-    memcpy(dh_inv_, dh_inv__, sizeof(double) * 9);
+
+  inline void set_lattice_vectors(const T *dh__, const T *dh_inv__) {
+    for (int i = 0; i < 9; ++i) {
+      dh_[i] = dh__[i];
+      dh_inv_[i] = dh_inv__[i];
+    }
   }
-
-  inline T *dh() { return dh_; }
-
-  inline T *dh_inv() { return dh_inv_; }
-
-  inline bool is_orthorhombic() { return orthorhombic_; }
 
   inline void is_distributed(const bool distributed__) {
     is_distributed_ = distributed__;
@@ -243,7 +286,7 @@ public:
       orthorhombic_ = true;
       return;
     }
-    double norm1, norm2, norm3;
+    T norm1, norm2, norm3;
     bool orthogonal[3] = {false, false, false};
     norm1 = dh_[0] * dh_[0] + dh_[1] * dh_[1] + dh_[2] * dh_[2];
     norm2 = dh_[3] * dh_[3] + dh_[4] * dh_[4] + dh_[5] * dh_[5];
@@ -269,16 +312,19 @@ public:
     orthorhombic_ = orthogonal[0] && orthogonal[1] && orthogonal[2];
   }
 
-  inline void copy_to_host(double *data__, offloadStream_t &stream) {
+  inline void copy_to_host(T *data__, offloadStream_t &stream) {
+    assert(data__ != nullptr);
     grid_.copy_from_gpu(data__, stream);
   }
 
   inline void copy_to_host(offloadStream_t &stream) {
-    grid_.copy_from_gpu(stream);
+    grid_.copy_gpu_to_associated_host(stream);
   }
 
   inline void associate(void *host_ptr__, void *device_ptr__,
                         const size_t size__) {
+    assert(host_ptr__ != nullptr);
+    assert(device_ptr__ != nullptr);
     grid_.associate(host_ptr__, device_ptr__, size__);
   }
   inline bool is_distributed() { return is_distributed_; }
@@ -302,6 +348,21 @@ public:
     assert(i < 3);
     return border_width_[i];
   }
+
+  inline T *data() { return grid_.data(); }
+  inline const T *data() const { return grid_.data(); }
+
+  inline gpu_vector<T> &grid() { return grid_; }
+  inline const gpu_vector<T> &grid() const { return grid_; }
+
+  inline T *dh() { return dh_.data(); }
+  inline const T *dh() const { return dh_.data(); }
+
+  inline T *dh_inv() { return dh_inv_.data(); }
+  inline const T *dh_inv() const { return dh_inv_.data(); }
+
+  inline bool is_orthorhombic() const { return orthorhombic_; }
+  inline bool is_distributed() const { return is_distributed_; }
 
 private:
   void initialize(const int *const full_size__, const int *const local_size__,
@@ -346,6 +407,7 @@ struct task_info {
   int ikind, jkind;
   int border_mask;
   int block_num;
+  int max_cab_size{0};
   double radius;
   double ra[3], rb[3], rp[3];
   double rab2;
@@ -353,7 +415,6 @@ struct task_info {
   double rab[3];
   int lp_max{0};
   size_t coef_offset{0};
-  size_t cab_offset{0};
   int la_max, lb_max, la_min, lb_min, first_coseta, first_cosetb, ncoseta,
       ncosetb, nsgfa, nsgfb, nsgf_seta, nsgf_setb, maxcoa, maxcob;
   int sgfa, sgfb, subblock_offset;
@@ -372,9 +433,9 @@ struct task_info {
  ******************************************************************************/
 
 struct kernel_params {
-  int smem_alpha_offset{0};
-  int smem_cab_offset{0};
   int first_task{0};
+  // max size of cab.
+  int cab_size_{0};
   int grid_full_size_[3] = {0, 0, 0};
   int grid_local_size_[3] = {0, 0, 0};
   int grid_lower_corner_[3] = {0, 0, 0};
@@ -395,6 +456,7 @@ struct kernel_params {
   int *task_sorted_by_blocks_dev{nullptr};
   int *sorted_blocks_offset_dev{nullptr};
   int *num_tasks_per_block_dev{nullptr};
+  int *cab_block_offset_dev{nullptr};
 };
 
 /* regroup all information about the context. */
@@ -410,6 +472,7 @@ public:
   int natoms{0};
   int nkinds{0};
   int nblocks{0};
+  int cab_size_per_block_{0};
   std::vector<double *> sphi;
   std::vector<offloadStream_t> level_streams;
   offloadStream_t main_stream;
@@ -417,6 +480,7 @@ public:
   // all these tables are on the gpu. we can resize them copy to them and copy
   // from them
   gpu_vector<int> block_offsets_dev;
+  gpu_vector<int> cab_block_offset_dev;
   gpu_vector<double> coef_dev_;
   gpu_vector<double> cab_dev_;
   gpu_vector<double> pab_block_;
@@ -435,21 +499,140 @@ public:
   bool calculate_virial{false};
   bool compute_tau{false};
   bool apply_border_mask{false};
+  // Default constructor
+  context_info() = default;
 
-  context_info() {}
-  context_info(const int device_id__) {
-    if (device_id__ < 0)
-      device_id_ = 0;
-    else
-      device_id_ = device_id__;
+  explicit context_info(int device_id__) {
+    device_id_ = (device_id__ < 0) ? 0 : device_id__;
   }
+
   ~context_info() { clear(); }
 
+  // Non-copyable
+  context_info(const context_info &) = delete;
+  context_info &operator=(const context_info &) = delete;
+
+  // Movable
+  context_info(context_info &&other) noexcept
+      : device_id_{other.device_id_}, lmax_{other.lmax_},
+        checksum_{other.checksum_}, ntasks{other.ntasks},
+        nlevels{other.nlevels}, natoms{other.natoms}, nkinds{other.nkinds},
+        nblocks{other.nblocks}, cab_size_per_block_{other.cab_size_per_block_},
+        sphi{std::move(other.sphi)},
+        level_streams{std::move(other.level_streams)},
+        main_stream{other.main_stream},
+        block_offsets_dev{std::move(other.block_offsets_dev)},
+        cab_block_offset_dev{std::move(other.cab_block_offset_dev)},
+        coef_dev_{std::move(other.coef_dev_)},
+        cab_dev_{std::move(other.cab_dev_)},
+        pab_block_{std::move(other.pab_block_)},
+        hab_block_{std::move(other.hab_block_)},
+        forces_{std::move(other.forces_)}, virial_{std::move(other.virial_)},
+        tasks_dev{std::move(other.tasks_dev)},
+        num_tasks_per_block_dev_{std::move(other.num_tasks_per_block_dev_)},
+        grid_{std::move(other.grid_)},
+        number_of_tasks_per_level_{std::move(number_of_tasks_per_level_)},
+        first_task_per_level_{std::move(first_task_per_level_)},
+        sphi_size{std::move(other.sphi_size)},
+        sphi_dev{std::move(other.sphi_dev)},
+        task_sorted_by_blocks_dev{std::move(other.task_sorted_by_blocks_dev)},
+        sorted_blocks_offset_dev{std::move(other.sorted_blocks_offset_dev)},
+        calculate_forces{other.calculate_forces},
+        calculate_virial{other.calculate_virial},
+        compute_tau{other.compute_tau},
+        apply_border_mask{other.apply_border_mask} {
+
+    // copy stats
+    for (int i = 0; i < 2; ++i)
+      for (int j = 0; j < 20; ++j)
+        stats[i][j] = other.stats[i][j];
+
+    // leave other in a safe state (no ownership)
+    other.device_id_ = -1;
+    other.lmax_ = 0;
+    other.checksum_ = 0;
+    other.ntasks = 0;
+    other.nlevels = 0;
+    other.natoms = 0;
+    other.nkinds = 0;
+    other.nblocks = 0;
+    other.main_stream = {};
+    other.calculate_forces = false;
+    other.calculate_virial = false;
+    other.compute_tau = false;
+    other.apply_border_mask = false;
+  }
+
+  context_info &operator=(context_info &&other) noexcept {
+    if (this != &other) {
+      clear(); // free current GPU resources and streams
+
+      device_id_ = other.device_id_;
+      lmax_ = other.lmax_;
+      checksum_ = other.checksum_;
+      ntasks = other.ntasks;
+      nlevels = other.nlevels;
+      natoms = other.natoms;
+      nkinds = other.nkinds;
+      nblocks = other.nblocks;
+      sphi = std::move(other.sphi);
+      level_streams = std::move(other.level_streams);
+      main_stream = other.main_stream;
+
+      for (int i = 0; i < 2; ++i)
+        for (int j = 0; j < 20; ++j)
+          stats[i][j] = other.stats[i][j];
+
+      block_offsets_dev = std::move(other.block_offsets_dev);
+      cab_block_offset_dev = std::move(other.cab_block_offset_dev);
+      coef_dev_ = std::move(other.coef_dev_);
+      cab_dev_ = std::move(other.cab_dev_);
+      pab_block_ = std::move(other.pab_block_);
+      hab_block_ = std::move(other.hab_block_);
+      forces_ = std::move(other.forces_);
+      virial_ = std::move(other.virial_);
+      tasks_dev = std::move(other.tasks_dev);
+      num_tasks_per_block_dev_ = std::move(other.num_tasks_per_block_dev_);
+      grid_ = std::move(other.grid_);
+      number_of_tasks_per_level_ = std::move(other.number_of_tasks_per_level_);
+      first_task_per_level_ = std::move(other.first_task_per_level_);
+      sphi_size = std::move(other.sphi_size);
+      sphi_dev = std::move(other.sphi_dev);
+      task_sorted_by_blocks_dev = std::move(other.task_sorted_by_blocks_dev);
+      sorted_blocks_offset_dev = std::move(other.sorted_blocks_offset_dev);
+
+      calculate_forces = other.calculate_forces;
+      calculate_virial = other.calculate_virial;
+      compute_tau = other.compute_tau;
+      apply_border_mask = other.apply_border_mask;
+
+      // reset other
+      other.device_id_ = -1;
+      other.lmax_ = 0;
+      other.checksum_ = 0;
+      other.ntasks = 0;
+      other.nlevels = 0;
+      other.natoms = 0;
+      other.nkinds = 0;
+      other.nblocks = 0;
+      other.main_stream = {};
+      other.calculate_forces = false;
+      other.calculate_virial = false;
+      other.compute_tau = false;
+      other.apply_border_mask = false;
+    }
+    return *this;
+  }
+
   void clear() {
-    offload_set_chosen_device(device_id_);
-    offload_activate_chosen_device();
+    if (device_id_ >= 0) {
+      offload_set_chosen_device(device_id_);
+      offload_activate_chosen_device();
+    }
+
     tasks_dev.reset();
     block_offsets_dev.reset();
+    cab_block_offset_dev.reset();
     coef_dev_.reset();
     cab_dev_.reset();
     task_sorted_by_blocks_dev.reset();
@@ -457,20 +640,26 @@ public:
     sphi_dev.reset();
     forces_.reset();
     virial_.reset();
-    for (auto &phi : sphi)
+
+    for (auto &phi : sphi) {
       if (phi != nullptr)
         offloadFree(phi);
+    }
     sphi.clear();
 
-    offloadStreamDestroy(main_stream);
+    if (main_stream) {
+      offloadStreamDestroy(main_stream);
+      main_stream = {};
+    }
 
-    for (int i = 0; i < nlevels; i++) {
-      offloadStreamDestroy(level_streams[i]);
+    for (auto &stream : level_streams) {
+      if (stream)
+        offloadStreamDestroy(stream);
     }
     level_streams.clear();
 
-    for (auto &grid : grid_) {
-      grid.reset();
+    for (auto &g : grid_) {
+      g.reset();
     }
     grid_.clear();
   }
@@ -502,7 +691,7 @@ public:
                       basis_set->nsgf * basis_set->maxco * sizeof(double));
         sphi_size[i] = basis_set->nsgf * basis_set->maxco;
       }
-      offloadMemset(sphi[i], 0, sizeof(double) * sphi_size[i]);
+      //      offloadMemset(sphi[i], 0, sizeof(double) * sphi_size[i]);
       offloadMemcpyHtoD(sphi[i], basis_set->sphi,
                         basis_set->nsgf * basis_set->maxco * sizeof(double));
     }
@@ -557,6 +746,7 @@ public:
       abort();
     }
   }
+  void calculate_all_coefficients(const enum grid_func func, int *lp_diff);
 
 private:
   kernel_params set_kernel_parameters(const int level,

--- a/src/grid/gpu/grid_gpu_integrate.cu
+++ b/src/grid/gpu/grid_gpu_integrate.cu
@@ -30,6 +30,7 @@
 #endif
 
 namespace rocm_backend {
+
 // do a warp reduction and return the final sum to thread_id = 0
 template <typename T>
 __device__ __inline__ T warp_reduce(T *table, const int tid) {
@@ -59,19 +60,113 @@ __device__ __inline__ T warp_reduce(T *table, const int tid) {
 }
 // #endif
 
-template <typename T, typename T3, bool COMPUTE_TAU, bool CALCULATE_FORCES>
-__global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
+template <typename T>
+__device__ __inline__ T reduce_two_warps(const T in, const int tid) {
+  int lane = tid & 31; // lane within warp
+  int warp = tid >> 5; // warp index (0 or 1)
+
+  T x = in;
+  __shared__ T sdata[2];
+  // Step 1: per‑warp reduction via shuffles
+#if defined(__CUDACC__)
+  unsigned mask = 0xffffffff;
+  for (int offset = 16; offset > 0; offset >>= 1)
+    x += __shfl_down_sync(mask, x, offset);
+#else
+  for (int offset = warpSize / 2; offset > 0; offset >>= 1)
+    x += __shfl_down(x, offset);
+#endif
+  // Step 2: each warp writes its partial sum to shared memory
+  if (lane == 0)
+    sdata[warp] = x;
+
+  __syncthreads(); // ensures both partial sums are visible
+
+  // Step 3: first warp loads the partials and finishes reduction
+  if (warp == 0) {
+    T v = (lane < 2) ? sdata[lane] : 0; // 2 warps → 2 partials
+
+#if defined(__CUDACC__)
+    // reduce across first warp only
+    for (int offset = 16; offset > 0; offset >>= 1)
+      v += __shfl_down_sync(mask, v, offset);
+#else
+    for (int offset = warpSize / 2; offset > 0; offset >>= 1)
+      v += __shfl_down(v, offset);
+#endif
+    return v;
+  }
+}
+
+template <typename T, bool COMPUTE_TAU>
+__global__ __launch_bounds__(64) void compute_hab_v4(const kernel_params dev_) {
   // Copy task from global to shared memory and precompute some stuff.
   extern __shared__ T shared_memory[];
   // T *smem_cab = &shared_memory[dev_.smem_cab_offset];
-  T *smem_alpha = &shared_memory[dev_.smem_alpha_offset];
-  const int tid =
-      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
-  const int offset = dev_.sorted_blocks_offset_dev[blockIdx.x];
   const int number_of_tasks = dev_.num_tasks_per_block_dev[blockIdx.x];
 
   if (number_of_tasks == 0)
     return;
+
+  T *smem_alpha = &shared_memory[0];
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+  const int offset = dev_.sorted_blocks_offset_dev[blockIdx.x];
+  T *smem_cab = allocate_workspace<T>(dev_);
+
+  for (int tk = 0; tk < number_of_tasks; tk++) {
+    __shared__ smem_task<T> task;
+    const int task_id = dev_.task_sorted_by_blocks_dev[offset + tk];
+    if (dev_.tasks[task_id].skip_task)
+      continue;
+    fill_smem_task_coef(dev_, task_id, task);
+
+    T *coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
+
+    compute_alpha(task, smem_alpha);
+    __syncthreads();
+    cxyz_to_cab(task, smem_alpha, coef_, smem_cab);
+    __syncthreads();
+
+    for (int jco = task.first_cosetb; jco < task.ncosetb; jco++) {
+      const auto &b = coset_inv[jco];
+      for (int ico = task.first_coseta; ico < task.ncoseta; ico++) {
+        const auto &a = coset_inv[ico];
+        const T hab = get_hab<COMPUTE_TAU, T>(a, b, task.zeta, task.zetb,
+                                              task.n1, smem_cab);
+        __syncthreads();
+        // Try to use as many contiguous threads as possible and limit the
+        // number of warps that do partial work
+        for (int ix = tid; ix < task.nsgf_setb * task.nsgf_seta;
+             ix += blockDim.x * blockDim.y * blockDim.z) {
+          const int i = ix / task.nsgf_seta;
+          const int j = ix % task.nsgf_seta;
+          const T sphia_times_sphib = task.sphia[j * task.maxcoa + ico] *
+                                      task.sphib[i * task.maxcob + jco];
+          if (task.block_transposed) {
+            task.hab_block[j * task.nsgfb + i] += hab * sphia_times_sphib;
+          } else {
+            task.hab_block[i * task.nsgfa + j] += hab * sphia_times_sphib;
+          }
+        }
+      }
+    }
+  }
+}
+
+template <typename T, typename T3, bool COMPUTE_TAU, bool CALCULATE_FORCES>
+__global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
+  // Copy task from global to shared memory and precompute some stuff.
+  extern __shared__ T shared_memory[];
+  const int number_of_tasks = dev_.num_tasks_per_block_dev[blockIdx.x];
+
+  if (number_of_tasks == 0)
+    return;
+
+  T *smem_alpha = &shared_memory[0];
+  const int tid =
+      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+  const int offset = dev_.sorted_blocks_offset_dev[blockIdx.x];
 
   T fa[3], fb[3];
   T virial[9];
@@ -92,6 +187,7 @@ __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
   virial[6] = 0.0;
   virial[7] = 0.0;
   virial[8] = 0.0;
+  T *smem_cab = allocate_workspace<T>(dev_);
 
   for (int tk = 0; tk < number_of_tasks; tk++) {
     __shared__ smem_task<T> task;
@@ -101,7 +197,6 @@ __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
     fill_smem_task_coef(dev_, task_id, task);
 
     T *coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
-    T *smem_cab = &dev_.ptr_dev[6][dev_.tasks[task_id].cab_offset];
 
     compute_alpha(task, smem_alpha);
     __syncthreads();
@@ -135,28 +230,30 @@ __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
           }
         }
         __syncthreads();
+
         T block_val1 = 0.0;
-        for (int i = tid / 8; i < task.nsgf_setb; i += 8) {
+        // Try to use as many contiguous threads as possible and limit the
+        // number of warps that do partial work
+
+        for (int elem = tid; elem < task.nsgf_setb * task.nsgf_seta;
+             elem += blockDim.x * blockDim.y * blockDim.z) {
+          const int i = elem / task.nsgf_seta;
+          const int j = elem % task.nsgf_seta;
           const T sphib = task.sphib[i * task.maxcob + jco];
-          for (int j = tid % 8; j < task.nsgf_seta; j += 8) {
-            const T sphia_times_sphib =
-                task.sphia[j * task.maxcoa + ico] * sphib;
-
-            if (CALCULATE_FORCES) {
-              if (task.block_transposed) {
-                block_val1 += task.pab_block[j * task.nsgfb + i] *
-                              task.off_diag_twice * sphia_times_sphib;
-              } else {
-                block_val1 += task.pab_block[i * task.nsgfa + j] *
-                              task.off_diag_twice * sphia_times_sphib;
-              }
-            }
-
+          const T sphia_times_sphib = task.sphia[j * task.maxcoa + ico] * sphib;
+          if (CALCULATE_FORCES) {
             if (task.block_transposed) {
-              task.hab_block[j * task.nsgfb + i] += hab * sphia_times_sphib;
+              block_val1 += task.pab_block[j * task.nsgfb + i] *
+                            task.off_diag_twice * sphia_times_sphib;
             } else {
-              task.hab_block[i * task.nsgfa + j] += hab * sphia_times_sphib;
+              block_val1 += task.pab_block[i * task.nsgfa + j] *
+                            task.off_diag_twice * sphia_times_sphib;
             }
+          }
+          if (task.block_transposed) {
+            task.hab_block[j * task.nsgfb + i] += hab * sphia_times_sphib;
+          } else {
+            task.hab_block[i * task.nsgfa + j] += hab * sphia_times_sphib;
           }
         }
 
@@ -562,101 +659,77 @@ __launch_bounds__(64) void integrate_kernel(const kernel_params dev_) {
       }
     }
 
+    const int max_i = min(length - ico, lbatch);
+
     __syncthreads();
 
-    // we know there is only 1 wavefront in each block
-    // lbatch threads could reduce the values saved by all threads of the warp
-    // and save results do a shuffle_down by hand
+    // we know there is only 1 wavefront in each block lbatch threads could
+    // reduce the values saved by all threads of the warp and save results do a
+    // shuffle_down by hand
+
     if (tid < 32) {
-      for (int i = 0; i < min(length - ico, lbatch); i++) {
+      for (int i = 0; i < max_i; i++) {
         accumulator[i][tid] += accumulator[i][tid + 32];
       }
     }
+
     __syncthreads();
-    if (tid < 16) {
-      for (int i = 0; i < min(length - ico, lbatch); i++) {
-        accumulator[i][tid] += accumulator[i][tid + 16];
-      }
-    }
-    __syncthreads();
-    if (tid < 8) {
-      for (int i = 0; i < min(length - ico, lbatch); i++) {
-        accumulator[i][tid] += accumulator[i][tid + 8];
-      }
-    }
-    __syncthreads();
-    if (tid < 4) {
-      for (int i = 0; i < min(length - ico, lbatch); i++) {
-        accumulator[i][tid] += accumulator[i][tid + 4];
-      }
-    }
-    __syncthreads();
-    if (tid < 2) {
-      for (int i = 0; i < min(length - ico, lbatch); i++) {
-        accumulator[i][tid] += accumulator[i][tid + 2];
+
+    if (tid < 32) {
+      for (int i = 0; i < max_i; i++) {
+        // Load local value
+        T val = accumulator[i][tid];
+
+        // Warp-level reduction (32 lanes)
+        // After this loop, lane 0 of warp 0 holds the result
+        for (int offset = 16; offset > 0; offset >>= 1) {
+          val += __shfl_down_sync(0xffffffff, val, offset);
+        }
+
+        if (tid == 0)
+          sum[i] = val;
       }
     }
     __syncthreads();
 
-    if (tid == 0) {
-      for (int i = 0; i < min(length - ico, lbatch); i++) {
-        sum[i] = accumulator[i][0] + accumulator[i][1];
-      }
-    }
-    __syncthreads();
+    // if (tid < 16) {
+    //   for (int i = 0; i < min(length - ico, lbatch); i++) {
+    //     accumulator[i][tid] += accumulator[i][tid + 16];
+    //   }
+    // }
+    // __syncthreads();
+    // if (tid < 8) {
+    //   for (int i = 0; i < min(length - ico, lbatch); i++) {
+    //     accumulator[i][tid] += accumulator[i][tid + 8];
+    //   }
+    // }
+    // __syncthreads();
+    // if (tid < 4) {
+    //   for (int i = 0; i < min(length - ico, lbatch); i++) {
+    //     accumulator[i][tid] += accumulator[i][tid + 4];
+    //   }
+    // }
+    // __syncthreads();
+    // if (tid < 2) {
+    //   for (int i = 0; i < min(length - ico, lbatch); i++) {
+    //     accumulator[i][tid] += accumulator[i][tid + 2];
+    //   }
+    // }
+    // __syncthreads();
+
+    // if (tid == 0) {
+    //   for (int i = 0; i < min(length - ico, lbatch); i++) {
+    //     sum[i] = accumulator[i][0] + accumulator[i][1];
+    //   }
+    // }
+
+    // __syncthreads();
 
     if (tid < min(length - ico, lbatch))
       dev_.ptr_dev[2][dev_.tasks[dev_.first_task + blockIdx.x].coef_offset +
                       tid + ico] = sum[tid];
     __syncthreads();
   }
-}
-
-kernel_params
-context_info::set_kernel_parameters(const int level,
-                                    const smem_parameters &smem_params) {
-  kernel_params params;
-  params.smem_cab_offset = smem_params.smem_cab_offset();
-  params.smem_alpha_offset = smem_params.smem_alpha_offset();
-  params.first_task = 0;
-
-  params.la_min_diff = smem_params.ldiffs().la_min_diff;
-  params.lb_min_diff = smem_params.ldiffs().lb_min_diff;
-
-  params.la_max_diff = smem_params.ldiffs().la_max_diff;
-  params.lb_max_diff = smem_params.ldiffs().lb_max_diff;
-  params.first_task = 0;
-  params.tasks = this->tasks_dev.data();
-  params.task_sorted_by_blocks_dev = task_sorted_by_blocks_dev.data();
-  params.sorted_blocks_offset_dev = sorted_blocks_offset_dev.data();
-  params.num_tasks_per_block_dev = this->num_tasks_per_block_dev_.data();
-  params.block_offsets = this->block_offsets_dev.data();
-  params.la_min_diff = smem_params.ldiffs().la_min_diff;
-  params.lb_min_diff = smem_params.ldiffs().lb_min_diff;
-  params.la_max_diff = smem_params.ldiffs().la_max_diff;
-  params.lb_max_diff = smem_params.ldiffs().lb_max_diff;
-
-  params.ptr_dev[0] = pab_block_.data();
-
-  if (level >= 0) {
-    params.ptr_dev[1] = grid_[level].data();
-    for (int i = 0; i < 3; i++) {
-      memcpy(params.dh_, grid_[level].dh(), 9 * sizeof(double));
-      memcpy(params.dh_inv_, grid_[level].dh_inv(), 9 * sizeof(double));
-      params.grid_full_size_[i] = grid_[level].full_size(i);
-      params.grid_local_size_[i] = grid_[level].local_size(i);
-      params.grid_lower_corner_[i] = grid_[level].lower_corner(i);
-      params.grid_border_width_[i] = grid_[level].border_width(i);
-    }
-    params.first_task = first_task_per_level_[level];
-  }
-  params.ptr_dev[2] = this->coef_dev_.data();
-  params.ptr_dev[3] = hab_block_.data();
-  params.ptr_dev[4] = forces_.data();
-  params.ptr_dev[5] = virial_.data();
-  params.ptr_dev[6] = this->cab_dev_.data();
-  params.sphi_dev = this->sphi_dev.data();
-  return params;
 }
 
 /*******************************************************************************
@@ -728,9 +801,12 @@ void context_info::compute_hab_coefficients() {
   const dim3 threads_per_block(4, 4, 4);
 
   if (!compute_tau && !calculate_forces) {
-    compute_hab_v2<double, double3, false, false>
+    compute_hab_v4<double, false>
         <<<this->nblocks, threads_per_block, smem_params.smem_per_block(),
            this->main_stream>>>(params);
+    // compute_hab_v2<double, double3, false, false>
+    //   <<<this->nblocks, threads_per_block, smem_params.smem_per_block(),
+    //   this->main_stream>>>(params);
     return;
   }
 

--- a/src/grid/gpu/grid_gpu_integrate.cu
+++ b/src/grid/gpu/grid_gpu_integrate.cu
@@ -89,10 +89,10 @@ __device__ __inline__ T reduce_two_warps(const T in, const int tid) {
 #if defined(__CUDACC__)
     // reduce across first warp only
     for (int offset = 16; offset > 0; offset >>= 1)
-      v += __shfl_down_sync(mask, v, offset);
+      v += __shfl_down_sync(0xFFFFFFFF, v, offset);
 #else
     for (int offset = warpSize / 2; offset > 0; offset >>= 1)
-      v += __shfl_down(v, offset);
+      v += __shfl_down_sync(0xFFFFFFFFFFFFFFFF, v, offset);
 #endif
     return v;
   }
@@ -683,7 +683,11 @@ __launch_bounds__(64) void integrate_kernel(const kernel_params dev_) {
         // Warp-level reduction (32 lanes)
         // After this loop, lane 0 of warp 0 holds the result
         for (int offset = 16; offset > 0; offset >>= 1) {
+#if defined(__CUDA_CC__)
           val += __shfl_down_sync(0xffffffff, val, offset);
+#else
+          val += __shfl_down_sync(0xffffffffffffffff, val, offset);
+#endif
         }
 
         if (tid == 0)

--- a/src/grid/gpu/grid_gpu_internal_header.h
+++ b/src/grid/gpu/grid_gpu_internal_header.h
@@ -278,6 +278,16 @@ inline static void init_constant_memory() {
   initialized = true;
 }
 
+// calculate the global index of a thread block
+__inline__ __device__ unsigned int block_index() {
+  return blockIdx.x + gridDim.x * (blockIdx.y + gridDim.y * blockIdx.z);
+}
+
+// Calculating the global index of any given device thread
+__inline__ __device__ unsigned int thread_global_index() {
+  return threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+}
+
 __inline__ __device__ double3
 compute_coordinates(const double *__restrict__ dh_, const double x,
                     const double y, const double z) {
@@ -735,6 +745,7 @@ __device__ __inline__ void fill_smem_task_coef(const kernel_params &dev,
     // size of decontracted set, ie. pab and hab
     task.ncoseta = ncoset(la_max_basis);
     task.ncosetb = ncoset(lb_max_basis);
+
     // size of the cab matrix
     task.n1 = ncoset(task.la_max);
     task.n2 = ncoset(task.lb_max);
@@ -778,8 +789,8 @@ private:
   int la_max_{-1};
   int lb_max_{-1};
   int smem_per_block_{0};
-  int alpha_len_{-1};
-  int cab_len_{-1};
+  int alpha_size_{-1};
+  int cab_size_{-1};
   int lp_max_{-1};
   ldiffs_value ldiffs_;
   int lp_diff_{-1};
@@ -792,16 +803,18 @@ public:
     lb_max_ = lmax + ldiffs.lb_max_diff;
     lp_max_ = la_max_ + lb_max_;
 
-    cab_len_ = ncoset(lb_max_) * ncoset(la_max_);
-    alpha_len_ = 3 * (lb_max_ + 1) * (la_max_ + 1) * (lp_max_ + 1);
-    smem_per_block_ = std::max(alpha_len_, 64) * sizeof(double);
+    // NB: cab is allocated in global memory not shared memory. Each block has
+    // its own cab space
+
+    cab_size_ = (rocm_backend::ncoset(la_max_) * rocm_backend::ncoset(lb_max_));
+    alpha_size_ = 3 * (lb_max_ + 1) * (la_max_ + 1) * (lp_max_ + 1);
+    smem_per_block_ = std::max(alpha_size_, 64) * sizeof(double);
 
     if (smem_per_block_ > 64 * 1024) {
       fprintf(stderr,
               "ERROR: Not enough shared memory in grid_gpu_collocate.\n");
-      fprintf(stderr, "cab_len: %i, ", cab_len_);
-      fprintf(stderr, "alpha_len: %i, ", alpha_len_);
-      fprintf(stderr, "total smem_per_block: %f kb\n\n",
+      fprintf(stderr, "alpha_len: %i, ", alpha_size_);
+      fprintf(stderr, "total smem_per_block: %f kB\n\n",
               smem_per_block_ / 1024.0);
       abort();
     }
@@ -811,11 +824,9 @@ public:
 
   // copy and move are trivial
 
-  inline int smem_alpha_offset() const { return 0; }
+  inline int alpha_size() const { return alpha_size_; }
 
-  inline int smem_cab_offset() const { return alpha_len_; }
-
-  inline int smem_cxyz_offset() const { return alpha_len_ + cab_len_; }
+  inline int cab_size() const { return cab_size_; }
 
   inline int smem_per_block() const { return smem_per_block_; }
 
@@ -825,8 +836,13 @@ public:
 
   inline int lp_max() const { return lp_max_; }
 
-  inline int cxyz_len() const { return ncoset(lp_max_); }
+  inline int cxyz_size() const { return ncoset(lp_max_); }
 };
+template <typename T>
+__inline__ __device__ T *allocate_workspace(const kernel_params &dev_) {
+  unsigned int offset = dev_.cab_block_offset_dev[block_index()];
+  return (T *)(dev_.ptr_dev[6] + offset);
+}
 
 } // namespace rocm_backend
 #endif

--- a/src/grid/grid_replay.c
+++ b/src/grid/grid_replay.c
@@ -23,6 +23,7 @@
 #include "cpu/grid_cpu_collocate.h"
 #include "cpu/grid_cpu_integrate.h"
 #include "grid_task_list.h"
+#include "grid_task_list_internal.h"
 
 /*******************************************************************************
  * \brief Reads next line from given filehandle and handles errors.

--- a/src/grid/grid_task_list.c
+++ b/src/grid/grid_task_list.c
@@ -12,10 +12,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "common/grid_common.h"
-#include "common/grid_constants.h"
-#include "common/grid_library.h"
 #include "grid_task_list.h"
+#include "grid_task_list_internal.h"
 
 /*******************************************************************************
  * \brief Allocates a task list which can be passed to grid_collocate_task_list.
@@ -39,16 +37,19 @@ void grid_create_task_list(
 
   const grid_library_config config = grid_library_get_config();
 
-  grid_task_list *task_list = NULL;
+  grid_task_list_internal *task_list = NULL;
 
   if (*task_list_out == NULL) {
-    task_list = malloc(sizeof(grid_task_list));
+    task_list = malloc(sizeof(grid_task_list_internal));
+    // not a proper handling of errors. assert is a debug tool
     assert(task_list != NULL);
-    memset(task_list, 0, sizeof(grid_task_list));
+    memset(task_list, 0, sizeof(grid_task_list_internal));
+    *task_list_out = task_list;
 
     // Resolve AUTO to a concrete backend.
     if (config.backend == GRID_BACKEND_AUTO) {
-#if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_GRID)
+#if (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP)) &&                     \
+    !defined(__NO_OFFLOAD_GRID)
       task_list->backend = GRID_BACKEND_GPU;
 #else
       task_list->backend = GRID_BACKEND_CPU;
@@ -58,14 +59,25 @@ void grid_create_task_list(
     }
   } else {
     // Reuse existing task list.
-    task_list = *task_list_out;
+    task_list = (grid_task_list_internal *)*task_list_out;
+  }
+
+  if ((nblocks == 0) || (ntasks == 0) || (nlevels == 0)) {
+    task_list->empty = true;
+    return;
+  } else {
+    task_list->empty = false;
+  }
+
+  size_t size = (size_t)nlevels * 3 * sizeof(int);
+
+  if (task_list->nlevels < nlevels) {
     free(task_list->npts_local);
+    task_list->npts_local = malloc(size);
   }
 
   // Store npts_local for bounds checking and validation.
   task_list->nlevels = nlevels;
-  size_t size = nlevels * 3 * sizeof(int);
-  task_list->npts_local = malloc(size);
   assert(task_list->npts_local != NULL);
   memcpy(task_list->npts_local, npts_local, size);
 
@@ -99,7 +111,8 @@ void grid_create_task_list(
     break;
 
   case GRID_BACKEND_GPU:
-#if (defined(__OFFLOAD) && !defined(__NO_OFFLOAD_GRID))
+#if (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP)) &&                     \
+    !defined(__NO_OFFLOAD_GRID)
     grid_gpu_create_task_list(
         orthorhombic, ntasks, nlevels, natoms, nkinds, nblocks, block_offsets,
         &atom_positions[0][0], atom_kinds, basis_sets, level_list, iatom_list,
@@ -119,15 +132,17 @@ void grid_create_task_list(
     abort();
     break;
   }
-
-  *task_list_out = task_list;
 }
 
 /*******************************************************************************
  * \brief Deallocates given task list, basis_sets have to be freed separately.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_free_task_list(grid_task_list *task_list) {
+void grid_free_task_list(grid_task_list *ptr) {
+  if (ptr == NULL)
+    return;
+
+  grid_task_list_internal *task_list = (grid_task_list_internal *)ptr;
 
   if (task_list->ref != NULL) {
     grid_ref_free_task_list(task_list->ref);
@@ -157,11 +172,21 @@ void grid_free_task_list(grid_task_list *task_list) {
  *        See grid_task_list.h for details.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_collocate_task_list(const grid_task_list *task_list,
+void grid_collocate_task_list(const grid_task_list *ptr,
                               const enum grid_func func, const int nlevels,
                               const int npts_local[nlevels][3],
                               const offload_buffer *pab_blocks,
                               offload_buffer *grids[nlevels]) {
+  if (ptr == NULL)
+    return;
+
+  grid_task_list_internal *task_list = (grid_task_list_internal *)ptr;
+
+  if (task_list->empty) {
+    for (int level = 0; level < nlevels; level++)
+      memset(grids[level]->host_buffer, 0, grids[level]->size);
+    return;
+  }
 
   // Bounds check.
   assert(task_list->nlevels == nlevels);
@@ -184,7 +209,8 @@ void grid_collocate_task_list(const grid_task_list *task_list,
     grid_dgemm_collocate_task_list(task_list->dgemm, func, nlevels, pab_blocks,
                                    grids);
     break;
-#if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_GRID)
+#if (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP)) &&                     \
+    !defined(__NO_OFFLOAD_GRID)
   case GRID_BACKEND_GPU:
     grid_gpu_collocate_task_list(task_list->gpu, func, nlevels, pab_blocks,
                                  grids);
@@ -248,11 +274,41 @@ void grid_collocate_task_list(const grid_task_list *task_list,
  *        See grid_task_list.h for details.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_integrate_task_list(
-    const grid_task_list *task_list, const bool compute_tau, const int natoms,
-    const int nlevels, const int npts_local[nlevels][3],
-    const offload_buffer *pab_blocks, const offload_buffer *grids[nlevels],
-    offload_buffer *hab_blocks, double forces[natoms][3], double virial[3][3]) {
+void grid_integrate_task_list(const grid_task_list *ptr, const bool compute_tau,
+                              const int natoms, const int nlevels,
+                              const int npts_local[nlevels][3],
+                              const offload_buffer *pab_blocks,
+                              const offload_buffer *grids[nlevels],
+                              offload_buffer *hab_blocks,
+                              double forces[natoms][3], double virial[3][3]) {
+
+  if (ptr == NULL)
+    return;
+
+  grid_task_list_internal *task_list = (grid_task_list_internal *)ptr;
+
+  if (task_list->empty) {
+    memset(hab_blocks->host_buffer, 0, hab_blocks->size);
+    if (virial) {
+      virial[0][0] = 0.0;
+      virial[0][1] = 0.0;
+      virial[0][2] = 0.0;
+      virial[1][0] = 0.0;
+      virial[1][1] = 0.0;
+      virial[1][2] = 0.0;
+      virial[2][0] = 0.0;
+      virial[2][1] = 0.0;
+      virial[2][2] = 0.0;
+    }
+    if (forces) {
+      for (int atom = 0; atom < natoms; atom++) {
+        forces[atom][0] = 0.0;
+        forces[atom][1] = 0.0;
+        forces[atom][2] = 0.0;
+      }
+    }
+    return;
+  }
 
   // Bounds check.
   assert(task_list->nlevels == nlevels);
@@ -266,7 +322,8 @@ void grid_integrate_task_list(
   assert(virial == NULL || pab_blocks != NULL);
 
   switch (task_list->backend) {
-#if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_GRID)
+#if (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP)) &&                     \
+    !defined(__NO_OFFLOAD_GRID)
   case GRID_BACKEND_GPU:
     grid_gpu_integrate_task_list(task_list->gpu, compute_tau, nlevels,
                                  pab_blocks, grids, hab_blocks, &forces[0][0],

--- a/src/grid/grid_task_list.h
+++ b/src/grid/grid_task_list.h
@@ -10,30 +10,10 @@
 #include <stdbool.h>
 
 #include "../offload/offload_buffer.h"
-#include "../offload/offload_runtime.h"
 #include "common/grid_basis_set.h"
 #include "common/grid_constants.h"
-#include "cpu/grid_cpu_task_list.h"
-#include "dgemm/grid_dgemm_task_list.h"
-#include "gpu/grid_gpu_task_list.h"
-#include "ref/grid_ref_task_list.h"
 
-/*******************************************************************************
- * \brief Internal representation of a task list, abstracting various backends.
- * \author Ole Schuett
- ******************************************************************************/
-typedef struct {
-  int backend;
-  int nlevels;
-  int (*npts_local)[3];
-  grid_ref_task_list *ref;
-  grid_cpu_task_list *cpu;
-  grid_dgemm_task_list *dgemm;
-#if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_GRID)
-  grid_gpu_task_list *gpu;
-#endif
-  // more backends to be added here
-} grid_task_list;
+typedef void grid_task_list;
 
 /*******************************************************************************
  * \brief Allocates a task list which can be passed to grid_collocate_task_list.

--- a/src/grid/grid_task_list_internal.h
+++ b/src/grid/grid_task_list_internal.h
@@ -1,0 +1,39 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2026 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: BSD-3-Clause                                     */
+/*----------------------------------------------------------------------------*/
+
+#ifndef GRID_TASK_LIST_INTERNAL_H
+#define GRID_TASK_LIST_INTERNAL_H
+
+#include "common/grid_basis_set.h"
+#include "common/grid_common.h"
+#include "common/grid_constants.h"
+#include "common/grid_library.h"
+#include "cpu/grid_cpu_task_list.h"
+#include "dgemm/grid_dgemm_task_list.h"
+#include "gpu/grid_gpu_task_list.h"
+#include "ref/grid_ref_task_list.h"
+
+/*******************************************************************************
+ * \brief Internal representation of a task list, abstracting various backends.
+ * \author Ole Schuett
+ ******************************************************************************/
+typedef struct {
+  bool empty;
+  int backend;
+  int nlevels;
+  int (*npts_local)[3];
+  grid_ref_task_list *ref;
+  grid_cpu_task_list *cpu;
+  grid_dgemm_task_list *dgemm;
+#if (defined(__OFFLOAD_CUDA) || defined(__OFFLOAD_HIP)) &&                     \
+    !defined(__NO_OFFLOAD_GRID)
+  grid_gpu_task_list *gpu;
+#endif
+  // more backends to be added here
+} grid_task_list_internal;
+
+#endif

--- a/src/grid/ref/grid_ref_task_list.c
+++ b/src/grid/ref/grid_ref_task_list.c
@@ -17,6 +17,7 @@
 #include "grid_ref_collocate.h"
 #include "grid_ref_integrate.h"
 #include "grid_ref_task_list.h"
+#include "grid_ref_task_list_internal.h"
 
 /*******************************************************************************
  * \brief Comperator passed to qsort to compare two tasks.
@@ -59,7 +60,8 @@ void grid_ref_create_task_list(
     grid_ref_free_task_list(*task_list_out);
   }
 
-  grid_ref_task_list *task_list = malloc(sizeof(grid_ref_task_list));
+  grid_ref_task_list_internal *task_list =
+      malloc(sizeof(grid_ref_task_list_internal));
   assert(task_list != NULL);
 
   task_list->orthorhombic = orthorhombic;
@@ -183,7 +185,12 @@ void grid_ref_create_task_list(
  * \brief Deallocates given task list, basis_sets have to be freed separately.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_ref_free_task_list(grid_ref_task_list *task_list) {
+void grid_ref_free_task_list(grid_ref_task_list *ptr) {
+  if (ptr == NULL)
+    return;
+
+  grid_ref_task_list_internal *task_list = (grid_ref_task_list_internal *)ptr;
+
   free(task_list->block_offsets);
   free(task_list->atom_positions);
   free(task_list->atom_kinds);
@@ -268,11 +275,16 @@ static void load_pab(const grid_basis_set *ibasis, const grid_basis_set *jbasis,
  * \author Ole Schuett
  ******************************************************************************/
 static void collocate_one_grid_level(
-    const grid_ref_task_list *task_list, const int *first_block_task,
+    const grid_ref_task_list *ptr, const int *first_block_task,
     const int *last_block_task, const enum grid_func func,
     const int npts_global[3], const int npts_local[3], const int shift_local[3],
     const int border_width[3], const double dh[3][3], const double dh_inv[3][3],
     const double *pab_blocks, offload_buffer *grid) {
+
+  if (ptr == NULL)
+    return;
+
+  grid_ref_task_list_internal *task_list = (grid_ref_task_list_internal *)ptr;
 
 // Using default(shared) because with GCC 9 the behavior around const changed:
 // https://www.gnu.org/software/gcc/gcc-9/porting_to.html
@@ -419,10 +431,15 @@ static void collocate_one_grid_level(
  *        See grid_task_list.h for details.
  * \author Ole Schuett
  ******************************************************************************/
-void grid_ref_collocate_task_list(const grid_ref_task_list *task_list,
+void grid_ref_collocate_task_list(const grid_ref_task_list *ptr,
                                   const enum grid_func func, const int nlevels,
                                   const offload_buffer *pab_blocks,
                                   offload_buffer *grids[nlevels]) {
+
+  if (ptr == NULL)
+    return;
+
+  grid_ref_task_list_internal *task_list = (grid_ref_task_list_internal *)ptr;
 
   assert(task_list->nlevels == nlevels);
 
@@ -486,12 +503,17 @@ static inline void store_hab(const grid_basis_set *ibasis,
  * \author Ole Schuett
  ******************************************************************************/
 static void integrate_one_grid_level(
-    const grid_ref_task_list *task_list, const int *first_block_task,
+    const grid_ref_task_list *ptr, const int *first_block_task,
     const int *last_block_task, const bool compute_tau, const int natoms,
     const int npts_global[3], const int npts_local[3], const int shift_local[3],
     const int border_width[3], const double dh[3][3], const double dh_inv[3][3],
     const offload_buffer *pab_blocks, const offload_buffer *grid,
     offload_buffer *hab_blocks, double forces[natoms][3], double virial[3][3]) {
+
+  if (ptr == NULL)
+    return;
+
+  grid_ref_task_list_internal *task_list = (grid_ref_task_list_internal *)ptr;
 
 // Using default(shared) because with GCC 9 the behavior around const changed:
 // https://www.gnu.org/software/gcc/gcc-9/porting_to.html
@@ -635,11 +657,14 @@ static void integrate_one_grid_level(
  * \author Ole Schuett
  ******************************************************************************/
 void grid_ref_integrate_task_list(
-    const grid_ref_task_list *task_list, const bool compute_tau,
-    const int natoms, const int nlevels, const offload_buffer *pab_blocks,
+    const grid_ref_task_list *ptr, const bool compute_tau, const int natoms,
+    const int nlevels, const offload_buffer *pab_blocks,
     const offload_buffer *grids[nlevels], offload_buffer *hab_blocks,
     double forces[natoms][3], double virial[3][3]) {
+  if (ptr == NULL)
+    return;
 
+  grid_ref_task_list_internal *task_list = (grid_ref_task_list_internal *)ptr;
   assert(task_list->nlevels == nlevels);
   assert(task_list->natoms == natoms);
 

--- a/src/grid/ref/grid_ref_task_list.h
+++ b/src/grid/ref/grid_ref_task_list.h
@@ -13,60 +13,7 @@
 #include "../common/grid_basis_set.h"
 #include "../common/grid_constants.h"
 
-/*******************************************************************************
- * \brief Internal representation of a task.
- * \author Ole Schuett
- ******************************************************************************/
-typedef struct {
-  int level;
-  int iatom;
-  int jatom;
-  int iset;
-  int jset;
-  int ipgf;
-  int jpgf;
-  int border_mask;
-  int block_num;
-  double radius;
-  double rab[3];
-} grid_ref_task;
-
-/*******************************************************************************
- * \brief Internal representation of a grid layout.
- * \author Ole Schuett
- ******************************************************************************/
-typedef struct {
-  int npts_global[3];
-  int npts_local[3];
-  int shift_local[3];
-  int border_width[3];
-  double dh[3][3];
-  double dh_inv[3][3];
-} grid_ref_layout;
-
-/*******************************************************************************
- * \brief Internal representation of a task list.
- * \author Ole Schuett
- ******************************************************************************/
-typedef struct {
-  bool orthorhombic;
-  int ntasks;
-  int nlevels;
-  int natoms;
-  int nkinds;
-  int nblocks;
-  int *block_offsets;
-  double *atom_positions;
-  int *atom_kinds;
-  grid_basis_set **basis_sets;
-  grid_ref_task *tasks;
-  grid_ref_layout *layouts;
-  int *first_level_block_task;
-  int *last_level_block_task;
-  int maxco;
-  double **threadlocals;
-  size_t *threadlocal_sizes;
-} grid_ref_task_list;
+typedef void grid_ref_task_list;
 
 /*******************************************************************************
  * \brief Allocates a task list for the reference backend.

--- a/src/grid/ref/grid_ref_task_list_internal.h
+++ b/src/grid/ref/grid_ref_task_list_internal.h
@@ -1,0 +1,71 @@
+/*----------------------------------------------------------------------------*/
+/*  CP2K: A general program to perform molecular dynamics simulations         */
+/*  Copyright 2000-2026 CP2K developers group <https://cp2k.org>              */
+/*                                                                            */
+/*  SPDX-License-Identifier: BSD-3-Clause                                     */
+/*----------------------------------------------------------------------------*/
+#ifndef GRID_REF_TASK_LIST_INTERNAL_H
+#define GRID_REF_TASK_LIST_INTERNAL_H
+
+#include <stdbool.h>
+
+#include "../../offload/offload_buffer.h"
+#include "../common/grid_basis_set.h"
+#include "../common/grid_constants.h"
+
+/*******************************************************************************
+ * \brief Internal representation of a task.
+ * \author Ole Schuett
+ ******************************************************************************/
+typedef struct {
+  int level;
+  int iatom;
+  int jatom;
+  int iset;
+  int jset;
+  int ipgf;
+  int jpgf;
+  int border_mask;
+  int block_num;
+  double radius;
+  double rab[3];
+} grid_ref_task;
+
+/*******************************************************************************
+ * \brief Internal representation of a grid layout.
+ * \author Ole Schuett
+ ******************************************************************************/
+typedef struct {
+  int npts_global[3];
+  int npts_local[3];
+  int shift_local[3];
+  int border_width[3];
+  double dh[3][3];
+  double dh_inv[3][3];
+} grid_ref_layout;
+
+/*******************************************************************************
+ * \brief Internal representation of a task list.
+ * \author Ole Schuett
+ ******************************************************************************/
+typedef struct {
+  bool orthorhombic;
+  int ntasks;
+  int nlevels;
+  int natoms;
+  int nkinds;
+  int nblocks;
+  int *block_offsets;
+  double *atom_positions;
+  int *atom_kinds;
+  grid_basis_set **basis_sets;
+  grid_ref_task *tasks;
+  grid_ref_layout *layouts;
+  int *first_level_block_task;
+  int *last_level_block_task;
+  int maxco;
+  double **threadlocals;
+  size_t *threadlocal_sizes;
+} grid_ref_task_list_internal;
+
+#endif


### PR DESCRIPTION
This PR fixes few issues 

- The previous implementation was allocating scratch memory for each task instead of block which wasted a large amount GPU memory for no performance gain. The new implementation restricts memory allocation to blocks (hab, pab) instead. It also fixes the dashboard issue observed after merging the GPU and HIP backends.

- Fix API encapsulation: make grid_task_list opaque

The top-level `grid_task_list` was exposing internal backend pointers in the public header, breaking encapsulation and forcing all backend headers into the public API namespace.

`GPU` and `DGEMM` backends already use opaque handles. This change makes the top-level wrapper and the remaining backends consistent with GPU and DGEMM.

Benefits:
- Callers cannot depend on internal layout
- Backend changes don't break the API
- Reduced compile-time coupling
- Standard C library design pattern

Any code that directly access `task_list->cpu`, `task_list->gpu`, etc. is violating the abstraction and must be fixed to use the public API instead.

- Minor performance improvements
