### PR TITLE
Set OpenMPI default binding policy to none via environment variable

### DIFF
--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1523,10 +1523,11 @@ done
 ln -sf cp2k."${VERSION}" cp2k_shell
 cd "${CP2K_ROOT}" || ${EXIT_CMD} 1
 
-# Allow to run as root with OpenMPI
+# Configure Open MPI environment for local CP2K runs
 if [[ "${MPI_MODE}" == "openmpi" ]]; then
-  OMPI_VARS="export OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 OMPI_MCA_plm_rsh_agent=/bin/false"
+  OMPI_VARS="export OMPI_MCA_plm_rsh_agent=/bin/false PRTE_MCA_hwloc_default_binding_policy=none"
   if [[ "${IN_CONTAINER}" == "yes" ]]; then
+    OMPI_VARS="${OMPI_VARS} OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"
     OMPI_VARS="${OMPI_VARS} OMPI_MCA_mpi_yield_when_idle=1 OMPI_MCA_btl=self,sm OMPI_MCA_pml=ob1"
   fi
 else

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -105,6 +105,7 @@ export MPICXX="${MPICXX}"
 export MPIFC="${MPIFC}"
 export MPIFORT="${MPIFORT}"
 export MPIF77="${MPIF77}"
+export PRTE_MCA_hwloc_default_binding_policy=none
 EOF
   if [ "${with_openmpi}" != "__SYSTEM__" ]; then
     cat << EOF >> "${BUILDDIR}/setup_openmpi"


### PR DESCRIPTION
Open MPI's deefault process binding policy can break hybrid MPI+OpenMP parallelism by restricting each MPI rank, together with all of its OpenMP threads, to too few CPU cores. Open MPI does not infer `OMP_NUM_THREADS`, so a binding that is appropriate for MPI-only runs may force all OpenMP threads of a rank to share a single core. This is not user-friendly since CP2K is OpenMP-parallelized. Therefore, default to `--bind-to none` via setting environment to make hybrid parallelism (MPI+OpenMP) happy, which is also [suggested in OpenMPI documentation](https://docs.open-mpi.org/en/main/man-openmpi/man1/mpirun.1.html#quick-summary).

This change does not affect any OpenMPI Docker testers since they already have variables regarding root in both [toolchain tests](https://github.com/cp2k/cp2k/blob/5976d25a45174d28df9c77845b753e0a0585d6d8/tools/docker/scripts/test_regtest.sh#L41-L42) and [Spack tests](https://github.com/cp2k/cp2k/blob/5976d25a45174d28df9c77845b753e0a0585d6d8/make_cp2k.sh#L1527-L1528), as well as `--bind-to none` in [do_regtest.py](https://github.com/cp2k/cp2k/blob/5976d25a45174d28df9c77845b753e0a0585d6d8/tests/do_regtest.py#L70).