### PR TITLE
Avoid tblite TDDFPT OECORR COULOMB neighborlist crash

### DIFF
--- a/src/qs_tddfpt2_utils.F
+++ b/src/qs_tddfpt2_utils.F
@@ -73,6 +73,7 @@ MODULE qs_tddfpt2_utils
    USE util,                            ONLY: sort
    USE xc_pot_saop,                     ONLY: add_saop_pot
    USE xtb_ks_matrix,                   ONLY: build_xtb_ks_matrix
+   USE qs_neighbor_lists,               ONLY: build_qs_neighbor_lists  
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -635,6 +636,8 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: hfx_section, xc_fun_empty, &
                                                             xc_fun_original
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
+      TYPE(mp_para_env_type), POINTER                    :: para_env  
+
 
       CALL timeset(routineN, handle)
 
@@ -688,6 +691,8 @@ CONTAINS
          ELSEIF (dft_control%qs_control%dftb) THEN
             CPABORT("TDDFPT with DFTB not possible")
          ELSEIF (dft_control%qs_control%xtb) THEN
+            CALL get_qs_env(qs_env=qs_env, para_env=para_env)                
+            CALL build_qs_neighbor_lists(qs_env, para_env, molecular=.FALSE., force_env_section=qs_env%input) 
             CALL build_xtb_ks_matrix(qs_env, calculate_forces=.FALSE., just_energy=.FALSE., &
                                      ext_ks_matrix=matrix_ks_oep)
          ELSE

--- a/src/qs_tddfpt2_utils.F
+++ b/src/qs_tddfpt2_utils.F
@@ -70,10 +70,10 @@ MODULE qs_tddfpt2_utils
    USE qs_scf_types,                    ONLY: ot_method_nr,&
                                               qs_scf_env_type
    USE qs_tddfpt2_types,                ONLY: tddfpt_ground_state_mos
+   USE tblite_ks_matrix,                ONLY: build_tblite_ks_matrix
    USE util,                            ONLY: sort
    USE xc_pot_saop,                     ONLY: add_saop_pot
    USE xtb_ks_matrix,                   ONLY: build_xtb_ks_matrix
-   USE qs_neighbor_lists,               ONLY: build_qs_neighbor_lists  
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -636,8 +636,6 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: hfx_section, xc_fun_empty, &
                                                             xc_fun_original
       TYPE(tddfpt2_control_type), POINTER                :: tddfpt_control
-      TYPE(mp_para_env_type), POINTER                    :: para_env  
-
 
       CALL timeset(routineN, handle)
 
@@ -691,10 +689,13 @@ CONTAINS
          ELSEIF (dft_control%qs_control%dftb) THEN
             CPABORT("TDDFPT with DFTB not possible")
          ELSEIF (dft_control%qs_control%xtb) THEN
-            CALL get_qs_env(qs_env=qs_env, para_env=para_env)                
-            CALL build_qs_neighbor_lists(qs_env, para_env, molecular=.FALSE., force_env_section=qs_env%input) 
-            CALL build_xtb_ks_matrix(qs_env, calculate_forces=.FALSE., just_energy=.FALSE., &
-                                     ext_ks_matrix=matrix_ks_oep)
+            IF (dft_control%qs_control%xtb_control%do_tblite) THEN
+               CALL build_tblite_ks_matrix(qs_env, calculate_forces=.FALSE., just_energy=.FALSE., &
+                                           ext_ks_matrix=matrix_ks_oep)
+            ELSE
+               CALL build_xtb_ks_matrix(qs_env, calculate_forces=.FALSE., just_energy=.FALSE., &
+                                        ext_ks_matrix=matrix_ks_oep)
+            END IF
          ELSE
             CALL qs_ks_build_kohn_sham_matrix(qs_env, calculate_forces=.FALSE., just_energy=.FALSE., &
                                               ext_ks_matrix=matrix_ks_oep)

--- a/src/xtb_coulomb.F
+++ b/src/xtb_coulomb.F
@@ -202,7 +202,7 @@ CONTAINS
       kg = xtb_control%kg
       NULLIFY (n_list)
       CALL get_qs_env(qs_env=qs_env, sab_xtbe=n_list)
-      IF (.NOT. ASSOCIATED(n_list)) THEN                        
+      IF (.NOT. ASSOCIATED(n_list)) THEN
          CPABORT("sab_xtbe neighbor list is not associated in build_xtb_coulomb")
       END IF
       CALL neighbor_list_iterator_create(nl_iterator, n_list)

--- a/src/xtb_coulomb.F
+++ b/src/xtb_coulomb.F
@@ -202,6 +202,9 @@ CONTAINS
       kg = xtb_control%kg
       NULLIFY (n_list)
       CALL get_qs_env(qs_env=qs_env, sab_xtbe=n_list)
+      IF (.NOT. ASSOCIATED(n_list)) THEN                        
+         CPABORT("sab_xtbe neighbor list is not associated in build_xtb_coulomb")
+      END IF
       CALL neighbor_list_iterator_create(nl_iterator, n_list)
       DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
          CALL get_iterator_info(nl_iterator, ikind=ikind, jkind=jkind, &

--- a/src/xtb_ks_matrix.F
+++ b/src/xtb_ks_matrix.F
@@ -374,11 +374,12 @@ CONTAINS
             mcharge(iatom) = SUM(charges(iatom, :))
          END DO
       END IF
-
-      IF (dft_control%qs_control%xtb_control%coulomb_interaction) THEN
-         CALL build_xtb_coulomb(qs_env, ks_matrix, rho, charges, mcharge, energy, &
+      
+       IF (dft_control%qs_control%xtb_control%coulomb_interaction .AND. &               
+           (.NOT. dft_control%qs_control%xtb_control%do_tblite)) THEN
+          CALL build_xtb_coulomb(qs_env, ks_matrix, rho, charges, mcharge, energy, &
                                 calculate_forces, just_energy)
-      END IF
+       END IF                                                                           
 
       IF (do_efield) THEN
          CALL efield_tb_matrix(qs_env, ks_matrix, rho, mcharge, energy, calculate_forces, just_energy)

--- a/src/xtb_ks_matrix.F
+++ b/src/xtb_ks_matrix.F
@@ -374,12 +374,11 @@ CONTAINS
             mcharge(iatom) = SUM(charges(iatom, :))
          END DO
       END IF
-      
-       IF (dft_control%qs_control%xtb_control%coulomb_interaction .AND. &               
-           (.NOT. dft_control%qs_control%xtb_control%do_tblite)) THEN
-          CALL build_xtb_coulomb(qs_env, ks_matrix, rho, charges, mcharge, energy, &
+      IF (dft_control%qs_control%xtb_control%coulomb_interaction .AND. &
+          (.NOT. dft_control%qs_control%xtb_control%do_tblite)) THEN
+         CALL build_xtb_coulomb(qs_env, ks_matrix, rho, charges, mcharge, energy, &
                                 calculate_forces, just_energy)
-       END IF                                                                           
+      END IF
 
       IF (do_efield) THEN
          CALL efield_tb_matrix(qs_env, ks_matrix, rho, mcharge, energy, calculate_forces, just_energy)

--- a/tests/xTB/regtest-stda/TEST_FILES.toml
+++ b/tests/xTB/regtest-stda/TEST_FILES.toml
@@ -6,4 +6,5 @@
 #
 "water_xTB.inp"                         = [{matcher="TDDFPT_Check_Energy", tol=2.0E-05, ref=0.125917E+00}]
 "water_xTB_2.inp"                       = [{matcher="TDDFPT_Check_Energy", tol=2.0E-05, ref=0.186821E+00}]
+"ch2o_tblite_oecorr.inp"                = []
 #EOF

--- a/tests/xTB/regtest-stda/ch2o_tblite_oecorr.inp
+++ b/tests/xTB/regtest-stda/ch2o_tblite_oecorr.inp
@@ -1,0 +1,55 @@
+&GLOBAL
+  PRINT_LEVEL LOW
+  PROJECT ch2o_tblite_oecorr
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    &QS
+      METHOD xTB
+      &XTB
+        GFN_TYPE TBLITE
+        &TBLITE
+          METHOD GFN1
+        &END TBLITE
+      &END XTB
+    &END QS
+    &SCF
+      EPS_SCF 1.e-8
+      MAX_SCF 100
+      SCF_GUESS MOPAC
+      &MIXING
+        ALPHA 0.2
+        METHOD DIRECT_P_MIXING
+      &END MIXING
+    &END SCF
+  &END DFT
+  &PROPERTIES
+    &TDDFPT
+      CONVERGENCE [eV] 1.0e-7
+      EV_SHIFT [eV] 0.5
+      KERNEL sTDA
+      MAX_ITER 50
+      NSTATES 1
+      OE_CORR SHIFT
+      RKS_TRIPLETS F
+      &STDA
+        FRACTION 0.50
+      &END STDA
+    &END TDDFPT
+  &END PROPERTIES
+  &SUBSYS
+    &CELL
+      ABC 10.0 10.0 10.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O     0.051368    0.000000    0.000000
+      C     1.278612    0.000000    0.000000
+      H     1.870460    0.939607    0.000000
+      H     1.870460   -0.939607    0.000000
+    &END COORD
+  &END SUBSYS
+&END FORCE_EVAL


### PR DESCRIPTION
## Summary

Avoid calling `build_xtb_coulomb()` in the tblite TDDFPT/OE_CORR path.

## Problem

TDDFPT calculations with orbital energy corrections (`OE_CORR`) and tblite-enabled xTB crash with a segmentation fault in:

```text
tddfpt_oecorr
→ build_xtb_ks_matrix
→ build_xtb_coulomb
→ neighbor_list_iterate
```

The issue originates from the `sab_xtbe` neighbor list not being initialized for the tblite branch. In `qs_neighbor_lists.F`, `sab_xtbe` is only built when:

```fortran id="ztz5ix"
xtb .AND. (.NOT. do_tblite)
```

However, `build_xtb_coulomb()` was still called from `xtb_ks_matrix.F` during the TDDFPT OE_CORR path.

## Current Fix

The patch skips the additional CP2K-internal xTB Coulomb build when `do_tblite` is enabled:

```fortran id="sq2b8n"
IF (xtb_control%coulomb_interaction .AND. &
    (.NOT. xtb_control%do_tblite)) THEN
```

This avoids the segmentation fault and allows the TDDFPT/OE_CORR tblite calculations to complete.

## Notes

This should currently be considered a workaround rather than a fully validated physical fix. It still needs to be investigated whether the corresponding Coulomb/SCC contributions are already fully handled internally by tblite in this TDDFPT/OE_CORR context.

