### PR TITLE
benchmarks: Add IGNORE_CONVERGENCE_FAILURE to w64PBE.inp

### DIFF
--- a/benchmarks/QS_reference/w64PBE.inp
+++ b/benchmarks/QS_reference/w64PBE.inp
@@ -31,6 +31,7 @@
     &END QS
     &SCF
       EPS_SCF 1.E-7
+      IGNORE_CONVERGENCE_FAILURE
       MAX_SCF 10
       SCF_GUESS ATOMIC
       &OT ON


### PR DESCRIPTION
...to restore the [CUDA performance test](https://dashboard.cp2k.org/archive/perf-cuda-volta/index.html).