### PR TITLE
Add hint regarding missing FFTW3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1358,7 +1358,9 @@ if(NOT CP2K_USE_VORI)
 endif()
 
 if(NOT CP2K_USE_FFTW3)
-  message("   - FFTW3")
+  message(
+    "   - FFTW3: FFTW3 may become mandatory in future releases of CP2K. Please consider installing and enabling it. Some features of CP2K may not work properly without FFTW3."
+  )
 endif()
 
 if(NOT CP2K_USE_LIBTORCH)


### PR DESCRIPTION
As discussed at the develepers' meeting, FFTW3 may be turned into a hard dependency in the future (new FFT backend WIP). FFTW3 is precompiled on many clusters or directly available in the math libraries of hardware developers (MKL, AOCL, cuFFT). Already now, some features are not available without FFTW3 (or at least only in case of very large unit cells).
So, I add a warning if a user decides to compile CP2K with FFTW3 support.