### PR TITLE
Fix periodic e-field force prefactors

### DIFF
--- a/src/qs_efield_berry.F
+++ b/src/qs_efield_berry.F
@@ -497,7 +497,7 @@ CONTAINS
                      icol = iatom
                   END IF
 
-                  IF (iatom == jatom .AND. dab < 1.e-10_dp) THEN
+                  IF (iatom == jatom) THEN
                      fab = 1.0_dp*occ
                   ELSE
                      fab = 2.0_dp*occ
@@ -982,7 +982,7 @@ CONTAINS
                   icol = iatom
                END IF
 
-               IF (iatom == jatom .AND. dab < 1.e-10_dp) THEN
+               IF (iatom == jatom) THEN
                   fab = 1.0_dp*occ
                ELSE
                   fab = 2.0_dp*occ

--- a/tests/QS/regtest-dcdr/TEST_FILES.toml
+++ b/tests/QS/regtest-dcdr/TEST_FILES.toml
@@ -12,5 +12,5 @@
 "h2o_apt_pbc.inp"                       = [{matcher="M096", tol=1e-06, ref=-0.938707}]
 "h2o_apt_pbc_loc.inp"                   = [{matcher="M096", tol=1e-06, ref=-0.938770}]
 "h2o_aat.inp"                           = [{matcher="M100", tol=1e-06, ref=-0.857427}]
-"h2o_apt_fdiff.inp"                     = [{matcher="M127", tol=1e-04, ref=0.0034319}]
+"h2o_apt_fdiff.inp"                     = [{matcher="M127", tol=1e-04, ref=0.0028031231}]
 #EOF

--- a/tests/QS/regtest-p-efield/TEST_FILES.toml
+++ b/tests/QS/regtest-p-efield/TEST_FILES.toml
@@ -4,17 +4,17 @@
 #      1 compares the last total energy in the file
 #      for details see cp2k/tools/do_regtest
 # test mulliken constraints
-"H2O-field-gopt.inp"                    = [{matcher="E_total", tol=3e-11, ref=-17.10019432940533}]
-"H2O-field-gopt-lsd.inp"                = [{matcher="E_total", tol=4e-12, ref=-17.09678495009813}]
+"H2O-field-gopt.inp"                    = [{matcher="E_total", tol=3e-11, ref=-17.10019430634432}]
+"H2O-field-gopt-lsd.inp"                = [{matcher="E_total", tol=4e-12, ref=-17.09678495224495}]
 "H2O-field.inp"                         = [{matcher="E_total", tol=4e-13, ref=-16.55393361851538}]
 "H2O-field-lsd.inp"                     = [{matcher="E_total", tol=4e-13, ref=-16.54297492085963}]
 "H2O-field-list.inp"                    = [{matcher="M002", tol=1e-14, ref=-17.110097457}]
 "H2O-field-file.inp"                    = [{matcher="M002", tol=1e-14, ref=-17.110097457}]
 "HF-field.inp"                          = [{matcher="E_total", tol=1e-12, ref=-24.70767796237102}]
-"HF-field-gopt.inp"                     = [{matcher="E_total", tol=1e-12, ref=-24.70292863028889}]
+"HF-field-gopt.inp"                     = [{matcher="E_total", tol=1e-12, ref=-24.70292860329709}]
 "HF-field-debug.inp"                    = []
 "HF-dfilter-debug.inp"                  = []
-"HF-dfield-gopt.inp"                    = [{matcher="E_total", tol=1e-12, ref=-24.70417205608725}]
+"HF-dfield-gopt.inp"                    = [{matcher="E_total", tol=1e-12, ref=-24.70417205666021}]
 "HF-dfield.inp"                         = [{matcher="E_total", tol=1e-12, ref=-24.70404339826408}]
 "HF-dfield-debug.inp"                   = []
 "HF-loc-field.inp"                      = [{matcher="E_total", tol=1e-12, ref=-24.70412191165735}]


### PR DESCRIPTION
## Summary

This PR fixes the force prefactor used for periodic self-image atom pairs in the Berry-phase electric-field derivative code.

For atom pairs with `iatom == jatom`, the contribution is diagonal in the atom index even when the pair comes from a periodic image (`rab /= 0`). These terms must therefore use the diagonal prefactor `occ`, not the off-diagonal prefactor `2*occ`. The old `dab < 1.e-10_dp` guard incorrectly treated periodic self-image pairs as off-diagonal terms and double-counted their electric-field force contribution.

The same correction is applied to both:

- `qs_efield_derivatives`
- `qs_dispfield_derivatives`

This removes the spurious center-of-mass residual in the periodic electric-field force contribution without applying a posteriori force-sum projection.

## Manual Reproducer

The motivating case is a 30-atom calcite GAPW_XC calculation with `PERIODIC_EFIELD` along z, `INTENSITY 1.25e-4`, `GAPW_ACCURATE_XCINT`, and `EPS_SCF 1e-9`.

Before the fix, the isolated periodic electric-field force contribution had a nonzero center-of-mass residual. With the corrected diagonal prefactor, this residual is removed at the source.

## Testing

```text
cmake --build build-pr5308-mpi --target cp2k-bin -j 4
python3 tests/do_regtest.py --mpiranks 1 --ompthreads 1 --maxtasks 2 --timeout 180 --restrictdir QS/regtest-dcdr --workbasedir /tmp/cp2k-regtest-pr5308-dcdr-hutter --cp2kdatadir data build-pr5308-mpi/bin psmp
  Summary: correct: 10 / 10; 0min

python3 tests/do_regtest.py --mpiranks 1 --ompthreads 1 --maxtasks 2 --timeout 180 --restrictdir QS/regtest-p-efield --workbasedir /tmp/cp2k-regtest-pr5308-pefield-hutter-rerun --cp2kdatadir data build-pr5308-mpi/bin psmp
  Summary: correct: 16 / 16; 1min

python3 tests/do_regtest.py --mpiranks 2 --ompthreads 1 --maxtasks 4 --timeout 240 --restrictdir QS/regtest-p-efield --workbasedir /tmp/cp2k-regtest-pr5308-pefield-hutter-mpi2 --cp2kdatadir data build-pr5308-mpi/bin psmp
  Summary: correct: 16 / 16; 1min

git diff --check HEAD^..HEAD
```

`h2o_apt_fdiff.inp` is updated to the corrected value exposed by the CI `Regtest pdbg` run:

```text
h2o_apt_fdiff.inp  0.0028031231  OK
```
