### PR TITLE
Docker: Disable PyTorch in generic toolchain tester

### DIFF
--- a/tools/docker/Dockerfile.test_generic_psmp
+++ b/tools/docker/Dockerfile.test_generic_psmp
@@ -26,6 +26,7 @@ RUN ./install_cp2k_toolchain.sh \
     --with-gcc=system \
     --target-cpu=generic \
     --with-gauxc=no \
+    --with-libtorch=no \
     --dry-run
 
 # Dry-run leaves behind config files for the followup install scripts.

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -26,7 +26,11 @@ def main() -> None:
         f.write(regtest("toolchain", "psmp", testopts=testopts))
 
     with OutputFile(f"Dockerfile.test_generic_psmp", args.check) as f:
-        f.write(install_deps_toolchain(target_cpu="generic", with_gauxc="no"))
+        f.write(
+            install_deps_toolchain(
+                target_cpu="generic", with_gauxc="no", with_libtorch="no"
+            )
+        )
         f.write(regtest("toolchain_generic", "psmp"))
 
     with OutputFile(f"Dockerfile.test_openmpi-psmp", args.check) as f:

--- a/tools/docker/scripts/cmake_cp2k.sh
+++ b/tools/docker/scripts/cmake_cp2k.sh
@@ -184,6 +184,7 @@ elif [[ "${PROFILE}" == "toolchain_generic" ]] && [[ "${VERSION}" == "psmp" ]]; 
     -DCP2K_USE_DLAF=OFF \
     -DCP2K_USE_PEXSI=OFF \
     -DCP2K_USE_DEEPMD=OFF \
+    -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_OPENPMD=OFF \
     -DCP2K_USE_GAUXC=OFF \
     -Werror=dev \


### PR DESCRIPTION
Follow up to #5516. See also #5528.