### PR TITLE
Toolchain: Speed up ELPA and GauXC installation

### DIFF
--- a/tools/toolchain/scripts/stage5/elpa-2026.02.001-library-only.patch
+++ b/tools/toolchain/scripts/stage5/elpa-2026.02.001-library-only.patch
@@ -1,0 +1,11 @@
+--- a/Makefile.in	2026-03-04 17:57:56.000000000 +0000
++++ b/Makefile.in	2026-06-15 16:37:06.464630054 +0000
+@@ -43753,7 +43753,7 @@
+
+ # library with shared sources for the test files
+ noinst_LTLIBRARIES = libelpa@SUFFIX@_public.la \
+-	libelpa@SUFFIX@_private.la libelpatest@SUFFIX@.la
++	libelpa@SUFFIX@_private.la
+ libelpa@SUFFIX@_public_la_FCFLAGS = $(AM_FCFLAGS) $(FC_MODOUT)modules $(FC_MODINC)private_modules
+ libelpa@SUFFIX@_public_la_SOURCES = \
+   src/elpa.F90 \

--- a/tools/toolchain/scripts/stage5/install_elpa.sh
+++ b/tools/toolchain/scripts/stage5/install_elpa.sh
@@ -58,6 +58,9 @@ case "${with_elpa}" in
       # with long lines, and that a bunch of libs can be found
       cd elpa-${elpa_ver}
 
+      patch -l -p1 < "${SCRIPT_DIR}/stage5/elpa-${elpa_ver}-library-only.patch" \
+        > elpa_library_only.patch.log 2>&1 || tail_excerpt elpa_library_only.patch.log
+
       # Ensure a successful installation of nVidia version built with "-std=c++14" flag
       sed -i 's/creal(/__real__(/g' src/GPU/CUDA/cudaFunctions_template.h
       sed -i 's/cimag(/__imag__(/g' src/GPU/CUDA/cudaFunctions_template.h
@@ -101,7 +104,8 @@ case "${with_elpa}" in
           --libdir="${pkg_install_dir}/${TARGET}/lib" \
           --enable-openmp=${enable_openmp} \
           --enable-shared=yes \
-          --enable-static=yes \
+          --disable-static \
+          --with-test-programs=no \
           --disable-c-tests \
           --disable-cpp-tests \
           ${config_flags} \
@@ -126,7 +130,8 @@ case "${with_elpa}" in
         cd ..
       done
       cd ..
-      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage5/$(basename ${SCRIPT_NAME})"
+      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage5/$(basename ${SCRIPT_NAME})" \
+        "${SCRIPT_DIR}/stage5/elpa-${elpa_ver}-library-only.patch"
     fi
     [ "$enable_openmp" != "yes" ] && elpa_dir_openmp=""
     elpa_include="${pkg_install_dir}/IF_CUDA(nvidia|cpu)/include/elpa${elpa_dir_openmp}-${elpa_ver}"

--- a/tools/toolchain/scripts/stage6/exchcxx-disable-builtin.patch
+++ b/tools/toolchain/scripts/stage6/exchcxx-disable-builtin.patch
@@ -1,0 +1,55 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0d604c3..95140eb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,0 +14 @@ option( BUILD_SHARED_LIBS        "Build Shared Libs"            OFF )
++option( EXCHCXX_ENABLE_BUILTIN   "Enable Builtin Backend"       ON  )
+diff --git a/cmake/ExchCXXConfig.cmake.in b/cmake/ExchCXXConfig.cmake.in
+index 8897548..b7122db 100644
+--- a/cmake/ExchCXXConfig.cmake.in
++++ b/cmake/ExchCXXConfig.cmake.in
+@@ -12,0 +13 @@ set( EXCHCXX_ENABLE_DEVICE @EXCHCXX_ENABLE_DEVICE@ )
++set( EXCHCXX_ENABLE_BUILTIN @EXCHCXX_ENABLE_BUILTIN@ )
+diff --git a/include/exchcxx/exchcxx_config.hpp.in b/include/exchcxx/exchcxx_config.hpp.in
+index 37e4383..cb96182 100644
+--- a/include/exchcxx/exchcxx_config.hpp.in
++++ b/include/exchcxx/exchcxx_config.hpp.in
+@@ -51,0 +52 @@
++#cmakedefine EXCHCXX_ENABLE_BUILTIN
+diff --git a/include/exchcxx/factory/xc_kernel.hpp b/include/exchcxx/factory/xc_kernel.hpp
+index dafb2e7..5863de7 100644
+--- a/include/exchcxx/factory/xc_kernel.hpp
++++ b/include/exchcxx/factory/xc_kernel.hpp
+@@ -54,0 +55,2 @@
++#include <stdexcept>
++
+@@ -61,0 +64 @@ XCKernel libxc_kernel_factory(const std::string xc_name, const Spin polar );
++#ifdef EXCHCXX_ENABLE_BUILTIN
+@@ -62,0 +66 @@ XCKernel builtin_kernel_factory( Kernel, Spin );
++#endif
+@@ -71 +74,0 @@ static inline XCKernel kernel_factory(
+-  else
+@@ -73 +76,6 @@ static inline XCKernel kernel_factory(
+-    return builtin_kernel_factory( kern, polar );
++#ifdef EXCHCXX_ENABLE_BUILTIN
++  return builtin_kernel_factory( kern, polar );
++#else
++  (void)backend;
++  throw std::runtime_error("Builtin backend disabled");
++#endif
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index ec0adad..e12c1c4 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -5,3 +4,0 @@ set( EXCHCXX_SOURCES
+-     builtin.cxx
+-     builtin_interface.cxx
+-     builtin_kernel.cxx
+@@ -8,0 +6,7 @@ set( EXCHCXX_SOURCES
++if(EXCHCXX_ENABLE_BUILTIN)
++  list(APPEND EXCHCXX_SOURCES
++       builtin.cxx
++       builtin_interface.cxx
++       builtin_kernel.cxx
++  )
++endif()

--- a/tools/toolchain/scripts/stage6/gauxc-libxc-only-exchcxx.patch
+++ b/tools/toolchain/scripts/stage6/gauxc-libxc-only-exchcxx.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 98ef82d..df87f75 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,0 +40,5 @@ option( GAUXC_ENABLE_ONEDFT     "Enable ONEDFT Functional"    ON )
++option(
++  GAUXC_ENABLE_EXCHCXX_BUILTIN
++  "Enable ExchCXX builtin backend when ExchCXX is built by GauXC"
++  ON
++)
+diff --git a/cmake/gauxc-exchcxx.cmake b/cmake/gauxc-exchcxx.cmake
+index 412df9b..9e027c3 100644
+--- a/cmake/gauxc-exchcxx.cmake
++++ b/cmake/gauxc-exchcxx.cmake
+@@ -12 +12,2 @@ if( NOT ${ExchCXX_FOUND} )
+-  set( EXCHCXX_ENABLE_TESTS OFF               CACHE BOOL "" )
++  set( EXCHCXX_ENABLE_TESTS   OFF                            CACHE BOOL "" )
++  set( EXCHCXX_ENABLE_BUILTIN ${GAUXC_ENABLE_EXCHCXX_BUILTIN} CACHE BOOL "" )
+@@ -17 +18,2 @@ if( NOT ${ExchCXX_FOUND} )
+-    GIT_TAG        ${GAUXC_EXCHCXX_REVISION} 
++    GIT_TAG        ${GAUXC_EXCHCXX_REVISION}
++    PATCH_COMMAND  patch -p1 -i ${CMAKE_CURRENT_LIST_DIR}/exchcxx-disable-builtin.patch
+diff --git a/src/c-api/c_functional.cxx b/src/c-api/c_functional.cxx
+index d866a6c..1af44e7 100644
+--- a/src/c-api/c_functional.cxx
++++ b/src/c-api/c_functional.cxx
+@@ -72,2 +72 @@ GauXCFunctional gauxc_functional_from_string(
+-      func = functional_type( ExchCXX::Backend::builtin, ExchCXX::functional_map.value(functional_spec), 
+-        polar );
++      func = functional_type(ExchCXX::functional_map.value(functional_spec), polar);
+@@ -106,2 +105 @@ GauXCFunctional gauxc_functional_from_enum(
+-    functional_type func( ExchCXX::Backend::builtin, 
+-      static_cast<ExchCXX::Functional>(functional_enum), polar );
++    functional_type func(static_cast<ExchCXX::Functional>(functional_enum), polar);

--- a/tools/toolchain/scripts/stage6/install_gauxc.sh
+++ b/tools/toolchain/scripts/stage6/install_gauxc.sh
@@ -78,13 +78,33 @@ case "${with_gauxc}" in
       rm -rf "GauXC-${gauxc_rev}" "${pkg_install_dir}"
       tar -xzf "${gauxc_pkg}"
       cd "GauXC-${gauxc_rev}"
+
+      # CMake configuration modification
       if ! patch -l -p1 < "${SCRIPT_DIR}/stage6/gauxc-${gauxc_ver}.patch" \
         > gauxc_cp2k_rks_density_fix.patch.log 2>&1; then
         tail_excerpt gauxc_cp2k_rks_density_fix.patch.log
-        exit 1
       fi
+      install -m 0644 "${SCRIPT_DIR}/stage6/exchcxx-disable-builtin.patch" \
+        cmake/exchcxx-disable-builtin.patch
+      if ! patch -l -p1 < "${SCRIPT_DIR}/stage6/gauxc-libxc-only-exchcxx.patch" \
+        > gauxc_libxc_only_exchcxx.patch.log 2>&1; then
+        tail_excerpt gauxc_libxc_only_exchcxx.patch.log
+      fi
+
       sed -i.bak '/find_dependency.*nlohmann_json/d' cmake/gauxc-config.cmake.in
       rm -f cmake/gauxc-config.cmake.in.bak
+
+      # Regenerate Obara-Saika kernels with lower unroll threshold
+      cd src/xc_integrator/local_work_driver/host/obara_saika/generator
+      make > make.log 2>&1 || tail_excerpt make.log
+      cd ../src
+      ../generator/generate_cpu_code.x 4 4
+      perl -pi -e 's#\.\./include/#../include/cpu/#g' \
+        integral_*.cxx \
+        integral_*.hpp \
+        obara_saika_integrals.cxx
+      cd "${BUILDDIR}/GauXC-${gauxc_rev}"
+
       mkdir -p build
       cd build
 
@@ -126,28 +146,21 @@ case "${with_gauxc}" in
         -DGAUXC_ENABLE_HIP=OFF \
         -DGAUXC_ENABLE_HDF5=OFF \
         -DGAUXC_ENABLE_ONEDFT=ON \
+        -DGAUXC_ENABLE_EXCHCXX_BUILTIN=OFF \
         -DGAUXC_NLOHMANN_JSON_URL="${BUILDDIR}/${nlohmann_json_pkg}" \
         -DGAUXC_ENABLE_MAGMA=OFF \
         -DGAUXC_ENABLE_NCCL=OFF \
         -DGAUXC_ENABLE_CUTLASS="${gauxc_enable_cutlass}" \
         ${gauxc_cuda_architectures_option} \
-        .. > configure.log 2>&1 || {
-        tail_excerpt configure.log
-        exit 1
-      }
-      make -j $(get_nprocs) > make.log 2>&1 || {
-        tail_excerpt make.log
-        exit 1
-      }
-      make install > install.log 2>&1 || {
-        tail_excerpt install.log
-        exit 1
-      }
+        .. > configure.log 2>&1 || tail_excerpt configure.log
+      make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
       mkdir -p "${pkg_install_dir}/share/gauxc/onedft_models"
       install -m 0644 "${BUILDDIR}/${skala_model_pkg}" \
         "${pkg_install_dir}/share/gauxc/onedft_models/${skala_model_pkg}"
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage6/$(basename ${SCRIPT_NAME})" \
-        "${SCRIPT_DIR}/stage6/gauxc-${gauxc_ver}.patch" "${BUILDDIR}/${gauxc_pkg}" \
+        "${SCRIPT_DIR}/stage6/gauxc-${gauxc_ver}.patch" \
+        "${SCRIPT_DIR}/stage6/gauxc-libxc-only-exchcxx.patch" \
+        "${SCRIPT_DIR}/stage6/exchcxx-disable-builtin.patch" "${BUILDDIR}/${gauxc_pkg}" \
         "${BUILDDIR}/${nlohmann_json_pkg}" "${BUILDDIR}/${skala_model_pkg}"
     fi
     GAUXC_CFLAGS="-I'${pkg_install_dir}/include' -I'${pkg_install_dir}/include/gauxc/modules'"

--- a/tools/toolchain/scripts/tool_kit.sh
+++ b/tools/toolchain/scripts/tool_kit.sh
@@ -39,7 +39,7 @@ report_error() {
     local __message="$1"
   fi
   echo "ERROR: (${SCRIPT_NAME}${__lineno}) $__message" >&2
-  exit 1
+  return 1
 }
 
 # error handler for line trap from set -e


### PR DESCRIPTION
### ELPA

Build ELPA as a library-only dependency by disabling the static library and the remaining test targets.

Enabling both shared and static build causes libtool to compile many heavy kernel sources twice (PIC and non-PIC objects), and the ELPA tests are not used by the CP2K toolchain installation. Disabling static build and tests significantly reduces build time, roughly by half in local tests, without changing the shared ELPA library used by CP2K.

### GauXC

- Regenerate GauXC host Obara-Saika kernels with a lower unroll threshold. This preserves the angular-momentum coverage while replacing fully unrolled code for the largest shell pairs with the compact loop-based code path, reducing GauXC-owned compile-time hotspots such as integral_4_4.cxx.o.
- Add an opt-in Libxc-only ExchCXX path for CP2K's GauXC/SKALA build. This avoids compiling ExchCXX's expensive builtin_kernel.cxx translation unit when only the Libxc backend is needed, while keeping the default builtin backend available for full functional coverage.