### PR TITLE
Refactor DOS and PDOS input sections and output options

### DIFF
--- a/src/input_cp2k_print_dft.F
+++ b/src/input_cp2k_print_dft.F
@@ -164,8 +164,7 @@ MODULE input_cp2k_print_dft
    USE qs_density_mixing_types, ONLY: create_mixing_section
    USE qs_fb_input, ONLY: create_filtermatrix_section
    USE qs_mom_types, ONLY: create_mom_section
-   USE string_utilities, ONLY: newline, &
-                               s2a
+   USE string_utilities, ONLY: s2a
 
    USE cp_output_handling_openpmd, ONLY: cp_openpmd_get_default_extension
 
@@ -176,7 +175,7 @@ MODULE input_cp2k_print_dft
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'input_cp2k_print_dft'
 
-   PUBLIC :: create_print_dft_section, create_pdos_section
+   PUBLIC :: add_dos_keywords, create_print_dft_section
 
 CONTAINS
 
@@ -1179,11 +1178,21 @@ CONTAINS
       CALL section_add_subsection(section, print_key)
       CALL section_release(print_key)
 
-      CALL create_dos_section(print_key)
-      CALL section_add_subsection(section, print_key)
-      CALL section_release(print_key)
+      CALL cp_print_key_section_create(print_key, __LOCATION__, "DOS", &
+                                       description="Print density of states (DOS). "// &
+                                       "Projected DOS output can be enabled with PDOS.", &
+                                       print_level=debug_print_level, common_iter_levels=1, filename="")
 
-      CALL create_pdos_section(print_key)
+      CALL add_dos_keywords(print_key, xas_mode=.FALSE.)
+
+      CALL keyword_create(keyword, __LOCATION__, name="MP_GRID", &
+                          description="Specify a Monkhorst-Pack grid with which to compute the density of states. "// &
+                          "Works only for a k-point calculation", &
+                          usage="MP_GRID {integer} {integer} {integer}", default_i_vals=[-1], &
+                          n_var=3, type_of_var=integer_t)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
+
       CALL section_add_subsection(section, print_key)
       CALL section_release(print_key)
 
@@ -2662,39 +2671,37 @@ CONTAINS
    END SUBROUTINE create_elf_print_section
 
 ! **************************************************************************************************
-!> \brief Add keywords shared by DOS and PDOS print sections.
+!> \brief Add projected-DOS related keywords to a DOS or XAS PDOS print section.
 !> \param print_key print key section to add keywords to
-!> \param label spectrum label used in keyword descriptions
-!> \param width_desc extra description for BROADEN_WIDTH
-!> \param ndigits_desc description for NDIGITS
+!> \param xas_mode if true, add keywords for the XAS-specific standalone PDOS section
 ! **************************************************************************************************
-   SUBROUTINE add_dos_pdos_common_keywords(print_key, label, width_desc, ndigits_desc)
+   SUBROUTINE add_dos_keywords(print_key, xas_mode)
 
       TYPE(section_type), POINTER                        :: print_key
-      CHARACTER(LEN=*), INTENT(IN)                       :: label, width_desc, ndigits_desc
+      LOGICAL, INTENT(IN)                                :: xas_mode
 
       TYPE(keyword_type), POINTER                        :: keyword
+      TYPE(section_type), POINTER                        :: subsection
 
+      NULLIFY (subsection)
       NULLIFY (keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="APPEND", &
-                          description="Append the "//TRIM(label)//" obtained at different iterations to the "// &
-                          TRIM(label)//" output file. By default the file is overwritten", &
-                          usage="APPEND", default_l_val=.FALSE., &
-                          lone_keyword_l_val=.TRUE.)
+                          description="Append the DOS/PDOS obtained at different iterations to the output file. "// &
+                          "By default the file is overwritten", &
+                          usage="APPEND", default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="DELTA_E", &
-                          description="Energy spacing of the broadened "//TRIM(label)//" output grid.", &
+                          description="Energy spacing of the broadened DOS/PDOS output grid.", &
                           usage="DELTA_E 0.0005", type_of_var=real_t, default_r_val=0.001_dp)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="ENERGY_UNIT", &
-                          description="Energy unit used for the printed energy axis of the "//TRIM(label)// &
-                          ". For broadened spectra, the "//TRIM(label)// &
-                          " intensity is converted consistently to the selected energy unit.", &
+                          description="Energy unit used for the printed DOS/PDOS energy axis. "// &
+                          "For broadened spectra, intensities are converted consistently to the selected energy unit.", &
                           usage="ENERGY_UNIT HARTREE", type_of_var=enum_t, &
                           enum_c_vals=s2a("HARTREE", "EV"), &
                           enum_i_vals=[1, 2], &
@@ -2705,7 +2712,7 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="ENERGY_ZERO", &
-                          description="Reference energy used for the printed energy axis of the "//TRIM(label)//". "// &
+                          description="Reference energy used for the printed DOS/PDOS energy axis. "// &
                           "With AUTO, the Fermi energy is used if smearing is enabled or fractional "// &
                           "occupations are found; otherwise the highest occupied crystal orbital is used.", &
                           usage="ENERGY_ZERO AUTO", type_of_var=enum_t, &
@@ -2720,7 +2727,7 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="BROADEN_TYPE", &
-                          description="Type of broadening function used to produce the "//TRIM(label)//" curve.", &
+                          description="Type of broadening function used to produce the DOS/PDOS curve.", &
                           usage="BROADEN_TYPE GAUSSIAN", type_of_var=enum_t, &
                           enum_c_vals=s2a("GAUSSIAN", "LORENTZIAN", "PSEUDO_VOIGT"), &
                           enum_i_vals=[1, 2, 3], &
@@ -2732,8 +2739,7 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="BROADEN_WIDTH", &
-                          description="Full width at half maximum (FWHM) of the "//TRIM(label)// &
-                          " broadening function. "//TRIM(width_desc), &
+                          description="Full width at half maximum (FWHM) of the DOS/PDOS broadening function.", &
                           usage="BROADEN_WIDTH [eV] 0.1", type_of_var=real_t, &
                           default_r_val=cp_unit_to_cp2k(value=0.1_dp, unit_str="eV"), unit_str="eV")
       CALL section_add_keyword(print_key, keyword)
@@ -2746,82 +2752,41 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="NDIGITS", &
-                          description=ndigits_desc, &
+                          description="Specify the number of digits used to print DOS/PDOS values.", &
                           default_i_val=6)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="NLUMO", &
-                          description="Number of unoccupied orbitals to include in the "//TRIM(label)// &
-                          " (-1=all)."//newline// &
-                          "For OT calculations, the requested virtual orbitals are generated after "// &
-                          "SCF using the OT eigensolver. For diagonalization calculations, "// &
-                          "SCF%ADDED_MOS is increased if needed to make the requested unoccupied "// &
-                          "orbitals available.", &
+                          description="Number of unoccupied orbitals to include in the DOS/PDOS (-1=all). "// &
+                          "For OT calculations, the requested virtual orbitals are generated after SCF using the "// &
+                          "OT eigensolver. For diagonalization calculations, SCF%ADDED_MOS is increased if needed "// &
+                          "to make the requested unoccupied orbitals available.", &
                           usage="NLUMO integer", default_i_val=0)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
 
-   END SUBROUTINE add_dos_pdos_common_keywords
+      IF (.NOT. xas_mode) THEN
+         CALL keyword_create(keyword, __LOCATION__, name="PDOS", &
+                             description="Print projected DOS in addition to the total DOS.", &
+                             usage="PDOS", default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+         CALL section_add_keyword(print_key, keyword)
+         CALL keyword_release(keyword)
 
-! **************************************************************************************************
-!> \brief ...
-!> \param print_key ...
-! **************************************************************************************************
-   SUBROUTINE create_dos_section(print_key)
+         CALL keyword_create(keyword, __LOCATION__, name="PDOS_RAW", &
+                             description="Print MO-resolved projected DOS weights to *.pdos_raw. "// &
+                             "If PDOS is not enabled, PDOS will be enabled automatically.", &
+                             usage="PDOS_RAW", default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+         CALL section_add_keyword(print_key, keyword)
+         CALL keyword_release(keyword)
+      END IF
 
-      TYPE(section_type), POINTER                        :: print_key
-
-      TYPE(keyword_type), POINTER                        :: keyword
-
-      NULLIFY (keyword)
-
-      CALL cp_print_key_section_create(print_key, __LOCATION__, "DOS", &
-                                       description="Print Density of States (DOS) (only available states from SCF)", &
-                                       print_level=debug_print_level, common_iter_levels=1, filename="")
-
-      CALL add_dos_pdos_common_keywords(print_key, "DOS", &
-                                        "Set to zero to recover the unbroadened histogram output.", &
-                                        "Specify the number of digits used to print density and occupation.")
-
-      CALL keyword_create(keyword, __LOCATION__, name="MP_GRID", &
-                          description="Specify a Monkhorst-Pack grid with which to compute the density of states. "// &
-                          "Works only for a k-point calculation", &
-                          usage="MP_GRID {integer} {integer} {integer}", default_i_vals=[-1], &
-                          n_var=3, type_of_var=integer_t)
-      CALL section_add_keyword(print_key, keyword)
-      CALL keyword_release(keyword)
-
-   END SUBROUTINE create_dos_section
-
-! **************************************************************************************************
-!> \brief ...
-!> \param print_key ...
-! **************************************************************************************************
-   SUBROUTINE create_pdos_section(print_key)
-
-      TYPE(section_type), POINTER                        :: print_key
-
-      TYPE(keyword_type), POINTER                        :: keyword
-      TYPE(section_type), POINTER                        :: subsection
-
-      NULLIFY (subsection)
-      NULLIFY (keyword)
-
-      CALL cp_print_key_section_create(print_key, __LOCATION__, "PDOS", &
-                                       description="Print out the DOS projected per kind and angular momentum  ", &
-                                       print_level=debug_print_level, common_iter_levels=1, filename="")
       CALL keyword_create(keyword, __LOCATION__, name="COMPONENTS", &
                           description="Print out PDOS distinguishing all angular momentum components.", &
-                          usage="COMPONENTS", default_l_val=.FALSE., &
-                          lone_keyword_l_val=.TRUE.)
+                          usage="COMPONENTS", default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
-      CALL add_dos_pdos_common_keywords(print_key, "PDOS", &
-                                        "The broadened PDOS curve is written to *.pdos, while the "// &
-                                        "MO-resolved projected weights are written to *.pdos_raw. "// &
-                                        "Set to zero to skip the broadened PDOS curve.", &
-                                        "Specify the number of digits used to print broadened PDOS values.")
+
       CALL keyword_create(keyword, __LOCATION__, name="OUT_EACH_STATE", &
                           variants=["OUT_EACH_MO"], &
                           description="Output on the status of the calculation every OUT_EACH_MO states. If -1 no output", &
@@ -2835,33 +2800,28 @@ CONTAINS
                           n_keywords=4, n_subsections=0, repeats=.TRUE.)
       CALL keyword_create(keyword, __LOCATION__, name="COMPONENTS", &
                           description="Print out PDOS distinguishing all angular momentum components.", &
-                          usage="COMPONENTS", default_l_val=.FALSE., &
-                          lone_keyword_l_val=.TRUE.)
+                          usage="COMPONENTS", default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
-
       CALL keyword_create(keyword, __LOCATION__, name="LIST", &
-                          description="Specifies a list of indexes of atoms where to project the DOS  ", &
-                          usage="LIST {integer}  {integer} ..  {integer} ", type_of_var=integer_t, &
+                          description="Specifies a list of indexes of atoms where to project the DOS", &
+                          usage="LIST {integer} {integer} .. {integer}", type_of_var=integer_t, &
                           n_var=-1, repeats=.TRUE.)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
-
       CALL section_add_subsection(print_key, subsection)
       CALL section_release(subsection)
 
       CALL section_create(subsection, __LOCATION__, name="R_LDOS", &
-                          description="Controls the printing of local PDOS, projected on 3D volume in real space,"// &
-                          " the volume is defined in terms of position with respect to atoms in the lists", &
+                          description="Controls the printing of local PDOS, projected on 3D volume in real space, "// &
+                          "the volume is defined in terms of position with respect to atoms in the lists", &
                           n_keywords=4, n_subsections=0, repeats=.TRUE.)
-
       CALL keyword_create(keyword, __LOCATION__, name="LIST", &
-                          description="Specifies a list of indexes of atoms used to define the real space volume  ", &
-                          usage="LIST {integer}  {integer} ..  {integer} ", type_of_var=integer_t, &
+                          description="Specifies a list of indexes of atoms used to define the real space volume", &
+                          usage="LIST {integer} {integer} .. {integer}", type_of_var=integer_t, &
                           n_var=-1, repeats=.TRUE.)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
-
       CALL keyword_create(keyword, __LOCATION__, name="XRANGE", &
                           description="range of positions in Cartesian direction x: all grid points within "// &
                           "this range from at least one atom of the list are considered", &
@@ -2880,22 +2840,20 @@ CONTAINS
                           usage="ZRANGE -10.0 10.0", unit_str="angstrom", n_var=2, type_of_var=real_t)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
-
       CALL keyword_create(keyword, __LOCATION__, name="ERANGE", &
                           description="Only project states with the energy values in the given interval. "// &
                           "Default is all states.", &
                           usage="ERANGE -1.0 1.0", unit_str="hartree", n_var=2, type_of_var=real_t)
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
-
       CALL section_add_subsection(print_key, subsection)
       CALL section_release(subsection)
 
-   END SUBROUTINE create_pdos_section
+   END SUBROUTINE add_dos_keywords
 
 ! **************************************************************************************************
-!> \brief ...
-!> \param print_key ...
+!> \brief Create WANNIER90 print section.
+!> \param print_key print key section to create
 ! **************************************************************************************************
    SUBROUTINE create_wannier_section(print_key)
 

--- a/src/input_cp2k_print_dft.F
+++ b/src/input_cp2k_print_dft.F
@@ -2691,6 +2691,34 @@ CONTAINS
       CALL section_add_keyword(print_key, keyword)
       CALL keyword_release(keyword)
 
+      CALL keyword_create(keyword, __LOCATION__, name="ENERGY_UNIT", &
+                          description="Energy unit used for the printed energy axis of the "//TRIM(label)// &
+                          ". For broadened spectra, the "//TRIM(label)// &
+                          " intensity is converted consistently to the selected energy unit.", &
+                          usage="ENERGY_UNIT HARTREE", type_of_var=enum_t, &
+                          enum_c_vals=s2a("HARTREE", "EV"), &
+                          enum_i_vals=[1, 2], &
+                          enum_desc=s2a("Print energies in Hartree (a.u.).", &
+                                        "Print energies in electronvolt."), &
+                          default_i_val=1)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="ENERGY_ZERO", &
+                          description="Reference energy used for the printed energy axis of the "//TRIM(label)//". "// &
+                          "With AUTO, the Fermi energy is used if smearing is enabled or fractional "// &
+                          "occupations are found; otherwise the highest occupied crystal orbital is used.", &
+                          usage="ENERGY_ZERO AUTO", type_of_var=enum_t, &
+                          enum_c_vals=s2a("AUTO", "ABSOLUTE", "FERMI", "HOCO"), &
+                          enum_i_vals=[1, 2, 3, 4], &
+                          enum_desc=s2a("Choose FERMI for smeared or fractionally occupied systems, otherwise HOCO.", &
+                                        "Print absolute orbital energies.", &
+                                        "Shift orbital energies by the Fermi energy.", &
+                                        "Shift orbital energies by the highest occupied crystal orbital."), &
+                          default_i_val=1)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
+
       CALL keyword_create(keyword, __LOCATION__, name="BROADEN_TYPE", &
                           description="Type of broadening function used to produce the "//TRIM(label)//" curve.", &
                           usage="BROADEN_TYPE GAUSSIAN", type_of_var=enum_t, &

--- a/src/input_cp2k_xas.F
+++ b/src/input_cp2k_xas.F
@@ -29,7 +29,7 @@ MODULE input_cp2k_xas
         xas_tp_flex, xas_tp_hh, xas_tp_xfh, xas_tp_xhh, xes_tp_val
    USE input_cp2k_loc,                  ONLY: create_localize_section,&
                                               print_wanniers
-   USE input_cp2k_print_dft,            ONLY: create_pdos_section
+   USE input_cp2k_print_dft,            ONLY: add_dos_keywords
    USE input_cp2k_scf,                  ONLY: create_scf_section
    USE input_cp2k_xc,                   ONLY: create_xc_fun_section
    USE input_keyword_types,             ONLY: keyword_create,&
@@ -56,6 +56,21 @@ MODULE input_cp2k_xas
    PUBLIC :: create_xas_section, create_xas_tdp_section
 
 CONTAINS
+
+! **************************************************************************************************
+!> \brief Create the XAS-specific PDOS print section.
+!> \param print_key the PDOS print section
+! **************************************************************************************************
+   SUBROUTINE create_xas_pdos_section(print_key)
+
+      TYPE(section_type), POINTER                        :: print_key
+
+      CALL cp_print_key_section_create(print_key, __LOCATION__, "PDOS", &
+                                       description="Print out the XAS PDOS projected per kind and angular momentum", &
+                                       print_level=debug_print_level, common_iter_levels=1, filename="")
+      CALL add_dos_keywords(print_key, xas_mode=.TRUE.)
+
+   END SUBROUTINE create_xas_pdos_section
 
 ! **************************************************************************************************
 !> \brief makes the input section for core-level spectroscopy simulations
@@ -296,7 +311,7 @@ CONTAINS
       CALL section_add_subsection(subsection, print_key)
       CALL section_release(print_key)
 
-      CALL create_pdos_section(print_key)
+      CALL create_xas_pdos_section(print_key)
       CALL section_add_subsection(subsection, print_key)
       CALL section_release(print_key)
 
@@ -975,7 +990,7 @@ CONTAINS
       CALL section_add_subsection(subsection, print_key)
       CALL section_release(print_key)
 
-      CALL create_pdos_section(print_key)
+      CALL create_xas_pdos_section(print_key)
       CALL section_add_subsection(subsection, print_key)
       CALL section_release(print_key)
 

--- a/src/qs_dos.F
+++ b/src/qs_dos.F
@@ -29,9 +29,10 @@ MODULE qs_dos
                                               kpoint_type
    USE message_passing,                 ONLY: mp_para_env_type
    USE qs_band_structure,               ONLY: calculate_kp_orbitals
-   USE qs_dos_utils,                    ONLY: add_broadened_peak,&
-                                              broadening_cutoff,&
-                                              write_broadening_info
+   USE qs_dos_utils,                    ONLY: &
+        add_broadened_peak, broadening_cutoff, dos_density_scale, dos_energy_label, &
+        dos_energy_scale, dos_energy_unit_ev, dos_energy_zero_absolute, dos_energy_zero_auto, &
+        dos_energy_zero_hoco, dos_energy_zero_label, dos_resolve_energy_zero, write_broadening_info
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_mo_types,                     ONLY: get_mo_set,&
@@ -55,29 +56,34 @@ CONTAINS
 !> \param mos ...
 !> \param dft_section ...
 !> \param unoccupied_evals ...
+!> \param smearing_enabled ...
 !> \date    26.02.2008
 !> \par History:
 !> \author  JGH
 !> \version 1.0
 ! **************************************************************************************************
-   SUBROUTINE calculate_dos(mos, dft_section, unoccupied_evals)
+   SUBROUTINE calculate_dos(mos, dft_section, unoccupied_evals, smearing_enabled)
 
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
       TYPE(section_vals_type), POINTER                   :: dft_section
       TYPE(cp_1d_r_p_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: unoccupied_evals
+      LOGICAL, INTENT(IN), OPTIONAL                      :: smearing_enabled
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'calculate_dos'
 
+      CHARACTER(LEN=16)                                  :: energy_label
       CHARACTER(LEN=20)                                  :: fmtstr_data
+      CHARACTER(LEN=32)                                  :: zero_label
       CHARACTER(LEN=default_string_length)               :: my_act, my_pos
-      INTEGER                                            :: broaden_type, handle, i, iounit, ispin, &
-                                                            iterstep, iv, iw, ndigits, nhist, &
-                                                            nmo(2), nspins, nstates(2), nvirt(2)
-      LOGICAL                                            :: append, do_broaden, ionode, should_output
-      REAL(KIND=dp)                                      :: broaden_cutoff, broaden_width, de, e1, &
-                                                            e2, e_fermi(2), emax, emin, eval, &
-                                                            voigt_mixing
+      INTEGER :: broaden_type, energy_unit, energy_zero, handle, i, iounit, ispin, iterstep, iv, &
+         iw, ndigits, nhist, nmo(2), nspins, nstates(2), nvirt(2), resolved_energy_zero
+      LOGICAL                                            :: append, do_broaden, &
+                                                            fractional_occupation, ionode, &
+                                                            should_output, smear_on
+      REAL(KIND=dp) :: broaden_cutoff, broaden_width, de, density_factor, e1, e2, e_fermi(2), &
+         emax, emin, energy_factor, energy_ref(2), ev_factor, eval, hoco(2), out_density, out_occ, &
+         voigt_mixing
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: ehist, hist, occval
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation_numbers
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -100,6 +106,8 @@ CONTAINS
       CALL section_vals_val_get(dft_section, "PRINT%DOS%DELTA_E", r_val=de)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%APPEND", l_val=append)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%NDIGITS", i_val=ndigits)
+      CALL section_vals_val_get(dft_section, "PRINT%DOS%ENERGY_UNIT", i_val=energy_unit)
+      CALL section_vals_val_get(dft_section, "PRINT%DOS%ENERGY_ZERO", i_val=energy_zero)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%BROADEN_TYPE", i_val=broaden_type)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%BROADEN_WIDTH", r_val=broaden_width)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%VOIGT_MIXING", r_val=voigt_mixing)
@@ -118,11 +126,22 @@ CONTAINS
       nmo(:) = 0
       nvirt(:) = 0
       nstates(:) = 0
+      hoco(:) = -HUGE(0.0_dp)
+      fractional_occupation = .FALSE.
+      smear_on = .FALSE.
+      IF (PRESENT(smearing_enabled)) smear_on = smearing_enabled
 
       DO ispin = 1, nspins
          mo_set => mos(ispin)
          CALL get_mo_set(mo_set=mo_set, nmo=nmo(ispin), mu=e_fermi(ispin))
          eigenvalues => mo_set%eigenvalues
+         occupation_numbers => mo_set%occupation_numbers
+         DO i = 1, nmo(ispin)
+            IF (occupation_numbers(i) > 1.0e-10_dp) hoco(ispin) = MAX(hoco(ispin), eigenvalues(i))
+            IF (ABS(occupation_numbers(i) - REAL(NINT(occupation_numbers(i)), KIND=dp)) > &
+                1.0e-8_dp) fractional_occupation = .TRUE.
+         END DO
+         IF (hoco(ispin) < -0.5_dp*HUGE(0.0_dp)) hoco(ispin) = e_fermi(ispin)
          IF (PRESENT(unoccupied_evals)) THEN
             IF (ASSOCIATED(unoccupied_evals(ispin)%array)) nvirt(ispin) = SIZE(unoccupied_evals(ispin)%array)
          END IF
@@ -215,38 +234,74 @@ CONTAINS
          END DO
       END IF
 
+      resolved_energy_zero = dos_resolve_energy_zero(energy_zero, smear_on, fractional_occupation)
+      SELECT CASE (resolved_energy_zero)
+      CASE (dos_energy_zero_absolute)
+         energy_ref(:) = 0.0_dp
+      CASE (dos_energy_zero_hoco)
+         energy_ref(:) = hoco(:)
+      CASE DEFAULT
+         energy_ref(:) = e_fermi(:)
+      END SELECT
+      energy_factor = dos_energy_scale(energy_unit)
+      density_factor = dos_density_scale(energy_unit)
+      energy_label = dos_energy_label(energy_unit)
+      zero_label = dos_energy_zero_label(resolved_energy_zero)
+      IF (energy_zero == dos_energy_zero_auto) zero_label = "AUTO -> "//TRIM(zero_label)
+      ev_factor = dos_energy_scale(dos_energy_unit_ev)
+
       my_act = "WRITE"
       iw = cp_print_key_unit_nr(logger, dft_section, "PRINT%DOS", &
                                 extension=".dos", file_position=my_pos, file_action=my_act, &
                                 file_form="FORMATTED")
       IF (iw > 0) THEN
+         WRITE (UNIT=iw, FMT="(A,I0)") "# DOS at iteration step i = ", iterstep
          IF (nspins == 2) THEN
-            WRITE (UNIT=iw, FMT="(A,I0,A,2F12.6)") &
-               "# DOS at iteration step i = ", iterstep, ", E_Fermi[a.u.] = ", e_fermi(1:2)
+            WRITE (UNIT=iw, FMT="(A,2F12.6,A,2F12.6,A)") &
+               "# E(Fermi) = ", e_fermi(1:2), " a.u. = ", e_fermi(1:2)*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,2F12.6,A,2F12.6,A)") &
+               "# E(HOCO)  = ", hoco(1:2), " a.u. = ", hoco(1:2)*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
             IF (do_broaden) CALL write_broadening_info(iw, broaden_type, broaden_width, voigt_mixing)
-            WRITE (UNIT=iw, FMT="(T2,A, A)") "#  Energy[a.u.]  Alpha_Density    Occupation", &
-               "    Energy[a.u.]  Beta_Density     Occupation"
+            WRITE (UNIT=iw, FMT="(T2,A,A,A)") "#  "//TRIM(energy_label)//"  Alpha_Density    Occupation", &
+               "    "//TRIM(energy_label), "  Beta_Density     Occupation"
             ! (2(F15.8,2F20.ndigits))
             WRITE (UNIT=fmtstr_data, FMT="(A,I0,A)") "(2(F15.8,2F20.", ndigits, "))"
          ELSE
-            WRITE (UNIT=iw, FMT="(A,I0,A,F12.6)") &
-               "# DOS at iteration step i = ", iterstep, ", E_Fermi[a.u.] = ", e_fermi(1)
+            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+               "# E(Fermi) = ", e_fermi(1), " a.u. = ", e_fermi(1)*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+               "# E(HOCO)  = ", hoco(1), " a.u. = ", hoco(1)*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
             IF (do_broaden) CALL write_broadening_info(iw, broaden_type, broaden_width, voigt_mixing)
-            WRITE (UNIT=iw, FMT="(A)") "# Energy[a.u.]       Density     Occupation"
+            WRITE (UNIT=iw, FMT="(A,A)") "# "//TRIM(energy_label), "       Density     Occupation"
             ! (F15.8,2F20.ndigits)
             WRITE (UNIT=fmtstr_data, FMT="(A,I0,A)") "(F15.8,2F20.", ndigits, ")"
          END IF
          DO i = 1, nhist
             IF (nspins == 2) THEN
-               e1 = ehist(i, 1)
-               e2 = ehist(i, 2)
+               e1 = (ehist(i, 1) - energy_ref(1))*energy_factor
+               e2 = (ehist(i, 2) - energy_ref(2))*energy_factor
                ! fmtstr_data == "(2(F15.8,2F20.xx))"
-               WRITE (UNIT=iw, FMT=fmtstr_data) e1, hist(i, 1), occval(i, 1), &
-                  e2, hist(i, 2), occval(i, 2)
+               IF (do_broaden) THEN
+                  WRITE (UNIT=iw, FMT=fmtstr_data) e1, hist(i, 1)*density_factor, &
+                     occval(i, 1)*density_factor, e2, hist(i, 2)*density_factor, &
+                     occval(i, 2)*density_factor
+               ELSE
+                  WRITE (UNIT=iw, FMT=fmtstr_data) e1, hist(i, 1), occval(i, 1), &
+                     e2, hist(i, 2), occval(i, 2)
+               END IF
             ELSE
-               eval = ehist(i, 1)
+               eval = (ehist(i, 1) - energy_ref(1))*energy_factor
                ! fmtstr_data == "(F15.8,2F20.xx)"
-               WRITE (UNIT=iw, FMT=fmtstr_data) eval, hist(i, 1), occval(i, 1)
+               IF (do_broaden) THEN
+                  out_density = hist(i, 1)*density_factor
+                  out_occ = occval(i, 1)*density_factor
+               ELSE
+                  out_density = hist(i, 1)
+                  out_occ = occval(i, 1)
+               END IF
+               WRITE (UNIT=iw, FMT=fmtstr_data) eval, out_density, out_occ
             END IF
          END DO
       END IF
@@ -273,16 +328,19 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'calculate_dos_kp'
 
-      CHARACTER(LEN=16)                                  :: fmtstr_data
+      CHARACTER(LEN=16)                                  :: energy_label, fmtstr_data
+      CHARACTER(LEN=32)                                  :: zero_label
       CHARACTER(LEN=default_string_length)               :: my_act, my_pos
-      INTEGER                                            :: broaden_type, handle, i, ik, iounit, &
-                                                            ispin, iterstep, iv, iw, ndigits, &
-                                                            nhist, nmo(2), nmo_kp, nspins
+      INTEGER :: broaden_type, energy_unit, energy_zero, fractional_occupation_int, handle, i, ik, &
+         iounit, ispin, iterstep, iv, iw, ndigits, nhist, nmo(2), nmo_kp, nspins, &
+         resolved_energy_zero
       INTEGER, DIMENSION(:), POINTER                     :: nkp_grid
-      LOGICAL                                            :: append, do_broaden, explicit, ionode, &
+      LOGICAL                                            :: append, do_broaden, explicit, &
+                                                            fractional_occupation, ionode, &
                                                             should_output
-      REAL(KIND=dp)                                      :: broaden_cutoff, broaden_width, de, e1, &
-                                                            e2, emax, emin, eval, voigt_mixing, wkp
+      REAL(KIND=dp) :: broaden_cutoff, broaden_width, de, density_factor, e1, e2, e_fermi(2), &
+         emax, emin, energy_factor, energy_ref(2), ev_factor, eval, hoco(2), out_density, out_occ, &
+         voigt_mixing, wkp
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: ehist, hist, occval
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation_numbers
       TYPE(cp_logger_type), POINTER                      :: logger
@@ -330,6 +388,8 @@ CONTAINS
       CALL section_vals_val_get(dft_section, "PRINT%DOS%DELTA_E", r_val=de)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%APPEND", l_val=append)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%NDIGITS", i_val=ndigits)
+      CALL section_vals_val_get(dft_section, "PRINT%DOS%ENERGY_UNIT", i_val=energy_unit)
+      CALL section_vals_val_get(dft_section, "PRINT%DOS%ENERGY_ZERO", i_val=energy_zero)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%BROADEN_TYPE", i_val=broaden_type)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%BROADEN_WIDTH", r_val=broaden_width)
       CALL section_vals_val_get(dft_section, "PRINT%DOS%VOIGT_MIXING", r_val=voigt_mixing)
@@ -350,14 +410,23 @@ CONTAINS
       emin = 1.e10_dp
       emax = -1.e10_dp
       nmo(:) = 0
+      e_fermi(:) = 0.0_dp
+      hoco(:) = -HUGE(0.0_dp)
+      fractional_occupation = .FALSE.
       IF (kpoints%nkp /= 0) THEN
          DO ik = 1, SIZE(kpoints%kp_env)
             mos => kpoints%kp_env(ik)%kpoint_env%mos
             CPASSERT(ASSOCIATED(mos))
             DO ispin = 1, nspins
                mo_set => mos(1, ispin)
-               CALL get_mo_set(mo_set=mo_set, nmo=nmo_kp)
+               CALL get_mo_set(mo_set=mo_set, nmo=nmo_kp, mu=e_fermi(ispin))
                eigenvalues => mo_set%eigenvalues
+               occupation_numbers => mo_set%occupation_numbers
+               DO i = 1, nmo_kp
+                  IF (occupation_numbers(i) > 1.0e-10_dp) hoco(ispin) = MAX(hoco(ispin), eigenvalues(i))
+                  IF (ABS(occupation_numbers(i) - REAL(NINT(occupation_numbers(i)), KIND=dp)) > &
+                      1.0e-8_dp) fractional_occupation = .TRUE.
+               END DO
                e1 = MINVAL(eigenvalues(1:nmo_kp))
                e2 = MAXVAL(eigenvalues(1:nmo_kp))
                emin = MIN(emin, e1)
@@ -369,6 +438,14 @@ CONTAINS
       CALL para_env%min(emin)
       CALL para_env%max(emax)
       CALL para_env%max(nmo)
+      CALL para_env%max(e_fermi)
+      CALL para_env%max(hoco)
+      fractional_occupation_int = MERGE(1, 0, fractional_occupation)
+      CALL para_env%max(fractional_occupation_int)
+      fractional_occupation = (fractional_occupation_int /= 0)
+      DO ispin = 1, nspins
+         IF (hoco(ispin) < -0.5_dp*HUGE(0.0_dp)) hoco(ispin) = e_fermi(ispin)
+      END DO
 
       IF (do_broaden) THEN
          broaden_cutoff = broadening_cutoff(broaden_type, broaden_width)
@@ -418,34 +495,71 @@ CONTAINS
          ehist(i, 1:nspins) = emin + (i - 1)*de
       END DO
 
+      resolved_energy_zero = dos_resolve_energy_zero(energy_zero, dft_control%smear, fractional_occupation)
+      SELECT CASE (resolved_energy_zero)
+      CASE (dos_energy_zero_absolute)
+         energy_ref(:) = 0.0_dp
+      CASE (dos_energy_zero_hoco)
+         energy_ref(:) = hoco(:)
+      CASE DEFAULT
+         energy_ref(:) = e_fermi(:)
+      END SELECT
+      energy_factor = dos_energy_scale(energy_unit)
+      density_factor = dos_density_scale(energy_unit)
+      energy_label = dos_energy_label(energy_unit)
+      zero_label = dos_energy_zero_label(resolved_energy_zero)
+      IF (energy_zero == dos_energy_zero_auto) zero_label = "AUTO -> "//TRIM(zero_label)
+      ev_factor = dos_energy_scale(dos_energy_unit_ev)
+
       my_act = "WRITE"
       iw = cp_print_key_unit_nr(logger, dft_section, "PRINT%DOS", &
                                 extension=".dos", file_position=my_pos, file_action=my_act, &
                                 file_form="FORMATTED")
       IF (iw > 0) THEN
+         WRITE (UNIT=iw, FMT="(A,I0)") "# DOS at iteration step i = ", iterstep
          IF (nspins == 2) THEN
-            WRITE (UNIT=iw, FMT="(T2,A,I0)") "# DOS at iteration step i = ", iterstep
+            WRITE (UNIT=iw, FMT="(A,2F12.6,A,2F12.6,A)") &
+               "# E(Fermi) = ", e_fermi(1:2), " a.u. = ", e_fermi(1:2)*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,2F12.6,A,2F12.6,A)") &
+               "# E(HOCO)  = ", hoco(1:2), " a.u. = ", hoco(1:2)*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
             IF (do_broaden) CALL write_broadening_info(iw, broaden_type, broaden_width, voigt_mixing)
-            WRITE (UNIT=iw, FMT="(T2,A,A)") "#  Energy[a.u.]  Alpha_Density    Occupation", &
+            WRITE (UNIT=iw, FMT="(A,A)") "#  "//TRIM(energy_label)//"  Alpha_Density    Occupation", &
                "   Beta_Density     Occupation"
             ! (F15.8,4F20.ndigits)
             WRITE (UNIT=fmtstr_data, FMT="(A,I0,A)") "(F15.8,4F20.", ndigits, ")"
          ELSE
-            WRITE (UNIT=iw, FMT="(T2,A,I0)") "# DOS at iteration step i = ", iterstep
+            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+               "# E(Fermi) = ", e_fermi(1), " a.u. = ", e_fermi(1)*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+               "# E(HOCO)  = ", hoco(1), " a.u. = ", hoco(1)*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
             IF (do_broaden) CALL write_broadening_info(iw, broaden_type, broaden_width, voigt_mixing)
-            WRITE (UNIT=iw, FMT="(T2,A)") "#  Energy[a.u.]       Density     Occupation"
+            WRITE (UNIT=iw, FMT="(A,A)") "#  "//TRIM(energy_label), "       Density     Occupation"
             ! (F15.8,2F20.ndigits)
             WRITE (UNIT=fmtstr_data, FMT="(A,I0,A)") "(F15.8,2F20.", ndigits, ")"
          END IF
          DO i = 1, nhist
-            eval = ehist(i, 1)
+            eval = (ehist(i, 1) - energy_ref(1))*energy_factor
             IF (nspins == 2) THEN
                ! fmtstr_data == "(F15.8,4F20.xx)"
-               WRITE (UNIT=iw, FMT=fmtstr_data) eval, hist(i, 1), occval(i, 1), &
-                  hist(i, 2), occval(i, 2)
+               IF (do_broaden) THEN
+                  WRITE (UNIT=iw, FMT=fmtstr_data) eval, hist(i, 1)*density_factor, &
+                     occval(i, 1)*density_factor, hist(i, 2)*density_factor, occval(i, 2)*density_factor
+               ELSE
+                  WRITE (UNIT=iw, FMT=fmtstr_data) eval, hist(i, 1), occval(i, 1), &
+                     hist(i, 2), occval(i, 2)
+               END IF
             ELSE
                ! fmtstr_data == "(F15.8,2F20.xx)"
-               WRITE (UNIT=iw, FMT=fmtstr_data) eval, hist(i, 1), occval(i, 1)
+               IF (do_broaden) THEN
+                  out_density = hist(i, 1)*density_factor
+                  out_occ = occval(i, 1)*density_factor
+               ELSE
+                  out_density = hist(i, 1)
+                  out_occ = occval(i, 1)
+               END IF
+               WRITE (UNIT=iw, FMT=fmtstr_data) eval, out_density, out_occ
             END IF
          END DO
       END IF

--- a/src/qs_dos_utils.F
+++ b/src/qs_dos_utils.F
@@ -10,6 +10,10 @@
 ! **************************************************************************************************
 MODULE qs_dos_utils
    USE cp_units,                        ONLY: cp_unit_from_cp2k
+   USE input_section_types,             ONLY: section_vals_get,&
+                                              section_vals_get_subs_vals,&
+                                              section_vals_type,&
+                                              section_vals_val_get
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: pi
 #include "./base/base_uses.f90"
@@ -32,7 +36,7 @@ MODULE qs_dos_utils
 
    PUBLIC :: add_broadened_peak, add_broadened_value, broadening_cutoff, broadening_function, &
              dos_density_scale, dos_energy_label, dos_energy_scale, dos_energy_zero_label, &
-             dos_resolve_energy_zero, write_broadening_info
+             dos_resolve_energy_zero, get_dos_pdos_flags, write_broadening_info
 
 CONTAINS
 
@@ -135,6 +139,48 @@ CONTAINS
       END IF
 
    END FUNCTION dos_resolve_energy_zero
+
+! **************************************************************************************************
+!> \brief ...
+!> \param dos_section DOS print section
+!> \param do_dos_output whether the DOS print key is active
+!> \param do_pdos whether projected DOS output is requested or implied
+!> \param do_pdos_raw whether raw projected DOS output is requested
+!> rief Resolve projected-DOS requests from a DOS print section.
+! **************************************************************************************************
+   SUBROUTINE get_dos_pdos_flags(dos_section, do_dos_output, do_pdos, do_pdos_raw)
+
+      TYPE(section_vals_type), POINTER                   :: dos_section
+      LOGICAL, INTENT(IN)                                :: do_dos_output
+      LOGICAL, INTENT(OUT)                               :: do_pdos, do_pdos_raw
+
+      INTEGER                                            :: nrep
+      LOGICAL                                            :: has_ldos, has_r_ldos, requested_pdos
+      TYPE(section_vals_type), POINTER                   :: ldos_section
+
+      requested_pdos = .FALSE.
+      do_pdos_raw = .FALSE.
+      has_ldos = .FALSE.
+      has_r_ldos = .FALSE.
+
+      IF (do_dos_output) THEN
+         CALL section_vals_val_get(dos_section, "PDOS", l_val=requested_pdos)
+         CALL section_vals_val_get(dos_section, "PDOS_RAW", l_val=do_pdos_raw)
+         ldos_section => section_vals_get_subs_vals(dos_section, "LDOS")
+         CALL section_vals_get(ldos_section, n_repetition=nrep)
+         has_ldos = (nrep > 0)
+         ldos_section => section_vals_get_subs_vals(dos_section, "R_LDOS")
+         CALL section_vals_get(ldos_section, n_repetition=nrep)
+         has_r_ldos = (nrep > 0)
+      END IF
+
+      do_pdos = requested_pdos .OR. do_pdos_raw .OR. has_ldos .OR. has_r_ldos
+      IF (do_pdos .AND. .NOT. requested_pdos) THEN
+         IF (do_pdos_raw) CPWARN("PRINT%DOS%PDOS_RAW requires PDOS; enabling PDOS output.")
+         IF (has_ldos .OR. has_r_ldos) CPWARN("PRINT%DOS%LDOS/R_LDOS require PDOS; enabling PDOS output.")
+      END IF
+
+   END SUBROUTINE get_dos_pdos_flags
 
 ! **************************************************************************************************
 !> \brief Add a broadened spectral line to a DOS curve.

--- a/src/qs_dos_utils.F
+++ b/src/qs_dos_utils.F
@@ -23,11 +23,118 @@ MODULE qs_dos_utils
    INTEGER, PARAMETER, PUBLIC :: broadening_gaussian = 1, &
                                  broadening_lorentzian = 2, &
                                  broadening_pseudo_voigt = 3
+   INTEGER, PARAMETER, PUBLIC :: dos_energy_unit_hartree = 1, &
+                                 dos_energy_unit_ev = 2
+   INTEGER, PARAMETER, PUBLIC :: dos_energy_zero_auto = 1, &
+                                 dos_energy_zero_absolute = 2, &
+                                 dos_energy_zero_fermi = 3, &
+                                 dos_energy_zero_hoco = 4
 
    PUBLIC :: add_broadened_peak, add_broadened_value, broadening_cutoff, broadening_function, &
-             write_broadening_info
+             dos_density_scale, dos_energy_label, dos_energy_scale, dos_energy_zero_label, &
+             dos_resolve_energy_zero, write_broadening_info
 
 CONTAINS
+
+! **************************************************************************************************
+!> \brief Return the conversion factor from internal energy units to the selected DOS energy unit.
+!> \param energy_unit ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION dos_energy_scale(energy_unit) RESULT(scale)
+
+      INTEGER, INTENT(IN)                                :: energy_unit
+      REAL(KIND=dp)                                      :: scale
+
+      SELECT CASE (energy_unit)
+      CASE (dos_energy_unit_ev)
+         scale = cp_unit_from_cp2k(value=1.0_dp, unit_str="eV")
+      CASE DEFAULT
+         scale = 1.0_dp
+      END SELECT
+
+   END FUNCTION dos_energy_scale
+
+! **************************************************************************************************
+!> \brief Return the DOS-density conversion factor for the selected energy unit.
+!> \param energy_unit ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION dos_density_scale(energy_unit) RESULT(scale)
+
+      INTEGER, INTENT(IN)                                :: energy_unit
+      REAL(KIND=dp)                                      :: scale
+
+      scale = 1.0_dp/dos_energy_scale(energy_unit)
+
+   END FUNCTION dos_density_scale
+
+! **************************************************************************************************
+!> \brief Return the energy-column label for DOS-like output.
+!> \param energy_unit ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION dos_energy_label(energy_unit) RESULT(label)
+
+      INTEGER, INTENT(IN)                                :: energy_unit
+      CHARACTER(LEN=16)                                  :: label
+
+      SELECT CASE (energy_unit)
+      CASE (dos_energy_unit_ev)
+         label = "Energy[eV]"
+      CASE DEFAULT
+         label = "Energy[a.u.]"
+      END SELECT
+
+   END FUNCTION dos_energy_label
+
+! **************************************************************************************************
+!> \brief Return the label for the selected DOS energy zero.
+!> \param energy_zero ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION dos_energy_zero_label(energy_zero) RESULT(label)
+
+      INTEGER, INTENT(IN)                                :: energy_zero
+      CHARACTER(LEN=16)                                  :: label
+
+      SELECT CASE (energy_zero)
+      CASE (dos_energy_zero_absolute)
+         label = "ABSOLUTE"
+      CASE (dos_energy_zero_hoco)
+         label = "HOCO"
+      CASE (dos_energy_zero_auto)
+         label = "AUTO"
+      CASE DEFAULT
+         label = "FERMI"
+      END SELECT
+
+   END FUNCTION dos_energy_zero_label
+
+! **************************************************************************************************
+!> \brief Resolve AUTO energy-zero selection for DOS-like output.
+!> \param energy_zero ...
+!> \param smearing_enabled ...
+!> \param fractional_occupation ...
+!> \return ...
+! **************************************************************************************************
+   FUNCTION dos_resolve_energy_zero(energy_zero, smearing_enabled, fractional_occupation) RESULT(resolved)
+
+      INTEGER, INTENT(IN)                                :: energy_zero
+      LOGICAL, INTENT(IN)                                :: smearing_enabled, fractional_occupation
+      INTEGER                                            :: resolved
+
+      IF (energy_zero == dos_energy_zero_auto) THEN
+         IF (smearing_enabled .OR. fractional_occupation) THEN
+            resolved = dos_energy_zero_fermi
+         ELSE
+            resolved = dos_energy_zero_hoco
+         END IF
+      ELSE
+         resolved = energy_zero
+      END IF
+
+   END FUNCTION dos_resolve_energy_zero
 
 ! **************************************************************************************************
 !> \brief Add a broadened spectral line to a DOS curve.

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -981,8 +981,8 @@ CONTAINS
       CHARACTER(len=2)                                   :: element_symbol
       INTEGER :: gfn_type, handle, ikind, ispin, iw, lmax_sphere, maxl, maxlgto, maxlgto_lri, &
          maxlgto_nuc, maxlppl, maxlppnl, method_id, multiplicity, my_ival, n_ao, n_mo_add, natom, &
-         nelectron, ngauss, nkind, nlumo_dos, nlumo_molden, nlumo_pdos, nlumo_required, &
-         output_unit, sort_basis, tnadd_method
+         nelectron, ngauss, nkind, nlumo_dos, nlumo_molden, nlumo_required, output_unit, &
+         sort_basis, tnadd_method
       INTEGER, DIMENSION(2)                              :: n_mo, nelectron_spin
       INTEGER, DIMENSION(5)                              :: occ
       INTEGER, DIMENSION(:), POINTER                     :: mo_index_range
@@ -2119,10 +2119,9 @@ CONTAINS
       END IF
 
       nlumo_dos = section_get_ival(dft_section, "PRINT%DOS%NLUMO")
-      nlumo_pdos = section_get_ival(dft_section, "PRINT%PDOS%NLUMO")
       nlumo_molden = section_get_ival(dft_section, "PRINT%MO_MOLDEN%NLUMO")
-      nlumo_required = MAX(nlumo_dos, nlumo_pdos, nlumo_molden)
-      IF (nlumo_dos == -1 .OR. nlumo_pdos == -1 .OR. nlumo_molden == -1) nlumo_required = -1
+      nlumo_required = MAX(nlumo_dos, nlumo_molden)
+      IF (nlumo_dos == -1 .OR. nlumo_molden == -1) nlumo_required = -1
       IF (.NOT. scf_control%use_ot .AND. nlumo_required /= 0) THEN
          IF (nlumo_required == -1) THEN
             IF (scf_control%added_mos(1) /= -1 .OR. &

--- a/src/qs_pdos.F
+++ b/src/qs_pdos.F
@@ -70,10 +70,11 @@ MODULE qs_pdos
    USE pw_types,                        ONLY: pw_c1d_gs_type,&
                                               pw_r3d_rs_type
    USE qs_collocate_density,            ONLY: calculate_wavefunction
-   USE qs_dos_utils,                    ONLY: add_broadened_value,&
-                                              broadening_cutoff,&
-                                              broadening_function,&
-                                              write_broadening_info
+   USE qs_dos_utils,                    ONLY: &
+        add_broadened_value, broadening_cutoff, broadening_function, dos_density_scale, &
+        dos_energy_label, dos_energy_scale, dos_energy_unit_ev, dos_energy_zero_absolute, &
+        dos_energy_zero_auto, dos_energy_zero_hoco, dos_energy_zero_label, &
+        dos_resolve_energy_zero, write_broadening_info
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_kind_types,                   ONLY: get_qs_kind,&
@@ -163,28 +164,27 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_projected_dos'
 
-      CHARACTER(LEN=16)                                  :: fmtstr2
+      CHARACTER(LEN=16)                                  :: energy_label, fmtstr2
       CHARACTER(LEN=27)                                  :: fmtstr1
+      CHARACTER(LEN=32)                                  :: zero_label
       CHARACTER(LEN=6), ALLOCATABLE, DIMENSION(:, :, :)  :: tmp_str
       CHARACTER(LEN=default_string_length)               :: kind_name, my_act, my_mittle, my_pos, &
                                                             spin(2)
       CHARACTER(LEN=default_string_length), &
          ALLOCATABLE, DIMENSION(:)                       :: ldos_index, r_ldos_index
-      INTEGER :: broaden_type, handle, homo, i, iatom, ikind, il, ildos, im, imo, in_x, in_y, &
-         in_z, ir, irow, iset, isgf, ishell, iso, iterstep, iw, j, jx, jy, jz, k, lcomponent, &
-         lshell, maxl, maxlgto, my_spin, n_dependent, n_r_ldos, n_rep, nao, natom, ncol_global, &
-         ndigits, nkind, nldos, nmo, np_tot, npoints, nrow_global, nset, nsgf, nvirt, out_each, &
-         output_unit
+      INTEGER :: broaden_type, energy_unit, energy_zero, handle, homo, i, iatom, ikind, il, ildos, &
+         im, imo, in_x, in_y, in_z, ir, irow, iset, isgf, ishell, iso, iterstep, iw, j, jx, jy, &
+         jz, k, lcomponent, lshell, maxl, maxlgto, my_spin, n_dependent, n_r_ldos, n_rep, nao, &
+         natom, ncol_global, ndigits, nkind, nldos, nmo, np_tot, npoints, nrow_global, nset, nsgf, &
+         nvirt, out_each, output_unit, resolved_energy_zero
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: firstrow
       INTEGER, DIMENSION(:), POINTER                     :: list, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: bo, l
-      LOGICAL                                            :: append, calc_matsh, do_broaden, do_ldos, &
-                                                            do_r_ldos, do_virt, ionode, &
-                                                            separate_components, should_output
+      LOGICAL :: append, calc_matsh, do_broaden, do_ldos, do_r_ldos, do_virt, &
+         fractional_occupation, ionode, separate_components, should_output
       LOGICAL, DIMENSION(:, :), POINTER                  :: read_r
-      REAL(KIND=dp)                                      :: broaden_width, de, dh(3, 3), dvol, &
-                                                            e_fermi, r(3), r_vec(3), ratom(3), &
-                                                            voigt_mixing
+      REAL(KIND=dp) :: broaden_width, de, dh(3, 3), dvol, e_fermi, energy_factor, energy_ref, &
+         ev_factor, hoco, r(3), r_vec(3), ratom(3), voigt_mixing
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, evals_virt, &
                                                             occupation_numbers
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: vecbuffer
@@ -251,6 +251,8 @@ CONTAINS
       CALL section_vals_val_get(dft_section, "PRINT%PDOS%BROADEN_WIDTH", r_val=broaden_width)
       CALL section_vals_val_get(dft_section, "PRINT%PDOS%VOIGT_MIXING", r_val=voigt_mixing)
       CALL section_vals_val_get(dft_section, "PRINT%PDOS%NDIGITS", i_val=ndigits)
+      CALL section_vals_val_get(dft_section, "PRINT%PDOS%ENERGY_UNIT", i_val=energy_unit)
+      CALL section_vals_val_get(dft_section, "PRINT%PDOS%ENERGY_ZERO", i_val=energy_zero)
       ndigits = MIN(MAX(ndigits, 1), 10)
       do_broaden = (broaden_width > 0.0_dp)
       IF (do_broaden) de = MAX(de, 0.00001_dp)
@@ -534,6 +536,29 @@ CONTAINS
          occupation_numbers => mo_set%occupation_numbers
       END IF
 
+      hoco = -HUGE(0.0_dp)
+      fractional_occupation = .FALSE.
+      DO imo = 1, nmo + nvirt
+         IF (occupation_numbers(imo) > 1.0e-10_dp) hoco = MAX(hoco, eigenvalues(imo))
+         IF (ABS(occupation_numbers(imo) - REAL(NINT(occupation_numbers(imo)), KIND=dp)) > &
+             1.0e-8_dp) fractional_occupation = .TRUE.
+      END DO
+      IF (hoco < -0.5_dp*HUGE(0.0_dp)) hoco = e_fermi
+      resolved_energy_zero = dos_resolve_energy_zero(energy_zero, dft_control%smear, fractional_occupation)
+      SELECT CASE (resolved_energy_zero)
+      CASE (dos_energy_zero_absolute)
+         energy_ref = 0.0_dp
+      CASE (dos_energy_zero_hoco)
+         energy_ref = hoco
+      CASE DEFAULT
+         energy_ref = e_fermi
+      END SELECT
+      energy_factor = dos_energy_scale(energy_unit)
+      energy_label = dos_energy_label(energy_unit)
+      zero_label = dos_energy_zero_label(resolved_energy_zero)
+      IF (energy_zero == dos_energy_zero_auto) zero_label = "AUTO -> "//TRIM(zero_label)
+      ev_factor = dos_energy_scale(dos_energy_unit_ev)
+
       pdos_array = 0.0_dp
       nao = mo_set%nao
       ALLOCATE (vecbuffer(1, nao))
@@ -715,13 +740,15 @@ CONTAINS
          IF (do_broaden) THEN
             IF (separate_components) THEN
                CALL write_broadened_pdos(logger, dft_section, TRIM(my_mittle), my_pos, my_act, iterstep, &
-                                         e_fermi, "Projected DOS for atomic kind "//TRIM(kind_name), &
+                                         e_fermi, hoco, energy_ref, TRIM(zero_label), &
+                                         "Projected DOS for atomic kind "//TRIM(kind_name), &
                                          maxl, .TRUE., pdos_array(1:nsoset(maxl), ikind, :), &
                                          eigenvalues, nmo + nvirt, de, broaden_type, broaden_width, &
                                          voigt_mixing, ndigits)
             ELSE
                CALL write_broadened_pdos(logger, dft_section, TRIM(my_mittle), my_pos, my_act, iterstep, &
-                                         e_fermi, "Projected DOS for atomic kind "//TRIM(kind_name), &
+                                         e_fermi, hoco, energy_ref, TRIM(zero_label), &
+                                         "Projected DOS for atomic kind "//TRIM(kind_name), &
                                          maxl, .FALSE., pdos_array(0:maxl, ikind, :), &
                                          eigenvalues, nmo + nvirt, de, broaden_type, broaden_width, &
                                          voigt_mixing, ndigits)
@@ -736,16 +763,20 @@ CONTAINS
             fmtstr1 = "(I8,2X,2F16.6,  (2X,F16.8))"
             fmtstr2 = "(A42,  (10X,A8))"
             IF (separate_components) THEN
-               WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") nsoset(maxl)
-               WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") nsoset(maxl)
+               WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") nsoset(maxl) + 1
+               WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") nsoset(maxl) + 1
             ELSE
-               WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") maxl + 1
-               WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") maxl + 1
+               WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") maxl + 2
+               WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") maxl + 2
             END IF
 
-            WRITE (UNIT=iw, FMT="(A,I0,A,F12.6,A)") &
-               "# Projected DOS for atomic kind "//TRIM(kind_name)//" at iteration step i = ", &
-               iterstep, ", E(Fermi) = ", e_fermi, " a.u."
+            WRITE (UNIT=iw, FMT="(A,I0)") &
+               "# Projected DOS for atomic kind "//TRIM(kind_name)//" at iteration step i = ", iterstep
+            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+               "# E(Fermi) = ", e_fermi, " a.u. = ", e_fermi*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+               "# E(HOCO)  = ", hoco, " a.u. = ", hoco*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
             IF (separate_components) THEN
                ALLOCATE (tmp_str(0:0, 0:maxl, -maxl:maxl))
                tmp_str = ""
@@ -756,19 +787,21 @@ CONTAINS
                END DO
 
                WRITE (UNIT=iw, FMT=fmtstr2) &
-                  "#     MO Eigenvalue [a.u.]      Occupation", &
+                  "#          MO "//TRIM(energy_label)//"      Occupation", "Total", &
                   ((TRIM(tmp_str(0, il, im)), im=-il, il), il=0, maxl)
                DO imo = 1, nmo + nvirt
-                  WRITE (UNIT=iw, FMT=fmtstr1) imo, eigenvalues(imo), occupation_numbers(imo), &
+                  WRITE (UNIT=iw, FMT=fmtstr1) imo, (eigenvalues(imo) - energy_ref)*energy_factor, &
+                     occupation_numbers(imo), SUM(pdos_array(1:nsoset(maxl), ikind, imo)), &
                      (pdos_array(lshell, ikind, imo), lshell=1, nsoset(maxl))
                END DO
                DEALLOCATE (tmp_str)
             ELSE
                WRITE (UNIT=iw, FMT=fmtstr2) &
-                  "#     MO Eigenvalue [a.u.]      Occupation", &
+                  "#          MO "//TRIM(energy_label)//"      Occupation", "Total", &
                   (TRIM(l_sym(il)), il=0, maxl)
                DO imo = 1, nmo + nvirt
-                  WRITE (UNIT=iw, FMT=fmtstr1) imo, eigenvalues(imo), occupation_numbers(imo), &
+                  WRITE (UNIT=iw, FMT=fmtstr1) imo, (eigenvalues(imo) - energy_ref)*energy_factor, &
+                     occupation_numbers(imo), SUM(pdos_array(0:maxl, ikind, imo)), &
                      (pdos_array(lshell, ikind, imo), lshell=0, maxl)
                END DO
             END IF
@@ -799,14 +832,16 @@ CONTAINS
             IF (do_broaden) THEN
                IF (ldos_p(ildos)%ldos%separate_components) THEN
                   CALL write_broadened_pdos(logger, dft_section, TRIM(my_mittle), my_pos, my_act, iterstep, &
-                                            e_fermi, "Projected DOS for atom list "//TRIM(ldos_index(ildos)), &
+                                            e_fermi, hoco, energy_ref, TRIM(zero_label), &
+                                            "Projected DOS for atom list "//TRIM(ldos_index(ildos)), &
                                             ldos_p(ildos)%ldos%maxl, .TRUE., &
                                             ldos_p(ildos)%ldos%pdos_array(1:nsoset(ldos_p(ildos)%ldos%maxl), :), &
                                             eigenvalues, nmo + nvirt, de, broaden_type, broaden_width, &
                                             voigt_mixing, ndigits)
                ELSE
                   CALL write_broadened_pdos(logger, dft_section, TRIM(my_mittle), my_pos, my_act, iterstep, &
-                                            e_fermi, "Projected DOS for atom list "//TRIM(ldos_index(ildos)), &
+                                            e_fermi, hoco, energy_ref, TRIM(zero_label), &
+                                            "Projected DOS for atom list "//TRIM(ldos_index(ildos)), &
                                             ldos_p(ildos)%ldos%maxl, .FALSE., &
                                             ldos_p(ildos)%ldos%pdos_array(0:ldos_p(ildos)%ldos%maxl, :), &
                                             eigenvalues, nmo + nvirt, de, broaden_type, broaden_width, &
@@ -822,17 +857,21 @@ CONTAINS
                fmtstr1 = "(I8,2X,2F16.6,  (2X,F16.8))"
                fmtstr2 = "(A42,  (10X,A8))"
                IF (ldos_p(ildos)%ldos%separate_components) THEN
-                  WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") nsoset(ldos_p(ildos)%ldos%maxl)
-                  WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") nsoset(ldos_p(ildos)%ldos%maxl)
+                  WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") nsoset(ldos_p(ildos)%ldos%maxl) + 1
+                  WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") nsoset(ldos_p(ildos)%ldos%maxl) + 1
                ELSE
-                  WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") ldos_p(ildos)%ldos%maxl + 1
-                  WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") ldos_p(ildos)%ldos%maxl + 1
+                  WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") ldos_p(ildos)%ldos%maxl + 2
+                  WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") ldos_p(ildos)%ldos%maxl + 2
                END IF
 
-               WRITE (UNIT=iw, FMT="(A,I0,A,I0,A,I0,A,F12.6,A)") &
+               WRITE (UNIT=iw, FMT="(A,I0,A,I0,A,I0)") &
                   "# Projected DOS for list ", ildos, " of ", ldos_p(ildos)%ldos%nlist, &
-                  " atoms, at iteration step i = ", iterstep, &
-                  ", E(Fermi) = ", e_fermi, " a.u."
+                  " atoms, at iteration step i = ", iterstep
+               WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+                  "# E(Fermi) = ", e_fermi, " a.u. = ", e_fermi*ev_factor, " eV"
+               WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+                  "# E(HOCO)  = ", hoco, " a.u. = ", hoco*ev_factor, " eV"
+               WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
                IF (ldos_p(ildos)%ldos%separate_components) THEN
                   ALLOCATE (tmp_str(0:0, 0:ldos_p(ildos)%ldos%maxl, -ldos_p(ildos)%ldos%maxl:ldos_p(ildos)%ldos%maxl))
                   tmp_str = ""
@@ -843,19 +882,24 @@ CONTAINS
                   END DO
 
                   WRITE (UNIT=iw, FMT=fmtstr2) &
-                     "#     MO Eigenvalue [a.u.]      Occupation", &
+                     "#          MO "//TRIM(energy_label)//"      Occupation", "Total", &
                      ((TRIM(tmp_str(0, il, im)), im=-il, il), il=0, ldos_p(ildos)%ldos%maxl)
                   DO imo = 1, nmo + nvirt
-                     WRITE (UNIT=iw, FMT=fmtstr1) imo, eigenvalues(imo), occupation_numbers(imo), &
-                        (ldos_p(ildos)%ldos%pdos_array(lshell, imo), lshell=1, nsoset(ldos_p(ildos)%ldos%maxl))
+                     WRITE (UNIT=iw, FMT=fmtstr1) imo, (eigenvalues(imo) - energy_ref)*energy_factor, &
+                        occupation_numbers(imo), &
+                        SUM(ldos_p(ildos)%ldos%pdos_array(1:nsoset(ldos_p(ildos)%ldos%maxl), imo)), &
+                        (ldos_p(ildos)%ldos%pdos_array(lshell, imo), &
+                         lshell=1, nsoset(ldos_p(ildos)%ldos%maxl))
                   END DO
                   DEALLOCATE (tmp_str)
                ELSE
                   WRITE (UNIT=iw, FMT=fmtstr2) &
-                     "#     MO Eigenvalue [a.u.]      Occupation", &
+                     "#          MO "//TRIM(energy_label)//"      Occupation", "Total", &
                      (TRIM(l_sym(il)), il=0, ldos_p(ildos)%ldos%maxl)
                   DO imo = 1, nmo + nvirt
-                     WRITE (UNIT=iw, FMT=fmtstr1) imo, eigenvalues(imo), occupation_numbers(imo), &
+                     WRITE (UNIT=iw, FMT=fmtstr1) imo, (eigenvalues(imo) - energy_ref)*energy_factor, &
+                        occupation_numbers(imo), &
+                        SUM(ldos_p(ildos)%ldos%pdos_array(0:ldos_p(ildos)%ldos%maxl, imo)), &
                         (ldos_p(ildos)%ldos%pdos_array(lshell, imo), lshell=0, ldos_p(ildos)%ldos%maxl)
                   END DO
                END IF
@@ -892,16 +936,21 @@ CONTAINS
             fmtstr1 = "(I8,2X,2F16.6,  (2X,F16.8))"
             fmtstr2 = "(A42,  (10X,A8))"
 
-            WRITE (UNIT=iw, FMT="(A,I0,A,F12.6,F12.6,A,F12.6,A)") &
+            WRITE (UNIT=iw, FMT="(A,I0,A,F12.6,F12.6,A)") &
                "# Projected DOS in real space, using ", npoints, &
-               " points of the grid, and eval in the range", r_ldos_p(ildos)%ldos%eval_range(1:2), &
-               " Hartree, E(Fermi) = ", e_fermi, " a.u."
-            WRITE (UNIT=iw, FMT="(A)") &
-               "#     MO Eigenvalue [a.u.]      Occupation      LDOS"
+               " points of the grid, and eval in the range", r_ldos_p(ildos)%ldos%eval_range(1:2), " Hartree"
+            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+               "# E(Fermi) = ", e_fermi, " a.u. = ", e_fermi*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+               "# E(HOCO)  = ", hoco, " a.u. = ", hoco*ev_factor, " eV"
+            WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
+            WRITE (UNIT=iw, FMT="(A,A,A)") &
+               "#          MO ", TRIM(energy_label), "      Occupation      LDOS"
             DO imo = 1, nmo + nvirt
                IF (r_ldos_p(ildos)%ldos%eval_range(1) <= eigenvalues(imo) .AND. &
                    r_ldos_p(ildos)%ldos%eval_range(2) >= eigenvalues(imo)) THEN
-                  WRITE (UNIT=iw, FMT="(I8,2X,2F16.6,E20.10,E20.10)") imo, eigenvalues(imo), occupation_numbers(imo), &
+                  WRITE (UNIT=iw, FMT="(I8,2X,2F16.6,E20.10,E20.10)") imo, &
+                     (eigenvalues(imo) - energy_ref)*energy_factor, occupation_numbers(imo), &
                      r_ldos_p(ildos)%ldos%pdos_array(imo), r_ldos_p(ildos)%ldos%pdos_array(imo)*np_tot
                END IF
             END DO
@@ -970,21 +1019,24 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_projected_dos_kp'
 
+      CHARACTER(LEN=32)                                  :: zero_label
       CHARACTER(LEN=default_string_length)               :: kind_name, my_act, my_mittle, my_pos, &
                                                             spin(2)
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: zvecbuffer
-      INTEGER :: broaden_type, handle, icomp, ik, ikind, imo, ispin, iterstep, maxl, maxlgto, &
-         n_r_ldos, nao, ncomp, ndigits, nhist, nkind, nldos, nmo_kp, nspins, output_unit
+      INTEGER :: broaden_type, energy_zero, fractional_occupation_int, handle, icomp, ik, ikind, &
+         imo, ispin, iterstep, maxl, maxlgto, n_r_ldos, nao, ncomp, ndigits, nhist, nkind, nldos, &
+         nmo_kp, nspins, output_unit, resolved_energy_zero
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ao_comp, ao_kind, ao_l, kind_maxl
-      LOGICAL                                            :: append, separate_components, &
-                                                            should_output
+      LOGICAL                                            :: append, fractional_occupation, &
+                                                            separate_components, should_output
       REAL(KIND=dp)                                      :: broaden_cutoff, broaden_width, de, e1, &
-                                                            e2, e_fermi, emax, emin, voigt_mixing, &
+                                                            e2, e_fermi(2), emax, emin, &
+                                                            energy_ref(2), hoco(2), voigt_mixing, &
                                                             wkp
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: ao_weight
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: proj_weight, vecbuffer
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: pdos_curve
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation_numbers
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cp_cfm_type)                                  :: cshalfc
       TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_tmp
@@ -1047,6 +1099,7 @@ CONTAINS
       CALL section_vals_val_get(dft_section, "PRINT%PDOS%BROADEN_TYPE", i_val=broaden_type)
       CALL section_vals_val_get(dft_section, "PRINT%PDOS%BROADEN_WIDTH", r_val=broaden_width)
       CALL section_vals_val_get(dft_section, "PRINT%PDOS%VOIGT_MIXING", r_val=voigt_mixing)
+      CALL section_vals_val_get(dft_section, "PRINT%PDOS%ENERGY_ZERO", i_val=energy_zero)
       ndigits = MIN(MAX(ndigits, 1), 10)
       de = MAX(de, 0.00001_dp)
 
@@ -1079,14 +1132,22 @@ CONTAINS
 
       emin = HUGE(0.0_dp)
       emax = -HUGE(0.0_dp)
-      e_fermi = 0.0_dp
+      e_fermi(:) = 0.0_dp
+      hoco(:) = -HUGE(0.0_dp)
+      fractional_occupation = .FALSE.
       IF (kpoints%nkp /= 0) THEN
          DO ik = 1, SIZE(kpoints%kp_env)
             kp => kpoints%kp_env(ik)%kpoint_env
             DO ispin = 1, nspins
                mo_set => kp%mos(1, ispin)
-               CALL get_mo_set(mo_set=mo_set, nmo=nmo_kp, mu=e_fermi)
+               CALL get_mo_set(mo_set=mo_set, nmo=nmo_kp, mu=e_fermi(ispin))
                eigenvalues => mo_set%eigenvalues
+               occupation_numbers => mo_set%occupation_numbers
+               DO imo = 1, nmo_kp
+                  IF (occupation_numbers(imo) > 1.0e-10_dp) hoco(ispin) = MAX(hoco(ispin), eigenvalues(imo))
+                  IF (ABS(occupation_numbers(imo) - REAL(NINT(occupation_numbers(imo)), KIND=dp)) > &
+                      1.0e-8_dp) fractional_occupation = .TRUE.
+               END DO
                e1 = MINVAL(eigenvalues(1:nmo_kp))
                e2 = MAXVAL(eigenvalues(1:nmo_kp))
                emin = MIN(emin, e1)
@@ -1096,6 +1157,25 @@ CONTAINS
       END IF
       CALL para_env%min(emin)
       CALL para_env%max(emax)
+      CALL para_env%max(e_fermi)
+      CALL para_env%max(hoco)
+      fractional_occupation_int = MERGE(1, 0, fractional_occupation)
+      CALL para_env%max(fractional_occupation_int)
+      fractional_occupation = (fractional_occupation_int /= 0)
+      DO ispin = 1, nspins
+         IF (hoco(ispin) < -0.5_dp*HUGE(0.0_dp)) hoco(ispin) = e_fermi(ispin)
+      END DO
+      resolved_energy_zero = dos_resolve_energy_zero(energy_zero, dft_control%smear, fractional_occupation)
+      SELECT CASE (resolved_energy_zero)
+      CASE (dos_energy_zero_absolute)
+         energy_ref(:) = 0.0_dp
+      CASE (dos_energy_zero_hoco)
+         energy_ref(:) = hoco(:)
+      CASE DEFAULT
+         energy_ref(:) = e_fermi(:)
+      END SELECT
+      zero_label = dos_energy_zero_label(resolved_energy_zero)
+      IF (energy_zero == dos_energy_zero_auto) zero_label = "AUTO -> "//TRIM(zero_label)
       broaden_cutoff = broadening_cutoff(broaden_type, broaden_width)
       emin = emin - broaden_cutoff
       emax = emax + broaden_cutoff
@@ -1191,7 +1271,8 @@ CONTAINS
                my_mittle = "k"//TRIM(ADJUSTL(cp_to_string(ikind)))
             END IF
             CALL write_broadened_pdos_curve(logger, dft_section, TRIM(my_mittle), my_pos, my_act, &
-                                            iterstep, e_fermi, &
+                                            iterstep, e_fermi(ispin), hoco(ispin), energy_ref(ispin), &
+                                            TRIM(zero_label), &
                                             "K-point projected DOS for atomic kind "//TRIM(kind_name), &
                                             kind_maxl(ikind), separate_components, &
                                             pdos_curve(:, :, ikind, ispin), emin, de, &
@@ -1295,6 +1376,9 @@ CONTAINS
 !> \param file_action ...
 !> \param iterstep ...
 !> \param e_fermi ...
+!> \param hoco ...
+!> \param energy_ref ...
+!> \param zero_label ...
 !> \param title ...
 !> \param maxl ...
 !> \param separate_components ...
@@ -1307,7 +1391,8 @@ CONTAINS
 !> \param ndigits ...
 ! **************************************************************************************************
    SUBROUTINE write_broadened_pdos_curve(logger, dft_section, middle_name, file_position, &
-                                         file_action, iterstep, e_fermi, title, maxl, &
+                                         file_action, iterstep, e_fermi, hoco, energy_ref, zero_label, &
+                                         title, maxl, &
                                          separate_components, pdos_curve, emin, de, &
                                          broaden_type, broaden_width, voigt_mixing, ndigits)
 
@@ -1315,8 +1400,8 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: dft_section
       CHARACTER(LEN=*), INTENT(IN)                       :: middle_name, file_position, file_action
       INTEGER, INTENT(IN)                                :: iterstep
-      REAL(KIND=dp), INTENT(IN)                          :: e_fermi
-      CHARACTER(LEN=*), INTENT(IN)                       :: title
+      REAL(KIND=dp), INTENT(IN)                          :: e_fermi, hoco, energy_ref
+      CHARACTER(LEN=*), INTENT(IN)                       :: zero_label, title
       INTEGER, INTENT(IN)                                :: maxl
       LOGICAL, INTENT(IN)                                :: separate_components
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: pdos_curve
@@ -1325,10 +1410,13 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: broaden_width, voigt_mixing
       INTEGER, INTENT(IN)                                :: ndigits
 
+      CHARACTER(LEN=16)                                  :: energy_label
       CHARACTER(LEN=20)                                  :: fmtstr_data
       CHARACTER(LEN=6), ALLOCATABLE, DIMENSION(:, :, :)  :: tmp_str
-      INTEGER                                            :: i, icomp, il, im, iw, ncomponents, nhist
-      REAL(KIND=dp)                                      :: eval
+      INTEGER                                            :: energy_unit, i, icomp, il, im, iw, &
+                                                            ncomponents, nhist
+      REAL(KIND=dp)                                      :: density_factor, energy_factor, &
+                                                            ev_factor, eval
 
       nhist = SIZE(pdos_curve, 1)
       IF (separate_components) THEN
@@ -1336,14 +1424,24 @@ CONTAINS
       ELSE
          ncomponents = maxl + 1
       END IF
+      CALL section_vals_val_get(dft_section, "PRINT%PDOS%ENERGY_UNIT", i_val=energy_unit)
+      energy_factor = dos_energy_scale(energy_unit)
+      density_factor = dos_density_scale(energy_unit)
+      energy_label = dos_energy_label(energy_unit)
+      ev_factor = dos_energy_scale(dos_energy_unit_ev)
       iw = cp_print_key_unit_nr(logger, dft_section, "PRINT%PDOS", &
                                 extension=".pdos", file_position=file_position, file_action=file_action, &
                                 file_form="FORMATTED", middle_name=TRIM(middle_name))
       IF (iw > 0) THEN
-         WRITE (UNIT=iw, FMT="(A,I0,A,F12.6,A)") &
-            "# "//TRIM(title)//" at iteration step i = ", iterstep, ", E(Fermi) = ", e_fermi, " a.u."
+         WRITE (UNIT=iw, FMT="(A,I0)") "# "//TRIM(title)//" at iteration step i = ", iterstep
+         WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+            "# E(Fermi) = ", e_fermi, " a.u. = ", e_fermi*ev_factor, " eV"
+         WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+            "# E(HOCO)  = ", hoco, " a.u. = ", hoco*ev_factor, " eV"
+         WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
          CALL write_broadening_info(iw, broaden_type, broaden_width, voigt_mixing)
-         WRITE (UNIT=iw, FMT="(A)", ADVANCE="NO") "# Energy[a.u.]"
+         WRITE (UNIT=iw, FMT="(A)", ADVANCE="NO") "# "//TRIM(energy_label)
+         WRITE (UNIT=iw, FMT="(2X,A)", ADVANCE="NO") "total"
          IF (separate_components) THEN
             ALLOCATE (tmp_str(0:0, 0:maxl, -maxl:maxl))
             tmp_str = ""
@@ -1362,10 +1460,11 @@ CONTAINS
          WRITE (UNIT=iw, FMT="()")
          WRITE (UNIT=fmtstr_data, FMT="(A,I0,A)") "(2X,F20.", ndigits, ")"
          DO i = 1, nhist
-            eval = emin + (i - 1)*de
+            eval = (emin + (i - 1)*de - energy_ref)*energy_factor
             WRITE (UNIT=iw, FMT="(F15.8)", ADVANCE="NO") eval
+            WRITE (UNIT=iw, FMT=fmtstr_data, ADVANCE="NO") SUM(pdos_curve(i, 1:ncomponents))*density_factor
             DO icomp = 1, ncomponents
-               WRITE (UNIT=iw, FMT=fmtstr_data, ADVANCE="NO") pdos_curve(i, icomp)
+               WRITE (UNIT=iw, FMT=fmtstr_data, ADVANCE="NO") pdos_curve(i, icomp)*density_factor
             END DO
             WRITE (UNIT=iw, FMT="()")
          END DO
@@ -1383,6 +1482,9 @@ CONTAINS
 !> \param file_action ...
 !> \param iterstep ...
 !> \param e_fermi ...
+!> \param hoco ...
+!> \param energy_ref ...
+!> \param zero_label ...
 !> \param title ...
 !> \param maxl ...
 !> \param separate_components ...
@@ -1396,7 +1498,7 @@ CONTAINS
 !> \param ndigits ...
 ! **************************************************************************************************
    SUBROUTINE write_broadened_pdos(logger, dft_section, middle_name, file_position, file_action, &
-                                   iterstep, e_fermi, title, maxl, separate_components, weights, &
+                                   iterstep, e_fermi, hoco, energy_ref, zero_label, title, maxl, separate_components, weights, &
                                    eigenvalues, nstates, de, broaden_type, broaden_width, &
                                    voigt_mixing, ndigits)
 
@@ -1404,8 +1506,8 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: dft_section
       CHARACTER(LEN=*), INTENT(IN)                       :: middle_name, file_position, file_action
       INTEGER, INTENT(IN)                                :: iterstep
-      REAL(KIND=dp), INTENT(IN)                          :: e_fermi
-      CHARACTER(LEN=*), INTENT(IN)                       :: title
+      REAL(KIND=dp), INTENT(IN)                          :: e_fermi, hoco, energy_ref
+      CHARACTER(LEN=*), INTENT(IN)                       :: zero_label, title
       INTEGER, INTENT(IN)                                :: maxl
       LOGICAL, INTENT(IN)                                :: separate_components
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: weights
@@ -1443,7 +1545,7 @@ CONTAINS
       END DO
 
       CALL write_broadened_pdos_curve(logger, dft_section, middle_name, file_position, file_action, &
-                                      iterstep, e_fermi, title, maxl, separate_components, &
+                                      iterstep, e_fermi, hoco, energy_ref, zero_label, title, maxl, separate_components, &
                                       pdos_curve, emin, de, broaden_type, broaden_width, &
                                       voigt_mixing, ndigits)
 

--- a/src/qs_pdos.F
+++ b/src/qs_pdos.F
@@ -137,6 +137,8 @@ CONTAINS
 !> \param external_matrix_shalf ...
 !> \param unoccupied_orbs ...
 !> \param unoccupied_evals ...
+!> \param pdos_print_key ...
+!> \param write_pdos_raw ...
 !> \date    26.02.2008
 !> \par History:
 !>       - Added optional external matrix_shalf to avoid recomputing it (A. Bussy, 09.2019)
@@ -148,7 +150,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE calculate_projected_dos(mo_set, atomic_kind_set, qs_kind_set, particle_set, qs_env, &
                                       dft_section, ispin, xas_mittle, external_matrix_shalf, &
-                                      unoccupied_orbs, unoccupied_evals)
+                                      unoccupied_orbs, unoccupied_evals, pdos_print_key, write_pdos_raw)
 
       TYPE(mo_set_type), INTENT(IN)                      :: mo_set
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
@@ -161,6 +163,8 @@ CONTAINS
          OPTIONAL                                        :: xas_mittle
       TYPE(cp_fm_type), INTENT(IN), OPTIONAL, TARGET     :: external_matrix_shalf, unoccupied_orbs
       TYPE(cp_1d_r_p_type), INTENT(IN), OPTIONAL, TARGET :: unoccupied_evals
+      CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: pdos_print_key
+      LOGICAL, INTENT(IN), OPTIONAL                      :: write_pdos_raw
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_projected_dos'
 
@@ -169,7 +173,7 @@ CONTAINS
       CHARACTER(LEN=32)                                  :: zero_label
       CHARACTER(LEN=6), ALLOCATABLE, DIMENSION(:, :, :)  :: tmp_str
       CHARACTER(LEN=default_string_length)               :: kind_name, my_act, my_mittle, my_pos, &
-                                                            spin(2)
+                                                            my_print_key, spin(2)
       CHARACTER(LEN=default_string_length), &
          ALLOCATABLE, DIMENSION(:)                       :: ldos_index, r_ldos_index
       INTEGER :: broaden_type, energy_unit, energy_zero, handle, homo, i, iatom, ikind, il, ildos, &
@@ -181,7 +185,7 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: list, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: bo, l
       LOGICAL :: append, calc_matsh, do_broaden, do_ldos, do_r_ldos, do_virt, &
-         fractional_occupation, ionode, separate_components, should_output
+         fractional_occupation, ionode, separate_components, should_output, write_raw
       LOGICAL, DIMENSION(:, :), POINTER                  :: read_r
       REAL(KIND=dp) :: broaden_width, de, dh(3, 3), dvol, e_fermi, energy_factor, energy_ref, &
          ev_factor, hoco, r(3), r_vec(3), ratom(3), voigt_mixing
@@ -211,8 +215,12 @@ CONTAINS
       NULLIFY (logger)
       logger => cp_get_default_logger()
       ionode = logger%para_env%is_source()
+      my_print_key = "PRINT%PDOS"
+      IF (PRESENT(pdos_print_key)) my_print_key = TRIM(pdos_print_key)
+      write_raw = .TRUE.
+      IF (PRESENT(write_pdos_raw)) write_raw = write_pdos_raw
       should_output = BTEST(cp_print_key_should_output(logger%iter_info, dft_section, &
-                                                       "PRINT%PDOS"), cp_p_file)
+                                                       TRIM(my_print_key)), cp_p_file)
       output_unit = cp_logger_get_default_io_unit(logger)
 
       spin(1) = "ALPHA"
@@ -244,15 +252,15 @@ CONTAINS
                           nrow_global=nrow_global, &
                           ncol_global=ncol_global)
 
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%OUT_EACH_MO", i_val=out_each)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%OUT_EACH_MO", i_val=out_each)
       IF (out_each == -1) out_each = nao + 1
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%DELTA_E", r_val=de)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%BROADEN_TYPE", i_val=broaden_type)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%BROADEN_WIDTH", r_val=broaden_width)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%VOIGT_MIXING", r_val=voigt_mixing)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%NDIGITS", i_val=ndigits)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%ENERGY_UNIT", i_val=energy_unit)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%ENERGY_ZERO", i_val=energy_zero)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%DELTA_E", r_val=de)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%BROADEN_TYPE", i_val=broaden_type)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%BROADEN_WIDTH", r_val=broaden_width)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%VOIGT_MIXING", r_val=voigt_mixing)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%NDIGITS", i_val=ndigits)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%ENERGY_UNIT", i_val=energy_unit)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%ENERGY_ZERO", i_val=energy_zero)
       ndigits = MIN(MAX(ndigits, 1), 10)
       do_broaden = (broaden_width > 0.0_dp)
       IF (do_broaden) de = MAX(de, 0.00001_dp)
@@ -313,7 +321,7 @@ CONTAINS
       END IF
       ! Array to store the PDOS per kind and angular momentum
       do_ldos = .FALSE.
-      ldos_section => section_vals_get_subs_vals(dft_section, "PRINT%PDOS%LDOS")
+      ldos_section => section_vals_get_subs_vals(dft_section, TRIM(my_print_key)//"%LDOS")
 
       CALL section_vals_get(ldos_section, n_repetition=nldos)
       IF (nldos > 0) THEN
@@ -363,7 +371,7 @@ CONTAINS
       END IF
 
       do_r_ldos = .FALSE.
-      ldos_section => section_vals_get_subs_vals(dft_section, "PRINT%PDOS%R_LDOS")
+      ldos_section => section_vals_get_subs_vals(dft_section, TRIM(my_print_key)//"%R_LDOS")
       CALL section_vals_get(ldos_section, n_repetition=n_r_ldos)
       IF (n_r_ldos > 0) THEN
          do_r_ldos = .TRUE.
@@ -518,7 +526,7 @@ CONTAINS
          END DO
       END IF
 
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%COMPONENTS", l_val=separate_components)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%COMPONENTS", l_val=separate_components)
       IF (separate_components) THEN
          ALLOCATE (pdos_array(nsoset(maxlgto), nkind, nmo + nvirt))
       ELSE
@@ -708,7 +716,7 @@ CONTAINS
       CALL cp_fm_release(matrix_shalfc)
       DEALLOCATE (vecbuffer)
 
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%APPEND", l_val=append)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%APPEND", l_val=append)
       IF (append .AND. iterstep > 1) THEN
          my_pos = "APPEND"
       ELSE
@@ -744,70 +752,72 @@ CONTAINS
                                          "Projected DOS for atomic kind "//TRIM(kind_name), &
                                          maxl, .TRUE., pdos_array(1:nsoset(maxl), ikind, :), &
                                          eigenvalues, nmo + nvirt, de, broaden_type, broaden_width, &
-                                         voigt_mixing, ndigits)
+                                         voigt_mixing, ndigits, pdos_print_key=TRIM(my_print_key))
             ELSE
                CALL write_broadened_pdos(logger, dft_section, TRIM(my_mittle), my_pos, my_act, iterstep, &
                                          e_fermi, hoco, energy_ref, TRIM(zero_label), &
                                          "Projected DOS for atomic kind "//TRIM(kind_name), &
                                          maxl, .FALSE., pdos_array(0:maxl, ikind, :), &
                                          eigenvalues, nmo + nvirt, de, broaden_type, broaden_width, &
-                                         voigt_mixing, ndigits)
+                                         voigt_mixing, ndigits, pdos_print_key=TRIM(my_print_key))
             END IF
          END IF
 
-         iw = cp_print_key_unit_nr(logger, dft_section, "PRINT%PDOS", &
-                                   extension=".pdos_raw", file_position=my_pos, file_action=my_act, &
-                                   file_form="FORMATTED", middle_name=TRIM(my_mittle))
-         IF (iw > 0) THEN
+         IF (write_raw) THEN
+            iw = cp_print_key_unit_nr(logger, dft_section, TRIM(my_print_key), &
+                                      extension=".pdos_raw", file_position=my_pos, file_action=my_act, &
+                                      file_form="FORMATTED", middle_name=TRIM(my_mittle))
+            IF (iw > 0) THEN
 
-            fmtstr1 = "(I8,2X,2F16.6,  (2X,F16.8))"
-            fmtstr2 = "(A42,  (10X,A8))"
-            IF (separate_components) THEN
-               WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") nsoset(maxl) + 1
-               WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") nsoset(maxl) + 1
-            ELSE
-               WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") maxl + 2
-               WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") maxl + 2
-            END IF
+               fmtstr1 = "(I8,2X,2F16.6,  (2X,F16.8))"
+               fmtstr2 = "(A42,  (10X,A8))"
+               IF (separate_components) THEN
+                  WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") nsoset(maxl) + 1
+                  WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") nsoset(maxl) + 1
+               ELSE
+                  WRITE (UNIT=fmtstr1(15:16), FMT="(I2)") maxl + 2
+                  WRITE (UNIT=fmtstr2(6:7), FMT="(I2)") maxl + 2
+               END IF
 
-            WRITE (UNIT=iw, FMT="(A,I0)") &
-               "# Projected DOS for atomic kind "//TRIM(kind_name)//" at iteration step i = ", iterstep
-            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
-               "# E(Fermi) = ", e_fermi, " a.u. = ", e_fermi*ev_factor, " eV"
-            WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
-               "# E(HOCO)  = ", hoco, " a.u. = ", hoco*ev_factor, " eV"
-            WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
-            IF (separate_components) THEN
-               ALLOCATE (tmp_str(0:0, 0:maxl, -maxl:maxl))
-               tmp_str = ""
-               DO j = 0, maxl
-                  DO i = -j, j
-                     tmp_str(0, j, i) = sgf_symbol(0, j, i)
+               WRITE (UNIT=iw, FMT="(A,I0)") &
+                  "# Projected DOS for atomic kind "//TRIM(kind_name)//" at iteration step i = ", iterstep
+               WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+                  "# E(Fermi) = ", e_fermi, " a.u. = ", e_fermi*ev_factor, " eV"
+               WRITE (UNIT=iw, FMT="(A,F12.6,A,F12.6,A)") &
+                  "# E(HOCO)  = ", hoco, " a.u. = ", hoco*ev_factor, " eV"
+               WRITE (UNIT=iw, FMT="(A,A)") "# Energy zero: ", TRIM(zero_label)
+               IF (separate_components) THEN
+                  ALLOCATE (tmp_str(0:0, 0:maxl, -maxl:maxl))
+                  tmp_str = ""
+                  DO j = 0, maxl
+                     DO i = -j, j
+                        tmp_str(0, j, i) = sgf_symbol(0, j, i)
+                     END DO
                   END DO
-               END DO
 
-               WRITE (UNIT=iw, FMT=fmtstr2) &
-                  "#          MO "//TRIM(energy_label)//"      Occupation", "Total", &
-                  ((TRIM(tmp_str(0, il, im)), im=-il, il), il=0, maxl)
-               DO imo = 1, nmo + nvirt
-                  WRITE (UNIT=iw, FMT=fmtstr1) imo, (eigenvalues(imo) - energy_ref)*energy_factor, &
-                     occupation_numbers(imo), SUM(pdos_array(1:nsoset(maxl), ikind, imo)), &
-                     (pdos_array(lshell, ikind, imo), lshell=1, nsoset(maxl))
-               END DO
-               DEALLOCATE (tmp_str)
-            ELSE
-               WRITE (UNIT=iw, FMT=fmtstr2) &
-                  "#          MO "//TRIM(energy_label)//"      Occupation", "Total", &
-                  (TRIM(l_sym(il)), il=0, maxl)
-               DO imo = 1, nmo + nvirt
-                  WRITE (UNIT=iw, FMT=fmtstr1) imo, (eigenvalues(imo) - energy_ref)*energy_factor, &
-                     occupation_numbers(imo), SUM(pdos_array(0:maxl, ikind, imo)), &
-                     (pdos_array(lshell, ikind, imo), lshell=0, maxl)
-               END DO
+                  WRITE (UNIT=iw, FMT=fmtstr2) &
+                     "#          MO "//TRIM(energy_label)//"      Occupation", "Total", &
+                     ((TRIM(tmp_str(0, il, im)), im=-il, il), il=0, maxl)
+                  DO imo = 1, nmo + nvirt
+                     WRITE (UNIT=iw, FMT=fmtstr1) imo, (eigenvalues(imo) - energy_ref)*energy_factor, &
+                        occupation_numbers(imo), SUM(pdos_array(1:nsoset(maxl), ikind, imo)), &
+                        (pdos_array(lshell, ikind, imo), lshell=1, nsoset(maxl))
+                  END DO
+                  DEALLOCATE (tmp_str)
+               ELSE
+                  WRITE (UNIT=iw, FMT=fmtstr2) &
+                     "#          MO "//TRIM(energy_label)//"      Occupation", "Total", &
+                     (TRIM(l_sym(il)), il=0, maxl)
+                  DO imo = 1, nmo + nvirt
+                     WRITE (UNIT=iw, FMT=fmtstr1) imo, (eigenvalues(imo) - energy_ref)*energy_factor, &
+                        occupation_numbers(imo), SUM(pdos_array(0:maxl, ikind, imo)), &
+                        (pdos_array(lshell, ikind, imo), lshell=0, maxl)
+                  END DO
+               END IF
             END IF
+            CALL cp_print_key_finished_output(iw, logger, dft_section, &
+                                              TRIM(my_print_key))
          END IF
-         CALL cp_print_key_finished_output(iw, logger, dft_section, &
-                                           "PRINT%PDOS")
 
       END DO ! ikind
 
@@ -837,7 +847,7 @@ CONTAINS
                                             ldos_p(ildos)%ldos%maxl, .TRUE., &
                                             ldos_p(ildos)%ldos%pdos_array(1:nsoset(ldos_p(ildos)%ldos%maxl), :), &
                                             eigenvalues, nmo + nvirt, de, broaden_type, broaden_width, &
-                                            voigt_mixing, ndigits)
+                                            voigt_mixing, ndigits, pdos_print_key=TRIM(my_print_key))
                ELSE
                   CALL write_broadened_pdos(logger, dft_section, TRIM(my_mittle), my_pos, my_act, iterstep, &
                                             e_fermi, hoco, energy_ref, TRIM(zero_label), &
@@ -845,11 +855,11 @@ CONTAINS
                                             ldos_p(ildos)%ldos%maxl, .FALSE., &
                                             ldos_p(ildos)%ldos%pdos_array(0:ldos_p(ildos)%ldos%maxl, :), &
                                             eigenvalues, nmo + nvirt, de, broaden_type, broaden_width, &
-                                            voigt_mixing, ndigits)
+                                            voigt_mixing, ndigits, pdos_print_key=TRIM(my_print_key))
                END IF
             END IF
 
-            iw = cp_print_key_unit_nr(logger, dft_section, "PRINT%PDOS", &
+            iw = cp_print_key_unit_nr(logger, dft_section, TRIM(my_print_key), &
                                       extension=".pdos_raw", file_position=my_pos, file_action=my_act, &
                                       file_form="FORMATTED", middle_name=TRIM(my_mittle))
             IF (iw > 0) THEN
@@ -905,7 +915,7 @@ CONTAINS
                END IF
             END IF
             CALL cp_print_key_finished_output(iw, logger, dft_section, &
-                                              "PRINT%PDOS")
+                                              TRIM(my_print_key))
          END IF ! maxl>0
       END DO ! ildos
 
@@ -929,7 +939,7 @@ CONTAINS
             my_spin = 1
          END IF
 
-         iw = cp_print_key_unit_nr(logger, dft_section, "PRINT%PDOS", &
+         iw = cp_print_key_unit_nr(logger, dft_section, TRIM(my_print_key), &
                                    extension=".pdos_raw", file_position=my_pos, file_action=my_act, &
                                    file_form="FORMATTED", middle_name=TRIM(my_mittle))
          IF (iw > 0) THEN
@@ -957,7 +967,7 @@ CONTAINS
 
          END IF
          CALL cp_print_key_finished_output(iw, logger, dft_section, &
-                                           "PRINT%PDOS")
+                                           TRIM(my_print_key))
       END DO
 
       ! deallocate local variables
@@ -1011,24 +1021,29 @@ CONTAINS
 !> \brief Compute and write broadened projected density of states for k-point calculations.
 !> \param qs_env ...
 !> \param dft_section ...
+!> \param pdos_print_key ...
+!> \param write_pdos_raw ...
 ! **************************************************************************************************
-   SUBROUTINE calculate_projected_dos_kp(qs_env, dft_section)
+   SUBROUTINE calculate_projected_dos_kp(qs_env, dft_section, pdos_print_key, write_pdos_raw)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(section_vals_type), POINTER                   :: dft_section
+      CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: pdos_print_key
+      LOGICAL, INTENT(IN), OPTIONAL                      :: write_pdos_raw
 
       CHARACTER(len=*), PARAMETER :: routineN = 'calculate_projected_dos_kp'
 
       CHARACTER(LEN=32)                                  :: zero_label
       CHARACTER(LEN=default_string_length)               :: kind_name, my_act, my_mittle, my_pos, &
-                                                            spin(2)
+                                                            my_print_key, spin(2)
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: zvecbuffer
       INTEGER :: broaden_type, energy_zero, fractional_occupation_int, handle, icomp, ik, ikind, &
          imo, ispin, iterstep, maxl, maxlgto, n_r_ldos, nao, ncomp, ndigits, nhist, nkind, nldos, &
          nmo_kp, nspins, output_unit, resolved_energy_zero
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ao_comp, ao_kind, ao_l, kind_maxl
       LOGICAL                                            :: append, fractional_occupation, &
-                                                            separate_components, should_output
+                                                            separate_components, should_output, &
+                                                            write_raw
       REAL(KIND=dp)                                      :: broaden_cutoff, broaden_width, de, e1, &
                                                             e2, e_fermi(2), emax, emin, &
                                                             energy_ref(2), hoco(2), voigt_mixing, &
@@ -1058,8 +1073,12 @@ CONTAINS
       NULLIFY (matrix_s_kp, scf_env)
       NULLIFY (kp, mo_set, eigenvalues, fm_struct_tmp, orb_basis_set, ldos_section)
       logger => cp_get_default_logger()
+      my_print_key = "PRINT%PDOS"
+      IF (PRESENT(pdos_print_key)) my_print_key = TRIM(pdos_print_key)
+      write_raw = .FALSE.
+      IF (PRESENT(write_pdos_raw)) write_raw = write_pdos_raw
       should_output = BTEST(cp_print_key_should_output(logger%iter_info, dft_section, &
-                                                       "PRINT%PDOS"), cp_p_file)
+                                                       TRIM(my_print_key)), cp_p_file)
       output_unit = cp_logger_get_default_io_unit(logger)
       IF ((.NOT. should_output)) RETURN
 
@@ -1092,26 +1111,29 @@ CONTAINS
          RETURN
       END IF
 
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%DELTA_E", r_val=de)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%APPEND", l_val=append)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%COMPONENTS", l_val=separate_components)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%NDIGITS", i_val=ndigits)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%BROADEN_TYPE", i_val=broaden_type)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%BROADEN_WIDTH", r_val=broaden_width)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%VOIGT_MIXING", r_val=voigt_mixing)
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%ENERGY_ZERO", i_val=energy_zero)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%DELTA_E", r_val=de)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%APPEND", l_val=append)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%COMPONENTS", l_val=separate_components)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%NDIGITS", i_val=ndigits)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%BROADEN_TYPE", i_val=broaden_type)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%BROADEN_WIDTH", r_val=broaden_width)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%VOIGT_MIXING", r_val=voigt_mixing)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%ENERGY_ZERO", i_val=energy_zero)
       ndigits = MIN(MAX(ndigits, 1), 10)
       de = MAX(de, 0.00001_dp)
 
-      ldos_section => section_vals_get_subs_vals(dft_section, "PRINT%PDOS%LDOS")
+      ldos_section => section_vals_get_subs_vals(dft_section, TRIM(my_print_key)//"%LDOS")
       CALL section_vals_get(ldos_section, n_repetition=nldos)
-      ldos_section => section_vals_get_subs_vals(dft_section, "PRINT%PDOS%R_LDOS")
+      ldos_section => section_vals_get_subs_vals(dft_section, TRIM(my_print_key)//"%R_LDOS")
       CALL section_vals_get(ldos_section, n_repetition=n_r_ldos)
       IF (nldos > 0 .OR. n_r_ldos > 0) THEN
          CPWARN("LDOS/R_LDOS are not implemented for k-point PDOS and will be ignored")
       END IF
+      IF (write_raw) THEN
+         CPWARN("Raw k-point PDOS output is not implemented and will be ignored")
+      END IF
       IF (broaden_width <= 0.0_dp) THEN
-         CPWARN("Raw k-point PDOS output is not implemented; use a finite BROADEN_WIDTH")
+         CPWARN("Broadened k-point PDOS output requires a finite BROADEN_WIDTH")
          CALL timestop(handle)
          RETURN
       END IF
@@ -1276,7 +1298,7 @@ CONTAINS
                                             "K-point projected DOS for atomic kind "//TRIM(kind_name), &
                                             kind_maxl(ikind), separate_components, &
                                             pdos_curve(:, :, ikind, ispin), emin, de, &
-                                            broaden_type, broaden_width, voigt_mixing, ndigits)
+                                            broaden_type, broaden_width, voigt_mixing, ndigits, pdos_print_key=TRIM(my_print_key))
          END DO
       END DO
 
@@ -1389,12 +1411,13 @@ CONTAINS
 !> \param broaden_width ...
 !> \param voigt_mixing ...
 !> \param ndigits ...
+!> \param pdos_print_key ...
 ! **************************************************************************************************
    SUBROUTINE write_broadened_pdos_curve(logger, dft_section, middle_name, file_position, &
                                          file_action, iterstep, e_fermi, hoco, energy_ref, zero_label, &
                                          title, maxl, &
                                          separate_components, pdos_curve, emin, de, &
-                                         broaden_type, broaden_width, voigt_mixing, ndigits)
+                                         broaden_type, broaden_width, voigt_mixing, ndigits, pdos_print_key)
 
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(section_vals_type), POINTER                   :: dft_section
@@ -1409,14 +1432,19 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: broaden_type
       REAL(KIND=dp), INTENT(IN)                          :: broaden_width, voigt_mixing
       INTEGER, INTENT(IN)                                :: ndigits
+      CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: pdos_print_key
 
       CHARACTER(LEN=16)                                  :: energy_label
       CHARACTER(LEN=20)                                  :: fmtstr_data
       CHARACTER(LEN=6), ALLOCATABLE, DIMENSION(:, :, :)  :: tmp_str
+      CHARACTER(LEN=default_string_length)               :: my_print_key
       INTEGER                                            :: energy_unit, i, icomp, il, im, iw, &
                                                             ncomponents, nhist
       REAL(KIND=dp)                                      :: density_factor, energy_factor, &
                                                             ev_factor, eval
+
+      my_print_key = "PRINT%PDOS"
+      IF (PRESENT(pdos_print_key)) my_print_key = TRIM(pdos_print_key)
 
       nhist = SIZE(pdos_curve, 1)
       IF (separate_components) THEN
@@ -1424,12 +1452,12 @@ CONTAINS
       ELSE
          ncomponents = maxl + 1
       END IF
-      CALL section_vals_val_get(dft_section, "PRINT%PDOS%ENERGY_UNIT", i_val=energy_unit)
+      CALL section_vals_val_get(dft_section, TRIM(my_print_key)//"%ENERGY_UNIT", i_val=energy_unit)
       energy_factor = dos_energy_scale(energy_unit)
       density_factor = dos_density_scale(energy_unit)
       energy_label = dos_energy_label(energy_unit)
       ev_factor = dos_energy_scale(dos_energy_unit_ev)
-      iw = cp_print_key_unit_nr(logger, dft_section, "PRINT%PDOS", &
+      iw = cp_print_key_unit_nr(logger, dft_section, TRIM(my_print_key), &
                                 extension=".pdos", file_position=file_position, file_action=file_action, &
                                 file_form="FORMATTED", middle_name=TRIM(middle_name))
       IF (iw > 0) THEN
@@ -1469,7 +1497,7 @@ CONTAINS
             WRITE (UNIT=iw, FMT="()")
          END DO
       END IF
-      CALL cp_print_key_finished_output(iw, logger, dft_section, "PRINT%PDOS")
+      CALL cp_print_key_finished_output(iw, logger, dft_section, TRIM(my_print_key))
 
    END SUBROUTINE write_broadened_pdos_curve
 
@@ -1496,11 +1524,12 @@ CONTAINS
 !> \param broaden_width ...
 !> \param voigt_mixing ...
 !> \param ndigits ...
+!> \param pdos_print_key ...
 ! **************************************************************************************************
    SUBROUTINE write_broadened_pdos(logger, dft_section, middle_name, file_position, file_action, &
                                    iterstep, e_fermi, hoco, energy_ref, zero_label, title, maxl, separate_components, weights, &
                                    eigenvalues, nstates, de, broaden_type, broaden_width, &
-                                   voigt_mixing, ndigits)
+                                   voigt_mixing, ndigits, pdos_print_key)
 
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(section_vals_type), POINTER                   :: dft_section
@@ -1517,6 +1546,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: broaden_type
       REAL(KIND=dp), INTENT(IN)                          :: broaden_width, voigt_mixing
       INTEGER, INTENT(IN)                                :: ndigits
+      CHARACTER(LEN=*), INTENT(IN), OPTIONAL             :: pdos_print_key
 
       INTEGER                                            :: i, icomp, imo, ncomponents, nhist
       REAL(KIND=dp)                                      :: cutoff, emax, emin, eval, line_shape
@@ -1547,7 +1577,7 @@ CONTAINS
       CALL write_broadened_pdos_curve(logger, dft_section, middle_name, file_position, file_action, &
                                       iterstep, e_fermi, hoco, energy_ref, zero_label, title, maxl, separate_components, &
                                       pdos_curve, emin, de, broaden_type, broaden_width, &
-                                      voigt_mixing, ndigits)
+                                      voigt_mixing, ndigits, pdos_print_key=pdos_print_key)
 
       DEALLOCATE (pdos_curve)
 

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -137,6 +137,7 @@ MODULE qs_scf_post_gpw
    USE qs_core_energies,                ONLY: calculate_ptrace
    USE qs_dos,                          ONLY: calculate_dos,&
                                               calculate_dos_kp
+   USE qs_dos_utils,                    ONLY: get_dos_pdos_flags
    USE qs_electric_field_gradient,      ONLY: qs_efg_calc
    USE qs_elf_methods,                  ONLY: qs_elf_calc
    USE qs_energy_types,                 ONLY: qs_energy_type
@@ -2139,11 +2140,11 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'write_mo_dependent_results'
 
       INTEGER                                            :: handle, homo, ispin, nlumo_dos, &
-                                                            nlumo_molden, nlumo_pdos, &
-                                                            nlumo_required, nlumos, nmo, &
-                                                            output_unit
+                                                            nlumo_molden, nlumo_required, nlumos, &
+                                                            nmo, output_unit
       LOGICAL                                            :: all_equal, defer_molden, do_dos, &
-                                                            do_kpoints, do_pdos, explicit
+                                                            do_kpoints, do_pdos, do_pdos_raw, &
+                                                            explicit
       REAL(KIND=dp)                                      :: maxocc, s_square, s_square_ideal, &
                                                             total_abs_spin_dens, total_spin_dens
       REAL(KIND=dp), DIMENSION(:), POINTER               :: mo_eigenvalues, occupation_numbers
@@ -2171,8 +2172,9 @@ CONTAINS
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(qs_subsys_type), POINTER                      :: subsys
       TYPE(scf_control_type), POINTER                    :: scf_control
-      TYPE(section_vals_type), POINTER                   :: casino_section, dft_section, input, &
-                                                            sprint_section, trexio_section
+      TYPE(section_vals_type), POINTER                   :: casino_section, dft_section, &
+                                                            dos_section, input, sprint_section, &
+                                                            trexio_section
 
 ! TYPE(kpoint_type), POINTER                         :: kpoints
 
@@ -2182,7 +2184,7 @@ CONTAINS
                mo_coeff_deriv, mo_eigenvalues, mos, atomic_kind_set, qs_kind_set, &
                particle_set, rho, ks_rmpv, matrix_s, scf_control, dft_section, &
                molecule_set, input, particles, subsys, rho_r, unoccupied_orbs, &
-               unoccupied_evals, casino_section)
+               unoccupied_evals, casino_section, dos_section)
 
       logger => cp_get_default_logger()
       output_unit = cp_logger_get_default_io_unit(logger)
@@ -2260,10 +2262,9 @@ CONTAINS
             END IF
          END IF
 
-         do_dos = BTEST(cp_print_key_should_output(logger%iter_info, dft_section, "PRINT%DOS"), &
-                        cp_p_file)
-         do_pdos = BTEST(cp_print_key_should_output(logger%iter_info, dft_section, "PRINT%PDOS"), &
-                         cp_p_file)
+         dos_section => section_vals_get_subs_vals(dft_section, "PRINT%DOS")
+         do_dos = BTEST(cp_print_key_should_output(logger%iter_info, dos_section), cp_p_file)
+         CALL get_dos_pdos_flags(dos_section, do_dos, do_pdos, do_pdos_raw)
 
          ! For OT calculations, collect the largest request for additional unoccupied
          ! orbitals among DOS, PDOS, and Molden, and generate them only once.
@@ -2278,14 +2279,7 @@ CONTAINS
                      nlumo_required = MAX(nlumo_required, nlumo_dos)
                   END IF
                END IF
-               IF (do_pdos) THEN
-                  CALL section_vals_val_get(dft_section, "PRINT%PDOS%NLUMO", i_val=nlumo_pdos)
-                  IF (nlumo_pdos == -1) THEN
-                     nlumo_required = -1
-                  ELSEIF (nlumo_required /= -1) THEN
-                     nlumo_required = MAX(nlumo_required, nlumo_pdos)
-                  END IF
-               END IF
+
                IF (defer_molden) THEN
                   IF (nlumo_molden == -1) THEN
                      nlumo_required = -1
@@ -2357,7 +2351,8 @@ CONTAINS
          ! Print the projected density of states (pDOS) for each atomic kind
          IF (do_pdos) THEN
             IF (do_kpoints) THEN
-               CALL calculate_projected_dos_kp(qs_env, dft_section)
+               CALL calculate_projected_dos_kp(qs_env, dft_section, pdos_print_key="PRINT%DOS", &
+                                               write_pdos_raw=do_pdos_raw)
             ELSE
                CALL get_qs_env(qs_env, &
                                mos=mos, &
@@ -2368,20 +2363,24 @@ CONTAINS
                         CALL calculate_projected_dos(mos(ispin), atomic_kind_set, &
                                                      qs_kind_set, particle_set, qs_env, dft_section, ispin=ispin, &
                                                      unoccupied_orbs=unoccupied_orbs(ispin), &
-                                                     unoccupied_evals=unoccupied_evals(ispin))
+                                                     unoccupied_evals=unoccupied_evals(ispin), &
+                                                     pdos_print_key="PRINT%DOS", write_pdos_raw=do_pdos_raw)
                      ELSE
                         CALL calculate_projected_dos(mos(ispin), atomic_kind_set, &
-                                                     qs_kind_set, particle_set, qs_env, dft_section, ispin=ispin)
+                                                     qs_kind_set, particle_set, qs_env, dft_section, ispin=ispin, &
+                                                     pdos_print_key="PRINT%DOS", write_pdos_raw=do_pdos_raw)
                      END IF
                   ELSE
                      IF (ASSOCIATED(unoccupied_orbs)) THEN
                         CALL calculate_projected_dos(mos(ispin), atomic_kind_set, &
                                                      qs_kind_set, particle_set, qs_env, dft_section, &
                                                      unoccupied_orbs=unoccupied_orbs(ispin), &
-                                                     unoccupied_evals=unoccupied_evals(ispin))
+                                                     unoccupied_evals=unoccupied_evals(ispin), &
+                                                     pdos_print_key="PRINT%DOS", write_pdos_raw=do_pdos_raw)
                      ELSE
                         CALL calculate_projected_dos(mos(ispin), atomic_kind_set, &
-                                                     qs_kind_set, particle_set, qs_env, dft_section)
+                                                     qs_kind_set, particle_set, qs_env, dft_section, &
+                                                     pdos_print_key="PRINT%DOS", write_pdos_raw=do_pdos_raw)
                      END IF
                   END IF
                END DO

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -2346,9 +2346,10 @@ CONTAINS
             ELSE
                CALL get_qs_env(qs_env, mos=mos)
                IF (ASSOCIATED(unoccupied_evals)) THEN
-                  CALL calculate_dos(mos, dft_section, unoccupied_evals=unoccupied_evals)
+                  CALL calculate_dos(mos, dft_section, unoccupied_evals=unoccupied_evals, &
+                                     smearing_enabled=dft_control%smear)
                ELSE
-                  CALL calculate_dos(mos, dft_section)
+                  CALL calculate_dos(mos, dft_section, smearing_enabled=dft_control%smear)
                END IF
             END IF
          END IF

--- a/src/qs_scf_post_se.F
+++ b/src/qs_scf_post_se.F
@@ -608,7 +608,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'write_available_results'
 
       INTEGER                                            :: after, handle, ispin, iw, output_unit
-      LOGICAL                                            :: omit_headers
+      LOGICAL                                            :: omit_headers, requested_pdos
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: ks_rmpv, rho_ao
       TYPE(dft_control_type), POINTER                    :: dft_control
@@ -618,11 +618,11 @@ CONTAINS
       TYPE(qs_rho_type), POINTER                         :: rho
       TYPE(qs_scf_env_type), POINTER                     :: scf_env
       TYPE(qs_subsys_type), POINTER                      :: subsys
-      TYPE(section_vals_type), POINTER                   :: dft_section, input
+      TYPE(section_vals_type), POINTER                   :: dft_section, input, print_key
 
       CALL timeset(routineN, handle)
       NULLIFY (dft_control, particle_set, rho, ks_rmpv, dft_section, input, &
-               particles, subsys, para_env, rho_ao)
+               particles, subsys, para_env, rho_ao, print_key)
       logger => cp_get_default_logger()
       output_unit = cp_logger_get_default_io_unit(logger)
 
@@ -642,10 +642,14 @@ CONTAINS
       ! Print MO information if requested
       CALL qs_scf_write_mos(qs_env, scf_env, final_mos=.TRUE.)
 
-      ! Aat the end of SCF printout the projected DOS for each atomic kind
+      ! At the end of SCF printout the projected DOS for each atomic kind
       dft_section => section_vals_get_subs_vals(input, "DFT")
-      IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, "PRINT%PDOS") &
-                , cp_p_file)) THEN
+      print_key => section_vals_get_subs_vals(dft_section, "PRINT%DOS")
+      requested_pdos = .FALSE.
+      IF (BTEST(cp_print_key_should_output(logger%iter_info, print_key), cp_p_file)) THEN
+         CALL section_vals_val_get(print_key, "PDOS", l_val=requested_pdos)
+      END IF
+      IF (requested_pdos) THEN
          CPWARN("PDOS not implemented for Semi-Empirical calculations!")
       END IF
 

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -449,7 +449,7 @@ CONTAINS
                CALL calculate_dos_kp(qs_env, dft_section)
             ELSE
                CALL get_qs_env(qs_env, mos=mos)
-               CALL calculate_dos(mos, dft_section)
+               CALL calculate_dos(mos, dft_section, smearing_enabled=dft_control%smear)
             END IF
          END IF
       END IF

--- a/src/qs_scf_post_tb.F
+++ b/src/qs_scf_post_tb.F
@@ -104,6 +104,7 @@ MODULE qs_scf_post_tb
    USE qs_dftb_utils,                   ONLY: get_dftb_atom_param
    USE qs_dos,                          ONLY: calculate_dos,&
                                               calculate_dos_kp
+   USE qs_dos_utils,                    ONLY: get_dos_pdos_flags
    USE qs_elf_methods,                  ONLY: qs_elf_calc
    USE qs_energy_window,                ONLY: energy_windows
    USE qs_environment_types,            ONLY: get_qs_env,&
@@ -177,9 +178,9 @@ CONTAINS
       CHARACTER(LEN=default_string_length)               :: aname
       INTEGER :: after, gfn_type, handle, homo, iat, iatom, ikind, img, ispin, iw, nat, natom, &
          nkind, nlumo_stm, nlumos, nspins, print_level, unit_nr
-      LOGICAL                                            :: do_cube, do_kpoints, explicit, gfn0, &
-                                                            has_homo, omit_headers, print_it, &
-                                                            rebuild, vdip
+      LOGICAL                                            :: do_cube, do_dos, do_kpoints, do_pdos, &
+                                                            do_pdos_raw, explicit, gfn0, has_homo, &
+                                                            omit_headers, print_it, rebuild, vdip
       REAL(KIND=dp)                                      :: zeff
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: mcharge, zcharge
       REAL(KIND=dp), DIMENSION(2, 2)                     :: homo_lumo
@@ -444,7 +445,9 @@ CONTAINS
 
       IF (.NOT. no_mos) THEN
          print_key => section_vals_get_subs_vals(print_section, "DOS")
-         IF (BTEST(cp_print_key_should_output(logger%iter_info, print_key), cp_p_file)) THEN
+         do_dos = BTEST(cp_print_key_should_output(logger%iter_info, print_key), cp_p_file)
+         CALL get_dos_pdos_flags(print_key, do_dos, do_pdos, do_pdos_raw)
+         IF (do_dos) THEN
             IF (do_kpoints) THEN
                CALL calculate_dos_kp(qs_env, dft_section)
             ELSE
@@ -452,12 +455,9 @@ CONTAINS
                CALL calculate_dos(mos, dft_section, smearing_enabled=dft_control%smear)
             END IF
          END IF
-      END IF
 
-      ! PDOS
-      IF (.NOT. no_mos) THEN
-         print_key => section_vals_get_subs_vals(print_section, "PDOS")
-         IF (BTEST(cp_print_key_should_output(logger%iter_info, print_key), cp_p_file)) THEN
+         ! PDOS
+         IF (do_pdos) THEN
             IF (do_kpoints) THEN
                CPWARN("Projected density of states not implemented for k-points.")
             ELSE
@@ -478,10 +478,12 @@ CONTAINS
                   END IF
                   IF (dft_control%nspins == 2) THEN
                      CALL calculate_projected_dos(mos(ispin), atomic_kind_set, &
-                                                  qs_kind_set, particle_set, qs_env, dft_section, ispin=ispin)
+                                                  qs_kind_set, particle_set, qs_env, dft_section, ispin=ispin, &
+                                                  pdos_print_key="PRINT%DOS", write_pdos_raw=do_pdos_raw)
                   ELSE
                      CALL calculate_projected_dos(mos(ispin), atomic_kind_set, &
-                                                  qs_kind_set, particle_set, qs_env, dft_section)
+                                                  qs_kind_set, particle_set, qs_env, dft_section, &
+                                                  pdos_print_key="PRINT%DOS", write_pdos_raw=do_pdos_raw)
                   END IF
                END DO
             END IF

--- a/tests/QS/regtest-admm-3/admm_dbcsr_thread_dist.inp
+++ b/tests/QS/regtest-admm-3/admm_dbcsr_thread_dist.inp
@@ -25,8 +25,6 @@
     &PRINT
       &MULLIKEN OFF
       &END MULLIKEN
-      &PDOS OFF
-      &END PDOS
     &END PRINT
     &QS
       EPS_DEFAULT 1.0E-06

--- a/tests/QS/regtest-kp-3/cc9.inp
+++ b/tests/QS/regtest-kp-3/cc9.inp
@@ -18,10 +18,11 @@
       REL_CUTOFF 40
     &END MGRID
     &PRINT
-      &PDOS
+      &DOS
         COMPONENTS T
         NLUMO 5
-      &END PDOS
+        PDOS T
+      &END DOS
     &END PRINT
     &QS
       EPS_DEFAULT 1.0E-12

--- a/tests/QS/regtest-negf-1/H28.inp
+++ b/tests/QS/regtest-negf-1/H28.inp
@@ -154,10 +154,11 @@
       PERIODIC xyz
     &END POISSON
     &PRINT
-      &PDOS
+      &DOS
         COMPONENTS
         NLUMO -1
-      &END PDOS
+        PDOS T
+      &END DOS
     &END PRINT
     &SCF
       !atomic restart

--- a/tests/QS/regtest-ot/H2O-geo-ot-pdos-lumo-comp.inp
+++ b/tests/QS/regtest-ot/H2O-geo-ot-pdos-lumo-comp.inp
@@ -20,15 +20,16 @@
       CUTOFF 200
     &END MGRID
     &PRINT
-      &PDOS
+      &DOS
         ADD_LAST NUMERIC
         APPEND
         COMPONENTS
         NLUMO 5
+        PDOS T
         &EACH
           GEO_OPT 0
         &END EACH
-      &END PDOS
+      &END DOS
     &END PRINT
     &QS
       EPS_DEFAULT 1.0E-12

--- a/tests/QS/regtest-ot/H2O-geo-ot-pdos.inp
+++ b/tests/QS/regtest-ot/H2O-geo-ot-pdos.inp
@@ -20,7 +20,8 @@
       CUTOFF 200
     &END MGRID
     &PRINT
-      &PDOS
+      &DOS
+        PDOS T
         &EACH
           GEO_OPT 2
         &END EACH
@@ -30,7 +31,7 @@
         &LDOS
           LIST 3 2 1
         &END LDOS
-      &END PDOS
+      &END DOS
     &END PRINT
     &QS
       EPS_DEFAULT 1.0E-12

--- a/tests/QS/regtest-ot/H2O-geo-pdos.inp
+++ b/tests/QS/regtest-ot/H2O-geo-pdos.inp
@@ -20,11 +20,12 @@
       CUTOFF 200
     &END MGRID
     &PRINT
-      &PDOS
+      &DOS
+        PDOS T
         &EACH
           GEO_OPT 2
         &END EACH
-      &END PDOS
+      &END DOS
     &END PRINT
     &QS
       EPS_DEFAULT 1.0E-12

--- a/tests/QS/regtest-ot/H2O-geo-pdos_comp.inp
+++ b/tests/QS/regtest-ot/H2O-geo-pdos_comp.inp
@@ -20,15 +20,16 @@
       CUTOFF 200
     &END MGRID
     &PRINT
-      &PDOS
+      &DOS
         ADD_LAST NUMERIC
         APPEND
         COMPONENTS
         NLUMO 5
+        PDOS T
         &EACH
           GEO_OPT 0
         &END EACH
-      &END PDOS
+      &END DOS
     &END PRINT
     &QS
       EPS_DEFAULT 1.0E-12

--- a/tests/QS/regtest-ot/H2O-geo-pdos_comp_list.inp
+++ b/tests/QS/regtest-ot/H2O-geo-pdos_comp_list.inp
@@ -20,11 +20,12 @@
       CUTOFF 200
     &END MGRID
     &PRINT
-      &PDOS
+      &DOS
         ADD_LAST NUMERIC
         APPEND
         COMPONENTS
         NLUMO 5
+        PDOS T
         &EACH
           GEO_OPT 0
         &END EACH
@@ -42,7 +43,7 @@
         &LDOS
           LIST 3 2
         &END LDOS
-      &END PDOS
+      &END DOS
     &END PRINT
     &QS
       EPS_DEFAULT 1.0E-12

--- a/tests/xTB/regtest-3/H2O-geo-pdos.inp
+++ b/tests/xTB/regtest-3/H2O-geo-pdos.inp
@@ -15,11 +15,12 @@
   METHOD Quickstep
   &DFT
     &PRINT
-      &PDOS
+      &DOS
+        PDOS T
         &EACH
           GEO_OPT 2
         &END EACH
-      &END PDOS
+      &END DOS
     &END PRINT
     &QS
       METHOD xTB

--- a/tests/xTB/regtest-5/Ru_geo.inp
+++ b/tests/xTB/regtest-5/Ru_geo.inp
@@ -17,6 +17,11 @@
       &END EWALD
     &END POISSON
     &PRINT
+      &DOS
+        DELTA_E 0.01
+        NLUMO -1
+        PDOS T
+      &END DOS
       &MULLIKEN
         COMMON_ITERATION_LEVELS 10
         FILENAME=MULLIKEN
@@ -24,9 +29,6 @@
           MD 1
         &END EACH
       &END MULLIKEN
-      &PDOS
-        NLUMO -1
-      &END PDOS
     &END PRINT
     &QS
       METHOD xTB


### PR DESCRIPTION
This PR improves the DOS/PDOS output format and configurability:

- Add a `total` column to PDOS output before angular-momentum/component-resolved columns
- Add keyword `ENERGY_UNIT` for DOS and PDOS output: `HARTREE`(default), `EV`; convert broadened DOS/PDOS intensities consistently with chosen energy unit
- Add keyword `ENERGY_ZERO` for DOS and PDOS output: `AUTO`(default, use Fermi if smearing is enabled and/or fractional occupation is detected, otherwise HOCO), `ABSOLUTE`, `FERMI`, `HOCO`

Also refactors the input section:
- Unify DFT DOS and PDOS controls under `&DOS`, using `PDOS T` for projected DOS output.
- Keep XAS/XAS_TDP `&PDOS` as a dedicated print section, while sharing common DOS/PDOS keyword definitions.

An example: [example.zip](https://github.com/user-attachments/files/28441963/example.zip) (One can plot DOS and PDOS with e.g. gnuplot: `plot [-5:10] [*:*] 'dos-1.dos' u 1:2 w lines lw 1`, where `[-5:10] [*:*]` controls the X- and Y- range one is interested in, here `[*,*]` for Y-axis can be omitted.)