### PR TITLE
DBM: fixes and code cleanup

### DIFF
--- a/src/dbm/dbm_library.c
+++ b/src/dbm/dbm_library.c
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 #include "dbm_library.h"
 #include "../mpiwrap/cp_mpi.h"
+#include "../offload/offload_library.h"
 #include "../offload/offload_mempool.h"
 
 #include <assert.h>
@@ -38,6 +39,8 @@ void dbm_library_init(void) {
     fprintf(stderr, "DBM library was already initialized.\n");
     abort();
   }
+
+  offload_init();
 
   max_threads = omp_get_max_threads();
   per_thread_counters = malloc(max_threads * sizeof(int64_t *));
@@ -84,16 +87,7 @@ void dbm_library_finalize(void) {
  * \author Ole Schuett
  ******************************************************************************/
 static int floorlog10(const int x) {
-  if (x >= 1000) {
-    return 3;
-  }
-  if (x >= 100) {
-    return 2;
-  }
-  if (x >= 10) {
-    return 1;
-  }
-  return 0;
+  return (100 <= x ? (1000 <= x ? 3 : 2) : (10 <= x ? 1 : 0));
 }
 
 /*******************************************************************************

--- a/src/dbm/dbm_matrix.c
+++ b/src/dbm/dbm_matrix.c
@@ -24,7 +24,7 @@ void dbm_create(dbm_matrix_t **matrix_out, dbm_distribution_t *dist,
                 const int row_sizes[nrows], const int col_sizes[ncols]) {
   assert(omp_get_num_threads() == 1);
 
-  dbm_matrix_t *matrix = calloc(1, sizeof(dbm_matrix_t));
+  dbm_matrix_t *const matrix = calloc(1, sizeof(dbm_matrix_t));
 
   assert(dist->rows.length == nrows);
   assert(dist->cols.length == ncols);
@@ -131,9 +131,9 @@ void dbm_redistribute(const dbm_matrix_t *matrix, dbm_matrix_t *redist) {
   int send_count[nranks];
   memset(send_count, 0, nranks * sizeof(int));
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
-    dbm_shard_t *shard = &matrix->shards[ishard];
+    const dbm_shard_t *const shard = &matrix->shards[ishard];
     for (int iblock = 0; iblock < shard->nblocks; iblock++) {
-      const dbm_block_t *blk = &shard->blocks[iblock];
+      const dbm_block_t *const blk = &shard->blocks[iblock];
       const int row_size = matrix->row_sizes[blk->row];
       const int col_size = matrix->col_sizes[blk->col];
       const int block_size = row_size * col_size;
@@ -156,17 +156,17 @@ void dbm_redistribute(const dbm_matrix_t *matrix, dbm_matrix_t *redist) {
   }
   const int total_send_count = send_displ[nranks];
   const int total_recv_count = recv_displ[nranks];
-  double *data_send = cp_mpi_alloc_mem(total_send_count * sizeof(double));
-  double *data_recv = cp_mpi_alloc_mem(total_recv_count * sizeof(double));
+  double *const data_send = cp_mpi_alloc_mem(total_send_count * sizeof(double));
+  double *const data_recv = cp_mpi_alloc_mem(total_recv_count * sizeof(double));
 
   // 2nd pass: Fill send_data.
   int send_data_positions[nranks];
   memcpy(send_data_positions, send_displ, nranks * sizeof(int));
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
-    dbm_shard_t *shard = &matrix->shards[ishard];
+    const dbm_shard_t *const shard = &matrix->shards[ishard];
     for (int iblock = 0; iblock < shard->nblocks; iblock++) {
-      const dbm_block_t *blk = &shard->blocks[iblock];
-      const double *blk_data = &shard->data[blk->offset];
+      const dbm_block_t *const blk = &shard->blocks[iblock];
+      const double *const blk_data = &shard->data[blk->offset];
       const int row_size = matrix->row_sizes[blk->row];
       const int col_size = matrix->col_sizes[blk->col];
       const int block_size = row_size * col_size;
@@ -193,8 +193,8 @@ void dbm_redistribute(const dbm_matrix_t *matrix, dbm_matrix_t *redist) {
   while (recv_data_pos < total_recv_count) {
     const int row = (int)data_recv[recv_data_pos + 0];
     const int col = (int)data_recv[recv_data_pos + 1];
-    assert(data_recv[recv_data_pos + 0] - (double)row == 0.0);
-    assert(data_recv[recv_data_pos + 1] - (double)col == 0.0);
+    assert(data_recv[recv_data_pos + 0] == (double)row);
+    assert(data_recv[recv_data_pos + 1] == (double)col);
     dbm_put_block(redist, row, col, false, &data_recv[recv_data_pos + 2]);
     const int row_size = matrix->row_sizes[row];
     const int col_size = matrix->col_sizes[col];
@@ -220,8 +220,8 @@ void dbm_get_block_p(dbm_matrix_t *matrix, const int row, const int col,
   *block = NULL;
 
   const int ishard = dbm_get_shard_index(matrix, row, col);
-  const dbm_shard_t *shard = &matrix->shards[ishard];
-  dbm_block_t *blk = dbm_shard_lookup(shard, row, col);
+  const dbm_shard_t *const shard = &matrix->shards[ishard];
+  const dbm_block_t *const blk = dbm_shard_lookup(shard, row, col);
   if (blk != NULL) {
     *block = &shard->data[blk->offset];
   }
@@ -242,11 +242,11 @@ void dbm_put_block(dbm_matrix_t *matrix, const int row, const int col,
   const int block_size = row_size * col_size;
 
   const int ishard = dbm_get_shard_index(matrix, row, col);
-  dbm_shard_t *shard = &matrix->shards[ishard];
+  dbm_shard_t *const shard = &matrix->shards[ishard];
   omp_set_lock(&shard->lock);
-  dbm_block_t *blk =
+  const dbm_block_t *const blk =
       dbm_shard_get_or_allocate_block(shard, row, col, block_size);
-  double *blk_data = &shard->data[blk->offset];
+  double *const blk_data = &shard->data[blk->offset];
   if (summation) {
     assert(blk_data != NULL || 0 == block_size);
     for (int i = 0; i < block_size; i++) {
@@ -267,10 +267,8 @@ void dbm_clear(dbm_matrix_t *matrix) {
 
 #pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
-    dbm_shard_t *shard = &matrix->shards[ishard];
-    shard->nblocks = 0;
-    shard->data_size = 0;
-    shard->data_promised = 0;
+    dbm_shard_t *const shard = &matrix->shards[ishard];
+    shard->data_promised = shard->data_size = shard->nblocks = 0;
     // Does not deallocate memory, hence data_allocated remains unchanged.
     memset(shard->hashtable, 0, shard->hashtable_size * sizeof(int));
   }
@@ -291,10 +289,9 @@ void dbm_filter(dbm_matrix_t *matrix, const double eps) {
 
 #pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
-    dbm_shard_t *shard = &matrix->shards[ishard];
+    dbm_shard_t *const shard = &matrix->shards[ishard];
     const int old_nblocks = shard->nblocks;
-    shard->nblocks = 0;
-    shard->data_promised = 0;
+    shard->nblocks = shard->data_promised = 0;
     memset(shard->hashtable, 0, shard->hashtable_size * sizeof(int));
 
     for (int iblock = 0; iblock < old_nblocks; iblock++) {
@@ -316,7 +313,7 @@ void dbm_filter(dbm_matrix_t *matrix, const double eps) {
         continue; // filter the block
       }
       // Re-create block.
-      dbm_block_t *new_blk = dbm_shard_promise_new_block(
+      dbm_block_t *const new_blk = dbm_shard_promise_new_block(
           shard, old_blk.row, old_blk.col, block_size);
       assert(new_blk->offset <= old_blk.offset);
       if (new_blk->offset != old_blk.offset) {
@@ -340,24 +337,26 @@ void dbm_reserve_blocks(dbm_matrix_t *matrix, const int nblocks,
   assert(omp_get_num_threads() == omp_get_max_threads() &&
          "Please call dbm_reserve_blocks within an OpenMP parallel region.");
   const int my_rank = matrix->dist->my_rank;
+
   for (int i = 0; i < nblocks; i++) {
-    const int ishard = dbm_get_shard_index(matrix, rows[i], cols[i]);
-    dbm_shard_t *shard = &matrix->shards[ishard];
-    omp_set_lock(&shard->lock);
-    assert(0 <= rows[i] && rows[i] < matrix->nrows);
-    assert(0 <= cols[i] && cols[i] < matrix->ncols);
-    assert(dbm_get_stored_coordinates(matrix, rows[i], cols[i]) == my_rank);
-    const int row_size = matrix->row_sizes[rows[i]];
-    const int col_size = matrix->col_sizes[cols[i]];
+    const int row = rows[i], col = cols[i];
+    assert(0 <= row && row < matrix->nrows);
+    assert(0 <= col && col < matrix->ncols);
+    assert(dbm_get_stored_coordinates(matrix, row, col) == my_rank);
+    const int ishard = dbm_get_shard_index(matrix, row, col);
+    dbm_shard_t *const shard = &matrix->shards[ishard];
+    const int row_size = matrix->row_sizes[row];
+    const int col_size = matrix->col_sizes[col];
     const int block_size = row_size * col_size;
-    dbm_shard_get_or_promise_block(shard, rows[i], cols[i], block_size);
+    omp_set_lock(&shard->lock);
+    dbm_shard_get_or_promise_block(shard, row, col, block_size);
     omp_unset_lock(&shard->lock);
   }
 #pragma omp barrier
 
 #pragma omp for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
-    dbm_shard_t *shard = &matrix->shards[ishard];
+    dbm_shard_t *const shard = &matrix->shards[ishard];
     dbm_shard_allocate_promised_blocks(shard);
   }
 }
@@ -378,7 +377,7 @@ void dbm_scale(dbm_matrix_t *matrix, const double alpha) {
 
 #pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
-    dbm_shard_t *shard = &matrix->shards[ishard];
+    dbm_shard_t *const shard = &matrix->shards[ishard];
     for (int i = 0; i < shard->data_size; i++) {
       shard->data[i] *= alpha;
     }
@@ -394,7 +393,7 @@ void dbm_zero(dbm_matrix_t *matrix) {
 
 #pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix); ishard++) {
-    dbm_shard_t *shard = &matrix->shards[ishard];
+    dbm_shard_t *const shard = &matrix->shards[ishard];
     if (shard->data != NULL) {
       memset(shard->data, 0, shard->data_size * sizeof(double));
     }
@@ -411,7 +410,7 @@ void dbm_add(dbm_matrix_t *matrix_a, const dbm_matrix_t *matrix_b) {
 
 #pragma omp parallel for DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < dbm_get_num_shards(matrix_b); ishard++) {
-    dbm_shard_t *shard_a = &matrix_a->shards[ishard];
+    dbm_shard_t *const shard_a = &matrix_a->shards[ishard];
     const dbm_shard_t *shard_b = &matrix_b->shards[ishard];
     for (int iblock = 0; iblock < shard_b->nblocks; iblock++) {
       const dbm_block_t blk_b = shard_b->blocks[iblock];
@@ -420,10 +419,10 @@ void dbm_add(dbm_matrix_t *matrix_a, const dbm_matrix_t *matrix_b) {
       assert(row_size == matrix_a->row_sizes[blk_b.row]);
       assert(col_size == matrix_a->col_sizes[blk_b.col]);
       const int block_size = row_size * col_size;
-      dbm_block_t *blk_a = dbm_shard_get_or_allocate_block(
+      const dbm_block_t *const blk_a = dbm_shard_get_or_allocate_block(
           shard_a, blk_b.row, blk_b.col, block_size);
-      double *data_a = &shard_a->data[blk_a->offset];
-      const double *data_b = &shard_b->data[blk_b.offset];
+      double *const data_a = &shard_a->data[blk_a->offset];
+      const double *const data_b = &shard_b->data[blk_b.offset];
       for (int i = 0; i < block_size; i++) {
         data_a[i] += data_b[i];
       }
@@ -571,25 +570,41 @@ double dbm_maxeps(const dbm_matrix_t *matrix_a, const dbm_matrix_t *matrix_b) {
   assert(matrix_a->dist == matrix_b->dist);
   assert(num_shards == dbm_get_num_shards(matrix_b));
 
-#pragma omp parallel for DBM_OMP_SCHEDULE
+#pragma omp parallel for reduction(max : epsilon) DBM_OMP_SCHEDULE
   for (int ishard = 0; ishard < num_shards; ++ishard) {
     const dbm_shard_t *const shard_a = &matrix_a->shards[ishard];
     const dbm_shard_t *const shard_b = &matrix_b->shards[ishard];
-    assert(shard_a->nblocks == shard_b->nblocks);
     for (int iblock = 0; iblock < shard_a->nblocks; ++iblock) {
       const dbm_block_t *const blk_a = &shard_a->blocks[iblock];
       const dbm_block_t *const blk_b =
           dbm_shard_lookup(shard_b, blk_a->row, blk_a->col);
       const int row_size = matrix_a->row_sizes[blk_a->row];
       const int col_size = matrix_a->col_sizes[blk_a->col];
-      assert(row_size == matrix_b->row_sizes[blk_b->row]);
-      assert(col_size == matrix_b->col_sizes[blk_b->col]);
+      assert(NULL == blk_b || row_size == matrix_b->row_sizes[blk_b->row]);
+      assert(NULL == blk_b || col_size == matrix_b->col_sizes[blk_b->col]);
       const double *const data_a = &shard_a->data[blk_a->offset];
+      const double *const data_b =
+          (NULL == blk_b) ? NULL : &shard_b->data[blk_b->offset];
+      const int block_size = row_size * col_size;
+      for (int i = 0; i < block_size; ++i) {
+        const double d = data_a[i] - (NULL == data_b ? 0.0 : data_b[i]);
+        const double e = fabs(0 != data_a[i] ? (d / data_a[i]) : d);
+        if (epsilon < e) {
+          epsilon = e;
+        }
+      }
+    }
+    for (int iblock = 0; iblock < shard_b->nblocks; ++iblock) {
+      const dbm_block_t *const blk_b = &shard_b->blocks[iblock];
+      if (NULL != dbm_shard_lookup(shard_a, blk_b->row, blk_b->col)) {
+        continue;
+      }
+      const int row_size = matrix_b->row_sizes[blk_b->row];
+      const int col_size = matrix_b->col_sizes[blk_b->col];
       const double *const data_b = &shard_b->data[blk_b->offset];
       const int block_size = row_size * col_size;
       for (int i = 0; i < block_size; ++i) {
-        const double d = data_a[i] - data_b[i];
-        const double e = fabs(0 != data_a[i] ? (d / data_a[i]) : d);
+        const double e = fabs(data_b[i]);
         if (epsilon < e) {
           epsilon = e;
         }

--- a/src/dbm/dbm_miniapp.c
+++ b/src/dbm/dbm_miniapp.c
@@ -18,10 +18,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(__LIBXSMM)
-#include <libxsmm.h>
-#endif
-
 /*******************************************************************************
  * \brief Wrapper for printf, passed to dbm_library_print_stats.
  * \author Ole Schuett
@@ -274,11 +270,6 @@ int main(int argc, char *argv[]) {
   if (my_rank == 0) {
     printf("OpenMP-threads: %i  GPUs: %i", omp_get_max_threads(),
            imin(offload_get_device_count(), nranks));
-#if defined(__LIBXSMM)
-    printf("  Libxsmm: %s", LIBXSMM_VERSION);
-#else
-    printf("  Libxsmm: n/a");
-#endif
 #if defined(__parallel)
     printf("  MPI-ranks: %i  MPI-cart: %i x %i", nranks, dims[0], dims[1]);
 #else

--- a/src/dbm/dbm_multiply.c
+++ b/src/dbm/dbm_multiply.c
@@ -77,7 +77,7 @@ typedef struct {
  ******************************************************************************/
 static backend_context_t *backend_start(const dbm_matrix_t *matrix_c) {
   backend_context_t *const ctx = calloc(1, sizeof(backend_context_t));
-  // BLAS and LIBXSMM benefit in general from DBM_MULTIPLY_TASK_REORDER.
+  // BLAS and LIBXS benefit in general from DBM_MULTIPLY_TASK_REORDER.
   ctx->cpu_options = DBM_MULTIPLY_TASK_REORDER;
 
 #if defined(__OFFLOAD) && !defined(__NO_OFFLOAD_DBM)
@@ -163,7 +163,7 @@ static void multiply_packs(const bool transa, const bool transb,
                            int64_t *flop, backend_context_t *ctx) {
   // For validation, FLOPS do not count, and relying on ctx is not necessary.
   backend_context_t *const context = (NULL != flop ? ctx : NULL);
-  const float alpha2 = alpha * alpha;
+  const float alpha2 = (float)(alpha * alpha);
   int64_t flop_sum = 0;
 
   const int nshard_rows = matrix_c->dist->rows.nshards;
@@ -214,32 +214,69 @@ static void multiply_packs(const bool transa, const bool transb,
         dbm_shard_t *const shard_c = &matrix_c->shards[ishard];
         int ntasks = 0;
 
+        // Determine contiguous block ranges for this shard in A and B.
         // Use a merge-join to find pairs of blocks with matching sum indices.
         // This utilizes that blocks within a shard are ordered by sum_index.
         const int iblock_start = shard_row_start[shard_row];
-        int jblock_start = shard_col_start[shard_col];
-        for (int iblock = iblock_start; iblock < pack_a->nblocks; iblock++) {
-          const dbm_pack_block_t *blk_a = &pack_a->blocks[iblock];
-          if (blk_a->free_index % nshard_rows != shard_row) {
+        int iblock_end = pack_a->nblocks;
+        for (int t = iblock_start; t < pack_a->nblocks; ++t) {
+          if (pack_a->blocks[t].free_index % nshard_rows != shard_row) {
+            iblock_end = t;
             break;
           }
-          for (int jblock = jblock_start; jblock < pack_b->nblocks; jblock++) {
-            const dbm_pack_block_t *blk_b = &pack_b->blocks[jblock];
-            if (blk_b->free_index % nshard_cols != shard_col) {
-              jblock = pack_b->nblocks; // break
-              continue;
-            }
-            if (blk_a->sum_index < blk_b->sum_index) {
-              jblock = pack_b->nblocks; // break
-              continue;
-            }
-            if (blk_a->sum_index > blk_b->sum_index) {
-              jblock_start++;
-              continue;
-            }
-            // Found block pair with blk_a->sum_index == blk_b->sum_index.
+        }
+        const int jblock_start = shard_col_start[shard_col];
+        int jblock_end = pack_b->nblocks;
+        for (int t = jblock_start; t < pack_b->nblocks; ++t) {
+          if (pack_b->blocks[t].free_index % nshard_cols != shard_col) {
+            jblock_end = t;
+            break;
+          }
+        }
+        if (iblock_start >= iblock_end || jblock_start >= jblock_end) {
+          backend_process_batch(ntasks, batch, alpha, pack_a, pack_b, ishard,
+                                shard_c, true, force_cpu, context);
+          continue;
+        }
 
-            // Check norms.
+        // Merge over sum_index (both ranges sorted by sum_index).
+        int i = iblock_start, j = jblock_start, last_sum_index = -1;
+        int b_range_start = -1, b_range_end = -1;
+
+        while (i < iblock_end) {
+          const dbm_pack_block_t *blk_a = &pack_a->blocks[i];
+          const int sum_a = blk_a->sum_index;
+
+          // Advance j until sum_b >= sum_a.
+          while (j < jblock_end && pack_b->blocks[j].sum_index < sum_a) {
+            ++j;
+          }
+          if (j >= jblock_end) {
+            break; // No more matches possible.
+          }
+
+          const int sum_b = pack_b->blocks[j].sum_index;
+          if (sum_b > sum_a) {
+            ++i;
+            continue; // Need next A block with higher sum_index.
+          }
+
+          // sum_a == sum_b: establish (or reuse) B range with this sum_index.
+          if (sum_a != last_sum_index) {
+            b_range_start = j;
+            int t = j + 1;
+            while (t < jblock_end && pack_b->blocks[t].sum_index == sum_a) {
+              ++t;
+            }
+            b_range_end = t;
+            last_sum_index = sum_a;
+          }
+
+          // Iterate over B blocks in current sum_index range.
+          for (int jb = b_range_start; jb < b_range_end; ++jb) {
+            const dbm_pack_block_t *const blk_b = &pack_b->blocks[jb];
+
+            // Norm filter first (early reject).
             const float result_norm = alpha2 * blk_a->norm * blk_b->norm;
             if (result_norm < rows_max_eps[blk_a->free_index]) {
               continue;
@@ -248,17 +285,22 @@ static void multiply_packs(const bool transa, const bool transb,
             // Check block sizes.
             const int m = free_index_sizes_a[blk_a->free_index];
             const int n = free_index_sizes_b[blk_b->free_index];
-            const int k = sum_index_sizes_a[blk_a->sum_index];
+            const int k = sum_index_sizes_a[sum_a];
             assert(m == matrix_c->row_sizes[blk_a->free_index]);
             assert(n == matrix_c->col_sizes[blk_b->free_index]);
             assert(k == sum_index_sizes_b[blk_b->sum_index]);
 
+            if (m == 0 || n == 0 || k == 0) {
+              continue;
+            }
+
             // Get C block.
             const int row = blk_a->free_index, col = blk_b->free_index;
             dbm_block_t *blk_c = dbm_shard_lookup(shard_c, row, col);
-            if (blk_c == NULL && retain_sparsity) {
-              continue;
-            } else if (blk_c == NULL) {
+            if (blk_c == NULL) {
+              if (retain_sparsity) {
+                continue;
+              }
               assert(dbm_get_shard_index(matrix_c, row, col) == ishard);
               assert(dbm_get_stored_coordinates(matrix_c, row, col) ==
                      matrix_c->dist->my_rank);
@@ -267,19 +309,17 @@ static void multiply_packs(const bool transa, const bool transb,
 
             // Count flops.
             const int64_t task_flops = 2LL * m * n * k;
-            if (task_flops == 0) {
-              continue;
-            }
             flop_sum += task_flops;
             dbm_library_counter_increment(m, n, k);
 
             // Add block multiplication to batch.
-            batch[ntasks].m = m;
-            batch[ntasks].n = n;
-            batch[ntasks].k = k;
-            batch[ntasks].offset_a = blk_a->offset;
-            batch[ntasks].offset_b = blk_b->offset;
-            batch[ntasks].offset_c = blk_c->offset;
+            dbm_task_t *const tptr = &batch[ntasks];
+            tptr->offset_a = blk_a->offset;
+            tptr->offset_b = blk_b->offset;
+            tptr->offset_c = blk_c->offset;
+            tptr->m = m;
+            tptr->n = n;
+            tptr->k = k;
             ++ntasks;
 
             if (ntasks == DBM_MAX_BATCH_SIZE) {
@@ -288,6 +328,9 @@ static void multiply_packs(const bool transa, const bool transb,
               ntasks = 0;
             }
           }
+
+          // Advance i; if next A block has same sum_index, B range is reused.
+          ++i;
         }
         backend_process_batch(ntasks, batch, alpha, pack_a, pack_b, ishard,
                               shard_c, true, force_cpu, context);

--- a/src/dbm/dbm_multiply_comm.c
+++ b/src/dbm/dbm_multiply_comm.c
@@ -9,6 +9,7 @@
 #include "../offload/offload_mempool.h"
 
 #include <assert.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -34,6 +35,17 @@ static int gcd(const int a, const int b) {
 static int lcm(const int a, const int b) { return (a * b) / gcd(a, b); }
 
 /*******************************************************************************
+ * \brief Private routine for converting element counts to byte counts.
+ * \author Hans Pabst
+ ******************************************************************************/
+static int checked_byte_count(const int nelements, const size_t element_size) {
+  assert(0 <= nelements);
+  assert(element_size <= INT_MAX);
+  assert(nelements <= INT_MAX / (int)element_size);
+  return nelements * (int)element_size;
+}
+
+/*******************************************************************************
  * \brief Private routine for computing the sum of the given integers.
  * \author Ole Schuett
  ******************************************************************************/
@@ -47,12 +59,38 @@ static inline int isum(const int n, const int input[n]) {
 
 /*******************************************************************************
  * \brief Private routine for computing the cumulative sums of given numbers.
- * \author Ole Schuett
+ * \author Ole Schuett and Hans Pabst
  ******************************************************************************/
 static inline void icumsum(const int n, const int input[n], int output[n]) {
-  output[0] = 0;
+  int oval = output[0] = 0, ival = input[0];
   for (int i = 1; i < n; i++) {
-    output[i] = output[i - 1] + input[i - 1];
+    output[i] = (oval += ival);
+    ival = input[i];
+  }
+}
+
+/*******************************************************************************
+ * \brief Private routine computing received data counts from block metadata.
+ * \author Hans Pabst
+ ******************************************************************************/
+static void compute_data_recv_count(const int nranks,
+                                    const int blks_recv_count[nranks],
+                                    const int blks_recv_displ[nranks],
+                                    const int free_index_sizes[],
+                                    const int sum_index_sizes[],
+                                    const dbm_pack_block_t blks_recv[],
+                                    int data_recv_count[nranks]) {
+  memset(data_recv_count, 0, nranks * sizeof(int));
+  for (int irank = 0; irank < nranks; irank++) {
+    for (int i = 0; i < blks_recv_count[irank]; i++) {
+      const dbm_pack_block_t *const blk =
+          &blks_recv[blks_recv_displ[irank] + i];
+      const int block_size =
+          free_index_sizes[blk->free_index] * sum_index_sizes[blk->sum_index];
+      assert(block_size >= 0);
+      assert(data_recv_count[irank] <= INT_MAX - block_size);
+      data_recv_count[irank] += block_size;
+    }
   }
 }
 
@@ -89,7 +127,6 @@ static void create_pack_plans(const bool trans_matrix, const bool trans_dist,
                               const int npacks, plan_t *plans_per_pack[npacks],
                               int nblks_per_pack[npacks],
                               int ndata_per_pack[npacks]) {
-
   memset(nblks_per_pack, 0, npacks * sizeof(int));
   memset(ndata_per_pack, 0, npacks * sizeof(int));
 
@@ -170,7 +207,6 @@ static void fill_send_buffers(
     int blks_send_count[nranks], int data_send_count[nranks],
     int blks_send_displ[nranks], int data_send_displ[nranks],
     dbm_pack_block_t blks_send[nblks_send], double data_send[ndata_send]) {
-
   memset(blks_send_count, 0, nranks * sizeof(int));
   memset(data_send_count, 0, nranks * sizeof(int));
 
@@ -198,7 +234,7 @@ static void fill_send_buffers(
 #pragma omp barrier
 
     // Compute send displacements.
-#pragma omp master
+#pragma omp single
     {
       icumsum(nranks, blks_send_count, blks_send_displ);
       icumsum(nranks, data_send_count, data_send_displ);
@@ -211,10 +247,10 @@ static void fill_send_buffers(
     // 4th pass: Fill blks_send and data_send arrays.
 #pragma omp for schedule(static) // Need static to match previous loop.
     for (int iblock = 0; iblock < nblks_send; iblock++) {
-      const plan_t *plan = &plans[iblock];
-      const dbm_block_t *blk = plan->blk;
+      const plan_t *const plan = &plans[iblock];
+      const dbm_block_t *const blk = plan->blk;
       const int ishard = dbm_get_shard_index(matrix, blk->row, blk->col);
-      const dbm_shard_t *shard = &matrix->shards[ishard];
+      const dbm_shard_t *const shard = &matrix->shards[ishard];
       const double *blk_data = &shard->data[blk->offset];
       const int row_size = plan->row_size, col_size = plan->col_size;
       const int plan_size = row_size * col_size;
@@ -276,7 +312,6 @@ static void postprocess_received_blocks(
     const int blks_recv_count[nranks], const int blks_recv_displ[nranks],
     const int data_recv_displ[nranks],
     dbm_pack_block_t blks_recv[nblocks_recv]) {
-
   int nblocks_per_shard[nshards], shard_start[nshards];
   memset(nblocks_per_shard, 0, nshards * sizeof(int));
   dbm_pack_block_t *blocks_tmp =
@@ -308,7 +343,7 @@ static void postprocess_received_blocks(
       nblocks_mythread[ishard] = nblocks_per_shard[ishard];
     }
 #pragma omp barrier
-#pragma omp master
+#pragma omp single
     icumsum(nshards, nblocks_per_shard, shard_start);
 #pragma omp barrier
 #pragma omp for schedule(static) // Need static to match previous loop.
@@ -337,16 +372,19 @@ static void postprocess_received_blocks(
  ******************************************************************************/
 static dbm_packed_matrix_t pack_matrix(const bool trans_matrix,
                                        const bool trans_dist,
-                                       const dbm_matrix_t *matrix,
-                                       const dbm_distribution_t *dist,
+                                       const dbm_matrix_t *restrict matrix,
+                                       const dbm_distribution_t *restrict dist,
                                        const int nticks) {
-
   assert(cp_mpi_comms_are_similar(matrix->dist->comm, dist->comm));
 
   // The row/col indicies are distributed along one cart dimension and the
   // ticks are distributed along the other cart dimension.
   const dbm_dist_1d_t *dist_indices = (trans_dist) ? &dist->cols : &dist->rows;
   const dbm_dist_1d_t *dist_ticks = (trans_dist) ? &dist->rows : &dist->cols;
+  const int *free_index_sizes =
+      (trans_matrix) ? matrix->col_sizes : matrix->row_sizes;
+  const int *sum_index_sizes =
+      (trans_matrix) ? matrix->row_sizes : matrix->col_sizes;
 
   // Allocate packed matrix.
   const int nsend_packs = nticks / dist_ticks->nranks;
@@ -399,19 +437,24 @@ static dbm_packed_matrix_t pack_matrix(const bool trans_matrix,
     int blks_send_count_byte[nranks], blks_send_displ_byte[nranks];
     int blks_recv_count_byte[nranks], blks_recv_displ_byte[nranks];
     for (int i = 0; i < nranks; i++) { // TODO: this is ugly!
-      blks_send_count_byte[i] = blks_send_count[i] * sizeof(dbm_pack_block_t);
-      blks_send_displ_byte[i] = blks_send_displ[i] * sizeof(dbm_pack_block_t);
-      blks_recv_count_byte[i] = blks_recv_count[i] * sizeof(dbm_pack_block_t);
-      blks_recv_displ_byte[i] = blks_recv_displ[i] * sizeof(dbm_pack_block_t);
+      blks_send_count_byte[i] =
+          checked_byte_count(blks_send_count[i], sizeof(dbm_pack_block_t));
+      blks_send_displ_byte[i] =
+          checked_byte_count(blks_send_displ[i], sizeof(dbm_pack_block_t));
+      blks_recv_count_byte[i] =
+          checked_byte_count(blks_recv_count[i], sizeof(dbm_pack_block_t));
+      blks_recv_displ_byte[i] =
+          checked_byte_count(blks_recv_displ[i], sizeof(dbm_pack_block_t));
     }
     cp_mpi_alltoallv_byte(blks_send, blks_send_count_byte, blks_send_displ_byte,
                           blks_recv, blks_recv_count_byte, blks_recv_displ_byte,
                           dist->comm);
 
-    // 3rd communication: Exchange data counts.
-    // TODO: could be computed from blks_recv.
+    // Compute data counts from the received block metadata.
     int data_recv_count[nranks], data_recv_displ[nranks];
-    cp_mpi_alltoall_int(data_send_count, 1, data_recv_count, 1, dist->comm);
+    compute_data_recv_count(nranks, blks_recv_count, blks_recv_displ,
+                            free_index_sizes, sum_index_sizes, blks_recv,
+                            data_recv_count);
     icumsum(nranks, data_recv_count, data_recv_displ);
     const int ndata_recv = isum(nranks, data_recv_count);
 
@@ -491,11 +534,13 @@ static dbm_pack_t *sendrecv_pack(const int itick, const int nticks,
     // Exchange blocks.
     const int nblocks_in_bytes = cp_mpi_sendrecv_byte(
         /*sendbuf=*/send_pack->blocks,
-        /*sendcound=*/send_pack->nblocks * sizeof(dbm_pack_block_t),
+        /*sendcound=*/
+        checked_byte_count(send_pack->nblocks, sizeof(dbm_pack_block_t)),
         /*dest=*/send_rank,
         /*sendtag=*/send_ipack,
         /*recvbuf=*/packed->recv_pack.blocks,
-        /*recvcount=*/packed->max_nblocks * sizeof(dbm_pack_block_t),
+        /*recvcount=*/
+        checked_byte_count(packed->max_nblocks, sizeof(dbm_pack_block_t)),
         /*source=*/recv_rank,
         /*recvtag=*/recv_ipack,
         /*comm=*/packed->dist_ticks->comm);
@@ -550,7 +595,6 @@ dbm_comm_iterator_t *dbm_comm_iterator_start(const bool transa,
                                              const dbm_matrix_t *matrix_a,
                                              const dbm_matrix_t *matrix_b,
                                              const dbm_matrix_t *matrix_c) {
-
   dbm_comm_iterator_t *iter = malloc(sizeof(dbm_comm_iterator_t));
   assert(iter != NULL);
   iter->dist = matrix_c->dist;
@@ -571,7 +615,7 @@ dbm_comm_iterator_t *dbm_comm_iterator_start(const bool transa,
 }
 
 /*******************************************************************************
- * \brief Internal routine for retriving next pair of packs from given iterator.
+ * \brief Internal routine for retrieving next pair of packs of given iterator.
  * \author Ole Schuett
  ******************************************************************************/
 bool dbm_comm_iterator_next(dbm_comm_iterator_t *iter, dbm_pack_t **pack_a,
@@ -582,11 +626,11 @@ bool dbm_comm_iterator_next(dbm_comm_iterator_t *iter, dbm_pack_t **pack_a,
 
   // Start each rank at a different tick to spread the load on the sources.
   const int shift = iter->dist->rows.my_rank + iter->dist->cols.my_rank;
-  const int shifted_itick = (iter->itick + shift) % iter->nticks;
-  *pack_a = sendrecv_pack(shifted_itick, iter->nticks, &iter->packed_a);
-  *pack_b = sendrecv_pack(shifted_itick, iter->nticks, &iter->packed_b);
+  const int itick = (iter->itick + shift) % iter->nticks;
+  *pack_a = sendrecv_pack(itick, iter->nticks, &iter->packed_a);
+  *pack_b = sendrecv_pack(itick, iter->nticks, &iter->packed_b);
 
-  iter->itick++;
+  ++iter->itick;
   return true;
 }
 

--- a/src/dbm/dbm_multiply_comm.h
+++ b/src/dbm/dbm_multiply_comm.h
@@ -50,7 +50,7 @@ dbm_comm_iterator_t *dbm_comm_iterator_start(const bool transa,
                                              const dbm_matrix_t *matrix_c);
 
 /*******************************************************************************
- * \brief Internal routine for retriving next pair of packs from given iterator.
+ * \brief Internal routine for retrieving next pair of packs.
  * \author Ole Schuett
  ******************************************************************************/
 bool dbm_comm_iterator_next(dbm_comm_iterator_t *iter, dbm_pack_t **pack_a,

--- a/src/dbm/dbm_multiply_gpu.c
+++ b/src/dbm/dbm_multiply_gpu.c
@@ -41,10 +41,10 @@ void dbm_multiply_gpu_start(const int max_batch_size, const int nshards,
   assert(ctx->shards_c_dev != NULL || nshards == 0);
   for (int i = 0; i < nshards; i++) {
     const dbm_shard_t *const shard_c_host = &shards_c_host[i];
-    dbm_shard_gpu_t *shard_g = &ctx->shards_c_dev[i];
+    dbm_shard_gpu_t *const shard_g = &ctx->shards_c_dev[i];
+    shard_g->data_size = shard_c_host->data_size;
     offloadStreamCreate(&shard_g->stream);
     offloadEventCreate(&shard_g->event);
-    shard_g->data_size = shard_c_host->data_size;
     // only allocate data_size on device rather than data_allocated
     shard_g->data_allocated = shard_c_host->data_size;
     shard_g->data =
@@ -59,13 +59,13 @@ void dbm_multiply_gpu_start(const int max_batch_size, const int nshards,
  * \brief Private routine for uploading a single pack onto the device.
  * \author Ole Schuett
  ******************************************************************************/
-static void upload_pack(const dbm_pack_t *pack_host, dbm_pack_t *pack_dev,
+static void upload_pack(const dbm_pack_t *pack_host, dbm_pack_gpu_t *pack_dev,
                         const offloadStream_t stream) {
-
   const size_t size = pack_host->data_size * sizeof(double);
-  if (pack_dev->data_size < pack_host->data_size) {
+  if (pack_dev->data_allocated < pack_host->data_size) {
     offload_mempool_device_free(pack_dev->data);
     pack_dev->data = offload_mempool_device_malloc(size);
+    pack_dev->data_allocated = pack_host->data_size;
   }
   offloadMemcpyAsyncHtoD(pack_dev->data, pack_host->data, size, stream);
 }

--- a/src/dbm/dbm_multiply_gpu.h
+++ b/src/dbm/dbm_multiply_gpu.h
@@ -25,6 +25,11 @@ typedef struct {
   offloadEvent_t event;
 } dbm_shard_gpu_t;
 
+typedef struct {
+  double *data; // on the device
+  int data_allocated;
+} dbm_pack_gpu_t;
+
 /*******************************************************************************
  * \brief Internal struct for storing the gpu backend's context.
  * \author Ole Schuett
@@ -36,8 +41,8 @@ typedef struct {
   int nshards;
   dbm_shard_gpu_t *shards_c_dev;
 
-  dbm_pack_t pack_a_dev;
-  dbm_pack_t pack_b_dev;
+  dbm_pack_gpu_t pack_a_dev;
+  dbm_pack_gpu_t pack_b_dev;
 
   int max_batch_size;
   dbm_task_t *batches_dev;

--- a/src/dbm/dbm_multiply_gpu_kernel.cu
+++ b/src/dbm/dbm_multiply_gpu_kernel.cu
@@ -51,7 +51,6 @@ __device__ static void process_task(const int m, const int n, const int k,
                                     const double alpha, const double *block_a,
                                     const double *block_b, double *block_c,
                                     double *shared_mem) {
-
   constexpr int MAXEXTENT = (M > N ? M : N);
   constexpr int K = NUM_THREADS / MAXEXTENT;
 
@@ -72,8 +71,8 @@ __device__ static void process_task(const int m, const int n, const int k,
   for (int i_tile = 0; i_tile < m; i_tile += M) {
     for (int j_tile = 0; j_tile < n; j_tile += N) {
       double result = 0.0;
-      for (int l_tile = 0; l_tile < k; l_tile += K) {
 
+      for (int l_tile = 0; l_tile < k; l_tile += K) {
         // Load tile_a from global into shared memory.
         if (x < M && y < K) {
           const int i = i_tile + x;
@@ -127,7 +126,6 @@ __global__ static void process_batch_kernel(const double alpha,
                                             const double *pack_a_data,
                                             const double *pack_b_data,
                                             double *shard_c_data) {
-
   __shared__ double shared_mem[2 * NUM_THREADS];
 
   const dbm_task_t task = batch[blockIdx.x];

--- a/src/dbm/dbm_shard.c
+++ b/src/dbm/dbm_shard.c
@@ -161,14 +161,14 @@ static void hashtable_insert(dbm_shard_t *shard, const int block_idx) {
   const dbm_block_t *blk = &shard->blocks[block_idx];
   const unsigned int h = hash(blk->row, blk->col);
   int slot = (shard->hashtable_prime * h) & hashtable_mask(shard);
-  for (;; slot = (slot + 1) & hashtable_mask(shard)) { // linear probing
-    for (int i = slot; i < shard->hashtable_size; ++i) {
-      if (shard->hashtable[i] == 0) {        // 0 means empty
-        shard->hashtable[i] = block_idx + 1; // 1-based
-        return;
-      }
+  for (int i = 0; i < shard->hashtable_size; ++i) { // linear probing
+    if (shard->hashtable[slot] == 0) {              // 0 means empty
+      shard->hashtable[slot] = block_idx + 1;       // 1-based
+      return;
     }
+    slot = (slot + 1) & hashtable_mask(shard);
   }
+  assert(false);
 }
 
 /*******************************************************************************
@@ -178,19 +178,19 @@ static void hashtable_insert(dbm_shard_t *shard, const int block_idx) {
 dbm_block_t *dbm_shard_lookup(const dbm_shard_t *shard, const int row,
                               const int col) {
   int slot = (shard->hashtable_prime * hash(row, col)) & hashtable_mask(shard);
-  for (;; slot = (slot + 1) & hashtable_mask(shard)) { // linear probing
-    for (int i = slot; i < shard->hashtable_size; ++i) {
-      const int block_idx = shard->hashtable[i];
-      if (block_idx == 0) { // 1-based, 0 means empty
-        return NULL;        // block not found
-      }
-      assert(0 < block_idx && block_idx <= shard->nblocks);
-      dbm_block_t *blk = &shard->blocks[block_idx - 1];
-      if (blk->row == row && blk->col == col) {
-        return blk;
-      }
+  for (int i = 0; i < shard->hashtable_size; ++i) { // linear probing
+    const int block_idx = shard->hashtable[slot];
+    if (block_idx == 0) { // 1-based, 0 means empty
+      return NULL;        // block not found
     }
+    assert(0 < block_idx && block_idx <= shard->nblocks);
+    dbm_block_t *blk = &shard->blocks[block_idx - 1];
+    if (blk->row == row && blk->col == col) {
+      return blk;
+    }
+    slot = (slot + 1) & hashtable_mask(shard);
   }
+  return NULL;
 }
 
 /*******************************************************************************
@@ -232,9 +232,8 @@ dbm_block_t *dbm_shard_promise_new_block(dbm_shard_t *shard, const int row,
  * \author Ole Schuett
  ******************************************************************************/
 void dbm_shard_allocate_promised_blocks(dbm_shard_t *shard) {
-
   // Reallocate data array if necessary.
-  if (shard->data_promised > shard->data_allocated) {
+  if (shard->data_allocated < shard->data_promised) {
     const double *data = shard->data;
     shard->data_allocated = DBM_ALLOCATION_FACTOR * shard->data_promised;
     assert(shard->data_promised <= shard->data_allocated);
@@ -250,7 +249,7 @@ void dbm_shard_allocate_promised_blocks(dbm_shard_t *shard) {
   // Zero new blocks.
   // The following memset is usually the first touch of the memory, which leads
   // to frequent page faults. The executing thread determines the NUMA location
-  if (shard->data_promised > shard->data_size) {
+  if (shard->data_size < shard->data_promised) {
     const int tail = shard->data_promised - shard->data_size;
     memset(shard->data + shard->data_size, 0, tail * sizeof(double));
     shard->data_size = shard->data_promised;

--- a/src/dbm/dbm_shard.h
+++ b/src/dbm/dbm_shard.h
@@ -36,11 +36,10 @@ typedef struct {
   int hashtable_prime; // should be a coprime of hashtable_size
   int *hashtable;      // maps row/col to block numbers
 
-  int data_promised;  // referenced by a dbm_block_t.offset, but not yet
-                      // allocated
-  int data_allocated; // over-allocated to amortize the cost of resizing
+  int data_promised;  // ref'd by dbm_block_t.offset (not yet allocated)
+  int data_allocated; // actually allocated (capacity of data buffer)
   int data_size;      // actually allocated and initialized
-  double *data;
+  double *data;       // potentially over-allocated (to amortize resizing)
 
   omp_lock_t lock; // used by dbm_put_block
 } dbm_shard_t;


### PR DESCRIPTION
- Avoid excessive scans (hashtable_insert/dbm_shard_lookup).
- Fixed upload_pack and improved meta-data.
- Fixed data race in dbm_maxeps.
- Improved comm slightly. Avoid allt2all to figure out data amount.  
  This was an open TODO in the code.