### PR TITLE
Dimer: add control of initialization method and implement read from molden

### DIFF
--- a/src/input_constants.F
+++ b/src/input_constants.F
@@ -551,6 +551,9 @@ MODULE input_constants
    INTEGER, PARAMETER, PUBLIC               :: none_ts_method_id = 0, &
                                                default_dimer_method_id = 1
 
+   INTEGER, PARAMETER, PUBLIC               :: dimer_init_random = 0, &
+                                               dimer_init_molden = 1
+
    INTEGER, PARAMETER, PUBLIC               :: do_first_rotation_step = 0, &
                                                do_second_rotation_step = 1, &
                                                do_third_rotation_step = 2

--- a/src/motion/dimer_types.F
+++ b/src/motion/dimer_types.F
@@ -16,16 +16,27 @@ MODULE dimer_types
    USE cell_types,                      ONLY: &
         cell_transform_input_cartesian, cell_type, use_perd_x, use_perd_xy, use_perd_xyz, &
         use_perd_xz, use_perd_y, use_perd_yz, use_perd_z
-   USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
+   USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit,&
+                                              cp_to_string
+   USE cp_parser_methods,               ONLY: parser_get_next_line,&
+                                              parser_search_string
+   USE cp_parser_types,                 ONLY: cp_parser_type,&
+                                              parser_create,&
+                                              parser_release
    USE cp_subsys_types,                 ONLY: cp_subsys_get,&
                                               cp_subsys_type
+   USE force_env_types,                 ONLY: force_env_type
    USE global_types,                    ONLY: global_environment_type
-   USE input_constants,                 ONLY: do_first_rotation_step
+   USE input_constants,                 ONLY: dimer_init_molden,&
+                                              dimer_init_random,&
+                                              do_first_rotation_step
    USE input_section_types,             ONLY: section_vals_get,&
                                               section_vals_get_subs_vals,&
                                               section_vals_type,&
                                               section_vals_val_get
-   USE kinds,                           ONLY: dp
+   USE kinds,                           ONLY: default_path_length,&
+                                              dp
+   USE message_passing,                 ONLY: mp_para_env_type
    USE molecule_kind_list_types,        ONLY: molecule_kind_list_type
    USE molecule_kind_types,             ONLY: fixd_constraint_type,&
                                               get_molecule_kind,&
@@ -42,7 +53,9 @@ MODULE dimer_types
              dimer_env_create, &
              dimer_env_retain, &
              dimer_env_release, &
-             dimer_fixed_atom_control
+             dimer_fixed_atom_control, &
+             dimer_init_vector, &
+             vib_get_index_weight
 
 ! **************************************************************************************************
 !> \brief Type containing all informations abour the rotation of the Dimer
@@ -106,23 +119,22 @@ CONTAINS
 !> \param subsys ...
 !> \param globenv ...
 !> \param dimer_section ...
+!> \param force_env ...
 !> \par History
 !>      Luca Bellucci 11.2017 added K-DIMER and BETA
 !>      2016/03/03 [LTong] changed input natom to subsys
 !> \author Luca Bellucci and Teodoro Laino - created [tlaino] - 01.2008
 ! **************************************************************************************************
-   SUBROUTINE dimer_env_create(dimer_env, subsys, globenv, dimer_section)
+   SUBROUTINE dimer_env_create(dimer_env, subsys, globenv, dimer_section, force_env)
       TYPE(dimer_env_type), POINTER                      :: dimer_env
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(global_environment_type), POINTER             :: globenv
       TYPE(section_vals_type), POINTER                   :: dimer_section
+      TYPE(force_env_type), POINTER                      :: force_env
 
-      INTEGER                                            :: i, isize, j, k, n_rep_val, natom, unit_nr
-      LOGICAL                                            :: explicit
+      INTEGER                                            :: i, j, k, natom, unit_nr
       REAL(KIND=dp)                                      :: norm, xval(3)
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: array
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(section_vals_type), POINTER                   :: nvec_section
 
       NULLIFY (cell)
       unit_nr = cp_logger_get_default_io_unit()
@@ -133,34 +145,26 @@ CONTAINS
       ! get natom
       CALL cp_subsys_get(subsys=subsys, cell=cell, natom=natom)
       ! Allocate the working arrays
-      ALLOCATE (dimer_env%nvec(natom*3))
       ALLOCATE (dimer_env%rot%g0(natom*3))
       ALLOCATE (dimer_env%rot%g1(natom*3))
       ALLOCATE (dimer_env%rot%g1p(natom*3))
-      ! Check if the dimer vector is available in the input or not..
-      nvec_section => section_vals_get_subs_vals(dimer_section, "DIMER_VECTOR")
-      CALL section_vals_get(nvec_section, explicit=explicit)
-      IF (explicit) THEN
-         IF (unit_nr > 0) WRITE (unit_nr, *) "Reading Dimer Vector from file!"
-         NULLIFY (array)
-         CALL section_vals_val_get(nvec_section, "_DEFAULT_KEYWORD_", n_rep_val=n_rep_val)
-         isize = 0
-         DO i = 1, n_rep_val
-            CALL section_vals_val_get(nvec_section, "_DEFAULT_KEYWORD_", r_vals=array, i_rep_val=i)
-            DO j = 1, SIZE(array)
-               isize = isize + 1
-               dimer_env%nvec(isize) = array(j)
-            END DO
+      ! Read dimer vector from input
+      CALL dimer_init_vector(dimer_env, dimer_section, natom, &
+                             unit_nr, globenv, force_env)
+      IF (unit_nr > 0) THEN
+         WRITE (unit_nr, "(/,T2,A,T9,A,T71,I10)") &
+            "DIMER|", "Dimension of dimer vector (natom * 3)", natom*3
+         DO j = 1, natom
+            WRITE (unit_nr, "(T2,A,T9,3(F12.6,3X))") &
+               "DIMER|", dimer_env%nvec(3*j - 2:3*j)
          END DO
-         CPASSERT(isize == SIZE(dimer_env%nvec))
-         DO i = 1, natom
-            xval(:) = dimer_env%nvec(3*i - 2:3*i)
-            CALL cell_transform_input_cartesian(cell, xval)
-            dimer_env%nvec(3*i - 2:3*i) = xval(:)
-         END DO
-      ELSE
-         CALL globenv%gaussian_rng_stream%fill(dimer_env%nvec)
       END IF
+      ! Transform input cell
+      DO i = 1, natom
+         xval(:) = dimer_env%nvec(3*i - 2:3*i)
+         CALL cell_transform_input_cartesian(cell, xval)
+         dimer_env%nvec(3*i - 2:3*i) = xval(:)
+      END DO
       ! Check for translation in the dimer vector and remove them
       IF (natom > 1) THEN
          xval = 0.0_dp
@@ -170,6 +174,12 @@ CONTAINS
                xval(k) = xval(k) + dimer_env%nvec(i)
             END DO
          END DO
+         IF (unit_nr > 0) THEN
+            WRITE (unit_nr, "(/,T2,A,T9,A)") &
+               "DIMER|", "Overall translation to be removed from the initial dimer vector"
+            WRITE (unit_nr, "(T2,A,T9,3(F12.6,3X))") &
+               "DIMER|", xval(1:3)
+         END IF
          ! Subtract net translations
          xval = xval/REAL(natom*3, KIND=dp)
          DO j = 1, natom
@@ -180,10 +190,15 @@ CONTAINS
          END DO
       END IF
       ! set nvec components to zero for the corresponding constraints
-      CALL dimer_fixed_atom_control(dimer_env%nvec, subsys)
+      CALL dimer_fixed_atom_control(dimer_env%nvec, subsys, unit_nr)
+      ! Normalize dimer vector
       norm = SQRT(SUM(dimer_env%nvec**2))
       IF (norm <= EPSILON(0.0_dp)) &
          CPABORT("The norm of the dimer vector is 0! Calculation cannot proceed further.")
+      IF (unit_nr > 0) THEN
+         WRITE (unit_nr, "(T2,A,T9,A,T69,F12.6)") &
+            "DIMER|", "Norm of dimer vector to be removed by normalization", norm
+      END IF
       dimer_env%nvec = dimer_env%nvec/norm
       dimer_env%rot%rotation_step = do_first_rotation_step
       CALL section_vals_val_get(dimer_section, "DR", r_val=dimer_env%dr)
@@ -261,13 +276,15 @@ CONTAINS
 !>        of the gradient in CG should also be set to zero.
 !> \param vec : vector to be modified
 !> \param subsys : subsys type object used by CP2k
+!> \param unit : unit to write message to
 !> \par History
 !>      2016/03/03 [LTong] created
 !> \author Lianheng Tong [LTong]
 ! **************************************************************************************************
-   SUBROUTINE dimer_fixed_atom_control(vec, subsys)
+   SUBROUTINE dimer_fixed_atom_control(vec, subsys, unit)
       REAL(KIND=dp), DIMENSION(:), INTENT(INOUT)         :: vec
       TYPE(cp_subsys_type), POINTER                      :: subsys
+      INTEGER, INTENT(IN), OPTIONAL                      :: unit
 
       INTEGER                                            :: ii, ikind, ind, iparticle, nfixed_atoms, &
                                                             nkinds
@@ -292,6 +309,10 @@ CONTAINS
                                 nfixd=nfixed_atoms, &
                                 fixd_list=fixd_list)
          IF (ASSOCIATED(fixd_list)) THEN
+            IF (PRESENT(unit) .AND. unit > 0) THEN
+               WRITE (unit, "(/,T2,A,T9,A,T71,I10)") &
+                  "DIMER|", "Number of fixed atoms to adjust dimer vector", nfixed_atoms
+            END IF
             DO ii = 1, nfixed_atoms
                IF (.NOT. fixd_list(ii)%restraint%active) THEN
                   iparticle = fixd_list(ii)%fixd
@@ -323,5 +344,193 @@ CONTAINS
          END IF ! ASSOCIATED(fixd_list)
       END DO ! ikind
    END SUBROUTINE dimer_fixed_atom_control
+
+! **************************************************************************************************
+!> \brief Read dimer vector from input and store into dimer_env%nvec
+!> \param dimer_env ...
+!> \param dimer_section ...
+!> \param natom ...
+!> \param unit ...
+!> \param globenv ...
+!> \param force_env ...
+!> \par History
+!>      2026/05  created
+!> \author HE Zilong
+! **************************************************************************************************
+   SUBROUTINE dimer_init_vector(dimer_env, dimer_section, natom, unit, globenv, force_env)
+      TYPE(dimer_env_type), INTENT(INOUT), POINTER       :: dimer_env
+      TYPE(section_vals_type), INTENT(INOUT), POINTER    :: dimer_section
+      INTEGER, INTENT(IN)                                :: natom, unit
+      TYPE(global_environment_type), INTENT(IN), POINTER :: globenv
+      TYPE(force_env_type), POINTER                      :: force_env
+
+      CHARACTER(LEN=17)                                  :: vib_name
+      CHARACTER(LEN=default_path_length)                 :: molden_name
+      INTEGER                                            :: dimer_init_method, i, ierr, isize, j, &
+                                                            n_rep_val, nvec_size, vib_list_size
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: vib_id_list
+      LOGICAL                                            :: explicit, found
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: array_r, vib_wt_list
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: array
+      TYPE(cp_parser_type)                               :: parser
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(section_vals_type), POINTER                   :: nvec_section
+
+      para_env => force_env%para_env
+      nvec_section => section_vals_get_subs_vals(dimer_section, "DIMER_VECTOR")
+      NULLIFY (array)
+      nvec_size = natom*3
+
+      ALLOCATE (dimer_env%nvec(nvec_size))
+      dimer_env%nvec(:) = 0.0_dp
+      CALL section_vals_get(nvec_section, explicit=explicit)
+      IF (explicit) THEN
+         IF (unit > 0) WRITE (unit, "(/,T2,A,T9,A)") &
+            "DIMER|", "Initial dimer vector read from input DIMER_VECTOR section"
+         isize = 0
+         CALL section_vals_val_get(nvec_section, "_DEFAULT_KEYWORD_", n_rep_val=n_rep_val)
+         DO i = 1, n_rep_val
+            CALL section_vals_val_get(nvec_section, "_DEFAULT_KEYWORD_", r_vals=array, i_rep_val=i)
+            DO j = 1, SIZE(array)
+               isize = isize + 1
+               IF (isize <= nvec_size) THEN
+                  dimer_env%nvec(isize) = array(j)
+               ELSE
+                  CPABORT("Size of input DIMER_VECTOR more than natom * 3")
+               END IF
+            END DO
+         END DO
+         IF (isize /= nvec_size) THEN
+            CPABORT("Size of input DIMER_VECTOR inconsistent with natom * 3")
+         END IF
+      ELSE
+         CALL section_vals_val_get(dimer_section, "INITIALIZATION_METHOD", i_val=dimer_init_method)
+         SELECT CASE (dimer_init_method)
+         CASE (dimer_init_random)
+            IF (unit > 0) WRITE (unit, "(/,T2,A,T9,A)") &
+               "DIMER|", "Initial dimer vector generated randomly"
+            CALL globenv%gaussian_rng_stream%fill(dimer_env%nvec)
+         CASE (dimer_init_molden)
+            CALL section_vals_val_get(dimer_section, "VIB_MOLDEN_NAME", explicit=explicit)
+            IF (.NOT. explicit) &
+               CPABORT("INITIALIZATION_METHOD MOLDEN requires VIB_MOLDEN_NAME")
+            CALL section_vals_val_get(dimer_section, "VIB_MOLDEN_NAME", c_val=molden_name)
+            IF (unit > 0) THEN
+               WRITE (unit, "(/,T2,A,T9,A)") &
+                  "DIMER|", "Initial dimer vector by linear combination of normal modes from:"
+               WRITE (unit, "(T2,A,T9,A)") &
+                  "DIMER|", TRIM(ADJUSTL(molden_name))
+            END IF
+            ! Build lists of indices and weights for linear combination
+            CALL vib_get_index_weight(dimer_section, vib_id_list, vib_wt_list, &
+                                      vib_list_size, unit)
+            ! Find vibrational modes in molden and do linear combination
+            ALLOCATE (array_r(nvec_size))
+            CALL parser_create(parser, molden_name, para_env=para_env, apply_preprocessing=.FALSE.)
+            Vib_modes: DO i = 1, vib_list_size
+               ! Format below is from molden_utils.F
+               WRITE (UNIT=vib_name, FMT='(T2,A,1X,I6)') "vibration", vib_id_list(i)
+               CALL parser_search_string(parser, TRIM(vib_name), &
+                                         ignore_case=.FALSE., found=found, &
+                                         begin_line=.TRUE., search_from_begin_of_file=.TRUE.)
+               IF (.NOT. found) CALL cp_abort(__LOCATION__, &
+                                              "Could not found <"//vib_name//"> from molden file")
+               DO j = 1, natom
+                  CALL parser_get_next_line(parser, 1)
+                  READ (UNIT=parser%input_line, FMT=*, IOSTAT=ierr) &
+                     array_r(3*j - 2), array_r(3*j - 1), array_r(3*j)
+                  IF (ierr /= 0) &
+                     CALL cp_abort(__LOCATION__, &
+                                   "Error while reading MOLDEN file: cannot parse the line "// &
+                                   TRIM(ADJUSTL(cp_to_string(j)))//" of <"//vib_name//"> "// &
+                                   "for components of the normal mode")
+               END DO
+               dimer_env%nvec(:) = dimer_env%nvec(:) + array_r(:)*vib_wt_list(i)
+            END DO Vib_modes
+            CALL parser_release(parser)
+            IF (ALLOCATED(array_r)) DEALLOCATE (array_r)
+            IF (ALLOCATED(vib_id_list)) DEALLOCATE (vib_id_list)
+            IF (ALLOCATED(vib_wt_list)) DEALLOCATE (vib_wt_list)
+         CASE DEFAULT
+            CPABORT("Invalid or not yet implemented dimer initialization method")
+         END SELECT
+      END IF
+
+   END SUBROUTINE dimer_init_vector
+
+! **************************************************************************************************
+!> \brief Read VIB_INDEX and VIB_WEIGHT under DIMER section
+!> \param dimer_section ...
+!> \param vib_id_list ...
+!> \param vib_wt_list ...
+!> \param vib_list_size ...
+!> \param unit ...
+!> \par History
+!>      2026/05  created
+!> \author HE Zilong
+! **************************************************************************************************
+   SUBROUTINE vib_get_index_weight(dimer_section, vib_id_list, vib_wt_list, vib_list_size, unit)
+      TYPE(section_vals_type), INTENT(IN), POINTER       :: dimer_section
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: vib_id_list
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: vib_wt_list
+      INTEGER, INTENT(OUT)                               :: vib_list_size
+      INTEGER, INTENT(IN)                                :: unit
+
+      INTEGER                                            :: i, isize, n_rep_val, vib_id_size, &
+                                                            vib_wt_size
+      INTEGER, DIMENSION(:), POINTER                     :: tmpilist
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: tmprlist
+
+      vib_id_size = 0
+      CALL section_vals_val_get(dimer_section, "VIB_INDEX", n_rep_val=n_rep_val)
+      DO i = 1, n_rep_val
+         CALL section_vals_val_get(dimer_section, "VIB_INDEX", &
+                                   i_vals=tmpilist, i_rep_val=i)
+         vib_id_size = vib_id_size + SIZE(tmpilist)
+      END DO
+      ALLOCATE (vib_id_list(vib_id_size))
+      isize = 0
+      DO i = 1, n_rep_val
+         CALL section_vals_val_get(dimer_section, "VIB_INDEX", &
+                                   i_vals=tmpilist, i_rep_val=i)
+         vib_id_list(isize + 1:isize + SIZE(tmpilist)) = tmpilist
+         isize = isize + SIZE(tmpilist)
+      END DO
+
+      vib_wt_size = 0
+      CALL section_vals_val_get(dimer_section, "VIB_WEIGHT", n_rep_val=n_rep_val)
+      DO i = 1, n_rep_val
+         CALL section_vals_val_get(dimer_section, "VIB_WEIGHT", &
+                                   r_vals=tmprlist, i_rep_val=i)
+         vib_wt_size = vib_wt_size + SIZE(tmprlist)
+      END DO
+      ALLOCATE (vib_wt_list(vib_wt_size))
+      isize = 0
+      DO i = 1, n_rep_val
+         CALL section_vals_val_get(dimer_section, "VIB_WEIGHT", &
+                                   r_vals=tmprlist, i_rep_val=i)
+         vib_wt_list(isize + 1:isize + SIZE(tmprlist)) = tmprlist
+         isize = isize + SIZE(tmprlist)
+      END DO
+
+      IF (vib_id_size /= vib_wt_size) THEN
+         CALL cp_abort(__LOCATION__, &
+                       "Inconsistent count of values speficied in input between "// &
+                       "VIB_INDEX ("//TRIM(ADJUSTL(cp_to_string(vib_id_size)))//") "// &
+                       "and VIB_WEIGHT ("//TRIM(ADJUSTL(cp_to_string(vib_wt_size)))//")")
+      ELSE
+         vib_list_size = vib_id_size
+      END IF
+      IF (unit > 0) THEN
+         WRITE (unit, "(/,T2,A,T9,A)") &
+            "DIMER|", "Weight and indices of vibrational modes in linear combination"
+         DO i = 1, vib_list_size
+            WRITE (unit, "(T2,A,T10,I6,T18,F12.6)") &
+               "DIMER|", vib_id_list(i), vib_wt_list(i)
+         END DO
+      END IF
+
+   END SUBROUTINE vib_get_index_weight
 
 END MODULE dimer_types

--- a/src/motion/dimer_types.F
+++ b/src/motion/dimer_types.F
@@ -197,7 +197,7 @@ CONTAINS
          CPABORT("The norm of the dimer vector is 0! Calculation cannot proceed further.")
       IF (unit_nr > 0) THEN
          WRITE (unit_nr, "(T2,A,T9,A,T69,F12.6)") &
-            "DIMER|", "Norm of dimer vector to be removed by normalization", norm
+            "DIMER|", "Norm of dimer vector to be normalized by rescaling", norm
       END IF
       dimer_env%nvec = dimer_env%nvec/norm
       dimer_env%rot%rotation_step = do_first_rotation_step
@@ -524,7 +524,7 @@ CONTAINS
       END IF
       IF (unit > 0) THEN
          WRITE (unit, "(/,T2,A,T9,A)") &
-            "DIMER|", "Weight and indices of vibrational modes in linear combination"
+            "DIMER|", "Indices and weights of vibrational modes in linear combination"
          DO i = 1, vib_list_size
             WRITE (unit, "(T2,A,T10,I6,T18,F12.6)") &
                "DIMER|", vib_id_list(i), vib_wt_list(i)

--- a/src/motion/gopt_f_types.F
+++ b/src/motion/gopt_f_types.F
@@ -146,7 +146,7 @@ CONTAINS
                ! already defined for cp2k..
                natom = force_env_get_natom(force_env)
                dimer_section => section_vals_get_subs_vals(geo_opt_section, "TRANSITION_STATE%DIMER")
-               CALL dimer_env_create(gopt_env%dimer_env, subsys, globenv, dimer_section)
+               CALL dimer_env_create(gopt_env%dimer_env, subsys, globenv, dimer_section, force_env)
 
                ! Setup the GEO_OPT environment for the rotation of the Dimer
                rot_opt_section => section_vals_get_subs_vals(dimer_section, "ROT_OPT")

--- a/src/start/input_cp2k_motion.F
+++ b/src/start/input_cp2k_motion.F
@@ -31,6 +31,7 @@ MODULE input_cp2k_motion
    USE input_constants, ONLY: &
       debug_lbfgs, default_bfgs_method_id, default_cg_method_id, default_dimer_method_id, &
       default_lbfgs_method_id, default_minimization_method_id, default_ts_method_id, &
+      dimer_init_molden, dimer_init_random, &
       do_mc_gemc_npt, do_mc_gemc_nvt, do_mc_traditional, do_mc_virial, fix_none, fix_x, fix_xy, &
       fix_xz, fix_y, fix_yz, fix_z, fmt_id_pdb, fmt_id_xyz, gaussian, helium_cell_shape_cube, &
       helium_cell_shape_octahedron, helium_forces_average, helium_forces_last, &
@@ -61,6 +62,7 @@ MODULE input_cp2k_motion
                                   section_release, &
                                   section_type
    USE input_val_types, ONLY: integer_t, &
+                              lchar_t, &
                               logical_t, &
                               real_t, &
                               char_t
@@ -1166,6 +1168,52 @@ CONTAINS
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create(keyword, __LOCATION__, name="INITIALIZATION_METHOD", &
+                          description="Specify the initialization method of the dimer vector, "// &
+                          "which is crucial for converging to the desired transition state. "// &
+                          "If the DIMER_VECTOR section is defined explicitly, it will always "// &
+                          "be parsed directly (e.g. in restart files); INITIALIZATION_METHOD "// &
+                          "is only effective if the DIMER_VECTOR section is not explicit.", &
+                          usage="INITIALIZATION_METHOD (RANDOM|MOLDEN)", &
+                          enum_desc=s2a("Generate the initial dimer vector randomly. This is "// &
+                                        "the default for backwards compatibility; in practice "// &
+                                        "it may distort the structure and slow down convergence.", &
+                                        "Generate the initial dimer vector from one or more "// &
+                                        "vibrational normal modes as read from a MOLDEN file "// &
+                                        "produced by `VIBRATIONAL_ANALYSIS%PRINT%MOLDEN_VIB` "// &
+                                        "in a vibrational analysis task. Requires setting up "// &
+                                        "keywords `VIB_MOLDEN_NAME`, `VIB_INDEX` and `VIB_WEIGHT`."), &
+                          enum_c_vals=s2a("RANDOM", "MOLDEN"), &
+                          enum_i_vals=[dimer_init_random, dimer_init_molden], &
+                          default_i_val=dimer_init_random)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="VIB_MOLDEN_NAME", &
+                          description="The external molden file containing vibrational "// &
+                          "normal modes for `INITIALIZATION_METHOD MOLDEN`.", &
+                          usage="VIB_MOLDEN_NAME <CHARACTER>", type_of_var=lchar_t)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="VIB_INDEX", &
+                          description="The index of one or more vibrational normal modes "// &
+                          "from the file whose linear combination will form the initial "// &
+                          "dimer vector.", &
+                          usage="VIB_INDEX {integer} {integer} .. {integer}", repeats=.TRUE., &
+                          n_var=-1, default_i_vals=[1], type_of_var=integer_t)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="VIB_WEIGHT", &
+                          description="The weight of one or more vibrational normal modes "// &
+                          "from the file whose linear combination will form the initial "// &
+                          "dimer vector.", &
+                          usage="VIB_WEIGHT {real} {real} .. {real}", repeats=.TRUE., &
+                          n_var=-1, default_r_vals=[1.0_dp], type_of_var=real_t)
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+
       CALL keyword_create(keyword, __LOCATION__, name="INTERPOLATE_GRADIENT", &
                           description="This keyword controls the interpolation of the gradient whenever possible"// &
                           " during the optimization of the Dimer. The use of this keywords saves 1 evaluation"// &
@@ -1235,8 +1283,9 @@ CONTAINS
       CALL section_release(subsection2)
 
       CALL section_create(subsection2, __LOCATION__, name="DIMER_VECTOR", &
-                          description="Specifies the initial dimer vector (used frequently to restart DIMER calculations)."// &
-                          " If not provided the starting orientation of the dimer is chosen randomly.", &
+                          description="Specifies the initial dimer vector. This "// &
+                          "section overrides INITIALIZATION_METHOD, and will be "// &
+                          "updated on each step for producing the restart files.", &
                           n_keywords=0, n_subsections=1, repeats=.FALSE.)
       CALL keyword_create(keyword, __LOCATION__, name="_DEFAULT_KEYWORD_", &
                           description="Specify on each line the components of the dimer vector.", repeats=.TRUE., &

--- a/tests/Fist/regtest-5-vib/TEST_FILES.toml
+++ b/tests/Fist/regtest-5-vib/TEST_FILES.toml
@@ -17,4 +17,7 @@
 "N3dye_vib_restart_vec2.inp"            = [{matcher="M018", tol=1.0E-14, ref=1434.156631}]
 "N3dye_vib_restart_vec.inp"             = [{matcher="M018", tol=1.0E-14, ref=1720.504999}]
 "N3dye_vib_restart_vec4.inp"            = [{matcher="M018", tol=1.0E-14, ref=1720.506967}]
+# write vibrational normal modes to molden, then re-read as initial dimer vector
+"argon_vib_molden_write.inp"            = [{matcher="Vib_freq", tol=1.0E-14, ref=33.245417079}]
+"argon_dimer_molden_read.inp"           = [{matcher="M007", tol=1.0E-7, ref=0.0000033386}]
 #EOF

--- a/tests/Fist/regtest-5-vib/argon_dimer_molden_read.inp
+++ b/tests/Fist/regtest-5-vib/argon_dimer_molden_read.inp
@@ -1,0 +1,93 @@
+&GLOBAL
+  PRINT_LEVEL low
+  PROJECT argon_dimer_molden_read
+  RUN_TYPE GEO_OPT
+&END GLOBAL
+
+#CPQA DEPENDS argon_vib_molden_write.inp
+&MOTION
+  &GEO_OPT
+    MAX_ITER 6
+    OPTIMIZER CG
+    TYPE TRANSITION_STATE
+    &CG
+      &LINE_SEARCH
+        TYPE 2PNT
+      &END LINE_SEARCH
+    &END CG
+    &TRANSITION_STATE
+      METHOD DIMER
+      &DIMER
+        ANGLE_TOLERANCE [deg] 2.0
+        INITIALIZATION_METHOD MOLDEN
+        VIB_INDEX 1
+        VIB_MOLDEN_NAME argon_vib_molden_write-VIBRATIONS-1.mol
+        VIB_WEIGHT 1.00
+        &ROT_OPT
+          OPTIMIZER CG
+          &CG
+            &LINE_SEARCH
+              TYPE 2PNT
+            &END LINE_SEARCH
+          &END CG
+        &END ROT_OPT
+      &END DIMER
+    &END TRANSITION_STATE
+  &END GEO_OPT
+  &PRINT
+    &RESTART OFF
+    &END RESTART
+    &TRAJECTORY ON
+      FORMAT EXTXYZ
+    &END TRAJECTORY
+  &END PRINT
+&END MOTION
+
+&FORCE_EVAL
+  METHOD FIST
+  &MM
+    &FORCEFIELD
+      &CHARGE
+        ATOM Ar
+        CHARGE 0.0
+      &END CHARGE
+      &NONBONDED
+        &LENNARD-JONES
+          ATOMS Ar Ar
+          EPSILON 119.8
+          RCUT 11.66
+          SIGMA 3.405
+        &END LENNARD-JONES
+      &END NONBONDED
+      &SPLINE
+        EMAX_ACCURACY 500.0
+        EMAX_SPLINE 1000.0
+        EPS_SPLINE 1.0E-9
+      &END SPLINE
+    &END FORCEFIELD
+    &POISSON
+      &EWALD
+        EWALD_TYPE none
+      &END EWALD
+    &END POISSON
+    &PRINT
+      &FF_INFO
+      &END FF_INFO
+    &END PRINT
+  &END MM
+  &SUBSYS
+    &CELL
+      ABC 13.9057 12.9595 13.9676
+    &END CELL
+    &COORD
+      Ar                 8.75404000    7.58124000    3.09502000
+      Ar                 5.47128000    5.68592000    3.09502000
+      Ar                 7.65982000    5.68592000    6.19005000
+      Ar                 7.65982000    9.47654000    6.19005000
+      Ar                 4.37703000    7.58124000    6.19005000
+    &END COORD
+    &TOPOLOGY
+      CONNECTIVITY OFF
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/Fist/regtest-5-vib/argon_vib_molden_write.inp
+++ b/tests/Fist/regtest-5-vib/argon_vib_molden_write.inp
@@ -1,0 +1,62 @@
+&GLOBAL
+  PRINT_LEVEL low
+  PROJECT argon_vib_molden_write
+  RUN_TYPE VIBRATIONAL_ANALYSIS
+&END GLOBAL
+
+&VIBRATIONAL_ANALYSIS
+  DX 0.001
+  &PRINT
+    &MOLDEN_VIB
+    &END MOLDEN_VIB
+  &END PRINT
+&END VIBRATIONAL_ANALYSIS
+
+&FORCE_EVAL
+  METHOD FIST
+  &MM
+    &FORCEFIELD
+      &CHARGE
+        ATOM Ar
+        CHARGE 0.0
+      &END CHARGE
+      &NONBONDED
+        &LENNARD-JONES
+          ATOMS Ar Ar
+          EPSILON 119.8
+          RCUT 11.66
+          SIGMA 3.405
+        &END LENNARD-JONES
+      &END NONBONDED
+      &SPLINE
+        EMAX_ACCURACY 500.0
+        EMAX_SPLINE 1000.0
+        EPS_SPLINE 1.0E-9
+      &END SPLINE
+    &END FORCEFIELD
+    &POISSON
+      &EWALD
+        EWALD_TYPE none
+      &END EWALD
+    &END POISSON
+    &PRINT
+      &FF_INFO
+      &END FF_INFO
+    &END PRINT
+  &END MM
+  &SUBSYS
+    &CELL
+      ABC 13.9057 12.9595 13.9676
+    &END CELL
+    &COORD
+      Ar                 8.75404000    7.58124000    3.09502000
+      Ar                 5.47128000    5.68592000    3.09502000
+      Ar                 7.65982000    5.68592000    6.19005000
+      Ar                 7.65982000    9.47654000    6.19005000
+      Ar                 4.37703000    7.58124000    6.19005000
+    &END COORD
+    &TOPOLOGY
+      CONNECTIVITY OFF
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL


### PR DESCRIPTION
The dimer method for searching transition state requires an initial dimer vector. Previously it is read from the `&TRANSITION_STATE/&DIMER/&DIMER_VECTOR` section, or if not available, generated randomly. In practice, the latter makes a poor guess that may distort the structure.

This PR adds a keyword `INITIALIZATION_METHOD` to control the initialization, which for backwards compatibility defaults to `RANDOM` and is ignored if the `&DIMER_VECTOR` section is present (e.g. in restart files). A new option `MOLDEN` is created which allows reading a molden file from a vibrational analysis of the input structure and forming an initial dimer vector by a linear combination of one or more vibrational normal modes with indices `VIB_INDEX` and weights `VIB_WEIGHT`. For instance:

```
&DIMER
  INITIALIZATION_METHOD MOLDEN
  VIB_INDEX 1 2
  VIB_WEIGHT 0.4 0.6
  VIB_MOLDEN_NAME TS_guess_freq-VIBRATIONS-1.mol
```

The default value for `VIB_INDEX` and `VIB_WEIGHT` takes the very first vibrational normal mode directly as the initial dimer vector, which may be a much better guess than the randomly generated one. The reason to parse the molden file is because it is plaintext-readable and likely have been visualized by user in order to pick the vibrational normal mode with appropriate atomic motion.