### PR TITLE
make_cp2k.sh: Use Spack v1.2.0

### DIFF
--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1159,7 +1159,7 @@ if [[ ! -f "${SPACK_BUILD_PATH}/BUILD_DEPENDENCIES_COMPLETED" ]]; then
   spack compiler list
 
   # Retrieve the newest compiler version found by spack
-  GCC_VERSION_NEWEST="$(spack compilers | awk '/gcc/ {print $2}' | sort -V | tail -n 1)"
+  GCC_VERSION_NEWEST="$(spack compilers | sed -nE 's/.*gcc@([0-9]+(\.[0-9]+)*).*/\1/p' | sort -V | tail -n 1)"
   echo "The newest GCC compiler version found by spack is ${GCC_VERSION_NEWEST}"
   GCC_VERSION_NEWEST="$(echo "${GCC_VERSION_NEWEST}" | sed -E -e 's/.*@([0-9]+).*/\1/' | cut -d. -f1)"
 

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -914,7 +914,7 @@ echo ""
 ### Build CP2K dependencies with Spack if needed or requested ###
 
 # Spack version
-export SPACK_VERSION="${SPACK_VERSION:-1.2.0}"
+export SPACK_VERSION="${SPACK_VERSION:-1.2.1}"
 export SPACK_BUILD_PATH="${BUILD_PATH}/spack"
 export SPACK_ROOT="${SPACK_BUILD_PATH}/spack"
 

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -914,7 +914,7 @@ echo ""
 ### Build CP2K dependencies with Spack if needed or requested ###
 
 # Spack version
-export SPACK_VERSION="${SPACK_VERSION:-1.1.1}"
+export SPACK_VERSION="${SPACK_VERSION:-1.2.0}"
 export SPACK_BUILD_PATH="${BUILD_PATH}/spack"
 export SPACK_ROOT="${SPACK_BUILD_PATH}/spack"
 

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1257,7 +1257,7 @@ if [[ ! -f "${SPACK_BUILD_PATH}/BUILD_DEPENDENCIES_COMPLETED" ]]; then
         spack compiler list
       fi
     fi
-    if ! spack -e "${CP2K_ENV}" --no-user-config --no-system-config concretize --fresh --jobs $((NUM_PROCS)); then
+    if ! spack -e "${CP2K_ENV}" concretize --fresh --jobs $((NUM_PROCS)); then
       echo -e "\nERROR: The spack concretize for environment \"${CP2K_ENV}\" failed"
       ${EXIT_CMD} 1
     fi

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1230,7 +1230,7 @@ if [[ ! -f "${SPACK_BUILD_PATH}/BUILD_DEPENDENCIES_COMPLETED" ]]; then
       ${EXIT_CMD} 1
     fi
     # Concretize CP2K dependencies
-    if ! spack -e "${CP2K_ENV}" concretize --fresh --jobs $((NUM_PROCS)); then
+    if ! spack -e "${CP2K_ENV}" concretize --fresh --jobs "${NUM_PROCS}"; then
       echo -e "\nERROR: The spack concretize for environment \"${CP2K_ENV}\" failed"
       echo ""
       echo "HINT: The (-ue | --use_externals) flags can cause conflicts with outdated"
@@ -1257,7 +1257,7 @@ if [[ ! -f "${SPACK_BUILD_PATH}/BUILD_DEPENDENCIES_COMPLETED" ]]; then
         spack compiler list
       fi
     fi
-    if ! spack -e "${CP2K_ENV}" concretize --fresh --jobs $((NUM_PROCS)); then
+    if ! spack -e "${CP2K_ENV}" concretize --fresh --jobs "${NUM_PROCS}"; then
       echo -e "\nERROR: The spack concretize for environment \"${CP2K_ENV}\" failed"
       ${EXIT_CMD} 1
     fi
@@ -1266,7 +1266,7 @@ if [[ ! -f "${SPACK_BUILD_PATH}/BUILD_DEPENDENCIES_COMPLETED" ]]; then
   ((VERBOSE > 0)) && spack find -c
 
   # Install CP2K dependencies via Spack
-  if ! spack -e "${CP2K_ENV}" install --jobs "$((NUM_PROCS / NUM_PACKAGES))" --concurrent-packages "${NUM_PACKAGES}" "${VERBOSE_SPACK}"; then
+  if ! spack -e "${CP2K_ENV}" install -j "${NUM_PROCS}" -p "${NUM_PACKAGES}" "${VERBOSE_SPACK}"; then
     echo "ERROR: Building the CP2K dependencies with spack failed"
     if [[ "${USE_EXTERNALS}" == "yes" ]]; then
       echo "HINT:  Try to re-run the build without the (-ue | --use_externals) flag which avoids"

--- a/tools/docker/Dockerfile.test_spack_ssmp-static
+++ b/tools/docker/Dockerfile.test_spack_ssmp-static
@@ -48,7 +48,7 @@ WORKDIR /opt/cp2k
 COPY ./tools/spack ./tools/spack
 COPY ./tools/docker ./tools/docker
 COPY ./make_cp2k.sh .
-RUN ./make_cp2k.sh -bd_only -cv ssmp-static -gpu none -mpi no  
+RUN ./make_cp2k.sh -bd_only -cv ssmp-static -gpu none  -mpi no  
 
 ###### Stage 2: Build CP2K ######
 
@@ -60,7 +60,7 @@ COPY ./tools/build_utils ./tools/build_utils
 COPY ./cmake ./cmake
 COPY ./CMakeLists.txt .
 
-RUN ./make_cp2k.sh -cv ssmp-static -gpu none -mpi no 
+RUN ./make_cp2k.sh -cv ssmp-static  -gpu none -mpi no 
 
 ###### Stage 3: Install CP2K ######
 
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_ssmp-static
+++ b/tools/docker/Dockerfile.test_spack_ssmp-static
@@ -3,7 +3,7 @@
 # Usage: ./spack_cache_start.sh; podman build --shm-size=1g -t spack_ssmp-static -f ./Dockerfile.test_spack_ssmp-static ../../
 #
 
-ARG BASE_IMAGE="ubuntu:24.04"
+ARG BASE_IMAGE="ubuntu:26.04"
 
 ###### Stage 1: Build CP2K dependencies ######
 
@@ -48,7 +48,7 @@ WORKDIR /opt/cp2k
 COPY ./tools/spack ./tools/spack
 COPY ./tools/docker ./tools/docker
 COPY ./make_cp2k.sh .
-RUN ./make_cp2k.sh -bd_only -cv ssmp-static -gpu none -gv 14 -mpi no  
+RUN ./make_cp2k.sh -bd_only -cv ssmp-static -gpu none -mpi no  
 
 ###### Stage 2: Build CP2K ######
 
@@ -60,7 +60,7 @@ COPY ./tools/build_utils ./tools/build_utils
 COPY ./cmake ./cmake
 COPY ./CMakeLists.txt .
 
-RUN ./make_cp2k.sh -cv ssmp-static -gv 14 -gpu none -mpi no 
+RUN ./make_cp2k.sh -cv ssmp-static -gpu none -mpi no 
 
 ###### Stage 3: Install CP2K ######
 
@@ -91,7 +91,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Tests failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests || echo "ERROR: Tests failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -192,8 +192,6 @@ def main() -> None:
             install_cp2k_spack(
                 version="ssmp-static",
                 mpi_mode="no",
-                base_image="ubuntu:24.04",
-                gcc_version=14,
                 testopts=testopts,
                 image_tag=f.image_tag,
             )

--- a/tools/spack/spack_repo/cp2k_dev/packages/libint/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/libint/package.py
@@ -48,8 +48,8 @@ class Libint(CMakePackage):
     depends_on("cxx", type="build")
     depends_on("fortran", type="build", when="+fortran")
 
-    depends_on("boost", type="build")
-    depends_on("eigen", type="build")
+    depends_on("boost")
+    depends_on("eigen")
 
     def setup_build_environment(self, env):
         env.append_flags("CXXFLAGS", "-g1")


### PR DESCRIPTION
When `--use_externals` is enabled, Spack 1.1.1 can register the same Python installation more than once during external discovery. In particular, the Python installation used by the virtual environment and the system Python are both detected as equivalent external candidates. This leaves `meson` with multiple matching `python` dependencies and causes concretization to fail.

Spack 1.2.0 includes upstream PR https://github.com/spack/spack/pull/52100. External detection now keeps the first occurrence of a spec, warns about later identical detections at other prefixes, and does not add the duplicates to `packages.yaml`. This update therefore avoids the duplicate-Python external ambiguity during `make_cp2k.sh --use_externals` runs, without changing the package constraints or dependency recipes.

However, keep using old installer in `spack install` stage, because new installer of Spack v1.2 can't work correctly with Python 3.14 (see https://github.com/spack/spack/issues/52573).