### PR TITLE
Shorten New Pulay iteration label

### DIFF
--- a/src/qs_gspace_mixing.F
+++ b/src/qs_gspace_mixing.F
@@ -173,7 +173,7 @@ CONTAINS
             mixing_store%iter_method = "Pulay"
          ELSEIF (mixing_method == new_pulay_mixing_nr) THEN
             CALL pulay_mixing(qs_env, mixing_store, rho, para_env)
-            mixing_store%iter_method = "New Pulay"
+            mixing_store%iter_method = "NPulay"
          ELSEIF (mixing_method == broyden_mixing_nr) THEN
             CALL cite_reference(Broyden1965)
             CALL broyden_mixing(qs_env, mixing_store, rho, para_env)


### PR DESCRIPTION
`New Pulay` exceeds the available width in the SCF iteration output and can be truncated or overwritten. Rename the displayed label to `NPulay`, which fits the existing layout while retaining a clear association with the New Pulay mixing method.

This is an output-only change; the mixing implementation is unchanged.