### PR TITLE
Colvar: add VoronoiIPZ to identify the absolute location of H3O+ ions along the z-axis

### DIFF
--- a/src/colvar_methods.F
+++ b/src/colvar_methods.F
@@ -28,7 +28,7 @@ MODULE colvar_methods
         plane_def_vec, plane_distance_colvar_id, plane_plane_angle_colvar_id, &
         population_colvar_id, qparm_colvar_id, reaction_path_colvar_id, ring_puckering_colvar_id, &
         rmsd_colvar_id, rotation_colvar_id, torsion_colvar_id, u_colvar_id, xyz_diag_colvar_id, &
-        xyz_outerdiag_colvar_id
+        xyz_outerdiag_colvar_id, voronoiipz_colvar_id
    USE constraint_fxd,                  ONLY: check_fixed_atom_cns_colv
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
@@ -101,6 +101,8 @@ MODULE colvar_methods
    IMPLICIT NONE
    PRIVATE
 
+   INTEGER :: i, j, n
+
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'colvar_methods'
    REAL(KIND=dp), PRIVATE, PARAMETER    :: tolerance_acos = 1.0E-5_dp
 
@@ -143,7 +145,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: iatms
       INTEGER, DIMENSION(:, :), POINTER                  :: p_bounds
       LOGICAL                                            :: check, use_mixed_energy
-      LOGICAL, DIMENSION(26)                             :: my_subsection
+      LOGICAL, DIMENSION(27)                             :: my_subsection
+
       REAL(dp), DIMENSION(:), POINTER                    :: s1, wei, weights
       REAL(dp), DIMENSION(:, :), POINTER                 :: p_range, s1v
       REAL(KIND=dp), DIMENSION(1)                        :: my_val
@@ -153,7 +156,7 @@ CONTAINS
       TYPE(enumeration_type), POINTER                    :: enum
       TYPE(keyword_type), POINTER                        :: keyword
       TYPE(section_type), POINTER                        :: section
-      TYPE(section_vals_type), POINTER :: acid_hyd_dist_section, acid_hyd_shell_section, &
+      TYPE(section_vals_type), POINTER :: voronoiipz_section, acid_hyd_dist_section, acid_hyd_shell_section, &
          angle_section, colvar_subsection, combine_section, coordination_section, dfunct_section, &
          distance_from_path_section, distance_section, frame_section, gyration_section, &
          HBP_section, hydronium_dist_section, hydronium_shell_section, mindist_section, &
@@ -181,6 +184,8 @@ CONTAINS
       hydronium_shell_section => section_vals_get_subs_vals(colvar_section, "HYDRONIUM_SHELL", i_rep_section=icol)
       hydronium_dist_section => section_vals_get_subs_vals(colvar_section, "HYDRONIUM_DISTANCE", i_rep_section=icol)
       acid_hyd_dist_section => section_vals_get_subs_vals(colvar_section, "ACID_HYDRONIUM_DISTANCE", i_rep_section=icol)
+      voronoiipz_section => section_vals_get_subs_vals(colvar_section, "VORONOIIPZ", i_rep_section=icol)
+
       acid_hyd_shell_section &
          => section_vals_get_subs_vals(colvar_section, "ACID_HYDRONIUM_SHELL", i_rep_section=icol)
       reaction_path_section => section_vals_get_subs_vals(colvar_section, "REACTION_PATH", i_rep_section=icol, &
@@ -239,6 +244,7 @@ CONTAINS
       CALL section_vals_get(acid_hyd_dist_section, explicit=my_subsection(24))
       CALL section_vals_get(acid_hyd_shell_section, explicit=my_subsection(25))
       CALL section_vals_get(hydronium_dist_section, explicit=my_subsection(26))
+      CALL section_vals_get(voronoiipz_section, explicit=my_subsection(27))
 
       ! Only one colvar can be present
       CPASSERT(COUNT(my_subsection) == 1)
@@ -1072,6 +1078,13 @@ CONTAINS
                                      colvar%hydronium_dist_param%n_hydrogens, &
                                      colvar%hydronium_dist_param%i_oxygens, &
                                      colvar%hydronium_dist_param%i_hydrogens)
+      ELSE IF (my_subsection(27)) THEN
+         CALL colvar_create(colvar, voronoiipz_colvar_id)
+         IF (ASSOCIATED(voronoiipz_section)) THEN
+            CALL read_voronoiipz_colvars(voronoiipz_section, colvar)
+         ELSE
+            WRITE(*,*) "ERROR: voronoiipz_section is NULL at index:", icol
+         END IF
       END IF
       CALL colvar_setup(colvar)
 
@@ -1342,6 +1355,7 @@ CONTAINS
                   ' Puckering Angle', &
                   colvar%ring_puckering_param%iq
             END IF
+
          CASE (mindist_colvar_id)
             WRITE (iw, '( A)') ' COLVARS| CONDITIONED DISTANCE>> '
             WRITE (iw, '( A,T71,I10)') (' COLVARS| COND.DISTANCE  >>> DISTANCE FROM '//tag, &
@@ -1672,6 +1686,7 @@ CONTAINS
       END IF
       ! Initialize the content of the derivative
       colvar%dsdr = 0.0_dp
+
       SELECT CASE (colvar%type_id)
       CASE (dist_colvar_id)
          CALL dist_colvar(colvar, cell, particles=particles)
@@ -1727,8 +1742,10 @@ CONTAINS
       CASE (HBP_colvar_id)
          !!! FIXME this is rubbish at the moment as we have no force to be computed on this
          CALL HBP_colvar(colvar, cell, particles=particles)
+      CASE (voronoiipz_colvar_id)
+         CALL colvar_eval_voronoiipz(colvar, cell, particles=particles) 
       CASE DEFAULT
-         CPABORT("Unknown colvar type for colvar_eval_mol_f")
+         CPABORT("")
       END SELECT
       ! Check for fixed atom constraints
       IF (PRESENT(fixd_list)) CALL check_fixed_atom_cns_colv(fixd_list, colvar)
@@ -1815,8 +1832,14 @@ CONTAINS
          CALL ring_puckering_colvar(colvar, cell, subsys=subsys)
       CASE (mindist_colvar_id)
          CALL mindist_colvar(colvar, cell, subsys=subsys)
+      !*CASE (voronoiipz_colvar_id)
+      !*   CALL colvar_eval_voronoiipz(colvar, cell, particles_set=subsys%particles%els)
+      CASE (voronoiipz_colvar_id)
+         CALL colvar_eval_voronoiipz(colvar, cell, subsys=subsys)
+
+
       CASE DEFAULT
-         CPABORT("Unknown colvar type for colvar_eval_glob_f")
+         CPABORT("")
       END SELECT
       ! Check for fixed atom constraints
       CALL check_fixed_atom_cns_colv(subsys%gci%fixd_list, colvar)
@@ -1888,7 +1911,7 @@ CONTAINS
       CASE (HBP_colvar_id)
          CALL HBP_colvar(colvar, cell, particles=particles)
       CASE DEFAULT
-         CPABORT("Unknown colvar type for colvar_recursive_eval")
+         CPABORT("")
       END SELECT
    END SUBROUTINE colvar_recursive_eval
 
@@ -2049,7 +2072,8 @@ CONTAINS
             xi(2) = 0.0_dp
             xi(3) = 1.0_dp
          CASE DEFAULT
-            CPABORT("xyz_diag_colvar not implemented for anything which is not a single component")
+            !Not implemented for anything which is not a single component.
+            CPABORT("")
          END SELECT
          fi(:) = xi
       END IF
@@ -6081,4 +6105,245 @@ CONTAINS
 
    END SUBROUTINE HBP_colvar
 
+!     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+!     COLVAR_VORONOIIPZ EVALUATION
+!     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+SUBROUTINE colvar_eval_voronoiipz(colvar, cell, subsys, particles)
+    TYPE(colvar_type), POINTER               :: colvar
+    TYPE(cell_type), POINTER                 :: cell
+    TYPE(cp_subsys_type), OPTIONAL, POINTER  :: subsys
+    TYPE(particle_type), DIMENSION(:), &
+      OPTIONAL, POINTER                      :: particles
+
+    TYPE(particle_type), DIMENSION(:), POINTER :: my_particles
+
+    INTEGER                                    :: n
+    INTEGER                                  :: i, j, k, i0, i1, zidx, num_atomsa, num_atomso, idx_a
+    INTEGER                                  :: nrx, lambda, d_in
+    REAL(KIND=dp)                            :: d0, d1, d2, d3, zmid, ion_z, buf, fk
+    REAL(KIND=dp), DIMENSION(3)              :: r0, r1, r_ij, dd
+    REAL(KIND=dp)                            :: dist_mod
+    REAL(KIND=dp)                            :: nl_cutoff
+
+    REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)   :: nnexp, nnexpnorm, charge, charget
+    REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)   :: c, distABinvmod
+    REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:) :: distAB
+    REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:) :: dsdr_tmp
+
+    ! Check presence and assign the pointer dynamically
+    IF (PRESENT(particles)) THEN
+       my_particles => particles
+    ELSEIF (PRESENT(subsys)) THEN
+       my_particles => subsys%particles%els
+    ELSE
+       CPABORT("colvar_eval_voronoiipz: neither particles nor subsys present")
+    END IF
+
+    ! Extract CV-specific configuration parameters mapped from input_cp2k
+    zidx       = colvar%voronoiipz_params%zidx ! 1=X, 2=Y, 3=Z format (Fortran index shift)
+    nrx        = colvar%voronoiipz_params%nrx
+    lambda     = colvar%voronoiipz_params%lambda
+    zmid       = colvar%voronoiipz_params%zmid
+    d0         = colvar%voronoiipz_params%d0
+    d1         = colvar%voronoiipz_params%d1
+    d2         = colvar%voronoiipz_params%d2
+    d3         = colvar%voronoiipz_params%d3
+    nl_cutoff  = colvar%voronoiipz_params%nl_cutoff
+
+    num_atomsa = SIZE(colvar%voronoiipz_params%group_a)
+    num_atomso = num_atomsa - nrx
+    n = SIZE(my_particles)
+
+    ! Initialize memory
+    ALLOCATE(nnexpnorm(n), charge(n), charget(n))
+    ALLOCATE(nnexp(colvar%voronoiipz_params%n_pairs))
+
+    ALLOCATE(c(colvar%voronoiipz_params%n_pairs))
+    ALLOCATE(distAB(colvar%voronoiipz_params%n_pairs, 3))
+    ALLOCATE(distABinvmod(colvar%voronoiipz_params%n_pairs))
+    ALLOCATE(dsdr_tmp(3, n)) 
+    dsdr_tmp = 0.0_dp
+
+    nnexpnorm = 0.0_dp
+    charge    = 0.0_dp
+    charget   = 0.0_dp
+    c         = 0.0_dp
+    ion_z     = 0.0_dp
+    colvar%dsdr = 0.0_dp  ! CP2K collective variable derivatives array (3, NumAtoms)
+
+    ! 3. LOOP 1: Distance calculation and normalization building
+    !$OMP PARALLEL DO PRIVATE(i, i0, i1, r0, r1, r_ij, dist_mod)
+    do i = 1, colvar%voronoiipz_params%n_pairs
+       i0 = colvar%voronoiipz_params%pair_i0(i) ! Map to group A global index
+       i1 = colvar%voronoiipz_params%pair_i1(i) ! Map to group B global index
+
+       r0 = my_particles(i0)%r
+       r1 = my_particles(i1)%r
+
+       r_ij = pbc(r0, r1, cell)
+       dist_mod = SQRT(SUM(r_ij**2))
+
+       ! CHANGE THESE LINES TO INDEX BY i:
+       distAB(i, :) = r_ij
+
+       distABinvmod(i) = 1.0_dp / MAX(dist_mod, 1.0E-12_dp)
+
+       ! CUTOFF
+       if (dist_mod > nl_cutoff) then
+          nnexp(i) = 0.0_dp
+       else
+          nnexp(i) = EXP(REAL(lambda, dp) * dist_mod)
+       end if
+
+       !$OMP CRITICAL(voronoi_norm_update)
+       nnexpnorm(i1) = nnexpnorm(i1) + nnexp(i)
+       !$OMP END CRITICAL(voronoi_norm_update)
+
+    end do
+    !$OMP END PARALLEL DO
+
+    ! 4. LOOP 2: Compute local unshifted charges
+    !$OMP PARALLEL DO PRIVATE(i, i0, i1)
+    do i = 1, colvar%voronoiipz_params%n_pairs
+       i0 = colvar%voronoiipz_params%pair_i0(i)
+       i1 = colvar%voronoiipz_params%pair_i1(i)
+       c(i) = nnexp(i) / MAX(nnexpnorm(i1), 1.0E-12_dp)
+    
+       !$OMP CRITICAL(voronoi_charge_update)
+       charget(i0) = charget(i0) + c(i)
+       !$OMP END CRITICAL(voronoi_charge_update)
+    end do
+    !$OMP END PARALLEL DO
+    charge(:) = charget(:)
+
+    ! 5. LOOP 2.5: Shift charges & absolute distance metric execution
+    do j = 1, num_atomsa
+       i0 = colvar%voronoiipz_params%group_a(j)
+
+       if (j == num_atomso) then
+          charge(i0) = charge(i0) - d1
+       else if (j == num_atomso + 1) then
+          charge(i0) = charge(i0) - d2
+       else if (j == num_atomso + 2) then
+          charge(i0) = charge(i0) - d3
+       else
+          charge(i0) = charge(i0) - d0
+       end if
+
+       ion_z = ion_z + ABS(my_particles(i0)%r(zidx) - zmid) * (charge(i0)**2)
+       
+       if ((my_particles(i0)%r(zidx) - zmid) >= 0.0_dp) then
+          colvar%dsdr(zidx, i0) = colvar%dsdr(zidx, i0) + (charge(i0)**2)
+       else
+          colvar%dsdr(zidx, i0) = colvar%dsdr(zidx, i0) - (charge(i0)**2)
+       end if
+
+    end do
+
+    ! 6. LOOP 4: Double loop analytical force gradients mapping back to CP2K atoms
+    !$OMP PARALLEL DO PRIVATE(i, k, i0, i1, d_in, fk, buf, dd)
+    do i = 1, colvar%voronoiipz_params%n_pairs
+       i0 = colvar%voronoiipz_params%pair_i0(i)
+       i1 = colvar%voronoiipz_params%pair_i1(i)
+
+       idx_a = i0
+
+       do k = 1, num_atomsa
+          idx_a = colvar%voronoiipz_params%group_a(k)
+          if (i0 == idx_a) then
+             d_in = 1
+          else
+             d_in = 0
+          end if
+
+          fk = REAL(lambda, dp) * c(i) * (REAL(d_in, dp) - c(i))
+          if (charge(i0) > 0.0_dp .AND. i0 < num_atomso) then
+             buf = 2.0_dp * ABS(my_particles(i0)%r(zidx) - zmid) * charge(i0) * fk
+          else
+             buf = 0.0_dp
+          end if
+
+          dd = buf * distABinvmod(i) * distAB(i, :)
+
+          !!$OMP CRITICAL(voronoi_dsdr_update)
+          dsdr_tmp(:, i1) = dsdr_tmp(:, i1) + dd
+          dsdr_tmp(:, idx_a)  = dsdr_tmp(:, idx_a)  - dd
+          !!$OMP END CRITICAL(voronoi_dsdr_update)
+       end do
+    end do
+    !$OMP END PARALLEL DO
+    colvar%dsdr = colvar%dsdr + dsdr_tmp
+
+    colvar%ss = ion_z ! Assign final updated collective variable value 
+    DEALLOCATE(nnexp, nnexpnorm, charge, charget, c, distABinvmod, distAB, dsdr_tmp)
+  END SUBROUTINE colvar_eval_voronoiipz
+
+
+SUBROUTINE read_voronoiipz_colvars(voronoiipz_section, colvar)
+    TYPE(section_vals_type), POINTER         :: voronoiipz_section
+    TYPE(colvar_type), POINTER               :: colvar
+    
+    ! --- Local Variable Declarations ---
+    INTEGER, DIMENSION(:), POINTER           :: temp_array
+    INTEGER                                  :: i, j, n
+
+    IF (.NOT. ASSOCIATED(colvar%voronoiipz_params)) THEN
+       ALLOCATE (colvar%voronoiipz_params)
+    END IF
+
+    ! Read scalar values
+    CALL section_vals_val_get(voronoiipz_section, "LAMBDA", i_val=colvar%voronoiipz_params%lambda)
+    CALL section_vals_val_get(voronoiipz_section, "ZIDX", i_val=colvar%voronoiipz_params%zidx)
+    CALL section_vals_val_get(voronoiipz_section, "NRX", i_val=colvar%voronoiipz_params%nrx)
+    CALL section_vals_val_get(voronoiipz_section, "ZMID", r_val=colvar%voronoiipz_params%zmid)
+    CALL section_vals_val_get(voronoiipz_section, "D_0", r_val=colvar%voronoiipz_params%d0)
+    CALL section_vals_val_get(voronoiipz_section, "D_1", r_val=colvar%voronoiipz_params%d1)
+    CALL section_vals_val_get(voronoiipz_section, "D_2", r_val=colvar%voronoiipz_params%d2)
+    CALL section_vals_val_get(voronoiipz_section, "D_3", r_val=colvar%voronoiipz_params%d3)
+    CALL section_vals_val_get(voronoiipz_section, "NL_CUTOFF", r_val=colvar%voronoiipz_params%nl_cutoff)
+
+
+    ! Read arrays (GROUPA)
+    NULLIFY(temp_array)
+    CALL section_vals_val_get(voronoiipz_section, "GROUPA", i_vals=temp_array)
+    IF (ASSOCIATED(temp_array)) THEN
+       ALLOCATE(colvar%voronoiipz_params%group_a(SIZE(temp_array)))
+       colvar%voronoiipz_params%group_a(:) = temp_array(:)
+    END IF
+
+    ! Read arrays (GROUPB)
+    NULLIFY(temp_array)
+    CALL section_vals_val_get(voronoiipz_section, "GROUPB", i_vals=temp_array)
+    IF (ASSOCIATED(temp_array)) THEN
+       ALLOCATE(colvar%voronoiipz_params%group_b(SIZE(temp_array)))
+       colvar%voronoiipz_params%group_b(:) = temp_array(:)
+    END IF
+
+    ! ==========================================================================
+    ! INTEGRATED PAIRWISE MAPPING CONSTRUCTION
+    IF (ASSOCIATED(colvar%voronoiipz_params%group_a) .AND. ASSOCIATED(colvar%voronoiipz_params%group_b)) THEN
+       
+       ! Calculate total pairs
+       colvar%voronoiipz_params%n_pairs = SIZE(colvar%voronoiipz_params%group_a) * SIZE(colvar%voronoiipz_params%group_b)
+       
+       ! Allocate mapping lookup vectors
+       ALLOCATE(colvar%voronoiipz_params%pair_i0(colvar%voronoiipz_params%n_pairs))
+       ALLOCATE(colvar%voronoiipz_params%pair_i1(colvar%voronoiipz_params%n_pairs))
+       
+       ! Populate pairwise grids
+       n = 0
+       do i = 1, SIZE(colvar%voronoiipz_params%group_a)
+          do j = 1, SIZE(colvar%voronoiipz_params%group_b)
+             n = n + 1
+             colvar%voronoiipz_params%pair_i0(n) = colvar%voronoiipz_params%group_a(i)
+             colvar%voronoiipz_params%pair_i1(n) = colvar%voronoiipz_params%group_b(j)
+          end do
+       end do
+       
+    ELSE
+       colvar%voronoiipz_params%n_pairs = 0
+    END IF
+
+END SUBROUTINE read_voronoiipz_colvars
+   
 END MODULE colvar_methods

--- a/src/colvar_methods.F
+++ b/src/colvar_methods.F
@@ -27,8 +27,8 @@ MODULE colvar_methods
         hydronium_dist_colvar_id, hydronium_shell_colvar_id, mindist_colvar_id, plane_def_atoms, &
         plane_def_vec, plane_distance_colvar_id, plane_plane_angle_colvar_id, &
         population_colvar_id, qparm_colvar_id, reaction_path_colvar_id, ring_puckering_colvar_id, &
-        rmsd_colvar_id, rotation_colvar_id, torsion_colvar_id, u_colvar_id, xyz_diag_colvar_id, &
-        xyz_outerdiag_colvar_id, voronoiipz_colvar_id
+        rmsd_colvar_id, rotation_colvar_id, torsion_colvar_id, u_colvar_id, voronoiipz_colvar_id, &
+        xyz_diag_colvar_id, xyz_outerdiag_colvar_id
    USE constraint_fxd,                  ONLY: check_fixed_atom_cns_colv
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_get_default_io_unit,&
@@ -101,8 +101,6 @@ MODULE colvar_methods
    IMPLICIT NONE
    PRIVATE
 
-   INTEGER :: i, j, n
-
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'colvar_methods'
    REAL(KIND=dp), PRIVATE, PARAMETER    :: tolerance_acos = 1.0E-5_dp
 
@@ -146,7 +144,6 @@ CONTAINS
       INTEGER, DIMENSION(:, :), POINTER                  :: p_bounds
       LOGICAL                                            :: check, use_mixed_energy
       LOGICAL, DIMENSION(27)                             :: my_subsection
-
       REAL(dp), DIMENSION(:), POINTER                    :: s1, wei, weights
       REAL(dp), DIMENSION(:, :), POINTER                 :: p_range, s1v
       REAL(KIND=dp), DIMENSION(1)                        :: my_val
@@ -156,15 +153,15 @@ CONTAINS
       TYPE(enumeration_type), POINTER                    :: enum
       TYPE(keyword_type), POINTER                        :: keyword
       TYPE(section_type), POINTER                        :: section
-      TYPE(section_vals_type), POINTER :: voronoiipz_section, acid_hyd_dist_section, acid_hyd_shell_section, &
+      TYPE(section_vals_type), POINTER :: acid_hyd_dist_section, acid_hyd_shell_section, &
          angle_section, colvar_subsection, combine_section, coordination_section, dfunct_section, &
          distance_from_path_section, distance_section, frame_section, gyration_section, &
          HBP_section, hydronium_dist_section, hydronium_shell_section, mindist_section, &
          path_section, plane_dist_section, plane_plane_angle_section, plane_sections, &
          point_section, population_section, qparm_section, reaction_path_section, &
          ring_puckering_section, rmsd_section, rotation_section, torsion_section, u_section, &
-         Wc_section, wrk_section
-      TYPE(section_vals_type), POINTER :: xyz_diag_section, xyz_outerdiag_section
+         voronoiipz_section, Wc_section
+      TYPE(section_vals_type), POINTER :: wrk_section, xyz_diag_section, xyz_outerdiag_section
 
       CALL timeset(routineN, handle)
       NULLIFY (logger, c_kinds, iatms)
@@ -1080,11 +1077,8 @@ CONTAINS
                                      colvar%hydronium_dist_param%i_hydrogens)
       ELSE IF (my_subsection(27)) THEN
          CALL colvar_create(colvar, voronoiipz_colvar_id)
-         IF (ASSOCIATED(voronoiipz_section)) THEN
-            CALL read_voronoiipz_colvars(voronoiipz_section, colvar)
-         ELSE
-            WRITE(*,*) "ERROR: voronoiipz_section is NULL at index:", icol
-         END IF
+         CPASSERT(ASSOCIATED(voronoiipz_section))
+         CALL read_voronoiipz_colvars(voronoiipz_section, colvar)
       END IF
       CALL colvar_setup(colvar)
 
@@ -1355,7 +1349,6 @@ CONTAINS
                   ' Puckering Angle', &
                   colvar%ring_puckering_param%iq
             END IF
-
          CASE (mindist_colvar_id)
             WRITE (iw, '( A)') ' COLVARS| CONDITIONED DISTANCE>> '
             WRITE (iw, '( A,T71,I10)') (' COLVARS| COND.DISTANCE  >>> DISTANCE FROM '//tag, &
@@ -1686,7 +1679,6 @@ CONTAINS
       END IF
       ! Initialize the content of the derivative
       colvar%dsdr = 0.0_dp
-
       SELECT CASE (colvar%type_id)
       CASE (dist_colvar_id)
          CALL dist_colvar(colvar, cell, particles=particles)
@@ -1743,9 +1735,9 @@ CONTAINS
          !!! FIXME this is rubbish at the moment as we have no force to be computed on this
          CALL HBP_colvar(colvar, cell, particles=particles)
       CASE (voronoiipz_colvar_id)
-         CALL colvar_eval_voronoiipz(colvar, cell, particles=particles) 
+         CALL colvar_eval_voronoiipz(colvar, cell, particles=particles)
       CASE DEFAULT
-         CPABORT("")
+         CPABORT("Unknown colvar type for colvar_eval_mol_f")
       END SELECT
       ! Check for fixed atom constraints
       IF (PRESENT(fixd_list)) CALL check_fixed_atom_cns_colv(fixd_list, colvar)
@@ -1832,14 +1824,10 @@ CONTAINS
          CALL ring_puckering_colvar(colvar, cell, subsys=subsys)
       CASE (mindist_colvar_id)
          CALL mindist_colvar(colvar, cell, subsys=subsys)
-      !*CASE (voronoiipz_colvar_id)
-      !*   CALL colvar_eval_voronoiipz(colvar, cell, particles_set=subsys%particles%els)
       CASE (voronoiipz_colvar_id)
          CALL colvar_eval_voronoiipz(colvar, cell, subsys=subsys)
-
-
       CASE DEFAULT
-         CPABORT("")
+         CPABORT("Unknown colvar type for colvar_eval_glob_f")
       END SELECT
       ! Check for fixed atom constraints
       CALL check_fixed_atom_cns_colv(subsys%gci%fixd_list, colvar)
@@ -1910,8 +1898,10 @@ CONTAINS
          CALL Wc_colvar(colvar, cell, particles=particles)
       CASE (HBP_colvar_id)
          CALL HBP_colvar(colvar, cell, particles=particles)
+      CASE (voronoiipz_colvar_id)
+         CALL colvar_eval_voronoiipz(colvar, cell, particles=particles)
       CASE DEFAULT
-         CPABORT("")
+         CPABORT("Unknown colvar type for colvar_recursive_eval")
       END SELECT
    END SUBROUTINE colvar_recursive_eval
 
@@ -2072,8 +2062,7 @@ CONTAINS
             xi(2) = 0.0_dp
             xi(3) = 1.0_dp
          CASE DEFAULT
-            !Not implemented for anything which is not a single component.
-            CPABORT("")
+            CPABORT("xyz_diag_colvar not implemented for anything which is not a single component")
          END SELECT
          fi(:) = xi
       END IF
@@ -6105,245 +6094,206 @@ CONTAINS
 
    END SUBROUTINE HBP_colvar
 
-!     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-!     COLVAR_VORONOIIPZ EVALUATION
-!     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-SUBROUTINE colvar_eval_voronoiipz(colvar, cell, subsys, particles)
-    TYPE(colvar_type), POINTER               :: colvar
-    TYPE(cell_type), POINTER                 :: cell
-    TYPE(cp_subsys_type), OPTIONAL, POINTER  :: subsys
-    TYPE(particle_type), DIMENSION(:), &
-      OPTIONAL, POINTER                      :: particles
+! **************************************************************************************************
+!> \brief Evaluate the absolute location of a hydronium ion using Voronoi weights
+!> \param colvar the collective variable
+!> \param cell the simulation cell
+!> \param subsys the simulation subsystem
+!> \param particles the particles, when evaluated for a molecule
+! **************************************************************************************************
+   SUBROUTINE colvar_eval_voronoiipz(colvar, cell, subsys, particles)
+      TYPE(colvar_type), POINTER                         :: colvar
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(cp_subsys_type), OPTIONAL, POINTER            :: subsys
+      TYPE(particle_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: particles
 
-    TYPE(particle_type), DIMENSION(:), POINTER :: my_particles
+      INTEGER                                            :: i, iatom, j, jatom, n_atoms_a, &
+                                                            n_atoms_o, n_atoms_b, zidx
+      REAL(KIND=dp)                                      :: charge_deriv, cutoff, denominator, &
+                                                            distance, exponent_max, factor, ion_z, &
+                                                            lambda, weighted_charge_deriv, zdist, zmid
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: charge, charge_factor
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: inv_distance, weight
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: distance_vector
+      TYPE(particle_type), DIMENSION(:), POINTER         :: my_particles
 
-    INTEGER                                    :: n
-    INTEGER                                  :: i, j, k, i0, i1, zidx, num_atomsa, num_atomso, idx_a
-    INTEGER                                  :: nrx, lambda, d_in
-    REAL(KIND=dp)                            :: d0, d1, d2, d3, zmid, ion_z, buf, fk
-    REAL(KIND=dp), DIMENSION(3)              :: r0, r1, r_ij, dd
-    REAL(KIND=dp)                            :: dist_mod
-    REAL(KIND=dp)                            :: nl_cutoff
+      CPASSERT(colvar%type_id == voronoiipz_colvar_id)
+      IF (PRESENT(particles)) THEN
+         my_particles => particles
+      ELSE
+         CPASSERT(PRESENT(subsys))
+         my_particles => subsys%particles%els
+      END IF
 
-    REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)   :: nnexp, nnexpnorm, charge, charget
-    REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)   :: c, distABinvmod
-    REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:) :: distAB
-    REAL(KIND=dp), ALLOCATABLE, DIMENSION(:,:) :: dsdr_tmp
+      n_atoms_a = SIZE(colvar%voronoiipz_params%group_a)
+      n_atoms_b = SIZE(colvar%voronoiipz_params%group_b)
+      n_atoms_o = n_atoms_a - colvar%voronoiipz_params%nrx
+      cutoff = colvar%voronoiipz_params%nl_cutoff
+      lambda = colvar%voronoiipz_params%lambda
+      zidx = colvar%voronoiipz_params%zidx
+      zmid = colvar%voronoiipz_params%zmid
 
-    ! Check presence and assign the pointer dynamically
-    IF (PRESENT(particles)) THEN
-       my_particles => particles
-    ELSEIF (PRESENT(subsys)) THEN
-       my_particles => subsys%particles%els
-    ELSE
-       CPABORT("colvar_eval_voronoiipz: neither particles nor subsys present")
-    END IF
+      ALLOCATE (charge(n_atoms_a), charge_factor(n_atoms_a))
+      ALLOCATE (distance_vector(3, n_atoms_a, n_atoms_b))
+      ALLOCATE (inv_distance(n_atoms_a, n_atoms_b), weight(n_atoms_a, n_atoms_b))
+      charge = 0.0_dp
+      charge_factor = 0.0_dp
+      distance_vector = 0.0_dp
+      inv_distance = 0.0_dp
+      weight = 0.0_dp
 
-    ! Extract CV-specific configuration parameters mapped from input_cp2k
-    zidx       = colvar%voronoiipz_params%zidx ! 1=X, 2=Y, 3=Z format (Fortran index shift)
-    nrx        = colvar%voronoiipz_params%nrx
-    lambda     = colvar%voronoiipz_params%lambda
-    zmid       = colvar%voronoiipz_params%zmid
-    d0         = colvar%voronoiipz_params%d0
-    d1         = colvar%voronoiipz_params%d1
-    d2         = colvar%voronoiipz_params%d2
-    d3         = colvar%voronoiipz_params%d3
-    nl_cutoff  = colvar%voronoiipz_params%nl_cutoff
+      ! Each hydrogen is assigned continuously to all oxygen sites within the cutoff.
+      ! Subtracting the largest exponent makes the softmax stable for either sign of lambda.
+      DO j = 1, n_atoms_b
+         jatom = colvar%voronoiipz_params%group_b(j)
+         exponent_max = -HUGE(0.0_dp)
+         DO i = 1, n_atoms_a
+            iatom = colvar%voronoiipz_params%group_a(i)
+            distance_vector(:, i, j) = pbc(my_particles(iatom)%r, my_particles(jatom)%r, cell)
+            distance = NORM2(distance_vector(:, i, j))
+            IF (distance <= cutoff) THEN
+               IF (distance <= EPSILON(0.0_dp)) THEN
+                  CPABORT("VORONOIIPZ is undefined for coincident GROUPA and GROUPB atoms")
+               END IF
+               inv_distance(i, j) = 1.0_dp/distance
+               weight(i, j) = lambda*distance
+               exponent_max = MAX(exponent_max, weight(i, j))
+            END IF
+         END DO
 
-    num_atomsa = SIZE(colvar%voronoiipz_params%group_a)
-    num_atomso = num_atomsa - nrx
-    n = SIZE(my_particles)
+         denominator = 0.0_dp
+         DO i = 1, n_atoms_a
+            IF (inv_distance(i, j) > 0.0_dp) THEN
+               weight(i, j) = EXP(weight(i, j) - exponent_max)
+               denominator = denominator + weight(i, j)
+            END IF
+         END DO
+         IF (denominator <= 0.0_dp) THEN
+            CPABORT("VORONOIIPZ found a GROUPB atom without a GROUPA neighbor inside NL_CUTOFF")
+         END IF
+         weight(:, j) = weight(:, j)/denominator
+      END DO
 
-    ! Initialize memory
-    ALLOCATE(nnexpnorm(n), charge(n), charget(n))
-    ALLOCATE(nnexp(colvar%voronoiipz_params%n_pairs))
+      charge(:) = SUM(weight, DIM=2)
+      DO i = 1, n_atoms_a
+         IF (i <= n_atoms_o) THEN
+            charge(i) = charge(i) - colvar%voronoiipz_params%d0
+         ELSE
+            SELECT CASE (i - n_atoms_o)
+            CASE (1)
+               charge(i) = charge(i) - colvar%voronoiipz_params%d1
+            CASE (2)
+               charge(i) = charge(i) - colvar%voronoiipz_params%d2
+            CASE (3)
+               charge(i) = charge(i) - colvar%voronoiipz_params%d3
+            END SELECT
+         END IF
+      END DO
 
-    ALLOCATE(c(colvar%voronoiipz_params%n_pairs))
-    ALLOCATE(distAB(colvar%voronoiipz_params%n_pairs, 3))
-    ALLOCATE(distABinvmod(colvar%voronoiipz_params%n_pairs))
-    ALLOCATE(dsdr_tmp(3, n)) 
-    dsdr_tmp = 0.0_dp
+      ion_z = 0.0_dp
+      DO i = 1, n_atoms_o
+         IF (charge(i) > 0.0_dp) THEN
+            iatom = colvar%voronoiipz_params%group_a(i)
+            zdist = my_particles(iatom)%r(zidx) - zmid
+            ion_z = ion_z + ABS(zdist)*charge(i)**2
+            charge_factor(i) = 2.0_dp*ABS(zdist)*charge(i)
+            IF (zdist > 0.0_dp) THEN
+               colvar%dsdr(zidx, i) = colvar%dsdr(zidx, i) + charge(i)**2
+            ELSE IF (zdist < 0.0_dp) THEN
+               colvar%dsdr(zidx, i) = colvar%dsdr(zidx, i) - charge(i)**2
+            END IF
+         END IF
+      END DO
 
-    nnexpnorm = 0.0_dp
-    charge    = 0.0_dp
-    charget   = 0.0_dp
-    c         = 0.0_dp
-    ion_z     = 0.0_dp
-    colvar%dsdr = 0.0_dp  ! CP2K collective variable derivatives array (3, NumAtoms)
+      ! ds/d(r_ij) = lambda*w_ij*(ds/dq_i - sum_k(w_kj*ds/dq_k)).
+      DO j = 1, n_atoms_b
+         weighted_charge_deriv = SUM(weight(:, j)*charge_factor)
+         DO i = 1, n_atoms_a
+            IF (weight(i, j) > 0.0_dp) THEN
+               charge_deriv = charge_factor(i) - weighted_charge_deriv
+               factor = lambda*weight(i, j)*charge_deriv*inv_distance(i, j)
+               colvar%dsdr(:, i) = colvar%dsdr(:, i) - factor*distance_vector(:, i, j)
+               colvar%dsdr(:, n_atoms_a + j) = colvar%dsdr(:, n_atoms_a + j) + &
+                                               factor*distance_vector(:, i, j)
+            END IF
+         END DO
+      END DO
 
-    ! 3. LOOP 1: Distance calculation and normalization building
-    !$OMP PARALLEL DO PRIVATE(i, i0, i1, r0, r1, r_ij, dist_mod)
-    do i = 1, colvar%voronoiipz_params%n_pairs
-       i0 = colvar%voronoiipz_params%pair_i0(i) ! Map to group A global index
-       i1 = colvar%voronoiipz_params%pair_i1(i) ! Map to group B global index
+      colvar%ss = ion_z
+      DEALLOCATE (charge, charge_factor, distance_vector, inv_distance, weight)
 
-       r0 = my_particles(i0)%r
-       r1 = my_particles(i1)%r
+   END SUBROUTINE colvar_eval_voronoiipz
 
-       r_ij = pbc(r0, r1, cell)
-       dist_mod = SQRT(SUM(r_ij**2))
+! **************************************************************************************************
+!> \brief Read and validate the VORONOIIPZ collective variable
+!> \param voronoiipz_section the input section
+!> \param colvar the collective variable
+! **************************************************************************************************
+   SUBROUTINE read_voronoiipz_colvars(voronoiipz_section, colvar)
+      TYPE(section_vals_type), POINTER                   :: voronoiipz_section
+      TYPE(colvar_type), POINTER                         :: colvar
 
-       ! CHANGE THESE LINES TO INDEX BY i:
-       distAB(i, :) = r_ij
+      INTEGER                                            :: i, j, n_atoms_a
+      INTEGER, DIMENSION(:), POINTER                     :: atom_list
 
-       distABinvmod(i) = 1.0_dp / MAX(dist_mod, 1.0E-12_dp)
+      CALL section_vals_val_get(voronoiipz_section, "LAMBDA", r_val=colvar%voronoiipz_params%lambda)
+      CALL section_vals_val_get(voronoiipz_section, "ZIDX", i_val=colvar%voronoiipz_params%zidx)
+      CALL section_vals_val_get(voronoiipz_section, "NRX", i_val=colvar%voronoiipz_params%nrx)
+      CALL section_vals_val_get(voronoiipz_section, "ZMID", r_val=colvar%voronoiipz_params%zmid)
+      CALL section_vals_val_get(voronoiipz_section, "D_0", r_val=colvar%voronoiipz_params%d0)
+      CALL section_vals_val_get(voronoiipz_section, "D_1", r_val=colvar%voronoiipz_params%d1)
+      CALL section_vals_val_get(voronoiipz_section, "D_2", r_val=colvar%voronoiipz_params%d2)
+      CALL section_vals_val_get(voronoiipz_section, "D_3", r_val=colvar%voronoiipz_params%d3)
+      CALL section_vals_val_get(voronoiipz_section, "NL_CUTOFF", r_val=colvar%voronoiipz_params%nl_cutoff)
 
-       ! CUTOFF
-       if (dist_mod > nl_cutoff) then
-          nnexp(i) = 0.0_dp
-       else
-          nnexp(i) = EXP(REAL(lambda, dp) * dist_mod)
-       end if
+      NULLIFY (atom_list)
+      CALL section_vals_val_get(voronoiipz_section, "GROUPA", i_vals=atom_list)
+      IF (.NOT. ASSOCIATED(atom_list)) THEN
+         CPABORT("VORONOIIPZ requires a non-empty GROUPA")
+      END IF
+      IF (SIZE(atom_list) == 0) CPABORT("VORONOIIPZ requires a non-empty GROUPA")
+      ALLOCATE (colvar%voronoiipz_params%group_a(SIZE(atom_list)))
+      colvar%voronoiipz_params%group_a = atom_list
 
-       !$OMP CRITICAL(voronoi_norm_update)
-       nnexpnorm(i1) = nnexpnorm(i1) + nnexp(i)
-       !$OMP END CRITICAL(voronoi_norm_update)
+      NULLIFY (atom_list)
+      CALL section_vals_val_get(voronoiipz_section, "GROUPB", i_vals=atom_list)
+      IF (.NOT. ASSOCIATED(atom_list)) THEN
+         CPABORT("VORONOIIPZ requires a non-empty GROUPB")
+      END IF
+      IF (SIZE(atom_list) == 0) CPABORT("VORONOIIPZ requires a non-empty GROUPB")
+      ALLOCATE (colvar%voronoiipz_params%group_b(SIZE(atom_list)))
+      colvar%voronoiipz_params%group_b = atom_list
 
-    end do
-    !$OMP END PARALLEL DO
+      n_atoms_a = SIZE(colvar%voronoiipz_params%group_a)
+      IF (colvar%voronoiipz_params%zidx < 1 .OR. colvar%voronoiipz_params%zidx > 3) THEN
+         CPABORT("VORONOIIPZ ZIDX must be 1, 2, or 3")
+      END IF
+      IF (colvar%voronoiipz_params%nrx < 0 .OR. colvar%voronoiipz_params%nrx > 3 .OR. &
+          colvar%voronoiipz_params%nrx >= n_atoms_a) THEN
+         CPABORT("VORONOIIPZ NRX must be between zero and three and smaller than the size of GROUPA")
+      END IF
+      IF (colvar%voronoiipz_params%nl_cutoff <= 0.0_dp) THEN
+         CPABORT("VORONOIIPZ NL_CUTOFF must be positive")
+      END IF
+      IF (ANY(colvar%voronoiipz_params%group_a <= 0) .OR. &
+          ANY(colvar%voronoiipz_params%group_b <= 0)) THEN
+         CPABORT("VORONOIIPZ atom indices must be positive")
+      END IF
+      DO i = 1, n_atoms_a
+         IF (ANY(colvar%voronoiipz_params%group_a(i) == colvar%voronoiipz_params%group_a(i + 1:))) THEN
+            CPABORT("VORONOIIPZ GROUPA contains duplicate atom indices")
+         END IF
+         IF (ANY(colvar%voronoiipz_params%group_a(i) == colvar%voronoiipz_params%group_b)) THEN
+            CPABORT("VORONOIIPZ GROUPA and GROUPB must be disjoint")
+         END IF
+      END DO
+      DO j = 1, SIZE(colvar%voronoiipz_params%group_b)
+         IF (ANY(colvar%voronoiipz_params%group_b(j) == colvar%voronoiipz_params%group_b(j + 1:))) THEN
+            CPABORT("VORONOIIPZ GROUPB contains duplicate atom indices")
+         END IF
+      END DO
 
-    ! 4. LOOP 2: Compute local unshifted charges
-    !$OMP PARALLEL DO PRIVATE(i, i0, i1)
-    do i = 1, colvar%voronoiipz_params%n_pairs
-       i0 = colvar%voronoiipz_params%pair_i0(i)
-       i1 = colvar%voronoiipz_params%pair_i1(i)
-       c(i) = nnexp(i) / MAX(nnexpnorm(i1), 1.0E-12_dp)
-    
-       !$OMP CRITICAL(voronoi_charge_update)
-       charget(i0) = charget(i0) + c(i)
-       !$OMP END CRITICAL(voronoi_charge_update)
-    end do
-    !$OMP END PARALLEL DO
-    charge(:) = charget(:)
+   END SUBROUTINE read_voronoiipz_colvars
 
-    ! 5. LOOP 2.5: Shift charges & absolute distance metric execution
-    do j = 1, num_atomsa
-       i0 = colvar%voronoiipz_params%group_a(j)
-
-       if (j == num_atomso) then
-          charge(i0) = charge(i0) - d1
-       else if (j == num_atomso + 1) then
-          charge(i0) = charge(i0) - d2
-       else if (j == num_atomso + 2) then
-          charge(i0) = charge(i0) - d3
-       else
-          charge(i0) = charge(i0) - d0
-       end if
-
-       ion_z = ion_z + ABS(my_particles(i0)%r(zidx) - zmid) * (charge(i0)**2)
-       
-       if ((my_particles(i0)%r(zidx) - zmid) >= 0.0_dp) then
-          colvar%dsdr(zidx, i0) = colvar%dsdr(zidx, i0) + (charge(i0)**2)
-       else
-          colvar%dsdr(zidx, i0) = colvar%dsdr(zidx, i0) - (charge(i0)**2)
-       end if
-
-    end do
-
-    ! 6. LOOP 4: Double loop analytical force gradients mapping back to CP2K atoms
-    !$OMP PARALLEL DO PRIVATE(i, k, i0, i1, d_in, fk, buf, dd)
-    do i = 1, colvar%voronoiipz_params%n_pairs
-       i0 = colvar%voronoiipz_params%pair_i0(i)
-       i1 = colvar%voronoiipz_params%pair_i1(i)
-
-       idx_a = i0
-
-       do k = 1, num_atomsa
-          idx_a = colvar%voronoiipz_params%group_a(k)
-          if (i0 == idx_a) then
-             d_in = 1
-          else
-             d_in = 0
-          end if
-
-          fk = REAL(lambda, dp) * c(i) * (REAL(d_in, dp) - c(i))
-          if (charge(i0) > 0.0_dp .AND. i0 < num_atomso) then
-             buf = 2.0_dp * ABS(my_particles(i0)%r(zidx) - zmid) * charge(i0) * fk
-          else
-             buf = 0.0_dp
-          end if
-
-          dd = buf * distABinvmod(i) * distAB(i, :)
-
-          !!$OMP CRITICAL(voronoi_dsdr_update)
-          dsdr_tmp(:, i1) = dsdr_tmp(:, i1) + dd
-          dsdr_tmp(:, idx_a)  = dsdr_tmp(:, idx_a)  - dd
-          !!$OMP END CRITICAL(voronoi_dsdr_update)
-       end do
-    end do
-    !$OMP END PARALLEL DO
-    colvar%dsdr = colvar%dsdr + dsdr_tmp
-
-    colvar%ss = ion_z ! Assign final updated collective variable value 
-    DEALLOCATE(nnexp, nnexpnorm, charge, charget, c, distABinvmod, distAB, dsdr_tmp)
-  END SUBROUTINE colvar_eval_voronoiipz
-
-
-SUBROUTINE read_voronoiipz_colvars(voronoiipz_section, colvar)
-    TYPE(section_vals_type), POINTER         :: voronoiipz_section
-    TYPE(colvar_type), POINTER               :: colvar
-    
-    ! --- Local Variable Declarations ---
-    INTEGER, DIMENSION(:), POINTER           :: temp_array
-    INTEGER                                  :: i, j, n
-
-    IF (.NOT. ASSOCIATED(colvar%voronoiipz_params)) THEN
-       ALLOCATE (colvar%voronoiipz_params)
-    END IF
-
-    ! Read scalar values
-    CALL section_vals_val_get(voronoiipz_section, "LAMBDA", i_val=colvar%voronoiipz_params%lambda)
-    CALL section_vals_val_get(voronoiipz_section, "ZIDX", i_val=colvar%voronoiipz_params%zidx)
-    CALL section_vals_val_get(voronoiipz_section, "NRX", i_val=colvar%voronoiipz_params%nrx)
-    CALL section_vals_val_get(voronoiipz_section, "ZMID", r_val=colvar%voronoiipz_params%zmid)
-    CALL section_vals_val_get(voronoiipz_section, "D_0", r_val=colvar%voronoiipz_params%d0)
-    CALL section_vals_val_get(voronoiipz_section, "D_1", r_val=colvar%voronoiipz_params%d1)
-    CALL section_vals_val_get(voronoiipz_section, "D_2", r_val=colvar%voronoiipz_params%d2)
-    CALL section_vals_val_get(voronoiipz_section, "D_3", r_val=colvar%voronoiipz_params%d3)
-    CALL section_vals_val_get(voronoiipz_section, "NL_CUTOFF", r_val=colvar%voronoiipz_params%nl_cutoff)
-
-
-    ! Read arrays (GROUPA)
-    NULLIFY(temp_array)
-    CALL section_vals_val_get(voronoiipz_section, "GROUPA", i_vals=temp_array)
-    IF (ASSOCIATED(temp_array)) THEN
-       ALLOCATE(colvar%voronoiipz_params%group_a(SIZE(temp_array)))
-       colvar%voronoiipz_params%group_a(:) = temp_array(:)
-    END IF
-
-    ! Read arrays (GROUPB)
-    NULLIFY(temp_array)
-    CALL section_vals_val_get(voronoiipz_section, "GROUPB", i_vals=temp_array)
-    IF (ASSOCIATED(temp_array)) THEN
-       ALLOCATE(colvar%voronoiipz_params%group_b(SIZE(temp_array)))
-       colvar%voronoiipz_params%group_b(:) = temp_array(:)
-    END IF
-
-    ! ==========================================================================
-    ! INTEGRATED PAIRWISE MAPPING CONSTRUCTION
-    IF (ASSOCIATED(colvar%voronoiipz_params%group_a) .AND. ASSOCIATED(colvar%voronoiipz_params%group_b)) THEN
-       
-       ! Calculate total pairs
-       colvar%voronoiipz_params%n_pairs = SIZE(colvar%voronoiipz_params%group_a) * SIZE(colvar%voronoiipz_params%group_b)
-       
-       ! Allocate mapping lookup vectors
-       ALLOCATE(colvar%voronoiipz_params%pair_i0(colvar%voronoiipz_params%n_pairs))
-       ALLOCATE(colvar%voronoiipz_params%pair_i1(colvar%voronoiipz_params%n_pairs))
-       
-       ! Populate pairwise grids
-       n = 0
-       do i = 1, SIZE(colvar%voronoiipz_params%group_a)
-          do j = 1, SIZE(colvar%voronoiipz_params%group_b)
-             n = n + 1
-             colvar%voronoiipz_params%pair_i0(n) = colvar%voronoiipz_params%group_a(i)
-             colvar%voronoiipz_params%pair_i1(n) = colvar%voronoiipz_params%group_b(j)
-          end do
-       end do
-       
-    ELSE
-       colvar%voronoiipz_params%n_pairs = 0
-    END IF
-
-END SUBROUTINE read_voronoiipz_colvars
-   
 END MODULE colvar_methods

--- a/src/common/bibliography.F
+++ b/src/common/bibliography.F
@@ -98,7 +98,7 @@ MODULE bibliography
                             KuhneHeskeProdan2020, Schreder2021, Schreder2024_1, Schreder2024_2, &
                             Shiga2022, Lindh1995, Chai2024a, Rullan2026, Sundararaman2017, Andreussi2019, &
                             Chai2025a, Neugebauer2023, Chai2024b, Moynihan2017, Cococcioni2005, &
-                            Cances2000, Herbst2022
+                            Cances2000, Herbst2022, Zhang2025
 
 CONTAINS
 
@@ -2272,6 +2272,13 @@ CONTAINS
                          "effective interaction parameters in the LDA+U method", &
                          source="Phys. Rev. B", volume="71", pages="035105", &
                          year=2005, doi="10.1103/PhysRevB.71.035105")
+
+      CALL add_reference(key=Zhang2025, &
+                         authors=s2a("P. Zhang", "X. Xu"), &
+                         title="Propensity of Water Self-Ions at Air(Oil)-Water Interfaces Revealed by "// &
+                         "Deep Potential Molecular Dynamics with Enhanced Sampling", &
+                         source="Langmuir", volume="41", pages="3675-3683", &
+                         year=2025, doi="10.1021/acs.langmuir.4c05004")
 
    END SUBROUTINE add_all_references
 

--- a/src/common/bibliography.F
+++ b/src/common/bibliography.F
@@ -97,7 +97,8 @@ MODULE bibliography
                             FuHo1983, MethfesselPaxton1989, Marzari1999, dosSantos2023, Mermin1965, &
                             KuhneHeskeProdan2020, Schreder2021, Schreder2024_1, Schreder2024_2, &
                             Shiga2022, Lindh1995, Chai2024a, Rullan2026, Sundararaman2017, Andreussi2019, &
-                            Chai2025a, Neugebauer2023, Chai2024b, Moynihan2017, Cococcioni2005
+                            Chai2025a, Neugebauer2023, Chai2024b, Moynihan2017, Cococcioni2005, &
+                            Zhang2025
 
 CONTAINS
 
@@ -2252,6 +2253,13 @@ CONTAINS
                          "effective interaction parameters in the LDA+U method", &
                          source="Phys. Rev. B", volume="71", pages="035105", &
                          year=2005, doi="10.1103/PhysRevB.71.035105")
+
+      CALL add_reference(key=Zhang2025, &
+                         authors=s2a("P. Zhang", "X. Xu"), &
+                         title="Propensity of Water Self-Ions at Air(Oil)-Water Interfaces Revealed by "// &
+                         "Deep Potential Molecular Dynamics with Enhanced Sampling", &
+                         source="Langmuir", volume="41", pages="3675-3683", &
+                         year=2025, doi="10.1021/acs.langmuir.4c05004")
 
    END SUBROUTINE add_all_references
 

--- a/src/input_cp2k_colvar.F
+++ b/src/input_cp2k_colvar.F
@@ -50,7 +50,7 @@ MODULE input_cp2k_colvar
 
    PUBLIC :: create_colvar_section, &
              create_colvar_xyz_d_section, &
-             create_colvar_xyz_od_section
+             create_colvar_xyz_od_section, create_voronoiipz_section
 
 CONTAINS
 
@@ -228,6 +228,10 @@ CONTAINS
       CALL section_release(subsection)
 
       CALL create_colvar_cond_dist_section(subsection)
+      CALL section_add_subsection(section, subsection)
+      CALL section_release(subsection)
+
+      CALL create_voronoiipz_section(subsection)
       CALL section_add_subsection(section, subsection)
       CALL section_release(subsection)
 
@@ -2300,5 +2304,94 @@ CONTAINS
    END SUBROUTINE create_colvar_ring_puckering_section
 
 ! **************************************************************************************************
+!> \brief Creates the VORONOIIPZ collective variable input section
+!> \param section the section to create
+! **************************************************************************************************
+   SUBROUTINE create_voronoiipz_section(section)
+      TYPE(section_type), POINTER                        :: section
+
+      TYPE(keyword_type), POINTER                        :: keyword
+      NULLIFY(keyword)
+
+      CPASSERT(.NOT. ASSOCIATED(section))
+      CALL section_create(section, __LOCATION__, name="VORONOIIPZ", &
+                          description="Parameters for the VoronoiIPZ collective variable.", &
+                          n_subsections=0, repeats=.FALSE.)
+      CALL keyword_create(keyword, __LOCATION__, name="LAMBDA", &
+                          description="Smoothing exponent parameter lambda.", &
+                          usage="LAMBDA 2", type_of_var=integer_t, default_i_val=1)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="ZMID", &
+                          description="Reference center midplane Z coordinate.", &
+                          usage="ZMID 0.0", type_of_var=real_t, default_r_val=0.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="ZIDX", &
+                          description="Index mapping descriptor for Z tracking.", &
+                          usage="ZIDX 1", type_of_var=integer_t, default_i_val=1)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+
+      CALL keyword_create(keyword, __LOCATION__, name="D_0", &
+                          description="Coefficient d0.", usage="D_0 1.0", &
+                          type_of_var=real_t, default_r_val=0.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="D_1", &
+                          description="Coefficient d1.", usage="D_1 1.0", &
+                          type_of_var=real_t, default_r_val=0.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="D_2", &
+                          description="Coefficient d2.", usage="D_2 1.0", &
+                          type_of_var=real_t, default_r_val=0.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="D_3", &
+                          description="Coefficient d3.", usage="D_3 1.0", &
+                          type_of_var=real_t, default_r_val=0.0_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="NL_CUTOFF", &
+           description="Neighbor list cutoff radius for the Voronoi calculation [Bohr]", &
+           usage="NL_CUTOFF 4.536862", default_r_val=4.536862_dp)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)      
+
+      CALL keyword_create(keyword, __LOCATION__, name="GROUPA", &
+           description="Atom indices for group A", &
+           usage="GROUPA 1 2 3", &
+           repeats=.TRUE., &
+           n_var=-1, &
+           type_of_var=integer_t) 
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="GROUPB", &
+           description="Atom indices for group B", &
+           usage="GROUPB 4 5 6", &
+           repeats=.TRUE., &
+           n_var=-1, &
+           type_of_var=integer_t)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+      CALL keyword_create(keyword, __LOCATION__, name="NRX", &
+                       description="Grid descriptor integer for region scaling.", &
+                       usage="NRX 10", &
+                       type_of_var=integer_t, &
+                       default_i_val=0)
+      CALL section_add_keyword(section, keyword)
+      CALL keyword_release(keyword)
+
+   END SUBROUTINE create_voronoiipz_section
 
 END MODULE input_cp2k_colvar

--- a/src/input_cp2k_colvar.F
+++ b/src/input_cp2k_colvar.F
@@ -11,7 +11,8 @@
 !> \author teo & fawzi
 ! **************************************************************************************************
 MODULE input_cp2k_colvar
-   USE bibliography,                    ONLY: Branduardi2007
+   USE bibliography,                    ONLY: Branduardi2007,&
+                                              Zhang2025
    USE colvar_types,                    ONLY: &
         do_clv_fix_point, do_clv_geo_center, do_clv_x, do_clv_xy, do_clv_xyz, do_clv_xz, do_clv_y, &
         do_clv_yz, do_clv_z, plane_def_atoms, plane_def_vec
@@ -50,7 +51,7 @@ MODULE input_cp2k_colvar
 
    PUBLIC :: create_colvar_section, &
              create_colvar_xyz_d_section, &
-             create_colvar_xyz_od_section, create_voronoiipz_section
+             create_colvar_xyz_od_section
 
 CONTAINS
 
@@ -2311,84 +2312,85 @@ CONTAINS
       TYPE(section_type), POINTER                        :: section
 
       TYPE(keyword_type), POINTER                        :: keyword
-      NULLIFY(keyword)
 
       CPASSERT(.NOT. ASSOCIATED(section))
+      NULLIFY (keyword)
       CALL section_create(section, __LOCATION__, name="VORONOIIPZ", &
-                          description="Parameters for the VoronoiIPZ collective variable.", &
-                          n_subsections=0, repeats=.FALSE.)
+                          description="Absolute location of a hydronium ion along a Cartesian axis, "// &
+                          "based on continuous Voronoi weights.", &
+                          citations=[Zhang2025], n_subsections=0, repeats=.FALSE.)
+
       CALL keyword_create(keyword, __LOCATION__, name="LAMBDA", &
-                          description="Smoothing exponent parameter lambda.", &
-                          usage="LAMBDA 2", type_of_var=integer_t, default_i_val=1)
+                          description="Exponent in the Voronoi weight exp(LAMBDA*r). "// &
+                          "Negative values assign each hydrogen predominantly to nearby oxygen atoms.", &
+                          usage="LAMBDA [angstrom^-1] -8.0", type_of_var=real_t, &
+                          default_r_val=cp_unit_to_cp2k(value=-8.0_dp, unit_str="angstrom^-1"), &
+                          unit_str="angstrom^-1", n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="ZMID", &
-                          description="Reference center midplane Z coordinate.", &
-                          usage="ZMID 0.0", type_of_var=real_t, default_r_val=0.0_dp)
+                          description="Coordinate of the reference plane along the selected axis.", &
+                          usage="ZMID [angstrom] 0.0", type_of_var=real_t, default_r_val=0.0_dp, &
+                          unit_str="angstrom", n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="ZIDX", &
-                          description="Index mapping descriptor for Z tracking.", &
-                          usage="ZIDX 1", type_of_var=integer_t, default_i_val=1)
+                          description="Cartesian direction used for the ion location: 1=X, 2=Y, 3=Z.", &
+                          usage="ZIDX 3", type_of_var=integer_t, default_i_val=3, n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
-
       CALL keyword_create(keyword, __LOCATION__, name="D_0", &
-                          description="Coefficient d0.", usage="D_0 1.0", &
-                          type_of_var=real_t, default_r_val=0.0_dp)
+                          description="Reference coordination of the non-reactive GROUPA atoms.", &
+                          usage="D_0 2.0", type_of_var=real_t, default_r_val=2.0_dp, n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="D_1", &
-                          description="Coefficient d1.", usage="D_1 1.0", &
-                          type_of_var=real_t, default_r_val=0.0_dp)
+                          description="Reference coordination of the first reactive GROUPA atom.", &
+                          usage="D_1 2.0", type_of_var=real_t, default_r_val=2.0_dp, n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="D_2", &
-                          description="Coefficient d2.", usage="D_2 1.0", &
-                          type_of_var=real_t, default_r_val=0.0_dp)
+                          description="Reference coordination of the second reactive GROUPA atom.", &
+                          usage="D_2 2.0", type_of_var=real_t, default_r_val=2.0_dp, n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="D_3", &
-                          description="Coefficient d3.", usage="D_3 1.0", &
-                          type_of_var=real_t, default_r_val=0.0_dp)
+                          description="Reference coordination of the third reactive GROUPA atom.", &
+                          usage="D_3 2.0", type_of_var=real_t, default_r_val=2.0_dp, n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="NL_CUTOFF", &
-           description="Neighbor list cutoff radius for the Voronoi calculation [Bohr]", &
-           usage="NL_CUTOFF 4.536862", default_r_val=4.536862_dp)
+                          description="Maximum GROUPA-GROUPB distance included in the Voronoi weights.", &
+                          usage="NL_CUTOFF [angstrom] 2.4", &
+                          default_r_val=cp_unit_to_cp2k(value=2.4_dp, unit_str="angstrom"), &
+                          unit_str="angstrom", n_var=1)
       CALL section_add_keyword(section, keyword)
-      CALL keyword_release(keyword)      
+      CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="GROUPA", &
-           description="Atom indices for group A", &
-           usage="GROUPA 1 2 3", &
-           repeats=.TRUE., &
-           n_var=-1, &
-           type_of_var=integer_t) 
+                          description="Oxygen atoms used as Voronoi sites. Any reactive sites must "// &
+                          "be the final NRX entries.", &
+                          usage="GROUPA 1 4 7", n_var=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="GROUPB", &
-           description="Atom indices for group B", &
-           usage="GROUPB 4 5 6", &
-           repeats=.TRUE., &
-           n_var=-1, &
-           type_of_var=integer_t)
+                          description="Hydrogen atoms assigned to the GROUPA sites.", &
+                          usage="GROUPB 2 3 5 6 8 9", n_var=-1, type_of_var=integer_t)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="NRX", &
-                       description="Grid descriptor integer for region scaling.", &
-                       usage="NRX 10", &
-                       type_of_var=integer_t, &
-                       default_i_val=0)
+                          description="Number of reactive sites at the end of GROUPA (zero to three). "// &
+                          "Their reference coordinations are D_1 through D_3.", &
+                          usage="NRX 0", type_of_var=integer_t, default_i_val=0, n_var=1)
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/subsys/colvar_types.F
+++ b/src/subsys/colvar_types.F
@@ -79,7 +79,8 @@ MODULE colvar_types
                                  mindist_colvar_id = 23, &
                                  acid_hyd_dist_colvar_id = 24, &
                                  acid_hyd_shell_colvar_id = 25, &
-                                 hydronium_dist_colvar_id = 26
+                                 hydronium_dist_colvar_id = 26, &
+                                 voronoiipz_colvar_id = 27
 
 ! **************************************************************************************************
 !> \brief parameters for the distance collective variable
@@ -222,6 +223,27 @@ MODULE colvar_types
                                          i_hydrogens => NULL()
       REAL(KIND=dp)                   :: rwoh = 0.0_dp, raoh = 0.0_dp, lambda = 0.0_dp, nc = 0.0_dp
    END TYPE acid_hyd_dist_colvar_type
+
+
+! **************************************************************************************************
+   TYPE voronoiipz_parameters_type
+      INTEGER, DIMENSION(:), POINTER :: group_a => NULL()
+      INTEGER, DIMENSION(:), POINTER :: group_b => NULL()
+      INTEGER, DIMENSION(:), POINTER :: pair_i0 => NULL()
+      INTEGER, DIMENSION(:), POINTER :: pair_i1 => NULL()
+      INTEGER                        :: n_pairs = 0
+      INTEGER                        :: lambda = 1
+      INTEGER                        :: zidx = 3
+      INTEGER                        :: nrx = 0
+      REAL(KIND=dp)                  :: d0 = 2.0_dp
+      REAL(KIND=dp)                  :: d1 = 2.0_dp
+      REAL(KIND=dp)                  :: d2 = 2.0_dp
+      REAL(KIND=dp)                  :: d3 = 2.0_dp
+      REAL(KIND=dp)                  :: zmid = 0.0_dp
+      REAL(KIND=dp)                  :: nl_cutoff = 4.536862_dp
+   END TYPE voronoiipz_parameters_type
+! **************************************************************************************************
+
 
 ! **************************************************************************************************
    TYPE acid_hyd_shell_colvar_type
@@ -377,6 +399,7 @@ MODULE colvar_types
       TYPE(HBP_colvar_type), POINTER               :: HBP => NULL()
       TYPE(ring_puckering_colvar_type), POINTER    :: ring_puckering_param => NULL()
       TYPE(mindist_colvar_type), POINTER           :: mindist_param => NULL()
+      TYPE(voronoiipz_parameters_type), POINTER :: voronoiipz_params => NULL()
    END TYPE colvar_type
 
 ! **************************************************************************************************
@@ -485,10 +508,17 @@ CONTAINS
          ALLOCATE (colvar%ring_puckering_param)
       CASE (mindist_colvar_id)
          ALLOCATE (colvar%mindist_param)
+      CASE (voronoiipz_colvar_id)
+         ALLOCATE (colvar%voronoiipz_params)
+         ! Initialize any primitive scalar parameters to default values if needed
+         colvar%voronoiipz_params%lambda = 0
+         colvar%voronoiipz_params%zidx   = 3
+         NULLIFY (colvar%voronoiipz_params%group_a)
+         NULLIFY (colvar%voronoiipz_params%group_b)
       CASE (no_colvar_id)
          ! Do nothing
       CASE DEFAULT
-         CPABORT("Unknown colvar type")
+         CPABORT("")
       END SELECT
 
    END SUBROUTINE colvar_create
@@ -958,6 +988,15 @@ CONTAINS
                list(idum) = colvar%combine_cvs_param%colvar_p(ii)%colvar%i_atom(j)
             END DO
          END DO
+      
+      CASE (voronoiipz_colvar_id)
+         colvar%use_points = .FALSE.
+         ! 1. Combine group_a and group_b into the setup list
+         ALLOCATE(list(SIZE(colvar%voronoiipz_params%group_a) + SIZE(colvar%voronoiipz_params%group_b)))
+         list(1:SIZE(colvar%voronoiipz_params%group_a)) = colvar%voronoiipz_params%group_a(:)
+         list(SIZE(colvar%voronoiipz_params%group_a)+1:SIZE(list)) = colvar%voronoiipz_params%group_b(:)
+         colvar%n_atom_s = SIZE(list) 
+         
       END SELECT
 
       IF (ASSOCIATED(colvar%dsdr)) THEN
@@ -1343,10 +1382,25 @@ CONTAINS
             DEALLOCATE (colvar%mindist_param%k_coord_to)
          END IF
          DEALLOCATE (colvar%mindist_param)
+
+      CASE (voronoiipz_colvar_id)
+         IF (ASSOCIATED(colvar%voronoiipz_params%group_a)) THEN
+            DEALLOCATE (colvar%voronoiipz_params%group_a)
+         END IF
+         IF (ASSOCIATED(colvar%voronoiipz_params%group_b)) THEN
+            DEALLOCATE (colvar%voronoiipz_params%group_b)
+         END IF
+
+         ! Finally, deallocate the master parameter block itself
+         DEALLOCATE (colvar%voronoiipz_params)
+
+       ! ----
+
+
       CASE (no_colvar_id)
          ! Do nothing
       CASE default
-         CPABORT("Unknown colvar type")
+         CPABORT("")
       END SELECT
       DEALLOCATE (colvar)
 
@@ -1372,6 +1426,29 @@ CONTAINS
       CALL colvar_clone_points(colvar_out, colvar_in, my_offset)
       IF (colvar_in%use_points) my_offset = 0
       SELECT CASE (colvar_out%type_id)
+      CASE (voronoiipz_colvar_id)
+         ! 1. Allocate the container structure on the cloned object
+         ALLOCATE (colvar_out%voronoiipz_params)
+         ! 2. Copy over the scalar variables
+         colvar_out%voronoiipz_params%lambda = colvar_in%voronoiipz_params%lambda
+         colvar_out%voronoiipz_params%zidx   = colvar_in%voronoiipz_params%zidx
+         colvar_out%voronoiipz_params%nrx    = colvar_in%voronoiipz_params%nrx
+         colvar_out%voronoiipz_params%zmid   = colvar_in%voronoiipz_params%zmid
+         colvar_out%voronoiipz_params%d0     = colvar_in%voronoiipz_params%d0
+         colvar_out%voronoiipz_params%d1     = colvar_in%voronoiipz_params%d1
+         colvar_out%voronoiipz_params%d2     = colvar_in%voronoiipz_params%d2
+         colvar_out%voronoiipz_params%d3     = colvar_in%voronoiipz_params%d3
+         ! 3. Copy the allocated tracking arrays if present
+         IF (ASSOCIATED(colvar_in%voronoiipz_params%group_a)) THEN
+            ALLOCATE (colvar_out%voronoiipz_params%group_a(SIZE(colvar_in%voronoiipz_params%group_a)))
+            colvar_out%voronoiipz_params%group_a(:) = colvar_in%voronoiipz_params%group_a(:)
+         END IF
+
+         IF (ASSOCIATED(colvar_in%voronoiipz_params%group_b)) THEN
+            ALLOCATE (colvar_out%voronoiipz_params%group_b(SIZE(colvar_in%voronoiipz_params%group_b)))
+            colvar_out%voronoiipz_params%group_b(:) = colvar_in%voronoiipz_params%group_b(:)
+         END IF
+
       CASE (dist_colvar_id)
          colvar_out%dist_param%i_at = colvar_in%dist_param%i_at + my_offset
          colvar_out%dist_param%j_at = colvar_in%dist_param%j_at + my_offset

--- a/src/subsys/colvar_types.F
+++ b/src/subsys/colvar_types.F
@@ -224,26 +224,13 @@ MODULE colvar_types
       REAL(KIND=dp)                   :: rwoh = 0.0_dp, raoh = 0.0_dp, lambda = 0.0_dp, nc = 0.0_dp
    END TYPE acid_hyd_dist_colvar_type
 
-
 ! **************************************************************************************************
-   TYPE voronoiipz_parameters_type
-      INTEGER, DIMENSION(:), POINTER :: group_a => NULL()
-      INTEGER, DIMENSION(:), POINTER :: group_b => NULL()
-      INTEGER, DIMENSION(:), POINTER :: pair_i0 => NULL()
-      INTEGER, DIMENSION(:), POINTER :: pair_i1 => NULL()
-      INTEGER                        :: n_pairs = 0
-      INTEGER                        :: lambda = 1
-      INTEGER                        :: zidx = 3
-      INTEGER                        :: nrx = 0
-      REAL(KIND=dp)                  :: d0 = 2.0_dp
-      REAL(KIND=dp)                  :: d1 = 2.0_dp
-      REAL(KIND=dp)                  :: d2 = 2.0_dp
-      REAL(KIND=dp)                  :: d3 = 2.0_dp
-      REAL(KIND=dp)                  :: zmid = 0.0_dp
-      REAL(KIND=dp)                  :: nl_cutoff = 4.536862_dp
-   END TYPE voronoiipz_parameters_type
-! **************************************************************************************************
-
+   TYPE voronoiipz_colvar_type
+      INTEGER, DIMENSION(:), POINTER :: group_a => NULL(), group_b => NULL()
+      INTEGER                        :: nrx = 0, zidx = 3
+      REAL(KIND=dp)                  :: d0 = 2.0_dp, d1 = 2.0_dp, d2 = 2.0_dp, d3 = 2.0_dp, &
+                                        lambda = -8.0_dp, nl_cutoff = 4.536862_dp, zmid = 0.0_dp
+   END TYPE voronoiipz_colvar_type
 
 ! **************************************************************************************************
    TYPE acid_hyd_shell_colvar_type
@@ -399,7 +386,7 @@ MODULE colvar_types
       TYPE(HBP_colvar_type), POINTER               :: HBP => NULL()
       TYPE(ring_puckering_colvar_type), POINTER    :: ring_puckering_param => NULL()
       TYPE(mindist_colvar_type), POINTER           :: mindist_param => NULL()
-      TYPE(voronoiipz_parameters_type), POINTER :: voronoiipz_params => NULL()
+      TYPE(voronoiipz_colvar_type), POINTER        :: voronoiipz_params => NULL()
    END TYPE colvar_type
 
 ! **************************************************************************************************
@@ -429,6 +416,7 @@ MODULE colvar_types
       INTEGER :: ngyration = 0
       INTEGER :: nxyz_diag = 0
       INTEGER :: nxyz_outerdiag = 0
+      INTEGER :: nvoronoiipz = 0
       INTEGER :: ntot = 0
    END TYPE colvar_counters
 
@@ -510,15 +498,10 @@ CONTAINS
          ALLOCATE (colvar%mindist_param)
       CASE (voronoiipz_colvar_id)
          ALLOCATE (colvar%voronoiipz_params)
-         ! Initialize any primitive scalar parameters to default values if needed
-         colvar%voronoiipz_params%lambda = 0
-         colvar%voronoiipz_params%zidx   = 3
-         NULLIFY (colvar%voronoiipz_params%group_a)
-         NULLIFY (colvar%voronoiipz_params%group_b)
       CASE (no_colvar_id)
          ! Do nothing
       CASE DEFAULT
-         CPABORT("")
+         CPABORT("Unknown colvar type")
       END SELECT
 
    END SUBROUTINE colvar_create
@@ -988,15 +971,12 @@ CONTAINS
                list(idum) = colvar%combine_cvs_param%colvar_p(ii)%colvar%i_atom(j)
             END DO
          END DO
-      
       CASE (voronoiipz_colvar_id)
          colvar%use_points = .FALSE.
-         ! 1. Combine group_a and group_b into the setup list
-         ALLOCATE(list(SIZE(colvar%voronoiipz_params%group_a) + SIZE(colvar%voronoiipz_params%group_b)))
+         ALLOCATE (list(SIZE(colvar%voronoiipz_params%group_a) + SIZE(colvar%voronoiipz_params%group_b)))
          list(1:SIZE(colvar%voronoiipz_params%group_a)) = colvar%voronoiipz_params%group_a(:)
-         list(SIZE(colvar%voronoiipz_params%group_a)+1:SIZE(list)) = colvar%voronoiipz_params%group_b(:)
-         colvar%n_atom_s = SIZE(list) 
-         
+         list(SIZE(colvar%voronoiipz_params%group_a) + 1:SIZE(list)) = colvar%voronoiipz_params%group_b(:)
+         colvar%n_atom_s = SIZE(list)
       END SELECT
 
       IF (ASSOCIATED(colvar%dsdr)) THEN
@@ -1384,23 +1364,13 @@ CONTAINS
          DEALLOCATE (colvar%mindist_param)
 
       CASE (voronoiipz_colvar_id)
-         IF (ASSOCIATED(colvar%voronoiipz_params%group_a)) THEN
-            DEALLOCATE (colvar%voronoiipz_params%group_a)
-         END IF
-         IF (ASSOCIATED(colvar%voronoiipz_params%group_b)) THEN
-            DEALLOCATE (colvar%voronoiipz_params%group_b)
-         END IF
-
-         ! Finally, deallocate the master parameter block itself
+         DEALLOCATE (colvar%voronoiipz_params%group_a)
+         DEALLOCATE (colvar%voronoiipz_params%group_b)
          DEALLOCATE (colvar%voronoiipz_params)
-
-       ! ----
-
-
       CASE (no_colvar_id)
          ! Do nothing
       CASE default
-         CPABORT("")
+         CPABORT("Unknown colvar type")
       END SELECT
       DEALLOCATE (colvar)
 
@@ -1427,28 +1397,19 @@ CONTAINS
       IF (colvar_in%use_points) my_offset = 0
       SELECT CASE (colvar_out%type_id)
       CASE (voronoiipz_colvar_id)
-         ! 1. Allocate the container structure on the cloned object
-         ALLOCATE (colvar_out%voronoiipz_params)
-         ! 2. Copy over the scalar variables
          colvar_out%voronoiipz_params%lambda = colvar_in%voronoiipz_params%lambda
-         colvar_out%voronoiipz_params%zidx   = colvar_in%voronoiipz_params%zidx
-         colvar_out%voronoiipz_params%nrx    = colvar_in%voronoiipz_params%nrx
-         colvar_out%voronoiipz_params%zmid   = colvar_in%voronoiipz_params%zmid
-         colvar_out%voronoiipz_params%d0     = colvar_in%voronoiipz_params%d0
-         colvar_out%voronoiipz_params%d1     = colvar_in%voronoiipz_params%d1
-         colvar_out%voronoiipz_params%d2     = colvar_in%voronoiipz_params%d2
-         colvar_out%voronoiipz_params%d3     = colvar_in%voronoiipz_params%d3
-         ! 3. Copy the allocated tracking arrays if present
-         IF (ASSOCIATED(colvar_in%voronoiipz_params%group_a)) THEN
-            ALLOCATE (colvar_out%voronoiipz_params%group_a(SIZE(colvar_in%voronoiipz_params%group_a)))
-            colvar_out%voronoiipz_params%group_a(:) = colvar_in%voronoiipz_params%group_a(:)
-         END IF
-
-         IF (ASSOCIATED(colvar_in%voronoiipz_params%group_b)) THEN
-            ALLOCATE (colvar_out%voronoiipz_params%group_b(SIZE(colvar_in%voronoiipz_params%group_b)))
-            colvar_out%voronoiipz_params%group_b(:) = colvar_in%voronoiipz_params%group_b(:)
-         END IF
-
+         colvar_out%voronoiipz_params%zidx = colvar_in%voronoiipz_params%zidx
+         colvar_out%voronoiipz_params%nrx = colvar_in%voronoiipz_params%nrx
+         colvar_out%voronoiipz_params%zmid = colvar_in%voronoiipz_params%zmid
+         colvar_out%voronoiipz_params%d0 = colvar_in%voronoiipz_params%d0
+         colvar_out%voronoiipz_params%d1 = colvar_in%voronoiipz_params%d1
+         colvar_out%voronoiipz_params%d2 = colvar_in%voronoiipz_params%d2
+         colvar_out%voronoiipz_params%d3 = colvar_in%voronoiipz_params%d3
+         colvar_out%voronoiipz_params%nl_cutoff = colvar_in%voronoiipz_params%nl_cutoff
+         ALLOCATE (colvar_out%voronoiipz_params%group_a(SIZE(colvar_in%voronoiipz_params%group_a)))
+         ALLOCATE (colvar_out%voronoiipz_params%group_b(SIZE(colvar_in%voronoiipz_params%group_b)))
+         colvar_out%voronoiipz_params%group_a = colvar_in%voronoiipz_params%group_a + my_offset
+         colvar_out%voronoiipz_params%group_b = colvar_in%voronoiipz_params%group_b + my_offset
       CASE (dist_colvar_id)
          colvar_out%dist_param%i_at = colvar_in%dist_param%i_at + my_offset
          colvar_out%dist_param%j_at = colvar_in%dist_param%j_at + my_offset

--- a/src/subsys/molecule_kind_types.F
+++ b/src/subsys/molecule_kind_types.F
@@ -31,7 +31,8 @@ MODULE molecule_kind_types
         hydronium_shell_colvar_id, mindist_colvar_id, no_colvar_id, plane_distance_colvar_id, &
         plane_plane_angle_colvar_id, population_colvar_id, qparm_colvar_id, &
         reaction_path_colvar_id, ring_puckering_colvar_id, rmsd_colvar_id, rotation_colvar_id, &
-        torsion_colvar_id, u_colvar_id, xyz_diag_colvar_id, xyz_outerdiag_colvar_id
+        torsion_colvar_id, u_colvar_id, voronoiipz_colvar_id, xyz_diag_colvar_id, &
+        xyz_outerdiag_colvar_id
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
                                               cp_logger_type
    USE cp_output_handling,              ONLY: cp_print_key_finished_output,&
@@ -286,6 +287,8 @@ CONTAINS
                ncolv%nreactionpath = ncolv%nreactionpath + 1
             CASE (combine_colvar_id)
                ncolv%ncombinecvs = ncolv%ncombinecvs + 1
+            CASE (voronoiipz_colvar_id)
+               ncolv%nvoronoiipz = ncolv%nvoronoiipz + 1
             CASE DEFAULT
                CPABORT("Unknown colvar type")
             END SELECT
@@ -309,7 +312,8 @@ CONTAINS
                    ncolv%nreactionpath + &
                    ncolv%ncombinecvs + &
                    ncolv%npopulation + &
-                   ncolv%ngyration
+                   ncolv%ngyration + &
+                   ncolv%nvoronoiipz
 
    END SUBROUTINE setup_colvar_counters
 
@@ -1115,6 +1119,8 @@ CONTAINS
             type_string = "Acid hydronium shell"
          CASE (hydronium_dist_colvar_id)
             type_string = "Hydronium distance"
+         CASE (voronoiipz_colvar_id)
+            type_string = "Voronoi ion position"
          CASE DEFAULT
             CPABORT("Invalid collective variable ID specified. Check the code!")
          END SELECT

--- a/tests/Fist/regtest-12/TEST_FILES.toml
+++ b/tests/Fist/regtest-12/TEST_FILES.toml
@@ -72,4 +72,5 @@
 "ch4legendre.inp"                       = [{matcher="M011", tol=1.0E-14, ref=0.000337730329915}]
 # mixed stretch-bend form
 "bonded-3.inp"                          = [{matcher="M002", tol=1.0E-14, ref=0.168535489010E-02}]
+"voronoiipz.inp"                       = []
 #EOF

--- a/tests/Fist/regtest-12/voronoiipz.inp
+++ b/tests/Fist/regtest-12/voronoiipz.inp
@@ -1,0 +1,95 @@
+&GLOBAL
+  PRINT_LEVEL LOW
+  PROJECT voronoiipz
+  RUN_TYPE DEBUG
+&END GLOBAL
+
+&DEBUG
+  CHECK_ATOM_FORCE 2 XYZ
+  CHECK_ATOM_FORCE 4 XYZ
+  CHECK_ATOM_FORCE 5 XYZ
+  DX 1.0E-4
+  MAX_RELATIVE_ERROR 0.1
+&END DEBUG
+
+&MOTION
+  &CONSTRAINT
+    &COLLECTIVE
+      COLVAR 1
+      INTERMOLECULAR
+      TARGET [angstrom] 0.0
+      &RESTRAINT
+        K [hartree*bohr^-2] 0.01
+      &END RESTRAINT
+    &END COLLECTIVE
+  &END CONSTRAINT
+&END MOTION
+
+&FORCE_EVAL
+  METHOD FIST
+  &MM
+    &FORCEFIELD
+      &CHARGE
+        ATOM O
+        CHARGE 0.0
+      &END CHARGE
+      &CHARGE
+        ATOM H
+        CHARGE 0.0
+      &END CHARGE
+      &NONBONDED
+        &LENNARD-JONES
+          ATOMS O O
+          EPSILON 0.0
+          RCUT 8.0
+          SIGMA 3.0
+        &END LENNARD-JONES
+        &LENNARD-JONES
+          ATOMS O H
+          EPSILON 0.0
+          RCUT 8.0
+          SIGMA 3.0
+        &END LENNARD-JONES
+        &LENNARD-JONES
+          ATOMS H H
+          EPSILON 0.0
+          RCUT 8.0
+          SIGMA 3.0
+        &END LENNARD-JONES
+      &END NONBONDED
+    &END FORCEFIELD
+    &POISSON
+      &EWALD
+        EWALD_TYPE NONE
+      &END EWALD
+    &END POISSON
+  &END MM
+  &SUBSYS
+    &CELL
+      ABC 20.0 20.0 20.0
+      PERIODIC NONE
+    &END CELL
+    &COLVAR
+      &VORONOIIPZ
+        GROUPA 2 5
+        GROUPB 1 3 4 6 7
+        LAMBDA [angstrom^-1] -2.0
+        NL_CUTOFF [angstrom] 8.0
+        ZIDX 3
+        ZMID [angstrom] 8.1
+      &END VORONOIIPZ
+    &END COLVAR
+    &COORD
+      H 5.8 5.1 7.2
+      O 5.0 5.0 7.0
+      H 4.7 5.8 6.9
+      H 6.2 5.4 8.0
+      O 7.4 5.7 9.2
+      H 8.1 5.4 9.5
+      H 7.1 6.5 9.0
+    &END COORD
+    &TOPOLOGY
+      CONNECTIVITY OFF
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL


### PR DESCRIPTION
Add a new collective variable (CV) named VoronoiIPZ to CP2K's colvar infrastructure. This collective variable is designed to identify the absolute location of ions in a slab system relative to a reference layer.

Specifically, it calculates the absolute location of H3O+ ions along the z-axis relative to the designated reference layer in slab geometries. This feature is useful for examining interface phenomena and ion-slab interactions.

The algorithm is ported from the original C++ implementation in the PLUMED software package.

Reference:
- https://doi.org/10.1021/acs.langmuir.4c05004