### PR TITLE
Docker: Test "keepalive" case specifically

### DIFF
--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -298,6 +298,17 @@ timeout:     170
 host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_psmp-4ranks_report.txt
 
+[current-psmp-keepalive]
+name:        Current Toolchain (psmp, keepalive)
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_psmp-keepalive_report.txt
+
+[spack-psmp-keepalive]
+name:        Spack (psmp, keepalive)
+timeout:     170
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-keepalive_report.txt
+
 [spack-psmp-4x2]
 name:        Spack (psmp, 4x2)
 timeout:     170

--- a/tools/docker/Dockerfile.test_psmp_keepalive
+++ b/tools/docker/Dockerfile.test_psmp_keepalive
@@ -1,0 +1,86 @@
+#
+# This file was created by generate_dockerfiles.py.
+# Usage: podman build --shm-size=1g -f ./Dockerfile.test_psmp_keepalive ../../
+#
+
+FROM ubuntu:26.04
+
+# Install requirements for the toolchain.
+WORKDIR /opt/cp2k-toolchain
+COPY ./tools/toolchain/install_requirements*.sh ./
+RUN ./install_requirements.sh ubuntu:26.04
+
+# Install the toolchain.
+RUN mkdir scripts
+COPY ./tools/toolchain/scripts/VERSION \
+     ./tools/toolchain/scripts/tool_kit.sh \
+     ./tools/toolchain/scripts/common_vars.sh \
+     ./tools/toolchain/scripts/signal_trap.sh \
+     ./tools/toolchain/scripts/get_openblas_arch.sh \
+     ./scripts/
+COPY ./tools/toolchain/install_cp2k_toolchain.sh .
+RUN ./install_cp2k_toolchain.sh \
+    --install-all \
+    --mpi-mode=mpich \
+    --with-dbcsr \
+    --with-gcc=system \
+    --dry-run
+
+# Dry-run leaves behind config files for the followup install scripts.
+# This breaks up the lengthy installation into smaller build steps.
+COPY ./tools/toolchain/scripts/stage0/ ./scripts/stage0/
+RUN  ./scripts/stage0/install_stage0.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage1/ ./scripts/stage1/
+RUN  ./scripts/stage1/install_stage1.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage2/ ./scripts/stage2/
+RUN  ./scripts/stage2/install_stage2.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage3/ ./scripts/stage3/
+RUN  ./scripts/stage3/install_stage3.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage4/ ./scripts/stage4/
+RUN  ./scripts/stage4/install_stage4.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage5/ ./scripts/stage5/
+RUN  ./scripts/stage5/install_stage5.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage6/ ./scripts/stage6/
+RUN  ./scripts/stage6/install_stage6.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage7/ ./scripts/stage7/
+RUN  ./scripts/stage7/install_stage7.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage8/ ./scripts/stage8/
+RUN  ./scripts/stage8/install_stage8.sh && rm -rf ./build
+
+COPY ./tools/toolchain/scripts/stage9/ ./scripts/stage9/
+RUN  ./scripts/stage9/install_stage9.sh && rm -rf ./build
+
+# Install CP2K sources.
+WORKDIR /opt/cp2k
+COPY ./src ./src
+COPY ./data ./data
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./cmake ./cmake
+COPY ./CMakeLists.txt .
+
+# Compile CP2K.
+COPY ./tools/docker/scripts/build_cp2k.sh ./tools/docker/scripts/cmake_cp2k.sh ./
+RUN ./build_cp2k.sh toolchain psmp
+
+# Run regression tests.
+ARG TESTOPTS="--keepalive"
+COPY ./tests ./tests
+COPY ./tools/docker/scripts/test_regtest.sh ./
+RUN /bin/bash -o pipefail -c " \
+    TESTOPTS='${TESTOPTS}' \
+    ./test_regtest.sh toolchain psmp |& tee report.log && \
+    rm -rf regtesting"
+
+# Output the report if the image is old and was therefore pulled from the build cache.
+CMD cat $(find ./report.log -mmin +10) | sed '/^Summary:/ s/$/ (cached)/'
+ENTRYPOINT []
+
+#EOF

--- a/tools/docker/Dockerfile.test_spack_openmpi-pdbg
+++ b/tools/docker/Dockerfile.test_spack_openmpi-pdbg
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests  || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_openmpi-pdbg
+++ b/tools/docker/Dockerfile.test_spack_openmpi-pdbg
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests  || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_spack_openmpi-psmp
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_pdbg
+++ b/tools/docker/Dockerfile.test_spack_pdbg
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests  || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_pdbg
+++ b/tools/docker/Dockerfile.test_spack_pdbg
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests  || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_pdbg-rawhide
+++ b/tools/docker/Dockerfile.test_spack_pdbg-rawhide
@@ -83,7 +83,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests  || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_pdbg-rawhide
+++ b/tools/docker/Dockerfile.test_spack_pdbg-rawhide
@@ -83,7 +83,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-4x2
+++ b/tools/docker/Dockerfile.test_spack_psmp-4x2
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive --mpiranks=4 --ompthreads=2 || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow --mpiranks=4 --ompthreads=2 || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-P100
+++ b/tools/docker/Dockerfile.test_spack_psmp-P100
@@ -55,7 +55,7 @@ WORKDIR /opt/cp2k
 COPY ./tools/spack ./tools/spack
 COPY ./tools/docker ./tools/docker
 COPY ./make_cp2k.sh .
-RUN ./make_cp2k.sh -bd_only -cv psmp -gpu P100 -gv 13 -mpi mpich -ue 
+RUN ./make_cp2k.sh -bd_only -cv psmp -gpu P100 -gv 13 -mpi mpich -ue --keepalive
 
 ###### Stage 2: Build CP2K ######
 
@@ -67,7 +67,7 @@ COPY ./tools/build_utils ./tools/build_utils
 COPY ./cmake ./cmake
 COPY ./CMakeLists.txt .
 
-RUN ./make_cp2k.sh -cv psmp -gv 13 -gpu P100 -mpi mpich 
+RUN ./make_cp2k.sh -cv psmp -gv 13 -gpu P100 -mpi mpich --keepalive
 
 ###### Stage 3: Install CP2K ######
 
@@ -105,7 +105,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc10
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc10
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc11
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc11
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc12
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc12
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc13
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc13
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc14
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc14
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc15
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc15
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc16
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc16
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-keepalive
+++ b/tools/docker/Dockerfile.test_spack_psmp-keepalive
@@ -1,35 +1,44 @@
 #
 # This file was created by generate_dockerfiles.py.
-# Usage: ./spack_cache_start.sh; podman build --shm-size=1g -t spack_psmp-fedora -f ./Dockerfile.test_spack_psmp-fedora ../../
+# Usage: ./spack_cache_start.sh; podman build --shm-size=1g -t spack_psmp-keepalive -f ./Dockerfile.test_spack_psmp-keepalive ../../
 #
 
-ARG BASE_IMAGE="fedora:latest"
+ARG BASE_IMAGE="ubuntu:26.04"
 
 ###### Stage 1: Build CP2K dependencies ######
 
 FROM "${BASE_IMAGE}" AS build_deps
 
-RUN dnf -qy install \
+RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+    bzip2 \
+    ca-certificates \
     cmake \
     g++ gcc gfortran \
     git \
-    libffi-devel \
-    liblsan \
+    gnupg \
+    libssh-dev \
+    libssl-dev \
     libtool \
+    libtool-bin \
+    lsb-release \
     make \
     patch \
-    perl-core \
-    pkg-config \
+    pkgconf \
     python3 \
-    python3-devel \
+    python3-dev \
+    python3-pip \
+    python3-venv \
     unzip \
     wget \
-    zlib-devel \
-    zlib-static \
-    && dnf clean -q all
+    xxd \
+    xz-utils \
+    zlib1g \
+    zlib1g-dev \
+    zstd \
+    && rm -rf /var/lib/apt/lists/*
 
 ARG IMAGE_TAG
-ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-fedora}
+ENV IMAGE_TAG=${IMAGE_TAG:-spack_psmp-keepalive}
 
 ARG SPACK_CACHE
 ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
@@ -57,11 +66,10 @@ RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich
 
 FROM "${BASE_IMAGE}" AS install_cp2k
 
-RUN dnf -qy install \
+RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
     g++ gcc gfortran \
     python3 \
-    liblsan \
-    && dnf clean -q all
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/cp2k
 
@@ -83,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-opensuse
+++ b/tools/docker/Dockerfile.test_spack_psmp-opensuse
@@ -88,7 +88,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_psmp-rockylinux
+++ b/tools/docker/Dockerfile.test_spack_psmp-rockylinux
@@ -84,7 +84,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_ssmp
+++ b/tools/docker/Dockerfile.test_spack_ssmp
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_ssmp-static
+++ b/tools/docker/Dockerfile.test_spack_ssmp-static
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --flagslow || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -390,7 +390,7 @@ build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_spack_openmpi-pdbg
 
 [spack-psmp-keepalive]
-display_name: Spack psmp (keepalive)
+display_name: Spack (psmp, keepalive)
 tags:         weekly-morning
 cpu:          32
 nodepools:    pool-main

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -389,6 +389,23 @@ nodepools:    pool-main
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_spack_openmpi-pdbg
 
+[spack-psmp-keepalive]
+display_name: Spack psmp (keepalive)
+tags:         weekly-morning
+cpu:          32
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-keepalive
+
+[psmp-keepalive]
+display_name: Regtest psmp (keepalive)
+tags:         weekly-morning
+cpu:          32
+nodepools:    pool-main
+cache_from:   pdbg
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_psmp_keepalive
+
 [openmpi-psmp]
 display_name: OpenMPI
 tags:         weekly-morning

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -71,7 +71,7 @@ def main() -> None:
                 version="pdbg",
                 mpi_mode="mpich",
                 feature_flags="",
-                testopts=testopts,
+                testopts="",
                 image_tag=f.image_tag,
             )
         )
@@ -112,7 +112,7 @@ def main() -> None:
                 mpi_mode="mpich",
                 base_image="fedora:rawhide",
                 feature_flags="",
-                testopts=testopts,
+                testopts="",
                 image_tag=f.image_tag,
             )
         )
@@ -172,7 +172,7 @@ def main() -> None:
                 version="pdbg",
                 mpi_mode="openmpi",
                 feature_flags="",
-                testopts=testopts,
+                testopts="",
                 image_tag=f.image_tag,
             )
         )

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -25,6 +25,10 @@ def main() -> None:
         f.write(install_deps_toolchain())
         f.write(regtest("toolchain", "psmp", testopts=testopts))
 
+    with OutputFile(f"Dockerfile.test_psmp_keepalive", args.check) as f:
+        f.write(install_deps_toolchain())
+        f.write(regtest("toolchain", "psmp", testopts=f"--keepalive"))
+
     with OutputFile(f"Dockerfile.test_generic_psmp", args.check) as f:
         f.write(install_deps_toolchain(target_cpu="generic"))
         f.write(regtest("toolchain_generic", "psmp"))
@@ -89,6 +93,17 @@ def main() -> None:
                     image_tag=f.image_tag,
                 )
             )
+
+    with OutputFile(f"Dockerfile.test_spack_psmp-keepalive", args.check) as f:
+        f.write(
+            install_cp2k_spack(
+                version="psmp",
+                mpi_mode="mpich",
+                feature_flags="",
+                testopts=f"--keepalive --flagslow",
+                image_tag=f.image_tag,
+            )
+        )
 
     with OutputFile(f"Dockerfile.test_spack_pdbg-rawhide", args.check) as f:
         f.write(

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -59,7 +59,7 @@ def main() -> None:
 
     # Spack/CMake based testers
 
-    testopts = f"--keepalive"
+    testopts = f"--flagslow"
 
     with OutputFile(f"Dockerfile.test_spack_pdbg", args.check) as f:
         f.write(
@@ -67,7 +67,7 @@ def main() -> None:
                 version="pdbg",
                 mpi_mode="mpich",
                 feature_flags="",
-                testopts="",
+                testopts=testopts,
                 image_tag=f.image_tag,
             )
         )
@@ -146,7 +146,7 @@ def main() -> None:
                 version="psmp",
                 mpi_mode="mpich",
                 feature_flags="",
-                testopts=f"--keepalive --mpiranks=4 --ompthreads=2",
+                testopts=f"--flagslow --mpiranks=4 --ompthreads=2",
                 image_tag=f.image_tag,
             )
         )
@@ -157,7 +157,7 @@ def main() -> None:
                 version="pdbg",
                 mpi_mode="openmpi",
                 feature_flags="",
-                testopts="",
+                testopts=testopts,
                 image_tag=f.image_tag,
             )
         )
@@ -203,7 +203,7 @@ def main() -> None:
                 base_image="docker.io/nvidia/cuda:12.9.1-devel-ubuntu24.04",
                 gcc_version=13,
                 gpu_model="P100",
-                testopts=testopts,
+                testopts=f"--keepalive",
                 image_tag=f.image_tag,
             )
         )
@@ -216,7 +216,7 @@ def main() -> None:
                 base_image="docker.io/nvidia/cuda:12.9.1-devel-ubuntu24.04",
                 gcc_version=13,
                 gpu_model="P100",
-                feature_flags="",
+                feature_flags=f"--keepalive",
                 testopts=testopts,
                 image_tag=f.image_tag,
             )


### PR DESCRIPTION
This PR runs the Spack-based CPU regtest configurations with `--flagslow` and remove `--keepalive` from their default test options.

However, from https://github.com/cp2k/cp2k/pull/5365#issuecomment-4732850294 and #5406 it seems some cases are detected only in keepalive mode. Therefore, add two tests dedicatedly to retain explicit coverage for that mode.
