### PR TITLE
Expose libcp2k C API procedures explicitly

### DIFF
--- a/src/start/libcp2k.F
+++ b/src/start/libcp2k.F
@@ -49,6 +49,17 @@ MODULE libcp2k
 
    PRIVATE
 
+   PUBLIC :: cp2k_get_version, cp2k_init, cp2k_init_without_mpi, cp2k_init_without_mpi_comm, &
+             cp2k_finalize, cp2k_finalize_without_mpi, cp2k_create_force_env, &
+             cp2k_create_force_env_comm, cp2k_destroy_force_env, cp2k_set_positions, &
+             cp2k_set_velocities, cp2k_set_cell, cp2k_get_result, cp2k_get_natom, &
+             cp2k_get_nparticle, cp2k_get_positions, cp2k_get_forces, &
+             cp2k_get_potential_energy, cp2k_get_cell, cp2k_get_qmmm_cell, &
+             cp2k_calc_energy_force, cp2k_calc_energy, cp2k_run_input, cp2k_run_input_comm, &
+             cp2k_transport_set_callback, cp2k_active_space_get_mo_count, &
+             cp2k_active_space_get_fock_sub, cp2k_active_space_get_eri_nze_count, &
+             cp2k_active_space_get_eri
+
    TYPE, EXTENDS(eri_type_eri_element_func) :: eri2array
       INTEGER(C_INT), POINTER :: coords(:) => NULL()
       REAL(C_DOUBLE), POINTER :: values(:) => NULL()


### PR DESCRIPTION
The libcp2k module uses `PRIVATE` by default, while the `BIND(C)` procedures declared in `libcp2k.h` are intended to be exported as the public C API.

With the Fedora Rawhide/GCC 16 RPM build these symbols are present in `libcp2k.so`, but they are emitted as LOCAL symbols and therefore are not available from the dynamic symbol table. As a result, linking `libcp2k_unittest` against `libcp2k.so` fails with unresolved references to `cp2k_get_version`, `cp2k_init`, `cp2k_create_force_env`, and related API entry points (https://github.com/cp2k/cp2k/issues/5392#issuecomment-4912437404).

This PR makes the C API procedures explicitly `PUBLIC`. This documents the intended API boundary and avoids relying on compiler-specific handling of private module procedures with C binding.