### PR TITLE
Smearing: various fixes

### DIFF
--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -1223,7 +1223,7 @@ CONTAINS
                                                             nb, ncol_global, ne_a, ne_b, &
                                                             nelectron, nkp, nmo, nrow_global, nspin
       INTEGER, DIMENSION(2)                              :: kp_range
-      REAL(KIND=dp)                                      :: kTS, mu, mus(2), nel
+      REAL(KIND=dp)                                      :: kTS, kTS_spin(2), mu, mus(2), nel
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: smatrix
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: weig, wocc
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :)  :: icoeff, rcoeff
@@ -1301,6 +1301,7 @@ CONTAINS
       END IF
 
       CALL get_kpoint_info(kpoint, wkp=wkp)
+      kTS_spin = 0.0_dp
 
 !calling of HP module HERE, before smear
       IF (PRESENT(probe)) THEN
@@ -1371,18 +1372,22 @@ CONTAINS
                   nel = REAL(nelectron, KIND=dp)
                   CALL Smearkp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                                smear%electronic_temperature, 2.0_dp, smear_fermi_dirac)
+                  kTS_spin(1) = kTS
                ELSE IF (smear%fixed_mag_mom > 0.0_dp) THEN
                   nel = REAL(ne_a, KIND=dp)
                   CALL Smearkp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                                smear%electronic_temperature, 1.0_dp, smear_fermi_dirac)
+                  kTS_spin(1) = kTS
                   nel = REAL(ne_b, KIND=dp)
                   CALL Smearkp(wocc(:, :, 2), mus(2), kTS, weig(:, :, 2), nel, wkp, &
                                smear%electronic_temperature, 1.0_dp, smear_fermi_dirac)
+                  kTS_spin(2) = kTS
                ELSE
                   nel = REAL(ne_a, KIND=dp) + REAL(ne_b, KIND=dp)
                   CALL Smearkp2(wocc(:, :, :), mu, kTS, weig(:, :, :), nel, wkp, &
                                 smear%electronic_temperature, smear_fermi_dirac)
                   kTS = kTS/2._dp
+                  kTS_spin(1:2) = kTS
                   mus(1:2) = mu
                END IF
             CASE (smear_gaussian, smear_mp, smear_mv)
@@ -1390,18 +1395,22 @@ CONTAINS
                   nel = REAL(nelectron, KIND=dp)
                   CALL Smearkp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                                smear%smearing_width, 2.0_dp, smear%method)
+                  kTS_spin(1) = kTS
                ELSE IF (smear%fixed_mag_mom > 0.0_dp) THEN
                   nel = REAL(ne_a, KIND=dp)
                   CALL Smearkp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                                smear%smearing_width, 1.0_dp, smear%method)
+                  kTS_spin(1) = kTS
                   nel = REAL(ne_b, KIND=dp)
                   CALL Smearkp(wocc(:, :, 2), mus(2), kTS, weig(:, :, 2), nel, wkp, &
                                smear%smearing_width, 1.0_dp, smear%method)
+                  kTS_spin(2) = kTS
                ELSE
                   nel = REAL(ne_a, KIND=dp) + REAL(ne_b, KIND=dp)
                   CALL Smearkp2(wocc(:, :, :), mu, kTS, weig(:, :, :), nel, wkp, &
                                 smear%smearing_width, smear%method)
                   kTS = kTS/2._dp
+                  kTS_spin(1:2) = kTS
                   mus(1:2) = mu
                END IF
             CASE DEFAULT
@@ -1413,13 +1422,16 @@ CONTAINS
                nel = REAL(nelectron, KIND=dp)
                CALL Smearkp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                             0.0_dp, 2.0_dp, smear_gaussian)
+               kTS_spin(1) = kTS
             ELSE
                nel = REAL(ne_a, KIND=dp)
                CALL Smearkp(wocc(:, :, 1), mus(1), kTS, weig(:, :, 1), nel, wkp, &
                             0.0_dp, 1.0_dp, smear_gaussian)
+               kTS_spin(1) = kTS
                nel = REAL(ne_b, KIND=dp)
                CALL Smearkp(wocc(:, :, 2), mus(2), kTS, weig(:, :, 2), nel, wkp, &
                             0.0_dp, 1.0_dp, smear_gaussian)
+               kTS_spin(2) = kTS
             END IF
          END IF
          DO ikpgr = 1, kplocal
@@ -1430,7 +1442,7 @@ CONTAINS
                CALL get_mo_set(mo_set, eigenvalues=eigenvalues, occupation_numbers=occupation)
                eigenvalues(1:nmo) = weig(1:nmo, ik, ispin)
                occupation(1:nmo) = wocc(1:nmo, ik, ispin)
-               mo_set%kTS = kTS
+               mo_set%kTS = kTS_spin(ispin)
                mo_set%mu = mus(ispin)
             END DO
          END DO

--- a/src/qs_mo_occupation.F
+++ b/src/qs_mo_occupation.F
@@ -656,7 +656,11 @@ CONTAINS
                   EXIT
                END IF
             END DO
-            is_large = ABS(MAXVAL(mo_set%occupation_numbers) - mo_set%maxocc) > smear%eps_fermi_dirac
+            IF (i_first <= nmo) THEN
+               is_large = ABS(mo_set%occupation_numbers(i_first) - mo_set%maxocc) > smear%eps_fermi_dirac
+            ELSE
+               is_large = .FALSE.
+            END IF
             ! this is not a real problem, but the temperature might be a bit large
             CPWARN_IF(is_large, "Fermi-Dirac smearing includes the first MO")
 
@@ -709,7 +713,11 @@ CONTAINS
                   EXIT
                END IF
             END DO
-            is_large = ABS(mo_set%occupation_numbers(1) - mo_set%maxocc) > smear%eps_fermi_dirac
+            IF (i_first <= nmo) THEN
+               is_large = ABS(mo_set%occupation_numbers(i_first) - mo_set%maxocc) > smear%eps_fermi_dirac
+            ELSE
+               is_large = .FALSE.
+            END IF
             CPWARN_IF(is_large, TRIM(method_label)//" smearing includes the first MO")
 
             ! Find the highest (fractional) occupied MO which will be now the HOMO

--- a/src/qs_mo_occupation.F
+++ b/src/qs_mo_occupation.F
@@ -68,13 +68,14 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'set_mo_occupation_3'
 
+      CHARACTER(LEN=32)                                  :: method_label
       INTEGER                                            :: all_nmo, handle, homo_a, homo_b, i, &
                                                             lfomo_a, lfomo_b, nmo_a, nmo_b, &
                                                             xas_estate
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: all_index
       LOGICAL                                            :: is_large
       REAL(KIND=dp)                                      :: all_nelec, kTS, mu, nelec_a, nelec_b, &
-                                                            occ_estate
+                                                            occ_estate, smear_width
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: all_eigval, all_occ
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigval_a, eigval_b, occ_a, occ_b
 
@@ -113,17 +114,34 @@ CONTAINS
          END IF
       END DO
 
+      SELECT CASE (smear%method)
+      CASE (smear_fermi_dirac)
+         smear_width = smear%electronic_temperature
+         method_label = "Fermi-Dirac"
+      CASE (smear_gaussian)
+         smear_width = smear%smearing_width
+         method_label = "Gaussian"
+      CASE (smear_mp)
+         smear_width = smear%smearing_width
+         method_label = "Methfessel-Paxton"
+      CASE (smear_mv)
+         smear_width = smear%smearing_width
+         method_label = "Marzari-Vanderbilt"
+      CASE DEFAULT
+         CPABORT("set_mo_occupation_3: unsupported smearing method")
+      END SELECT
+
       CALL SmearFixed(all_occ, mu, kTS, all_eigval, all_nelec, &
-                      smear%electronic_temperature, 1._dp, smear%method, xas_estate, occ_estate)
+                      smear_width, 1._dp, smear%method, xas_estate, occ_estate)
 
-      is_large = ABS(MAXVAL(all_occ) - 1.0_dp) > smear%eps_fermi_dirac
-      ! this is not a real problem, but the temperature might be a bit large
-      CPWARN_IF(is_large, "Fermi-Dirac smearing includes the first MO")
+      is_large = ABS(all_occ(1) - 1.0_dp) > smear%eps_fermi_dirac
+      ! this is not a real problem, but the smearing width might be a bit large
+      CPWARN_IF(is_large, TRIM(method_label)//" smearing includes the first MO")
 
-      is_large = ABS(MINVAL(all_occ)) > smear%eps_fermi_dirac
+      is_large = ABS(all_occ(all_nmo)) > smear%eps_fermi_dirac
       IF (is_large) &
          CALL cp_warn(__LOCATION__, &
-                      "Fermi-Dirac smearing includes the last MO => "// &
+                      TRIM(method_label)//" smearing includes the last MO => "// &
                       "Add more MOs for proper smearing.")
 
       ! check that the total electron count is accurate

--- a/src/smearing_utils.F
+++ b/src/smearing_utils.F
@@ -343,11 +343,11 @@ CONTAINS
          DO
             iter = iter + 1
             CALL SmearOcc(f, N_tmp, kTS, e, mu_min, sigma, maxocc, smear_gaussian, my_estate, my_festate)
-            IF (N_tmp > N .OR. iter > 20) THEN
-               mu_min = mu_min - sigma
-            ELSE
-               EXIT
+            IF (N_tmp <= N) EXIT
+            IF (iter > 20) THEN
+               CPABORT("SmearFixed: failed to bracket lower chemical potential")
             END IF
+            mu_min = mu_min - sigma
          END DO
 
          mu_max = MAXVAL(e)
@@ -355,11 +355,11 @@ CONTAINS
          DO
             iter = iter + 1
             CALL SmearOcc(f, N_tmp, kTS, e, mu_max, sigma, maxocc, smear_gaussian, my_estate, my_festate)
-            IF (N_tmp < N .OR. iter > 20) THEN
-               mu_max = mu_max + sigma
-            ELSE
-               EXIT
+            IF (N_tmp >= N) EXIT
+            IF (iter > 20) THEN
+               CPABORT("SmearFixed: failed to bracket upper chemical potential")
             END IF
+            mu_max = mu_max + sigma
          END DO
 
          iter = 0
@@ -390,6 +390,9 @@ CONTAINS
 
          ! Final evaluation
          CALL SmearOcc(f, N_now, kTS, e, mu, sigma, maxocc, method, my_estate, my_festate)
+         IF (ABS(N_now - N) >= N*1.0e-12_dp) THEN
+            CPWARN("SmearFixed: MP/MV smearing did not reach the requested electron count")
+         END IF
 
          ! Monotonic methods (FD, Gaussian): pure bisection
       CASE DEFAULT
@@ -398,11 +401,11 @@ CONTAINS
          DO
             iter = iter + 1
             CALL SmearOcc(f, N_tmp, kTS, e, mu_min, sigma, maxocc, method, my_estate, my_festate)
-            IF (N_tmp > N .OR. iter > 20) THEN
-               mu_min = mu_min - sigma
-            ELSE
-               EXIT
+            IF (N_tmp <= N) EXIT
+            IF (iter > 20) THEN
+               CPABORT("SmearFixed: failed to bracket lower chemical potential")
             END IF
+            mu_min = mu_min - sigma
          END DO
 
          mu_max = MAXVAL(e)
@@ -410,11 +413,11 @@ CONTAINS
          DO
             iter = iter + 1
             CALL SmearOcc(f, N_tmp, kTS, e, mu_max, sigma, maxocc, method, my_estate, my_festate)
-            IF (N_tmp < N .OR. iter > 20) THEN
-               mu_max = mu_max + sigma
-            ELSE
-               EXIT
+            IF (N_tmp >= N) EXIT
+            IF (iter > 20) THEN
+               CPABORT("SmearFixed: failed to bracket upper chemical potential")
             END IF
+            mu_max = mu_max + sigma
          END DO
 
          iter = 0
@@ -553,6 +556,12 @@ CONTAINS
 
       ! Final evaluation with the actual method
       CALL Smear2(f, N_now, kTS, e, mu, wk, sigma, maxocc, method)
+      SELECT CASE (method)
+      CASE (smear_mp, smear_mv)
+         IF (ABS(N_now - nel) >= nel*epsocc) THEN
+            CPWARN("Smearkp: MP/MV smearing did not reach the requested electron count")
+         END IF
+      END SELECT
 
    END SUBROUTINE Smearkp
 
@@ -673,7 +682,14 @@ CONTAINS
       ! Final evaluation with the actual method
       CALL Smear2(f(:, :, 1), na, kTSa, e(:, :, 1), mu, wk, sigma, 1.0_dp, method)
       CALL Smear2(f(:, :, 2), nb, kTSb, e(:, :, 2), mu, wk, sigma, 1.0_dp, method)
+      N_now = na + nb
       kTS = kTSa + kTSb
+      SELECT CASE (method)
+      CASE (smear_mp, smear_mv)
+         IF (ABS(N_now - nel) >= nel*epsocc) THEN
+            CPWARN("Smearkp2: MP/MV smearing did not reach the requested electron count")
+         END IF
+      END SELECT
 
    END SUBROUTINE Smearkp2
 
@@ -689,8 +705,8 @@ CONTAINS
 !>          MV:           g_i = occ * (2 + sqrt(2)*x) / (sigma*sqrt(pi)) * exp(-u^2)
 !>
 !>          Note: g_i can be negative for MP-1 (|x| > sqrt(3/2)) and MV
-!>          (x < -sqrt(2)).  This does not break bisection (N(mu) is still
-!>          monotone) but the Jacobian routines must guard against G = sum(g_i)
+!>          (x < -sqrt(2)).  Consequently, N(mu) is not guaranteed to be
+!>          monotone and the Jacobian routines must guard against G = sum(g_i)
 !>          being near zero.
 !>
 !> \param gvec    weight vector (Nstate, output)

--- a/src/smearing_utils.F
+++ b/src/smearing_utils.F
@@ -52,6 +52,8 @@ MODULE smearing_utils
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'smearing_utils'
    INTEGER, PARAMETER, PRIVATE                           :: BISECT_MAX_ITER = 400
    INTEGER, PARAMETER, PRIVATE                           :: NEWTON_MAX_ITER = 50
+   INTEGER, PARAMETER, PRIVATE                           :: NEWTON_MAX_BACKTRACK = 20
+   REAL(KIND=dp), PARAMETER, PRIVATE                     :: MPMV_MAX_NEWTON_STEP = 2.0_dp
 
 CONTAINS
 ! **************************************************************************************************
@@ -316,9 +318,9 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL                      :: estate
       REAL(KIND=dp), INTENT(IN), OPTIONAL                :: festate
 
-      INTEGER                                            :: iter, my_estate, Nstate
-      REAL(KIND=dp)                                      :: Gsum, mu_max, mu_min, mu_now, &
-                                                            my_festate, N_now, N_tmp
+      INTEGER                                            :: iback, iter, my_estate, Nstate
+      REAL(KIND=dp) :: Gsum, mu_best, mu_max, mu_min, mu_now, mu_trial, my_festate, N_now, N_tmp, &
+         N_trial, res_best, res_now, res_trial, step, step_try
       REAL(KIND=dp), ALLOCATABLE                         :: gvec(:)
 
       IF (PRESENT(estate) .AND. PRESENT(festate)) THEN
@@ -376,17 +378,45 @@ CONTAINS
          END DO
          mu = (mu_max + mu_min)/2.0_dp
 
-         ! Step 2: Newton refinement with the actual method
+         ! Step 2: damped Newton refinement with the actual method.  MP/MV
+         ! occupations are not monotonic functions of mu, therefore an
+         ! unrestricted Newton step can jump to a remote root or increase the
+         ! electron-count residual.  Keep the root closest to the Gaussian
+         ! solution by accepting only residual-reducing, size-limited steps.
          ALLOCATE (gvec(Nstate))
+         CALL SmearOcc(f, N_now, kTS, e, mu, sigma, maxocc, method, my_estate, my_festate)
+         res_best = ABS(N_now - N)
+         mu_best = mu
          DO iter = 1, NEWTON_MAX_ITER
-            CALL SmearOcc(f, N_now, kTS, e, mu, sigma, maxocc, method, my_estate, my_festate)
-            IF (ABS(N_now - N) < N*1.0e-12_dp) EXIT
+            res_now = ABS(N_now - N)
+            IF (res_now < N*1.0e-12_dp) EXIT
             CALL compute_gvec(gvec, f, e, mu, sigma, maxocc, Nstate, method, my_estate, my_festate)
             Gsum = accurate_sum(gvec)
             IF (ABS(Gsum) < EPSILON(Gsum)) EXIT
-            mu = mu + (N - N_now)/Gsum
+
+            step = (N - N_now)/Gsum
+            step = SIGN(MIN(ABS(step), MPMV_MAX_NEWTON_STEP*sigma), step)
+            step_try = step
+            DO iback = 1, NEWTON_MAX_BACKTRACK
+               mu_trial = mu + step_try
+               CALL SmearOcc(f, N_trial, kTS, e, mu_trial, sigma, maxocc, method, &
+                             my_estate, my_festate)
+               res_trial = ABS(N_trial - N)
+               IF (res_trial < res_now) THEN
+                  mu = mu_trial
+                  N_now = N_trial
+                  IF (res_trial < res_best) THEN
+                     res_best = res_trial
+                     mu_best = mu
+                  END IF
+                  EXIT
+               END IF
+               step_try = 0.5_dp*step_try
+            END DO
+            IF (iback > NEWTON_MAX_BACKTRACK) EXIT
          END DO
          DEALLOCATE (gvec)
+         mu = mu_best
 
          ! Final evaluation
          CALL SmearOcc(f, N_now, kTS, e, mu, sigma, maxocc, method, my_estate, my_festate)
@@ -475,9 +505,12 @@ CONTAINS
 
       REAL(KIND=dp), PARAMETER                           :: epsocc = 1.0e-12_dp
 
-      INTEGER                                            :: bisect_method, ik, is, iter, nkp, nmo
-      REAL(KIND=dp)                                      :: de, dNdmu, expu2, expx2, mu_max, mu_min, &
-                                                            N_now, u, x
+      INTEGER                                            :: bisect_method, iback, ik, is, iter, nkp, &
+                                                            nmo
+      REAL(KIND=dp)                                      :: de, dNdmu, expu2, expx2, mu_best, &
+                                                            mu_max, mu_min, N_now, N_trial, &
+                                                            res_best, res_now, res_trial, step, &
+                                                            step_try, u, x
 
       nmo = SIZE(e, 1)
       nkp = SIZE(e, 2)
@@ -525,12 +558,17 @@ CONTAINS
       END DO
       mu = (mu_max + mu_min)/2.0_dp
 
-      ! Newton refinement for non-monotonic methods
+      ! Damped Newton refinement for non-monotonic methods.  Accept only
+      ! residual-reducing steps and limit the displacement from the local
+      ! Gaussian solution to avoid jumping to a remote MP/MV root.
       SELECT CASE (method)
       CASE (smear_mp, smear_mv)
+         CALL Smear2(f, N_now, kTS, e, mu, wk, sigma, maxocc, method)
+         res_best = ABS(N_now - nel)
+         mu_best = mu
          DO iter = 1, NEWTON_MAX_ITER
-            CALL Smear2(f, N_now, kTS, e, mu, wk, sigma, maxocc, method)
-            IF (ABS(N_now - nel) < nel*epsocc) EXIT
+            res_now = ABS(N_now - nel)
+            IF (res_now < nel*epsocc) EXIT
 
             ! Compute dN/dmu = sum_{ik} wk * g_i(k)  inline
             dNdmu = 0.0_dp
@@ -550,8 +588,26 @@ CONTAINS
             END DO
 
             IF (ABS(dNdmu) < EPSILON(dNdmu)) EXIT
-            mu = mu + (nel - N_now)/dNdmu
+            step = (nel - N_now)/dNdmu
+            step = SIGN(MIN(ABS(step), MPMV_MAX_NEWTON_STEP*sigma), step)
+            step_try = step
+            DO iback = 1, NEWTON_MAX_BACKTRACK
+               CALL Smear2(f, N_trial, kTS, e, mu + step_try, wk, sigma, maxocc, method)
+               res_trial = ABS(N_trial - nel)
+               IF (res_trial < res_now) THEN
+                  mu = mu + step_try
+                  N_now = N_trial
+                  IF (res_trial < res_best) THEN
+                     res_best = res_trial
+                     mu_best = mu
+                  END IF
+                  EXIT
+               END IF
+               step_try = 0.5_dp*step_try
+            END DO
+            IF (iback > NEWTON_MAX_BACKTRACK) EXIT
          END DO
+         mu = mu_best
       END SELECT
 
       ! Final evaluation with the actual method
@@ -593,10 +649,10 @@ CONTAINS
 
       REAL(KIND=dp), PARAMETER                           :: epsocc = 1.0e-12_dp
 
-      INTEGER                                            :: bisect_method, ik, is, ispin, iter, nkp, &
-                                                            nmo
-      REAL(KIND=dp)                                      :: de, dNdmu, expu2, expx2, kTSa, kTSb, &
-                                                            mu_max, mu_min, N_now, na, nb, u, x
+      INTEGER                                            :: bisect_method, iback, ik, is, ispin, &
+                                                            iter, nkp, nmo
+      REAL(KIND=dp) :: de, dNdmu, expu2, expx2, kTSa, kTSb, mu_best, mu_max, mu_min, N_now, &
+         N_trial, na, nb, res_best, res_now, res_trial, step, step_try, u, x
 
       CPASSERT(SIZE(f, 3) == 2 .AND. SIZE(e, 3) == 2)
 
@@ -646,14 +702,19 @@ CONTAINS
       END DO
       mu = (mu_max + mu_min)/2.0_dp
 
-      ! Newton refinement for non-monotonic methods
+      ! Damped Newton refinement for non-monotonic methods.  Accept only
+      ! residual-reducing steps and limit the displacement from the local
+      ! Gaussian solution to avoid jumping to a remote MP/MV root.
       SELECT CASE (method)
       CASE (smear_mp, smear_mv)
+         CALL Smear2(f(:, :, 1), na, kTSa, e(:, :, 1), mu, wk, sigma, 1.0_dp, method)
+         CALL Smear2(f(:, :, 2), nb, kTSb, e(:, :, 2), mu, wk, sigma, 1.0_dp, method)
+         N_now = na + nb
+         res_best = ABS(N_now - nel)
+         mu_best = mu
          DO iter = 1, NEWTON_MAX_ITER
-            CALL Smear2(f(:, :, 1), na, kTSa, e(:, :, 1), mu, wk, sigma, 1.0_dp, method)
-            CALL Smear2(f(:, :, 2), nb, kTSb, e(:, :, 2), mu, wk, sigma, 1.0_dp, method)
-            N_now = na + nb
-            IF (ABS(N_now - nel) < nel*epsocc) EXIT
+            res_now = ABS(N_now - nel)
+            IF (res_now < nel*epsocc) EXIT
 
             ! dN/dmu across both spin channels (maxocc=1 per spin)
             dNdmu = 0.0_dp
@@ -675,8 +736,28 @@ CONTAINS
             END DO
 
             IF (ABS(dNdmu) < EPSILON(dNdmu)) EXIT
-            mu = mu + (nel - N_now)/dNdmu
+            step = (nel - N_now)/dNdmu
+            step = SIGN(MIN(ABS(step), MPMV_MAX_NEWTON_STEP*sigma), step)
+            step_try = step
+            DO iback = 1, NEWTON_MAX_BACKTRACK
+               CALL Smear2(f(:, :, 1), na, kTSa, e(:, :, 1), mu + step_try, wk, sigma, 1.0_dp, method)
+               CALL Smear2(f(:, :, 2), nb, kTSb, e(:, :, 2), mu + step_try, wk, sigma, 1.0_dp, method)
+               N_trial = na + nb
+               res_trial = ABS(N_trial - nel)
+               IF (res_trial < res_now) THEN
+                  mu = mu + step_try
+                  N_now = N_trial
+                  IF (res_trial < res_best) THEN
+                     res_best = res_trial
+                     mu_best = mu
+                  END IF
+                  EXIT
+               END IF
+               step_try = 0.5_dp*step_try
+            END DO
+            IF (iback > NEWTON_MAX_BACKTRACK) EXIT
          END DO
+         mu = mu_best
       END SELECT
 
       ! Final evaluation with the actual method

--- a/tests/QS/regtest-gapw-1/TEST_FILES.toml
+++ b/tests/QS/regtest-gapw-1/TEST_FILES.toml
@@ -16,8 +16,8 @@
 # density mixing
 "c8_pmix_gapw_all.inp"                  = [{matcher="E_total", tol=2e-04, ref=-302.63376739633446}]
 "c8_pmix_gapw_all_xashh.inp"            = [{matcher="E_total", tol=2e-04, ref=-297.79190173209122}]
-"c8_broy_gapw_all.inp"                  = [{matcher="E_total", tol=5e-09, ref=-302.99557091768804}]
-"c8_broy_gapw_all_xashh.inp"            = [{matcher="E_total", tol=8e-08, ref=-298.17220723878080}]
+"c8_broy_gapw_all.inp"                  = [{matcher="E_total", tol=5e-09, ref=-302.9969250529296}]
+"c8_broy_gapw_all_xashh.inp"            = [{matcher="E_total", tol=8e-08, ref=-298.1724738051678}]
 # different scf_env
 "CO_xastpfh_gsot.inp"                   = [{matcher="E_total", tol=8e-14, ref=-79.09997113686542}]
 # XAS TP choice of core occ from input


### PR DESCRIPTION
- Fixes the relaxed-spin smearing path in `set_mo_occupation_3`, where Gaussian, Methfessel-Paxton, and Marzari-Vanderbilt smearing incorrectly used the electronic temperature instead of the smearing width (`SIGMA`). The warning messages are also generalized to report the actual smearing method instead of always referring to Fermi-Dirac smearing.
- The k-point fixed-magnetic-moment path now stores the entropy correction separately for each spin channel. Previously, the second `Smearkp` call overwrote `kTS`, so both spin channels received the same final value.
- The `SmearFixed` chemical-potential bracketing loops now abort cleanly when a bracket cannot be found. The previous `iter > 20` condition kept expanding the bracket instead of exiting, which could lead to an infinite loop in pathological cases.
- The first-MO smearing warning now ignores intentionally constrained XAS core-hole orbitals, avoiding misleading warnings in TP_HH/half-hole calculations.
- The MP/MV chemical-potential Newton refinement is now damped and backtracked to avoid jumps to remote roots with inaccurate electron counts.