### PR TITLE
Avoid full k-point symmetry for skew cells

### DIFF
--- a/src/kpoint_types.F
+++ b/src/kpoint_types.F
@@ -737,7 +737,8 @@ CONTAINS
          DIMENSION(:), POINTER                           :: tmpstringlist
       INTEGER                                            :: i, n_rep, nval, wfntype
       LOGICAL                                            :: available, backend_explicit, &
-                                                            reduction_explicit
+                                                            non_lower_triangular_cell, &
+                                                            non_orthogonal_cell, reduction_explicit
       REAL(KIND=dp)                                      :: ff
       REAL(KIND=dp), DIMENSION(3, 3)                     :: cart_a_vec
       REAL(KIND=dp), DIMENSION(:), POINTER               :: reallist
@@ -840,15 +841,30 @@ CONTAINS
          CALL resolve_kpoint_symmetry_settings(kpoint, backend_explicit, reduction_explicit)
          CALL section_vals_val_get(kpoint_section, "EPS_SYMMETRY", r_val=kpoint%eps_geo)
          IF ((kpoint%kp_scheme == "MONKHORST-PACK" .OR. kpoint%kp_scheme == "MACDONALD") .AND. &
-             ((ABS(a_vec(2, 1)) > eps_cell) .OR. (ABS(a_vec(3, 1)) > eps_cell) .OR. &
-              (ABS(a_vec(3, 2)) > eps_cell)) .AND. kpoint%symmetry .AND. &
-             .NOT. kpoint%full_grid .AND. .NOT. kpoint%inversion_symmetry_only) THEN
-            kpoint%inversion_symmetry_only = .TRUE.
-            CALL cp_warn(__LOCATION__, &
-                         "Full atomic k-point symmetry was requested for a cell matrix that does "// &
-                         "not follow the CP2K lower-triangular convention. Falling back to "// &
-                         "KPOINTS%INVERSION_SYMMETRY_ONLY. Use ABC/ALPHA_BETA_GAMMA or canonical "// &
-                         "A/B/C vectors to enable full point-group k-point reduction.")
+             kpoint%symmetry .AND. .NOT. kpoint%full_grid .AND. &
+             .NOT. kpoint%inversion_symmetry_only) THEN
+            non_lower_triangular_cell = (ABS(a_vec(2, 1)) > eps_cell) .OR. &
+                                        (ABS(a_vec(3, 1)) > eps_cell) .OR. &
+                                        (ABS(a_vec(3, 2)) > eps_cell)
+            non_orthogonal_cell = (ABS(DOT_PRODUCT(a_vec(:, 1), a_vec(:, 2))) > eps_cell) .OR. &
+                                  (ABS(DOT_PRODUCT(a_vec(:, 1), a_vec(:, 3))) > eps_cell) .OR. &
+                                  (ABS(DOT_PRODUCT(a_vec(:, 2), a_vec(:, 3))) > eps_cell)
+            ! The full point-group density-matrix transform is not charge-conserving for skew cells.
+            IF (non_orthogonal_cell) THEN
+               kpoint%inversion_symmetry_only = .TRUE.
+               CALL cp_warn(__LOCATION__, &
+                            "Full atomic k-point symmetry was requested for a non-orthogonal cell. "// &
+                            "Falling back to KPOINTS%INVERSION_SYMMETRY_ONLY because the full "// &
+                            "point-group density-matrix symmetrization is only charge-conserving for "// &
+                            "orthogonal cell matrices.")
+            ELSEIF (non_lower_triangular_cell) THEN
+               kpoint%inversion_symmetry_only = .TRUE.
+               CALL cp_warn(__LOCATION__, &
+                            "Full atomic k-point symmetry was requested for a cell matrix that does "// &
+                            "not follow the CP2K lower-triangular convention. Falling back to "// &
+                            "KPOINTS%INVERSION_SYMMETRY_ONLY. Use ABC/ALPHA_BETA_GAMMA or canonical "// &
+                            "A/B/C vectors to enable full point-group k-point reduction.")
+            END IF
          END IF
          CALL section_vals_val_get(kpoint_section, "PARALLEL_GROUP_SIZE", &
                                    i_val=kpoint%parallel_group_size)

--- a/tests/QS/regtest-kp-1-spg/TEST_FILES.toml
+++ b/tests/QS/regtest-kp-1-spg/TEST_FILES.toml
@@ -16,7 +16,7 @@
 "h_hex_c3_sym_red.inp"                  = [{matcher="E_total", tol=1e-8, ref=-9.17691856252346},
                                            {matcher="N_special_kpoints", tol=0.0, ref=9}]
 "h_hex_c3_gamma_spglib.inp"             = [{matcher="E_total", tol=1e-7, ref=-9.41333967352940},
-                                           {matcher="N_special_kpoints", tol=0.0, ref=8}]
+                                           {matcher="N_special_kpoints", tol=0.0, ref=20}]
 "h_hex_c3_gamma_macdonald_spglib.inp"   = [{matcher="E_total", tol=1e-7, ref=-9.41375200649571},
-                                           {matcher="N_special_kpoints", tol=0.0, ref=12}]
+                                           {matcher="N_special_kpoints", tol=0.0, ref=32}]
 #EOF

--- a/tests/QS/regtest-kp-1/TEST_FILES.toml
+++ b/tests/QS/regtest-kp-1/TEST_FILES.toml
@@ -27,7 +27,7 @@
 "h_ortho_sym_red.inp"                   = [{matcher="E_total", tol=1e-8, ref=-2.73592238316042}]
 "h_mono_sym_red.inp"                    = [{matcher="E_total", tol=1e-10, ref=-3.15139711262736}]
 "h_hex_c3_gamma_k290.inp"               = [{matcher="E_total", tol=1e-7, ref=-9.41333967352938},
-                                           {matcher="N_special_kpoints", tol=0.0, ref=8}]
+                                           {matcher="N_special_kpoints", tol=0.0, ref=20}]
 "h_fcc_wannier90_scf_mp.inp"            = [{matcher="E_total", tol=1e-13, ref=-4.34524388359536},
                                            {matcher="N_special_kpoints", tol=0.0, ref=1},
                                            {matcher="WANNIER90_SCF_MO_REUSE"},

--- a/tests/QS/regtest-kp-hfx-ri/TEST_FILES.toml
+++ b/tests/QS/regtest-kp-hfx-ri/TEST_FILES.toml
@@ -1,7 +1,7 @@
 "diamond_gapw_tc.inp"                   = [{matcher="M011", tol=1.0E-10, ref=-75.317785150617567}]
 "diamond_gpw_extRI.inp"                 = [{matcher="M011", tol=1.0E-10, ref=-8.128239211260716}]
 "diamond_gpw_extRI_kpsym.inp"           = [{matcher="M011", tol=1.0E-10, ref=-8.128239211227628},
-                                           {matcher="N_special_kpoints", tol=0.0, ref=2}]
+                                           {matcher="N_special_kpoints", tol=0.0, ref=4}]
 "hBN_gapw_ovlp.inp"                     = [{matcher="M011", tol=1.0E-10, ref=-86.213599739489808}]
 "hBN_gapw_tc.inp"                       = [{matcher="M011", tol=1.0E-10, ref=-77.588144157636464}]
 "hBN_gapw_mix_cl_tc.inp"                = [{matcher="M011", tol=1.0E-10, ref=-81.58088407995704}]

--- a/tests/xTB/regtest-tblite-gfn2/TEST_FILES.toml
+++ b/tests/xTB/regtest-tblite-gfn2/TEST_FILES.toml
@@ -42,7 +42,7 @@
 "Si_gfn2_kp_spglib_backend.inp"          = [{matcher="E_total", tol=1.0E-8, ref=-13.65677573470654},
                                              {matcher="N_special_kpoints", tol=0.0, ref=4}]
 "Zn_fcc_gfn2_kp_k290.inp"                = [{matcher="E_total", tol=1.0E-8, ref=-0.528740963544749},
-                                             {matcher="N_special_kpoints", tol=0.0, ref=4}]
+                                             {matcher="N_special_kpoints", tol=0.0, ref=14}]
 "Ar_fcc_gfn2_ls.inp"                     = [{matcher="M011", tol=5.0E-8, ref=-17.12154132132343}]
 "Ar_fcc_gfn2_force.inp"                  = [{matcher="M082", tol=1.0E-5, ref=0.0000000}]
 "Ar_fcc_gfn2_stress.inp"                 = [{matcher="M042", tol=1.0E-5, ref=0.0000000}]


### PR DESCRIPTION
## Summary

This PR keeps reduced k-point calculations on a charge-conserving path for non-orthogonal cells. If `MONKHORST-PACK` or `MACDONALD` k-points request full atomic k-point symmetry for a skew cell, CP2K now falls back to `KPOINTS%INVERSION_SYMMETRY_ONLY` and emits a warning. The existing non-lower-triangular-cell fallback is preserved.

The regtest references are updated where the safe fallback increases the number of special k-points:

- `h_hex_c3_gamma_k290`: 8 -> 20
- `h_hex_c3_gamma_spglib`: 8 -> 20
- `h_hex_c3_gamma_macdonald_spglib`: 12 -> 32
- `diamond_gpw_extRI_kpsym`: 2 -> 4
- `Zn_fcc_gfn2_kp_k290`: 4 -> 14

## Motivation

This completes the follow-up investigation to #5301/#5307. On current master after #5307, rewriting the Fe benchmark cell into canonical `ABC`/`ALPHA_BETA_GAMMA` form does not fix the full point-group k-point reduction: both K290 and spglib reduce the 16x16x16 grid to 140 k-points, but the integrated electronic density is not neutral and the total energy is shifted relative to the full-grid reference.

Representative current-master results before this PR:

| case | k-points | integrated density error | total energy [Ha] |
| --- | ---: | ---: | ---: |
| canonical full grid | 4096 | `1e-10` | `-123.54254579485098` |
| canonical inversion only | 2048 | `1e-10` | `-123.54254579449282` |
| canonical K290 full symmetry | 140 | `-0.0272115182` | `-123.53278963531541` |
| canonical spglib backend | 140 | `-0.0272115182` | `-123.53278963521340` |

The same behaviour appears for the non-canonical Fe cell. K290 and spglib are therefore consistent with each other, but both exercise the same unsafe density-matrix symmetrization path for skew cells. Mesh sweeps over 8/12/16 keep the same qualitative problem, so this is not a simple k-point convergence issue. I also checked the obvious internal suspects in the transform path (reciprocal folding phase, little-group averaging via `nwred`, and the AO block rotation convention); none restored charge conservation.

Until the full point-group density-matrix transform is made robust for non-orthogonal cells, using inversion-only reduction is the safe user-visible behaviour.

## Validation

Built and tested on the NVIDIA Spark host with current `master` at `48c63364e3` plus this branch.

Final Fe 16x16x16 check after this PR:

The 2048-point K290/spglib rows are intentional: these are user requests that now trigger the new inversion-only fallback, not full point-group reductions to 140 k-points.

| case | k-points | integrated density error | total energy [Ha] |
| --- | ---: | ---: | ---: |
| canonical full grid | 4096 | `1e-10` | `-123.54254579436157` |
| canonical inversion only | 2048 | `1e-10` | `-123.54254579479700` |
| canonical K290 request -> inversion fallback | 2048 | `1e-10` | `-123.54254579473296` |
| canonical spglib request -> inversion fallback | 2048 | `1e-10` | `-123.54254579481585` |
| non-canonical full grid | 4096 | `1e-10` | `-123.54254578592314` |
| non-canonical inversion only | 2048 | `1e-10` | `-123.54254578564385` |
| non-canonical K290 request -> inversion fallback -> inversion fallback | 2048 | `1e-10` | `-123.54254578579067` |
| non-canonical spglib request -> inversion fallback -> inversion fallback | 2048 | `1e-10` | `-123.54254578544521` |

Regtests:

- `QS/regtest-kp-1-spg` + `QS/regtest-kp-hfx-ri`: `23 / 23` correct after the final patch.
- Broader affected-directory sweep also passed all non-Wannier90 checks: `DFTB/regtest-scc`, `DFTB/regtest-scc-spglib`, `DFTB/regtest-nonscc`, `QS/regtest-kp-2`, `QS/regtest-kp-3`, `QS/regtest-kp-spglib`, `QS/regtest-harris-kp`. The local Spark build lacks the Wannier90 output path and tblite support, so Wannier90 text matchers in `QS/regtest-kp-1`/`QS/regtest-kp-1-spglib` and the tblite-only `xTB/regtest-tblite-gfn2` case could not all be validated locally. The CI `Regtest pdbg` run supplied the missing tblite k-point reference for `Zn_fcc_gfn2_kp_k290` (`4 -> 14`); its energy matcher was already OK.

Manual final check:

- `QS/regtest-kp-1/h_hex_c3_gamma_k290.inp`: `N_special_kpoints = 20`, `E_total = -9.413339735078168 Ha`, with the new non-orthogonal-cell fallback warning.


