### PR TITLE
 Fix CMake toolchain support for MKL and LIBXSMM with Intel builds

### DIFF
--- a/tools/toolchain/build_cp2k.sh
+++ b/tools/toolchain/build_cp2k.sh
@@ -197,6 +197,9 @@ fi
 if [ ${DEBUG_BUILD} == "__TRUE__" ]; then
   CMAKE_OPTIONS+=" -DCMAKE_BUILD_TYPE=Debug"
 fi
+if [ "${math_mode}" = "mkl" ]; then
+  CMAKE_OPTIONS+=" -DCP2K_BLAS_VENDOR=MKL -DCP2K_BLAS_THREADING=sequential"
+fi
 if [ -n "$(grep -- "--install-all" "${TOOLCHAIN_ROOTDIR}/toolchain_settings")" ]; then
   CMAKE_OPTIONS+=" -DCP2K_USE_EVERYTHING=ON -DCP2K_USE_DLAF=OFF -DCP2K_USE_PEXSI=OFF -DCP2K_USE_OPENPMD=OFF"
   # If MPI is disabled, set "CP2K_USE_MPI" to "OFF"

--- a/tools/toolchain/scripts/stage4/install_libxsmm.sh
+++ b/tools/toolchain/scripts/stage4/install_libxsmm.sh
@@ -47,6 +47,12 @@ EOF
         -DLIBXSMM_FORTRAN=ON \
         .. > configure.log 2>&1 || tail_excerpt configure.log
       make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
+      sed -i \
+        's/INTERFACE_COMPILE_DEFINITIONS "LIBXSMM_DEFAULT_CONFIG"/INTERFACE_COMPILE_DEFINITIONS "LIBXSMM_CONFIGURED"/' \
+        "${pkg_install_dir}/lib/cmake/libxsmm/libxsmmTargets.cmake"
+      if grep -R -q "LIBXSMM_DEFAULT_CONFIG" "${pkg_install_dir}/lib/cmake/libxsmm"; then
+        report_error ${LINENO} "Installed libxsmm target still exports LIBXSMM_DEFAULT_CONFIG."
+      fi
       cd ..
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage4/$(basename ${SCRIPT_NAME})"
     fi


### PR DESCRIPTION
 ## Summary

  This PR fixes two CMake/toolchain integration issues seen with Intel oneAPI builds:

  - passes the resolved MKL configuration through the generated CMake flags
  - fixes the exported LIBXSMM CMake configuration so CP2K sees a configured LIBXSMM build instead of reporting `LIBXSMM_VERSION: unconfigured`

## Details
The toolchain now propagates MKL-related settings into CMake, including the MKL root and CP2K BLAS/ScaLAPACK vendor options. The LIBXSMM install step also adjusts the generated CMake package metadata so downstream CP2K configuration receives the configured LIBXSMM compile definition. This prevents the installed CP2K binary from being linked against a LIBXSMM configuration that reports itself as unconfigured at runtime.