### PR TITLE
Improve MD step header output

### DIFF
--- a/src/motion/md_run.F
+++ b/src/motion/md_run.F
@@ -19,7 +19,7 @@ MODULE md_run
    USE cell_types,                      ONLY: cell_type
    USE cp_external_control,             ONLY: external_control
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
-                                              cp_logger_get_default_unit_nr,&
+                                              cp_logger_get_default_io_unit,&
                                               cp_logger_type
    USE cp_output_handling,              ONLY: cp_add_iter_level,&
                                               cp_iterate,&
@@ -50,7 +50,8 @@ MODULE md_run
                                               section_vals_val_get
    USE kinds,                           ONLY: default_string_length,&
                                               dp
-   USE machine,                         ONLY: m_walltime
+   USE machine,                         ONLY: m_flush,&
+                                              m_walltime
    USE md_ener_types,                   ONLY: create_md_ener,&
                                               md_ener_type
    USE md_energies,                     ONLY: initialize_md_ener,&
@@ -190,6 +191,7 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'qs_mol_dyn_low'
 
+      CHARACTER(LEN=80)                                  :: md_step_line
       CHARACTER(LEN=default_string_length)               :: my_act, my_pos
       INTEGER                                            :: handle, i, istep, md_stride, &
                                                             output_unit, run_type_id
@@ -227,7 +229,7 @@ CONTAINS
                constraint_section, thermal_regions, virial, subsys_i)
       logger => cp_get_default_logger()
       para_env => force_env%para_env
-      output_unit = cp_logger_get_default_unit_nr()
+      output_unit = cp_logger_get_default_io_unit(logger)
 
       global_section => section_vals_get_subs_vals(force_env%root_section, "GLOBAL")
       free_energy_section => section_vals_get_subs_vals(motion_section, "FREE_ENERGY")
@@ -460,7 +462,12 @@ CONTAINS
       ! Real MD Loop
       DO istep = 1, simpar%nsteps, md_stride
          IF (output_unit > 0) THEN
-            WRITE (output_unit, "(T3,A,I7,A,I7)") "MD step: ", istep, "/", simpar%nsteps
+            WRITE (md_step_line, FMT="(A,I12,A,I0)") "MD STEP: ", istep, " / ", simpar%nsteps
+
+            WRITE (UNIT=output_unit, FMT="(/,T2,A)") REPEAT("-", LEN_TRIM(md_step_line))
+            WRITE (UNIT=output_unit, FMT="(T2,A)") TRIM(md_step_line)
+            WRITE (UNIT=output_unit, FMT="(T2,A)") REPEAT("-", LEN_TRIM(md_step_line))
+            CALL m_flush(output_unit)
          END IF
          ! Increase counters
          itimes = itimes + 1


### PR DESCRIPTION
- Use the global logger output unit for the MD step header to avoid creating per-rank files such as `md_localLog_p*.out`.
- Tidy the MD step counter format from e.g. `1/    200` to a more readable form.
- Add separator whose length adapt to the actual `MD STEP` line length.

The output with the change applied looks like:

<img width="1266" height="1029" alt="图片" src="https://github.com/user-attachments/assets/8ce7fffb-0f35-483b-8276-c92f64cd5b9d" />
