### PR TITLE
Enable CUDA for py-torch in spack recipe

### DIFF
--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -120,6 +120,7 @@ spack:
         - "~cutlass"
         - "+fortran"
         - "+openmp"
+        - "+onedft"
         - "+skala"
 
     hdf5:
@@ -156,7 +157,6 @@ spack:
       require:
         - "~distributed"
         - "~kineto"
-        - "~magma"
         - "~mkldnn"
         - "~rocm"
         - "~valgrind"

--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -32,6 +32,7 @@ spack:
         - "+openmp"
         - "+pic"
         - "~rocm"
+        - "~tests"
         - "build_system=cmake"
         - "build_type=Release"
 
@@ -116,6 +117,7 @@ spack:
     gauxc:
       require:
         - "+c"
+        - "~cutlass"
         - "+fortran"
         - "+openmp"
         - "+skala"
@@ -152,9 +154,9 @@ spack:
 
     py-torch:
       require:
-        - "~cuda"
         - "~distributed"
         - "~kineto"
+        - "~magma"
         - "~mkldnn"
         - "~rocm"
         - "~valgrind"

--- a/tools/spack/cp2k_deps_s.yaml
+++ b/tools/spack/cp2k_deps_s.yaml
@@ -32,6 +32,7 @@ spack:
         - "+openmp"
         - "+pic"
         - "~rocm"
+        - "~tests"
         - "build_system=cmake"
         - "build_type=Release"
 
@@ -67,6 +68,7 @@ spack:
     dbcsr:
       require:
         - "~examples"
+        - "+fortran"
         - "+openmp"
         - "smm=libxsmm"
 
@@ -81,6 +83,7 @@ spack:
     gauxc:
       require:
         - "+c"
+        - "~cutlass"
         - "+fortran"
         - "+openmp"
         - "+skala"
@@ -100,9 +103,9 @@ spack:
 
     py-torch:
       require:
-        - "~cuda"
         - "~distributed"
         - "~kineto"
+        - "~magma"
         - "~mkldnn"
         - "~rocm"
         - "~valgrind"

--- a/tools/spack/cp2k_deps_s.yaml
+++ b/tools/spack/cp2k_deps_s.yaml
@@ -68,7 +68,6 @@ spack:
     dbcsr:
       require:
         - "~examples"
-        - "+fortran"
         - "+openmp"
         - "smm=libxsmm"
 

--- a/tools/spack/cp2k_deps_s.yaml
+++ b/tools/spack/cp2k_deps_s.yaml
@@ -85,6 +85,7 @@ spack:
         - "~cutlass"
         - "+fortran"
         - "+openmp"
+        - "+onedft"
         - "+skala"
 
     hdf5:
@@ -104,7 +105,6 @@ spack:
       require:
         - "~distributed"
         - "~kineto"
-        - "~magma"
         - "~mkldnn"
         - "~rocm"
         - "~valgrind"

--- a/tools/spack/spack_repo/cp2k_dev/packages/exchcxx/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/exchcxx/package.py
@@ -58,5 +58,5 @@ class Exchcxx(CMakePackage, CudaPackage):
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
         if self.spec.satisfies("+cuda"):
-            args.append(CMakeBuilder.define_cuda_architectures(self))
+            args.append(self.define_cuda_architectures(self))
         return args

--- a/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
@@ -116,7 +116,7 @@ class Gauxc(CMakePackage, CudaPackage):
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
         if spec.satisfies("+cuda"):
-            args.append(CMakeBuilder.define_cuda_architectures(self))
+            args.append(self.define_cuda_architectures(self))
         return args
 
     def install(self, spec, prefix):


### PR DESCRIPTION
- py-torch has been built and tested without CUDA support sofar. It is time to move forward and try it out.
- Remove `+fortran` mistakenly added for `dbcsr`
- Fix function name for `define_cuda_architectures`