### PR TITLE
CMake: Remove cmake_minimum_required from Config

### DIFF
--- a/cmake/cp2kConfig.cmake.in
+++ b/cmake/cp2kConfig.cmake.in
@@ -5,6 +5,10 @@
 #!   SPDX-License-Identifier: GPL-2.0-or-later                                                     !
 #!-------------------------------------------------------------------------------------------------!
 
+if(CMAKE_VERSION VERSION_LESS "3.24")
+  message(FATAL_ERROR "CP2K requires CMake 3.24 or newer.")
+endif()
+
 include(CMakeFindDependencyMacro)
 
 if(NOT TARGET cp2k::cp2k)

--- a/cmake/cp2kConfig.cmake.in
+++ b/cmake/cp2kConfig.cmake.in
@@ -5,7 +5,6 @@
 #!   SPDX-License-Identifier: GPL-2.0-or-later                                                     !
 #!-------------------------------------------------------------------------------------------------!
 
-cmake_minimum_required(VERSION 3.22)
 include(CMakeFindDependencyMacro)
 
 if(NOT TARGET cp2k::cp2k)


### PR DESCRIPTION
Setting `cmake_minimum_required()` in `cp2kConfig.cmake.in` will override the policy settings inherited from downstream projects, such as `CMP0144`.