### PR TITLE
Fix an erroneous loop size from #5395

### DIFF
--- a/src/motion/vibrational_analysis.F
+++ b/src/motion/vibrational_analysis.F
@@ -627,11 +627,11 @@ CONTAINS
                CALL diamat_all(Hint2, H_eigval2)
                IF (output_unit > 0) THEN
                   WRITE (output_unit, '(/,T2,"VIB| Frequencies after removal of the rotations and translations")')
-                  ! Frequency at the moment are in a.u. and the last 6 are meaningless
+                  ! Frequency at the moment are in a.u
                   WRITE (output_unit, '(/,T2,A)') "VIB| Internal  Low frequencies ---"
-                  DO i = 1, ncoord - 6, 5
+                  DO i = 1, SIZE(D, 2), 5
                      WRITE (output_unit, '(T2,A,T6,5(1X,ES14.7E2))') &
-                        "VIB|", H_eigval2(i:MIN(i + 4, ncoord - 6))
+                        "VIB|", H_eigval2(i:MIN(i + 4, SIZE(D, 2)))
                   END DO
                END IF
                Hessian = 0.0_dp


### PR DESCRIPTION
The frequencies printed just under `VIB| Internal Low frequencies ---` are from the `H_eigval2` list whose dimension is `SIZE(D, 2)`, essentially the number of vibrations which is dependent not only on `ncoord` (3*number_of_atoms) but also the `FULLY_PERIODIC` option for the rotovibrational analysis subroutine `rot_ana()` in `src/motion_utils.F` called from the main `vb_anal()`. The revision in #5395 incorrectly assumed it to be `ncoord - 6`, which is fixed here.