### PR TITLE
Docker: Improve Spack image build caching

### DIFF
--- a/tools/docker/Dockerfile.test_spack_openmpi-pdbg
+++ b/tools/docker/Dockerfile.test_spack_openmpi-pdbg
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_openmpi-pdbg}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi openmpi  -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv pdbg  -gpu none -mpi openmpi -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_spack_openmpi-psmp
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_openmpi-psmp}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi openmpi  -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi openmpi -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_pdbg
+++ b/tools/docker/Dockerfile.test_spack_pdbg
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_pdbg}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv pdbg  -gpu none -mpi mpich -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_pdbg-rawhide
+++ b/tools/docker/Dockerfile.test_spack_pdbg-rawhide
@@ -34,17 +34,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_pdbg-rawhide}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv pdbg  -gpu none -mpi mpich -ef openpmd
 
@@ -67,11 +72,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-4x2
+++ b/tools/docker/Dockerfile.test_spack_psmp-4x2
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-4x2}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-P100
+++ b/tools/docker/Dockerfile.test_spack_psmp-P100
@@ -50,17 +50,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-P100}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu P100 -gv 13 -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 13 -gpu P100 -mpi mpich -ef openpmd
 
@@ -89,11 +94,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-fedora
+++ b/tools/docker/Dockerfile.test_spack_psmp-fedora
@@ -34,17 +34,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-fedora}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich -ef openpmd
 
@@ -67,11 +72,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc10
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc10
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc10}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 10 -mpi mpich -ue -df libtorch -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 10 -gpu none -mpi mpich -df libtorch -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc11
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc11
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc11}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 11 -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 11 -gpu none -mpi mpich -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc12
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc12
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc12}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 12 -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 12 -gpu none -mpi mpich -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc13
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc13
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc13}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 13 -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 13 -gpu none -mpi mpich -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc14
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc14
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc14}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 14 -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 14 -gpu none -mpi mpich -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc15
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc15
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc15}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 15 -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 15 -gpu none -mpi mpich -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc16
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc16
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-gcc16}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 16 -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 16 -gpu none -mpi mpich -ef openpmd
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-opensuse
+++ b/tools/docker/Dockerfile.test_spack_psmp-opensuse
@@ -39,17 +39,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-opensuse}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 13 -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 13 -gpu none -mpi mpich -ef openpmd
 
@@ -72,11 +77,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_psmp-rockylinux
+++ b/tools/docker/Dockerfile.test_spack_psmp-rockylinux
@@ -34,17 +34,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-rockylinux}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 14 -mpi mpich -ue -ef openpmd
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv psmp -gv 14 -gpu none -mpi mpich -ef openpmd
 
@@ -68,11 +73,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_sdbg
+++ b/tools/docker/Dockerfile.test_spack_sdbg
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv sdbg -gpu none  -mpi no -ue 
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv sdbg  -gpu none -mpi no 
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_ssmp
+++ b/tools/docker/Dockerfile.test_spack_ssmp
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_ssmp}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu none  -mpi no -ue 
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv ssmp  -gpu none -mpi no 
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_ssmp-P100
+++ b/tools/docker/Dockerfile.test_spack_ssmp-P100
@@ -50,17 +50,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_ssmp-P100}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu P100 -gv 13 -mpi no -ue 
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv ssmp -gv 13 -gpu P100 -mpi no 
 
@@ -89,11 +94,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/Dockerfile.test_spack_ssmp-static
+++ b/tools/docker/Dockerfile.test_spack_ssmp-static
@@ -43,17 +43,22 @@ ENV IMAGE_TAG=${IMAGE_TAG:-spack_ssmp-static}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv ssmp-static -gpu none -gv 14 -mpi no  
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv ssmp-static -gv 14 -gpu none -mpi no 
 
@@ -75,11 +80,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -733,17 +733,22 @@ ENV IMAGE_TAG=${{IMAGE_TAG:-{image_tag}}}
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${{SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}}"
 
-# Copy CP2K repository into container
-WORKDIR /opt
-COPY . cp2k/
-
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
 RUN ./make_cp2k.sh -bd_only -cv {version} -gpu {gpu_model} {gcc_version_flag} -mpi {mpi_mode} {use_externals} {feature_flags}
 
 ###### Stage 2: Build CP2K ######
 
 FROM build_deps AS build_cp2k
+
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
 
 RUN ./make_cp2k.sh -cv {version} {gcc_version_flag} -gpu {gpu_model} -mpi {mpi_mode} {feature_flags}
 """
@@ -762,11 +767,11 @@ COPY --from=build_cp2k /opt/cp2k/spack/spack/opt/spack ./spack/spack/opt/spack
 COPY --from=build_cp2k /opt/cp2k/install ./install
 
 # Install CP2K regression tests
-COPY --from=build_cp2k /opt/cp2k/tests ./tests
+COPY ./tests ./tests
 COPY --from=build_cp2k /opt/cp2k/src/grid/sample_tasks ./src/grid/sample_tasks
 
 # Install CP2K/Quickstep CI benchmarks
-COPY --from=build_cp2k /opt/cp2k/benchmarks/CI ./benchmarks/CI
+COPY ./benchmarks/CI ./benchmarks/CI
 
 # Do not rely only on LD_LIBRARY_PATH because it is fragile
 COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf


### PR DESCRIPTION
This reorganizes the generated Spack Dockerfiles to further separate dependency installation, CP2K compilation, and test resources into distinct cache layers.

Previously, the complete repository was copied before running `make_cp2k.sh -bd_only`, so any change in the Docker build context caused Docker to rerun the dependency setup step. Although Spack can still reuse packages from `SPACK_CACHE`, this unnecessarily repeats dependency resolution and installation setup.

The dependency stage now copies only `make_cp2k.sh` and `tools/spack`, while the source files required for the CMake build are copied in the subsequent build stage. Regression tests and CI benchmark inputs are also copied directly into the final test image.