### PR TITLE
Toolchain: Update ELPA patch and libxsmm version

### DIFF
--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -6,8 +6,8 @@
 [ "${BASH_SOURCE[0]}" ] && SCRIPT_NAME="${BASH_SOURCE[0]}" || SCRIPT_NAME=$0
 SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_NAME")/.." && pwd -P)"
 
-libxsmm_ver="db07b74"
-libxsmm_sha256="741c1ca39deee4bd01fc62c076b68a5623bb5e1aeaea0368fb65d2fdf7bdbed7"
+libxsmm_ver="2.0.0"
+libxsmm_sha256="7e532dc5520f864ce6d7f44f3fd50365e3edb23da97dbdc54fd53845d86a290b"
 source "${SCRIPT_DIR}"/common_vars.sh
 source "${SCRIPT_DIR}"/tool_kit.sh
 source "${SCRIPT_DIR}"/signal_trap.sh
@@ -34,7 +34,14 @@ EOF
     if verify_checksums "${install_lock_file}"; then
       echo "libxsmm-${libxsmm_ver} is already installed, skipping it."
     else
-      retrieve_package "${libxsmm_sha256}" "libxsmm-${libxsmm_ver}.tar.gz"
+      # retrieve_package "${libxsmm_sha256}" "libxsmm-${libxsmm_ver}.tar.gz"
+      if [ -f libxsmm-${libxsmm_ver}.tar.gz ]; then
+        echo "libxsmm-${libxsmm_ver}.tar.gz is found"
+      else
+        download_pkg_from_urlpath "${libxsmm_sha256}" "${libxsmm_ver}.tar.gz" \
+          https://github.com/libxsmm/libxsmm/archive/refs/tags \
+          "libxsmm-${libxsmm_ver}.tar.gz"
+      fi
       echo "Installing from scratch into ${pkg_install_dir}"
       [ -d libxsmm-${libxsmm_ver} ] && rm -rf libxsmm-${libxsmm_ver}
       tar -xzf libxsmm-${libxsmm_ver}.tar.gz

--- a/tools/toolchain/scripts/stage5/elpa-2026.02.001-library-only.patch
+++ b/tools/toolchain/scripts/stage5/elpa-2026.02.001-library-only.patch
@@ -1,7 +1,6 @@
---- a/Makefile.in	2026-03-04 17:57:56.000000000 +0000
-+++ b/Makefile.in	2026-06-15 16:37:06.464630054 +0000
-@@ -43753,7 +43753,7 @@
-
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -43752,6 +43752,6 @@
  # library with shared sources for the test files
  noinst_LTLIBRARIES = libelpa@SUFFIX@_public.la \
 -	libelpa@SUFFIX@_private.la libelpatest@SUFFIX@.la
@@ -9,3 +8,13 @@
  libelpa@SUFFIX@_public_la_FCFLAGS = $(AM_FCFLAGS) $(FC_MODOUT)modules $(FC_MODINC)private_modules
  libelpa@SUFFIX@_public_la_SOURCES = \
    src/elpa.F90 \
+--- a/src/solve_tridi/merge_systems_template.F90
++++ b/src/solve_tridi/merge_systems_template.F90
+@@ -809,4 +809,6 @@
+-        write(error_unit,*) "Returing early from merge_systems (na1==1 .or. na1==2)"
++        if (wantDebug) then
++          write(error_unit,*) "Returing early from merge_systems (na1==1 .or. na1==2)"
++        endif
+         ! na=1 can be tested with "mpirun -n 4 ./validate_real_double_solve_tridiagonal_1stage_gpu_blocktridi 3 3 1"
+         ! na=2 can be tested with "mpirun -n 4 ./validate_real_double_solve_tridiagonal_1stage_gpu_toeplitz 4 4 2"
+       else if (na1>2) then


### PR DESCRIPTION
- ELPA: Avoid flooding stderr with the useless `Returing early from merge_systems (na1==1 .or. na1==2)` message during normal ELPA runs.
- LibXSMM: Update to version 2.0.0.