### PR TITLE
Add libxsmm explicitly to the link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1131,7 +1131,7 @@ if(CP2K_USE_LIBXSMM)
   message(
     "  - LIBXSMM\n"
     "    - include directories: ${CP2K_LIBXSMM_INCLUDE_DIRS}\n"
-    "    - libraries: ${CP2K_LIBXSMMEXT_LINK_LIBRARIES};${CP2K_LIBXSMMF_LINK_LIBRARIES}\n\n"
+    "    - libraries: ${CP2K_LIBXSMMEXT_LINK_LIBRARIES};${CP2K_LIBXSMMF_LINK_LIBRARIES};${CP2K_LIBXSMM_LINK_LIBRARIES}\n\n"
   )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1623,6 +1623,7 @@ target_link_libraries(
   INTERFACE cp2k::LAPACK::lapack
             $<$<BOOL:${CP2K_USE_LIBXSMM}>:cp2k::LibXSMM::libxsmmf>
             $<$<BOOL:${CP2K_USE_LIBXSMM}>:cp2k::LibXSMM::libxsmmext>
+            $<$<BOOL:${CP2K_USE_LIBXSMM}>:cp2k::LibXSMM::libxsmm>
             cp2k::BLAS::blas
             $<$<BOOL:${CP2K_USE_CUDA}>:cp2k_cuda_libs>
             $<$<BOOL:${CP2K_USE_HIP}>:cp2k_hip_libs>


### PR DESCRIPTION
When building the latest CP2K main (f0dc442c7c0ff4526c26d4749b5a45c149bdf039) with dependencies fetched from conda-forge, I noticed that `libxsmm` is not linked during the build process (maybe assumed to be implicitly included via `libxsmmf`?). Adding libxsmm explicitly to the link libraries seems to solve this issue.

---

For completeness here is my setup for building CP2K, in case I missed something and there is a better way to fix this link issue:

<details><summary>conda env setup</summary>

````
mamba create -p /opt/cp2k \
    fortran-compiler \
    c-compiler \
    cxx-compiler \
    cmake \
    make \
    pkg-config \
    'dbcsr=*=mpi_*' \
    'exchcxx=*=cpu_*' \
    'fftw=*=mpi_*' \
    'gau2grid=2.0.9' \
    'hdf5=*=mpi_*' \
    'integratorxx' \
    'libblas=*=*openblas*' \
    'libint-fortran-devel' \
    'libtorch=*=cpu_generic*' \
    'libxc=*=cpu*' \
    'libxsmm' \
    'nlohmann_json' \
    'openmpi' \
    'plumed=*=mpi_*' \
    'scalapack' \
    'sirius=*=mpi_*' \
    'spfft=*=mpi_*' \
    'spglib' \
    'spla=*=mpi_*' \
    'trexio'
````
</details>

<details><summary>toolchain setup</summary>

````
(/opt/cp2k) ➜ .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain $ ./install_cp2k_toolchain.sh \
  --with-gauxc=install \
  --install-dir=/opt/cp2k \
  -j 8 \
  --with-{cmake,fftw,openmpi,sirius,spla,spfft,hdf5,gcc,libint,libxc,libxsmm,scalapack,libtorch,dbcsr,spglib,plumed,openblas}=${CP2K_DIR} \
  --with-{cosma,elpa,libvori}=no
````
</details>

<details><summary>CMake config setup</summary>

````bash
(/opt/cp2k) ➜ .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain $ cmake -S ../.. -B build \
  -DCMAKE_INSTALL_PREFIX=/opt/cp2k \
  -DBUILD_SHARED_LIBS=ON \
  -DCP2K_USE_MPI=ON \
  -DCP2K_USE_MPI_F08=ON \
  -DCP2K_USE_FFTW3=ON \
  -DCP2K_USE_LIBINT2=ON \
  -DCP2K_USE_LIBXC=ON \
  -DCP2K_USE_GAUXC=ON \
  -DCP2K_USE_LIBXSMM=ON \
  -DCP2K_USE_SPLA=ON \
  -DCP2K_USE_SPGLIB=ON \
  -DCP2K_USE_HDF5=ON \
  -DCP2K_USE_SIRIUS=ON \
  -DCP2K_USE_VORI=OFF \
  -DCP2K_USE_LIBTORCH=ON
-- Found MPI: TRUE (found version "3.1") found components: C CXX Fortran
-- Found MPI: TRUE (found version "3.1") found components: CXX C Fortran
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP_C: -fopenmp (found version "4.5")
-- Found OpenMP_Fortran: -fopenmp (found version "4.5")
-- Could NOT find MKL (missing: CP2K_MKL_INCLUDE_DIRS) 
-- Checking for module 'libxsmm-shared'
--   No package 'libxsmm-shared' found
-- Checking for module 'libxsmmf-shared'
--   No package 'libxsmmf-shared' found
-- Checking for module 'libxsmmext-shared'
--   No package 'libxsmmext-shared' found
-- Checking for module 'libxsmmnoblas-shared'
--   No package 'libxsmmnoblas-shared' found
-- Checking for module 'libxsmm'
--   No package 'libxsmm' found
-- Checking for module 'libxsmmf'
--   No package 'libxsmmf' found
-- Checking for module 'libxsmmext'
--   No package 'libxsmmext' found
-- Checking for module 'libxsmmnoblas'
--   No package 'libxsmmnoblas' found
-- Using LIBXSMM for Small Matrix Multiplication
-- Checking for module 'scalapack'
--   Package 'mpi', required by 'scalapack', not found

------------------------------------------------------------
-                          OPENMP                          -
------------------------------------------------------------

-- Found OpenMP_Fortran: -fopenmp (found version "4.5")
-- Found OpenMP_C: -fopenmp (found version "4.5")
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5") found components: Fortran C CXX

------------------------------------------------------------
-                          DBCSR                           -
------------------------------------------------------------

-- Found MPI: TRUE (found version "3.1")
-- Found OpenMP_C: -fopenmp (found version "4.5")
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP_Fortran: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5")

------------------------------------------------------------
-                    Other dependencies                    -
------------------------------------------------------------

-- Performing Test BLAS_LOWER_UNDERSCORE
-- Performing Test BLAS_LOWER_UNDERSCORE -- found
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR) 
-- Caffe2: Found protobuf with new-style protobuf targets.
-- Caffe2: Protobuf version 33.5.0
-- Found MPI: TRUE (found version "3.1") found components: CXX C Fortran
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP_C: -fopenmp (found version "4.5")
-- Found OpenMP_Fortran: -fopenmp (found version "4.5")
-- Found OpenMP: TRUE (found version "4.5") found components: CXX C Fortran
CMake Warning at /opt/cp2k/share/cmake/Torch/TorchConfig.cmake:22 (message):
  static library kineto_LIBRARY-NOTFOUND not found.
Call Stack (most recent call first):
  /opt/cp2k/share/cmake/Torch/TorchConfig.cmake:126 (append_torchlib_if_found)
  /opt/cp2k/share/cmake-4.3/Modules/CMakeFindDependencyMacro.cmake:93 (find_package)
  /opt/cp2k/share/cmake-4.3/Modules/CMakeFindDependencyMacro.cmake:125 (__find_dependency_common)
  /opt/cp2k/gauxc-1.1-skala-cp2k-fixes/lib/cmake/gauxc/gauxc-config.cmake:87 (find_dependency)
  CMakeLists.txt:690 (find_package)


-- HDF5 C compiler wrapper is unable to compile a minimal HDF5 program.
-- HDF5 Fortran compiler wrapper is unable to compile a minimal HDF5 program.
-- Checking for one of the modules 'fftw3q'
-- Checking for module 'libint2'
--   No package 'libint2' found
-- Component omp of Spglib: NOT FOUND
-- Component fortran of Spglib: FOUND (LIB_TYPE: shared)
-- Found package: Spglib
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR) 
-- Caffe2: Found protobuf with new-style protobuf targets.
-- Caffe2: Protobuf version 33.5.0
-- Found OpenMP_CXX: -fopenmp (found version "4.5")
-- Found OpenMP_C: -fopenmp (found version "4.5")
-- Found OpenMP_Fortran: -fopenmp (found version "4.5")
CMake Warning at /opt/cp2k/share/cmake/Torch/TorchConfig.cmake:22 (message):
  static library kineto_LIBRARY-NOTFOUND not found.
Call Stack (most recent call first):
  /opt/cp2k/share/cmake/Torch/TorchConfig.cmake:126 (append_torchlib_if_found)
  CMakeLists.txt:920 (find_package)


-- FYPP preprocessor found.

--------------------------------------------------------------------
-                                                                  -
-               Summary of enabled dependencies                    -
-                                                                  -
--------------------------------------------------------------------

  - BLAS
    - vendor: OpenBLAS
    - include directories: /opt/cp2k/include
    - libraries: /opt/cp2k/lib/libopenblas.so


  - LAPACK
    - include directories: /opt/cp2k/include
    - libraries: /opt/cp2k/lib/libopenblas.so


  - MPI
    - include directories: /opt/cp2k/include
    - libraries: /opt/cp2k/lib/libmpi.so


  - MPI_F08: ON

  - ScaLAPACK
    - vendor: auto
    - include directories: 
    - libraries: /opt/cp2k/lib/libscalapack.so


  - LibXC
    - version:  7.0.0
    - include directories: /opt/cp2k/include
    - libraries: /opt/cp2k/lib/libxcf03.so.15;/opt/cp2k/lib/libxc.so.15


  - GauXC
    - version:  1.0.0
    - install directories:  /opt/cp2k/gauxc-1.1-skala-cp2k-fixes/lib/cmake/gauxc
  - Spglib
    - include directories: /opt/cp2k/include;$<BUILD_INTERFACE:/opt/cp2k/include>


  - LibTorch
    - extra CXX flags: 
    - include directories: /opt/cp2k/include/torch/csrc/api/include
    - libraries: /opt/cp2k/lib/libtorch.so

  - HDF5
    - version: 1.14.6
    - include directories: /opt/cp2k/include
    - libraries: /opt/cp2k/lib/libhdf5.so;/opt/cp2k/lib/libhdf5_fortran.so;/opt/cp2k/lib/libhdf5.so


  - FFTW3
    - include directories: /opt/cp2k/include
    - libraries: /opt/cp2k/lib/libfftw3.so


  - LIBXSMM
    - include directories: /opt/cp2k/include
    - libraries: /opt/cp2k/lib/libxsmmext.so;/opt/cp2k/lib/libxsmmf.so


 - SpLA
   - include directories: /opt/cp2k/include;/opt/cp2k/include/spla
   - libraries: MPI::MPI_CXX;MPI::MPI_C;MPI::MPI_Fortran


 - SIRIUS
   - include directories: 
   - libraries: 


 - Libint2
   - include directories: /opt/cp2k/include
   - libraries: /opt/cp2k/lib/libint2.so


--------------------------------------------------------------------
-                                                                  -
-        List of dependencies not included in this build           -
-                                                                  -
--------------------------------------------------------------------

   - DFTD4
   - DeePMD
   - PEXSI
   - ACE (libpace)
   - TBLITE
   - LibSMEAGOL
   - COSMA
   - MiMiC
   - openPMD
   - GPU acceleration is disabled
   - ELPA
   - DLA-Future
   - PLUMED
   - LibFCI
   - Libvori
   - TREXIO
   - GreenX


After building and installing CP2K the regtests can be run with the following command:
   .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tests/do_regtest.py /opt/cp2k/bin psmp


-- Configuring done (3.8s)
-- Generating done (0.7s)
-- Build files have been written to: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build
````
</details>

<details><summary>Link error without libxsmm</summary>

````
(/opt/cp2k) ➜ .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain $ make -C build/ -j 8
make: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[1]: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Leaving directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Leaving directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Leaving directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
[  0%] Linking CXX executable ../bin/dbm_miniapp.psmp
make[2]: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
[  0%] Linking CXX executable ../bin/grid_miniapp.psmp
[  0%] Linking CXX executable ../bin/grid_unittest.psmp
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/dbm_miniapp.dir/dbm/dbm_multiply_cpu.c.o: in function `dbm_multiply_cpu_process_batch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/dbm/dbm_multiply_cpu.c:139:(.text.dbm_multiply_cpu_process_batch+0x906): undefined reference to `libxsmm_dmmdispatch'
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/dbm_miniapp.dir/build.make:286: bin/dbm_miniapp.psmp] Error 1
make[2]: Leaving directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[1]: *** [CMakeFiles/Makefile2:734: src/CMakeFiles/dbm_miniapp.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_unittest.dir/grid/dgemm/grid_dgemm_coefficients.c.o: in function `grid_allocate_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_xzy_to_ikj+0x6b): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_xzy_to_ikj+0x79): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_xzy_to_ikj+0xb7): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_xzy_to_ikj+0xc9): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_unittest.dir/grid/dgemm/grid_dgemm_coefficients.c.o: in function `grid_free_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.grid_transform_coef_xzy_to_ikj+0x11f7): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.grid_transform_coef_xzy_to_ikj+0x1213): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_unittest.dir/grid/dgemm/grid_dgemm_coefficients.c.o: in function `grid_allocate_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_jik_to_yxz+0x6b): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_jik_to_yxz+0x79): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_jik_to_yxz+0xb7): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_jik_to_yxz+0xc9): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_unittest.dir/grid/dgemm/grid_dgemm_coefficients.c.o: in function `grid_free_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.grid_transform_coef_jik_to_yxz+0x149e): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.grid_transform_coef_jik_to_yxz+0x14ba): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_unittest.dir/grid/dgemm/grid_dgemm_utils.c.o: in function `dgemm_simplified':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.c:58:(.text.dgemm_simplified+0x24f): undefined reference to `libxsmm_dmmdispatch'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_miniapp.dir/grid/dgemm/grid_dgemm_coefficients.c.o: in function `grid_allocate_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_xzy_to_ikj+0x6b): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_xzy_to_ikj+0x79): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_xzy_to_ikj+0xb7): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_xzy_to_ikj+0xc9): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_miniapp.dir/grid/dgemm/grid_dgemm_coefficients.c.o: in function `grid_free_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.grid_transform_coef_xzy_to_ikj+0x11f7): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.grid_transform_coef_xzy_to_ikj+0x1213): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_miniapp.dir/grid/dgemm/grid_dgemm_coefficients.c.o: in function `grid_allocate_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_jik_to_yxz+0x6b): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_jik_to_yxz+0x79): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_jik_to_yxz+0xb7): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_transform_coef_jik_to_yxz+0xc9): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_miniapp.dir/grid/dgemm/grid_dgemm_coefficients.c.o: in function `grid_free_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld143:: (.text.grid_transform_coef_jik_to_yxz+0x149e): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.grid_transform_coef_jik_to_yxz+0x14ba): undefined reference to `libxsmm_free'
CMakeFiles/grid_unittest.dir/grid/dgemm/grid_dgemm_collocate.c.o: in function `grid_free_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.grid_dgemm_collocate_task_list+0x199): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_unittest.dir/grid/dgemm/grid_dgemm_collocate.c.o: in function `grid_allocate_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_dgemm_collocate_task_list+0x4ea): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_dgemm_collocate_task_list+0x53b): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_miniapp.dir/grid/dgemm/grid_dgemm_utils.c.o: in function `dgemm_simplified':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.c:58:(.text.dgemm_simplified+0x24f): undefined reference to `libxsmm_dmmdispatch'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_unittest.dir/grid/dgemm/grid_dgemm_non_orthorombic_corrections.c.o: in function `grid_allocate_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.calculate_non_orthorombic_corrections_tensor+0x18a): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.calculate_non_orthorombic_corrections_tensor+0x19b): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.calculate_non_orthorombic_corrections_tensor+0x1ab): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.calculate_non_orthorombic_corrections_tensor+0x1b9): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_unittest.dir/grid/dgemm/grid_dgemm_non_orthorombic_corrections.c.o: in function `grid_free_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.calculate_non_orthorombic_corrections_tensor+0x220): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.calculate_non_orthorombic_corrections_tensor+0x24e): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_miniapp.dir/grid/dgemm/grid_dgemm_collocate.c.o: in function `grid_free_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.grid_dgemm_collocate_task_list+0x199): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_miniapp.dir/grid/dgemm/grid_dgemm_collocate.c.o: in function `grid_allocate_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_dgemm_collocate_task_list+0x4ea): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.grid_dgemm_collocate_task_list+0x53b): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_miniapp.dir/grid/dgemm/grid_dgemm_non_orthorombic_corrections.c.o: in function `grid_allocate_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.calculate_non_orthorombic_corrections_tensor+0x18a): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.calculate_non_orthorombic_corrections_tensor+0x19b): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.calculate_non_orthorombic_corrections_tensor+0x1ab): undefined reference to `libxsmm_hash_string'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:135:(.text.calculate_non_orthorombic_corrections_tensor+0x1b9): undefined reference to `libxsmm_scratch_malloc'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: CMakeFiles/grid_miniapp.dir/grid/dgemm/grid_dgemm_non_orthorombic_corrections.c.o: in function `grid_free_scratch':
.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.calculate_non_orthorombic_corrections_tensor+0x220): undefined reference to `libxsmm_free'
/opt/cp2k/bin/../libexec/gcc/x86_64-conda-linux-gnu/14.3.0/ld: .../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/src/grid/dgemm/grid_dgemm_utils.h:143:(.text.calculate_non_orthorombic_corrections_tensor+0x24e): undefined reference to `libxsmm_free'
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/grid_unittest.dir/build.make:526: bin/grid_unittest.psmp] Error 1
make[2]: Leaving directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[1]: *** [CMakeFiles/Makefile2:798: src/CMakeFiles/grid_unittest.dir/all] Error 2
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/grid_miniapp.dir/build.make:526: bin/grid_miniapp.psmp] Error 1
make[2]: Leaving directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[1]: *** [CMakeFiles/Makefile2:766: src/CMakeFiles/grid_miniapp.dir/all] Error 2
make[2]: Leaving directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
make[2]: Entering directory '.../cp2k-f0dc442c7c0ff4526c26d4749b5a45c149bdf039/tools/toolchain/build'
````
</details>