### PR TITLE
Reorganize dashboard and reduce Spack testing cadence

### DIFF
--- a/tools/dashboard/README.md
+++ b/tools/dashboard/README.md
@@ -52,7 +52,6 @@ typical entry looks like this:
 
 ```
 [mkrack-pdbg]
-sortkey:     100
 name:        Linux-x86-64-gfortran.pdbg
 host:        PSI, merlinl03
 notify:      off
@@ -65,7 +64,6 @@ The fields have the following meaning:
 | Field        | Meaning                                                                                   |
 | ------------ | ----------------------------------------------------------------------------------------- |
 | `[foo_bar]`  | internal name of the tester, it shows up e.g. in the archive-url                          |
-| `sortkey`    | used to order the entries in the dashboard, low means high up                             |
 | `name`       | displayed in the first column of the dashboard                                            |
 | `host`       | displayed in the second column of the dashboard                                           |
 | `info_url`   | optional, if provided it is shows up as the "more information"-link on the archive-page   |

--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -1,26 +1,22 @@
 [cscs-daint-psmp]
-sortkey:     111
 name:        CSCS Daint (psmp)
 host:        Alps Daint (CSCS)
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_cscs-daint-psmp_report.txt
 info_url:    https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/3546923033037693/3295760759903023/-/pipelines
 
 [cscs-daint-psmp-h100]
-sortkey:     121
 name:        CSCS Daint (psmp, H100)
 host:        Alps Daint (CSCS)
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_cscs-daint-psmp-h100_report.txt
 info_url:    https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/3546923033037693/3295760759903023/-/pipelines
 
 [cscs-eiger-ssmp]
-sortkey:     201
 name:        CSCS Eiger (ssmp)
 host:        Alps Eiger (CSCS)
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_cscs-eiger-ssmp_report.txt
 info_url:    https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/3546923033037693/3295760759903023/-/pipelines
 
 [cscs-eiger-psmp]
-sortkey:     211
 name:        CSCS Eiger (psmp)
 host:        Alps Eiger (CSCS)
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_cscs-eiger-psmp_report.txt
@@ -29,131 +25,95 @@ info_url:    https://gitlab.com/cscs-ci/ci-testing/webhook-ci/mirrors/3546923033
 # ==============================================================================
 
 [precommit]
-sortkey:     431
 name:        Precommit
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_precommit_report.txt
 info_url:    http://www.cp2k.org/dev:formattingconventions
 
+[misc]
+name:        Misc
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_misc_report.txt
+
 [conventions]
-sortkey:     432
 name:        Coding conventions
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_conventions_report.txt
 info_url:    http://www.cp2k.org/dev:codingconventions
 
+# ==============================================================================
+
+[current-pdbg]
+name:        Current Toolchain (pdbg)
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_pdbg_report.txt
+
+[current-psmp]
+name:        Current Toolchain (psmp)
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_psmp_report.txt
+
+[current-sdbg]
+name:        Current Toolchain (sdbg)
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_sdbg_report.txt
+
+[current-ssmp]
+name:        Current Toolchain (ssmp)
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_ssmp_report.txt
+
 [spack-pdbg]
-sortkey:     435
 name:        Spack (pdbg)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-pdbg_report.txt
 
 [spack-sdbg]
-sortkey:     436
 name:        Spack (sdbg)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-sdbg_report.txt
 
-[current-pdbg]
-sortkey:     440
-name:        Current Toolchain (pdbg)
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_pdbg_report.txt
-
-[current-psmp]
-sortkey:     442
-name:        Current Toolchain (psmp)
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_psmp_report.txt
-
-[current-sdbg]
-sortkey:     443
-name:        Current Toolchain (sdbg)
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_sdbg_report.txt
-
-[spack-ssmp-static]
-sortkey:     444
-name:        Spack (ssmp-static)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-ssmp-static_report.txt
-
-[current-ssmp]
-sortkey:     445
-name:        Current Toolchain (ssmp)
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_ssmp_report.txt
-
-[spack-ssmp]
-sortkey:     447
-name:        Spack (ssmp)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-ssmp_report.txt
-
-[spack-openmpi-psmp]
-sortkey:     448
-name:        Spack (OpenMPI, psmp)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-openmpi-psmp_report.txt
-
-[spack-openmpi-pdbg]
-sortkey:     449
-name:        Spack (OpenMPI, pdbg)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-openmpi-pdbg_report.txt
 
 # ==============================================================================
 
 [gcc16]
-sortkey:     491
 name:        Ubuntu, GCC 16 (ssmp)
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gcc16_report.txt
 
 [gcc15]
-sortkey:     492
 name:        Ubuntu, GCC 15 (ssmp)
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gcc15_report.txt
 
 [gcc14]
-sortkey:     493
 name:        Ubuntu, GCC 14 (ssmp)
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gcc14_report.txt
 
 [gcc13]
-sortkey:     494
 name:        Ubuntu, GCC 13 (ssmp)
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gcc13_report.txt
 
 [gcc12]
-sortkey:     495
 name:        Ubuntu, GCC 12 (ssmp)
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gcc12_report.txt
 
 [gcc11]
-sortkey:     496
 name:        Ubuntu, GCC 11 (ssmp)
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gcc11_report.txt
 
 [gcc10]
-sortkey:     497
 name:        Ubuntu, GCC 10 (ssmp)
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gcc10_report.txt
 
 [gcc9]
-sortkey:     498
 name:        Ubuntu, GCC 9 (ssmp)
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gcc9_report.txt
@@ -161,13 +121,11 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gcc9_report.txt
 # ==============================================================================
 
 [minimal]
-sortkey:     581
 name:        Minimal build
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_minimal_report.txt
 
 [coverage]
-sortkey:     583
 name:        Coverage
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_coverage_report.txt
@@ -176,62 +134,48 @@ info_url:    https://www.cp2k.org/static/coverage/
 # ==============================================================================
 
 [manual]
-sortkey:     601
 name:        Manual generation
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_manual_report.txt
 info_url:    https://manual.cp2k.org
 
 [doxygen]
-sortkey:     605
 name:        Doxygen generation
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_doxygen_report.txt
 info_url:    https://doxygen.cp2k.org
 
 [ase]
-sortkey:     610
 name:        ASE Calculator
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_ase_report.txt
 info_url:    http://cp2k.org/tools:ase
 
 [aiida]
-sortkey:     611
 name:        AiiDA-CP2K Plugin
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_aiida_report.txt
 info_url:    http://cp2k.org/tools:aiida
 
 [i-pi]
-sortkey:     612
 name:        i-Pi
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_i-pi_report.txt
 info_url:    http://cp2k.org/tools:ipi
 
 [phonopy]
-sortkey:     613
 name:        Phonopy
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_phonopy_report.txt
 info_url:    https://www.cp2k.org/tools:phonopy
 
 [gromacs]
-sortkey:     614
 name:        Gromacs QM/MM
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_gromacs_report.txt
 info_url:    http://cp2k.org/tools:gromacs
 
-[misc]
-sortkey:     620
-name:        Misc
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_misc_report.txt
-
 [perf-openmp]
-sortkey:     625
 name:        Performance OpenMP
 timeout:     170
 host:        GCP
@@ -239,7 +183,6 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_perf-openmp_report
 info_url:    https://storage.googleapis.com/cp2k-ci/dashboard_perf-openmp_artifacts.tgz
 
 [perf-cuda-volta]
-sortkey:     630
 name:        Performance CUDA Volta
 timeout:     170
 host:        GCP
@@ -247,7 +190,6 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_perf-cuda-volta_re
 info_url:    https://storage.googleapis.com/cp2k-ci/dashboard_perf-cuda-volta_artifacts.tgz
 
 [arm64-psmp]
-sortkey:     635
 name:        ARM64
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_arm64-psmp_report.txt
@@ -255,7 +197,6 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_arm64-psmp_report.
 # ==============================================================================
 
 [darwin-gnu-arm64-psmp]
-sortkey:     703
 name:        macOS on Apple M1 (psmp)
 host:        MacStadium
 report_url:  http://www.cp2k.org/static/regtest/trunk/Darwin-gnu-arm64/latest-openmpi-psmp/regtest-0
@@ -264,28 +205,24 @@ info_url:    http://www.cp2k.org/static/regtest/trunk/Darwin-gnu-arm64/latest-op
 # ==============================================================================
 
 [spack-ssmp-p100]
-sortkey:     810
 name:        Spack (ssmp, CUDA P100)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-ssmp-p100_report.txt
 
 [spack-psmp-p100]
-sortkey:     820
 name:        Spack (psmp, CUDA P100)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-p100_report.txt
 
 [cuda-pascal]
-sortkey:     1011
 name:        CUDA Pascal (psmp)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_cuda-pascal_report.txt
 
 [hip-rocm-build]
-sortkey:     1013
 name:        HIP ROCm build (psmp)
 timeout:     170
 host:        GCP
@@ -294,98 +231,112 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_hip-rocm-build_rep
 # ==============================================================================
 
 [intel-ifx-ssmp]
-sortkey:     1028
 name:        Intel oneAPI (ssmp, ifx)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-ifx-ssmp_report.txt
 
 [intel-ifx-psmp]
-sortkey:     1029
 name:        Intel oneAPI (psmp, ifx)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-ifx-psmp_report.txt
 
 [intel-ifort-ssmp]
-sortkey:     1030
 name:        Intel oneAPI (ssmp, ifort)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-ifort-ssmp_report.txt
 
 [intel-ifort-psmp]
-sortkey:     1031
 name:        Intel oneAPI (psmp, ifort)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_intel-ifort-psmp_report.txt
 
+# ==============================================================================
+
+[spack-ssmp]
+name:        Spack (ssmp)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-ssmp_report.txt
+
+[spack-ssmp-static]
+name:        Spack (ssmp-static)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-ssmp-static_report.txt
+
+[spack-openmpi-psmp]
+name:        Spack (OpenMPI, psmp)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-openmpi-psmp_report.txt
+
+[spack-openmpi-pdbg]
+name:        Spack (OpenMPI, pdbg)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-openmpi-pdbg_report.txt
+
 [openmpi-psmp]
-sortkey:     1032
 name:        OpenMPI Toolchain (psmp)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_openmpi-psmp_report.txt
 
-[fedora-psmp]
-sortkey:     1034
-name:        Fedora Toolchain (psmp)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_fedora-psmp_report.txt
-
-[rawhide-psmp]
-sortkey:     1035
-name:        Rawhide Toolchain (psmp)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_rawhide-psmp_report.txt
-
 [generic-psmp]
-sortkey:     1036
 name:        Generic Toolchain (psmp)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_generic-psmp_report.txt
 
 [psmp-4ranks]
-sortkey:     1037
 name:        4 MPI ranks (psmp)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_psmp-4ranks_report.txt
 
 [spack-psmp-4x2]
-sortkey:     1040
 name:        Spack (psmp, 4x2)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-4x2_report.txt
 
+# ==============================================================================
+
+[fedora-psmp]
+name:        Fedora Toolchain (psmp)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_fedora-psmp_report.txt
+
+[rawhide-psmp]
+name:        Rawhide Toolchain (psmp)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_rawhide-psmp_report.txt
+
 [spack-psmp-rawhide]
-sortkey:     1041
 name:        Spack (psmp, rawhide)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-rawhide_report.txt
 
 [spack-psmp-fedora]
-sortkey:     1042
 name:        Spack (psmp, fedora)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-fedora_report.txt
 
 [spack-psmp-rockylinux]
-sortkey:     1043
 name:        Spack (psmp, rockylinux)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-rockylinux_report.txt
 
 [spack-psmp-opensuse]
-sortkey:     1044
 name:        Spack (psmp, opensuse)
 timeout:     170
 host:        GCP
@@ -393,59 +344,51 @@ report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-opensus
 
 # ==============================================================================
 
-[spack-psmp-gcc10]
-sortkey:     2010
-name:        Spack (psmp, GCC 10)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc10_report.txt
-
-[spack-psmp-gcc11]
-sortkey:     2011
-name:        Spack (psmp, GCC 11)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc11_report.txt
-
-[spack-psmp-gcc12]
-sortkey:     2012
-name:        Spack (psmp, GCC 12)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc12_report.txt
-
-[spack-psmp-gcc13]
-sortkey:     2013
-name:        Spack (psmp, GCC 13)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc13_report.txt
-
-[spack-psmp-gcc14]
-sortkey:     2014
-name:        Spack (psmp, GCC 14)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc14_report.txt
-
-[spack-psmp-gcc15]
-sortkey:     2015
-name:        Spack (psmp, GCC 15)
-timeout:     170
-host:        GCP
-report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc15_report.txt
-
 [spack-psmp-gcc16]
-sortkey:     2016
 name:        Spack (psmp, GCC 16)
 timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc16_report.txt
 
+[spack-psmp-gcc15]
+name:        Spack (psmp, GCC 15)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc15_report.txt
+
+[spack-psmp-gcc14]
+name:        Spack (psmp, GCC 14)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc14_report.txt
+
+[spack-psmp-gcc13]
+name:        Spack (psmp, GCC 13)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc13_report.txt
+
+[spack-psmp-gcc12]
+name:        Spack (psmp, GCC 12)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc12_report.txt
+
+[spack-psmp-gcc11]
+name:        Spack (psmp, GCC 11)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc11_report.txt
+
+[spack-psmp-gcc10]
+name:        Spack (psmp, GCC 10)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-gcc10_report.txt
+
 # ==============================================================================
 
 [asan-psmp]
-sortkey:     3000
 name:        Address Sanitizer
 timeout:     170
 host:        GCP

--- a/tools/dashboard/generate_dashboard.py
+++ b/tools/dashboard/generate_dashboard.py
@@ -169,7 +169,7 @@ def gen_frontpage(
 
     now = datetime.utcnow().replace(microsecond=0)
 
-    for s in sorted(config.sections(), key=lambda s: config.getint(s, "sortkey")):
+    for s in config.sections():
         print("Working on summary entry of: " + s)
         name = config.get(s, "name")
         host = config.get(s, "host")

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -26,7 +26,7 @@ tags:          daily
 cpu:           0.1
 nodepools:     default-pool
 
-#-------------------------------------------------------------------------------
+# ==============================================================================
 
 [precommit]
 display_name: Precommit
@@ -44,24 +44,16 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_misc
 
-#-------------------------------------------------------------------------------
-
-[sdbg]
-display_name: Regtest sdbg
-tags:         asap
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_sdbg
-
-[ssmp]
-display_name: Regtest ssmp
+[conventions]
+display_name: Conventions
 tags:         daily
-cpu:          32
+cpu:          16
 nodepools:    pool-main
-cache_from:   sdbg
+cache_from:   pdbg
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_ssmp
+dockerfile:   /tools/docker/Dockerfile.test_conventions
+
+# ==============================================================================
 
 [pdbg]
 display_name: Regtest pdbg
@@ -80,9 +72,26 @@ cache_from:   pdbg
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_psmp
 
+[sdbg]
+display_name: Regtest sdbg
+tags:         asap
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_sdbg
+
+[ssmp]
+display_name: Regtest ssmp
+tags:         daily
+cpu:          32
+nodepools:    pool-main
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_ssmp
+
 [spack-pdbg]
 display_name: Spack pdbg
-tags:         asap
+tags:         daily
 cpu:          32
 nodepools:    pool-main
 build_path:   /
@@ -97,46 +106,93 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_spack_sdbg
 
-[spack-ssmp]
-display_name: Spack ssmp
+# ==============================================================================
+
+[gcc16]
+display_name: Ubuntu, GCC 16 (ssmp)
 tags:         daily
 cpu:          32
 nodepools:    pool-main
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_ssmp
+dockerfile:   /tools/docker/Dockerfile.test_gcc16
 
-[spack-ssmp-static]
-display_name: Spack ssmp-static
+[gcc15]
+display_name: Ubuntu, GCC 15 (ssmp)
 tags:         daily
 cpu:          32
 nodepools:    pool-main
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_ssmp-static
+dockerfile:   /tools/docker/Dockerfile.test_gcc15
 
-[spack-openmpi-psmp]
-display_name: Spack OpenMPI psmp
+[gcc14]
+display_name: Ubuntu, GCC 14 (ssmp)
 tags:         daily
 cpu:          32
 nodepools:    pool-main
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_openmpi-psmp
+dockerfile:   /tools/docker/Dockerfile.test_gcc14
 
-[spack-openmpi-pdbg]
-display_name: Spack OpenMPI pdbg
+[gcc13]
+display_name: Ubuntu, GCC 13 (ssmp)
 tags:         daily
 cpu:          32
 nodepools:    pool-main
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_openmpi-pdbg
+dockerfile:   /tools/docker/Dockerfile.test_gcc13
 
-[conventions]
-display_name: Conventions
+[gcc12]
+display_name: Ubuntu, GCC 12 (ssmp)
 tags:         daily
-cpu:          16
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_gcc12
+
+[gcc11]
+display_name: Ubuntu, GCC 11 (ssmp)
+tags:         daily
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_gcc11
+
+[gcc10]
+display_name: Ubuntu, GCC 10 (ssmp)
+tags:         daily
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_gcc10
+
+[gcc9]
+display_name: Ubuntu, GCC 9 (ssmp)
+tags:         daily
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_gcc9
+
+# ==============================================================================
+
+[minimal]
+display_name: Minimal build
+tags:         daily
+cpu:          32
+nodepools:    pool-main
+cache_from:   sdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_minimal
+
+[coverage]
+display_name: Coverage
+tags:         daily
+cpu:          32
 nodepools:    pool-main
 cache_from:   pdbg
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_conventions
+dockerfile:   /tools/docker/Dockerfile.test_coverage
+
+# ==============================================================================
 
 [manual]
 display_name: Manual generation
@@ -147,6 +203,14 @@ cache_from:   pdbg
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_manual
 trigger_path: docs/
+
+[doxygen]
+display_name: Doxygen generation
+tags:         daily
+cpu:          16
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_doxygen
 
 [ase]
 display_name: ASE
@@ -193,107 +257,6 @@ cache_from:   sdbg
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_gromacs
 
-[minimal]
-display_name: Minimal build
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-cache_from:   sdbg
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_minimal
-
-[coverage]
-display_name: Coverage
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-cache_from:   pdbg
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_coverage
-
-#-------------------------------------------------------------------------------
-
-[gcc9]
-display_name: Ubuntu, GCC 9 (ssmp)
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_gcc9
-
-[gcc10]
-display_name: Ubuntu, GCC 10 (ssmp)
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_gcc10
-
-[gcc11]
-display_name: Ubuntu, GCC 11 (ssmp)
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_gcc11
-
-[gcc12]
-display_name: Ubuntu, GCC 12 (ssmp)
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_gcc12
-
-[gcc13]
-display_name: Ubuntu, GCC 13 (ssmp)
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_gcc13
-
-[gcc14]
-display_name: Ubuntu, GCC 14 (ssmp)
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_gcc14
-
-[gcc15]
-display_name: Ubuntu, GCC 15 (ssmp)
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_gcc15
-
-[gcc16]
-display_name: Ubuntu, GCC 16 (ssmp)
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_gcc16
-
-[doxygen]
-display_name: Doxygen generation
-tags:         daily
-cpu:          16
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_doxygen
-
-[arm64-psmp]
-display_name: ARM64
-tags:         daily
-cpu:          16
-arch:         arm64
-nodepools:    pool-arm
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_arm64-psmp
-
 [perf-openmp]
 display_name: Performance OpenMP
 tags:         daily
@@ -312,72 +275,16 @@ nodepools:    pool-nvidia-volta
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_performance_cuda_V100
 
-
-#-------------------------------------------------------------------------------
-
-[openmpi-psmp]
-display_name: OpenMPI
-tags:         weekly-morning
-cpu:          32
-nodepools:    pool-main
+[arm64-psmp]
+display_name: ARM64
+tags:         daily
+cpu:          16
+arch:         arm64
+nodepools:    pool-arm
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_openmpi-psmp
+dockerfile:   /tools/docker/Dockerfile.test_arm64-psmp
 
-[intel-ifx-ssmp]
-display_name: Intel oneAPI (ssmp, ifx)
-tags:         weekly-morning
-cpu:          20
-nodepools:    pool-intel
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_intel-ifx-ssmp
-
-[intel-ifx-psmp]
-display_name: Intel oneAPI (psmp, ifx)
-tags:         weekly-afternoon
-cpu:          20
-nodepools:    pool-intel
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_intel-ifx-psmp
-
-[intel-ifort-ssmp]
-display_name: Intel oneAPI (ssmp, ifort)
-tags:         weekly-morning
-cpu:          20
-nodepools:    pool-intel
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_intel-ifort-ssmp
-
-[intel-ifort-psmp]
-display_name: Intel oneAPI (psmp, ifort)
-tags:         weekly-afternoon
-cpu:          20
-nodepools:    pool-intel
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_intel-ifort-psmp
-
-[fedora-psmp]
-display_name: Fedora
-tags:         weekly-afternoon
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_fedora-psmp
-
-[rawhide-psmp]
-display_name: Fedora Rawhide
-tags:         weekly-afternoon
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_rawhide-psmp
-
-[generic-psmp]
-display_name: Generic
-tags:         weekly-afternoon
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_generic_psmp
+# ==============================================================================
 
 [spack-ssmp-p100]
 display_name: Spack (ssmp, CUDA P100)
@@ -414,6 +321,90 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.build_hip_rocm_Mi100
 
+# ==============================================================================
+
+[intel-ifx-ssmp]
+display_name: Intel oneAPI (ssmp, ifx)
+tags:         weekly-morning
+cpu:          20
+nodepools:    pool-intel
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_intel-ifx-ssmp
+
+[intel-ifx-psmp]
+display_name: Intel oneAPI (psmp, ifx)
+tags:         weekly-afternoon
+cpu:          20
+nodepools:    pool-intel
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_intel-ifx-psmp
+
+[intel-ifort-ssmp]
+display_name: Intel oneAPI (ssmp, ifort)
+tags:         weekly-morning
+cpu:          20
+nodepools:    pool-intel
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_intel-ifort-ssmp
+
+[intel-ifort-psmp]
+display_name: Intel oneAPI (psmp, ifort)
+tags:         weekly-afternoon
+cpu:          20
+nodepools:    pool-intel
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_intel-ifort-psmp
+
+# ==============================================================================
+
+[spack-ssmp]
+display_name: Spack ssmp
+tags:         weekly-morning
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_ssmp
+
+[spack-ssmp-static]
+display_name: Spack ssmp-static
+tags:         weekly-morning
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_ssmp-static
+
+[spack-openmpi-psmp]
+display_name: Spack OpenMPI psmp
+tags:         weekly-morning
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_openmpi-psmp
+
+[spack-openmpi-pdbg]
+display_name: Spack OpenMPI pdbg
+tags:         weekly-morning
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_openmpi-pdbg
+
+[openmpi-psmp]
+display_name: OpenMPI
+tags:         weekly-morning
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_openmpi-psmp
+
+[generic-psmp]
+display_name: Generic
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_generic_psmp
+
 [psmp-4ranks]
 display_name: Regtest psmp (4 MPI ranks)
 tags:         weekly-morning
@@ -430,6 +421,24 @@ cpu:          32
 nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-4x2
+
+# ==============================================================================
+
+[fedora-psmp]
+display_name: Fedora
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_fedora-psmp
+
+[rawhide-psmp]
+display_name: Fedora Rawhide
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_rawhide-psmp
 
 [spack-psmp-rawhide]
 display_name: Spack (psmp, rawhide)
@@ -463,45 +472,15 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-opensuse
 
-[spack-psmp-gcc10]
-display_name: Spack (psmp, GCC 10)
+# ==============================================================================
+
+[spack-psmp-gcc16]
+display_name: Spack (psmp, GCC 16)
 tags:         weekly-afternoon
 cpu:          32
 nodepools:    pool-main
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc10
-
-[spack-psmp-gcc11]
-display_name: Spack (psmp, GCC 11)
-tags:         weekly-afternoon
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc11
-
-[spack-psmp-gcc12]
-display_name: Spack (psmp, GCC 12)
-tags:         weekly-afternoon
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc12
-
-[spack-psmp-gcc13]
-display_name: Spack (psmp, GCC 13)
-tags:         weekly-afternoon
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc13
-
-[spack-psmp-gcc14]
-display_name: Spack (psmp, GCC 14)
-tags:         daily
-cpu:          32
-nodepools:    pool-main
-build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc14
+dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc16
 
 [spack-psmp-gcc15]
 display_name: Spack (psmp, GCC 15)
@@ -511,13 +490,47 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc15
 
-[spack-psmp-gcc16]
-display_name: Spack (psmp, GCC 16)
+[spack-psmp-gcc14]
+display_name: Spack (psmp, GCC 14)
 tags:         weekly-afternoon
 cpu:          32
 nodepools:    pool-main
 build_path:   /
-dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc16
+dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc14
+
+[spack-psmp-gcc13]
+display_name: Spack (psmp, GCC 13)
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc13
+
+[spack-psmp-gcc12]
+display_name: Spack (psmp, GCC 12)
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc12
+
+[spack-psmp-gcc11]
+display_name: Spack (psmp, GCC 11)
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc11
+
+[spack-psmp-gcc10]
+display_name: Spack (psmp, GCC 10)
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc10
+
+# ==============================================================================
 
 [asan-psmp]
 display_name: Address Sanitizer


### PR DESCRIPTION
Since we had a cloud bill of 673 USD last month, I'm reducing the cadence of some tests:

- spack-psmp-gcc14: `daily` -> `weekly`
- spack-pdbg: `asap` -> `daily`

Furthermore, I also synced the order of tests between `dashboard.conf` and `cp2k-ci.conf`.