### PR TITLE
Toolchain: Drop obsolete --without-slurm for MPICH

### DIFF
--- a/tools/toolchain/scripts/stage1/install_mpich.sh
+++ b/tools/toolchain/scripts/stage1/install_mpich.sh
@@ -50,7 +50,6 @@ case "${with_mpich}" in
         --prefix="${pkg_install_dir}" \
         --libdir="${pkg_install_dir}/lib" \
         --with-device=${MPICH_DEVICE} \
-        --without-slurm \
         ${FAST_OPTION} \
         FFLAGS="${FCFLAGS}" \
         FCFLAGS="${FCFLAGS}" \


### PR DESCRIPTION
Current MPICH version no longer probes or links against libslurm merely to parse Slurm node lists. Upstream removed that dependency after incompatible `hostlist_t` API changes across Slurm versions, using Hydra's internal parser instead. Therefore, drop the now-redundant `--without-slurm` workaround.