### PR TITLE
Revert "Libxc: Preserve aliases when registering XC functional sections"

### DIFF
--- a/src/xc/xc_libxc.F
+++ b/src/xc/xc_libxc.F
@@ -58,11 +58,13 @@ MODULE xc_libxc
                             xc_f03_func_init, &
                             xc_f03_func_end, &
                             xc_f03_func_info_t, &
+                            xc_f03_functional_get_name, &
                             xc_f03_func_get_info, &
                             xc_f03_func_info_get_family, &
                             xc_f03_func_info_get_kind, &
                             xc_f03_func_info_get_n_ext_params, &
                             xc_f03_func_info_get_name, &
+                            xc_f03_available_functional_numbers, &
                             xc_f03_available_functional_names, &
                             xc_f03_maximum_name_length, &
                             xc_f03_number_of_functionals, &
@@ -213,7 +215,7 @@ CONTAINS
       REAL(KIND=C_DOUBLE) :: default_val
       CHARACTER(LEN=128) :: func_name, param_name, param_descr, description
       CHARACTER(LEN=2*default_string_length) :: warning
-      CHARACTER(LEN=:), DIMENSION(:), ALLOCATABLE :: func_names
+      INTEGER(KIND=C_INT), DIMENSION(:), ALLOCATABLE :: func_ids
       TYPE(xc_f03_func_t)                      :: xc_func
       TYPE(xc_f03_func_info_t)                 :: xc_info
 
@@ -225,20 +227,20 @@ CONTAINS
       no_func = xc_f03_number_of_functionals()
       len_name = xc_f03_maximum_name_length()
 
-      ALLOCATE (CHARACTER(LEN=len_name) :: func_names(no_func))
+      ALLOCATE (func_ids(no_func))
 
-      CALL xc_f03_available_functional_names(func_names)
+      CALL xc_f03_available_functional_numbers(func_ids)
 
       DO ii = 1, no_func
 
-         func_name = func_names(ii)
-         func_id = xc_libxc_wrap_functional_get_number(func_name)
+         func_id = func_ids(ii)
 !$OMP CRITICAL(libxc_init)
          CALL xc_f03_func_init(xc_func, func_id, XC_UNPOLARIZED)
          xc_info = xc_f03_func_get_info(xc_func)
 !$OMP END CRITICAL(libxc_init)
 !$OMP BARRIER
 
+         func_name = xc_f03_functional_get_name(func_id)
          description = xc_f03_func_info_get_name(xc_info)
          n_param = xc_f03_func_info_get_n_ext_params(xc_info)
 

--- a/src/xc/xc_libxc.F
+++ b/src/xc/xc_libxc.F
@@ -234,6 +234,9 @@ CONTAINS
       DO ii = 1, no_func
 
          func_id = func_ids(ii)
+         IF (ii > 1) THEN
+            IF (func_id == func_ids(ii - 1)) CYCLE
+         END IF
 !$OMP CRITICAL(libxc_init)
          CALL xc_f03_func_init(xc_func, func_id, XC_UNPOLARIZED)
          xc_info = xc_f03_func_get_info(xc_func)
@@ -284,6 +287,8 @@ CONTAINS
          CALL xc_f03_func_end(xc_func)
 
       END DO
+
+      DEALLOCATE (func_ids)
 
       CALL timestop(handle)
 #else


### PR DESCRIPTION
Reverts cp2k/cp2k#5510