### PR TITLE
Allow k-point USE_PREV_WF to survive symmetry refresh when safe

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -325,6 +325,7 @@ list(
   kpoint_k_r_trafo_simple.F
   kpoint_methods.F
   kpoint_mo_dump.F
+  kpoint_mo_symmetry_methods.F
   kpoint_transitional.F
   kpoint_types.F
   kpsym.F

--- a/src/force_env_methods.F
+++ b/src/force_env_methods.F
@@ -169,8 +169,8 @@ MODULE force_env_methods
    USE qs_mo_types,                     ONLY: mo_set_type
    USE qs_rho_types,                    ONLY: qs_rho_get,&
                                               qs_rho_type
-   USE qs_wf_history_types,             ONLY: qs_wf_history_type,&
-                                              wfi_clear
+   USE qs_wf_history_methods,           ONLY: wfi_handle_kpoint_symmetry_refresh
+   USE qs_wf_history_types,             ONLY: qs_wf_history_type
    USE restraint,                       ONLY: restraint_control
    USE scine_utils,                     ONLY: write_scine
    USE string_utilities,                ONLY: compress
@@ -626,8 +626,8 @@ CONTAINS
       CALL kpoint_initialize(kpoints, particle_set, cell)
       CALL kpoint_env_initialize(kpoints, para_env, blacs_env, with_aux_fit=dft_control%do_admm)
       CALL kpoint_initialize_mos(kpoints, mos)
-      CALL wfi_clear(wf_history)
       CALL qs_basis_rotation(force_env%qs_env, kpoints)
+      CALL wfi_handle_kpoint_symmetry_refresh(wf_history, kpoints)
 
    END SUBROUTINE force_env_refresh_kpoint_symmetry
 

--- a/src/kpoint_mo_symmetry_methods.F
+++ b/src/kpoint_mo_symmetry_methods.F
@@ -1,0 +1,235 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2026 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief Utilities for transforming k-point MO coefficients under symmetry operations
+! **************************************************************************************************
+MODULE kpoint_mo_symmetry_methods
+   USE cp_fm_types,                     ONLY: cp_fm_copy_general,&
+                                              cp_fm_get_info,&
+                                              cp_fm_get_submatrix,&
+                                              cp_fm_set_submatrix,&
+                                              cp_fm_type
+   USE kinds,                           ONLY: dp
+   USE kpoint_types,                    ONLY: kind_rotmat_type,&
+                                              kpoint_sym_type,&
+                                              kpoint_type
+   USE mathconstants,                   ONLY: twopi
+   USE message_passing,                 ONLY: mp_para_env_type
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+   PRIVATE
+
+   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'kpoint_mo_symmetry_methods'
+
+   PUBLIC :: kpoint_same_periodic, &
+             kpoint_transform_scf_mo
+
+CONTAINS
+
+! **************************************************************************************************
+!> \brief Compare two fractional k-points modulo reciprocal lattice vectors.
+!> \param xkp_a first k-point
+!> \param xkp_b second k-point
+!> \return true if the k-points are equivalent
+! **************************************************************************************************
+   LOGICAL FUNCTION kpoint_same_periodic(xkp_a, xkp_b) RESULT(same)
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: xkp_a, xkp_b
+
+      REAL(KIND=dp), DIMENSION(3)                        :: diff
+
+      diff(1:3) = xkp_a(1:3) - xkp_b(1:3)
+      diff(1:3) = diff(1:3) - REAL(NINT(diff(1:3)), KIND=dp)
+      same = SUM(ABS(diff(1:3))) < 1.0e-8_dp
+
+   END FUNCTION kpoint_same_periodic
+
+! **************************************************************************************************
+!> \brief Transform one SCF MO coefficient matrix to an equivalent full-mesh k-point.
+!> \param src_real real part of source MO coefficients
+!> \param src_imag imaginary part of source MO coefficients
+!> \param dst_real real part of transformed MO coefficients
+!> \param dst_imag imaginary part of transformed MO coefficients
+!> \param qs_kpoint SCF k-point object containing symmetry operations
+!> \param ikred representative k-point index
+!> \param isym symmetry operation index; 0 direct copy, -1 time reversal
+!> \param para_env global parallel environment
+!> \param success true if the transformation was performed
+!> \param reason diagnostic message
+! **************************************************************************************************
+   SUBROUTINE kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, ikred, &
+                                      isym, para_env, success, reason)
+      TYPE(cp_fm_type), INTENT(IN)                       :: src_real, src_imag, dst_real, dst_imag
+      TYPE(kpoint_type), POINTER                         :: qs_kpoint
+      INTEGER, INTENT(IN)                                :: ikred, isym
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      LOGICAL, INTENT(OUT)                               :: success
+      CHARACTER(LEN=*), INTENT(OUT)                      :: reason
+
+      INTEGER :: iao, iatom, ikind, imo, irow, irow_source, irow_target, irow_work, nao, natom, &
+         nmo, rot_slot, source_atom, source_dim, target_atom, target_dim
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ao_size, ao_start
+      LOGICAL                                            :: reverse_phase, time_reversal
+      REAL(KIND=dp)                                      :: arg, coeff_imag, coeff_real, coskl, &
+                                                            phase_imag, phase_real, sinkl
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: dst_i, dst_r, src_i, src_r
+      REAL(KIND=dp), DIMENSION(3)                        :: xkp_phase
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rotmat
+      TYPE(kind_rotmat_type), DIMENSION(:), POINTER      :: kind_rot
+      TYPE(kpoint_sym_type), POINTER                     :: kpsym
+
+      success = .FALSE.
+      reason = ""
+      IF (isym == 0) THEN
+         CALL cp_fm_copy_general(src_real, dst_real, para_env)
+         CALL cp_fm_copy_general(src_imag, dst_imag, para_env)
+         success = .TRUE.
+         RETURN
+      END IF
+
+      CALL cp_fm_get_info(src_real, nrow_global=nao, ncol_global=nmo)
+      ALLOCATE (src_r(nao, nmo), src_i(nao, nmo), dst_r(nao, nmo), dst_i(nao, nmo))
+      CALL cp_fm_get_submatrix(src_real, src_r)
+      CALL cp_fm_get_submatrix(src_imag, src_i)
+      dst_r(:, :) = 0.0_dp
+      dst_i(:, :) = 0.0_dp
+
+      IF (isym == -1) THEN
+         dst_r(1:nao, 1:nmo) = src_r(1:nao, 1:nmo)
+         dst_i(1:nao, 1:nmo) = -src_i(1:nao, 1:nmo)
+         CALL cp_fm_set_submatrix(dst_real, dst_r)
+         CALL cp_fm_set_submatrix(dst_imag, dst_i)
+         DEALLOCATE (src_r, src_i, dst_r, dst_i)
+         success = .TRUE.
+         RETURN
+      END IF
+
+      IF (.NOT. ASSOCIATED(qs_kpoint%kp_sym)) THEN
+         reason = "SCF symmetry operation data are not available"
+         DEALLOCATE (src_r, src_i, dst_r, dst_i)
+         RETURN
+      END IF
+      kpsym => qs_kpoint%kp_sym(ikred)%kpoint_sym
+      IF (.NOT. ASSOCIATED(kpsym)) THEN
+         reason = "SCF k-point symmetry operation is not available"
+         DEALLOCATE (src_r, src_i, dst_r, dst_i)
+         RETURN
+      END IF
+      IF (isym > kpsym%nwred) THEN
+         reason = "SCF k-point symmetry operation index is out of range"
+         DEALLOCATE (src_r, src_i, dst_r, dst_i)
+         RETURN
+      END IF
+      IF (.NOT. ASSOCIATED(qs_kpoint%atype) .OR. .NOT. ASSOCIATED(qs_kpoint%kind_rotmat)) THEN
+         reason = "SCF atom mappings or basis rotation matrices are not available"
+         DEALLOCATE (src_r, src_i, dst_r, dst_i)
+         RETURN
+      END IF
+
+      rot_slot = find_kpoint_rotation_slot(qs_kpoint, kpsym%rotp(isym))
+      IF (rot_slot == 0) THEN
+         reason = "could not match the SCF symmetry operation to a basis rotation"
+         DEALLOCATE (src_r, src_i, dst_r, dst_i)
+         RETURN
+      END IF
+      kind_rot => qs_kpoint%kind_rotmat(rot_slot, :)
+      natom = SIZE(qs_kpoint%atype)
+      ALLOCATE (ao_start(natom), ao_size(natom))
+      irow = 1
+      DO iatom = 1, natom
+         ikind = qs_kpoint%atype(iatom)
+         IF (.NOT. ASSOCIATED(kind_rot(ikind)%rmat)) THEN
+            reason = "a required basis rotation matrix is not available"
+            DEALLOCATE (src_r, src_i, dst_r, dst_i, ao_start, ao_size)
+            RETURN
+         END IF
+         ao_start(iatom) = irow
+         ao_size(iatom) = SIZE(kind_rot(ikind)%rmat, 2)
+         irow = irow + ao_size(iatom)
+      END DO
+      IF (irow - 1 /= nao) THEN
+         reason = "atom-resolved AO dimensions do not match the MO coefficient matrix"
+         DEALLOCATE (src_r, src_i, dst_r, dst_i, ao_start, ao_size)
+         RETURN
+      END IF
+
+      time_reversal = kpsym%rotp(isym) < 0
+      reverse_phase = qs_kpoint%gamma_centered .AND. ANY(MOD(qs_kpoint%nkp_grid, 2) == 0)
+      xkp_phase(1:3) = kpsym%xkp(1:3, isym)
+      DO iatom = 1, natom
+         source_atom = iatom
+         target_atom = kpsym%f0(iatom, isym)
+         ikind = qs_kpoint%atype(source_atom)
+         rotmat => kind_rot(ikind)%rmat
+         source_dim = ao_size(source_atom)
+         target_dim = ao_size(target_atom)
+         IF (SIZE(rotmat, 1) /= target_dim .OR. SIZE(rotmat, 2) /= source_dim) THEN
+            reason = "basis rotation dimensions do not match the atom/AO symmetry transform"
+            DEALLOCATE (src_r, src_i, dst_r, dst_i, ao_start, ao_size)
+            RETURN
+         END IF
+         arg = REAL(kpsym%fcell(1, source_atom, isym), KIND=dp)*xkp_phase(1) + &
+               REAL(kpsym%fcell(2, source_atom, isym), KIND=dp)*xkp_phase(2) + &
+               REAL(kpsym%fcell(3, source_atom, isym), KIND=dp)*xkp_phase(3)
+         IF (ASSOCIATED(kpsym%kgphase)) THEN
+            arg = arg + kpsym%kgphase(source_atom, isym)
+         END IF
+         IF (reverse_phase) arg = -arg
+         coskl = COS(twopi*arg)
+         sinkl = SIN(twopi*arg)
+         DO imo = 1, nmo
+            DO irow_work = 1, source_dim
+               irow_source = ao_start(source_atom) + irow_work - 1
+               coeff_real = src_r(irow_source, imo)
+               coeff_imag = src_i(irow_source, imo)
+               IF (time_reversal) coeff_imag = -coeff_imag
+               phase_real = coskl*coeff_real - sinkl*coeff_imag
+               phase_imag = sinkl*coeff_real + coskl*coeff_imag
+               DO iao = 1, target_dim
+                  irow_target = ao_start(target_atom) + iao - 1
+                  dst_r(irow_target, imo) = dst_r(irow_target, imo) + &
+                                            rotmat(iao, irow_work)*phase_real
+                  dst_i(irow_target, imo) = dst_i(irow_target, imo) + &
+                                            rotmat(iao, irow_work)*phase_imag
+               END DO
+            END DO
+         END DO
+      END DO
+
+      CALL cp_fm_set_submatrix(dst_real, dst_r)
+      CALL cp_fm_set_submatrix(dst_imag, dst_i)
+      DEALLOCATE (src_r, src_i, dst_r, dst_i, ao_start, ao_size)
+      success = .TRUE.
+
+   END SUBROUTINE kpoint_transform_scf_mo
+
+! **************************************************************************************************
+!> \brief Locate the basis-rotation slot corresponding to a signed k-point symmetry operation.
+!> \param qs_kpoint SCF k-point object
+!> \param rotp signed operation identifier
+!> \return rotation slot, or zero when no slot matches
+! **************************************************************************************************
+   INTEGER FUNCTION find_kpoint_rotation_slot(qs_kpoint, rotp) RESULT(rot_slot)
+      TYPE(kpoint_type), POINTER                         :: qs_kpoint
+      INTEGER, INTENT(IN)                                :: rotp
+
+      INTEGER                                            :: irot, rot_abs
+
+      rot_slot = 0
+      rot_abs = ABS(rotp)
+      IF (.NOT. ASSOCIATED(qs_kpoint%ibrot)) RETURN
+      DO irot = 1, SIZE(qs_kpoint%ibrot)
+         IF (rot_abs == qs_kpoint%ibrot(irot)) THEN
+            rot_slot = irot
+            RETURN
+         END IF
+      END DO
+
+   END FUNCTION find_kpoint_rotation_slot
+
+END MODULE kpoint_mo_symmetry_methods

--- a/src/kpoint_mo_symmetry_methods.F
+++ b/src/kpoint_mo_symmetry_methods.F
@@ -9,8 +9,7 @@
 !> \brief Utilities for transforming k-point MO coefficients under symmetry operations
 ! **************************************************************************************************
 MODULE kpoint_mo_symmetry_methods
-   USE cp_fm_types,                     ONLY: cp_fm_copy_general,&
-                                              cp_fm_get_info,&
+   USE cp_fm_types,                     ONLY: cp_fm_get_info,&
                                               cp_fm_get_submatrix,&
                                               cp_fm_set_submatrix,&
                                               cp_fm_type
@@ -61,20 +60,22 @@ CONTAINS
 !> \param para_env global parallel environment
 !> \param success true if the transformation was performed
 !> \param reason diagnostic message
+!> \param inverse apply the inverse of the selected symmetry operation
 ! **************************************************************************************************
    SUBROUTINE kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, ikred, &
-                                      isym, para_env, success, reason)
+                                      isym, para_env, success, reason, inverse)
       TYPE(cp_fm_type), INTENT(IN)                       :: src_real, src_imag, dst_real, dst_imag
       TYPE(kpoint_type), POINTER                         :: qs_kpoint
       INTEGER, INTENT(IN)                                :: ikred, isym
       TYPE(mp_para_env_type), POINTER                    :: para_env
       LOGICAL, INTENT(OUT)                               :: success
       CHARACTER(LEN=*), INTENT(OUT)                      :: reason
+      LOGICAL, INTENT(IN), OPTIONAL                      :: inverse
 
       INTEGER :: iao, iatom, ikind, imo, irow, irow_source, irow_target, irow_work, nao, natom, &
          nmo, rot_slot, source_atom, source_dim, target_atom, target_dim
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ao_size, ao_start
-      LOGICAL                                            :: reverse_phase, time_reversal
+      LOGICAL                                            :: reverse_phase, time_reversal, use_inverse
       REAL(KIND=dp)                                      :: arg, coeff_imag, coeff_real, coskl, &
                                                             phase_imag, phase_real, sinkl
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: dst_i, dst_r, src_i, src_r
@@ -85,19 +86,22 @@ CONTAINS
 
       success = .FALSE.
       reason = ""
-      IF (isym == 0) THEN
-         CALL cp_fm_copy_general(src_real, dst_real, para_env)
-         CALL cp_fm_copy_general(src_imag, dst_imag, para_env)
-         success = .TRUE.
-         RETURN
-      END IF
-
+      use_inverse = .FALSE.
+      IF (PRESENT(inverse)) use_inverse = inverse
       CALL cp_fm_get_info(src_real, nrow_global=nao, ncol_global=nmo)
       ALLOCATE (src_r(nao, nmo), src_i(nao, nmo), dst_r(nao, nmo), dst_i(nao, nmo))
       CALL cp_fm_get_submatrix(src_real, src_r)
       CALL cp_fm_get_submatrix(src_imag, src_i)
       dst_r(:, :) = 0.0_dp
       dst_i(:, :) = 0.0_dp
+
+      IF (isym == 0) THEN
+         CALL cp_fm_set_submatrix(dst_real, src_r)
+         CALL cp_fm_set_submatrix(dst_imag, src_i)
+         DEALLOCATE (src_r, src_i, dst_r, dst_i)
+         success = .TRUE.
+         RETURN
+      END IF
 
       IF (isym == -1) THEN
          dst_r(1:nao, 1:nmo) = src_r(1:nao, 1:nmo)
@@ -182,23 +186,43 @@ CONTAINS
          IF (reverse_phase) arg = -arg
          coskl = COS(twopi*arg)
          sinkl = SIN(twopi*arg)
-         DO imo = 1, nmo
-            DO irow_work = 1, source_dim
-               irow_source = ao_start(source_atom) + irow_work - 1
-               coeff_real = src_r(irow_source, imo)
-               coeff_imag = src_i(irow_source, imo)
-               IF (time_reversal) coeff_imag = -coeff_imag
-               phase_real = coskl*coeff_real - sinkl*coeff_imag
-               phase_imag = sinkl*coeff_real + coskl*coeff_imag
-               DO iao = 1, target_dim
-                  irow_target = ao_start(target_atom) + iao - 1
-                  dst_r(irow_target, imo) = dst_r(irow_target, imo) + &
-                                            rotmat(iao, irow_work)*phase_real
-                  dst_i(irow_target, imo) = dst_i(irow_target, imo) + &
-                                            rotmat(iao, irow_work)*phase_imag
+         IF (use_inverse) THEN
+            DO imo = 1, nmo
+               DO irow_work = 1, source_dim
+                  coeff_real = 0.0_dp
+                  coeff_imag = 0.0_dp
+                  DO iao = 1, target_dim
+                     irow_target = ao_start(target_atom) + iao - 1
+                     coeff_real = coeff_real + rotmat(iao, irow_work)*src_r(irow_target, imo)
+                     coeff_imag = coeff_imag + rotmat(iao, irow_work)*src_i(irow_target, imo)
+                  END DO
+                  phase_real = coskl*coeff_real + sinkl*coeff_imag
+                  phase_imag = -sinkl*coeff_real + coskl*coeff_imag
+                  IF (time_reversal) phase_imag = -phase_imag
+                  irow_source = ao_start(source_atom) + irow_work - 1
+                  dst_r(irow_source, imo) = dst_r(irow_source, imo) + phase_real
+                  dst_i(irow_source, imo) = dst_i(irow_source, imo) + phase_imag
                END DO
             END DO
-         END DO
+         ELSE
+            DO imo = 1, nmo
+               DO irow_work = 1, source_dim
+                  irow_source = ao_start(source_atom) + irow_work - 1
+                  coeff_real = src_r(irow_source, imo)
+                  coeff_imag = src_i(irow_source, imo)
+                  IF (time_reversal) coeff_imag = -coeff_imag
+                  phase_real = coskl*coeff_real - sinkl*coeff_imag
+                  phase_imag = sinkl*coeff_real + coskl*coeff_imag
+                  DO iao = 1, target_dim
+                     irow_target = ao_start(target_atom) + iao - 1
+                     dst_r(irow_target, imo) = dst_r(irow_target, imo) + &
+                                               rotmat(iao, irow_work)*phase_real
+                     dst_i(irow_target, imo) = dst_i(irow_target, imo) + &
+                                               rotmat(iao, irow_work)*phase_imag
+                  END DO
+               END DO
+            END DO
+         END IF
       END DO
 
       CALL cp_fm_set_submatrix(dst_real, dst_r)

--- a/src/kpoint_mo_symmetry_methods.F
+++ b/src/kpoint_mo_symmetry_methods.F
@@ -18,7 +18,6 @@ MODULE kpoint_mo_symmetry_methods
                                               kpoint_sym_type,&
                                               kpoint_type
    USE mathconstants,                   ONLY: twopi
-   USE message_passing,                 ONLY: mp_para_env_type
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -57,17 +56,15 @@ CONTAINS
 !> \param qs_kpoint SCF k-point object containing symmetry operations
 !> \param ikred representative k-point index
 !> \param isym symmetry operation index; 0 direct copy, -1 time reversal
-!> \param para_env global parallel environment
 !> \param success true if the transformation was performed
 !> \param reason diagnostic message
 !> \param inverse apply the inverse of the selected symmetry operation
 ! **************************************************************************************************
    SUBROUTINE kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, ikred, &
-                                      isym, para_env, success, reason, inverse)
+                                      isym, success, reason, inverse)
       TYPE(cp_fm_type), INTENT(IN)                       :: src_real, src_imag, dst_real, dst_imag
       TYPE(kpoint_type), POINTER                         :: qs_kpoint
       INTEGER, INTENT(IN)                                :: ikred, isym
-      TYPE(mp_para_env_type), POINTER                    :: para_env
       LOGICAL, INTENT(OUT)                               :: success
       CHARACTER(LEN=*), INTENT(OUT)                      :: reason
       LOGICAL, INTENT(IN), OPTIONAL                      :: inverse

--- a/src/qs_wannier90.F
+++ b/src/qs_wannier90.F
@@ -57,8 +57,9 @@ MODULE qs_wannier90
                                               kpoint_initialize_mo_set,&
                                               kpoint_initialize_mos,&
                                               rskp_transform
+   USE kpoint_mo_symmetry_methods,      ONLY: kpoint_same_periodic,&
+                                              kpoint_transform_scf_mo
    USE kpoint_types,                    ONLY: get_kpoint_info,&
-                                              kind_rotmat_type,&
                                               kpoint_create,&
                                               kpoint_env_type,&
                                               kpoint_release,&
@@ -1168,12 +1169,12 @@ CONTAINS
                   num_candidates = 0
                   ! Little-group operations can reach the same target k-point; keep the first valid eigenspace.
                   DO isym_try = 1, kpsym%nwred
-                     IF (.NOT. same_periodic_kpoint(kpoint%xkp(1:3, ik), &
+                     IF (.NOT. kpoint_same_periodic(kpoint%xkp(1:3, ik), &
                                                     kpsym%xkp(1:3, isym_try))) CYCLE
                      num_candidates = num_candidates + 1
-                     CALL transform_wannier90_scf_mo(src_real, src_imag, dst_real, dst_imag, &
-                                                     qs_kpoint, ikred, isym_try, para_env, ok, &
-                                                     candidate_reason)
+                     CALL kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, &
+                                                  qs_kpoint, ikred, isym_try, para_env, ok, &
+                                                  candidate_reason)
                      IF (.NOT. ok) THEN
                         reason = candidate_reason
                         CYCLE
@@ -1191,9 +1192,9 @@ CONTAINS
                      END IF
                      IF (.NOT. ok) THEN
                         IF (source_window) THEN
-                           CALL transform_wannier90_scf_mo(src_real_full, src_imag_full, &
-                                                           dst_real_full, dst_imag_full, qs_kpoint, &
-                                                           ikred, isym_try, para_env, ok, candidate_reason)
+                           CALL kpoint_transform_scf_mo(src_real_full, src_imag_full, &
+                                                        dst_real_full, dst_imag_full, qs_kpoint, &
+                                                        ikred, isym_try, para_env, ok, candidate_reason)
                            IF (ok) THEN
                               CALL ritz_reconstruct_wannier90_window(dst_real_full, dst_imag_full, &
                                                                      dst_real, dst_imag, matrix_s, &
@@ -1239,8 +1240,8 @@ CONTAINS
                   reason = "SCF k-point symmetry operation is not available"
                END IF
             ELSE
-               CALL transform_wannier90_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, &
-                                               ikred, sym_index(ik), para_env, ok, reason)
+               CALL kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, &
+                                            ikred, sym_index(ik), para_env, ok, reason)
             END IF
             IF (ok .AND. sym_index(ik) <= 0) THEN
                ! Even a direct k-point copy must be a closed H(k),S(k) subspace. This catches
@@ -1251,9 +1252,9 @@ CONTAINS
                                                       ok, reason, aligned_blocks, aligned_max_size, &
                                                       aligned_min_svalue, candidate_residual)
                IF (.NOT. ok .AND. source_window) THEN
-                  CALL transform_wannier90_scf_mo(src_real_full, src_imag_full, dst_real_full, &
-                                                  dst_imag_full, qs_kpoint, ikred, sym_index(ik), &
-                                                  para_env, ok, reason)
+                  CALL kpoint_transform_scf_mo(src_real_full, src_imag_full, dst_real_full, &
+                                               dst_imag_full, qs_kpoint, ikred, sym_index(ik), &
+                                               para_env, ok, reason)
                   IF (ok) THEN
                      CALL ritz_reconstruct_wannier90_window(dst_real_full, dst_imag_full, dst_real, &
                                                             dst_imag, matrix_s, matrix_ks, &
@@ -1723,8 +1724,8 @@ CONTAINS
             best_residual = 0.0_dp
             best_svalue = 0.0_dp
             IF (sym_index(ik) <= 0) THEN
-               CALL transform_wannier90_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, &
-                                               ikred, sym_index(ik), para_env, ok, reason)
+               CALL kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, &
+                                            ikred, sym_index(ik), para_env, ok, reason)
                IF (ok) THEN
                   CALL measure_wannier90_subspace_error(ref_real, ref_imag, dst_real, dst_imag, matrix_s, &
                                                         kpoint%xkp(1:3, ik), cell_to_index, sab_nl, &
@@ -1756,10 +1757,10 @@ CONTAINS
                kpsym => qs_kpoint%kp_sym(ikred)%kpoint_sym
                IF (ASSOCIATED(kpsym)) THEN
                   DO isym_try = 1, kpsym%nwred
-                     IF (.NOT. same_periodic_kpoint(kpoint%xkp(1:3, ik), &
+                     IF (.NOT. kpoint_same_periodic(kpoint%xkp(1:3, ik), &
                                                     kpsym%xkp(1:3, isym_try))) CYCLE
-                     CALL transform_wannier90_scf_mo(src_real, src_imag, dst_real, dst_imag, &
-                                                     qs_kpoint, ikred, isym_try, para_env, ok, reason)
+                     CALL kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, &
+                                                  qs_kpoint, ikred, isym_try, para_env, ok, reason)
                      IF (.NOT. ok) CYCLE
                      CALL measure_wannier90_subspace_error(ref_real, ref_imag, dst_real, dst_imag, &
                                                            matrix_s, kpoint%xkp(1:3, ik), cell_to_index, &
@@ -2613,213 +2614,13 @@ CONTAINS
 
       ik_match = 0
       DO ik = 1, SIZE(xkp_mesh, 2)
-         IF (same_periodic_kpoint(xkp_mesh(1:3, ik), xkp_search)) THEN
+         IF (kpoint_same_periodic(xkp_mesh(1:3, ik), xkp_search)) THEN
             ik_match = ik
             RETURN
          END IF
       END DO
 
    END FUNCTION find_matching_kpoint
-
-! **************************************************************************************************
-!> \brief Compare two fractional k-points modulo reciprocal lattice vectors.
-!> \param xkp_a first k-point
-!> \param xkp_b second k-point
-!> \return true if the k-points are equivalent
-! **************************************************************************************************
-   LOGICAL FUNCTION same_periodic_kpoint(xkp_a, xkp_b) RESULT(same)
-      REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: xkp_a, xkp_b
-
-      REAL(KIND=dp), DIMENSION(3)                        :: diff
-
-      diff(1:3) = xkp_a(1:3) - xkp_b(1:3)
-      diff(1:3) = diff(1:3) - REAL(NINT(diff(1:3)), KIND=dp)
-      same = SUM(ABS(diff(1:3))) < 1.0e-8_dp
-
-   END FUNCTION same_periodic_kpoint
-
-! **************************************************************************************************
-!> \brief Transform one SCF MO coefficient matrix to an equivalent full-mesh k-point.
-!> \param src_real real part of source MO coefficients
-!> \param src_imag imaginary part of source MO coefficients
-!> \param dst_real real part of transformed MO coefficients
-!> \param dst_imag imaginary part of transformed MO coefficients
-!> \param qs_kpoint SCF k-point object containing symmetry operations
-!> \param ikred representative k-point index
-!> \param isym symmetry operation index; 0 direct copy, -1 time reversal
-!> \param para_env global parallel environment
-!> \param success true if the transformation was performed
-!> \param reason diagnostic message
-! **************************************************************************************************
-   SUBROUTINE transform_wannier90_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, ikred, &
-                                         isym, para_env, success, reason)
-      TYPE(cp_fm_type), INTENT(IN)                       :: src_real, src_imag, dst_real, dst_imag
-      TYPE(kpoint_type), POINTER                         :: qs_kpoint
-      INTEGER, INTENT(IN)                                :: ikred, isym
-      TYPE(mp_para_env_type), POINTER                    :: para_env
-      LOGICAL, INTENT(OUT)                               :: success
-      CHARACTER(LEN=*), INTENT(OUT)                      :: reason
-
-      INTEGER :: iao, iatom, ikind, imo, irow, irow_source, irow_target, irow_work, nao, natom, &
-         nmo, rot_slot, source_atom, source_dim, target_atom, target_dim
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ao_size, ao_start
-      LOGICAL                                            :: reverse_phase, time_reversal
-      REAL(KIND=dp)                                      :: arg, coeff_imag, coeff_real, coskl, &
-                                                            phase_imag, phase_real, sinkl
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: dst_i, dst_r, src_i, src_r
-      REAL(KIND=dp), DIMENSION(3)                        :: xkp_phase
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: rotmat
-      TYPE(kind_rotmat_type), DIMENSION(:), POINTER      :: kind_rot
-      TYPE(kpoint_sym_type), POINTER                     :: kpsym
-
-      success = .FALSE.
-      reason = ""
-      IF (isym == 0) THEN
-         CALL cp_fm_copy_general(src_real, dst_real, para_env)
-         CALL cp_fm_copy_general(src_imag, dst_imag, para_env)
-         success = .TRUE.
-         RETURN
-      END IF
-
-      CALL cp_fm_get_info(src_real, nrow_global=nao, ncol_global=nmo)
-      ALLOCATE (src_r(nao, nmo), src_i(nao, nmo), dst_r(nao, nmo), dst_i(nao, nmo))
-      CALL cp_fm_get_submatrix(src_real, src_r)
-      CALL cp_fm_get_submatrix(src_imag, src_i)
-      dst_r(:, :) = 0.0_dp
-      dst_i(:, :) = 0.0_dp
-
-      IF (isym == -1) THEN
-         dst_r(1:nao, 1:nmo) = src_r(1:nao, 1:nmo)
-         dst_i(1:nao, 1:nmo) = -src_i(1:nao, 1:nmo)
-         CALL cp_fm_set_submatrix(dst_real, dst_r)
-         CALL cp_fm_set_submatrix(dst_imag, dst_i)
-         DEALLOCATE (src_r, src_i, dst_r, dst_i)
-         success = .TRUE.
-         RETURN
-      END IF
-
-      IF (.NOT. ASSOCIATED(qs_kpoint%kp_sym)) THEN
-         reason = "SCF symmetry operation data are not available"
-         DEALLOCATE (src_r, src_i, dst_r, dst_i)
-         RETURN
-      END IF
-      kpsym => qs_kpoint%kp_sym(ikred)%kpoint_sym
-      IF (.NOT. ASSOCIATED(kpsym)) THEN
-         reason = "SCF k-point symmetry operation is not available"
-         DEALLOCATE (src_r, src_i, dst_r, dst_i)
-         RETURN
-      END IF
-      IF (isym > kpsym%nwred) THEN
-         reason = "SCF k-point symmetry operation index is out of range"
-         DEALLOCATE (src_r, src_i, dst_r, dst_i)
-         RETURN
-      END IF
-      IF (.NOT. ASSOCIATED(qs_kpoint%atype) .OR. .NOT. ASSOCIATED(qs_kpoint%kind_rotmat)) THEN
-         reason = "SCF atom mappings or basis rotation matrices are not available"
-         DEALLOCATE (src_r, src_i, dst_r, dst_i)
-         RETURN
-      END IF
-
-      rot_slot = find_wannier90_rotation_slot(qs_kpoint, kpsym%rotp(isym))
-      IF (rot_slot == 0) THEN
-         reason = "could not match the SCF symmetry operation to a basis rotation"
-         DEALLOCATE (src_r, src_i, dst_r, dst_i)
-         RETURN
-      END IF
-      kind_rot => qs_kpoint%kind_rotmat(rot_slot, :)
-      natom = SIZE(qs_kpoint%atype)
-      ALLOCATE (ao_start(natom), ao_size(natom))
-      irow = 1
-      DO iatom = 1, natom
-         ikind = qs_kpoint%atype(iatom)
-         IF (.NOT. ASSOCIATED(kind_rot(ikind)%rmat)) THEN
-            reason = "a required basis rotation matrix is not available"
-            DEALLOCATE (src_r, src_i, dst_r, dst_i, ao_start, ao_size)
-            RETURN
-         END IF
-         ao_start(iatom) = irow
-         ao_size(iatom) = SIZE(kind_rot(ikind)%rmat, 2)
-         irow = irow + ao_size(iatom)
-      END DO
-      IF (irow - 1 /= nao) THEN
-         reason = "atom-resolved AO dimensions do not match the MO coefficient matrix"
-         DEALLOCATE (src_r, src_i, dst_r, dst_i, ao_start, ao_size)
-         RETURN
-      END IF
-
-      time_reversal = kpsym%rotp(isym) < 0
-      reverse_phase = qs_kpoint%gamma_centered .AND. ANY(MOD(qs_kpoint%nkp_grid, 2) == 0)
-      xkp_phase(1:3) = kpsym%xkp(1:3, isym)
-      DO iatom = 1, natom
-         source_atom = iatom
-         target_atom = kpsym%f0(iatom, isym)
-         ikind = qs_kpoint%atype(source_atom)
-         rotmat => kind_rot(ikind)%rmat
-         source_dim = ao_size(source_atom)
-         target_dim = ao_size(target_atom)
-         IF (SIZE(rotmat, 1) /= target_dim .OR. SIZE(rotmat, 2) /= source_dim) THEN
-            reason = "basis rotation dimensions do not match the atom/AO symmetry transform"
-            DEALLOCATE (src_r, src_i, dst_r, dst_i, ao_start, ao_size)
-            RETURN
-         END IF
-         arg = REAL(kpsym%fcell(1, source_atom, isym), KIND=dp)*xkp_phase(1) + &
-               REAL(kpsym%fcell(2, source_atom, isym), KIND=dp)*xkp_phase(2) + &
-               REAL(kpsym%fcell(3, source_atom, isym), KIND=dp)*xkp_phase(3)
-         IF (ASSOCIATED(kpsym%kgphase)) THEN
-            arg = arg + kpsym%kgphase(source_atom, isym)
-         END IF
-         IF (reverse_phase) arg = -arg
-         coskl = COS(twopi*arg)
-         sinkl = SIN(twopi*arg)
-         DO imo = 1, nmo
-            DO irow_work = 1, source_dim
-               irow_source = ao_start(source_atom) + irow_work - 1
-               coeff_real = src_r(irow_source, imo)
-               coeff_imag = src_i(irow_source, imo)
-               IF (time_reversal) coeff_imag = -coeff_imag
-               phase_real = coskl*coeff_real - sinkl*coeff_imag
-               phase_imag = sinkl*coeff_real + coskl*coeff_imag
-               DO iao = 1, target_dim
-                  irow_target = ao_start(target_atom) + iao - 1
-                  dst_r(irow_target, imo) = dst_r(irow_target, imo) + &
-                                            rotmat(iao, irow_work)*phase_real
-                  dst_i(irow_target, imo) = dst_i(irow_target, imo) + &
-                                            rotmat(iao, irow_work)*phase_imag
-               END DO
-            END DO
-         END DO
-      END DO
-
-      CALL cp_fm_set_submatrix(dst_real, dst_r)
-      CALL cp_fm_set_submatrix(dst_imag, dst_i)
-      DEALLOCATE (src_r, src_i, dst_r, dst_i, ao_start, ao_size)
-      success = .TRUE.
-
-   END SUBROUTINE transform_wannier90_scf_mo
-
-! **************************************************************************************************
-!> \brief Locate the basis-rotation slot corresponding to a signed k-point symmetry operation.
-!> \param qs_kpoint SCF k-point object
-!> \param rotp signed operation identifier
-!> \return rotation slot, or zero when no slot matches
-! **************************************************************************************************
-   INTEGER FUNCTION find_wannier90_rotation_slot(qs_kpoint, rotp) RESULT(rot_slot)
-      TYPE(kpoint_type), POINTER                         :: qs_kpoint
-      INTEGER, INTENT(IN)                                :: rotp
-
-      INTEGER                                            :: irot, rot_abs
-
-      rot_slot = 0
-      rot_abs = ABS(rotp)
-      IF (.NOT. ASSOCIATED(qs_kpoint%ibrot)) RETURN
-      DO irot = 1, SIZE(qs_kpoint%ibrot)
-         IF (rot_abs == qs_kpoint%ibrot(irot)) THEN
-            rot_slot = irot
-            RETURN
-         END IF
-      END DO
-
-   END FUNCTION find_wannier90_rotation_slot
 
 ! **************************************************************************************************
 !> \brief Infer a tensor-product Wannier90 mesh from explicit fractional k-point coordinates.

--- a/src/qs_wannier90.F
+++ b/src/qs_wannier90.F
@@ -1173,8 +1173,7 @@ CONTAINS
                                                     kpsym%xkp(1:3, isym_try))) CYCLE
                      num_candidates = num_candidates + 1
                      CALL kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, &
-                                                  qs_kpoint, ikred, isym_try, para_env, ok, &
-                                                  candidate_reason)
+                                                  qs_kpoint, ikred, isym_try, ok, candidate_reason)
                      IF (.NOT. ok) THEN
                         reason = candidate_reason
                         CYCLE
@@ -1194,7 +1193,7 @@ CONTAINS
                         IF (source_window) THEN
                            CALL kpoint_transform_scf_mo(src_real_full, src_imag_full, &
                                                         dst_real_full, dst_imag_full, qs_kpoint, &
-                                                        ikred, isym_try, para_env, ok, candidate_reason)
+                                                        ikred, isym_try, ok, candidate_reason)
                            IF (ok) THEN
                               CALL ritz_reconstruct_wannier90_window(dst_real_full, dst_imag_full, &
                                                                      dst_real, dst_imag, matrix_s, &
@@ -1241,7 +1240,7 @@ CONTAINS
                END IF
             ELSE
                CALL kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, &
-                                            ikred, sym_index(ik), para_env, ok, reason)
+                                            ikred, sym_index(ik), ok, reason)
             END IF
             IF (ok .AND. sym_index(ik) <= 0) THEN
                ! Even a direct k-point copy must be a closed H(k),S(k) subspace. This catches
@@ -1254,7 +1253,7 @@ CONTAINS
                IF (.NOT. ok .AND. source_window) THEN
                   CALL kpoint_transform_scf_mo(src_real_full, src_imag_full, dst_real_full, &
                                                dst_imag_full, qs_kpoint, ikred, sym_index(ik), &
-                                               para_env, ok, reason)
+                                               ok, reason)
                   IF (ok) THEN
                      CALL ritz_reconstruct_wannier90_window(dst_real_full, dst_imag_full, dst_real, &
                                                             dst_imag, matrix_s, matrix_ks, &
@@ -1725,7 +1724,7 @@ CONTAINS
             best_svalue = 0.0_dp
             IF (sym_index(ik) <= 0) THEN
                CALL kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, qs_kpoint, &
-                                            ikred, sym_index(ik), para_env, ok, reason)
+                                            ikred, sym_index(ik), ok, reason)
                IF (ok) THEN
                   CALL measure_wannier90_subspace_error(ref_real, ref_imag, dst_real, dst_imag, matrix_s, &
                                                         kpoint%xkp(1:3, ik), cell_to_index, sab_nl, &
@@ -1760,7 +1759,7 @@ CONTAINS
                      IF (.NOT. kpoint_same_periodic(kpoint%xkp(1:3, ik), &
                                                     kpsym%xkp(1:3, isym_try))) CYCLE
                      CALL kpoint_transform_scf_mo(src_real, src_imag, dst_real, dst_imag, &
-                                                  qs_kpoint, ikred, isym_try, para_env, ok, reason)
+                                                  qs_kpoint, ikred, isym_try, ok, reason)
                      IF (.NOT. ok) CYCLE
                      CALL measure_wannier90_subspace_error(ref_real, ref_imag, dst_real, dst_imag, &
                                                            matrix_s, kpoint%xkp(1:3, ik), cell_to_index, &

--- a/src/qs_wf_history_methods.F
+++ b/src/qs_wf_history_methods.F
@@ -80,8 +80,11 @@ MODULE qs_wf_history_methods
                                               kpoint_density_transform,&
                                               kpoint_set_mo_occupation,&
                                               rskp_transform
+   USE kpoint_mo_symmetry_methods,      ONLY: kpoint_same_periodic,&
+                                              kpoint_transform_scf_mo
    USE kpoint_types,                    ONLY: get_kpoint_info,&
                                               kpoint_env_type,&
+                                              kpoint_sym_type,&
                                               kpoint_type
    USE mathconstants,                   ONLY: gaussi,&
                                               twopi,&
@@ -119,6 +122,7 @@ MODULE qs_wf_history_methods
                                               qs_scf_env_type
    USE qs_wf_history_types,             ONLY: qs_wf_history_type,&
                                               qs_wf_snapshot_type,&
+                                              wfi_clear,&
                                               wfi_get_snapshot,&
                                               wfi_release
    USE scf_control_types,               ONLY: scf_control_type
@@ -132,6 +136,7 @@ MODULE qs_wf_history_methods
 
    PUBLIC :: wfi_create, wfi_update, wfi_create_for_kp, &
              wfi_extrapolate, wfi_get_method_label, &
+             wfi_handle_kpoint_symmetry_refresh, &
              reorthogonalize_vectors, wfi_purge_history
 
 CONTAINS
@@ -733,7 +738,8 @@ CONTAINS
       INTEGER                                            :: actual_extrapolation_method_nr, handle, &
                                                             i, img, io_unit, ispin, k, n, nmo, &
                                                             nvec, print_level
-      LOGICAL                                            :: do_kpoints, my_orthogonal_wf, use_overlap
+      LOGICAL                                            :: do_kpoints, kp_prev_success, &
+                                                            my_orthogonal_wf, use_overlap
       REAL(KIND=dp)                                      :: alpha, t0, t1, t2
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: coeffs
       TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_mo_fm_pools
@@ -785,8 +791,6 @@ CONTAINS
          END IF
       END SELECT
 
-      IF (PRESENT(extrapolation_method_nr)) &
-         extrapolation_method_nr = actual_extrapolation_method_nr
       my_orthogonal_wf = .FALSE.
 
       SELECT CASE (actual_extrapolation_method_nr)
@@ -848,7 +852,12 @@ CONTAINS
          CALL wfi_set_history_variables(qs_env=qs_env, nvec=nvec)
 
          IF (do_kpoints) THEN
-            CALL wfi_use_prev_wf_kp(qs_env, io_unit, print_level)
+            kp_prev_success = .TRUE.
+            CALL wfi_use_prev_wf_kp(qs_env, io_unit, print_level, success=kp_prev_success)
+            IF (.NOT. kp_prev_success) THEN
+               actual_extrapolation_method_nr = wfi_use_guess_method_nr
+               my_orthogonal_wf = .FALSE.
+            END IF
          ELSE
             CALL qs_rho_get(rho, rho_ao=rho_ao)
             DO ispin = 1, SIZE(mos)
@@ -1342,11 +1351,181 @@ CONTAINS
                        "Unknown interpolation method: "// &
                        TRIM(ADJUSTL(cp_to_string(wf_history%interpolation_method_nr))))
       END SELECT
+      IF (PRESENT(extrapolation_method_nr)) &
+         extrapolation_method_nr = actual_extrapolation_method_nr
       IF (PRESENT(orthogonal_wf)) orthogonal_wf = my_orthogonal_wf
       CALL cp_print_key_finished_output(io_unit, logger, qs_env%input, &
                                         "DFT%SCF%PRINT%PROGRAM_RUN_INFO")
       CALL timestop(handle)
    END SUBROUTINE wfi_extrapolate
+
+! **************************************************************************************************
+!> \brief Decide whether k-point WFN history can survive a k-point symmetry refresh.
+!> \param wf_history wavefunction history
+!> \param kpoints refreshed k-point environment
+! **************************************************************************************************
+   SUBROUTINE wfi_handle_kpoint_symmetry_refresh(wf_history, kpoints)
+      TYPE(qs_wf_history_type), POINTER                  :: wf_history
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      TYPE(qs_wf_snapshot_type), POINTER                 :: snapshot
+
+      IF (.NOT. ASSOCIATED(wf_history)) RETURN
+      IF (wf_history%snapshot_count < 1) RETURN
+      IF (.NOT. wf_history%store_wf_kp) THEN
+         CALL wfi_clear(wf_history)
+         RETURN
+      END IF
+
+      snapshot => wfi_get_snapshot(wf_history, wf_index=1)
+      IF (.NOT. ASSOCIATED(snapshot%kp_xkp)) THEN
+         CALL wfi_clear(wf_history)
+         RETURN
+      END IF
+
+      IF (wfi_kp_snapshot_layout_matches(snapshot, kpoints)) RETURN
+
+      SELECT CASE (wf_history%interpolation_method_nr)
+      CASE (wfi_use_prev_wf_method_nr)
+         ! USE_PREV_WF only needs the latest WFN snapshot and can attempt a
+         ! symmetry remap later in wfi_use_prev_wf_kp.
+         RETURN
+      CASE DEFAULT
+         ! Higher-order extrapolation methods also need historical S(k) data in
+         ! a consistent representation; keep them conservative for now.
+         CALL wfi_clear(wf_history)
+      END SELECT
+
+   END SUBROUTINE wfi_handle_kpoint_symmetry_refresh
+
+! **************************************************************************************************
+!> \brief Check whether a saved local k-point snapshot layout matches the current one.
+!> \param snapshot latest WFN snapshot
+!> \param kpoints current k-point environment
+!> \return true if the local irreducible k-point layout is unchanged
+! **************************************************************************************************
+   LOGICAL FUNCTION wfi_kp_snapshot_layout_matches(snapshot, kpoints) RESULT(matches)
+      TYPE(qs_wf_snapshot_type), POINTER                 :: snapshot
+      TYPE(kpoint_type), POINTER                         :: kpoints
+
+      INTEGER                                            :: ik, ikp, kplocal, nkp
+      INTEGER, DIMENSION(2)                              :: kp_range
+      LOGICAL                                            :: use_real_wfn
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+
+      matches = .FALSE.
+      NULLIFY (xkp, wkp)
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, wkp=wkp, &
+                           use_real_wfn=use_real_wfn, kp_range=kp_range)
+
+      IF (snapshot%kp_nkp /= nkp) RETURN
+      IF (ANY(snapshot%kp_range /= kp_range)) RETURN
+      IF (snapshot%kp_use_real_wfn .NEQV. use_real_wfn) RETURN
+      IF (.NOT. ASSOCIATED(snapshot%kp_xkp)) RETURN
+      IF (.NOT. ASSOCIATED(snapshot%kp_wkp)) RETURN
+
+      kplocal = kp_range(2) - kp_range(1) + 1
+      IF (SIZE(snapshot%kp_xkp, 2) /= kplocal) RETURN
+      IF (SIZE(snapshot%kp_wkp) /= kplocal) RETURN
+
+      DO ikp = 1, kplocal
+         ik = kp_range(1) + ikp - 1
+         IF (.NOT. kpoint_same_periodic(snapshot%kp_xkp(1:3, ikp), xkp(1:3, ik))) RETURN
+         IF (ABS(snapshot%kp_wkp(ikp) - wkp(ik)) > 1.0E-10_dp) RETURN
+      END DO
+
+      matches = .TRUE.
+
+   END FUNCTION wfi_kp_snapshot_layout_matches
+
+! **************************************************************************************************
+!> \brief Find a local snapshot WFN that can be reused for the current k-point.
+!> \param snapshot latest WFN snapshot
+!> \param kpoints current k-point environment
+!> \param ik current global irreducible k-point index
+!> \param source_ikp local snapshot index of the source WFN
+!> \param source_isym symmetry operation mapping current k to the source k
+!> \param direct_copy true if no symmetry transform is required
+!> \param success true if a local source WFN was found
+! **************************************************************************************************
+   SUBROUTINE wfi_find_kp_snapshot_source(snapshot, kpoints, ik, source_ikp, source_isym, &
+                                          direct_copy, success)
+      TYPE(qs_wf_snapshot_type), POINTER                 :: snapshot
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER, INTENT(IN)                                :: ik
+      INTEGER, INTENT(OUT)                               :: source_ikp, source_isym
+      LOGICAL, INTENT(OUT)                               :: direct_copy, success
+
+      INTEGER                                            :: ikp_old, isym
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      TYPE(kpoint_sym_type), POINTER                     :: kpsym
+
+      source_ikp = 0
+      source_isym = 0
+      direct_copy = .FALSE.
+      success = .FALSE.
+      NULLIFY (xkp, kpsym)
+
+      IF (.NOT. ASSOCIATED(snapshot%kp_xkp)) RETURN
+      CALL get_kpoint_info(kpoints, xkp=xkp)
+
+      DO ikp_old = 1, SIZE(snapshot%kp_xkp, 2)
+         IF (kpoint_same_periodic(snapshot%kp_xkp(1:3, ikp_old), xkp(1:3, ik))) THEN
+            source_ikp = ikp_old
+            direct_copy = .TRUE.
+            success = .TRUE.
+            RETURN
+         END IF
+      END DO
+
+      IF (.NOT. ASSOCIATED(kpoints%kp_sym)) RETURN
+      kpsym => kpoints%kp_sym(ik)%kpoint_sym
+      IF (.NOT. ASSOCIATED(kpsym)) RETURN
+      IF (.NOT. ASSOCIATED(kpsym%xkp)) RETURN
+
+      DO isym = 1, kpsym%nwred
+         DO ikp_old = 1, SIZE(snapshot%kp_xkp, 2)
+            IF (kpoint_same_periodic(snapshot%kp_xkp(1:3, ikp_old), kpsym%xkp(1:3, isym))) THEN
+               source_ikp = ikp_old
+               source_isym = isym
+               direct_copy = .FALSE.
+               success = .TRUE.
+               RETURN
+            END IF
+         END DO
+      END DO
+
+   END SUBROUTINE wfi_find_kp_snapshot_source
+
+! **************************************************************************************************
+!> \brief Check whether the current local k-point set uses atomic symmetry expansion.
+!> \param kpoints current k-point environment
+!> \param kp_range local global k-point range
+!> \return true if any local k-point applies atomic k-point symmetry
+! **************************************************************************************************
+   LOGICAL FUNCTION wfi_kp_uses_atomic_symmetry(kpoints, kp_range) RESULT(uses_symmetry)
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER, DIMENSION(2), INTENT(IN)                  :: kp_range
+
+      INTEGER                                            :: ik
+      TYPE(kpoint_sym_type), POINTER                     :: kpsym
+
+      uses_symmetry = .FALSE.
+      IF (.NOT. ASSOCIATED(kpoints%kp_sym)) RETURN
+
+      DO ik = kp_range(1), kp_range(2)
+         NULLIFY (kpsym)
+         kpsym => kpoints%kp_sym(ik)%kpoint_sym
+         IF (ASSOCIATED(kpsym)) THEN
+            IF (kpsym%apply_symmetry) THEN
+               uses_symmetry = .TRUE.
+               RETURN
+            END IF
+         END IF
+      END DO
+
+   END FUNCTION wfi_kp_uses_atomic_symmetry
 
 ! **************************************************************************************************
 !> \brief Reorthogonalizes the wavefunctions from the previous step for k-points
@@ -1356,27 +1535,33 @@ CONTAINS
 !> \param print_level print level
 !> \param pbc_shift_ref ...
 !> \param load_snapshot_wf ...
+!> \param success ...
 ! **************************************************************************************************
-   SUBROUTINE wfi_use_prev_wf_kp(qs_env, io_unit, print_level, pbc_shift_ref, load_snapshot_wf)
+   SUBROUTINE wfi_use_prev_wf_kp(qs_env, io_unit, print_level, pbc_shift_ref, load_snapshot_wf, &
+                                 success)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: io_unit, print_level
       INTEGER, DIMENSION(:, :), INTENT(IN), OPTIONAL     :: pbc_shift_ref
       LOGICAL, INTENT(IN), OPTIONAL                      :: load_snapshot_wf
+      LOGICAL, INTENT(OUT), OPTIONAL                     :: success
 
       CHARACTER(len=*), PARAMETER :: routineN = 'wfi_use_prev_wf_kp'
 
+      CHARACTER(LEN=256)                                 :: remap_reason
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: col_scaling
-      INTEGER                                            :: chol_info, handle, igroup, ik, ikp, &
-                                                            indx, ispin, j, kplocal, nao, nkp, &
-                                                            nkp_groups, nmo, nspin
+      INTEGER :: chol_info, direct_count, handle, igroup, ik, ikp, indx, ispin, j, kplocal, nao, &
+         nkp, nkp_groups, nmo, nops_tried, nspin, sym_count
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: source_ikp, source_isym
       INTEGER, ALLOCATABLE, DIMENSION(:, :)              :: pbc_shift_cur, pbc_shift_src
       INTEGER, DIMENSION(2)                              :: kp_range
       INTEGER, DIMENSION(:, :), POINTER                  :: kp_dist
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
-      LOGICAL                                            :: my_kpgrp, reload_snapshot_wf, &
-                                                            use_pbc_phase_ref, use_real_wfn
+      LOGICAL :: atomic_kp_symmetry, my_kpgrp, pbc_shift_changed, prev_wf_success, &
+         reload_snapshot_wf, source_found, use_pbc_phase_ref, use_real_wfn
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: direct_source
       REAL(KIND=dp)                                      :: eval_thresh
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eigenvalues
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
       TYPE(copy_info_type), ALLOCATABLE, DIMENSION(:, :) :: info
       TYPE(cp_cfm_type)                                  :: cfm_evecs, cfm_mhalf, cfm_nao_nmo_work, &
@@ -1402,19 +1587,21 @@ CONTAINS
       TYPE(scf_control_type), POINTER                    :: scf_control
 
       CALL timeset(routineN, handle)
+      IF (PRESENT(success)) success = .FALSE.
 
       NULLIFY (kpoints, dft_control, matrix_s_kp, scf_env, scf_control, rho, sab_nl, kp, &
-               mo_coeff, rmos, imos, wf_history, t1_state)
+               mo_coeff, rmos, imos, wf_history, t1_state, xkp, wkp, kp_dist, cell_to_index)
 
       CALL get_qs_env(qs_env, kpoints=kpoints, dft_control=dft_control, &
                       matrix_s_kp=matrix_s_kp, scf_env=scf_env, &
                       scf_control=scf_control, rho=rho)
-      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, use_real_wfn=use_real_wfn, &
+      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, wkp=wkp, use_real_wfn=use_real_wfn, &
                            kp_range=kp_range, nkp_groups=nkp_groups, kp_dist=kp_dist, &
                            sab_nl=sab_nl, cell_to_index=cell_to_index)
       kplocal = kp_range(2) - kp_range(1) + 1
 
       IF (use_real_wfn) THEN
+         IF (PRESENT(success)) success = .TRUE.
          CALL timestop(handle)
          RETURN
       END IF
@@ -1441,6 +1628,145 @@ CONTAINS
          END IF
       END IF
       IF (use_pbc_phase_ref) CALL wfi_compute_kp_pbc_shift(qs_env, pbc_shift_cur)
+      pbc_shift_changed = .FALSE.
+      atomic_kp_symmetry = wfi_kp_uses_atomic_symmetry(kpoints, kp_range)
+
+      IF (reload_snapshot_wf) THEN
+         remap_reason = ""
+         IF (.NOT. ASSOCIATED(t1_state)) THEN
+            remap_reason = "no WFN snapshot is available"
+         ELSE IF (.NOT. ASSOCIATED(t1_state%wf_kp)) THEN
+            remap_reason = "the WFN snapshot does not contain k-point MOs"
+         ELSE IF (.NOT. ASSOCIATED(t1_state%kp_xkp)) THEN
+            remap_reason = "the WFN snapshot does not contain k-point coordinates"
+         ELSE IF (.NOT. ASSOCIATED(t1_state%kp_wkp)) THEN
+            remap_reason = "the WFN snapshot does not contain k-point weights"
+         ELSE IF (t1_state%kp_nkp /= nkp) THEN
+            WRITE (remap_reason, "(A,I0,A,I0)") &
+               "the number of irreducible k-points changed from ", t1_state%kp_nkp, " to ", nkp
+         ELSE IF (t1_state%kp_use_real_wfn .NEQV. use_real_wfn) THEN
+            remap_reason = "the real/complex k-point WFN representation changed"
+         END IF
+         IF (LEN_TRIM(remap_reason) > 0) THEN
+            IF ((io_unit > 0) .AND. (print_level >= low_print_level)) THEN
+               WRITE (UNIT=io_unit, FMT="(/,T2,A)") &
+                  "K-point USE_PREV_WF rejected after symmetry refresh:"
+               WRITE (UNIT=io_unit, FMT="(T3,A)") TRIM(remap_reason)
+               WRITE (UNIT=io_unit, FMT="(T3,A,I0,A,2I8)") &
+                  "current nkp=", nkp, ", current kp_range=", kp_range
+               IF (ASSOCIATED(t1_state)) THEN
+                  WRITE (UNIT=io_unit, FMT="(T3,A,I0,A,2I8)") &
+                     "snapshot nkp=", t1_state%kp_nkp, ", snapshot kp_range=", t1_state%kp_range
+               END IF
+            END IF
+            IF (ALLOCATED(pbc_shift_cur)) DEALLOCATE (pbc_shift_cur)
+            IF (ALLOCATED(pbc_shift_src)) DEALLOCATE (pbc_shift_src)
+            CALL timestop(handle)
+            RETURN
+         END IF
+
+         ALLOCATE (source_ikp(kplocal), source_isym(kplocal), direct_source(kplocal))
+         direct_count = 0
+         sym_count = 0
+         DO ikp = 1, kplocal
+            ik = kp_range(1) + ikp - 1
+            CALL wfi_find_kp_snapshot_source(t1_state, kpoints, ik, source_ikp(ikp), &
+                                             source_isym(ikp), direct_source(ikp), source_found)
+            IF (.NOT. source_found) THEN
+               WRITE (remap_reason, "(A,I0)") &
+                  "no local snapshot source was found for current k-point ", ik
+               IF ((io_unit > 0) .AND. (print_level >= low_print_level)) THEN
+                  WRITE (UNIT=io_unit, FMT="(/,T2,A)") &
+                     "K-point USE_PREV_WF rejected after symmetry refresh:"
+                  WRITE (UNIT=io_unit, FMT="(T3,A)") TRIM(remap_reason)
+                  WRITE (UNIT=io_unit, FMT="(T3,A,3F16.10)") "current k-point: ", xkp(1:3, ik)
+                  nops_tried = 0
+                  IF (ASSOCIATED(kpoints%kp_sym)) THEN
+                     IF (ASSOCIATED(kpoints%kp_sym(ik)%kpoint_sym)) &
+                        nops_tried = kpoints%kp_sym(ik)%kpoint_sym%nwred
+                  END IF
+                  WRITE (UNIT=io_unit, FMT="(T3,A,I0,A,I0)") &
+                     "local snapshot k-points=", SIZE(t1_state%kp_xkp, 2), &
+                     ", symmetry operations tried=", nops_tried
+               END IF
+               IF (ALLOCATED(pbc_shift_cur)) DEALLOCATE (pbc_shift_cur)
+               IF (ALLOCATED(pbc_shift_src)) DEALLOCATE (pbc_shift_src)
+               DEALLOCATE (source_ikp, source_isym, direct_source)
+               CALL timestop(handle)
+               RETURN
+            END IF
+            IF (source_ikp(ikp) < 1 .OR. source_ikp(ikp) > SIZE(t1_state%kp_xkp, 2)) THEN
+               WRITE (remap_reason, "(A,I0,A,I0)") &
+                  "invalid local snapshot source index ", source_ikp(ikp), " for current k-point ", ik
+            ELSE IF (ABS(t1_state%kp_wkp(source_ikp(ikp)) - wkp(ik)) > 1.0E-10_dp) THEN
+               WRITE (remap_reason, "(A,I0,A,ES16.8,A,ES16.8)") &
+                  "k-point weight mismatch for current k-point ", ik, &
+                  ": snapshot=", t1_state%kp_wkp(source_ikp(ikp)), ", current=", wkp(ik)
+            ELSE IF ((.NOT. direct_source(ikp)) .AND. source_isym(ikp) <= 0) THEN
+               WRITE (remap_reason, "(A,I0)") &
+                  "invalid symmetry remap operation for current k-point ", ik
+            ELSE
+               remap_reason = ""
+            END IF
+            IF (LEN_TRIM(remap_reason) > 0) THEN
+               IF ((io_unit > 0) .AND. (print_level >= low_print_level)) THEN
+                  WRITE (UNIT=io_unit, FMT="(/,T2,A)") &
+                     "K-point USE_PREV_WF rejected after symmetry refresh:"
+                  WRITE (UNIT=io_unit, FMT="(T3,A)") TRIM(remap_reason)
+                  WRITE (UNIT=io_unit, FMT="(T3,A,I0,A,L1,A,I0)") &
+                     "source_ikp=", source_ikp(ikp), ", direct=", direct_source(ikp), &
+                     ", source_isym=", source_isym(ikp)
+               END IF
+               IF (ALLOCATED(pbc_shift_cur)) DEALLOCATE (pbc_shift_cur)
+               IF (ALLOCATED(pbc_shift_src)) DEALLOCATE (pbc_shift_src)
+               DEALLOCATE (source_ikp, source_isym, direct_source)
+               CALL timestop(handle)
+               RETURN
+            END IF
+            IF (direct_source(ikp)) THEN
+               direct_count = direct_count + 1
+            ELSE
+               sym_count = sym_count + 1
+            END IF
+         END DO
+         IF (ALLOCATED(pbc_shift_cur)) THEN
+            IF (SIZE(pbc_shift_cur, 2) /= SIZE(pbc_shift_src, 2)) THEN
+               remap_reason = "the PBC image shift arrays have incompatible sizes"
+            ELSE
+               pbc_shift_changed = ANY(pbc_shift_cur /= pbc_shift_src)
+               IF (atomic_kp_symmetry .AND. pbc_shift_changed) THEN
+                  remap_reason = &
+                     "changed PBC image shifts with atomic k-point symmetry are disabled"
+               ELSE IF (ANY(.NOT. direct_source) .AND. pbc_shift_changed) THEN
+                  remap_reason = "symmetry remap together with changed PBC image shifts is disabled"
+               ELSE
+                  remap_reason = ""
+               END IF
+            END IF
+            IF (LEN_TRIM(remap_reason) > 0) THEN
+               IF ((io_unit > 0) .AND. (print_level >= low_print_level)) THEN
+                  WRITE (UNIT=io_unit, FMT="(/,T2,A)") &
+                     "K-point USE_PREV_WF rejected after symmetry refresh:"
+                  WRITE (UNIT=io_unit, FMT="(T3,A)") TRIM(remap_reason)
+                  WRITE (UNIT=io_unit, FMT="(T3,A,I0,A,I0)") &
+                     "direct sources=", direct_count, ", symmetry remaps=", sym_count
+                  WRITE (UNIT=io_unit, FMT="(T3,A,L1,A,L1)") &
+                     "atomic k-point symmetry=", atomic_kp_symmetry, &
+                     ", changed PBC image shifts=", pbc_shift_changed
+               END IF
+               DEALLOCATE (pbc_shift_cur, pbc_shift_src, source_ikp, source_isym, direct_source)
+               CALL timestop(handle)
+               RETURN
+            END IF
+         END IF
+         IF ((io_unit > 0) .AND. (print_level > low_print_level)) THEN
+            WRITE (UNIT=io_unit, FMT="(T3,A,I0,A,I0,A,L1,A,L1)") &
+               "K-point USE_PREV_WF sources: direct=", direct_count, &
+               ", symmetry remaps=", sym_count, &
+               ", atomic symmetry=", atomic_kp_symmetry, &
+               ", PBC shift changed=", pbc_shift_changed
+         END IF
+      END IF
 
       kp => kpoints%kp_env(1)%kpoint_env
       nspin = SIZE(kp%mos, 2)
@@ -1533,15 +1859,34 @@ CONTAINS
       ! the current convention, then orthogonalize it with respect to S(k).
       ALLOCATE (eigenvalues(nmo))
       eval_thresh = 1.0E-12_dp
+      prev_wf_success = .TRUE.
 
       DO ikp = 1, kplocal
          kp => kpoints%kp_env(ikp)%kpoint_env
+         ik = kp_range(1) + ikp - 1
          DO ispin = 1, nspin
             CALL get_mo_set(kp%mos(1, ispin), mo_coeff=rmos)
             CALL get_mo_set(kp%mos(2, ispin), mo_coeff=imos)
             IF (reload_snapshot_wf) THEN
-               CALL cp_fm_to_fm(t1_state%wf_kp(ikp, 1, ispin), rmos)
-               CALL cp_fm_to_fm(t1_state%wf_kp(ikp, 2, ispin), imos)
+               IF (direct_source(ikp)) THEN
+                  CALL kpoint_transform_scf_mo(t1_state%wf_kp(source_ikp(ikp), 1, ispin), &
+                                               t1_state%wf_kp(source_ikp(ikp), 2, ispin), &
+                                               rmos, imos, kpoints, ik, 0, &
+                                               para_env, source_found, remap_reason)
+                  IF (.NOT. source_found) THEN
+                     prev_wf_success = .FALSE.
+                     EXIT
+                  END IF
+               ELSE
+                  CALL kpoint_transform_scf_mo(t1_state%wf_kp(source_ikp(ikp), 1, ispin), &
+                                               t1_state%wf_kp(source_ikp(ikp), 2, ispin), &
+                                               rmos, imos, kpoints, ik, source_isym(ikp), &
+                                               para_env, source_found, remap_reason, inverse=.TRUE.)
+                  IF (.NOT. source_found) THEN
+                     prev_wf_success = .FALSE.
+                     EXIT
+                  END IF
+               END IF
             END IF
             IF (use_pbc_phase_ref) THEN
                ik = kp_range(1) + ikp - 1
@@ -1582,8 +1927,18 @@ CONTAINS
             END IF
             CALL cp_cfm_to_fm(cmos_new, rmos, imos)
          END DO
+         IF (.NOT. prev_wf_success) EXIT
       END DO
       DEALLOCATE (eigenvalues)
+
+      IF (.NOT. prev_wf_success) THEN
+         IF ((io_unit > 0) .AND. (print_level >= low_print_level)) THEN
+            WRITE (UNIT=io_unit, FMT="(/,T2,A)") &
+               "K-point USE_PREV_WF rejected after symmetry refresh:"
+            WRITE (UNIT=io_unit, FMT="(T3,A)") TRIM(remap_reason)
+         END IF
+         GOTO 100
+      END IF
 
       ! Phase C: Rebuild Density Matrix P(R)
       CALL kpoint_set_mo_occupation(kpoints, scf_control%smear)
@@ -1593,6 +1948,8 @@ CONTAINS
                                     matrix_s_kp(1, 1)%matrix, sab_nl, scf_env%scf_work1)
       CALL qs_rho_update_rho(rho, qs_env=qs_env)
       CALL qs_ks_did_change(qs_env%ks_env, rho_changed=.TRUE.)
+
+100   CONTINUE
 
       ! Cleanup
       DO ikp = 1, kplocal
@@ -1609,6 +1966,10 @@ CONTAINS
       CALL dbcsr_deallocate_matrix(tmpmat)
       IF (ALLOCATED(pbc_shift_cur)) DEALLOCATE (pbc_shift_cur)
       IF (ALLOCATED(pbc_shift_src)) DEALLOCATE (pbc_shift_src)
+      IF (ALLOCATED(source_ikp)) DEALLOCATE (source_ikp)
+      IF (ALLOCATED(source_isym)) DEALLOCATE (source_isym)
+      IF (ALLOCATED(direct_source)) DEALLOCATE (direct_source)
+      IF (PRESENT(success)) success = prev_wf_success
 
       CALL timestop(handle)
    END SUBROUTINE wfi_use_prev_wf_kp
@@ -1877,6 +2238,7 @@ CONTAINS
 
       DO ikp = 1, kplocal
          kp => kpoints%kp_env(ikp)%kpoint_env
+         ik = kp_range(1) + ikp - 1
          DO ispin = 1, nspin
             CALL get_mo_set(kp%mos(1, ispin), mo_coeff=rmos)
             CALL get_mo_set(kp%mos(2, ispin), mo_coeff=imos)
@@ -2130,6 +2492,7 @@ CONTAINS
       t1_state => wfi_get_snapshot(wf_history, wf_index=1)
       DO ikp = 1, kplocal
          kp => kpoints%kp_env(ikp)%kpoint_env
+         ik = kp_range(1) + ikp - 1
          DO ispin = 1, nspin
             CALL get_mo_set(kp%mos(1, ispin), mo_coeff=rmos)
             CALL get_mo_set(kp%mos(2, ispin), mo_coeff=imos)

--- a/src/qs_wf_history_methods.F
+++ b/src/qs_wf_history_methods.F
@@ -1872,7 +1872,7 @@ CONTAINS
                   CALL kpoint_transform_scf_mo(t1_state%wf_kp(source_ikp(ikp), 1, ispin), &
                                                t1_state%wf_kp(source_ikp(ikp), 2, ispin), &
                                                rmos, imos, kpoints, ik, 0, &
-                                               para_env, source_found, remap_reason)
+                                               source_found, remap_reason)
                   IF (.NOT. source_found) THEN
                      prev_wf_success = .FALSE.
                      EXIT
@@ -1881,7 +1881,7 @@ CONTAINS
                   CALL kpoint_transform_scf_mo(t1_state%wf_kp(source_ikp(ikp), 1, ispin), &
                                                t1_state%wf_kp(source_ikp(ikp), 2, ispin), &
                                                rmos, imos, kpoints, ik, source_isym(ikp), &
-                                               para_env, source_found, remap_reason, inverse=.TRUE.)
+                                               source_found, remap_reason, inverse=.TRUE.)
                   IF (.NOT. source_found) THEN
                      prev_wf_success = .FALSE.
                      EXIT

--- a/src/qs_wf_history_methods.F
+++ b/src/qs_wf_history_methods.F
@@ -150,8 +150,12 @@ CONTAINS
       NULLIFY (snapshot%wf, snapshot%rho_r, &
                snapshot%rho_g, snapshot%rho_ao, snapshot%rho_ao_kp, &
                snapshot%overlap, snapshot%wf_kp, snapshot%overlap_cfm_kp, &
-               snapshot%kp_pbc_shift, snapshot%rho_frozen)
+               snapshot%kp_xkp, snapshot%kp_wkp, snapshot%kp_pbc_shift, &
+               snapshot%rho_frozen)
       snapshot%dt = 1.0_dp
+      snapshot%kp_range = 0
+      snapshot%kp_nkp = 0
+      snapshot%kp_use_real_wfn = .FALSE.
    END SUBROUTINE wfs_create
 
 ! **************************************************************************************************
@@ -179,7 +183,8 @@ CONTAINS
       INTEGER, DIMENSION(2)                              :: kp_range
       INTEGER, DIMENSION(:, :), POINTER                  :: kp_dist
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
-      LOGICAL                                            :: my_kpgrp
+      LOGICAL                                            :: my_kpgrp, use_real_wfn
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
       TYPE(cell_type), POINTER                           :: cell
       TYPE(copy_info_type), ALLOCATABLE, DIMENSION(:, :) :: info_ft
@@ -210,7 +215,7 @@ CONTAINS
 
       NULLIFY (pw_env, auxbas_pw_pool, ao_mo_pools, ao_ao_fm_pools, dft_control, mos, mo_coeff, &
                rho, rho_r, rho_g, rho_ao, matrix_s, matrix_s_kp, kpoints, kp, cell, &
-               particle_set, kp_dist, cell_to_index, xkp, sab_nl, scf_env, mpools_kp, para_env_ft, &
+               particle_set, kp_dist, cell_to_index, wkp, xkp, sab_nl, scf_env, mpools_kp, para_env_ft, &
                rmat_ft, cmat_ft, tmpmat_ft, ao_ao_struct_ft)
       CALL get_qs_env(qs_env, pw_env=pw_env, &
                       dft_control=dft_control, rho=rho, cell=cell, particle_set=particle_set)
@@ -332,10 +337,24 @@ CONTAINS
          IF (ASSOCIATED(kpoints%kp_env)) THEN
             ! --- k-point WFN snapshot: store complex MO coefficients per local k-point ---
             IF (wf_history%store_wf_kp) THEN
-               CALL get_kpoint_info(kpoints, kp_range=kp_range)
+               CALL get_kpoint_info(kpoints, nkp=nkp_all, xkp=xkp, wkp=wkp, &
+                                    use_real_wfn=use_real_wfn, kp_range=kp_range)
                kplocal = kp_range(2) - kp_range(1) + 1
                nspin_kp = SIZE(kpoints%kp_env(1)%kpoint_env%mos, 2)
                nc = SIZE(kpoints%kp_env(1)%kpoint_env%mos, 1) ! 2=complex, 1=real
+
+               snapshot%kp_nkp = nkp_all
+               snapshot%kp_range(:) = kp_range(:)
+               snapshot%kp_use_real_wfn = use_real_wfn
+               IF (ASSOCIATED(snapshot%kp_xkp)) DEALLOCATE (snapshot%kp_xkp)
+               IF (ASSOCIATED(snapshot%kp_wkp)) DEALLOCATE (snapshot%kp_wkp)
+               ALLOCATE (snapshot%kp_xkp(3, kplocal))
+               ALLOCATE (snapshot%kp_wkp(kplocal))
+               DO ikp = 1, kplocal
+                  ik = kp_range(1) + ikp - 1
+                  snapshot%kp_xkp(:, ikp) = xkp(:, ik)
+                  snapshot%kp_wkp(ikp) = wkp(ik)
+               END DO
 
                CALL wfi_store_kp_pbc_shift(snapshot, cell, particle_set)
 

--- a/src/qs_wf_history_types.F
+++ b/src/qs_wf_history_types.F
@@ -66,9 +66,14 @@ MODULE qs_wf_history_types
       TYPE(dbcsr_type), POINTER :: overlap => NULL()
       TYPE(cp_fm_type), DIMENSION(:, :, :), POINTER :: wf_kp => NULL()
       TYPE(cp_cfm_type), DIMENSION(:), POINTER :: overlap_cfm_kp => NULL()
+      REAL(KIND=dp), DIMENSION(:, :), POINTER :: kp_xkp => NULL()
+      REAL(KIND=dp), DIMENSION(:), POINTER :: kp_wkp => NULL()
       INTEGER, DIMENSION(:, :), POINTER :: kp_pbc_shift => NULL()
       TYPE(qs_rho_type), POINTER :: rho_frozen => NULL()
       REAL(KIND=dp) :: dt = 0.0_dp
+      INTEGER, DIMENSION(2) :: kp_range = 0
+      INTEGER :: kp_nkp = 0
+      LOGICAL :: kp_use_real_wfn = .FALSE.
    END TYPE qs_wf_snapshot_type
 
 ! **************************************************************************************************
@@ -161,6 +166,12 @@ CONTAINS
             CALL cp_cfm_release(snapshot%overlap_cfm_kp(i))
          END DO
          DEALLOCATE (snapshot%overlap_cfm_kp)
+      END IF
+      IF (ASSOCIATED(snapshot%kp_xkp)) THEN
+         DEALLOCATE (snapshot%kp_xkp)
+      END IF
+      IF (ASSOCIATED(snapshot%kp_wkp)) THEN
+         DEALLOCATE (snapshot%kp_wkp)
       END IF
       IF (ASSOCIATED(snapshot%kp_pbc_shift)) THEN
          DEALLOCATE (snapshot%kp_pbc_shift)


### PR DESCRIPTION
Dynamic full k-point symmetry refresh currently clears the WFN history unconditionally. This makes USE_PREV_WF fall back to USE_GUESS at every geometry/cell step when atomic k-point symmetry is active.

This PR keeps the previous k-point WFN snapshot only when it can be safely reused. For `USE_PREV_WF`, the snapshot k-points are matched against the current irreducible k-point layout, and the previous WFN is reloaded when the representation is compatible. If compatibility checks fail, the code falls back to the initial guess. Higher-order extrapolation methods such as `ASPC`/`PS` are kept conservative and still require an unchanged k-point layout.

An independent issue is found when try further dealing with the extrapolation: full atomic k-point symmetry with changed PBC image conventions can already produce an incorrect density even with `USE_GUESS`. In such cases `USE_PREV_WF` is conservatively rejected. This is planned to be resolved in a seperated PR in the near future.