### PR TITLE
make_cp2k.sh: Avoid expanding unset SPACK_ENV

### DIFF
--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1155,9 +1155,7 @@ if [[ ! -f "${SPACK_BUILD_PATH}/BUILD_DEPENDENCIES_COMPLETED" ]]; then
 
   # Create CP2K environment if needed
   if spack env list | grep -q "${CP2K_ENV}"; then
-    if [[ -n "${SPACK_ENV}" ]]; then
-      echo "The Spack environment \"${CP2K_ENV}\" exists already"
-    fi
+    echo "The Spack environment \"${CP2K_ENV}\" exists already"
   else
     cat "${CP2K_CONFIG_FILE}"
     echo "The Spack environment \"${CP2K_ENV}\" does NOT exist"


### PR DESCRIPTION
Follow up to #5497: Avoid expanding `SPACK_ENV` after it has been [explicitly unset](https://github.com/cp2k/cp2k/blob/2c8265a529330abef610916e7989fde72eb0bdf5/make_cp2k.sh#L949-L950).

The existence of `cp2k_env` is already determined by `spack env list`; `SPACK_ENV` only describes the environment currently activated in the shell and is not needed here. This also prevents an `unbound variable` error with `set -u`.
