### PR TITLE
Toolchain cleanup: Remove unused flags (stage7-9)

### DIFF
--- a/tools/toolchain/scripts/stage7/install_fmt.sh
+++ b/tools/toolchain/scripts/stage7/install_fmt.sh
@@ -20,7 +20,7 @@ source "${INSTALLDIR}"/toolchain.env
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
-case "$with_fmt" in
+case "${with_fmt}" in
   __INSTALL__)
     echo "==================== Installing fmt ===================="
     pkg_install_dir="${INSTALLDIR}/fmt-${fmt_ver}"
@@ -33,8 +33,7 @@ case "$with_fmt" in
       [ -d fmt-${fmt_ver} ] && rm -rf fmt-${fmt_ver}
       unzip -q fmt-${fmt_ver}.zip
       cd fmt-${fmt_ver}
-      mkdir build
-      cd build
+      mkdir -p build && cd build
       cmake .. \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_INSTALL_LIBDIR="lib" \
@@ -49,6 +48,7 @@ case "$with_fmt" in
   __SYSTEM__)
     echo "==================== Finding fmt from system paths ===================="
     check_lib -lfmt "fmt"
+    pkg_install_dir="$(dirname $(dirname $(find_in_paths "libfmt.*" $LIB_PATHS)))"
     ;;
   __DONTUSE__)
     # Nothing to do
@@ -56,7 +56,9 @@ case "$with_fmt" in
   *)
     echo "==================== Linking fmt to user paths ===================="
     pkg_install_dir="${with_fmt}"
-    check_dir "${pkg_install_dir}/lib"
+    fmt_LIBDIR="${pkg_install_dir}/lib/MiMiC"
+    [ -d "${pkg_install_dir}/lib64" ] && fmt_LIBDIR="${pkg_install_dir}/lib64/MiMiC"
+    check_dir "${fmt_LIBDIR}"
     check_dir "${pkg_install_dir}/include"
     ;;
 esac

--- a/tools/toolchain/scripts/stage7/install_hdf5.sh
+++ b/tools/toolchain/scripts/stage7/install_hdf5.sh
@@ -36,7 +36,10 @@ case "$with_hdf5" in
       mkdir build
       cd build
       # Add "-DHDF5_ENABLE_ZLIB_SUPPORT=ON" because HDF5 2.x doesn't enable ZLIB support by default
-      CMAKE_OPTIONS="-DBUILD_TESTING=OFF -DHDF5_BUILD_FORTRAN=ON -DHDF5_ENABLE_ZLIB_SUPPORT=ON"
+      CMAKE_OPTIONS="-DBUILD_TESTING=OFF -DHDF5_BUILD_FORTRAN=ON"
+      if [ "$(find_in_paths "libz.*" $LIB_PATHS)" != "__FALSE__" ]; then
+        CMAKE_OPTIONS="${CMAKE_OPTIONS} -DHDF5_ENABLE_ZLIB_SUPPORT=ON"
+      fi
       if [ "$(find_in_paths "libsz.*" $LIB_PATHS)" != "__FALSE__" ]; then
         CMAKE_OPTIONS="${CMAKE_OPTIONS} -DHDF5_ENABLE_SZIP_SUPPORT=ON"
       fi
@@ -51,25 +54,11 @@ case "$with_hdf5" in
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename ${SCRIPT_NAME})"
     fi
-    HDF5_CFLAGS="-I${pkg_install_dir}/include"
-    HDF5_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding HDF5 from system paths ===================="
     check_command pkg-config --modversion hdf5
     pkg_install_dir=$(h5cc -showconfig | grep "Installation point" | awk '{print $3}')
-    if [ -d ${pkg_install_dir}/include ]; then
-      HDF5_INCLUDE_DIR=${pkg_install_dir}/include
-    else
-      HDF5_INCLUDE_DIR=${pkg_install_dir}
-    fi
-    HDF5_CFLAGS="-I${HDF5_INCLUDE_DIR}"
-    if [ -d ${pkg_install_dir}/lib ]; then
-      HDF5_LIB_DIR=${pkg_install_dir}/lib
-    else
-      HDF5_LIB_DIR=${pkg_install_dir}
-    fi
-    HDF5_LDFLAGS="-L'${HDF5_LIB_DIR}' -Wl,-rpath,'${HDF5_LIB_DIR}'"
     ;;
   __DONTUSE__)
     # Nothing to do
@@ -77,54 +66,25 @@ case "$with_hdf5" in
   *)
     echo "==================== Linking HDF5 to user paths ===================="
     pkg_install_dir="${with_hdf5}"
-    check_dir "${pkg_install_dir}/lib"
+    HDF5_LIBDIR="${pkg_install_dir}/lib/MiMiC"
+    [ -d "${pkg_install_dir}/lib64" ] && HDF5_LIBDIR="${pkg_install_dir}/lib64/MiMiC"
+    check_dir "${HDF5_LIBDIR}"
     check_dir "${pkg_install_dir}/include"
-    HDF5_CFLAGS="-I'${pkg_install_dir}/include'"
-    HDF5_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "${with_hdf5}" != "__DONTUSE__" ]; then
   if [ "${with_hdf5}" != "__SYSTEM__" ]; then
-    # Prefer static libraries if available
-    if [ -f "${pkg_install_dir}/lib/libhdf5.a" ]; then
-      HDF5_LIBS="-l:libhdf5_fortran.a -l:libhdf5_f90cstub.a -l:libhdf5.a -lz"
-    else
-      HDF5_LIBS="-lhdf5_fortran -lhdf5_f90cstub -lhdf5 -lz"
-    fi
-    if [ -n "$(grep "lsz" ${pkg_install_dir}/lib/pkgconfig/hdf5.pc)" ]; then
-      HDF5_LIBS="${HDF5_LIBS} -lsz"
-    fi
     cat << EOF > "${BUILDDIR}/setup_hdf5"
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path CPATH "${pkg_install_dir}/include"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
-  else
-    if [ -f "${pkg_install_dir}/lib/libhdf5.a" ]; then
-      HDF5_LIBS="-l:libhdf5_fortran.a -l:libhdf5_hl.a -l:libhdf5.a -lz"
-    else
-      HDF5_LIBS="-lhdf5_fortran -lhdf5_hl -lhdf5 -lz"
-    fi
-    if [ -n "$(grep "lsz" ${pkg_install_dir}/lib/pkgconfig/hdf5.pc)" ] ||
-      [ -n "$(grep "lsz" ${pkg_install_dir}/lib/libhdf5.settings)" ]; then
-      HDF5_LIBS="${HDF5_LIBS} -lsz"
-    fi
   fi
   cat << EOF >> "${BUILDDIR}/setup_hdf5"
 export HDF5_VER="${hdf5_ver}"
-export HDF5_CFLAGS="${HDF5_CFLAGS}"
-export HDF5_LDFLAGS="${HDF5_LDFLAGS}"
-export CP_DFLAGS="\${CP_DFLAGS} -D__HDF5"
-export CP_CFLAGS="\${CP_CFLAGS} ${HDF5_CFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${HDF5_LDFLAGS}"
-export CP_LIBS="${HDF5_LIBS} \${CP_LIBS}"
 export HDF5_ROOT="${pkg_install_dir}"
-export HDF5_LIBRARIES="${HDF5_LIBS}"
-export HDF5_HL_LIBRARIES="${HDF5_LIBS}"
-export HDF5_INCLUDE_DIRS="${pkg_install_dir}/include"
 EOF
   filter_setup "${BUILDDIR}/setup_hdf5" "${SETUPFILE}"
 fi

--- a/tools/toolchain/scripts/stage7/install_libfci.sh
+++ b/tools/toolchain/scripts/stage7/install_libfci.sh
@@ -25,8 +25,6 @@ case "$with_libfci" in
 
   __INSTALL__)
     echo "==================== Installing libfci ===================="
-    require_env MATH_LIBS
-
     pkg_install_dir="${INSTALLDIR}/libfci-${libfci_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
     if verify_checksums "${install_lock_file}"; then

--- a/tools/toolchain/scripts/stage7/install_libsmeagol.sh
+++ b/tools/toolchain/scripts/stage7/install_libsmeagol.sh
@@ -56,8 +56,6 @@ case "${with_libsmeagol}" in
       mkdir ${pkg_install_dir}/include && cp obj/*.mod ${pkg_install_dir}/include
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename ${SCRIPT_NAME})"
     fi
-    LIBSMEAGOL_CFLAGS="-I${pkg_install_dir}/include"
-    LIBSMEAGOL_LDFLAGS="-L${pkg_install_dir}/lib -Wl,-rpath,${pkg_install_dir}/lib"
     ;;
   __SYSTEM__)
     echo "==================== Finding libsmeagol from system paths ===================="
@@ -70,14 +68,12 @@ case "${with_libsmeagol}" in
     pkg_install_dir="${with_libsmeagol}"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/obj"
-    LIBSMEAGOL_CFLAGS="-I'${pkg_install_dir}/obj'"
-    LIBSMEAGOL_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 
 if [ "${with_libsmeagol}" != "__DONTUSE__" ]; then
-  LIBSMEAGOL_LIBS="-l:libsmeagol.a"
   cat << EOF > "${BUILDDIR}/setup_libsmeagol"
+export LIBSMEAGOL_ROOT="${pkg_install_dir}"
 export LIBSMEAGOL_VER="${libsmeagol_ver}"
 EOF
   if [ "${with_libsmeagol}" != "__SYSTEM__" ]; then
@@ -85,21 +81,9 @@ EOF
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path CPATH "${pkg_install_dir}/include"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
-  # libsmeagol depends on an MPI library. In its current state libsmeagol cannot be linked with a non-MPI code.
-  cat << EOF >> "${BUILDDIR}/setup_libsmeagol"
-export LIBSMEAGOL_CFLAGS="${LIBSMEAGOL_CFLAGS}"
-export LIBSMEAGOL_LDFLAGS="${LIBSMEAGOL_LDFLAGS}"
-export LIBSMEAGOL_LIBS="${LIBSMEAGOL_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__SMEAGOL|)"
-export CP_CFLAGS="\${CP_CFLAGS} IF_MPI(${LIBSMEAGOL_CFLAGS}|)"
-export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${LIBSMEAGOL_LDFLAGS}|)"
-export CP_LIBS="IF_MPI(${LIBSMEAGOL_LIBS}|) \${CP_LIBS}"
-export LIBSMEAGOL_ROOT="${pkg_install_dir}"
-EOF
   filter_setup "${BUILDDIR}/setup_libsmeagol" "${SETUPFILE}"
 fi
 

--- a/tools/toolchain/scripts/stage7/install_libvdwxc.sh
+++ b/tools/toolchain/scripts/stage7/install_libvdwxc.sh
@@ -32,7 +32,7 @@ case "$with_libvdwxc" in
 
     echo "==================== Installing libvdwxc ===================="
     pkg_install_dir="${INSTALLDIR}/libvdwxc-${libvdwxc_ver}"
-    install_lock_file="$pkg_install_dir/install_successful"
+    install_lock_file="${pkg_install_dir}/install_successful"
     if verify_checksums "${install_lock_file}"; then
       echo "libvdwxc-${libvdwxc_ver} is already installed, skipping it."
     else
@@ -72,48 +72,37 @@ case "$with_libvdwxc" in
       make install > install.log 2>&1 || tail_excerpt install.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename ${SCRIPT_NAME})"
     fi
-    LIBVDWXC_CFLAGS="-I${pkg_install_dir}/include"
-    LIBVDWXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding libvdwxc from system paths ===================="
-    check_command pkg-config --modversion libvdwxc
-    add_include_from_paths LIBVDWXC_CFLAGS "vdwxc.h" $INCLUDE_PATHS
-    add_lib_from_paths LIBVDWXC_LDFLAGS "libvdwxc*" $LIB_PATHS
+    check_lib -lvdwxc "libvdwxc"
+    pkg_install_dir="$(dirname $(dirname $(find_in_paths "libvdwxc.*" $LIB_PATHS)))"
     ;;
   __DONTUSE__)
     # Nothing to do
     ;;
   *)
     echo "==================== Linking libvdwxc to user paths ===================="
-    pkg_install_dir="$with_libvdwxc"
-    check_dir "$pkg_install_dir/lib"
-    check_dir "$pkg_install_dir/include"
-    LIBVDWXC_CFLAGS="-I'${pkg_install_dir}/include'"
-    LIBVDWXC_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
+    pkg_install_dir="${with_libvdwxc}"
+    VDWXC_LIBDIR="${pkg_install_dir}/lib"
+    [ -d "${pkg_install_dir}/lib64" ] && VDWXC_LIBDIR="${pkg_install_dir}/lib64"
+    check_dir "${VDWXC_LIBDIR}"
+    check_dir "${pkg_install_dir}/include"
     ;;
 esac
 if [ "$with_libvdwxc" != "__DONTUSE__" ]; then
-  LIBVDWXC_LIBS="-lvdwxc"
   if [ "$with_libvdwxc" != "__SYSTEM__" ]; then
     cat << EOF > "${BUILDDIR}/setup_libvdwxc"
-prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
-prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path CPATH "$pkg_install_dir/include"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_libvdwxc"
 export LIBVDWXC_VER="${libvdwxc_ver}"
-export LIBVDWXC_CFLAGS="-I${pkg_install_dir}/include ${LIBVDWXC_CFLAGS}"
-export LIBVDWXC_LDFLAGS="${LIBVDWXC_LDFLAGS}"
-export LIBVDWXC_LIBS="${LIBVDWXC_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__LIBVDWXC|)"
-export CP_CFLAGS="\${CP_CFLAGS} IF_MPI(${LIBVDWXC_CFLAGS}|)"
-export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(${LIBVDWXC_LDFLAGS}|)"
-export CP_LIBS="IF_MPI(${LIBVDWXC_LIBS}|) \${CP_LIBS}"
+export LIBVDWXC_ROOT="${pkg_install_dir}"
 export VDWXC_ROOT="${pkg_install_dir}"
 EOF
   filter_setup "${BUILDDIR}/setup_libvdwxc" "${SETUPFILE}"

--- a/tools/toolchain/scripts/stage7/install_libvori.sh
+++ b/tools/toolchain/scripts/stage7/install_libvori.sh
@@ -44,42 +44,33 @@ case "${with_libvori:=__INSTALL__}" in
         -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         .. > cmake.log 2>&1 || tail_excerpt cmake.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . > build.log 2>&1 || tail_excerpt build.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . --target test > test.log 2>&1 || tail_excerpt test.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . --target install > install.log 2>&1 || tail_excerpt install.log
-
+      make -j "$(get_nprocs)" install > make.log 2>&1 || tail_excerpt make.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename "${SCRIPT_NAME}")"
     fi
-    LIBVORI_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding libvori from system paths ===================="
     check_lib -lvori "libvori"
-    add_lib_from_paths LIBVORI_LDFLAGS "libvori.*" "$LIB_PATHS"
+    pkg_install_dir="$(dirname $(dirname $(find_in_paths "libvori.*" $LIB_PATHS)))"
     ;;
   __DONTUSE__) ;;
 
   *)
     echo "==================== Linking libvori to user paths ===================="
     pkg_install_dir="${with_libvori}"
-
     # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
     LIBVORI_LIBDIR="${pkg_install_dir}/lib"
     [ -d "${pkg_install_dir}/lib64" ] && LIBVORI_LIBDIR="${pkg_install_dir}/lib64"
-
     check_dir "${LIBVORI_LIBDIR}"
-    LIBVORI_LDFLAGS="-L'${LIBVORI_LIBDIR}' -Wl,-rpath,'${LIBVORI_LIBDIR}'"
     ;;
 esac
 
 if [ "$with_libvori" != "__DONTUSE__" ]; then
-  LIBVORI_LIBS="-lvori -lstdc++"
   if [ "$with_libvori" != "__SYSTEM__" ]; then
     cat << EOF > "${BUILDDIR}/setup_libvori"
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-export LIBVORI_LIBS="${LIBVORI_LIBS}"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF
@@ -87,11 +78,6 @@ EOF
   cat << EOF >> "${BUILDDIR}/setup_libvori"
 export LIBVORI_VER="${libvori_ver}"
 export LIBVORI_ROOT="${pkg_install_dir}"
-export LIBVORI_LDFLAGS="${LIBVORI_LDFLAGS}"
-export LIBVORI_LIBRARY="-lvori"
-export CP_DFLAGS="\${CP_DFLAGS} -D__LIBVORI"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${LIBVORI_LDFLAGS}"
-export CP_LIBS="\${CP_LIBS} ${LIBVORI_LIBS}"
 EOF
   filter_setup "${BUILDDIR}/setup_libvori" "${SETUPFILE}"
 fi

--- a/tools/toolchain/scripts/stage7/install_spglib.sh
+++ b/tools/toolchain/scripts/stage7/install_spglib.sh
@@ -23,7 +23,7 @@ case "$with_spglib" in
   __INSTALL__)
     echo "==================== Installing Spglib ===================="
     pkg_install_dir="${INSTALLDIR}/spglib-${spglib_ver}"
-    install_lock_file="$pkg_install_dir/install_successful"
+    install_lock_file="${pkg_install_dir}/install_successful"
     if verify_checksums "${install_lock_file}"; then
       echo "spglib-${spglib_ver} is already installed, skipping it."
     else
@@ -45,55 +45,39 @@ case "$with_spglib" in
         -DSPGLIB_WITH_Fortran=ON \
         -DSPGLIB_WITH_TESTS=OFF \
         .. > configure.log 2>&1 || tail_excerpt configure.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-      make install > install.log 2>&1 || tail_excerpt install.log
+      make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage7/$(basename ${SCRIPT_NAME})"
-    fi
-
-    SPGLIB_CFLAGS="-I${pkg_install_dir}/include"
-    SPGLIB_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
-    if [ -d "${pkg_install_dir}/lib64" ]; then
-      ln -sf lib64 ${pkg_install_dir}/lib
-      cd ${pkg_install_dir}
     fi
     ;;
   __SYSTEM__)
     echo "==================== Finding Spglib from system paths ===================="
     check_command pkg-config --modversion spglib
-    add_include_from_paths SPGLIB_CFLAGS "spglib.h" $INCLUDE_PATHS
-    add_lib_from_paths SPGLIB_LDFLAGS "libspglib.*" $LIB_PATHS
+    pkg_install_dir="$(pkg-config --variable=prefix spglib)"
     ;;
   __DONTUSE__) ;;
 
   *)
     echo "==================== Linking Spglib to user paths ===================="
-    pkg_install_dir="$with_spglib"
-    check_dir "$pkg_install_dir/lib"
-    check_dir "$pkg_install_dir/include"
-    SPGLIB_CFLAGS="-I'${pkg_install_dir}/include'"
-    SPGLIB_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
+    pkg_install_dir="${with_spglib}"
+    SPGLIB_LIBDIR="${pkg_install_dir}/lib"
+    [ -d "${pkg_install_dir}/lib64" ] && SPGLIB_LIBDIR="${pkg_install_dir}/lib64"
+    check_dir "${SPGLIB_LIBDIR}"
+    check_dir "${pkg_install_dir}/include"
     ;;
 esac
 if [ "$with_spglib" != "__DONTUSE__" ]; then
-  SPGLIB_LIBS="-lsymspg"
   if [ "$with_spglib" != "__SYSTEM__" ]; then
     cat << EOF > "${BUILDDIR}/setup_spglib"
-prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
-prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path CPATH "$pkg_install_dir/include"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_spglib"
+export SPGLIB_ROOT="${pkg_install_dir}"
 export SPGLIB_VER="${spglib_ver}"
-export SPGLIB_CFLAGS="-I${pkg_install_dir}/include ${SPGLIB_CFLAGS}"
-export SPGLIB_LDFLAGS="${SPGLIB_LDFLAGS}"
-export CP_DFLAGS="\${CP_DFLAGS} -D__SPGLIB"
-export CP_CFLAGS="\${CP_CFLAGS} ${SPGLIB_CFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${SPGLIB_LDFLAGS}"
-export CP_LIBS="${SPGLIB_LIBS} \${CP_LIBS}"
 EOF
   filter_setup "${BUILDDIR}/setup_spglib" "${SETUPFILE}"
 fi

--- a/tools/toolchain/scripts/stage8/install_dftd4.sh
+++ b/tools/toolchain/scripts/stage8/install_dftd4.sh
@@ -25,12 +25,8 @@ case "$with_dftd4" in
 
   __INSTALL__)
     echo "==================== Installing DFTD4 ===================="
-    require_env OPENBLAS_ROOT
-    require_env MATH_LIBS
-
     pkg_install_dir="${INSTALLDIR}/dftd4-${dftd4_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
-
     if verify_checksums "${install_lock_file}"; then
       echo "dftd4-${dftd4_ver} is already installed, skipping it."
     else
@@ -41,7 +37,7 @@ case "$with_dftd4" in
       cd dftd4-${dftd4_ver}
 
       mkdir build && cd build
-      CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${OPENBLAS_ROOT}" cmake \
+      cmake \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
@@ -52,79 +48,32 @@ case "$with_dftd4" in
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi
     ;;
-
   __SYSTEM__)
     echo "==================== Finding DFTD4 from system paths ===================="
     check_command pkg-config --modversion dftd4
-    DFTD4_INCLUDE_PATH=$(pkg-config --cflags dftd4 | awk '{print $1}' | cut -dI -f2)
-    pkg_install_dir=$(dirname ${DFTD4_INCLUDE_PATH})
-    add_include_from_paths DFTD4_CFLAGS "dftd4.h" $DFTD4_INCLUDE_PATH
-    add_include_from_paths DFTD4_CFLAGS "dftd4.mod" $DFTD4_INCLUDE_PATH
-    add_include_from_paths DFTD4_CFLAGS "mctc_io.mod" $DFTD4_INCLUDE_PATH
-    add_include_from_paths DFTD4_CFLAGS "mstore.mod" $DFTD4_INCLUDE_PATH
-    add_include_from_paths DFTD4_CFLAGS "multicharge.mod" $DFTD4_INCLUDE_PATH
-    add_lib_from_paths DFTD4_LDFLAGS "libdftd4.*" $LIB_PATHS
+    pkg_install_dir="$(pkg-config --variable=prefix dftd4)"
     ;;
-
   *)
     echo "==================== Linking DFTD4 to user paths ===================="
     pkg_install_dir="$with_dftd4"
     check_dir "${pkg_install_dir}/include"
     ;;
-
 esac
 
 if [ "$with_dftd4" != "__DONTUSE__" ]; then
-
-  DFTD4_DFLAGS="-D__DFTD4 -D__DFTD4_V4_2"
-  DFTD4_LIBS="-ldftd4 -lmstore -lmulticharge -lmctc-lib"
-
   cat << EOF > "${BUILDDIR}/setup_dftd4"
+export DFTD4_ROOT="${pkg_install_dir}"
 export DFTD4_VER="${dftd4_ver}"
 EOF
-
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "multicharge.mod")
-  MCHARGE=${TEMP_LOC%/*}
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "mstore.mod")
-  MSTORE=${TEMP_LOC%/*}
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "mctc_io.mod")
-  MCTC=${TEMP_LOC%/*}
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "dftd4.mod")
-  DFTD4=${TEMP_LOC%/*}
-
-  DFTD4_INCLUDE_DIRS="$pkg_install_dir/include"
-  DFTD4_LINK_LIBRARIES="${pkg_install_dir}/lib"
-  DFTD4_CFLAGS="-I'${MCHARGE}' -I'${MCTC}' -I'${DFTD4}'"
-  DFTD4_LDFLAGS="-L'${DFTD4_LINK_LIBRARIES}' -Wl,-rpath,'${DFTD4_LINK_LIBRARIES}'"
-
   if [ "$with_dftd4" != "__SYSTEM__" ]; then
     cat << EOF >> "${BUILDDIR}/setup_dftd4"
-prepend_path LD_LIBRARY_PATH "${DFTD4_LINK_LIBRARIES}"
-prepend_path LD_RUN_PATH "${DFTD4_LINK_LIBRARIES}"
-prepend_path LIBRARY_PATH "${DFTD4_LINK_LIBRARIES}"
-prepend_path CPATH "${DFTD4_INCLUDE_DIRS}"
-prepend_path PKG_CONFIG_PATH "${DFTD4_LINK_LIBRARIES}/pkgconfig"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
-
-  cat << EOF >> "${BUILDDIR}/setup_dftd4"
-export MCHARGE="${MCHARGE}"
-export MSTORE="${MSTORE}"
-export MCTC="${MCTC}"
-export DFTD4="${DFTD4}"
-export DFTD4_INCLUDE_DIRS="${DFTD4_INCLUDE_DIRS}"
-export DFTD4_LINK_LIBRARIES="${DFTD4_LINK_LIBRARIES}"
-export DFTD4_ROOT="${pkg_install_dir}"
-export DFTD4_DFLAGS="${DFTD4_DFLAGS}"
-export DFTD4_CFLAGS="${DFTD4_CFLAGS}"
-export DFTD4_LDFLAGS="${DFTD4_LDFLAGS}"
-export DFTD4_LIBS="${DFTD4_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} \${DFTD4_DFLAGS}"
-export CP_CFLAGS="\${CP_CFLAGS} \${DFTD4_CFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} \${DFTD4_LDFLAGS}"
-export CP_LIBS="\${DFTD4_LIBS} \${CP_LIBS}"
-EOF
   filter_setup "${BUILDDIR}/setup_dftd4" "${SETUPFILE}"
 fi
 

--- a/tools/toolchain/scripts/stage8/install_mcl.sh
+++ b/tools/toolchain/scripts/stage8/install_mcl.sh
@@ -84,61 +84,45 @@ EOF
       cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_LIBDIR="lib" \
-        -DBUILD_SHARED_LIBS=YES \
-        -DBUILD_FORTRAN_API=YES \
+        -DBUILD_SHARED_LIBS=ON \
+        -DBUILD_FORTRAN_API=ON \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
         "${CMAKE_MPI_COMPILERS[@]}" \
         .. > cmake.log 2>&1 || tail_excerpt cmake.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . > build.log 2>&1 || tail_excerpt build.log
-      CMAKE_BUILD_PARALLEL_LEVEL="$(get_nprocs)" cmake --build . --target install > install.log 2>&1 || tail_excerpt install.log
-
+      make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename "${SCRIPT_NAME}")"
     fi
-    MCL_LDFLAGS="-L'${pkg_install_dir}/lib/MiMiC' -Wl,-rpath,'${pkg_install_dir}/lib/MiMiC'"
     ;;
   __SYSTEM__)
     echo "==================== Finding MCL from system paths ===================="
     check_lib -lmclf "mcl"
-    add_lib_from_paths MCL_LDFLAGS "mclf.*" "$LIB_PATHS"
-    add_lib_from_paths MCL_LDFLAGS "mcl.*" "$LIB_PATHS"
+    pkg_install_dir="$(dirname $(dirname $(find_in_paths "libmclf.*" $LIB_PATHS)))"
     ;;
   __DONTUSE__) ;;
 
   *)
     echo "==================== Linking MCL to user paths ===================="
     pkg_install_dir="${with_mcl}"
-
-    # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
     MCL_LIBDIR="${pkg_install_dir}/lib/MiMiC"
     [ -d "${pkg_install_dir}/lib64" ] && MCL_LIBDIR="${pkg_install_dir}/lib64/MiMiC"
-
     check_dir "${MCL_LIBDIR}"
-    MCL_LDFLAGS="-L'${MCL_LIBDIR}' -Wl,-rpath,'$MCL_LIBDIR}'"
     ;;
 esac
 
 if [ "$with_mcl" != "__DONTUSE__" ]; then
-  MCL_LIBS="-lmcl -lmclf -lstdc++"
   if [ "$with_mcl" != "__SYSTEM__" ]; then
     cat << EOF > "${BUILDDIR}/setup_mcl"
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib/MiMiC"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib/MiMiC"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib/MiMiC"
-export MCL_LIBS="${MCL_LIBS}"
-export MCL_ROOT="${pkg_install_dir}"
-prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
-prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
+prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_mcl"
 export MCL_VER="${mcl_ver}"
 export MCL_ROOT="${pkg_install_dir}"
-export MCL_LDFLAGS="${MCL_LDFLAGS}"
-export MCL_LIBS="${MCL_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} -D__MIMIC"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${MCL_LDFLAGS}"
-export CP_LIBS="\${CP_LIBS} ${MCL_LIBS}"
 EOF
   filter_setup "${BUILDDIR}/setup_mcl" "${SETUPFILE}"
 fi

--- a/tools/toolchain/scripts/stage8/install_pugixml.sh
+++ b/tools/toolchain/scripts/stage8/install_pugixml.sh
@@ -39,19 +39,15 @@ case "${with_pugixml}" in
         -DCMAKE_INSTALL_LIBDIR=lib \
         .. \
         > cmake.log 2>&1 || tail_excerpt cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
+      make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi
-    PUGIXML_CFLAGS="-I'${pkg_install_dir}/include'"
-    PUGIXML_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding pugixml from system paths ===================="
     check_command pkg-config --modversion pugixml
-    add_include_from_paths PUGIXML_CFLAGS "pugixml.hpp" ${INCLUDE_PATHS}
-    add_lib_from_paths PUGIXML_LDFLAGS "libpugixml.*" ${LIB_PATHS}
+    pkg_install_dir="$(pkg-config --variable=prefix pugixml)"
     ;;
   __DONTUSE__)
     # Nothing to do
@@ -59,19 +55,16 @@ case "${with_pugixml}" in
   *)
     echo "==================== Linking pugixml to user paths ===================="
     pkg_install_dir="${with_pugixml}"
-    # Use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
     PUGIXML_LIBDIR="${pkg_install_dir}/lib"
     [ -d "${pkg_install_dir}/lib64" ] && PUGIXML_LIBDIR="${pkg_install_dir}/lib64"
     check_dir "${PUGIXML_LIBDIR}"
     check_dir "${pkg_install_dir}/include"
-    PUGIXML_CFLAGS="-I'${pkg_install_dir}/include'"
-    PUGIXML_LDFLAGS="-L'${PUGIXML_LIBDIR}' -Wl,-rpath,'${PUGIXML_LIBDIR}'"
     ;;
 esac
 
 if [ "${with_pugixml}" != "__DONTUSE__" ]; then
-  PUGIXML_LIBS="-lpugixml"
   cat << EOF > "${BUILDDIR}/setup_pugixml"
+export PUGIXML_ROOT="${pkg_install_dir}"
 export PUGIXML_VER="${pugixml_ver}"
 EOF
   if [ "${with_pugixml}" != "__SYSTEM__" ]; then
@@ -79,19 +72,10 @@ EOF
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path CPATH "${pkg_install_dir}/include"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
-  cat << EOF >> "${BUILDDIR}/setup_pugixml"
-export PUGIXML_CFLAGS="${PUGIXML_CFLAGS}"
-export PUGIXML_LDFLAGS="${PUGIXML_LDFLAGS}"
-export PUGIXML_LIBRARY="-lpugixml"
-export CP_CFLAGS="\${CP_CFLAGS} ${PUGIXML_CFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${PUGIXML_LDFLAGS}"
-export CP_LIBS="IF_MPI(${PUGIXML_LIBS}|) \${CP_LIBS}"
-EOF
   filter_setup "${BUILDDIR}/setup_pugixml" "${SETUPFILE}"
 fi
 

--- a/tools/toolchain/scripts/stage8/install_sirius.sh
+++ b/tools/toolchain/scripts/stage8/install_sirius.sh
@@ -132,11 +132,8 @@ case "$with_sirius" in
           ${EXTRA_CMAKE_FLAGS} .. \
           >> cmake.log 2>&1 || tail_excerpt cmake.log
         make -j $(get_nprocs) install >> make.log 2>&1 || tail_excerpt make.log
-        SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/cuda/lib' -Wl,-rpath,'${pkg_install_dir}/cuda/lib'"
         cd ..
       fi
-      SIRIUS_CFLAGS="-I'${pkg_install_dir}/include/sirius'"
-      SIRIUS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib"
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})" \
         "${SCRIPT_DIR}/stage8/sirius-linking.patch"
     fi
@@ -144,25 +141,21 @@ case "$with_sirius" in
   __SYSTEM__)
     check_lib -lsirius "sirius"
     check_lib -lsirius_cxx "sirius_cxx"
-    add_include_from_paths SIRIUS_CFLAGS "sirius*" $INCLUDE_PATHS
-    add_lib_from_paths SIRIUS_LDFLAGS "libsirius.*" $LIB_PATHS
-    add_lib_from_paths SIRIUS_LDFLAGS "libsirius_cxx.*" $LIB_PATHS
+    pkg_install_dir="$(dirname $(dirname $(find_in_paths "libsirius.*" $LIB_PATHS)))"
     ;;
   *)
     echo "==================== Linking SIRIUS to user paths ===================="
-    pkg_install_dir="$with_sirius"
-    check_dir "${pkg_install_dir}/lib"
-    check_dir "${pkg_install_dir}/lib64"
+    pkg_install_dir="${with_sirius}"
+    SIRIUS_LIBDIR="${pkg_install_dir}/lib"
+    [ -d "${pkg_install_dir}/lib64" ] && SIRIUS_LIBDIR="${pkg_install_dir}/lib64"
+    check_dir "${SIRIUS_LIBDIR}"
     check_dir "${pkg_install_dir}/include"
     ;;
 esac
 if [ "$with_sirius" != "__DONTUSE__" ]; then
-  SIRIUS_LIBS="-lsirius -lsirius_cxx IF_CUDA(-lcusolver|)"
-  SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/cuda/lib' -Wl,-rpath,'${pkg_install_dir}/cuda/lib'"
-  SIRIUS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
-  SIRIUS_CFLAGS="-I'${pkg_install_dir}/include/sirius'"
   cat << EOF > "${BUILDDIR}/setup_sirius"
 export SIRIUS_VER="${sirius_ver}"
+export SIRIUS_ROOT="${pkg_install_dir}"
 EOF
   if [ "$with_sirius" != "__SYSTEM__" ]; then
     cat << EOF >> "${BUILDDIR}/setup_sirius"
@@ -170,7 +163,6 @@ prepend_path PATH "${pkg_install_dir}/bin"
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path CPATH "${pkg_install_dir}/include/sirius"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
@@ -183,17 +175,6 @@ prepend_path LIBRARY_PATH "${pkg_install_dir}/cuda/lib"
 EOF
     fi
   fi
-  cat << EOF >> "${BUILDDIR}/setup_sirius"
-export SIRIUS_CFLAGS="IF_CUDA(-I${pkg_install_dir}/cuda/include/sirius|-I${pkg_install_dir}/include/sirius)"
-export SIRIUS_FFLAGS="IF_CUDA(-I${pkg_install_dir}/cuda/include/sirius|-I${pkg_install_dir}/include/sirius)"
-export SIRIUS_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
-export SIRIUS_CUDA_LDFLAGS="-L'${pkg_install_dir}/cuda/lib' -Wl,-rpath,'${pkg_install_dir}/cuda/lib'"
-export SIRIUS_LIBS="${SIRIUS_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} IF_MPI("-D__SIRIUS"|)"
-export CP_CFLAGS="\${CP_CFLAGS} IF_MPI("\${SIRIUS_CFLAGS}"|)"
-export CP_LDFLAGS="\${CP_LDFLAGS} IF_MPI(IF_CUDA("\${SIRIUS_CUDA_LDFLAGS}"|"\${SIRIUS_LDFLAGS}")|)"
-export CP_LIBS="IF_MPI("\${SIRIUS_LIBS}"|) \${CP_LIBS}"
-EOF
   filter_setup "${BUILDDIR}/setup_sirius" "${SETUPFILE}"
   cat << EOF >> ${INSTALLDIR}/lsan.supp
 # leaks related to SIRIUS

--- a/tools/toolchain/scripts/stage8/install_spfft.sh
+++ b/tools/toolchain/scripts/stage8/install_spfft.sh
@@ -54,9 +54,7 @@ case "${with_spfft}" in
         -DSPFFT_INSTALL=ON \
         ${EXTRA_CMAKE_FLAGS} .. \
         > cmake.log 2>&1 || tail_excerpt cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
-
+      make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
       cd ..
 
       if [ "$ENABLE_CUDA" = "__TRUE__" ]; then
@@ -137,61 +135,38 @@ case "${with_spfft}" in
       fi
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi
-    SpFFT_ROOT="${pkg_install_dir}"
-    SPFFT_CFLAGS="-I'${pkg_install_dir}/include'"
-    SPFFT_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
-    SPFFT_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath,'${pkg_install_dir}/lib/cuda'"
     ;;
   __SYSTEM__)
     echo "==================== Finding SpFFT from system paths ===================="
     check_command pkg-config --modversion spfft
-    add_include_from_paths SPFFT_CFLAGS "spfft.h" $INCLUDE_PATHS
-    add_lib_from_paths SPFFT_LDFLAGS "libspfft.*" $LIB_PATHS
+    pkg_install_dir="$(pkg-config --variable=prefix spfft)"
     ;;
   __DONTUSE__)
     # Nothing to do
     ;;
   *)
     echo "==================== Linking SpFFT to user paths ===================="
-    pkg_install_dir="$with_spfft"
-
+    pkg_install_dir="${with_spfft}"
     # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
     SPFFT_LIBDIR="${pkg_install_dir}/lib"
     [ -d "${pkg_install_dir}/lib64" ] && SPFFT_LIBDIR="${pkg_install_dir}/lib64"
-
     check_dir "${SPFFT_LIBDIR}"
     check_dir "${pkg_install_dir}/include"
-    SPFFT_CFLAGS="-I'${pkg_install_dir}/include'"
-    SPFFT_LDFLAGS="-L'${SPFFT_LIBDIR}' -Wl,-rpath,'${SPFFT_LIBDIR}'"
     ;;
 esac
 if [ "$with_spfft" != "__DONTUSE__" ]; then
-  SPFFT_LIBS="-lspfft"
   if [ "$with_spfft" != "__SYSTEM__" ]; then
     cat << EOF > "${BUILDDIR}/setup_spfft"
 prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path CPATH "$pkg_install_dir/include"
-export SPFFT_INCLUDE_DIR="$pkg_install_dir/include"
-export SPFFT_LIBS="-lspfft"
-export SpFFT_ROOT="${pkg_install_dir}"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_spfft"
-export SPFFT_VER="${spfft_ver}"
-export SPFFT_CFLAGS="${SPFFT_CFLAGS}"
-export SPFFT_LDFLAGS="${SPFFT_LDFLAGS}"
-export SPFFT_CUDA_LDFLAGS="${SPFFT_CUDA_LDFLAGS}"
-export CP_DFLAGS="\${CP_DFLAGS} IF_MPI(-D__SPFFT|)"
-export CP_CFLAGS="\${CP_CFLAGS} ${SPFFT_CFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} IF_CUDA(${SPFFT_CUDA_LDFLAGS}|${SPFFT_LDFLAGS})"
-export SPFFT_LIBRARY="-lspfft"
 export SpFFT_ROOT="${pkg_install_dir}"
-export SPFFT_INCLUDE_DIR="${pkg_install_dir}/include"
-export CP_LIBS="IF_MPI(${SPFFT_LIBS}|) \${CP_LIBS}"
+export SPFFT_VER="${spfft_ver}"
 EOF
   filter_setup "${BUILDDIR}/setup_spfft" "${SETUPFILE}"
 fi

--- a/tools/toolchain/scripts/stage8/install_spla.sh
+++ b/tools/toolchain/scripts/stage8/install_spla.sh
@@ -45,8 +45,7 @@ case "${with_spla}" in
         -DSPLA_STATIC=ON \
         .. \
         > cmake.log 2>&1 || tail_excerpt cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
+      make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
       cd ..
 
       if [ "$ENABLE_CUDA" = "__TRUE__" ]; then
@@ -65,8 +64,7 @@ case "${with_spla}" in
           -DSPLA_GPU_BACKEND=CUDA \
           .. \
           > cmake.log 2>&1 || tail_excerpt cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-        make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
+        make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
       fi
 
       if [ "$ENABLE_HIP" = "__TRUE__" ]; then
@@ -88,8 +86,7 @@ case "${with_spla}" in
               -DSPLA_GPU_BACKEND=CUDA \
               .. \
               > cmake.log 2>&1 || tail_excerpt cmake.log
-            make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-            make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
+            make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
             ;;
           Mi50 | Mi100 | Mi200 | Mi250)
             [ -d build-hip ] && rm -rf "build-hip"
@@ -107,25 +104,18 @@ case "${with_spla}" in
               -DSPLA_GPU_BACKEND=ROCM \
               .. \
               > cmake.log 2>&1 || tail_excerpt cmake.log
-            make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-            make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
+            make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
             ;;
           *) ;;
         esac
       fi
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi
-    SPLA_ROOT="${pkg_install_dir}"
-    SPLA_CFLAGS="-I'${pkg_install_dir}/include/spla'"
-    SPLA_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
-    SPLA_CUDA_LDFLAGS="-L'${pkg_install_dir}/lib/cuda' -Wl,-rpath,'${pkg_install_dir}/lib/cuda'"
-    SPLA_HIP_LDFLAGS="-L'${pkg_install_dir}/lib/hip' -Wl,-rpath,'${pkg_install_dir}/lib/hip'"
     ;;
   __SYSTEM__)
     echo "==================== Finding SpLA from system paths ===================="
     check_command pkg-config --modversion spla
-    add_include_from_paths SPLA_CFLAGS "spla.h" $INCLUDE_PATHS
-    add_lib_from_paths SPLA_LDFLAGS "libspla.*" $LIB_PATHS
+    pkg_install_dir="$(pkg-config --variable=prefix spla)"
     ;;
   __DONTUSE__)
     # Nothing to do
@@ -133,58 +123,27 @@ case "${with_spla}" in
   *)
     echo "==================== Linking SpLA to user paths ===================="
     pkg_install_dir="$with_spla"
-
     # use the lib64 directory if present (multi-abi distros may link lib/ to lib32/ instead)
     SPLA_LIBDIR="${pkg_install_dir}/lib"
     [ -d "${pkg_install_dir}/lib64" ] && SPLA_LIBDIR="${pkg_install_dir}/lib64"
-
     check_dir "${SPLA_LIBDIR}"
     check_dir "${pkg_install_dir}/include/spla"
-    SPLA_CFLAGS="-I'${pkg_install_dir}/include/spla'"
-    SPLA_LDFLAGS="-L'${SPLA_LIBDIR}' -Wl,-rpath,'${SPLA_LIBDIR}'"
     ;;
 esac
 if [ "$with_spla" != "__DONTUSE__" ]; then
-  SPLA_LIBS="-lspla"
   if [ "$with_spla" != "__SYSTEM__" ]; then
     cat << EOF > "${BUILDDIR}/setup_spla"
 prepend_path LD_LIBRARY_PATH "$pkg_install_dir/lib"
 prepend_path LD_RUN_PATH "$pkg_install_dir/lib"
 prepend_path LIBRARY_PATH "$pkg_install_dir/lib"
-prepend_path CPATH "$pkg_install_dir/include/spla"
-export SPLA_INCLUDE_DIR="$pkg_install_dir/include/spla"
-export SPLA_LIBS="-lspla"
-export SPLA_ROOT="${pkg_install_dir}"
 prepend_path PKG_CONFIG_PATH "$pkg_install_dir/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "$pkg_install_dir"
 EOF
   fi
   cat << EOF >> "${BUILDDIR}/setup_spla"
 export SPLA_VER="${spla_ver}"
-export SPLA_CFLAGS="${SPLA_CFLAGS}"
-export SPLA_LDFLAGS="${SPLA_LDFLAGS}"
-export SPLA_CUDA_LDFLAGS="${SPLA_CUDA_LDFLAGS}"
-export SPLA_HIP_LDFLAGS="${SPLA_HIP_LDFLAGS}"
-export CP_DFLAGS="\${CP_DFLAGS} IF_HIP(-D__OFFLOAD_GEMM|) IF_CUDA(-D__OFFLOAD_GEMM|) ${OFFLOAD_DFLAGS} IF_MPI(-D__SPLA|)"
-export CP_CFLAGS="\${CP_CFLAGS} ${SPLA_CFLAGS}"
-export SPLA_LIBRARY="-lspla"
 export SPLA_ROOT="${pkg_install_dir}"
-export SPLA_INCLUDE_DIR="${pkg_install_dir}/include/spla"
-export CP_LIBS="IF_MPI(${SPLA_LIBS}|) \${CP_LIBS}"
 EOF
-  if [ "$ENABLE_HIP" = "__TRUE__" ]; then
-    cat << EOF >> "${BUILDDIR}/setup_spla"
-export CP_LDFLAGS="\${CP_LDFLAGS} IF_HIP(${SPLA_HIP_LDFLAGS}|${SPLA_LDFLAGS})"
-EOF
-  elif [ "$ENABLE_CUDA" = "__TRUE__" ]; then
-    cat << EOF >> "${BUILDDIR}/setup_spla"
-export CP_LDFLAGS="\${CP_LDFLAGS} IF_CUDA(${SPLA_CUDA_LDFLAGS}|${SPLA_LDFLAGS})"
-EOF
-  else
-    cat << EOF >> "${BUILDDIR}/setup_spla"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${SPLA_LDFLAGS}"
-EOF
-  fi
   filter_setup "${BUILDDIR}/setup_spla" "${SETUPFILE}"
 fi
 

--- a/tools/toolchain/scripts/stage8/install_tblite.sh
+++ b/tools/toolchain/scripts/stage8/install_tblite.sh
@@ -27,12 +27,8 @@ case "$with_tblite" in
 
   __INSTALL__)
     echo "==================== Installing tblite ===================="
-    require_env OPENBLAS_ROOT
-    require_env MATH_LIBS
-
     pkg_install_dir="${INSTALLDIR}/tblite-${tblite_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
-
     if verify_checksums "${install_lock_file}"; then
       echo "tblite-${tblite_ver} is already installed, skipping it."
     else
@@ -46,11 +42,8 @@ case "$with_tblite" in
       patch -l -d subprojects/dftd4 -p1 < "${SCRIPT_DIR}/stage8/dftd4-${tblite_dftd4_ver}-gradient-fixes.patch" \
         > dftd4_gradient_fixes.patch.log 2>&1 || tail_excerpt dftd4_gradient_fixes.patch.log
 
-      rm -Rf build
-      mkdir build
-      cd build
-
-      CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:${OPENBLAS_ROOT}" cmake \
+      mkdir -p build && cd build
+      cmake \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_VERBOSE_MAKEFILE=ON \
@@ -65,95 +58,33 @@ case "$with_tblite" in
       cd ..
     fi
     ;;
-
   __SYSTEM__)
     echo "==================== Finding tblite from system paths ===================="
     check_command pkg-config --modversion tblite
-    TBLITE_INCLUDE_PATH=$(pkg-config --cflags tblite | awk '{print $1}' | cut -dI -f2)
-    pkg_install_dir=$(dirname ${TBLITE_INCLUDE_PATH})
-    add_include_from_paths TBLITE_CFLAGS "tblite.h" $TBLITE_INCLUDE_PATH
-    add_include_from_paths TBLITE_CFLAGS "tblite.mod" $TBLITE_INCLUDE_PATH
-    add_include_from_paths TBLITE_CFLAGS "dftd4.mod" $TBLITE_INCLUDE_PATH
-    add_include_from_paths TBLITE_CFLAGS "mctc_io.mod" $TBLITE_INCLUDE_PATH
-    add_include_from_paths TBLITE_CFLAGS "mstore.mod" $TBLITE_INCLUDE_PATH
-    add_include_from_paths TBLITE_CFLAGS "multicharge.mod" $TBLITE_INCLUDE_PATH
-    add_lib_from_paths TBLITE_LDFLAGS "libtblite.*" $LIB_PATHS
+    pkg_install_dir="$(pkg-config --variable=prefix tblite)"
     ;;
-
   *)
     echo "==================== Linking TBLITE to user paths ===================="
-    pkg_install_dir="$with_tblite"
+    pkg_install_dir="${with_tblite}"
     check_dir "${pkg_install_dir}/include"
     ;;
-
 esac
 
 if [ "$with_tblite" != "__DONTUSE__" ]; then
-
-  TBLITE_DFLAGS="-D__TBLITE -D__DFTD4"
-  TBLITE_LIBS="-ltblite -ldftd4 -ls-dftd3 -lmulticharge -lmctc-lib -ltoml-f"
-
   cat << EOF > "${BUILDDIR}/setup_tblite"
+export TBLITE_ROOT="${pkg_install_dir}"
 export TBLITE_VER="${tblite_ver}"
-export TBLITE_DFTD4_VER="${tblite_dftd4_ver}"
-export TBLITE_MULTICHARGE_VER="${tblite_multicharge_ver}"
-export TBLITE_SDFTD3_VER="${tblite_sdftd3_ver}"
-export TBLITE_MCTC_VER="${tblite_mctc_ver}"
-export TBLITE_TOMLF_VER="${tblite_tomlf_ver}"
 EOF
-
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "tomlf.mod")
-  TOMLF=${TEMP_LOC%/*}
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "multicharge.mod")
-  MCHARGE=${TEMP_LOC%/*}
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "mstore.mod")
-  MSTORE=${TEMP_LOC%/*}
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "mctc_io.mod")
-  MCTC=${TEMP_LOC%/*}
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "dftd3.mod")
-  SDFTD3=${TEMP_LOC%/*}
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "dftd4.mod")
-  DFTD4=${TEMP_LOC%/*}
-  TEMP_LOC=$(find ${pkg_install_dir}/include -name "tblite_xtb.mod")
-  TBLITE=${TEMP_LOC%/*}
-
-  TBLITE_INCLUDE_DIRS="${pkg_install_dir}/include"
-  TBLITE_LINK_LIBRARIES="${pkg_install_dir}/lib"
-  TBLITE_CFLAGS="-I'${TOMLF}' -I'${MCTC}' -I'${SDFTD3}' -I'${DFTD4}' -I'${TBLITE}'"
-  TBLITE_LDFLAGS="-L'${TBLITE_LINK_LIBRARIES}' -Wl,-rpath,'${TBLITE_LINK_LIBRARIES}'"
-
   if [ "$with_tblite" != "__SYSTEM__" ]; then
     cat << EOF >> "${BUILDDIR}/setup_tblite"
 prepend_path PATH "${pkg_install_dir}/bin"
-prepend_path LD_LIBRARY_PATH "${TBLITE_LINK_LIBRARIES}"
-prepend_path LD_RUN_PATH "${TBLITE_LINK_LIBRARIES}"
-prepend_path LIBRARY_PATH "${TBLITE_LINK_LIBRARIES}"
-prepend_path CPATH "${TBLITE_INCLUDE_DIRS}"
-prepend_path PKG_CONFIG_PATH "${TBLITE_LINK_LIBRARIES}/pkgconfig"
+prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
+prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
+prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
-
-  cat << EOF >> "${BUILDDIR}/setup_tblite"
-export TOMLF="${TOMLF}"
-export MCHARGE="${MCHARGE}"
-export MSTORE="${MSTORE}"
-export MCTC="${MCTC}"
-export SDFTD3="${SDFTD3}"
-export DFTD4="${DFTD4}"
-export TBLITE="${TBLITE}"
-export TBLITE_INCLUDE_DIRS="${TBLITE_INCLUDE_DIRS}"
-export TBLITE_LINK_LIBRARIES="${TBLITE_LINK_LIBRARIES}"
-export TBLITE_ROOT="${pkg_install_dir}"
-export TBLITE_DFLAGS="${TBLITE_DFLAGS}"
-export TBLITE_CFLAGS="${TBLITE_CFLAGS}"
-export TBLITE_LDFLAGS="${TBLITE_LDFLAGS}"
-export TBLITE_LIBS="${TBLITE_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} \${TBLITE_DFLAGS}"
-export CP_CFLAGS="\${CP_CFLAGS} \${TBLITE_CFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} \${TBLITE_LDFLAGS}"
-export CP_LIBS="\${TBLITE_LIBS} \${CP_LIBS}"
-EOF
   filter_setup "${BUILDDIR}/setup_tblite" "${SETUPFILE}"
 fi
 

--- a/tools/toolchain/scripts/stage8/install_trexio.sh
+++ b/tools/toolchain/scripts/stage8/install_trexio.sh
@@ -25,9 +25,7 @@ case "$with_trexio" in
 
   __INSTALL__)
     echo "==================== Installing TREXIO ===================="
-    require_env HDF5_LIBS
-    require_env HDF5_CFLAGS
-    require_env HDF5_LDFLAGS
+    require_env HDF5_ROOT
 
     pkg_install_dir="${INSTALLDIR}/trexio-${trexio_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
@@ -42,7 +40,7 @@ case "$with_trexio" in
 
       CMAKE_OPTIONS="-DCMAKE_VERBOSE_MAKEFILE=ON"
       if [ "${MPI_MODE}" != "no" ]; then
-        CMAKE_OPTIONS="-DCMAKE_C_COMPILER=${MPICC}"
+        CMAKE_OPTIONS+="-DCMAKE_C_COMPILER=${MPICC}"
       fi
 
       mkdir build && cd build
@@ -56,51 +54,34 @@ case "$with_trexio" in
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage8/$(basename ${SCRIPT_NAME})"
     fi
-    TREXIO_CFLAGS="-I${pkg_install_dir}/include"
-    TREXIO_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
   __SYSTEM__)
     echo "==================== Finding trexio from system paths ===================="
-    require_env HDF5_LIBS
-    require_env HDF5_CFLAGS
-    require_env HDF5_LDFLAGS
+    require_env HDF5_ROOT
     check_lib -ltrexio "trexio"
-    add_include_from_paths trexio_CFLAGS "trexio*" $INCLUDE_PATHS
-    add_lib_from_paths trexio_LDFLAGS "libtrexio.*" $LIB_PATHS
+    pkg_install_dir="$(dirname $(dirname $(find_in_paths "libtrexio.*" $LIB_PATHS)))"
     ;;
   *)
     echo "==================== Linking TREXIO to user paths ===================="
-    pkg_install_dir="$with_trexio"
+    pkg_install_dir="${with_trexio}"
     check_dir "${pkg_install_dir}/lib"
     check_dir "${pkg_install_dir}/include"
-    TREXIO_CFLAGS="-I'${pkg_install_dir}/include'"
-    TREXIO_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath,'${pkg_install_dir}/lib'"
     ;;
 esac
 if [ "$with_trexio" != "__DONTUSE__" ]; then
-  TREXIO_LIBS="-l:libtrexio.a"
   cat << EOF > "${BUILDDIR}/setup_trexio"
 export TREXIO_VER="${trexio_ver}"
+export TREXIO_ROOT="${pkg_install_dir}"
 EOF
   if [ "$with_trexio" != "__SYSTEM__" ]; then
     cat << EOF >> "${BUILDDIR}/setup_trexio"
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir}/lib"
-prepend_path CPATH "${pkg_install_dir}/include"
 prepend_path PKG_CONFIG_PATH "${pkg_install_dir}/lib/pkgconfig"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
 EOF
   fi
-  cat << EOF >> "${BUILDDIR}/setup_trexio"
-export TREXIO_CFLAGS="${TREXIO_CFLAGS}"
-export TREXIO_LDFLAGS="${TREXIO_LDFLAGS}"
-export TREXIO_LIB="${TREXIO_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} -D__TREXIO"
-export CP_CFLAGS="\${CP_CFLAGS} ${TREXIO_CFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${TREXIO_LDFLAGS}"
-export CP_LIBS="${TREXIO_LIBS} \${CP_LIBS}"
-EOF
   filter_setup "${BUILDDIR}/setup_trexio" "${SETUPFILE}"
 fi
 

--- a/tools/toolchain/scripts/stage9/install_dbcsr.sh
+++ b/tools/toolchain/scripts/stage9/install_dbcsr.sh
@@ -79,8 +79,7 @@ case "${with_dbcsr}" in
         -DCMAKE_INSTALL_PREFIX=${pkg_install_dir} \
         ${CMAKE_OPTIONS} .. \
         > cmake.log 2>&1 || tail_excerpt cmake.log
-      make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-      make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
+      make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
       cd ..
       if [ "${ENABLE_CUDA}" == "__TRUE__" ]; then
         mkdir build-cuda
@@ -91,8 +90,7 @@ case "${with_dbcsr}" in
           -DCMAKE_INSTALL_PREFIX=${pkg_install_dir}-cuda \
           ${CMAKE_OPTIONS} .. \
           > cmake.log 2>&1 || tail_excerpt cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-        make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
+        make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
         cd ..
       fi
       if [ "${ENABLE_HIP}" == "__TRUE__" ]; then
@@ -103,24 +101,16 @@ case "${with_dbcsr}" in
           -DCMAKE_INSTALL_PREFIX=${pkg_install_dir}-hip \
           ${CMAKE_OPTIONS} .. \
           > cmake.log 2>&1 || tail_excerpt cmake.log
-        make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
-        make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
+        make -j $(get_nprocs) install > make.log 2>&1 || tail_excerpt make.log
         cd ..
       fi
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage9/$(basename ${SCRIPT_NAME})"
-      DBCSR_CFLAGS="-I'${pkg_install_dir}/include'"
-      DBCSR_LDFLAGS="-L'${pkg_install_dir}/lib' -Wl,-rpath='${pkg_install_dir}/lib'"
-      DBCSR_CUDA_CFLAGS="-I'${pkg_install_dir}-cuda/include'"
-      DBCSR_CUDA_LDFLAGS="-L'${pkg_install_dir}-cuda/lib' -Wl,-rpath='${pkg_install_dir}-cuda/lib'"
-      DBCSR_HIP_CFLAGS="-I'${pkg_install_dir}-hip/include'"
-      DBCSR_HIP_LDFLAGS="-L'${pkg_install_dir}-hip/lib' -Wl,-rpath='${pkg_install_dir}-hip/lib'"
     fi
     ;;
   __SYSTEM__)
     echo "==================== Finding DBCSR from system paths ===================="
     check_lib -ldbcsr "dbcsr"
-    add_include_from_paths DBCSR_CFLAGS "dbcsr.h" $INCLUDE_PATHS
-    add_lib_from_paths DBCSR_LDFLAGS "dbcsr.*" $LIB_PATHS
+    pkg_install_dir="$(dirname $(dirname $(find_in_paths "libdbcsr.*" $LIB_PATHS)))"
     ;;
   __DONTUSE__)
     # Nothing to do
@@ -129,15 +119,13 @@ case "${with_dbcsr}" in
     echo "==================== Linking DBCSR to user paths ===================="
     pkg_install_dir="${with_dbcsr}"
     DBCSR_LIBDIR="${pkg_install_dir}/lib"
+    [ -d "${pkg_install_dir}/lib64" ] && DBCSR_LIBDIR="${pkg_install_dir}/lib64"
     check_dir "${DBCSR_LIBDIR}"
     check_dir "${pkg_install_dir}/include"
-    DBCSR_CFLAGS="-I'${pkg_install_dir}/include'"
-    DBCSR_LDFLAGS="-L'${DBCSR_LIBDIR}' -Wl,-rpath,'${DBCSR_LIBDIR}'"
     ;;
 esac
 
 if [ "${with_dbcsr}" != "__DONTUSE__" ]; then
-  DBCSR_LIBS="-ldbcsr"
   if [ "${with_dbcsr}" != "__SYSTEM__" ]; then
     if [ "${ENABLE_CUDA}" == "__TRUE__" ]; then
       pkg_install_dir1="${pkg_install_dir}-cuda"
@@ -153,20 +141,11 @@ if [ "${with_dbcsr}" != "__DONTUSE__" ]; then
 prepend_path LD_LIBRARY_PATH "${pkg_install_dir1}/lib"
 prepend_path LD_RUN_PATH "${pkg_install_dir1}/lib"
 prepend_path LIBRARY_PATH "${pkg_install_dir1}/lib"
-prepend_path CPATH "${pkg_install_dir1}/include"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir1}"
 export DBCSR_ROOT="${pkg_install_dir}"
 export DBCSR_HIP_ROOT="${pkg_install_dir}-hip"
 export DBCSR_CUDA_ROOT="${pkg_install_dir}-cuda"
 export DBCSR_VER="${dbcsr_ver}"
-export DBCSR_DIR="${pkg_install_dir1}/lib/cmake/dbcsr"
-export DBCSR_CFLAGS="${DBCSR_CFLAGS}"
-export DBCSR_LDFLAGS="IF_CUDA(${DBCSR_CUDA_LDFLAGS}|IF_HIP(${DBCSR_HIP_LDFLAGS}|${DBCSR_LDFLAGS}))"
-export DBCSR_LIBS="${DBCSR_LIBS}"
-export CP_DFLAGS="\${CP_DFLAGS} IF_CUDA(-D__DBCSR_ACC -D__DBCSR|IF_HIP(-D__DBCSR_ACC -D__DBCSR|-D__DBCSR))"
-export CP_CFLAGS="\${CP_CFLAGS} ${DBCSR_CFLAGS}"
-export CP_LDFLAGS="\${CP_LDFLAGS} ${DBCSR_LDFLAGS}"
-export CP_LIBS="${DBCSR_LIBS} \${CP_LIBS}"
 EOF
 else
   touch "${BUILDDIR}/setup_dbcsr"


### PR DESCRIPTION
Since CP2K is now built with CMake, there is no need to export so many flags that were originally added into arch files. This PR is a first step to clean up those unused flags. It starts from the last stages and is intentionally split into multiple steps (not including all changes at once) with caution in case there are still flags used by other dependencies.

With all changes done in the near future, the function `filter_setup()` could be finally revised or made easier.