### PR TITLE
Two small patches for `cell_methods.F` and `particle_methods.F`

### DIFF
--- a/src/cell_methods.F
+++ b/src/cell_methods.F
@@ -895,7 +895,8 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'read_cell_extxyz'
 
-      INTEGER                                            :: handle, i, id1, id2, j
+      CHARACTER(len=default_path_length)                 :: raw_cell_str
+      INTEGER                                            :: handle, i, id1, id2, ios, j
       REAL(KIND=dp), DIMENSION(3, 3)                     :: hmat
       TYPE(cp_parser_type)                               :: parser
 
@@ -908,7 +909,13 @@ CONTAINS
       id1 = INDEX(parser%input_line, "LATTICE=")
       IF (id1 > 0) THEN
          id2 = INDEX(parser%input_line(id1 + 9:), '"')
-         READ (parser%input_line(id1 + 9:id1 + id2 + 7), *) hmat(:, 1), hmat(:, 2), hmat(:, 3)
+         READ (parser%input_line(id1 + 9:id1 + id2 + 7), '(A)') raw_cell_str
+         READ (raw_cell_str, *, IOSTAT=ios) hmat(:, 1), hmat(:, 2), hmat(:, 3)
+         IF (ios /= 0) THEN
+            CALL cp_abort(__LOCATION__, "Error while parsing extended XYZ file "// &
+                          "<"//TRIM(extxyz_file_name)//"> for cell vectors: "// &
+                          "found <lattice=> field as <"//TRIM(raw_cell_str)//">")
+         END IF
          DO i = 1, 3
             DO j = 1, 3
                cell%hmat(j, i) = cp_unit_to_cp2k(hmat(j, i), "angstrom")
@@ -917,7 +924,7 @@ CONTAINS
 
       ELSE
          CALL cp_abort(__LOCATION__, &
-                       "The field (lattice=) was not found on comment line "// &
+                       "The field <lattice=> was not found on comment line "// &
                        "of XYZ file, so cell information cannot be set via "// &
                        "extended XYZ specification! ")
       END IF
@@ -955,7 +962,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'read_cell_pdb'
 
       CHARACTER(LEN=default_string_length)               :: cryst
-      INTEGER                                            :: handle, i
+      INTEGER                                            :: handle, i, ios
       INTEGER, DIMENSION(3)                              :: periodic
       LOGICAL                                            :: found
       REAL(KIND=dp), DIMENSION(3)                        :: cell_angles, cell_lengths
@@ -969,10 +976,15 @@ CONTAINS
       CALL parser_search_string(parser, "CRYST1", ignore_case=.FALSE., found=found, &
                                 begin_line=.TRUE., search_from_begin_of_file=.TRUE.)
       IF (.NOT. found) &
-         CPABORT("The field (CRYST1) was not found in PDB file! ")
+         CPABORT("The line <CRYST1> was not found in PDB file! ")
 
       periodic = 1
-      READ (parser%input_line, *) cryst, cell_lengths(:), cell_angles(:)
+      READ (parser%input_line, *, IOSTAT=ios) cryst, cell_lengths(:), cell_angles(:)
+      IF (ios /= 0) THEN
+         CALL cp_abort(__LOCATION__, "Error while parsing PDB file "// &
+                       "<"//TRIM(pdb_file_name)//"> for cell lengths and angles: "// &
+                       "found CRYST1 line as <"//TRIM(parser%input_line)//">")
+      END IF
       DO i = 1, 3
          cell_lengths(i) = cp_unit_to_cp2k(cell_lengths(i), "angstrom")
          cell_angles(i) = cp_unit_to_cp2k(cell_angles(i), "deg")

--- a/src/particle_methods.F
+++ b/src/particle_methods.F
@@ -1407,11 +1407,10 @@ CONTAINS
                "_atom_site_symmetry_multiplicity", "_atom_site_fract_x", &
                "_atom_site_fract_y", "_atom_site_fract_z", "_atom_site_occupancy"
             DO iatom = 1, natom
-               r(1:3) = pbc(particle_set(iatom)%r(1:3), cell)
+               ! positive_range=.TRUE. makes r(1:3) in [0, cell%hmat(i,i)] and
+               ! s(1:3) in [0, 1], so there is no need to MODULO s(1:3) by 1.0
+               r(1:3) = pbc(particle_set(iatom)%r(1:3), cell, positive_range=.TRUE.)
                CALL real_to_scaled(s, r, cell)
-               DO i = 1, 3
-                  s(i) = MODULO(s(i), 1.0_dp)
-               END DO
                WRITE (UNIT=file_unit, FMT=TRIM(f_cif)) &
                   cif_type_symbol(iatom), cif_label(iatom), 1, s(1:3), 1.0_dp
             END DO


### PR DESCRIPTION
For `cell_methods.F`, the `READ` commands handle reading from bad formats by capturing `IOSTAT`.

For `particle_methods.F`, the `positive_range=.TRUE.` flag of the `pbc` interface replaces MODULO 1.0 operations to get fractional coordinates in the range [0,1].