### PR TITLE
Docker [Spack]: Default to system GCC and enable Rawhide ssmp testing

### DIFF
--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -961,7 +961,11 @@ if [[ ! -d "${SPACK_BUILD_PATH}" ]]; then
     if command -v python3 -m pip --version &> /dev/null; then
       python3 -m pip install "${VERBOSE_FLAG}" --upgrade pip
       echo "Installing boto3 module"
-      python3 -m pip install "${VERBOSE_FLAG}" boto3==1.38.11 google-cloud-storage==3.1.0
+      if ! python3 -m pip install "${VERBOSE_FLAG}" \
+        boto3==1.38.11 google-cloud-storage==3.1.0; then
+        echo "ERROR: The installation of Python packages for the Spack cache failed"
+        ${EXIT_CMD} 1
+      fi
     else
       echo "ERROR: python3 -m pip was not found"
       ${EXIT_CMD} 1

--- a/src/openpmd_api.F
+++ b/src/openpmd_api.F
@@ -519,44 +519,41 @@ MODULE openpmd_api
       FUNCTION openpmd_get_default_extension() RESULT(extension)
          CHARACTER(len=default_string_length)               :: extension
 
-         CHARACTER(kind=C_CHAR), POINTER                    :: c_extension
-         INTEGER(C_SIZE_T)                                  :: length_of_c_string, i
+         CHARACTER(LEN=1, KIND=C_CHAR), DIMENSION(:), &
+            POINTER                                          :: c_extension_f
+         INTEGER(C_SIZE_T)                                  :: c_extension_length, extension_length
+         INTEGER                                            :: i
+         TYPE(C_PTR)                                        :: c_extension
          INTERFACE
             FUNCTION openpmd_c_get_default_extension() RESULT(extension) &
                BIND(c, name="openPMD_get_default_extension")
-               IMPORT :: C_CHAR
-               CHARACTER(kind=C_CHAR), POINTER :: extension
+               IMPORT :: C_PTR
+               TYPE(C_PTR) :: extension
             END FUNCTION openpmd_c_get_default_extension
          END INTERFACE
          INTERFACE
             FUNCTION get_strlen(c_string) RESULT(strlen) &
                BIND(C, NAME="CP2K_strlen")
-               IMPORT :: C_CHAR, C_SIZE_T
-               CHARACTER(kind=C_CHAR), DIMENSION(*), INTENT(IN) :: c_string
+               IMPORT :: C_PTR, C_SIZE_T
+               TYPE(C_PTR), VALUE :: c_string
                INTEGER(C_SIZE_T) :: strlen
             END FUNCTION get_strlen
          END INTERFACE
 
-         c_extension => openpmd_c_get_default_extension()
+         extension = ""
+         c_extension = openpmd_c_get_default_extension()
+         IF (.NOT. C_ASSOCIATED(c_extension)) RETURN
 
-         ! Find the length of the C string
-         IF (ASSOCIATED(c_extension)) THEN
-            !c_string_array => c_extension
-            length_of_c_string = get_strlen(c_extension)
-         ELSE
-            RETURN
-         END IF
+         ! Map the C string to a Fortran character array.
+         c_extension_length = get_strlen(c_extension)
+         CALL C_F_POINTER(c_extension, c_extension_f, &
+                          shape=[INT(c_extension_length) + 1])
+         CPASSERT(c_extension_f(INT(c_extension_length) + 1) == C_NULL_CHAR)
 
-         ! Ensure we do not exceed the length of extension
-         IF (length_of_c_string > default_string_length) THEN
-            length_of_c_string = default_string_length
-         END IF
-
-         ! Copy the contents from c_extension to extension
-         extension = TRIM(ADJUSTL(TRANSFER(c_extension(1:length_of_c_string), extension)))
-
-         DO i = length_of_c_string + 1, LEN(extension)
-            extension(i:i) = ' '
+         ! Copy the contents, truncating overly long extensions.
+         extension_length = MIN(c_extension_length, INT(default_string_length, C_SIZE_T))
+         DO i = 1, INT(extension_length)
+            extension(i:i) = c_extension_f(i)
          END DO
 
       END FUNCTION openpmd_get_default_extension

--- a/src/openpmd_api.F
+++ b/src/openpmd_api.F
@@ -641,9 +641,11 @@ MODULE openpmd_api
          CHARACTER(len=*), INTENT(IN)                       :: into, from
          CLASS(mp_comm_type), INTENT(in), OPTIONAL          :: mpi_comm
          CHARACTER(:), ALLOCATABLE                          :: merged
-         CHARACTER(kind=C_CHAR), POINTER                    :: c_merged
+         CHARACTER(LEN=1, KIND=C_CHAR), DIMENSION(:), &
+            POINTER                                          :: c_merged_f
          INTEGER(C_SIZE_T)                                  :: length_of_c_string
-         TYPE(c_ptr), SAVE                                  :: comm_c = C_NULL_PTR
+         INTEGER                                            :: i
+         TYPE(C_PTR)                                        :: c_merged, comm_c
 
          INTERFACE
 ! **************************************************************************************************
@@ -662,35 +664,47 @@ MODULE openpmd_api
          INTERFACE
             FUNCTION openpmd_c_json_merge(into, from, mpi_comm) RESULT(merged) &
                BIND(C, NAME="openPMD_json_merge")
-               IMPORT :: C_CHAR, C_INT, C_PTR
+               IMPORT :: C_CHAR, C_PTR
                CHARACTER(kind=C_CHAR), DIMENSION(*) :: into, from
-               TYPE(C_PTR), value                   :: mpi_comm
-               CHARACTER(kind=C_CHAR), POINTER      :: merged
+               TYPE(C_PTR), VALUE                   :: mpi_comm
+               TYPE(C_PTR)                          :: merged
             END FUNCTION openpmd_c_json_merge
          END INTERFACE
          INTERFACE
             FUNCTION get_strlen(c_string) RESULT(strlen) &
                BIND(C, NAME="CP2K_strlen")
-               IMPORT :: C_CHAR, C_SIZE_T
-               CHARACTER(kind=C_CHAR), DIMENSION(*), INTENT(IN) :: c_string
+               IMPORT :: C_PTR, C_SIZE_T
+               TYPE(C_PTR), VALUE :: c_string
                INTEGER(C_SIZE_T) :: strlen
             END FUNCTION get_strlen
          END INTERFACE
          INTERFACE
             SUBROUTINE free(c_string) &
                BIND(C, NAME="CP2K_free")
-               IMPORT :: C_CHAR
-               CHARACTER(kind=C_CHAR), DIMENSION(*) :: c_string
+               IMPORT :: C_PTR
+               TYPE(C_PTR), VALUE :: c_string
             END SUBROUTINE free
          END INTERFACE
 
+         comm_c = C_NULL_PTR
          IF (PRESENT(mpi_comm)) THEN
             CALL cp2k_c_mpi_comm_f2c(mpi_comm%get_handle(), comm_c)
          END IF
-         c_merged => openpmd_c_json_merge(into//C_NULL_CHAR, from//C_NULL_CHAR, comm_c)
+
+         c_merged = openpmd_c_json_merge( &
+                    into//C_NULL_CHAR, from//C_NULL_CHAR, comm_c)
+         CPASSERT(C_ASSOCIATED(c_merged))
+
          length_of_c_string = get_strlen(c_merged)
-         ALLOCATE (character(length_of_c_string) :: merged)
-         merged = TRIM(ADJUSTL(TRANSFER(c_merged(1:length_of_c_string), MERGED)))
+         CALL C_F_POINTER(c_merged, c_merged_f, &
+                          shape=[INT(length_of_c_string) + 1])
+         CPASSERT(c_merged_f(INT(length_of_c_string) + 1) == C_NULL_CHAR)
+
+         ALLOCATE (CHARACTER(LEN=INT(length_of_c_string)) :: merged)
+         DO i = 1, INT(length_of_c_string)
+            merged(i:i) = c_merged_f(i)
+         END DO
+
          CALL free(c_merged)
       END FUNCTION openpmd_json_merge
 

--- a/src/start/cp2k.F
+++ b/src/start/cp2k.F
@@ -154,8 +154,10 @@ PROGRAM cp2k
 
    ! Check if binary was invoked as sopt or popt alias
    l = LEN_TRIM(command)
-   IF (command(l - 4:l) == ".sopt" .OR. command(l - 4:l) == ".popt") THEN
-      CALL omp_set_num_threads(1)
+   IF (l >= 5) THEN
+      IF (command(l - 4:l) == ".sopt" .OR. command(l - 4:l) == ".popt") THEN
+         CALL omp_set_num_threads(1)
+      END IF
    END IF
 
 #ifdef __ACCELERATE

--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -318,6 +318,12 @@ timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_rawhide-psmp_report.txt
 
+[spack-ssmp-rawhide]
+name:        Spack (ssmp, rawhide)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-ssmp-rawhide_report.txt
+
 [spack-psmp-rawhide]
 name:        Spack (psmp, rawhide)
 timeout:     170

--- a/tools/docker/Dockerfile.test_spack_openmpi-pdbg
+++ b/tools/docker/Dockerfile.test_spack_openmpi-pdbg
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     bzip2 \
     ca-certificates \
     cmake \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     git \
     gnupg \
     libssh-dev \
@@ -49,20 +49,20 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none -gv 14 -mpi openmpi  -ef openpmd
+RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi openmpi  -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv pdbg -gv 14 -gpu none -mpi openmpi -ef openpmd
+RUN ./make_cp2k.sh -cv pdbg  -gpu none -mpi openmpi -ef openpmd
 
 ###### Stage 3: Install CP2K ######
 
 FROM "${BASE_IMAGE}" AS install_cp2k
 
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/docker/Dockerfile.test_spack_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_spack_openmpi-psmp
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     bzip2 \
     ca-certificates \
     cmake \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     git \
     gnupg \
     libssh-dev \
@@ -49,20 +49,20 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 14 -mpi openmpi  -ef openpmd
+RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi openmpi  -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv psmp -gv 14 -gpu none -mpi openmpi -ef openpmd
+RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi openmpi -ef openpmd
 
 ###### Stage 3: Install CP2K ######
 
 FROM "${BASE_IMAGE}" AS install_cp2k
 
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/docker/Dockerfile.test_spack_pdbg
+++ b/tools/docker/Dockerfile.test_spack_pdbg
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     bzip2 \
     ca-certificates \
     cmake \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     git \
     gnupg \
     libssh-dev \
@@ -49,20 +49,20 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none -gv 14 -mpi mpich -ue -ef openpmd
+RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv pdbg -gv 14 -gpu none -mpi mpich -ef openpmd
+RUN ./make_cp2k.sh -cv pdbg  -gpu none -mpi mpich -ef openpmd
 
 ###### Stage 3: Install CP2K ######
 
 FROM "${BASE_IMAGE}" AS install_cp2k
 
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/docker/Dockerfile.test_spack_psmp-4x2
+++ b/tools/docker/Dockerfile.test_spack_psmp-4x2
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     bzip2 \
     ca-certificates \
     cmake \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     git \
     gnupg \
     libssh-dev \
@@ -49,20 +49,20 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 14 -mpi mpich -ue -ef openpmd
+RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv psmp -gv 14 -gpu none -mpi mpich -ef openpmd
+RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich -ef openpmd
 
 ###### Stage 3: Install CP2K ######
 
 FROM "${BASE_IMAGE}" AS install_cp2k
 
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/docker/Dockerfile.test_spack_psmp-fedora
+++ b/tools/docker/Dockerfile.test_spack_psmp-fedora
@@ -13,6 +13,7 @@ RUN dnf -qy install \
     cmake \
     g++ gcc gfortran \
     git \
+    libffi-devel \
     libtool \
     make \
     patch \

--- a/tools/docker/Dockerfile.test_spack_psmp-fedora
+++ b/tools/docker/Dockerfile.test_spack_psmp-fedora
@@ -38,13 +38,13 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 15 -mpi mpich -ue -ef openpmd
+RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv psmp -gv 15 -gpu none -mpi mpich -ef openpmd
+RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich -ef openpmd
 
 ###### Stage 3: Install CP2K ######
 

--- a/tools/docker/Dockerfile.test_spack_psmp-rawhide
+++ b/tools/docker/Dockerfile.test_spack_psmp-rawhide
@@ -38,13 +38,13 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 16 -mpi mpich -ue -ef openpmd
+RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv psmp -gv 16 -gpu none -mpi mpich -ef openpmd
+RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich -ef openpmd
 
 ###### Stage 3: Install CP2K ######
 

--- a/tools/docker/Dockerfile.test_spack_psmp-rawhide
+++ b/tools/docker/Dockerfile.test_spack_psmp-rawhide
@@ -13,6 +13,7 @@ RUN dnf -qy install \
     cmake \
     g++ gcc gfortran \
     git \
+    libffi-devel \
     libtool \
     make \
     patch \

--- a/tools/docker/Dockerfile.test_spack_sdbg
+++ b/tools/docker/Dockerfile.test_spack_sdbg
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     bzip2 \
     ca-certificates \
     cmake \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     git \
     gnupg \
     libssh-dev \
@@ -49,20 +49,20 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv sdbg -gpu none -gv 14 -mpi no -ue 
+RUN ./make_cp2k.sh -bd_only -cv sdbg -gpu none  -mpi no -ue 
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv sdbg -gv 14 -gpu none -mpi no 
+RUN ./make_cp2k.sh -cv sdbg  -gpu none -mpi no 
 
 ###### Stage 3: Install CP2K ######
 
 FROM "${BASE_IMAGE}" AS install_cp2k
 
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/docker/Dockerfile.test_spack_ssmp
+++ b/tools/docker/Dockerfile.test_spack_ssmp
@@ -13,7 +13,7 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     bzip2 \
     ca-certificates \
     cmake \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     git \
     gnupg \
     libssh-dev \
@@ -49,20 +49,20 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu none -gv 14 -mpi no -ue 
+RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu none  -mpi no -ue 
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv ssmp -gv 14 -gpu none -mpi no 
+RUN ./make_cp2k.sh -cv ssmp  -gpu none -mpi no 
 
 ###### Stage 3: Install CP2K ######
 
 FROM "${BASE_IMAGE}" AS install_cp2k
 
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    g++ g++-14 gcc gcc-14 gfortran gfortran-14 \
+    g++ gcc gfortran \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/docker/Dockerfile.test_spack_ssmp-rawhide
+++ b/tools/docker/Dockerfile.test_spack_ssmp-rawhide
@@ -13,6 +13,7 @@ RUN dnf -qy install \
     cmake \
     g++ gcc gfortran \
     git \
+    libffi-devel \
     libtool \
     make \
     patch \

--- a/tools/docker/Dockerfile.test_spack_ssmp-rawhide
+++ b/tools/docker/Dockerfile.test_spack_ssmp-rawhide
@@ -38,13 +38,13 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu none -gv 16 -mpi no -ue 
+RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu none  -mpi no -ue 
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv ssmp -gv 16 -gpu none -mpi no 
+RUN ./make_cp2k.sh -cv ssmp  -gpu none -mpi no 
 
 ###### Stage 3: Install CP2K ######
 

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -440,6 +440,14 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_rawhide-psmp
 
+[spack-ssmp-rawhide]
+display_name: Spack (ssmp, rawhide)
+tags:         weekly-afternoon
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_ssmp-rawhide
+
 [spack-psmp-rawhide]
 display_name: Spack (psmp, rawhide)
 tags:         weekly-afternoon

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -95,7 +95,6 @@ def main() -> None:
                 version="ssmp",
                 mpi_mode="no",
                 base_image="fedora:rawhide",
-                gcc_version=None,
                 testopts=testopts,
                 image_tag=f.image_tag,
             )
@@ -107,7 +106,6 @@ def main() -> None:
                 version="psmp",
                 mpi_mode="mpich",
                 base_image="fedora:rawhide",
-                gcc_version=None,
                 feature_flags="-ef openpmd",
                 testopts=testopts,
                 image_tag=f.image_tag,
@@ -120,7 +118,6 @@ def main() -> None:
                 version="psmp",
                 mpi_mode="mpich",
                 base_image="fedora:latest",
-                gcc_version=None,
                 feature_flags="-ef openpmd",
                 testopts=testopts,
                 image_tag=f.image_tag,
@@ -701,13 +698,13 @@ def install_cp2k_spack(
     version: str,
     mpi_mode: str,
     base_image: str = "ubuntu:26.04",
-    gcc_version: int | None = 14,
+    gcc_version: int | None = None,
     gpu_model: str = "none",
     feature_flags: str = "",
     testopts: str = "",
     image_tag: str = "",
 ) -> str:
-    if "fedora" in base_image:
+    if gcc_version is None or "fedora" in base_image:
         gcc_compilers = "g++ gcc gfortran"
     elif "opensuse/leap" in base_image:
         gcc_compilers = f"gcc gcc{gcc_version} gcc-c++ gcc{gcc_version}-c++ gcc-fortran gcc{gcc_version}-fortran"

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -815,6 +815,7 @@ RUN dnf -qy install \
     cmake \
     {gcc_compilers} \
     git \
+    libffi-devel \
     libtool \
     make \
     patch \

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -95,7 +95,7 @@ def main() -> None:
                 version="ssmp",
                 mpi_mode="no",
                 base_image="fedora:rawhide",
-                gcc_version=16,
+                gcc_version=None,
                 testopts=testopts,
                 image_tag=f.image_tag,
             )
@@ -107,7 +107,7 @@ def main() -> None:
                 version="psmp",
                 mpi_mode="mpich",
                 base_image="fedora:rawhide",
-                gcc_version=16,
+                gcc_version=None,
                 feature_flags="-ef openpmd",
                 testopts=testopts,
                 image_tag=f.image_tag,
@@ -120,7 +120,7 @@ def main() -> None:
                 version="psmp",
                 mpi_mode="mpich",
                 base_image="fedora:latest",
-                gcc_version=15,
+                gcc_version=None,
                 feature_flags="-ef openpmd",
                 testopts=testopts,
                 image_tag=f.image_tag,
@@ -701,7 +701,7 @@ def install_cp2k_spack(
     version: str,
     mpi_mode: str,
     base_image: str = "ubuntu:26.04",
-    gcc_version: int = 14,
+    gcc_version: int | None = 14,
     gpu_model: str = "none",
     feature_flags: str = "",
     testopts: str = "",
@@ -715,6 +715,8 @@ def install_cp2k_spack(
         gcc_compilers = f"gcc gcc-c++ gcc-fortran"
     else:
         gcc_compilers = f"g++ g++-{gcc_version} gcc gcc-{gcc_version} gfortran gfortran-{gcc_version}"
+    # Use the system GCC when no version is specified.
+    gcc_version_flag = "" if gcc_version is None else f"-gv {gcc_version}"
     # Use external packages if possible
     use_externals = "-ue"
     # Static CP2K builds use the GCC compiler built with spack
@@ -748,13 +750,13 @@ COPY . cp2k/
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-RUN ./make_cp2k.sh -bd_only -cv {version} -gpu {gpu_model} -gv {gcc_version} -mpi {mpi_mode} {use_externals} {feature_flags}
+RUN ./make_cp2k.sh -bd_only -cv {version} -gpu {gpu_model} {gcc_version_flag} -mpi {mpi_mode} {use_externals} {feature_flags}
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
 
-RUN ./make_cp2k.sh -cv {version} -gv {gcc_version} -gpu {gpu_model} -mpi {mpi_mode} {feature_flags}
+RUN ./make_cp2k.sh -cv {version} {gcc_version_flag} -gpu {gpu_model} -mpi {mpi_mode} {feature_flags}
 """
     )
     output += (


### PR DESCRIPTION
- Let the Fedora and Rawhide Spack testers use the distribution-provided GCC instead of pinning versions that may become outdated as the base images advance. The Spack Fedora test fails because cuurent system `glibc-2.43` has incompatibility with `libgomp` in `gcc-15` while Fedora 44 uses `gcc-16`.
- Add the existing Rawhide ssmp Spack tester to the dashboard.
- Report error if cache Python packages installation failed. This probably helps locating why Rawhide test fails.