### PR TITLE
Reject NLCC with native-grid Skala

### DIFF
--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -644,6 +644,11 @@ CONTAINS
                IF (gapw) THEN
                   CPABORT(native_skala_gapw_msg)
                END IF
+               IF (ASSOCIATED(rho_nlcc)) THEN
+                  CALL cp_abort(__LOCATION__, &
+                                "Native SKALA grid evaluation with NLCC pseudopotentials is not implemented. "// &
+                                "The frozen core density would need a SKALA-consistent feature definition.")
+               END IF
                IF (nimages /= 1) THEN
                   CPABORT("Native SKALA grid evaluation supports single-image calculations only.")
                END IF


### PR DESCRIPTION
## Summary

- reject native-grid Skala calculations when NLCC pseudopotentials are active
- document the required missing piece in the abort message: a Skala-consistent frozen-core feature definition

## Testing

- `./make_pretty.sh -m src/qs_ks_methods.F`
- `git diff --check origin/master..HEAD`
- Spark: `QS/regtest-gauxc`, `mpiranks=1`, `ompthreads=1`: 70 / 70 correct
- Spark: `QS/regtest-gauxc`, `mpiranks=2`, `ompthreads=2`: 70 / 70 correct
- Spark: explicit native-grid Skala + NLCC input aborts at the intended guard
