### PR TITLE
offload: Complete removal of libxstream from mempool

### DIFF
--- a/src/offload/offload_library.c
+++ b/src/offload/offload_library.c
@@ -98,15 +98,14 @@ int offload_get_chosen_device(void) { return chosen_device_id; }
  * \author Ole Schuett
  ******************************************************************************/
 void offload_activate_chosen_device(void) {
-  if (chosen_device_id < 0) {
-    return;
-  }
 #if defined(__OFFLOAD_CUDA)
   OFFLOAD_CHECK(cudaSetDevice(chosen_device_id));
 #elif defined(__OFFLOAD_HIP)
   OFFLOAD_CHECK(hipSetDevice(chosen_device_id));
 #elif defined(__OFFLOAD_OPENCL)
-  OFFLOAD_CHECK(libxstream_device_set_active(chosen_device_id));
+  if (chosen_device_id >= 0) {
+    OFFLOAD_CHECK(libxstream_device_set_active(chosen_device_id));
+  }
 #endif
 }
 
@@ -170,26 +169,30 @@ void offload_mem_info(size_t *free, size_t *total) {
 #endif
 }
 
+/*******************************************************************************
+ * \brief Allocate pinned memory (or simple malloc when there is no gpu)
+ ******************************************************************************/
 int offload_host_malloc(void **ptr__, const size_t size__) {
 #if defined(__OFFLOAD)
-  if (chosen_device_id >= 0) {
-    offloadMallocHost(ptr__, size__); /* checked */
-    return offloadSuccess;
-  }
-#endif
+  offloadMallocHost(ptr__, size__); /* checked */
+  return offloadSuccess;
+#else
   *ptr__ = malloc(size__);
   return EXIT_SUCCESS;
+#endif
 }
 
+/*******************************************************************************
+ * \brief free pinned memory (or simple free when there is no gpu)
+ ******************************************************************************/
 int offload_host_free(void *ptr__) {
 #if defined(__OFFLOAD)
-  if (chosen_device_id >= 0) {
-    offloadFreeHost(ptr__); /* checked */
-    return offloadSuccess;
-  }
-#endif
+  offloadFreeHost(ptr__); /* checked */
+  return offloadSuccess;
+#else
   free(ptr__);
   return EXIT_SUCCESS;
+#endif
 }
 
 // EOF

--- a/src/offload/offload_mempool.c
+++ b/src/offload/offload_mempool.c
@@ -21,18 +21,10 @@
 #include <mpi.h>
 #endif
 
-#if defined(__LIBXSTREAM)
-#include <libxstream/libxstream.h>
-#include <libxstream/libxstream_opencl.h>
-#elif defined(__LIBXS)
-#include <libxs/libxs_malloc.h>
-#endif
-
 #define OFFLOAD_MEMPOOL_PRINT(FN, MSG, OUTPUT_UNIT)                            \
   ((FN)(MSG, (int)strlen(MSG), OUTPUT_UNIT))
 #define OFFLOAD_MEMPOOL_OMPALLOC 1
 
-#if !defined(__LIBXSTREAM)
 /*******************************************************************************
  * \brief Private struct for storing a chunk of memory.
  * \author Ole Schuett
@@ -49,25 +41,26 @@ typedef struct offload_memchunk {
  ******************************************************************************/
 typedef struct offload_mempool {
   offload_memchunk_t *available_head, *allocated_head; // single-linked lists
+  uint64_t peak_size;                                  // for statistics
 } offload_mempool_t;
 
 /*******************************************************************************
  * \brief Private pools for host and device memory.
  * \author Ole Schuett
  ******************************************************************************/
-static offload_mempool_t mempool_host = {0};
-static offload_mempool_t mempool_device = {0};
+static offload_mempool_t mempool_host = {0}, mempool_device = {0};
 
 /*******************************************************************************
  * \brief Private counters for statistics.
  * \author Hans Pabst
  ******************************************************************************/
-static struct {
-  uint64_t mallocs, mempeak;
-} host_stats = {0, 0};
-static struct {
-  uint64_t mallocs, mempeak;
-} device_stats = {0, 0};
+static uint64_t host_malloc_counter = 0, device_malloc_counter = 0;
+
+/*******************************************************************************
+ * \brief Returns the larger of two given integer (missing from the C standard)
+ * \author Ole Schuett
+ ******************************************************************************/
+static inline uint64_t imax(uint64_t x, uint64_t y) { return (x > y ? x : y); }
 
 /*******************************************************************************
  * \brief Private routine for actually allocating system memory.
@@ -79,6 +72,7 @@ static void *actual_malloc(const size_t size, const bool on_device) {
   }
 
   void *memory = NULL;
+
 #if defined(__OFFLOAD)
   if (on_device) {
     offload_activate_chosen_device();
@@ -102,10 +96,10 @@ static void *actual_malloc(const size_t size, const bool on_device) {
   // Update statistics.
   if (on_device) {
 #pragma omp atomic
-    ++device_stats.mallocs;
+    ++device_malloc_counter;
   } else {
 #pragma omp atomic
-    ++host_stats.mallocs;
+    ++host_malloc_counter;
   }
 
   assert(memory != NULL);
@@ -212,6 +206,22 @@ static void *internal_mempool_malloc(offload_mempool_t *pool, const size_t size,
 }
 
 /*******************************************************************************
+ * \brief Internal routine for allocating host memory from the pool.
+ * \author Ole Schuett
+ ******************************************************************************/
+void *offload_mempool_host_malloc(const size_t size) {
+  return internal_mempool_malloc(&mempool_host, size, false);
+}
+
+/*******************************************************************************
+ * \brief Internal routine for allocating device memory from the pool
+ * \author Ole Schuett
+ ******************************************************************************/
+void *offload_mempool_device_malloc(const size_t size) {
+  return internal_mempool_malloc(&mempool_device, size, true);
+}
+
+/*******************************************************************************
  * \brief Private routine for releasing memory back to the pool.
  * \author Ole Schuett
  ******************************************************************************/
@@ -222,76 +232,21 @@ static void internal_mempool_free(offload_mempool_t *pool, const void *mem) {
 
 #pragma omp critical(offload_mempool_modify)
   {
+    // Find chunk in allocated list.
     offload_memchunk_t **indirect = &pool->allocated_head;
     while (*indirect != NULL && (*indirect)->mem != mem) {
       indirect = &(*indirect)->next;
     }
     offload_memchunk_t *chunk = *indirect;
     assert(chunk != NULL && chunk->mem == mem);
+
+    // Remove chunk from allocated list.
     *indirect = chunk->next;
+
+    // Add chunk to available list.
     chunk->next = pool->available_head;
     pool->available_head = chunk;
   }
-}
-
-/*******************************************************************************
- * \brief Private routine for freeing all memory in the pool.
- * \author Ole Schuett and Hans Pabst
- ******************************************************************************/
-static void internal_mempool_clear(offload_mempool_t *pool,
-                                   const bool on_device) {
-#pragma omp critical(offload_mempool_modify)
-  {
-    assert(pool->allocated_head == NULL);
-    while (pool->available_head != NULL) {
-      offload_memchunk_t *chunk = pool->available_head;
-      pool->available_head = chunk->next;
-      actual_free(chunk->mem, on_device);
-      free(chunk);
-    }
-  }
-}
-
-/*******************************************************************************
- * \brief Private routine for summing alloc sizes of all chunks in given list.
- * \author Ole Schuett and Hans Pabst
- ******************************************************************************/
-static uint64_t sum_chunks_size(const offload_memchunk_t *head, size_t offset) {
-  uint64_t result = 0;
-  for (const offload_memchunk_t *chunk = head; chunk != NULL;
-       chunk = chunk->next) {
-    result += *(const size_t *)((const char *)chunk + offset);
-  }
-  return result;
-}
-#endif /* !defined(__LIBXSTREAM) */
-
-/*******************************************************************************
- * \brief Internal routine for allocating host memory from the pool.
- * \author Ole Schuett
- ******************************************************************************/
-void *offload_mempool_host_malloc(const size_t size) {
-#if defined(__LIBXSTREAM)
-  return libxs_malloc(libxstream_opencl_config.pool_hst, size,
-                      LIBXS_MALLOC_AUTO);
-#else
-  return internal_mempool_malloc(&mempool_host, size, false);
-#endif
-}
-
-/*******************************************************************************
- * \brief Internal routine for allocating device memory from the pool
- * \author Ole Schuett
- ******************************************************************************/
-void *offload_mempool_device_malloc(const size_t size) {
-#if defined(__LIBXSTREAM)
-  void *memory = NULL;
-  const int result = libxstream_mem_allocate(&memory, size);
-  assert(EXIT_SUCCESS == result);
-  return memory;
-#else
-  return internal_mempool_malloc(&mempool_device, size, true);
-#endif
 }
 
 /*******************************************************************************
@@ -299,11 +254,7 @@ void *offload_mempool_device_malloc(const size_t size) {
  * \author Ole Schuett
  ******************************************************************************/
 void offload_mempool_host_free(const void *memory) {
-#if defined(__LIBXSTREAM)
-  libxs_free((void *)memory);
-#else
   internal_mempool_free(&mempool_host, memory);
-#endif
 }
 
 /*******************************************************************************
@@ -311,39 +262,70 @@ void offload_mempool_host_free(const void *memory) {
  * \author Ole Schuett
  ******************************************************************************/
 void offload_mempool_device_free(const void *memory) {
-#if defined(__LIBXSTREAM)
-  const int result = libxstream_mem_deallocate((void *)memory);
-  assert(EXIT_SUCCESS == result);
-#else
   internal_mempool_free(&mempool_device, memory);
-#endif
+}
+
+/*******************************************************************************
+ * \brief Private routine for freeing all memory in the pool.
+ * \author Ole Schuett
+ ******************************************************************************/
+static void internal_mempool_clear(offload_mempool_t *pool,
+                                   const bool on_device) {
+
+#pragma omp critical(offload_mempool_modify)
+  {
+    uint64_t pool_size = 0;
+
+    // Check for leaks, i.e. that the allocated list is empty.
+    assert(pool->allocated_head == NULL);
+
+    // Free all chunks in available list.
+    while (pool->available_head != NULL) {
+      offload_memchunk_t *chunk = pool->available_head;
+      pool->available_head = chunk->next; // remove chunk
+      actual_free(chunk->mem, on_device);
+      pool_size += chunk->size;
+      free(chunk);
+    }
+
+    // Update stats.
+    pool->peak_size = imax(pool->peak_size, pool_size);
+  }
 }
 
 /*******************************************************************************
  * \brief Internal routine for freeing all memory in the pool.
- * \author Ole Schuett
+ * \author Ole Schuett and Hans Pabst
  ******************************************************************************/
 void offload_mempool_clear(void) {
-#if defined(__LIBXSTREAM)
-  (void)0;
-#else
-  {
-    const uint64_t hsize = sum_chunks_size(mempool_host.available_head,
-                                           offsetof(offload_memchunk_t, size)) +
-                           sum_chunks_size(mempool_host.allocated_head,
-                                           offsetof(offload_memchunk_t, size));
-    const uint64_t dsize = sum_chunks_size(mempool_device.available_head,
-                                           offsetof(offload_memchunk_t, size)) +
-                           sum_chunks_size(mempool_device.allocated_head,
-                                           offsetof(offload_memchunk_t, size));
-    if (host_stats.mempeak < hsize)
-      host_stats.mempeak = hsize;
-    if (device_stats.mempeak < dsize)
-      device_stats.mempeak = dsize;
-  }
   internal_mempool_clear(&mempool_host, false);
   internal_mempool_clear(&mempool_device, true);
-#endif
+}
+
+/*******************************************************************************
+ * \brief Private routine for summing alloc sizes of all chunks in given list.
+ * \author Ole Schuett
+ ******************************************************************************/
+static uint64_t sum_chunks_size(const offload_memchunk_t *head) {
+  uint64_t size_sum = 0;
+  for (const offload_memchunk_t *chunk = head; chunk != NULL;
+       chunk = chunk->next) {
+    size_sum += chunk->size;
+  }
+  return size_sum;
+}
+
+/*******************************************************************************
+ * \brief Private routine for summing used sizes of all chunks in given list.
+ * \author Ole Schuett
+ ******************************************************************************/
+static uint64_t sum_chunks_used(const offload_memchunk_t *head) {
+  uint64_t used_sum = 0;
+  for (const offload_memchunk_t *chunk = head; chunk != NULL;
+       chunk = chunk->next) {
+    used_sum += chunk->used;
+  }
+  return used_sum;
 }
 
 /*******************************************************************************
@@ -354,61 +336,20 @@ void offload_mempool_stats_get(offload_mempool_stats_t *memstats) {
   assert(NULL != memstats);
 #pragma omp critical(offload_mempool_modify)
   {
-#if defined(__LIBXSTREAM)
-    if (NULL != libxstream_opencl_config.pool_hst) {
-      libxs_malloc_pool_info_t info;
-      libxs_malloc_pool_info(libxstream_opencl_config.pool_hst, &info);
-      memstats->host_mallocs = info.nmallocs;
-      memstats->host_used = info.used;
-      memstats->host_size = info.size;
-      memstats->host_peak = info.peak;
-    } else {
-      memstats->host_mallocs = 0;
-      memstats->host_used = 0;
-      memstats->host_size = 0;
-      memstats->host_peak = 0;
-    }
-    if (NULL != libxstream_opencl_config.pool_dev) {
-      libxs_malloc_pool_info_t info;
-      libxs_malloc_pool_info(libxstream_opencl_config.pool_dev, &info);
-      memstats->device_mallocs = info.nmallocs;
-      memstats->device_used = info.used;
-      memstats->device_size = info.size;
-      memstats->device_peak = info.peak;
-    } else {
-      memstats->device_mallocs = 0;
-      memstats->device_used = 0;
-      memstats->device_size = 0;
-      memstats->device_peak = 0;
-    }
-#else
-    memstats->host_mallocs = host_stats.mallocs;
-    memstats->host_used = sum_chunks_size(mempool_host.available_head,
-                                          offsetof(offload_memchunk_t, used)) +
-                          sum_chunks_size(mempool_host.allocated_head,
-                                          offsetof(offload_memchunk_t, used));
-    memstats->host_size = sum_chunks_size(mempool_host.available_head,
-                                          offsetof(offload_memchunk_t, size)) +
-                          sum_chunks_size(mempool_host.allocated_head,
-                                          offsetof(offload_memchunk_t, size));
-    memstats->host_peak = memstats->host_size < host_stats.mempeak
-                              ? host_stats.mempeak
-                              : memstats->host_size;
-    memstats->device_mallocs = device_stats.mallocs;
-    memstats->device_used =
-        sum_chunks_size(mempool_device.available_head,
-                        offsetof(offload_memchunk_t, used)) +
-        sum_chunks_size(mempool_device.allocated_head,
-                        offsetof(offload_memchunk_t, used));
-    memstats->device_size =
-        sum_chunks_size(mempool_device.available_head,
-                        offsetof(offload_memchunk_t, size)) +
-        sum_chunks_size(mempool_device.allocated_head,
-                        offsetof(offload_memchunk_t, size));
-    memstats->device_peak = memstats->device_size < device_stats.mempeak
-                                ? device_stats.mempeak
-                                : memstats->device_size;
-#endif
+    memstats->host_mallocs = host_malloc_counter;
+    memstats->host_used = sum_chunks_used(mempool_host.available_head) +
+                          sum_chunks_used(mempool_host.allocated_head);
+    memstats->host_size = sum_chunks_size(mempool_host.available_head) +
+                          sum_chunks_size(mempool_host.allocated_head);
+    memstats->host_peak = imax(mempool_host.peak_size, memstats->device_size);
+
+    memstats->device_mallocs = device_malloc_counter;
+    memstats->device_used = sum_chunks_used(mempool_device.available_head) +
+                            sum_chunks_used(mempool_device.allocated_head);
+    memstats->device_size = sum_chunks_size(mempool_device.available_head) +
+                            sum_chunks_size(mempool_device.allocated_head);
+    memstats->device_peak =
+        imax(mempool_device.peak_size, memstats->device_size);
   }
 }
 


### PR DESCRIPTION
This completes the removal of libxstream from the mempool that was started by #5406.


~~This rolls back all the changes in `src/offload/` from #5343.~~
