### PR TITLE
CMake: Fix dependent option declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,18 +226,18 @@ cmake_dependent_option(
   CP2K_USE_CUSOLVER_MP "Enable cuSOLVERMp. Only active when CUDA is ON" OFF
   "CP2K_USE_ACCEL MATCHES \"CUDA\"" OFF)
 
-cmake_dependent_option(CP2K_USE_NVHPC OFF "Enable Nvidia NVHPC kit"
-                       "(NOT CP2K_USE_ACCEL MATCHES \"CUDA\")" OFF)
+cmake_dependent_option(CP2K_USE_NVHPC "Enable Nvidia NVHPC kit" OFF
+                       "CP2K_USE_ACCEL MATCHES \"CUDA\"" OFF)
 
 cmake_dependent_option(
-  CP2K_USE_SPLA_GEMM_OFFLOADING ON
-  "Enable SpLA dgemm offloading (only valid with GPU support on)"
-  "(NOT CP2K_USE_ACCEL MATCHES \"NONE\") AND (CP2K_USE_SPLA)" OFF)
+  CP2K_USE_SPLA_GEMM_OFFLOADING
+  "Enable SpLA dgemm offloading (only valid with GPU support on)" ON
+  "CP2K_USE_ACCEL MATCHES \"HIP|CUDA\" AND CP2K_USE_SPLA" OFF)
 
 cmake_dependent_option(
-  CP2K_USE_CRAY_PM_ACCEL_ENERGY ON
-  "Enable CRAY power management framework with gpu support"
-  "(NOT CP2K_USE_ACCEL MATCHES \"NONE\") AND (CP2K_USE_CRAY_PM_ENERGY)" OFF)
+  CP2K_USE_CRAY_PM_ACCEL_ENERGY
+  "Enable CRAY power management framework with gpu support" ON
+  "CP2K_USE_ACCEL MATCHES \"OPENCL|HIP|CUDA\" AND CP2K_USE_CRAY_PM_ENERGY" OFF)
 
 cmake_dependent_option(
   CP2K_USE_LIBGINT "Enable LibGint support" ${CP2K_USE_EVERYTHING}


### PR DESCRIPTION
## Description

Fix the declarations of the `CP2K_USE_NVHPC`,
`CP2K_USE_SPLA_GEMM_OFFLOADING`, and `CP2K_USE_CRAY_PM_ACCEL_ENERGY` CMake
options.

The arguments passed to `cmake_dependent_option` were in the wrong order, so
`OFF` was used as the help text and `"Enable Nvidia NVHPC kit"` was interpreted
as the default value. In addition, the dependency condition was inverted and
made the option unavailable when `CP2K_USE_ACCEL=CUDA`.

As a result, configuring a CUDA build with

```shell
-DCP2K_USE_ACCEL=CUDA -DCP2K_USE_NVHPC=ON
```

silently forced `CP2K_USE_NVHPC` to `OFF`, contrary to the documented CUDA
build option.

The SpLA GEMM offloading and Cray PM acceleration options had the same argument
ordering issue. This change restores the standard `cmake_dependent_option`
argument order for all three declarations. It also uses positive accelerator
backend checks for the SpLA and Cray PM options, so an unset accelerator value
cannot enable them before `CP2K_USE_ACCEL` receives its default value. The
existing defaults are preserved, including making `CP2K_USE_NVHPC` available
only when the CUDA backend is selected. It does not change runtime code.

## Verification

The option behavior was checked directly with CMake for the following cases:

- CUDA with `CP2K_USE_NVHPC=ON`: remains `ON` and is a visible `BOOL` option.
- CUDA without an explicit NVHPC setting: defaults to `OFF` as a `BOOL` option.
- HIP with `CP2K_USE_NVHPC=ON`: is hidden and forced to `OFF` as expected.
- SpLA GEMM offloading with acceleration and SpLA enabled: defaults to `ON` as
  a visible `BOOL` option with the expected help text.
- Cray PM acceleration with acceleration and Cray PM enabled: defaults to `ON`
  as a visible `BOOL` option with the expected help text.
- Both dependent options are forced to `OFF` when their conditions are not met.
- Both dependent options remain `OFF` when `CP2K_USE_ACCEL` is not yet defined.

The CP2K precommit check for `CMakeLists.txt` also passes:

```text
Summary: Found 1, skipped 0, checked 1, and failed 0 files.
Status: OK
```