### PR TITLE
Regtesting for secondary output files

### DIFF
--- a/tests/do_regtest.py
+++ b/tests/do_regtest.py
@@ -676,7 +676,7 @@ def eval_regtest(
             alt_path = test.out_path.parent / alt_file
             if not alt_path.exists():
                 err = f"{error}Spec: {spec}\nExpected output file not found: {alt_path}"
-                results += [TestResult(batch, test, spec, duration, "MISSING FILE", err)]
+                results += [TestResult(batch, test, spec, duration, "WRONG RESULT", err)]
                 continue
             match_output = alt_path.read_bytes().decode("utf8", errors="replace")
         else:

--- a/tests/do_regtest.py
+++ b/tests/do_regtest.py
@@ -676,7 +676,9 @@ def eval_regtest(
             alt_path = test.out_path.parent / alt_file
             if not alt_path.exists():
                 err = f"{error}Spec: {spec}\nExpected output file not found: {alt_path}"
-                results += [TestResult(batch, test, spec, duration, "WRONG RESULT", err)]
+                results += [
+                    TestResult(batch, test, spec, duration, "WRONG RESULT", err)
+                ]
                 continue
             match_output = alt_path.read_bytes().decode("utf8", errors="replace")
         else:

--- a/tests/do_regtest.py
+++ b/tests/do_regtest.py
@@ -670,7 +670,18 @@ def eval_regtest(
     # run the matchers
     results = []
     for spec in test.matcher_specs:
-        m = run_matcher(output, **spec)
+        spec = dict(spec)  # shallow copy so we can pop without mutating the original
+        alt_file = spec.pop("file", None)
+        if alt_file:
+            alt_path = test.out_path.parent / alt_file
+            if not alt_path.exists():
+                err = f"{error}Spec: {spec}\nExpected output file not found: {alt_path}"
+                results += [TestResult(batch, test, spec, duration, "MISSING FILE", err)]
+                continue
+            match_output = alt_path.read_bytes().decode("utf8", errors="replace")
+        else:
+            match_output = output
+        m = run_matcher(match_output, **spec)
         if m.error:
             m.error = f"{error}Spec: {spec}\n{m.error}"
         results += [TestResult(batch, test, spec, duration, m.status, m.error, m.value)]


### PR DESCRIPTION
This pull request adds an option for regtesting secondary output files when the code is run.

For example, the option "FILE_NAME" in the BAND_STRUCTURE section under the PRINT section in DFT can be used to have the band structure of the material along a k-point path printed in a "<file_name>.bs" file. This pull request adds an option to test the output of such a file.

In order to test these secondary files, the matchers in the "TEST_FILES.toml" file must contain the "file" option as follows:

{matcher="XX", file="<file_name>.bs", tol=abc, ref=xyz}

if no "file" option is provided, the default primary CP2K output file is read as before.