### PR TITLE
Toolchain: Print categorized configuration summary

### DIFF
--- a/tools/toolchain/build_cp2k.sh
+++ b/tools/toolchain/build_cp2k.sh
@@ -80,7 +80,6 @@ while [ $# -ge 1 ]; do
       PREFIX_SET="__TRUE__"
       if [[ "${2}" != /* ]]; then
         report_error "The path for --prefix must be an absolute path."
-        exit 1
       fi
       CMAKE_INSTALL_PREFIX="${2}"
       shift
@@ -146,19 +145,16 @@ if [ -d "${CP2K_ROOT}/src" ]; then
   echo "(path is exported to variable \${CP2K_ROOT})."
 else
   report_error ${LINENO} "\${CP2K_ROOT} does not have subdirectory src."
-  exit 1
 fi
 if [ -f "${CP2K_ROOT}/CMakeLists.txt" ] && [ -r "${CP2K_ROOT}/CMakeLists.txt" ]; then
   echo "\${CP2K_ROOT}/CMakeLists.txt exists; will be parsed for CMake options."
 else
   report_error ${LINENO} "\${CP2K_ROOT}/CMakeLists.txt cannot be found or read."
-  exit 1
 fi
 if [ -d "${CP2K_ROOT}/data" ]; then
   echo "Data directory ${CP2K_ROOT}/data is found."
 else
   report_error ${LINENO} "Data directory \${CP2K_ROOT}/data cannot be found."
-  exit 1
 fi
 
 # Require finished toolchain

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -32,7 +32,6 @@ export ROOTDIR="${PWD}"
 export SCRIPTDIR="${ROOTDIR}/scripts"
 export BUILDDIR="${ROOTDIR}/build"
 export INSTALLDIR="${ROOTDIR}/install"
-export SETUPFILE="${INSTALLDIR}/setup"
 export TOOLKIT_SCRIPT="${SCRIPTDIR}/tool_kit.sh"
 
 # ------------------------------------------------------------------------
@@ -649,9 +648,6 @@ while [ $# -ge 1 ]; do
         exit 1
       fi
       export INSTALLDIR="${1#--install-dir=}"
-      export SETUPFILE="${INSTALLDIR}/setup"
-      cp "${SCRIPTDIR}"/tool_kit.sh "${INSTALLDIR}"/
-      export TOOLKIT_SCRIPT="${INSTALLDIR}/tool_kit.sh"
       ;;
     --no-check-certificate)
       export DOWNLOADER_FLAGS="--no-check-certificate"
@@ -1261,6 +1257,12 @@ fi
 # ------------------------------------------------------------------------
 
 mkdir -p "${INSTALLDIR}"
+export SETUPFILE="${INSTALLDIR}/setup"
+
+if [ "${INSTALLDIR}" != "${ROOTDIR}/install" ]; then
+  cp "${SCRIPTDIR}"/tool_kit.sh "${INSTALLDIR}"/
+  export TOOLKIT_SCRIPT="${INSTALLDIR}/tool_kit.sh"
+fi
 
 # Select the correct compute number based on the GPU architecture
 case ${GPUVER} in

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -662,6 +662,8 @@ while [ $# -ge 1 ]; do
         if [ "${ii}" != "intel" ] &&
           [ "${ii}" != "intelmpi" ] &&
           [ "${ii}" != "amd" ] &&
+          [ "${ii}" != "mkl" ] &&
+          [ "${ii}" != "acml" ] &&
           [ "${ii}" != "cusolvermp" ]; then
           eval "with_${ii}=__INSTALL__"
         fi
@@ -1404,30 +1406,185 @@ for ii in ${package_list}; do
 done
 
 # ------------------------------------------------------------------------
-# Build packages unless dry-run mode is enabled.
+# Print the resolved toolchain configuration in a user-friendly form. The
+# raw with_* variables are still written to toolchain.conf below, but the
+# report groups packages by what the toolchain will actually do with them.
 # ------------------------------------------------------------------------
-if [ "${dry_run}" = "__TRUE__" ]; then
-  printf "With --dry-run option, this script concludes with a report.\n"
-  printf "The setup, toolchain env and conf files are written to ./install.\n"
-  printf "System specifications:\n"
+
+get_effective_package_mode() {
+  local pkg="$1"
+  local var_name="with_${pkg}"
+  local mode="${!var_name}"
+
+  # Only the selected math backend is active. Some non-selected math
+  # variables may keep their default value, but they are not used by
+  # stage2/install_mathlibs.sh.
+  case "${pkg}" in
+    mkl | acml | openblas)
+      if [ "${MATH_MODE}" != "${pkg}" ]; then
+        mode="__DONTUSE__"
+      fi
+      ;;
+  esac
+
+  # Likewise, only the selected MPI implementation is active.
+  case "${pkg}" in
+    mpich | openmpi | intelmpi)
+      if [ "${MPI_MODE}" = "no" ] || [ "${MPI_MODE}" != "${pkg}" ]; then
+        mode="__DONTUSE__"
+      fi
+      ;;
+  esac
+
+  printf '%s' "${mode}"
+}
+
+append_report_line() {
+  local var_name="$1"
+  local line="$2"
+  local current="${!var_name}"
+  if [ -z "${current}" ]; then
+    printf -v "${var_name}" '%s' "${line}"
+  else
+    printf -v "${var_name}" '%s\n%s' "${current}" "${line}"
+  fi
+}
+
+print_report_group() {
+  local title="$1"
+  local body="$2"
+  local width="${TOOLCHAIN_REPORT_WIDTH:-80}"
+  local indent="  "
+  local max_cols=5
+  local min_col_width=15
+  local item line padded
+  local n=0 max_len=0 col_width cols rows row col idx
+  local items=()
+
+  printf '%s\n' "${title}"
+  if [ -z "${body}" ]; then
+    printf '  (none)\n'
+    return
+  fi
+
+  while IFS= read -r item; do
+    [ -z "${item}" ] && continue
+    item="${item#  }"
+    items[n]="${item}"
+    [ "${#item}" -gt "${max_len}" ] && max_len="${#item}"
+    n=$((n + 1))
+  done << EOF
+${body}
+EOF
+
+  [ "${n}" -eq 0 ] && printf '  (none)\n' && return
+
+  col_width=$((max_len + 2))
+  [ "${col_width}" -lt "${min_col_width}" ] && col_width="${min_col_width}"
+
+  cols=$(((width - ${#indent}) / col_width))
+  [ "${cols}" -gt "${max_cols}" ] && cols="${max_cols}"
+  [ "${cols}" -lt 1 ] && cols=1
+  [ "${cols}" -gt "${n}" ] && cols="${n}"
+
+  rows=$(((n + cols - 1) / cols))
+  for ((row = 0; row < rows; row++)); do
+    line="${indent}"
+    for ((col = 0; col < cols; col++)); do
+      idx=$((row * cols + col))
+      [ "${idx}" -ge "${n}" ] && continue
+      item="${items[idx]}"
+      if [ "${col}" -lt $((cols - 1)) ]; then
+        printf -v padded '%-*s' "${col_width}" "${item}"
+        line="${line}${padded}"
+      else
+        line="${line}${item}"
+      fi
+    done
+    while [ "${line% }" != "${line}" ]; do
+      line="${line% }"
+    done
+    printf '%s\n' "${line}"
+  done
+}
+
+format_bool() {
+  case "$1" in
+    __TRUE__)
+      printf 'yes'
+      ;;
+    __FALSE__)
+      printf 'no'
+      ;;
+    *)
+      printf '%s' "$1"
+      ;;
+  esac
+}
+
+print_toolchain_summary() {
+  local pkg mode
+  local install_packages=""
+  local system_packages=""
+  local path_packages=""
+  local disabled_packages=""
+
+  for pkg in ${package_list}; do
+    mode=$(get_effective_package_mode "${pkg}")
+    case "${mode}" in
+      __INSTALL__)
+        append_report_line install_packages "  - ${pkg}"
+        ;;
+      __SYSTEM__)
+        append_report_line system_packages "  - ${pkg}"
+        ;;
+      __DONTUSE__)
+        append_report_line disabled_packages "  - ${pkg}"
+        ;;
+      *)
+        append_report_line path_packages "  - ${pkg}: ${mode}"
+        ;;
+    esac
+  done
+
+  printf '\nToolchain configuration summary\n'
+  printf '%s\n' '-------------------------------'
+  printf 'System specifications:\n'
   printf '   -%-20s = %s\n' "j" "${NPROCS_OVERWRITE}"
   printf '  --%-20s = %s\n' "target-cpu" "${TARGET_CPU}"
   printf '  --%-20s = %s\n' "gpu-ver" "${GPUVER}"
   printf '  --%-20s = %s\n' "mpi-mode" "${MPI_MODE}"
   printf '  --%-20s = %s\n' "math-mode" "${MATH_MODE}"
-  printf '  --%-20s = %s\n' "enable-tsan" "${enable_tsan}"
-  printf '  --%-20s = %s\n' "enable-cuda" "${enable_cuda}"
-  printf '  --%-20s = %s\n' "enable-gauxc-cutlass" "${enable_gauxc_cutlass}"
-  printf '  --%-20s = %s\n' "enable-hip" "${enable_hip}"
-  printf '  --%-20s = %s\n' "enable-opencl" "${enable_opencl}"
-  printf '  --%-20s = %s\n' "enable-cray" "${enable_cray}"
-  printf "List of effective settings after resolving package conflicts:\n"
-  for ii in ${package_list}; do
-    install_mode=$(eval "echo \${with_${ii}}")
-    printf '  --with-%-15s = %s\n' "${ii}" "${install_mode}"
-  done
+  printf '\nEnabled features:\n'
+  printf '  --%-20s = %s\n' "enable-tsan" "$(format_bool "${enable_tsan}")"
+  printf '  --%-20s = %s\n' "enable-cuda" "$(format_bool "${enable_cuda}")"
+  printf '  --%-20s = %s\n' "enable-gauxc-cutlass" "$(format_bool "${enable_gauxc_cutlass}")"
+  printf '  --%-20s = %s\n' "enable-hip" "$(format_bool "${enable_hip}")"
+  printf '  --%-20s = %s\n' "enable-opencl" "$(format_bool "${enable_opencl}")"
+  printf '  --%-20s = %s\n' "enable-cray" "$(format_bool "${enable_cray}")"
+  printf '\n'
+  print_report_group "Packages to be installed:" "${install_packages}"
+  printf '\n'
+  print_report_group "Packages to be detected from system:" "${system_packages}"
+  if [ -n "${path_packages}" ]; then
+    printf '\n'
+    print_report_group "Packages linked from user paths:" "${path_packages}"
+  fi
+  printf '\n'
+  print_report_group "Packages not used:" "${disabled_packages}"
+  printf '\n'
+}
+
+# ------------------------------------------------------------------------
+# Build packages unless dry-run mode is enabled.
+# ------------------------------------------------------------------------
+if [ "${dry_run}" = "__TRUE__" ]; then
+  printf "With --dry-run option, this script concludes with a report.\n"
+  printf "The setup, toolchain env and conf files are written to ./install.\n"
+  print_toolchain_summary
 else
   echo "Options have been parsed successfully."
+  print_toolchain_summary
   echo "Compiling with ${NPROCS_OVERWRITE} processes for target ${TARGET_CPU}."
   echo "# Leak suppressions" > "${INSTALLDIR}"/lsan.supp
   "${SCRIPTDIR}"/stage0/install_stage0.sh

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -635,7 +635,6 @@ while [ $# -ge 1 ]; do
           ;;
         *)
           report_error ${LINENO} "Non-integer argument ${2} for -j flag found."
-          exit 1
           ;;
       esac
       ;;
@@ -645,7 +644,6 @@ while [ $# -ge 1 ]; do
     --install-dir=*)
       if [[ "${1#--install-dir=}" != /* ]]; then
         report_error "The path for --install-dir must be an absolute path."
-        exit 1
       fi
       export INSTALLDIR="${1#--install-dir=}"
       ;;
@@ -683,7 +681,7 @@ while [ $# -ge 1 ]; do
           export MPI_MODE="no"
           ;;
         *)
-          report_error ${LINENO} "Invalid value for --mpi-mode found."
+          echo "ERROR: Invalid value for --mpi-mode found."
           echo "Currently only one of the following options is supported:
             openmpi, mpich, intelmpi.
 Otherwise use option no."
@@ -707,7 +705,7 @@ Otherwise use option no."
           export MATH_MODE="openblas"
           ;;
         *)
-          report_error ${LINENO} "Invalid value for --math-mode found."
+          echo "ERROR: Invalid value for --math-mode found."
           echo "Currently only one of the following options is supported:
             mkl, acml, openblas, cray."
           exit 1
@@ -721,7 +719,7 @@ Otherwise use option no."
           export GPUVER="${user_input}"
           ;;
         *)
-          report_error ${LINENO} "Invalid value for --gpu-ver found."
+          echo "ERROR: Invalid value for --gpu-ver found."
           echo "Currently only one of the following options is supported:
             K20X, K40, K80, P100, V100, A100, H100, GB10, A40, Mi50, Mi100, Mi250.
 Otherwise use option no."
@@ -741,7 +739,6 @@ Otherwise use option no."
           ;;
         *)
           report_error ${LINENO} "Non-integer ${user_input} for --log-lines."
-          exit 1
           ;;
       esac
       ;;
@@ -756,42 +753,36 @@ Otherwise use option no."
       enable_tsan=$(read_enable "${1}")
       if [ "${enable_tsan}" = "__INVALID__" ]; then
         report_error "invalid value for --enable-tsan, please use yes or no"
-        exit 1
       fi
       ;;
     --enable-cuda*)
       enable_cuda=$(read_enable "${1}")
       if [ "${enable_cuda}" = "__INVALID__" ]; then
         report_error "invalid value for --enable-cuda, please use yes or no"
-        exit 1
       fi
       ;;
     --enable-gauxc-cutlass*)
       enable_gauxc_cutlass=$(read_enable "${1}")
       if [ "${enable_gauxc_cutlass}" = "__INVALID__" ]; then
         report_error "invalid value for --enable-gauxc-cutlass, please use yes or no"
-        exit 1
       fi
       ;;
     --enable-hip*)
       enable_hip=$(read_enable "${1}")
       if [ "${enable_hip}" = "__INVALID__" ]; then
         report_error "invalid value for --enable-hip, please use yes or no"
-        exit 1
       fi
       ;;
     --enable-opencl*)
       enable_opencl=$(read_enable "${1}")
       if [ "${enable_opencl}" = "__INVALID__" ]; then
         report_error "invalid value for --enable-opencl, please use yes or no"
-        exit 1
       fi
       ;;
     --enable-cray*)
       enable_cray=$(read_enable "${1}")
       if [ "${enable_cray}" = "__INVALID__" ]; then
         report_error "invalid value for --enable-cray, please use yes or no"
-        exit 1
       fi
       ;;
     --with-gcc*)
@@ -970,7 +961,6 @@ Otherwise use option no."
     *)
       report_error ${LINENO} "Unknown flag: ${1}
 See help message of this script produced by --help option for supported ones."
-      exit 1
       ;;
   esac
   shift
@@ -1000,7 +990,6 @@ fi
 if [ "${with_amd}" != "__DONTUSE__" ]; then
   if [ "${with_intel}" != "__DONTUSE__" ]; then
     report_error ${LINENO} "The AMD and Intel compilers can't be used together."
-    exit 1
   fi
 fi
 # MPI library conflicts
@@ -1059,7 +1048,6 @@ else
         ;;
       intelmpi)
         report_error ${LINENO} "Incompatible --mpi-mode=intelmpi found."
-        exit 1
         ;;
     esac
   fi
@@ -1086,7 +1074,6 @@ else
         report_error ${LINENO} "While --mpi-mode=intelmpi is set, no Intel MPI
 could be found or linked in the system, and installation by toolchain is not
 supported. Please install manually and check executable path before rerunning."
-        exit 1
       fi
       ;;
   esac
@@ -1098,20 +1085,17 @@ if [ "${ENABLE_CUDA}" = "__TRUE__" ] || [ "${ENABLE_HIP}" = "__TRUE__" ]; then
     report_error ${LINENO} "Either CUDA or HIP is enabled, but --gpu-ver is not
 set to one of the known architectures. See help message of this script produced
 by --help option for supported ones."
-    exit 1
   fi
 fi
 
 if [ "${ENABLE_GAUXC_CUTLASS}" = "__TRUE__" ]; then
   if [ "${ENABLE_CUDA}" != "__TRUE__" ]; then
     report_error ${LINENO} "--enable-gauxc-cutlass requires --enable-cuda=yes."
-    exit 1
   fi
   case "${GPUVER}" in
     A100 | A40 | H100 | GB10) ;;
     *)
       report_error ${LINENO} "--enable-gauxc-cutlass requires CUDA compute capability >= 8.0."
-      exit 1
       ;;
   esac
   if [ "${with_gauxc}" = "__DONTUSE__" ]; then
@@ -1119,7 +1103,6 @@ if [ "${ENABLE_GAUXC_CUTLASS}" = "__TRUE__" ]; then
     with_gauxc="__INSTALL__"
   elif [ "${with_gauxc}" != "__INSTALL__" ]; then
     report_error ${LINENO} "--enable-gauxc-cutlass is only supported with --with-gauxc=install."
-    exit 1
   fi
 fi
 
@@ -1306,7 +1289,7 @@ case ${GPUVER} in
     export ARCH_NUM="no"
     ;;
   *)
-    report_error ${LINENO} "Invalid value for --gpu-ver found."
+    echo "ERROR: Invalid value for --gpu-ver found."
     echo "Currently only one of the following options is supported:
       K20X, K40, K80, P100, V100, A100, H100, A40, Mi50, Mi100, Mi250.
 Otherwise use option no."
@@ -1614,7 +1597,7 @@ print_toolchain_summary() {
 if [ "${dry_run}" = "__TRUE__" ]; then
   print_toolchain_summary
   printf "With --dry-run option, this script concludes with above report.\n"
-  printf "The setup, toolchain env and conf files are written to ./install.\n"
+  printf "The setup, toolchain env and conf files are written to %s.\n" "${INSTALLDIR}"
 else
   echo "Options have been parsed successfully."
   print_toolchain_summary

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -1514,23 +1514,28 @@ EOF
   [ "${cols}" -gt "${n}" ] && cols="${n}"
 
   rows=$(((n + cols - 1) / cols))
-  for ((row = 0; row < rows; row++)); do
+  row=0
+  while [ "${row}" -lt "${rows}" ]; do
     line="${indent}"
-    for ((col = 0; col < cols; col++)); do
+    col=0
+    while [ "${col}" -lt "${cols}" ]; do
       idx=$((row * cols + col))
-      [ "${idx}" -ge "${n}" ] && continue
-      item="${items[idx]}"
-      if [ "${col}" -lt $((cols - 1)) ]; then
-        printf -v padded '%-*s' "${col_width}" "${item}"
-        line="${line}${padded}"
-      else
-        line="${line}${item}"
+      if [ "${idx}" -lt "${n}" ]; then
+        item="${items[idx]}"
+        if [ "${col}" -lt $((cols - 1)) ]; then
+          printf -v padded '%-*s' "${col_width}" "${item}"
+          line="${line}${padded}"
+        else
+          line="${line}${item}"
+        fi
       fi
+      col=$((col + 1))
     done
     while [ "${line% }" != "${line}" ]; do
       line="${line% }"
     done
     printf '%s\n' "${line}"
+    row=$((row + 1))
   done
 }
 
@@ -1605,9 +1610,9 @@ print_toolchain_summary() {
 # Build packages unless dry-run mode is enabled.
 # ------------------------------------------------------------------------
 if [ "${dry_run}" = "__TRUE__" ]; then
-  printf "With --dry-run option, this script concludes with a report.\n"
-  printf "The setup, toolchain env and conf files are written to ./install.\n"
   print_toolchain_summary
+  printf "With --dry-run option, this script concludes with above report.\n"
+  printf "The setup, toolchain env and conf files are written to ./install.\n"
 else
   echo "Options have been parsed successfully."
   print_toolchain_summary

--- a/tools/toolchain/install_cp2k_toolchain.sh
+++ b/tools/toolchain/install_cp2k_toolchain.sh
@@ -1234,6 +1234,28 @@ if [ "${with_gauxc}" = "__INSTALL__" ]; then
   [ "${with_libtorch}" = "__DONTUSE__" ] && with_libtorch="__INSTALL__"
 fi
 
+# MKL may provide the FFTW3 interface and ScaLAPACK/BLACS. Resolve these
+# choices here so the package plan, toolchain.conf and summary stay in sync.
+if [ "${MATH_MODE}" = "mkl" ]; then
+  # Use standalone FFTW when FFTW-MPI wrappers are needed. Otherwise, use
+  # MKL's FFTW3 interface and do not install a separate FFTW package.
+  if [ "${with_libvdwxc}" != "__DONTUSE__" ] && [ "${MPI_MODE}" != "no" ]; then
+    if [ "${with_fftw}" = "__DONTUSE__" ]; then
+      report_warning ${LINENO} "libvdwxc with MPI needs FFTW-MPI wrappers; enabling FFTW."
+      with_fftw="__INSTALL__"
+    fi
+    export MKL_FFTW="no"
+  else
+    with_fftw="__DONTUSE__"
+    export MKL_FFTW="yes"
+  fi
+  # Use MKL-provided ScaLAPACK/BLACS for MPI builds.
+  if [ "${MPI_MODE}" != "no" ]; then
+    with_scalapack="__DONTUSE__"
+    export MKL_SCALAPACK="yes"
+  fi
+fi
+
 # ------------------------------------------------------------------------
 # Preliminaries
 # ------------------------------------------------------------------------
@@ -1393,6 +1415,10 @@ write_toolchain_env "${INSTALLDIR}"
 # Write toolchain config
 echo "tool_list=\"${tool_list}\"" > "${INSTALLDIR}"/toolchain.conf
 echo "mpi_mode=\"${MPI_MODE}\"" >> "${INSTALLDIR}"/toolchain.conf
+if [ "${MATH_MODE}" = "mkl" ]; then
+  echo "MKL_FFTW=\"${MKL_FFTW}\"" >> "${INSTALLDIR}"/toolchain.conf
+  echo "MKL_SCALAPACK=\"${MKL_SCALAPACK}\"" >> "${INSTALLDIR}"/toolchain.conf
+fi
 echo "ENABLE_CUDA=\"${ENABLE_CUDA}\"" >> "${INSTALLDIR}"/toolchain.conf
 echo "ENABLE_GAUXC_CUTLASS=\"${ENABLE_GAUXC_CUTLASS}\"" >> "${INSTALLDIR}"/toolchain.conf
 echo "ENABLE_HIP=\"${ENABLE_HIP}\"" >> "${INSTALLDIR}"/toolchain.conf
@@ -1407,8 +1433,8 @@ done
 
 # ------------------------------------------------------------------------
 # Print the resolved toolchain configuration in a user-friendly form. The
-# raw with_* variables are still written to toolchain.conf below, but the
-# report groups packages by what the toolchain will actually do with them.
+# raw with_* variables are written to toolchain.conf, while this report
+# groups packages by what the toolchain will actually do with them.
 # ------------------------------------------------------------------------
 
 get_effective_package_mode() {

--- a/tools/toolchain/scripts/stage0/install_amd.sh
+++ b/tools/toolchain/scripts/stage0/install_amd.sh
@@ -20,7 +20,7 @@ cd "${BUILDDIR}"
 case "${with_amd}" in
   __INSTALL__)
     echo "==================== Installing the AMD compiler ======================"
-    echo "__INSTALL__ is not supported; please install the AMD compiler manually"
+    echo "Installation of AMD compilers is not supported; please install manually"
     exit 1
     ;;
   __SYSTEM__)

--- a/tools/toolchain/scripts/stage0/install_cmake.sh
+++ b/tools/toolchain/scripts/stage0/install_cmake.sh
@@ -38,7 +38,6 @@ case "${with_cmake}" in
     else
       report_error ${LINENO} \
         "cmake installation for ARCH=${OPENBLAS_ARCH} under $(uname -s) is not supported. You can try to use the system installation using the flag --with-cmake=system instead."
-      exit 1
     fi
     pkg_install_dir="${INSTALLDIR}/cmake-${cmake_ver}"
     install_lock_file="$pkg_install_dir/install_successful"

--- a/tools/toolchain/scripts/stage0/install_intel.sh
+++ b/tools/toolchain/scripts/stage0/install_intel.sh
@@ -20,7 +20,7 @@ cd "${BUILDDIR}"
 case "${with_intel}" in
   __INSTALL__)
     echo "==================== Installing the Intel compiler ===================="
-    echo "__INSTALL__ is not supported; please install the Intel compiler manually"
+    echo "Installation of Intel compilers is not supported; please install manually"
     exit 1
     ;;
   __SYSTEM__)

--- a/tools/toolchain/scripts/stage1/install_intelmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_intelmpi.sh
@@ -21,7 +21,7 @@ cd "${BUILDDIR}"
 case "${with_intelmpi}" in
   __INSTALL__)
     echo "==================== Installing Intel MPI ===================="
-    echo '__INSTALL__ is not supported; please manually install Intel MPI'
+    echo "Installation of Intel MPI is not supported; please install manually"
     exit 1
     ;;
   __SYSTEM__)

--- a/tools/toolchain/scripts/stage2/install_acml.sh
+++ b/tools/toolchain/scripts/stage2/install_acml.sh
@@ -20,7 +20,7 @@ cd "${BUILDDIR}"
 case "$with_acml" in
   __INSTALL__)
     echo "==================== Installing ACML ===================="
-    report_error $LINENO "__INSTALL__ is not supported; please manually install ACML"
+    report_error $LINENO "Installation of ACML is not supported; please install manually"
     exit 1
     ;;
   __SYSTEM__)

--- a/tools/toolchain/scripts/stage2/install_mkl.sh
+++ b/tools/toolchain/scripts/stage2/install_mkl.sh
@@ -26,7 +26,7 @@ cd "${BUILDDIR}"
 case "${with_mkl}" in
   __INSTALL__)
     echo "==================== Installing MKL ===================="
-    report_error ${LINENO} "__INSTALL__ is not supported; please manually install Intel MKL."
+    report_error ${LINENO} "Installation of Intel MKL is not supported; please install manually."
     exit 1
     ;;
   __SYSTEM__)

--- a/tools/toolchain/scripts/stage2/install_mkl.sh
+++ b/tools/toolchain/scripts/stage2/install_mkl.sh
@@ -14,11 +14,8 @@ source "${INSTALLDIR}"/toolchain.env
 
 [ -f "${BUILDDIR}/setup_mkl" ] && rm "${BUILDDIR}/setup_mkl"
 
-MKL_FFTW="yes"
-if [ "${with_libvdwxc}" != "__DONTUSE__" ] && [ "${MPI_MODE}" != "no" ]; then
-  report_warning ${LINENO} "MKL FFTW3 interface is present, but FFTW library is needed for FFTW-MPI wrappers."
-  MKL_FFTW="no"
-fi
+MKL_FFTW="${MKL_FFTW}"
+MKL_SCALAPACK="${MKL_SCALAPACK}"
 
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
@@ -79,23 +76,23 @@ if [ "${with_mkl}" != "__DONTUSE__" ]; then
     fi
   done
 
-  case ${MPI_MODE} in
-    intelmpi | mpich)
-      mkl_scalapack_lib="IF_MPI(-lmkl_scalapack_lp64|)"
-      mkl_blacs_lib="IF_MPI(-lmkl_blacs_intelmpi_lp64|)"
-      ;;
-    openmpi)
-      mkl_scalapack_lib="IF_MPI(-lmkl_scalapack_lp64|)"
-      mkl_blacs_lib="IF_MPI(-lmkl_blacs_openmpi_lp64|)"
-      ;;
-    *)
-      echo "Not using MKL provided ScaLAPACK and BLACS"
-      mkl_scalapack_lib=""
-      mkl_blacs_lib=""
-      ;;
-  esac
+  if [ "${MKL_SCALAPACK}" = "yes" ]; then
+    mkl_scalapack_lib="IF_MPI(-lmkl_scalapack_lp64|)"
+    case ${MPI_MODE} in
+      intelmpi | mpich)
+        mkl_blacs_lib="IF_MPI(-lmkl_blacs_intelmpi_lp64|)"
+        ;;
+      openmpi)
+        mkl_blacs_lib="IF_MPI(-lmkl_blacs_openmpi_lp64|)"
+        ;;
+    esac
+  else
+    echo "Not using MKL provided ScaLAPACK and BLACS"
+    mkl_scalapack_lib=""
+    mkl_blacs_lib=""
+  fi
 
-  # set the correct lib flags from MLK link adviser
+  # set the correct lib flags from MKL link adviser
   MKL_LIBS="-L${mkl_lib_dir} -Wl,-rpath,${mkl_lib_dir} ${mkl_scalapack_lib}"
   MKL_LIBS+=" -Wl,--start-group -l${mkl_interface_lib} -lmkl_sequential -lmkl_core"
   MKL_LIBS+=" ${mkl_blacs_lib} -Wl,--end-group -lpthread -lm -ldl"
@@ -112,21 +109,16 @@ export MKL_CFLAGS="${MKL_CFLAGS}"
 export MKL_LIBS="${MKL_LIBS}"
 export MATH_CFLAGS="\${MATH_CFLAGS} ${MKL_CFLAGS}"
 export MATH_LIBS="\${MATH_LIBS} ${MKL_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} -D__MKL -D__FFTW3 IF_COVERAGE(IF_MPI(|-U__FFTW3)|)"
+export CP_DFLAGS="\${CP_DFLAGS} -D__MKL"
 EOF
-  if [ -n "${mkl_scalapack_lib}" ]; then
+  if [ "${MKL_FFTW}" = "yes" ]; then
     cat << EOF >> "${BUILDDIR}/setup_mkl"
-export with_scalapack="__DONTUSE__"
-EOF
-  fi
-  if [ "${MKL_FFTW}" != "no" ]; then
-    cat << EOF >> "${BUILDDIR}/setup_mkl"
-export with_fftw="__DONTUSE__"
 export FFTW3_INCLUDES="${MKL_CFLAGS}"
 export FFTW3_LIBS="${MKL_LIBS}"
 export FFTW_CFLAGS="${MKL_CFLAGS}"
 export FFTW_LDFLAGS="${MKL_LDFLAGS}"
 export FFTW_LIBS="${MKL_LIBS}"
+export CP_DFLAGS="\${CP_DFLAGS} -D__FFTW3 IF_COVERAGE(IF_MPI(|-U__FFTW3)|)"
 EOF
   fi
   filter_setup "${BUILDDIR}/setup_mkl" "${SETUPFILE}"

--- a/tools/toolchain/scripts/stage2/install_openblas.sh
+++ b/tools/toolchain/scripts/stage2/install_openblas.sh
@@ -65,7 +65,9 @@ case "${with_openblas}" in
           FC="${FC}" \
           PREFIX="${pkg_install_dir}" \
           > make.${OPENBLAS_LIBCORE}.log 2>&1; then
-          tail_excerpt make.${OPENBLAS_LIBCORE}.log
+          # If failed, fallback to the dynamic-arch build
+          # Not using tail_excerpt because it exits with 1
+          tail -v -n "${LOG_LINES}" make.${OPENBLAS_LIBCORE}.log
           BUILD_DYNAMIC=1
         fi
       fi

--- a/tools/toolchain/scripts/stage4/install_cosma.sh
+++ b/tools/toolchain/scripts/stage4/install_cosma.sh
@@ -24,6 +24,11 @@ source "${INSTALLDIR}"/toolchain.env
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
+# HIP-build of Tiled-MM and COSMA requires rocblas
+if [ "$with_cosma" != "__DONTUSE__" ] && [ "$ENABLE_HIP" = "__TRUE__" ]; then
+  check_lib -lrocblas "rocm"
+fi
+
 case "$with_cosma" in
   __INSTALL__)
     require_env OPENBLAS_ROOT
@@ -183,7 +188,7 @@ case "$with_cosma" in
       fi
 
       # Build HIP version.
-      if [ "$ENABLE_HIP" = "__TRUE__" ] && $(check_lib -lrocblas "rocm" &> /dev/null); then
+      if [ "$ENABLE_HIP" = "__TRUE__" ]; then
         [ -d build-hip ] && rm -rf "build-hip"
         mkdir build-hip
         cd build-hip
@@ -242,7 +247,7 @@ case "$with_cosma" in
 esac
 if [ "$with_cosma" != "__DONTUSE__" ]; then
   COSMA_LIBS="-lcosma_prefixed_pxgemm -lcosma -lcosta IF_CUDA(-lTiled-MM|)"
-  if [ "$ENABLE_HIP" = "__TRUE__" ] && $(check_lib -lrocblas "rocm" &> /dev/null); then
+  if [ "$ENABLE_HIP" = "__TRUE__" ]; then
     COSMA_LIBS+=" IF_HIP(-lTiled-MM|)"
   fi
   if [ "$with_cosma" != "__SYSTEM__" ]; then

--- a/tools/toolchain/scripts/stage4/install_libxs.sh
+++ b/tools/toolchain/scripts/stage4/install_libxs.sh
@@ -30,11 +30,9 @@ case "$with_libxs" in
       if [ -f libxs-${libxs_ver}.tar.gz ]; then
         echo "libxs-${libxs_ver}.tar.gz is found"
       else
-        if ! download_pkg_from_cp2k_org "${libxs_sha256}" "libxs-${libxs_ver}.tar.gz" 2> /dev/null; then
-          download_pkg_from_urlpath "${libxs_sha256}" "${libxs_ver}" \
-            https://codeload.github.com/hfp/libxs/tar.gz \
-            "libxs-${libxs_ver}.tar.gz"
-        fi
+        download_pkg_from_urlpath "${libxs_sha256}" "${libxs_ver}" \
+          https://codeload.github.com/hfp/libxs/tar.gz \
+          "libxs-${libxs_ver}.tar.gz"
       fi
       [ -d libxs-${libxs_ver} ] && rm -rf libxs-${libxs_ver}
       tar -xzf libxs-${libxs_ver}.tar.gz

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -37,11 +37,9 @@ EOF
       if [ -f libxsmm-${libxsmm_ver}.tar.gz ]; then
         echo "libxsmm-${libxsmm_ver}.tar.gz is found"
       else
-        if ! download_pkg_from_cp2k_org "${libxsmm_sha256}" "libxsmm-${libxsmm_ver}.tar.gz" 2> /dev/null; then
-          download_pkg_from_urlpath "${libxsmm_sha256}" "${libxsmm_ver}" \
-            https://codeload.github.com/libxsmm/libxsmm/tar.gz \
-            "libxsmm-${libxsmm_ver}.tar.gz"
-        fi
+        download_pkg_from_urlpath "${libxsmm_sha256}" "${libxsmm_ver}" \
+          https://codeload.github.com/libxsmm/libxsmm/tar.gz \
+          "libxsmm-${libxsmm_ver}.tar.gz"
       fi
       echo "Installing from scratch into ${pkg_install_dir}"
       [ -d libxsmm-${libxsmm_ver} ] && rm -rf libxsmm-${libxsmm_ver}

--- a/tools/toolchain/scripts/stage4/install_libxstream.sh
+++ b/tools/toolchain/scripts/stage4/install_libxstream.sh
@@ -37,11 +37,9 @@ case "$with_libxstream" in
       if [ -f libxstream-${libxstream_ver}.tar.gz ]; then
         echo "libxstream-${libxstream_ver}.tar.gz is found"
       else
-        if ! download_pkg_from_cp2k_org "${libxstream_sha256}" "libxstream-${libxstream_ver}.tar.gz" 2> /dev/null; then
-          download_pkg_from_urlpath "${libxstream_sha256}" "${libxstream_ver}" \
-            https://codeload.github.com/hfp/libxstream/tar.gz \
-            "libxstream-${libxstream_ver}.tar.gz"
-        fi
+        download_pkg_from_urlpath "${libxstream_sha256}" "${libxstream_ver}" \
+          https://codeload.github.com/hfp/libxstream/tar.gz \
+          "libxstream-${libxstream_ver}.tar.gz"
       fi
       [ -d libxstream-${libxstream_ver} ] && rm -rf libxstream-${libxstream_ver}
       tar -xzf libxstream-${libxstream_ver}.tar.gz

--- a/tools/toolchain/scripts/stage6/install_ace.sh
+++ b/tools/toolchain/scripts/stage6/install_ace.sh
@@ -73,7 +73,6 @@ case "$with_ace" in
     # add_include_from_paths ACE_CFLAGS "ace" $INCLUDE_PATHS
     # ACE_DFLAGS="-D__ACE"
     report_error "The system detection of Ace is not supported; please use \"--with-ace=install\"."
-    exit 1
     ;;
   __DONTUSE__) ;;
   *)

--- a/tools/toolchain/scripts/stage9/install_dbcsr.sh
+++ b/tools/toolchain/scripts/stage9/install_dbcsr.sh
@@ -30,11 +30,9 @@ case "${with_dbcsr}" in
       if [ -f dbcsr-${dbcsr_ver}.tar.gz ]; then
         echo "dbcsr-${dbcsr_ver}.tar.gz is found"
       else
-        if ! download_pkg_from_cp2k_org "${dbcsr_sha256}" "dbcsr-${dbcsr_ver}.tar.gz" 2> /dev/null; then
-          download_pkg_from_urlpath "${dbcsr_sha256}" "${dbcsr_ver}" \
-            https://codeload.github.com/cp2k/dbcsr/tar.gz \
-            "dbcsr-${dbcsr_ver}.tar.gz"
-        fi
+        download_pkg_from_urlpath "${dbcsr_sha256}" "${dbcsr_ver}" \
+          https://codeload.github.com/cp2k/dbcsr/tar.gz \
+          "dbcsr-${dbcsr_ver}.tar.gz"
       fi
       echo "Installing from scratch into ${pkg_install_dir}"
       [ -d dbcsr-${dbcsr_ver} ] && rm -rf dbcsr-${dbcsr_ver}
@@ -60,7 +58,6 @@ case "${with_dbcsr}" in
         FYPP_EXE="$(command -v fypp)"
       else
         report_error $LINENO "Failed to find the FYPP preprocessor."
-        exit 1
       fi
       mkdir build-cpu
       cd build-cpu

--- a/tools/toolchain/scripts/tool_kit.sh
+++ b/tools/toolchain/scripts/tool_kit.sh
@@ -39,12 +39,12 @@ report_error() {
     local __message="$1"
   fi
   echo "ERROR: (${SCRIPT_NAME}${__lineno}) $__message" >&2
+  exit 1
 }
 
 # error handler for line trap from set -e
 error_handler() {
   report_error "$1" "Non-zero exit code detected."
-  exit 1
 }
 
 # source a file if it exists, otherwise do nothing
@@ -333,7 +333,6 @@ require_env() {
   local __env_var="$(eval echo \"\$$__env_var_name\")"
   if [ -z "${__env_var+set}" ]; then
     report_error "requires environment variable $__env_var_name to work"
-    return 1
   fi
 }
 
@@ -357,7 +356,6 @@ check_command() {
     echo "path to ${__command} is $(real_path $(command -v ${__command}))"
   else
     report_error "Cannot find ${__command}, please check if the package ${__package} is installed or in system search path"
-    return 1
   fi
 }
 
@@ -368,7 +366,6 @@ check_dir() {
     echo "Found directory $__dir"
   else
     report_error "Cannot find $__dir"
-    return 1
   fi
 }
 
@@ -384,7 +381,6 @@ check_install() {
     echo "$(basename ${__command}) is installed as $(command -v ${__command})"
   else
     report_error "cannot find ${__command}, please check if the package ${__package} has been installed correctly"
-    return 1
   fi
 }
 
@@ -420,7 +416,6 @@ check_lib() {
     # containing the library name
     report_error \
       "ld cannot find -l$__libname, please check if $__package is installed or in system search path"
-    return 1
   else
     # if library is found, then ld will return error message about
     # not able to find _start or _main symbol
@@ -658,7 +653,6 @@ download_pkg_from_urlpath() {
   # download
   if ! eval "${__command}"; then
     report_error "failed to download ${__url}"
-    return 1
   fi
   # checksum
   if checksum "${__sha256}" "${__outfile}"; then
@@ -666,7 +660,6 @@ download_pkg_from_urlpath() {
   else
     rm -vf "${__outfile}"
     report_error "Checksum of $__filename could not be verified, abort."
-    return 1
   fi
 }
 
@@ -745,7 +738,6 @@ filter_setup() {
   # Check if setup_xxx file exists
   if [[ ! -f "$source_file" ]]; then
     report_error "File '$source_file' does not exist."
-    return 1
   fi
 
   local filename=$(basename "$source_file")

--- a/tools/toolchain/scripts/tool_kit.sh
+++ b/tools/toolchain/scripts/tool_kit.sh
@@ -55,7 +55,7 @@ load() {
 }
 
 # Take excerpt of ${LOG_LINES} lines from tail of a file, always reporting
-# its absolute path at the top
+# its absolute path at the top, and then exit with non-zero code
 tail_excerpt() {
   local __filename=$(real_path "$1")
   if [ -n "${LOG_LINES}" ]; then
@@ -64,6 +64,7 @@ tail_excerpt() {
     local __lines="$2"
   fi
   tail -v -n "${__lines}" "${__filename}"
+  exit 1
 }
 
 # A more portable command that will give the full path, removing


### PR DESCRIPTION
Replaces the raw list of resolved `--with-*` options with a clearer, categorized report that is printed in both `dry-run` and normal execution modes. Packages are grouped by whether they will be installed, detected from the system, linked from user-provided paths, or not used, while package lists are formatted compactly in columns to keep the output readable.

Also prevents `--install-all` from incorrectly marking MKL/ACML as an installable package, since they could only be detected from the system or linked from an existing installation.