### PR TITLE
Fix performance regression in the grid backend

### DIFF
--- a/src/grid/gpu/grid_gpu_collocate.cu
+++ b/src/grid/gpu/grid_gpu_collocate.cu
@@ -89,7 +89,8 @@ __launch_bounds__(64) void calculate_coefficients(const kernel_params dev_) {
   T *smem_alpha = &shared_memory[0];
   const int tid = thread_global_index();
   const int offset = dev_.sorted_blocks_offset_dev[block_index()];
-  T *smem_cab = allocate_workspace<T>(dev_);
+  T *smem_cab = reinterpret_cast<double *>(
+      __builtin_assume_aligned(allocate_workspace<T>(dev_), 32));
 
   for (int tk = 0; tk < number_of_tasks; tk++) {
     __shared__ smem_task<T> task;
@@ -98,9 +99,10 @@ __launch_bounds__(64) void calculate_coefficients(const kernel_params dev_) {
       continue;
     fill_smem_task_coef(dev_, task_id, task);
 
-    T *coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
+    T *__restrict__ coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
 
     compute_alpha(task, smem_alpha);
+
     for (int z = tid; z < task.n1 * task.n2;
          z += blockDim.x * blockDim.y * blockDim.z)
       smem_cab[z] = 0.0;
@@ -160,13 +162,11 @@ __launch_bounds__(64) void collocate_kernel(const kernel_params dev_) {
 
   T *coef_ =
       &dev_.ptr_dev[2][dev_.tasks[dev_.first_task + block_index()].coef_offset];
-  __shared__ T dh_[9], dh_inv_[9];
+  __shared__ T dh_[9];
 
   if (tid < 9) {
     // matrix from lattice coordinates to cartesian coordinates
     dh_[tid] = dev_.dh_[tid];
-    // matrix from  cartesian coordinates to lattice coordinates.
-    dh_inv_[tid] = dev_.dh_inv_[tid];
   }
 
   for (int i = tid; i < ncoset(6); i += blockDim.x * blockDim.y * blockDim.z)

--- a/src/grid/gpu/grid_gpu_context.cu
+++ b/src/grid/gpu/grid_gpu_context.cu
@@ -35,6 +35,11 @@ extern "C" {
 #endif
 
 namespace rocm_backend {
+
+constexpr size_t align_up_elems(size_t n_elems, size_t elem_alignment) {
+  return (n_elems + elem_alignment - 1) & ~(elem_alignment - 1);
+}
+
 kernel_params
 context_info::set_kernel_parameters(const int level,
                                     const smem_parameters &smem_params) {
@@ -235,8 +240,10 @@ extern "C" void grid_gpu_create_task_list(
     tasks_host[i].ncosetb = rocm_backend::ncoset(lb_max_basis);
     // it should lmax + 3 because calculating forces+stress+compute_tau requires
     // l + 3
-    tasks_host[i].max_cab_size = rocm_backend::ncoset(la_max_basis + 3) *
-                                 rocm_backend::ncoset(lb_max_basis + 3);
+    tasks_host[i].max_cab_size =
+        rocm_backend::align_up_elems(rocm_backend::ncoset(la_max_basis + 3) *
+                                         rocm_backend::ncoset(lb_max_basis + 3),
+                                     4);
 
     // size of entire spherical basis
     tasks_host[i].nsgfa = ibasis->nsgf;
@@ -274,9 +281,13 @@ extern "C" void grid_gpu_create_task_list(
     } else {
       tasks_host[i].coef_offset =
           tasks_host[i - 1].coef_offset +
-          rocm_backend::ncoset(tasks_host[i - 1].lp_max);
+          rocm_backend::align_up_elems(
+              rocm_backend::ncoset(tasks_host[i - 1].lp_max), 4);
     }
-    coef_size += rocm_backend::ncoset(tasks_host[i].lp_max);
+
+    // calculate the size such that the coef table is a multiple of 4.
+    coef_size += rocm_backend::align_up_elems(
+        rocm_backend::ncoset(tasks_host[i].lp_max), 4);
 
     auto &grid = ctx->grid_[tasks_host[i].level];
     // compute the cube properties

--- a/src/grid/gpu/grid_gpu_integrate.cu
+++ b/src/grid/gpu/grid_gpu_integrate.cu
@@ -73,7 +73,7 @@ __global__ __launch_bounds__(64) void compute_hab_v4(const kernel_params dev_) {
   T *smem_alpha = &shared_memory[0];
   const int tid = thread_global_index();
   const int offset = dev_.sorted_blocks_offset_dev[block_index()];
-  T *smem_cab = allocate_workspace<T>(dev_);
+  T *__restrict__ smem_cab = allocate_workspace<T>(dev_);
 
   for (int tk = 0; tk < number_of_tasks; tk++) {
     __shared__ smem_task<T> task;
@@ -82,8 +82,10 @@ __global__ __launch_bounds__(64) void compute_hab_v4(const kernel_params dev_) {
       continue;
     fill_smem_task_coef(dev_, task_id, task);
 
-    T *coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
+    T *__restrict__ coef_ = reinterpret_cast<double *>(__builtin_assume_aligned(
+        &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset], 32));
 
+    __syncthreads();
     compute_alpha(task, smem_alpha);
     __syncthreads();
 
@@ -96,19 +98,22 @@ __global__ __launch_bounds__(64) void compute_hab_v4(const kernel_params dev_) {
         const auto &a = coset_inv[ico];
         const T hab = get_hab<COMPUTE_TAU, T>(a, b, task.zeta, task.zetb,
                                               task.n1, smem_cab);
-        __syncthreads();
-        // Try to use as many contiguous threads as possible and limit the
-        // number of warps that do partial work
-        for (int ix = tid; ix < task.nsgf_setb * task.nsgf_seta;
-             ix += blockDim.x * blockDim.y * blockDim.z) {
-          const int i = ix / task.nsgf_seta;
-          const int j = ix % task.nsgf_seta;
-          const T sphia_times_sphib = task.sphia[j * task.maxcoa + ico] *
-                                      task.sphib[i * task.maxcob + jco];
-          if (task.block_transposed) {
-            task.hab_block[j * task.nsgfb + i] += hab * sphia_times_sphib;
-          } else {
-            task.hab_block[i * task.nsgfa + j] += hab * sphia_times_sphib;
+        if (task.block_transposed) {
+          for (int j = tid / 8; j < task.nsgf_seta; j += 8) {
+            const T sphia = task.sphia[j * task.maxcoa + ico];
+            for (int i = tid % 8; i < task.nsgf_setb; i += 8) {
+              const T sphib = task.sphib[i * task.maxcob + jco];
+              task.hab_block[j * task.nsgfb + i] += hab * sphia * sphib;
+            }
+          }
+        } else {
+          for (int i = tid / 8; i < task.nsgf_setb; i += 8) {
+            const T sphib = task.sphib[i * task.maxcob + jco];
+            for (int j = tid % 8; j < task.nsgf_seta; j += 8) {
+              const T sphia_times_sphib =
+                  task.sphia[j * task.maxcoa + ico] * sphib;
+              task.hab_block[i * task.nsgfa + j] += hab * sphia_times_sphib;
+            }
           }
         }
       }
@@ -151,7 +156,8 @@ __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
   virial[6] = 0.0;
   virial[7] = 0.0;
   virial[8] = 0.0;
-  T *smem_cab = allocate_workspace<T>(dev_);
+
+  T *__restrict__ smem_cab = allocate_workspace<T>(dev_);
 
   for (int tk = 0; tk < number_of_tasks; tk++) {
     __shared__ smem_task<T> task;
@@ -160,7 +166,8 @@ __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
       continue;
     fill_smem_task_coef(dev_, task_id, task);
 
-    T *coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
+    T *__restrict__ coef_ = &dev_.ptr_dev[2][dev_.tasks[task_id].coef_offset];
+    __syncthreads();
     compute_alpha(task, smem_alpha);
     __syncthreads();
     cxyz_to_cab(task, smem_alpha, coef_, smem_cab);
@@ -177,9 +184,6 @@ __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
         T *shared_virial = &shared_memory[6];
 
         if (CALCULATE_FORCES) {
-          // Important to synchronize the warps
-          __syncthreads();
-
           if (tid < 3) {
             shared_forces_a[tid] = get_force_a<COMPUTE_TAU, T>(
                 a, b, tid, task.zeta, task.zetb, task.n1, smem_cab);
@@ -194,36 +198,35 @@ __global__ __launch_bounds__(64) void compute_hab_v2(const kernel_params dev_) {
                                              task.zetb, task.rab, task.n1,
                                              smem_cab);
           }
-          __syncthreads();
         }
 
         T block_val1 = 0.0;
         // Try to use as many contiguous threads as possible and limit the
         // number of warps that do partial work
-
-        for (int elem = tid; elem < task.nsgf_setb * task.nsgf_seta;
-             elem += blockDim.x * blockDim.y * blockDim.z) {
-          const int i = elem / task.nsgf_seta;
-          const int j = elem % task.nsgf_seta;
+        for (int i = tid / 8; i < task.nsgf_setb; i += 8) {
           const T sphib = task.sphib[i * task.maxcob + jco];
-          const T sphia_times_sphib = task.sphia[j * task.maxcoa + ico] * sphib;
-          if (CALCULATE_FORCES) {
-            if (task.block_transposed) {
-              block_val1 += task.pab_block[j * task.nsgfb + i] *
-                            task.off_diag_twice * sphia_times_sphib;
-            } else {
-              block_val1 += task.pab_block[i * task.nsgfa + j] *
-                            task.off_diag_twice * sphia_times_sphib;
+          for (int j = tid % 8; j < task.nsgf_seta; j += 8) {
+            const T sphia_times_sphib =
+                task.sphia[j * task.maxcoa + ico] * sphib;
+            if (CALCULATE_FORCES) {
+              if (task.block_transposed) {
+                block_val1 += task.pab_block[j * task.nsgfb + i] *
+                              task.off_diag_twice * sphia_times_sphib;
+              } else {
+                block_val1 += task.pab_block[i * task.nsgfa + j] *
+                              task.off_diag_twice * sphia_times_sphib;
+              }
             }
-          }
-          if (task.block_transposed) {
-            task.hab_block[j * task.nsgfb + i] += hab * sphia_times_sphib;
-          } else {
-            task.hab_block[i * task.nsgfa + j] += hab * sphia_times_sphib;
+            if (task.block_transposed) {
+              task.hab_block[j * task.nsgfb + i] += hab * sphia_times_sphib;
+            } else {
+              task.hab_block[i * task.nsgfa + j] += hab * sphia_times_sphib;
+            }
           }
         }
 
         if (CALCULATE_FORCES) {
+          __syncthreads();
           for (int k = 0; k < 3; k++) {
             fa[k] += block_val1 * shared_forces_a[k];
             fb[k] += block_val1 * shared_forces_b[k];
@@ -312,14 +315,14 @@ __launch_bounds__(64) void integrate_kernel(const kernel_params dev_) {
 
   const int tid = thread_global_index();
 
-  __shared__ T dh_inv_[9];
+  // __shared__ T dh_inv_[9];
   __shared__ T dh_[9];
 
-  for (int d = tid; d < 9; d += blockDim.x * blockDim.y * blockDim.z)
-    dh_inv_[d] = dev_.dh_inv_[d];
+  // for (int d = tid; d < 9; d += blockDim.x * blockDim.y * blockDim.z)
+  //   dh_inv_[d] = dev_.dh_inv_[d];
 
-  for (int d = tid; d < 9; d += blockDim.x * blockDim.y * blockDim.z)
-    dh_[d] = dev_.dh_[d];
+  if (tid < 9)
+    dh_[tid] = dev_.dh_[tid];
 
   __shared__ smem_task_reduced<T, T3> task;
   fill_smem_task_reduced(dev_, dev_.first_task + block_index(), task);
@@ -330,7 +333,7 @@ __launch_bounds__(64) void integrate_kernel(const kernel_params dev_) {
   __syncthreads();
 
   __shared__ T accumulator[lbatch][64];
-  __shared__ T sum[lbatch];
+  // __shared__ T sum[lbatch];
 
   // we use a multi pass algorithm here because shared memory usage (or
   // register) would become too high for high angular momentum
@@ -462,101 +465,111 @@ __launch_bounds__(64) void integrate_kernel(const kernel_params dev_) {
               accumulator[8][tid] += grid_value * r3yz;
               accumulator[9][tid] += grid_value * r3z2;
             }
+            if (task.lp >= 3) {
+              T tmp = grid_value * r3x2;
+              accumulator[10][tid] += tmp * r3.x;
+              accumulator[11][tid] += tmp * r3.y;
+              accumulator[12][tid] += tmp * r3.z;
+              tmp = grid_value * r3.x;
+              accumulator[13][tid] += tmp * r3y2;
+              accumulator[14][tid] += tmp * r3yz;
+              accumulator[15][tid] += tmp * r3z2;
+              tmp = grid_value * r3y2;
+              accumulator[16][tid] += tmp * r3.y;
+              accumulator[17][tid] += tmp * r3.z;
+              tmp = grid_value * r3z2;
+              accumulator[18][tid] += tmp * r3.y;
+              accumulator[19][tid] += tmp * r3.z;
+            }
           } break;
           case 1: {
-            if (task.lp >= 3) {
-              accumulator[0][tid] += grid_value * r3x2 * r3.x;
-              accumulator[1][tid] += grid_value * r3x2 * r3.y;
-              accumulator[2][tid] += grid_value * r3x2 * r3.z;
-              accumulator[3][tid] += grid_value * r3.x * r3y2;
-              accumulator[4][tid] += grid_value * r3xy * r3.z;
-              accumulator[5][tid] += grid_value * r3.x * r3z2;
-              accumulator[6][tid] += grid_value * r3y2 * r3.y;
-              accumulator[7][tid] += grid_value * r3y2 * r3.z;
-              accumulator[8][tid] += grid_value * r3.y * r3z2;
-              accumulator[9][tid] += grid_value * r3z2 * r3.z;
+            if (task.lp >= 4) {
+              T tmp = grid_value * r3x2;
+              accumulator[0][tid] += tmp * r3x2;
+              accumulator[1][tid] += tmp * r3xy;
+              accumulator[2][tid] += tmp * r3xz;
+              accumulator[3][tid] += tmp * r3y2;
+              accumulator[4][tid] += tmp * r3yz;
+              accumulator[5][tid] += tmp * r3z2;
+              tmp = grid_value * r3y2;
+              accumulator[6][tid] += tmp * r3xy;
+              accumulator[7][tid] += tmp * r3xz;
+              tmp = grid_value * r3z2;
+              accumulator[8][tid] += tmp * r3xy;
+              accumulator[9][tid] += tmp * r3xz;
+            }
+            if (task.lp >= 4) {
+              T tmp = grid_value * r3y2;
+              accumulator[10][tid] += tmp * r3y2;
+              accumulator[11][tid] += tmp * r3yz;
+              accumulator[12][tid] += tmp * r3z2;
+              accumulator[13][tid] += grid_value * r3yz * r3z2;
+              accumulator[14][tid] += grid_value * r3z2 * r3z2;
+            }
+            if (task.lp >= 5) {
+              T tmp = grid_value * r3x2 * r3x2;
+              accumulator[15][tid] += tmp * r3.x;
+              accumulator[16][tid] += tmp * r3.y;
+              accumulator[17][tid] += tmp * r3.z;
+              tmp = grid_value * r3x2;
+              accumulator[18][tid] += tmp * r3.x * r3y2;
+              accumulator[19][tid] += tmp * r3xy * r3.z;
             }
           } break;
           case 2: {
-            if (task.lp >= 4) {
-              accumulator[0][tid] += grid_value * r3x2 * r3x2;
-              accumulator[1][tid] += grid_value * r3x2 * r3xy;
-              accumulator[2][tid] += grid_value * r3x2 * r3xz;
-              accumulator[3][tid] += grid_value * r3x2 * r3y2;
-              accumulator[4][tid] += grid_value * r3x2 * r3yz;
-              accumulator[5][tid] += grid_value * r3x2 * r3z2;
-              accumulator[6][tid] += grid_value * r3xy * r3y2;
-              accumulator[7][tid] += grid_value * r3xz * r3y2;
-              accumulator[8][tid] += grid_value * r3xy * r3z2;
-              accumulator[9][tid] += grid_value * r3xz * r3z2;
+            T tmp = grid_value * r3x2;
+            accumulator[0][tid] += tmp * r3.x * r3z2;
+            accumulator[1][tid] += tmp * r3y2 * r3.y;
+            accumulator[2][tid] += tmp * r3y2 * r3.z;
+            accumulator[3][tid] += tmp * r3.y * r3z2;
+            accumulator[4][tid] += tmp * r3z2 * r3.z;
+            tmp = grid_value * r3.x * r3y2;
+            accumulator[5][tid] += tmp * r3y2;
+            accumulator[6][tid] += tmp * r3yz;
+            accumulator[7][tid] += tmp * r3z2;
+            tmp = grid_value * r3.x * r3z2;
+            accumulator[8][tid] += tmp * r3yz;
+            accumulator[9][tid] += tmp * r3z2;
+            tmp = grid_value * r3y2 * r3.y;
+            accumulator[10][tid] += tmp * r3y2;
+            accumulator[11][tid] += tmp * r3yz;
+            accumulator[12][tid] += tmp * r3z2;
+            accumulator[13][tid] += grid_value * r3y2 * r3z2 * r3.z;
+            accumulator[14][tid] += grid_value * r3.y * r3z2 * r3z2;
+            accumulator[15][tid] += grid_value * r3z2 * r3z2 * r3.z;
+            if (task.lp >= 6) {
+              tmp = grid_value * r3x2 * r3x2;
+              accumulator[16][tid] += tmp * r3x2; // x^6
+              accumulator[17][tid] += tmp * r3xy; // x^5 y
+              accumulator[18][tid] += tmp * r3xz; // x^5 z
+              accumulator[19][tid] += tmp * r3y2; // x^4 y^2
             }
           } break;
           case 3: {
-            if (task.lp >= 4) {
-              accumulator[0][tid] += grid_value * r3y2 * r3y2;
-              accumulator[1][tid] += grid_value * r3y2 * r3yz;
-              accumulator[2][tid] += grid_value * r3y2 * r3z2;
-              accumulator[3][tid] += grid_value * r3yz * r3z2;
-              accumulator[4][tid] += grid_value * r3z2 * r3z2;
-            }
-            if (task.lp >= 5) {
-              accumulator[5][tid] += grid_value * r3x2 * r3x2 * r3.x;
-              accumulator[6][tid] += grid_value * r3x2 * r3x2 * r3.y;
-              accumulator[7][tid] += grid_value * r3x2 * r3x2 * r3.z;
-              accumulator[8][tid] += grid_value * r3x2 * r3.x * r3y2;
-              accumulator[9][tid] += grid_value * r3x2 * r3xy * r3.z;
-            }
-          } break;
-          case 4: {
-            accumulator[0][tid] += grid_value * r3x2 * r3.x * r3z2;
-            accumulator[1][tid] += grid_value * r3x2 * r3y2 * r3.y;
-            accumulator[2][tid] += grid_value * r3x2 * r3y2 * r3.z;
-            accumulator[3][tid] += grid_value * r3x2 * r3.y * r3z2;
-            accumulator[4][tid] += grid_value * r3x2 * r3z2 * r3.z;
-            accumulator[5][tid] += grid_value * r3.x * r3y2 * r3y2;
-            accumulator[6][tid] += grid_value * r3.x * r3y2 * r3yz;
-            accumulator[7][tid] += grid_value * r3.x * r3y2 * r3z2;
-            accumulator[8][tid] += grid_value * r3xy * r3z2 * r3.z;
-            accumulator[9][tid] += grid_value * r3.x * r3z2 * r3z2;
-          } break;
-          case 5: {
-            accumulator[0][tid] += grid_value * r3y2 * r3y2 * r3.y;
-            accumulator[1][tid] += grid_value * r3y2 * r3y2 * r3.z;
-            accumulator[2][tid] += grid_value * r3y2 * r3.y * r3z2;
-            accumulator[3][tid] += grid_value * r3y2 * r3z2 * r3.z;
-            accumulator[4][tid] += grid_value * r3.y * r3z2 * r3z2;
-            accumulator[5][tid] += grid_value * r3z2 * r3z2 * r3.z;
-            if (task.lp >= 6) {
-              accumulator[6][tid] += grid_value * r3x2 * r3x2 * r3x2; // x^6
-              accumulator[7][tid] += grid_value * r3x2 * r3x2 * r3xy; // x^5 y
-              accumulator[8][tid] += grid_value * r3x2 * r3x2 * r3xz; // x^5 z
-              accumulator[9][tid] += grid_value * r3x2 * r3x2 * r3y2; // x^4 y^2
-            }
-          } break;
-          case 6: {
-            accumulator[0][tid] += grid_value * r3x2 * r3x2 * r3yz; // x^4 y z
-            accumulator[1][tid] += grid_value * r3x2 * r3x2 * r3z2; // x^4 z^2
-            accumulator[2][tid] += grid_value * r3x2 * r3y2 * r3xy; // x^3 y^3
-            accumulator[3][tid] += grid_value * r3x2 * r3y2 * r3xz; // x^3 y^2 z
-            accumulator[4][tid] += grid_value * r3x2 * r3xy * r3z2; // x^3 y z^2
-            accumulator[5][tid] += grid_value * r3x2 * r3z2 * r3xz; // x^3 z^3
-            accumulator[6][tid] += grid_value * r3x2 * r3y2 * r3y2; // x^2 y^4
-            accumulator[7][tid] += grid_value * r3x2 * r3y2 * r3yz; // x^3 y^2 z
-            accumulator[8][tid] +=
-                grid_value * r3x2 * r3y2 * r3z2; // x^2 y^2 z^2
-            accumulator[9][tid] += grid_value * r3x2 * r3z2 * r3yz; // x^2 y z^3
-          } break;
-          case 7: {
-            accumulator[0][tid] += grid_value * r3x2 * r3z2 * r3z2; // x^2 z^4
-            accumulator[1][tid] += grid_value * r3y2 * r3y2 * r3xy; // x y^5
-            accumulator[2][tid] += grid_value * r3y2 * r3y2 * r3xz; // x y^4 z
-            accumulator[3][tid] += grid_value * r3y2 * r3xy * r3z2; // x y^3 z^2
-            accumulator[4][tid] += grid_value * r3y2 * r3z2 * r3xz; // x y^2 z^3
-            accumulator[5][tid] += grid_value * r3xy * r3z2 * r3z2; // x y z^4
-            accumulator[6][tid] += grid_value * r3z2 * r3z2 * r3xz; // x z^5
-            accumulator[7][tid] += grid_value * r3y2 * r3y2 * r3y2; // y^6
-            accumulator[8][tid] += grid_value * r3y2 * r3y2 * r3yz; // y^5 z
-            accumulator[9][tid] += grid_value * r3y2 * r3y2 * r3z2; // y^4 z^2
+            T tmp = grid_value * r3x2;
+            accumulator[0][tid] += tmp * r3x2 * r3yz;  // x^4 y z
+            accumulator[1][tid] += tmp * r3x2 * r3z2;  // x^4 z^2
+            accumulator[2][tid] += tmp * r3y2 * r3xy;  // x^3 y^3
+            accumulator[3][tid] += tmp * r3y2 * r3xz;  // x^3 y^2 z
+            accumulator[4][tid] += tmp * r3xy * r3z2;  // x^3 y z^2
+            accumulator[5][tid] += tmp * r3z2 * r3xz;  // x^3 z^3
+            accumulator[6][tid] += tmp * r3y2 * r3y2;  // x^2 y^4
+            accumulator[7][tid] += tmp * r3y2 * r3yz;  // x^3 y^2 z
+            accumulator[8][tid] += tmp * r3y2 * r3z2;  // x^2 y^2 z^2
+            accumulator[9][tid] += tmp * r3z2 * r3yz;  // x^2 y z^3
+            accumulator[10][tid] += tmp * r3z2 * r3z2; // x^2 z^4
+            tmp = grid_value * r3y2 * r3y2;
+            accumulator[11][tid] += tmp * r3xy; // x y^5
+            accumulator[12][tid] += tmp * r3xz; // x y^4 z
+            accumulator[13][tid] +=
+                grid_value * r3y2 * r3xy * r3z2; // x y^3 z^2
+            accumulator[14][tid] +=
+                grid_value * r3y2 * r3z2 * r3xz; // x y^2 z^3
+            accumulator[15][tid] += grid_value * r3xy * r3z2 * r3z2; // x y z^4
+            accumulator[16][tid] += grid_value * r3z2 * r3z2 * r3xz; // x z^5
+            accumulator[17][tid] += tmp * r3y2;                      // y^6
+            accumulator[18][tid] += tmp * r3yz;                      // y^5 z
+            accumulator[19][tid] += tmp * r3z2;                      // y^4 z^2
           } break;
           default:
             for (int ic = 0; (ic < lbatch) && ((ic + ico) < length); ic++) {
@@ -592,16 +605,8 @@ __launch_bounds__(64) void integrate_kernel(const kernel_params dev_) {
 
     if (tid < 32) {
       for (int i = 0; i < max_i; i++) {
-        accumulator[i][tid] += accumulator[i][tid + 32];
-      }
-    }
-
-    __syncthreads();
-
-    if (tid < 32) {
-      for (int i = 0; i < max_i; i++) {
         // Load local value
-        T val = accumulator[i][tid];
+        T val = accumulator[i][tid] + accumulator[i][tid + 32];
 
         // Warp-level reduction (32 lanes) After this loop, lane 0 of warp 0
         // holds the result All threads should execute this operation so
@@ -620,14 +625,14 @@ __launch_bounds__(64) void integrate_kernel(const kernel_params dev_) {
         }
 
         if (tid == 0)
-          sum[i] = val;
+          accumulator[i][0] = val;
       }
+      __syncwarp();
     }
-    __syncthreads();
 
     if (tid < min(length - ico, lbatch))
       dev_.ptr_dev[2][dev_.tasks[dev_.first_task + block_index()].coef_offset +
-                      tid + ico] = sum[tid];
+                      tid + ico] = accumulator[tid][0];
     __syncthreads();
   }
 }
@@ -660,21 +665,21 @@ void context_info::integrate_one_grid_level(const int level, int *lp_diff) {
   const dim3 threads_per_block(4, 4, 4);
   if (grid_[level].is_distributed()) {
     if (grid_[level].is_orthogonal()) {
-      integrate_kernel<double, double3, true, true, 10>
+      integrate_kernel<double, double3, true, true, 20>
           <<<number_of_tasks_per_level_[level], threads_per_block, 0,
              level_streams[level]>>>(params);
     } else {
-      integrate_kernel<double, double3, true, false, 10>
+      integrate_kernel<double, double3, true, false, 20>
           <<<number_of_tasks_per_level_[level], threads_per_block, 0,
              level_streams[level]>>>(params);
     }
   } else {
     if (grid_[level].is_orthogonal()) {
-      integrate_kernel<double, double3, false, true, 10>
+      integrate_kernel<double, double3, false, true, 20>
           <<<number_of_tasks_per_level_[level], threads_per_block, 0,
              level_streams[level]>>>(params);
     } else {
-      integrate_kernel<double, double3, false, false, 10>
+      integrate_kernel<double, double3, false, false, 20>
           <<<number_of_tasks_per_level_[level], threads_per_block, 0,
              level_streams[level]>>>(params);
     }

--- a/src/grid/gpu/grid_gpu_internal_header.h
+++ b/src/grid/gpu/grid_gpu_internal_header.h
@@ -332,8 +332,8 @@ __inline__ __device__ void compute_alpha(const smem_task<T> &task,
   const int s3 = (task.lp + 1);
   const int s2 = (task.la_max + 1) * s3;
   const int s1 = (task.lb_max + 1) * s2;
-  const int tid =
-      threadIdx.x + blockDim.x * (threadIdx.y + blockDim.y * threadIdx.z);
+  const int tid = thread_global_index();
+
   for (int i = tid; i < 3 * s1; i += blockDim.x * blockDim.y * blockDim.z)
     alpha[i] = 0.0;
 
@@ -358,7 +358,6 @@ __inline__ __device__ void compute_alpha(const smem_task<T> &task,
       }
     }
   }
-  __syncthreads(); // because of concurrent writes to alpha
 }
 
 __host__ __inline__ __device__ void


### PR DESCRIPTION
The performance cost comes from the number of iterations in the multipass algorithm. The original CUDA kernel was calculating 20 coefficients in a single pass while the hip version only 10 which requires twice as much time for the same calculation. 

The new implementation now calculate 20 coefficients in a single pass at the cost of shared memory that double. Occupancy will likely decrease because of this. 

I also tried a different implementation that would calculate all coefficients in a single pass up to lp = 5 but it is slower than the multipass implementation by a very large margin. 



 