### PR TITLE
Docker: Disable GauXC in generic toolchain tester

### DIFF
--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -25,6 +25,7 @@ RUN ./install_cp2k_toolchain.sh \
     --with-dbcsr \
     --with-gcc=system \
     --target-cpu=generic \
+    --with-gauxc=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -26,7 +26,7 @@ def main() -> None:
         f.write(regtest("toolchain", "psmp", testopts=testopts))
 
     with OutputFile(f"Dockerfile.test_generic_psmp", args.check) as f:
-        f.write(install_deps_toolchain(target_cpu="generic"))
+        f.write(install_deps_toolchain(target_cpu="generic", with_gauxc="no"))
         f.write(regtest("toolchain_generic", "psmp"))
 
     with OutputFile(f"Dockerfile.test_openmpi-psmp", args.check) as f:

--- a/tools/docker/scripts/cmake_cp2k.sh
+++ b/tools/docker/scripts/cmake_cp2k.sh
@@ -173,6 +173,7 @@ elif [[ "${PROFILE}" == "toolchain_generic" ]] && [[ "${VERSION}" == "psmp" ]]; 
     -DCP2K_USE_PEXSI=OFF \
     -DCP2K_USE_DEEPMD=OFF \
     -DCP2K_USE_OPENPMD=OFF \
+    -DCP2K_USE_GAUXC=OFF \
     -Werror=dev \
     .. |& tee ./cmake.log
   CMAKE_EXIT_CODE=$?


### PR DESCRIPTION
Though I know this is just a workaround, almost all failures in [Generic toolchain](https://dashboard.cp2k.org/archive/generic-psmp/commit_2c8265a529330abef610916e7989fde72eb0bdf5.txt) are under GauXC regtests. Previously there's also runtime failure regarding `Fist/regtest-nequip/water-bulk.inp`, but it was masked since the number of GauXC failure is large enough.