### PR TITLE
Fix MKL target selection for Intel-threaded BLAS

### DIFF
--- a/cmake/modules/FindMKL.cmake
+++ b/cmake/modules/FindMKL.cmake
@@ -375,19 +375,12 @@ if(MKL_FOUND)
     set(BLAS_mkl_INTFACE "intel")
   endif()
 
-  if(CP2K_BLAS_THREADING MATCHES "thread|gnu-thread")
-    set(BLAS_mkl_thread__ "omp")
-  endif()
-
-  if(CP2K_BLAS_THREADING MATCHES "sequential")
+  if(CP2K_BLAS_THREADING STREQUAL "sequential")
     set(BLAS_mkl_thread__ "seq")
-  endif()
-
-  if(CP2K_BLAS_THREADING MATCHES "intel-thread")
-    set(BLAS_mkl_thread__ "intel")
-  endif()
-
-  if(CP2K_BLAS_THREADING MATCHES "tbb")
+  elseif(CP2K_BLAS_THREADING MATCHES
+         "^(thread|gnu-thread|intel-thread|openmp)$")
+    set(BLAS_mkl_thread__ "omp")
+  elseif(CP2K_BLAS_THREADING STREQUAL "tbb-thread")
     set(BLAS_mkl_thread__ "tbb")
   endif()
 


### PR DESCRIPTION
PR #5343 made `intel-thread` the default BLAS threading mode for Intel compilers. However, FindMKL only creates `seq`, `omp`, and `tbb` target variants, while `intel-thread` was incorrectly mapped to the non-existent `intel` suffix. This PR maps all OpenMP-backed MKL modes, including `intel-thread`, to the existing `omp` target variant.