### PR TITLE
Spack [pace]: Use upstream CMake install rules instead

### DIFF
--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -204,7 +204,7 @@ spack:
     - "netlib-scalapack@2.2.3"
     - "openblas@0.3.33"
     - "openpmd-api@0.17.0"
-    - "pace@2025.12.4"
+    - "pace@2025.12.4.1"
     - "pexsi@2.0.0"
     - "plumed@2.10.0"
     - "py-torch@2.12.0"

--- a/tools/spack/cp2k_deps_s-static.yaml
+++ b/tools/spack/cp2k_deps_s-static.yaml
@@ -107,7 +107,7 @@ spack:
     - "libxc@7.0.0"
     - "libxsmm@1.17-cp2k"
     - "openblas@0.3.33"
-    - "pace@2025.12.4"
+    - "pace@2025.12.4.1"
     - "spglib@2.7.0"
     - "tblite@0.6.0"
 

--- a/tools/spack/cp2k_deps_s.yaml
+++ b/tools/spack/cp2k_deps_s.yaml
@@ -123,7 +123,7 @@ spack:
     - "libxc@7.0.0"
     - "libxsmm@1.17-cp2k"
     - "openblas@0.3.33"
-    - "pace@2025.12.4"
+    - "pace@2025.12.4.1"
     - "py-torch@2.12.0"
     - "spglib@2.7.0"
     - "tblite@0.6.0"

--- a/tools/spack/spack_repo/cp2k_dev/packages/pace/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/pace/package.py
@@ -29,34 +29,24 @@ class Pace(CMakePackage):
 
     license("GPL-2.0-or-later", checked_by="hjjvandam")
     version("main", branch="main")
+    version("2025.12.4.1", tag="v.2025.12.4.p1", commit="5844770144643f872db8aa06df02d64192a8160f")
     version("2025.12.4", tag="v.2025.12.4", commit="8d0483447e94d17e01cbc1826a88cae1d8c3aab6")
     version(
         "2023.11.25.2", tag="v.2023.11.25.fix2", commit="e60e850359b918ca93a5e9329548a58d31f4b12b"
     )
 
     variant("pic", default=True, description="Build position independent code")
-    variant("shared", default=False, description="Build shared libraries (otherwise static)")
 
     depends_on("cmake@3.10:", type="build")
     depends_on("cxx", type="build")
 
     # Build always with the yaml-cpp and cnpy version included in pace
-    depends_on("yaml-cpp")
-    depends_on("cnpy")
+    # depends_on("yaml-cpp")
+    # depends_on("cnpy")
 
     def cmake_args(self):
-        args = [
-            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+        return [
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+            self.define("CMAKE_DISABLE_FIND_PACKAGE_yaml-cpp", True),
+            self.define("CMAKE_DISABLE_FIND_PACKAGE_cnpy", True),
         ]
-        return args
-
-    def install(self, spec, prefix):
-        src = self.stage.source_path
-        install_tree(join_path(src, "ML-PACE/ace"), join_path(prefix.include, "ace"))
-        install_tree(
-            join_path(src, "ML-PACE/ace-evaluator"), join_path(prefix.include, "ace-evaluator")
-        )
-        install_tree(join_path(src, "yaml-cpp/include"), prefix.include)
-        mkdirp(prefix.lib)
-        install(join_path(self.build_directory, "libpace.a"), prefix.lib)


### PR DESCRIPTION
Two additional:
1. Force to use bundled `yaml-cpp` and `cnpy`, so none of them needed to be seperately downloaded by Spack.
2. `BUILD_SHARED_LIBS` is invalid for pace and therefore dropped, because the upstream [CMakeLists.txt](https://github.com/ICAMS/lammps-user-pace/blob/main/CMakeLists.txt) has forced pace to be built as [static library](https://github.com/ICAMS/lammps-user-pace/blob/99aa6e685cce24c24f81ce35b241d1b480d1ad05/CMakeLists.txt#L67).