### PR TITLE
Toolchain: Revise default behaviors

### DIFF
--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -289,6 +289,7 @@ Specific options of --with-PKG:
                           Default = install
   --with-fmt              Enable the formatting C/C++ library.
                           This package is required for SIRIUS.
+                          Default = no
   --with-libtorch         Enable libtorch as a machine learning framework.
                           This package is required for NequIP and Allegro, and
                           also for installing DeePMD-kit.
@@ -299,7 +300,7 @@ Specific options of --with-PKG:
                           Default = no
   --with-hdf5             Enable the hdf5 library for file format support.
                           This package is used by sirius and trexio.
-                          Default = install
+                          Default = no
   --with-libsmeagol       Enable interface to SMEAGOL NEGF library.
                           This package requires MPI.
                           Default = no
@@ -323,11 +324,11 @@ Specific options of --with-PKG:
                           If tblite is used, standalone DFTD4 package specified
                           by --with-dftd4 will not be used.
                           This package requires CMake.
-                          Default = no
-  --with-sirius           Enable interface to the plane wave SIRIUS library.
-                          This package requires GSL, libspg, ELPA, ScaLAPACK,
-                          HDF5, Libxc and pugixml, and libvdwxc is optinal.
                           Default = install
+  --with-sirius           Enable interface to the plane wave SIRIUS library.
+                          This package requires Libxc, ScaLAPACK, ELPA, GSL,
+                          libspg, HDF5, pugixml, and libvdwxc.
+                          Default = no
   --with-pugixml          Enable pugixml library for XML parsing.
                           This library is required by SIRIUS.
                           Default = no
@@ -492,7 +493,7 @@ with_libxsmm="__INSTALL__"
 with_libxc="__INSTALL__"
 with_gauxc="__DONTUSE__"
 with_scalapack="__INSTALL__"
-with_sirius="__INSTALL__"
+with_sirius="__DONTUSE__"
 with_gsl="__DONTUSE__"
 with_fmt="__DONTUSE__"
 with_spglib="__INSTALL__"
@@ -509,7 +510,7 @@ with_libvori="__INSTALL__"
 with_libtorch="__DONTUSE__"
 with_ninja="__DONTUSE__"
 with_dftd4="__DONTUSE__"
-with_tblite="__DONTUSE__"
+with_tblite="__INSTALL__"
 with_libsmeagol="__DONTUSE__"
 with_mcl="__DONTUSE__"
 


### PR DESCRIPTION
With this PR tblite would be installed by default, and SIRIUS would have to be requested explicitly (`--with-sirius`).

The change is based on the expected practical value and likely usage frequency of these optional dependencies for users: tblite, along with its subprojects, provides high practical value — not only supporting GFN2-xTB, but also, more importantly, D4 corrections (and possibly extra D3 functional parameters; see #5346) — and is more likely to be used frequently. SIRIUS provides the plane-wave module, while CP2K is most commonly used through Quickstep's efficient GPW/GAPW methods.