### PR TITLE
Address issues #1498 and #4023

### DIFF
--- a/src/auto_basis.F
+++ b/src/auto_basis.F
@@ -61,7 +61,7 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL                      :: basis_sort
 
       CHARACTER(LEN=2)                                   :: element_symbol
-      CHARACTER(LEN=default_string_length)               :: bsname
+      CHARACTER(LEN=default_string_length)               :: bsname, kname
       INTEGER                                            :: i, j, jj, l, laux, linc, lmax, lval, lx, &
                                                             nsets, nx, z
       INTEGER, DIMENSION(0:18)                           :: nval
@@ -84,7 +84,7 @@ CONTAINS
                   2.0_dp, 2.0_dp, 2.0_dp, 2.0_dp, 2.0_dp, 2.0_dp, 2.0_dp, 2.0_dp]
       !
       CPASSERT(.NOT. ASSOCIATED(ri_aux_basis_set))
-      NULLIFY (orb_basis_set)
+      NULLIFY (orb_basis_set, econf)
       IF (.NOT. PRESENT(basis_type)) THEN
          CALL get_qs_kind(qs_kind, basis_set=orb_basis_set, basis_type="ORB")
       ELSE
@@ -106,6 +106,15 @@ CONTAINS
          CALL init_orbital_pointers(2*lmax)
          CALL get_basis_products(lmax, zmin, zmax, zeff, pmin, pmax, peff)
          CALL get_qs_kind(qs_kind, zeff=zval, elec_conf=econf, element_symbol=element_symbol)
+         IF (.NOT. ASSOCIATED(econf)) THEN
+            CALL get_qs_kind(qs_kind, name=kname)
+            CALL cp_abort(__LOCATION__, &
+                          "AUTO_BASIS RI_AUX cannot process atom kind "// &
+                          "<"//TRIM(ADJUSTL(kname))//"> due to missing "// &
+                          "definition of potential or electron configuration; "// &
+                          "consider setting keyword ELEC_CONF explicitly for "// &
+                          "GHOST atom kind that has assigned a basis set")
+         END IF
          CALL get_ptable_info(element_symbol, ielement=z)
          lval = 0
          DO l = 0, MAXVAL(UBOUND(econf))
@@ -236,7 +245,7 @@ CONTAINS
       LOGICAL, INTENT(IN), OPTIONAL                      :: exact_1c_terms, tda_kernel
 
       CHARACTER(LEN=2)                                   :: element_symbol
-      CHARACTER(LEN=default_string_length)               :: bsname
+      CHARACTER(LEN=default_string_length)               :: bsname, kname
       INTEGER                                            :: i, j, l, laux, linc, lm, lmax, lval, n1, &
                                                             n2, nsets, z
       INTEGER, DIMENSION(0:18)                           :: nval
@@ -267,12 +276,21 @@ CONTAINS
       END IF
       !
       CPASSERT(.NOT. ASSOCIATED(lri_aux_basis_set))
-      NULLIFY (orb_basis_set)
+      NULLIFY (orb_basis_set, econf)
       CALL get_qs_kind(qs_kind, basis_set=orb_basis_set, basis_type="ORB")
       IF (ASSOCIATED(orb_basis_set)) THEN
          CALL get_basis_keyfigures(orb_basis_set, lmax, zmin, zmax, zeff)
          CALL get_basis_products(lmax, zmin, zmax, zeff, pmin, pmax, peff)
          CALL get_qs_kind(qs_kind, zeff=zval, elec_conf=econf, element_symbol=element_symbol)
+         IF (.NOT. ASSOCIATED(econf)) THEN
+            CALL get_qs_kind(qs_kind, name=kname)
+            CALL cp_abort(__LOCATION__, &
+                          "AUTO_BASIS LRI_AUX cannot process atom kind "// &
+                          "<"//TRIM(ADJUSTL(kname))//"> due to missing "// &
+                          "definition of potential or electron configuration; "// &
+                          "consider setting keyword ELEC_CONF explicitly for "// &
+                          "GHOST atom kind that has assigned a basis set")
+         END IF
          CALL get_ptable_info(element_symbol, ielement=z)
          lval = 0
          DO l = 0, MAXVAL(UBOUND(econf))

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -242,7 +242,18 @@ CONTAINS
             CALL uppercase(tmpstringlist(2))
             SELECT CASE (tmpstringlist(2))
             CASE ("X")
-               isize = -1
+               SELECT CASE (tmpstringlist(1))
+               CASE ("X")
+                  ! Do nothing
+               CASE DEFAULT
+                  CALL cp_abort(__LOCATION__, &
+                                "AUTO_BASIS: the size <X> is invalid for the "// &
+                                "type <"//TRIM(ADJUSTL(tmpstringlist(1)))//">; "// &
+                                "use one of SMALL, MEDIUM, LARGE, HUGE for "// &
+                                "the size. The syntax AUTO_BASIS X X is a "// &
+                                "reserved case for using NO automatically "// &
+                                "generated basis sets.")
+               END SELECT
             CASE ("SMALL")
                isize = 0
             CASE ("MEDIUM")
@@ -2126,7 +2137,18 @@ CONTAINS
             CALL uppercase(tmpstringlist(2))
             SELECT CASE (tmpstringlist(2))
             CASE ("X")
-               isize = -1
+               SELECT CASE (tmpstringlist(1))
+               CASE ("X")
+                  ! Do nothing
+               CASE DEFAULT
+                  CALL cp_abort(__LOCATION__, &
+                                "AUTO_BASIS: the size <X> is invalid for the "// &
+                                "type <"//TRIM(ADJUSTL(tmpstringlist(1)))//">; "// &
+                                "use one of SMALL, MEDIUM, LARGE, HUGE for "// &
+                                "the size. The syntax AUTO_BASIS X X is a "// &
+                                "reserved case for using NO automatically "// &
+                                "generated basis sets.")
+               END SELECT
             CASE ("SMALL")
                isize = 0
             CASE ("MEDIUM")

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -648,7 +648,11 @@ CONTAINS
          END IF
 
          ! periodic fields don't work with RTP
-         CPASSERT(.NOT. do_rtp)
+         IF (do_rtp) &
+            CALL cp_abort(__LOCATION__, &
+                          "Periodic efield cannot be used with RTP. When restarting a "// &
+                          "run with periodic efield, set RESTART_RTP under &EXT_RESTART "// &
+                          "section to .FALSE. explicitly if RESTART_DEFAULT is .TRUE.")
          IF (dft_control%period_efield%displacement_field) THEN
             CALL cite_reference(Stengel2009)
          ELSE

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -253,9 +253,11 @@ CONTAINS
                           description="Specify type and size of automatically generated auxiliary "// &
                           "(RI) basis sets. Exactly two arguments are required for this option. "// &
                           "The first argument of basis type should be one of the following: "// &
-                          "`RI_AUX`, `AUX_FIT`, `LRI_AUX`, `P_LRI_AUX`, `RI_HXC`, `RI_XAS`, "// &
-                          "`RI_HFX`, or `X`. The second argument of basis size should be one "// &
-                          "of the following: `SMALL`, `MEDIUM`, `LARGE`, `HUGE`, or `X`.", &
+                          "`RI_AUX`, `AUX_FIT`, `LRI_AUX`, `P_LRI_AUX`, `RI_HXC`, `RI_XAS`, or "// &
+                          "`RI_HFX`. The second argument of basis size should be one of the "// &
+                          "following: `SMALL`, `MEDIUM`, `LARGE`, or `HUGE`. The default is not "// &
+                          "using any of these basis sets, requested by `AUTO_BASIS X X` (exactly "// &
+                          "as written here).", &
                           usage="AUTO_BASIS {basis_type} {basis_size}", &
                           type_of_var=char_t, repeats=.TRUE., n_var=-1, default_c_vals=["X", "X"])
       CALL section_add_keyword(section, keyword)

--- a/src/input_cp2k_dft.F
+++ b/src/input_cp2k_dft.F
@@ -250,8 +250,12 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="AUTO_BASIS", &
-                          description="Specify size of automatically generated auxiliary (RI) basis sets: "// &
-                          "Options={small,medium,large,huge}", &
+                          description="Specify type and size of automatically generated auxiliary "// &
+                          "(RI) basis sets. Exactly two arguments are required for this option. "// &
+                          "The first argument of basis type should be one of the following: "// &
+                          "`RI_AUX`, `AUX_FIT`, `LRI_AUX`, `P_LRI_AUX`, `RI_HXC`, `RI_XAS`, "// &
+                          "`RI_HFX`, or `X`. The second argument of basis size should be one "// &
+                          "of the following: `SMALL`, `MEDIUM`, `LARGE`, `HUGE`, or `X`.", &
                           usage="AUTO_BASIS {basis_type} {basis_size}", &
                           type_of_var=char_t, repeats=.TRUE., n_var=-1, default_c_vals=["X", "X"])
       CALL section_add_keyword(section, keyword)

--- a/src/input_cp2k_properties_dft.F
+++ b/src/input_cp2k_properties_dft.F
@@ -1803,8 +1803,13 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="AUTO_BASIS", &
-                          description="Specify size of automatically generated auxiliary basis sets: "// &
-                          "Options={small,medium,large,huge}", &
+                          description="Specify type and size of automatically generated auxiliary "// &
+                          "(RI) basis sets. Exactly two arguments are required for this option. "// &
+                          "The first argument of basis type should be one of the following: "// &
+                          "`P_LRI_AUX`. The second argument of basis size should be one of the "// &
+                          "following: `SMALL`, `MEDIUM`, `LARGE`, or `HUGE`. The default is not "// &
+                          "using any of these basis sets, requested by `AUTO_BASIS X X` (exactly "// &
+                          "as written here).", &
                           usage="AUTO_BASIS {basis_type} {basis_size}", &
                           type_of_var=char_t, repeats=.TRUE., n_var=-1, default_c_vals=["X", "X"])
       CALL section_add_keyword(section, keyword)


### PR DESCRIPTION
This PR:

- closes #1498 by turning the CPASSERT into a CPABORT with a clear note;
- closes #4023 with error messages as suggested by Prof. Hutter.

Also, the possible arguments for `AUTO_BASIS` are listed simply in the description as a workaround; converting it to a "Valid values" list with full-fledged explanations would take more efforts.