### PR TITLE
DOS section explicit required and added new unit for electric field

### DIFF
--- a/src/common/cp_units.F
+++ b/src/common/cp_units.F
@@ -1059,7 +1059,7 @@ CONTAINS
          CASE (cp_units_au)
             res = "au_efield"
          CASE (cp_units_none)
-            res = "electric field strength"
+            res = "electric field"
             IF (.NOT. my_accept_undefined) &
                CALL cp_abort(__LOCATION__, &
                              "unit not yet fully specified, unit of kind "// &

--- a/src/common/cp_units.F
+++ b/src/common/cp_units.F
@@ -372,6 +372,9 @@ CONTAINS
          CASE ("AU_EFIELD")
             unit_id(i_unit) = cp_units_au
             kind_id(i_unit) = cp_ukind_efield
+         CASE ("EFIELD")
+            unit_id(i_unit) = cp_units_none
+            kind_id(i_unit) = cp_ukind_efield
          CASE ("AU")
             CALL cp_abort(__LOCATION__, &
                           "au unit without specifying its kind not accepted, use "// &
@@ -642,7 +645,7 @@ CONTAINS
       CASE (cp_ukind_efield)
          SELECT CASE (basic_unit)
          CASE (cp_units_volt_per_m, cp_units_volt_per_nm, &
-               cp_units_volt_per_angstrom, cp_units_au)
+               cp_units_volt_per_angstrom, cp_units_au, cp_units_none)
          CASE default
             CPABORT("unknown electric field unit:"//TRIM(cp_to_string(basic_unit)))
          END SELECT

--- a/src/common/cp_units.F
+++ b/src/common/cp_units.F
@@ -34,8 +34,8 @@ MODULE cp_units
    USE mathconstants,                   ONLY: radians,&
                                               twopi
    USE physcon,                         ONLY: &
-        a_bohr, angstrom, atm, bar, bohr, e_mass, evolt, femtoseconds, joule, kcalmol, kelvin, &
-        kjmol, massunit, newton, pascal, picoseconds, seconds, wavenumbers
+        atm, bar, bohr, e_mass, evolt, femtoseconds, joule, kcalmol, kelvin, kjmol, massunit, &
+        newton, pascal, picoseconds, seconds, wavenumbers
    USE string_utilities,                ONLY: compress,&
                                               s2a,&
                                               uppercase
@@ -818,11 +818,11 @@ CONTAINS
       CASE (cp_ukind_efield)
          SELECT CASE (basic_unit)
          CASE (cp_units_volt_per_m)
-            res = (evolt/a_bohr)**(-my_power)*value
+            res = (1.0E+10_dp*evolt*bohr)**(-my_power)*value
          CASE (cp_units_volt_per_nm)
-            res = (10.0_dp*evolt/angstrom)**(-my_power)*value
+            res = (10.0_dp*evolt*bohr)**(-my_power)*value
          CASE (cp_units_volt_per_angstrom)
-            res = (evolt/angstrom)**(-my_power)*value
+            res = (evolt*bohr)**(-my_power)*value
          CASE (cp_units_au)
             res = value
          CASE default

--- a/src/common/cp_units.F
+++ b/src/common/cp_units.F
@@ -34,8 +34,8 @@ MODULE cp_units
    USE mathconstants,                   ONLY: radians,&
                                               twopi
    USE physcon,                         ONLY: &
-        a_bohr, atm, bar, bohr, e_mass, evolt, femtoseconds, joule, kcalmol, kelvin, kjmol, &
-        massunit, newton, pascal, picoseconds, seconds, wavenumbers
+        a_bohr, angstrom, atm, bar, bohr, e_mass, evolt, femtoseconds, joule, kcalmol, kelvin, &
+        kjmol, massunit, newton, pascal, picoseconds, seconds, wavenumbers
    USE string_utilities,                ONLY: compress,&
                                               s2a,&
                                               uppercase
@@ -360,14 +360,14 @@ CONTAINS
          CASE ("FORCE")
             unit_id(i_unit) = cp_units_none
             kind_id(i_unit) = cp_ukind_force
-         CASE ("VM-1", "VOLT_PER_M", "V/M")
+         CASE ("VM-1", "VOLT_PER_M")
             unit_id(i_unit) = cp_units_volt_per_m
             kind_id(i_unit) = cp_ukind_efield
-         CASE ("VNM-1", "VOLT_PER_NM", "V/NM")
+         CASE ("VNM-1", "VOLT_PER_NM")
             unit_id(i_unit) = cp_units_volt_per_nm
             kind_id(i_unit) = cp_ukind_efield
-         CASE ("VA-1", "VOLT_PER_ANGSTROM", "V/A", "V/ANGSTROM")
-            unit_id(i_unit) = cp_units_volt_per_nm
+         CASE ("VA-1", "VOLT_PER_ANGSTROM")
+            unit_id(i_unit) = cp_units_volt_per_angstrom
             kind_id(i_unit) = cp_ukind_efield
          CASE ("AU_EFIELD")
             unit_id(i_unit) = cp_units_au
@@ -820,9 +820,9 @@ CONTAINS
          CASE (cp_units_volt_per_m)
             res = (evolt/a_bohr)**(-my_power)*value
          CASE (cp_units_volt_per_nm)
-            res = (10.0_dp*evolt/bohr)**(-my_power)*value
+            res = (10.0_dp*evolt/angstrom)**(-my_power)*value
          CASE (cp_units_volt_per_angstrom)
-            res = (evolt/bohr)**(-my_power)*value
+            res = (evolt/angstrom)**(-my_power)*value
          CASE (cp_units_au)
             res = value
          CASE default
@@ -1055,7 +1055,7 @@ CONTAINS
          CASE (cp_units_volt_per_nm)
             res = "Vnm-1"
          CASE (cp_units_volt_per_angstrom)
-            res = "V/angstrom"
+            res = "Vangstrom-1"
          CASE (cp_units_au)
             res = "au_efield"
          CASE (cp_units_none)
@@ -1388,8 +1388,8 @@ CONTAINS
       CALL format_units_as_xml("mass", s2a("kg", "amu", "m_e"), iw)
       CALL format_units_as_xml("potential", s2a("volt", "au_pot"), iw)
       CALL format_units_as_xml("force", s2a("N", "Newton", "mN", "mNewton", "au_f"), iw)
-      CALL format_units_as_xml("efield", s2a("Vm-1", "V/m", "Vnm-1", "V/nm", "VA-1", "V/A", &
-                                             "au_efield"), iw)
+      CALL format_units_as_xml("efield", s2a("Vm-1", "Vnm-1", "VA-1", "volt_per_m", "volt_per_nm", &
+                                             "volt_per_angstrom", "au_efield"), iw)
 
    END SUBROUTINE export_units_as_xml
 

--- a/src/common/cp_units.F
+++ b/src/common/cp_units.F
@@ -34,8 +34,8 @@ MODULE cp_units
    USE mathconstants,                   ONLY: radians,&
                                               twopi
    USE physcon,                         ONLY: &
-        atm, bar, bohr, e_mass, evolt, femtoseconds, joule, kcalmol, kelvin, kjmol, massunit, &
-        newton, pascal, picoseconds, seconds, wavenumbers
+        a_bohr, atm, bar, bohr, e_mass, evolt, femtoseconds, joule, kcalmol, kelvin, kjmol, &
+        massunit, newton, pascal, picoseconds, seconds, wavenumbers
    USE string_utilities,                ONLY: compress,&
                                               s2a,&
                                               uppercase
@@ -58,7 +58,8 @@ MODULE cp_units
                                  cp_ukind_undef = 8, &
                                  cp_ukind_potential = 9, &
                                  cp_ukind_force = 10, &
-                                 cp_ukind_max = 10
+                                 cp_ukind_efield = 11, &
+                                 cp_ukind_max = 11
 
    ! General
    INTEGER, PARAMETER, PUBLIC :: cp_units_none = 100, &
@@ -112,6 +113,11 @@ MODULE cp_units
    ! Force
    INTEGER, PARAMETER, PUBLIC :: cp_units_Newton = 200, &
                                  cp_units_mNewton = 201
+
+   ! Electric Field
+   INTEGER, PARAMETER, PUBLIC :: cp_units_volt_per_m = 202, &
+                                 cp_units_volt_per_nm = 203, &
+                                 cp_units_volt_per_angstrom = 204
 
    INTEGER, PARAMETER, PUBLIC :: cp_unit_max_kinds = 8, cp_unit_basic_desc_length = 15, &
                                  cp_unit_desc_length = cp_unit_max_kinds*cp_unit_basic_desc_length
@@ -354,10 +360,23 @@ CONTAINS
          CASE ("FORCE")
             unit_id(i_unit) = cp_units_none
             kind_id(i_unit) = cp_ukind_force
+         CASE ("VM-1", "VOLT_PER_M", "V/M")
+            unit_id(i_unit) = cp_units_volt_per_m
+            kind_id(i_unit) = cp_ukind_efield
+         CASE ("VNM-1", "VOLT_PER_NM", "V/NM")
+            unit_id(i_unit) = cp_units_volt_per_nm
+            kind_id(i_unit) = cp_ukind_efield
+         CASE ("VA-1", "VOLT_PER_ANGSTROM", "V/A", "V/ANGSTROM")
+            unit_id(i_unit) = cp_units_volt_per_nm
+            kind_id(i_unit) = cp_ukind_efield
+         CASE ("AU_EFIELD")
+            unit_id(i_unit) = cp_units_au
+            kind_id(i_unit) = cp_ukind_efield
          CASE ("AU")
             CALL cp_abort(__LOCATION__, &
                           "au unit without specifying its kind not accepted, use "// &
-                          "(au_e, au_f, au_t, au_temp, au_l, au_m, au_p, au_pot)")
+                          "(au_e, au_f, au_t, au_temp, au_l, au_m, au_p, au_pot, "// &
+                          "au_efield)")
          CASE default
             CPABORT("Unknown unit: "//string(i_low:i_high - 1))
          END SELECT
@@ -620,6 +639,13 @@ CONTAINS
          CASE default
             CPABORT("unknown force unit:"//TRIM(cp_to_string(basic_unit)))
          END SELECT
+      CASE (cp_ukind_efield)
+         SELECT CASE (basic_unit)
+         CASE (cp_units_volt_per_m, cp_units_volt_per_nm, &
+               cp_units_volt_per_angstrom, cp_units_au)
+         CASE default
+            CPABORT("unknown electric field unit:"//TRIM(cp_to_string(basic_unit)))
+         END SELECT
       CASE (cp_ukind_none)
          IF (basic_unit /= cp_units_none) &
             CALL cp_abort(__LOCATION__, &
@@ -785,6 +811,19 @@ CONTAINS
             res = value
          CASE default
             CPABORT("unknown force unit:"//TRIM(cp_to_string(basic_unit)))
+         END SELECT
+      CASE (cp_ukind_efield)
+         SELECT CASE (basic_unit)
+         CASE (cp_units_volt_per_m)
+            res = (evolt/a_bohr)**(-my_power)*value
+         CASE (cp_units_volt_per_nm)
+            res = (10.0_dp*evolt/bohr)**(-my_power)*value
+         CASE (cp_units_volt_per_angstrom)
+            res = (evolt/bohr)**(-my_power)*value
+         CASE (cp_units_au)
+            res = value
+         CASE default
+            CPABORT("unknown electric field unit:"//TRIM(cp_to_string(basic_unit)))
          END SELECT
       CASE (cp_ukind_none)
          CALL cp_abort(__LOCATION__, &
@@ -1005,6 +1044,25 @@ CONTAINS
                              TRIM(res))
          CASE default
             CPABORT("unknown potential unit:"//TRIM(cp_to_string(basic_unit)))
+         END SELECT
+      CASE (cp_ukind_efield)
+         SELECT CASE (basic_unit)
+         CASE (cp_units_volt_per_m)
+            res = "Vm-1"
+         CASE (cp_units_volt_per_nm)
+            res = "Vnm-1"
+         CASE (cp_units_volt_per_angstrom)
+            res = "V/angstrom"
+         CASE (cp_units_au)
+            res = "au_efield"
+         CASE (cp_units_none)
+            res = "electric field strength"
+            IF (.NOT. my_accept_undefined) &
+               CALL cp_abort(__LOCATION__, &
+                             "unit not yet fully specified, unit of kind "// &
+                             TRIM(res))
+         CASE default
+            CPABORT("unknown efield unit:"//TRIM(cp_to_string(basic_unit)))
          END SELECT
       CASE (cp_ukind_none)
          CALL cp_abort(__LOCATION__, &
@@ -1279,6 +1337,9 @@ CONTAINS
             CASE (cp_ukind_force)
                CALL cp_unit_create2(unit_set%units(i)%unit, kind_id=[i], unit_id=[cp_units_newton], &
                                     power=[1])
+            CASE (cp_ukind_efield)
+               CALL cp_unit_create2(unit_set%units(i)%unit, kind_id=[i], unit_id=[cp_units_volt_per_m], &
+                                    power=[1])
             CASE default
                CPABORT("unhandled unit type "//TRIM(cp_to_string(i)))
                EXIT
@@ -1324,6 +1385,8 @@ CONTAINS
       CALL format_units_as_xml("mass", s2a("kg", "amu", "m_e"), iw)
       CALL format_units_as_xml("potential", s2a("volt", "au_pot"), iw)
       CALL format_units_as_xml("force", s2a("N", "Newton", "mN", "mNewton", "au_f"), iw)
+      CALL format_units_as_xml("efield", s2a("Vm-1", "V/m", "Vnm-1", "V/nm", "VA-1", "V/A", &
+                                             "au_efield"), iw)
 
    END SUBROUTINE export_units_as_xml
 

--- a/src/cp_control_types.F
+++ b/src/cp_control_types.F
@@ -387,6 +387,7 @@ MODULE cp_control_types
       REAL(KIND=dp), DIMENSION(:), POINTER :: envelop_r_vars => NULL()
       INTEGER, DIMENSION(:), POINTER       :: envelop_i_vars => NULL()
       REAL(KIND=dp)                        :: strength = 0.0_dp
+      REAL(KIND=dp)                        :: amplitude = 0.0_dp
       REAL(KIND=dp)                        :: phase_offset = 0.0_dp
       REAL(KIND=dp)                        :: wavelength = 0.0_dp
       REAL(KIND=dp), DIMENSION(3)          :: vec_pot_initial = 0.0_dp

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -3144,8 +3144,17 @@ CONTAINS
                                    r_val=efield%strength, explicit=intensity_explicit)
          CALL section_vals_val_get(efield_section, "AMPLITUDE", i_rep_section=i, &
                                    r_val=efield%amplitude, explicit=amplitude_explicit)
+
          IF (intensity_explicit .AND. amplitude_explicit) THEN
             CPABORT("Both INTENSITY and AMPLITUDE provided in EFIELD section.")
+         END IF
+
+         IF (intensity_explicit) THEN
+            efield%amplitude = SQRT(efield%strength/(3.50944_dp*10.0_dp**16))
+         END IF
+
+         IF (amplitude_explicit) THEN
+            efield%strength = (3.50944_dp*10.0_dp**16)*(efield%amplitude)**2
          END IF
 
          CALL section_vals_val_get(efield_section, "POLARISATION", i_rep_section=i, &

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -3130,6 +3130,7 @@ CONTAINS
 
       CHARACTER(len=default_path_length)                 :: file_name
       INTEGER                                            :: i, io, j, n, unit_nr
+      LOGICAL                                            :: amplitude_explicit, intensity_explicit
       REAL(KIND=dp), DIMENSION(:), POINTER               :: tmp_vals
       TYPE(efield_type), POINTER                         :: efield
       TYPE(section_vals_type), POINTER                   :: tmp_section
@@ -3140,7 +3141,12 @@ CONTAINS
          efield => dft_control%efield_fields(i)%efield
          NULLIFY (efield%envelop_i_vars, efield%envelop_r_vars)
          CALL section_vals_val_get(efield_section, "INTENSITY", i_rep_section=i, &
-                                   r_val=efield%strength)
+                                   r_val=efield%strength, explicit=intensity_explicit)
+         CALL section_vals_val_get(efield_section, "AMPLITUDE", i_rep_section=i, &
+                                   r_val=efield%amplitude, explicit=amplitude_explicit)
+         IF (intensity_explicit .AND. amplitude_explicit) THEN
+            CPABORT("Both INTENSITY and AMPLITUDE provided in EFIELD section.")
+         END IF
 
          CALL section_vals_val_get(efield_section, "POLARISATION", i_rep_section=i, &
                                    r_vals=tmp_vals)

--- a/src/efield_utils.F
+++ b/src/efield_utils.F
@@ -27,8 +27,10 @@ MODULE efield_utils
                                               gaussian_env,&
                                               ramp_env
    USE kinds,                           ONLY: dp
-   USE mathconstants,                   ONLY: pi
+   USE mathconstants,                   ONLY: pi,&
+                                              twopi
    USE particle_types,                  ONLY: particle_type
+   USE physcon,                         ONLY: c_light_au
    USE qs_energy_types,                 ONLY: qs_energy_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
@@ -121,56 +123,60 @@ CONTAINS
       REAL(KIND=dp), INTENT(IN)                          :: sim_time
 
       INTEGER                                            :: i, lower, nfield, upper
-      REAL(dp)                                           :: c, env, nu, pol(3), strength
+      REAL(dp)                                           :: E_0, env, nu, pol(3), strength
       REAL(KIND=dp)                                      :: dt
       TYPE(efield_type), POINTER                         :: efield
 
-      c = 137.03599962875_dp
       field = 0._dp
-      nu = 0.0_dp
       nfield = SIZE(dft_control%efield_fields)
       DO i = 1, nfield
          efield => dft_control%efield_fields(i)%efield
-         IF (.NOT. efield%envelop_id == custom_env .AND. efield%wavelength > EPSILON(0.0_dp)) nu = c/(efield%wavelength) !in case of a custom efield we do not need nu
-         strength = SQRT(efield%strength/(3.50944_dp*10.0_dp**16))
-         IF (strength == 0) strength = efield%amplitude
+         nu = 0.0_dp
+         IF (.NOT. efield%envelop_id == custom_env .AND. efield%wavelength > EPSILON(0.0_dp)) THEN
+            nu = c_light_au/(efield%wavelength) !in case of a custom efield we do not need nu
+         END IF
+         E_0 = efield%amplitude
 
          IF (DOT_PRODUCT(efield%polarisation, efield%polarisation) == 0) THEN
             pol(:) = 1.0_dp/3.0_dp
          ELSE
             pol(:) = efield%polarisation(:)/(SQRT(DOT_PRODUCT(efield%polarisation, efield%polarisation)))
          END IF
-         IF (efield%envelop_id == constant_env) THEN
+
+         SELECT CASE (efield%envelop_id)
+         CASE (constant_env)
             IF (sim_step >= efield%envelop_i_vars(1) .AND. &
                 (sim_step <= efield%envelop_i_vars(2) .OR. efield%envelop_i_vars(2) < 0)) THEN
-               field = field + strength*COS(sim_time*nu*2.0_dp*pi + &
-                                            efield%phase_offset*pi)*pol(:)
+               field = field + E_0*COS(sim_time*nu*twopi + &
+                                       efield%phase_offset*pi)*pol(:)
             END IF
-         ELSE IF (efield%envelop_id == ramp_env) THEN
+         CASE (ramp_env)
             IF (sim_step >= efield%envelop_i_vars(1) .AND. sim_step <= efield%envelop_i_vars(2)) &
-               strength = strength*(sim_step - efield%envelop_i_vars(1))/(efield%envelop_i_vars(2) - efield%envelop_i_vars(1))
+               strength = E_0*(sim_step - efield%envelop_i_vars(1))/(efield%envelop_i_vars(2) - efield%envelop_i_vars(1))
             IF (sim_step >= efield%envelop_i_vars(3) .AND. sim_step <= efield%envelop_i_vars(4)) &
-               strength = strength*(efield%envelop_i_vars(4) - sim_step)/(efield%envelop_i_vars(4) - efield%envelop_i_vars(3))
+               strength = E_0*(efield%envelop_i_vars(4) - sim_step)/(efield%envelop_i_vars(4) - efield%envelop_i_vars(3))
             IF (sim_step > efield%envelop_i_vars(4) .AND. efield%envelop_i_vars(4) > 0) strength = 0.0_dp
             IF (sim_step <= efield%envelop_i_vars(1)) strength = 0.0_dp
-            field = field + strength*COS(sim_time*nu*2.0_dp*pi + &
+            field = field + strength*COS(sim_time*nu*twopi + &
                                          efield%phase_offset*pi)*pol(:)
-         ELSE IF (efield%envelop_id == gaussian_env) THEN
+         CASE (gaussian_env)
             env = EXP(-0.5_dp*((sim_time - efield%envelop_r_vars(1))/efield%envelop_r_vars(2))**2.0_dp)
-            field = field + strength*env*COS(sim_time*nu*2.0_dp*pi + &
-                                             efield%phase_offset*pi)*pol(:)
-         ELSE IF (efield%envelop_id == custom_env) THEN
+            field = field + E_0*env*COS(sim_time*nu*twopi + &
+                                        efield%phase_offset*pi)*pol(:)
+         CASE (custom_env)
             dt = efield%envelop_r_vars(1)
             IF (sim_time < (SIZE(efield%envelop_r_vars) - 2)*dt) THEN
                !make a linear interpolation between the two next points
                lower = FLOOR(sim_time/dt)
                upper = lower + 1
-     strength = (efield%envelop_r_vars(lower + 2)*(upper*dt - sim_time) + efield%envelop_r_vars(upper + 2)*(sim_time - lower*dt))/dt
+               strength = (efield%envelop_r_vars(lower + 2)*(upper*dt - sim_time) &
+                           + efield%envelop_r_vars(upper + 2)*(sim_time - lower*dt))/dt
             ELSE
                strength = 0.0_dp
             END IF
             field = field + strength*pol(:)
-         END IF
+         CASE default
+         END SELECT
       END DO
 
    END SUBROUTINE make_field

--- a/src/efield_utils.F
+++ b/src/efield_utils.F
@@ -133,6 +133,8 @@ CONTAINS
          efield => dft_control%efield_fields(i)%efield
          IF (.NOT. efield%envelop_id == custom_env .AND. efield%wavelength > EPSILON(0.0_dp)) nu = c/(efield%wavelength) !in case of a custom efield we do not need nu
          strength = SQRT(efield%strength/(3.50944_dp*10.0_dp**16))
+         IF (strength == 0) strength = efield%amplitude
+
          IF (DOT_PRODUCT(efield%polarisation, efield%polarisation) == 0) THEN
             pol(:) = 1.0_dp/3.0_dp
          ELSE

--- a/src/input_cp2k_field.F
+++ b/src/input_cp2k_field.F
@@ -12,26 +12,26 @@
 !> \author fawzi
 ! **************************************************************************************************
 MODULE input_cp2k_field
-   USE bibliography,                    ONLY: Souza2002,&
-                                              Stengel2009,&
-                                              Umari2002
-   USE input_constants,                 ONLY: constant_env,&
-                                              custom_env,&
-                                              gaussian,&
-                                              gaussian_env,&
-                                              ramp_env
-   USE input_keyword_types,             ONLY: keyword_create,&
-                                              keyword_release,&
-                                              keyword_type
-   USE input_section_types,             ONLY: section_add_keyword,&
-                                              section_add_subsection,&
-                                              section_create,&
-                                              section_release,&
-                                              section_type
-   USE input_val_types,                 ONLY: char_t,&
-                                              real_t
-   USE kinds,                           ONLY: dp
-   USE string_utilities,                ONLY: s2a
+   USE bibliography, ONLY: Souza2002, &
+                           Stengel2009, &
+                           Umari2002
+   USE input_constants, ONLY: constant_env, &
+                              custom_env, &
+                              gaussian, &
+                              gaussian_env, &
+                              ramp_env
+   USE input_keyword_types, ONLY: keyword_create, &
+                                  keyword_release, &
+                                  keyword_type
+   USE input_section_types, ONLY: section_add_keyword, &
+                                  section_add_subsection, &
+                                  section_create, &
+                                  section_release, &
+                                  section_type
+   USE input_val_types, ONLY: char_t, &
+                              real_t
+   USE kinds, ONLY: dp
+   USE string_utilities, ONLY: s2a
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -161,10 +161,16 @@ CONTAINS
       NULLIFY (keyword, subsection)
 
       CALL keyword_create(keyword, __LOCATION__, name="INTENSITY", &
-                          description="Intensity of the electric field. For real-time propagation (RTP) units are "// &
-                          "in W*cm-2 which corresponds "// &
-                          "to a maximal amplitude in a.u. of sqrt(I/(3.50944*10^16)). "// &
-                          "For a constant local field in isolated system calclulations, units are in a.u..", &
+                          description="Intensity of the electric field. "// &
+                          "For real-time propagation (RTP) calculations, the intensity is in "// &
+                          "$\mathrm{W/cm^2}$. The corresponding peak electric field amplitude "// &
+                          "$E_0$ in atomic units ($E_H/a_B \approx 82.4\,\mathrm{V/nm}$) is "// &
+                          "$E_0 = \sqrt{I\,[\mathrm{W/cm^2}]\;/\;(3.5094410 \cdot 10^{16})} "// &
+                          "\cdot E_H/a_B$, "// &
+                          "derived from the atomic unit of energy flux $I_0 = cE_H^2/(8\pi)$ "// &
+                          "and the relation $I = E_0^2$ in atomic units. "// &
+                          "For a constant local field in an isolated-system calculation, "// &
+                          "units are in a.u. In place of intensity, AMPLITUDE can be provided.", &
                           usage="INTENSITY  0.001", &
                           default_r_val=0._dp)
       CALL section_add_keyword(section, keyword)
@@ -172,8 +178,9 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="AMPLITUDE", &
                           description="Amplitude of the electric field of the light wave. "// &
-                          "To be provided in place of INTENSITY.", &
-                          usage="AMPLITUDE 1.E9", unit_str="VOLT_PER_M", &
+                          "One can specify either INTENSITY or AMPLITUDE. An error will be "// &
+                          "raised if both are specified.", &
+                          usage="AMPLITUDE [Vnm-1] 1.06", unit_str="Vm-1", &
                           default_r_val=0._dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_field.F
+++ b/src/input_cp2k_field.F
@@ -164,8 +164,17 @@ CONTAINS
                           description="Intensity of the electric field. For real-time propagation (RTP) units are "// &
                           "in W*cm-2 which corresponds "// &
                           "to a maximal amplitude in a.u. of sqrt(I/(3.50944*10^16)). "// &
+                          "($E_H/a_B \approx 82.4$ V/nm) since in SI, $I_0=cE_H^2/8\pi$ "// &
                           "For a constant local field in isolated system calclulations, units are in a.u..", &
                           usage="INTENSITY  0.001", &
+                          default_r_val=0._dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="AMPLITUDE", &
+                          description="Amplitude of the electric field of the light wave. "// &
+                          "To be provided in place of INTENSITY.", &
+                          usage="AMPLITUDE 1.E9", unit_str="VOLT_PER_M", &
                           default_r_val=0._dp)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)

--- a/src/input_cp2k_field.F
+++ b/src/input_cp2k_field.F
@@ -164,7 +164,6 @@ CONTAINS
                           description="Intensity of the electric field. For real-time propagation (RTP) units are "// &
                           "in W*cm-2 which corresponds "// &
                           "to a maximal amplitude in a.u. of sqrt(I/(3.50944*10^16)). "// &
-                          "($E_H/a_B \approx 82.4$ V/nm) since in SI, $I_0=cE_H^2/8\pi$ "// &
                           "For a constant local field in isolated system calclulations, units are in a.u..", &
                           usage="INTENSITY  0.001", &
                           default_r_val=0._dp)

--- a/src/post_scf_bandstructure_methods.F
+++ b/src/post_scf_bandstructure_methods.F
@@ -56,9 +56,7 @@ CONTAINS
       END IF
 
       ! density of states (DOS), projected DOS, local DOS for DFT, DFT+SOC, G0W0, G0W0+SOC
-      IF (qs_env%bs_env%do_dos_pdos_ldos) THEN
-         CALL dos_pdos_ldos(qs_env, qs_env%bs_env)
-      END IF
+      CALL dos_pdos_ldos(qs_env, qs_env%bs_env)
 
       CALL timestop(handle)
 

--- a/src/post_scf_bandstructure_methods.F
+++ b/src/post_scf_bandstructure_methods.F
@@ -56,7 +56,9 @@ CONTAINS
       END IF
 
       ! density of states (DOS), projected DOS, local DOS for DFT, DFT+SOC, G0W0, G0W0+SOC
-      CALL dos_pdos_ldos(qs_env, qs_env%bs_env)
+      IF (qs_env%bs_env%do_dos_pdos_ldos) THEN
+         CALL dos_pdos_ldos(qs_env, qs_env%bs_env)
+      END IF
 
       CALL timestop(handle)
 

--- a/src/post_scf_bandstructure_methods.F
+++ b/src/post_scf_bandstructure_methods.F
@@ -9,7 +9,7 @@ MODULE post_scf_bandstructure_methods
    USE gw_main,                         ONLY: gw
    USE input_section_types,             ONLY: section_vals_type
    USE post_scf_bandstructure_utils,    ONLY: create_and_init_bs_env,&
-                                              dos_pdos_ldos,&
+                                              eval_bandstructure_properties,&
                                               soc
    USE qs_environment_types,            ONLY: qs_environment_type
    USE qs_scf,                          ONLY: scf
@@ -56,7 +56,7 @@ CONTAINS
       END IF
 
       ! density of states (DOS), projected DOS, local DOS for DFT, DFT+SOC, G0W0, G0W0+SOC
-      CALL dos_pdos_ldos(qs_env, qs_env%bs_env)
+      CALL eval_bandstructure_properties(qs_env, qs_env%bs_env)
 
       CALL timestop(handle)
 

--- a/src/post_scf_bandstructure_types.F
+++ b/src/post_scf_bandstructure_types.F
@@ -87,7 +87,8 @@ MODULE post_scf_bandstructure_types
       LOGICAL                                         :: do_gw = .FALSE., &
                                                          do_soc = .FALSE., &
                                                          do_ldos = .FALSE., &
-                                                         do_gw_ri_rs = .FALSE.
+                                                         do_gw_ri_rs = .FALSE., &
+                                                         do_dos_pdos_ldos = .FALSE.
 
       ! various eigenvalues computed in GW code, some depend on k-points
       ! and have therefore three dimensions (band index, k-point, spin)

--- a/src/post_scf_bandstructure_types.F
+++ b/src/post_scf_bandstructure_types.F
@@ -88,7 +88,7 @@ MODULE post_scf_bandstructure_types
                                                          do_soc = .FALSE., &
                                                          do_ldos = .FALSE., &
                                                          do_gw_ri_rs = .FALSE., &
-                                                         do_dos_pdos_ldos = .FALSE.
+                                                         do_dos_pdos = .FALSE.
 
       ! various eigenvalues computed in GW code, some depend on k-points
       ! and have therefore three dimensions (band index, k-point, spin)

--- a/src/post_scf_bandstructure_utils.F
+++ b/src/post_scf_bandstructure_utils.F
@@ -226,7 +226,7 @@ CONTAINS
 
       NULLIFY (dos_pdos_sec)
       dos_pdos_sec => section_vals_get_subs_vals(bs_sec, "DOS")
-      CALL section_vals_get(dos_pdos_sec, explicit=bs_env%do_dos_pdos_ldos)
+      CALL section_vals_get(dos_pdos_sec, explicit=bs_env%do_dos_pdos)
 
       CALL section_vals_val_get(bs_sec, "DOS%KPOINTS", i_vals=bs_env%nkp_grid_DOS_input)
       CALL section_vals_val_get(bs_sec, "DOS%ENERGY_WINDOW", r_val=bs_env%energy_window_DOS)
@@ -1111,17 +1111,21 @@ CONTAINS
 
       n_E = INT(E_total_window/energy_step_DOS)
 
-      ALLOCATE (DOS_scf(n_E))
-      DOS_scf(:) = 0.0_dp
-      ALLOCATE (DOS_scf_SOC(n_E))
-      DOS_scf_SOC(:) = 0.0_dp
-
       CALL get_qs_env(qs_env, nkind=nkind)
 
-      ALLOCATE (PDOS_scf(n_E, nkind))
-      PDOS_scf(:, :) = 0.0_dp
-      ALLOCATE (PDOS_scf_SOC(n_E, nkind))
-      PDOS_scf_SOC(:, :) = 0.0_dp
+      IF (bs_env%do_dos_pdos) THEN
+
+         ALLOCATE (DOS_scf(n_E))
+         DOS_scf(:) = 0.0_dp
+         ALLOCATE (DOS_scf_SOC(n_E))
+         DOS_scf_SOC(:) = 0.0_dp
+
+         ALLOCATE (PDOS_scf(n_E, nkind))
+         PDOS_scf(:, :) = 0.0_dp
+         ALLOCATE (PDOS_scf_SOC(n_E, nkind))
+         PDOS_scf_SOC(:, :) = 0.0_dp
+
+      END IF
 
       ALLOCATE (proj_mo_on_kind(n_ao, nkind))
       proj_mo_on_kind(:, :) = 0.0_dp
@@ -1234,8 +1238,11 @@ CONTAINS
             CALL compute_proj_mo_on_kind(proj_mo_on_kind, qs_env, cfm_mos_ikp(ispin), cfm_s_ikp)
 
             ! 5. DOS and PDOS
-            CALL add_to_DOS_PDOS(DOS_scf, PDOS_scf, eigenval, ikp, bs_env, n_E, E_min, &
-                                 proj_mo_on_kind)
+            IF (bs_env%do_dos_pdos) THEN
+               CALL add_to_DOS_PDOS(DOS_scf, PDOS_scf, eigenval, ikp, bs_env, n_E, E_min, &
+                                    proj_mo_on_kind)
+            END IF
+
             IF (bs_env%do_gw) THEN
                CALL add_to_DOS_PDOS(DOS_G0W0, PDOS_G0W0, bs_env%eigenval_G0W0(:, ikp, ispin), &
                                     ikp, bs_env, n_E, E_min, proj_mo_on_kind)
@@ -1326,7 +1333,9 @@ CONTAINS
       END IF
 
       CALL write_band_edges(band_edges_scf, "SCF", bs_env)
-      CALL write_dos_pdos(DOS_scf, PDOS_scf, bs_env, qs_env, "SCF", E_min, band_edges_scf%VBM)
+      IF (bs_env%do_dos_pdos) THEN
+         CALL write_dos_pdos(DOS_scf, PDOS_scf, bs_env, qs_env, "SCF", E_min, band_edges_scf%VBM)
+      END IF
       IF (bs_env%do_ldos) THEN
          CALL print_LDOS_main(LDOS_scf_2d, bs_env, band_edges_scf, "SCF")
       END IF

--- a/src/post_scf_bandstructure_utils.F
+++ b/src/post_scf_bandstructure_utils.F
@@ -1668,8 +1668,6 @@ CONTAINS
 
       n_ao = bs_env%n_ao
       homo_spinor = bs_env%n_occ(1) + bs_env%n_occ(bs_env%n_spin)
-      n_E = SIZE(DOS)
-      nkind = SIZE(PDOS, 2)
       CALL get_qs_env(qs_env, nkind=nkind)
 
       CALL cp_cfm_create(cfm_ks_ikp_spinor, bs_env%cfm_SOC_spinor_ao(1)%matrix_struct)
@@ -1739,6 +1737,7 @@ CONTAINS
 
       ! 6. DOS from spinors, no PDOS
       IF (bs_env%do_dos_pdos) THEN
+         n_E = SIZE(DOS)
          CALL add_to_DOS_PDOS(DOS, PDOS, eigenval_spinor, &
                               ikp, bs_env, n_E, E_min, proj_mo_on_kind_spinor)
       END IF

--- a/src/post_scf_bandstructure_utils.F
+++ b/src/post_scf_bandstructure_utils.F
@@ -1117,11 +1117,17 @@ CONTAINS
 
          ALLOCATE (DOS_scf(n_E))
          DOS_scf(:) = 0.0_dp
-         ALLOCATE (DOS_scf_SOC(n_E))
-         DOS_scf_SOC(:) = 0.0_dp
 
          ALLOCATE (PDOS_scf(n_E, nkind))
          PDOS_scf(:, :) = 0.0_dp
+
+      END IF
+
+      IF (bs_env%do_soc) THEN
+
+         ALLOCATE (DOS_scf_SOC(n_E))
+         DOS_scf_SOC(:) = 0.0_dp
+
          ALLOCATE (PDOS_scf_SOC(n_E, nkind))
          PDOS_scf_SOC(:, :) = 0.0_dp
 

--- a/src/post_scf_bandstructure_utils.F
+++ b/src/post_scf_bandstructure_utils.F
@@ -1113,26 +1113,6 @@ CONTAINS
 
       CALL get_qs_env(qs_env, nkind=nkind)
 
-      IF (bs_env%do_dos_pdos) THEN
-
-         ALLOCATE (DOS_scf(n_E))
-         DOS_scf(:) = 0.0_dp
-
-         ALLOCATE (PDOS_scf(n_E, nkind))
-         PDOS_scf(:, :) = 0.0_dp
-
-      END IF
-
-      IF (bs_env%do_soc) THEN
-
-         ALLOCATE (DOS_scf_SOC(n_E))
-         DOS_scf_SOC(:) = 0.0_dp
-
-         ALLOCATE (PDOS_scf_SOC(n_E, nkind))
-         PDOS_scf_SOC(:, :) = 0.0_dp
-
-      END IF
-
       ALLOCATE (proj_mo_on_kind(n_ao, nkind))
       proj_mo_on_kind(:, :) = 0.0_dp
 
@@ -1141,18 +1121,38 @@ CONTAINS
       ALLOCATE (eigenval_spinor_no_SOC(2*n_ao))
       ALLOCATE (eigenval_spinor_G0W0(2*n_ao))
 
-      IF (bs_env%do_gw) THEN
+      IF (bs_env%do_dos_pdos) THEN
 
-         ALLOCATE (DOS_G0W0(n_E))
-         DOS_G0W0(:) = 0.0_dp
-         ALLOCATE (DOS_G0W0_SOC(n_E))
-         DOS_G0W0_SOC(:) = 0.0_dp
+         ALLOCATE (DOS_scf(n_E))
+         DOS_scf(:) = 0.0_dp
+         ALLOCATE (PDOS_scf(n_E, nkind))
+         PDOS_scf(:, :) = 0.0_dp
 
-         ALLOCATE (PDOS_G0W0(n_E, nkind))
-         PDOS_G0W0(:, :) = 0.0_dp
-         ALLOCATE (PDOS_G0W0_SOC(n_E, nkind))
-         PDOS_G0W0_SOC(:, :) = 0.0_dp
+         IF (bs_env%do_soc) THEN
 
+            ALLOCATE (DOS_scf_SOC(n_E))
+            DOS_scf_SOC(:) = 0.0_dp
+            ALLOCATE (PDOS_scf_SOC(n_E, nkind))
+            PDOS_scf_SOC(:, :) = 0.0_dp
+
+         END IF
+
+         IF (bs_env%do_gw) THEN
+
+            ALLOCATE (DOS_G0W0(n_E))
+            DOS_G0W0(:) = 0.0_dp
+            ALLOCATE (PDOS_G0W0(n_E, nkind))
+            PDOS_G0W0(:, :) = 0.0_dp
+
+            IF (bs_env%do_soc) THEN
+
+               ALLOCATE (DOS_G0W0_SOC(n_E))
+               DOS_G0W0_SOC(:) = 0.0_dp
+               ALLOCATE (PDOS_G0W0_SOC(n_E, nkind))
+               PDOS_G0W0_SOC(:, :) = 0.0_dp
+
+            END IF
+         END IF
       END IF
 
       CALL cp_cfm_create(cfm_mos_ikp(1), bs_env%fm_ks_Gamma(1)%matrix_struct)
@@ -1247,11 +1247,11 @@ CONTAINS
             IF (bs_env%do_dos_pdos) THEN
                CALL add_to_DOS_PDOS(DOS_scf, PDOS_scf, eigenval, ikp, bs_env, n_E, E_min, &
                                     proj_mo_on_kind)
-            END IF
 
-            IF (bs_env%do_gw) THEN
-               CALL add_to_DOS_PDOS(DOS_G0W0, PDOS_G0W0, bs_env%eigenval_G0W0(:, ikp, ispin), &
-                                    ikp, bs_env, n_E, E_min, proj_mo_on_kind)
+               IF (bs_env%do_gw) THEN
+                  CALL add_to_DOS_PDOS(DOS_G0W0, PDOS_G0W0, bs_env%eigenval_G0W0(:, ikp, ispin), &
+                                       ikp, bs_env, n_E, E_min, proj_mo_on_kind)
+               END IF
             END IF
 
             IF (bs_env%do_ldos) THEN
@@ -1348,8 +1348,10 @@ CONTAINS
 
       IF (bs_env%do_soc) THEN
          CALL write_band_edges(band_edges_scf_SOC, "SCF+SOC", bs_env)
-         CALL write_dos_pdos(DOS_scf_SOC, PDOS_scf_SOC, bs_env, qs_env, "SCF_SOC", &
-                             E_min, band_edges_scf_SOC%VBM)
+         IF (bs_env%do_dos_pdos) THEN
+            CALL write_dos_pdos(DOS_scf_SOC, PDOS_scf_SOC, bs_env, qs_env, "SCF_SOC", &
+                                E_min, band_edges_scf_SOC%VBM)
+         END IF
          IF (bs_env%do_ldos) THEN
             ! argument band_edges_scf is actually correct because the non-SOC band edges
             ! have been used as reference in add_to_LDOS_2d
@@ -1361,8 +1363,10 @@ CONTAINS
       IF (bs_env%do_gw) THEN
          CALL write_band_edges(band_edges_G0W0, "G0W0", bs_env)
          CALL write_band_edges(bs_env%band_edges_HF, "Hartree-Fock with SCF orbitals", bs_env)
-         CALL write_dos_pdos(DOS_G0W0, PDOS_G0W0, bs_env, qs_env, "G0W0", E_min, &
-                             band_edges_G0W0%VBM)
+         IF (bs_env%do_dos_pdos) THEN
+            CALL write_dos_pdos(DOS_G0W0, PDOS_G0W0, bs_env, qs_env, "G0W0", E_min, &
+                                band_edges_G0W0%VBM)
+         END IF
          IF (bs_env%do_ldos) THEN
             CALL print_LDOS_main(LDOS_G0W0_2d, bs_env, band_edges_G0W0, "G0W0")
          END IF
@@ -1370,8 +1374,10 @@ CONTAINS
 
       IF (bs_env%do_soc .AND. bs_env%do_gw) THEN
          CALL write_band_edges(band_edges_G0W0_SOC, "G0W0+SOC", bs_env)
-         CALL write_dos_pdos(DOS_G0W0_SOC, PDOS_G0W0_SOC, bs_env, qs_env, "G0W0_SOC", E_min, &
-                             band_edges_G0W0_SOC%VBM)
+         IF (bs_env%do_dos_pdos) THEN
+            CALL write_dos_pdos(DOS_G0W0_SOC, PDOS_G0W0_SOC, bs_env, qs_env, "G0W0_SOC", E_min, &
+                                band_edges_G0W0_SOC%VBM)
+         END IF
       END IF
 
       CALL cp_cfm_release(cfm_s_ikp)
@@ -1664,6 +1670,7 @@ CONTAINS
       homo_spinor = bs_env%n_occ(1) + bs_env%n_occ(bs_env%n_spin)
       n_E = SIZE(DOS)
       nkind = SIZE(PDOS, 2)
+      CALL get_qs_env(qs_env, nkind=nkind)
 
       CALL cp_cfm_create(cfm_ks_ikp_spinor, bs_env%cfm_SOC_spinor_ao(1)%matrix_struct)
       CALL cp_cfm_create(cfm_SOC_ikp_spinor, bs_env%cfm_SOC_spinor_ao(1)%matrix_struct)
@@ -1731,8 +1738,10 @@ CONTAINS
       CALL cp_cfm_heevd(cfm_ks_ikp_spinor, cfm_eigenvec_ikp_spinor, eigenval_spinor)
 
       ! 6. DOS from spinors, no PDOS
-      CALL add_to_DOS_PDOS(DOS, PDOS, eigenval_spinor, &
-                           ikp, bs_env, n_E, E_min, proj_mo_on_kind_spinor)
+      IF (bs_env%do_dos_pdos) THEN
+         CALL add_to_DOS_PDOS(DOS, PDOS, eigenval_spinor, &
+                              ikp, bs_env, n_E, E_min, proj_mo_on_kind_spinor)
+      END IF
 
       ! 7. valence band max. (VBM), conduction band min. (CBM) and direct bandgap (DBG)
       band_edges%VBM = MAX(band_edges%VBM, eigenval_spinor(homo_spinor))

--- a/src/post_scf_bandstructure_utils.F
+++ b/src/post_scf_bandstructure_utils.F
@@ -113,9 +113,9 @@ MODULE post_scf_bandstructure_utils
    PRIVATE
 
    PUBLIC :: create_and_init_bs_env, &
-             dos_pdos_ldos, cfm_ikp_from_fm_Gamma, MIC_contribution_from_ikp, &
-             compute_xkp, kpoint_init_cell_index_simple, rsmat_to_kp, soc, &
-             get_VBM_CBM_bandgaps, get_all_VBM_CBM_bandgaps
+             eval_bandstructure_properties, cfm_ikp_from_fm_Gamma, &
+             MIC_contribution_from_ikp, compute_xkp, kpoint_init_cell_index_simple, &
+             rsmat_to_kp, soc, get_VBM_CBM_bandgaps, get_all_VBM_CBM_bandgaps
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'post_scf_bandstructure_utils'
 
@@ -1034,11 +1034,11 @@ CONTAINS
 !> \param qs_env ...
 !> \param bs_env ...
 ! **************************************************************************************************
-   SUBROUTINE dos_pdos_ldos(qs_env, bs_env)
+   SUBROUTINE eval_bandstructure_properties(qs_env, bs_env)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(post_scf_bandstructure_type), POINTER         :: bs_env
 
-      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'dos_pdos_ldos'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'eval_bandstructure_properties'
 
       INTEGER                                            :: handle, homo, homo_1, homo_2, &
                                                             homo_spinor, ikp, ikp_for_file, ispin, &
@@ -1397,7 +1397,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE dos_pdos_ldos
+   END SUBROUTINE eval_bandstructure_properties
 
 ! **************************************************************************************************
 !> \brief ...

--- a/src/post_scf_bandstructure_utils.F
+++ b/src/post_scf_bandstructure_utils.F
@@ -197,8 +197,8 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(3)                        :: kpptr
       REAL(KIND=dp), DIMENSION(3, 3)                     :: cart_hmat
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(section_vals_type), POINTER                   :: gw_ri_rs_sec, gw_sec, kp_bs_sec, &
-                                                            ldos_sec, soc_sec
+      TYPE(section_vals_type), POINTER                   :: dos_pdos_sec, gw_ri_rs_sec, gw_sec, &
+                                                            kp_bs_sec, ldos_sec, soc_sec
 
       CALL timeset(routineN, handle)
       NULLIFY (cell)
@@ -223,6 +223,10 @@ CONTAINS
       CALL section_vals_get(soc_sec, explicit=bs_env%do_soc)
 
       CALL section_vals_val_get(soc_sec, "ENERGY_WINDOW", r_val=bs_env%energy_window_soc)
+
+      NULLIFY (dos_pdos_sec)
+      dos_pdos_sec => section_vals_get_subs_vals(bs_sec, "DOS")
+      CALL section_vals_get(dos_pdos_sec, explicit=bs_env%do_dos_pdos_ldos)
 
       CALL section_vals_val_get(bs_sec, "DOS%KPOINTS", i_vals=bs_env%nkp_grid_DOS_input)
       CALL section_vals_val_get(bs_sec, "DOS%ENERGY_WINDOW", r_val=bs_env%energy_window_DOS)


### PR DESCRIPTION
Adding a new unit kind Electric Field with the units:
volt per meter (Vm-1), volt per nm (Vnm-1) and volt per angstrom (VA-1).

When including &PROPERTIES, the Density of states is currently always printed with default values even without the &DOS section being explicit. This pull request will ensure that the DOS section must be explicit in order to print the DOS_PDOS.out file.

The EFIELD section gets a new AMPLITUDE option where the electric field strength can be included in volt per meter (default) or volt per nm or volt per angstrom instead of needing to specify INTENSITY.

If BOTH options AMPLITUDE and INTENSITY are used, raise error "Both INTENSITY and AMPLITUDE provided in EFIELD section."
Backward compatibility is maintained such that all existing input files that only contain "INTENSITY" proceed with the calculations as before and yield the same result.