### PR TITLE
CMake: Make native optimization an option

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,10 +22,8 @@ test_command:
 targets:
   - fedora-development-x86_64
   - fedora-development-aarch64
-  - fedora-development-ppc64le
   - fedora-latest-x86_64
   - fedora-latest-aarch64
-  - fedora-latest-ppc64le
 
 jobs:
   - &copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,8 +22,10 @@ test_command:
 targets:
   - fedora-development-x86_64
   - fedora-development-aarch64
+  - fedora-development-ppc64le
   - fedora-latest-x86_64
   - fedora-latest-aarch64
+  - fedora-latest-ppc64le
 
 jobs:
   - &copr_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,14 @@ endforeach()
 
 # =================================================================================================
 # OPTIONS
+
+# Native CPU optimization
+string(TOUPPER "${CMAKE_BUILD_TYPE}" _CP2K_BUILD_TYPE)
+cmake_dependent_option(
+  CP2K_ENABLE_NATIVE_OPTIMIZATION "Optimize for the build host CPU" OFF
+  "NOT _CP2K_BUILD_TYPE STREQUAL GENERIC" OFF)
+unset(_CP2K_BUILD_TYPE)
+
 option(CMAKE_POSITION_INDEPENDENT_CODE "Enable position independent code" ON)
 
 option(CP2K_ENABLE_CONSISTENCY_CHECKS

--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -53,12 +53,16 @@ add_compile_options(
 # -- Apple Silicon + GCC: -march=native expands internally to -march=apple-m1
 # (invalid). Use -mcpu=native instead.
 set(_CP2K_GNU_NATIVE_TUNE "-march=native;-mtune=native")
+set(_CP2K_GNU_GENERIC_TUNE "-mtune=generic")
 if(APPLE
    AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64"
    AND (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU"
         OR CMAKE_C_COMPILER_ID STREQUAL "GNU"
         OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
   set(_CP2K_GNU_NATIVE_TUNE "-mcpu=native")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|ppc64le")
+  set(_CP2K_GNU_NATIVE_TUNE "-mcpu=native")
+  set(_CP2K_GNU_GENERIC_TUNE "")
 endif()
 if(APPLE)
   add_definitions(-D__MACOSX)
@@ -76,9 +80,9 @@ add_compile_options(
 
 # Generic
 add_compile_options(
-  "$<$<AND:$<CONFIG:GENERIC>,$<COMPILE_LANG_AND_ID:Fortran,GNU>>:-O3;-mtune=generic;-funroll-loops>"
-  "$<$<AND:$<CONFIG:GENERIC>,$<COMPILE_LANG_AND_ID:CXX,GNU>>:-O3;-mtune=generic;-funroll-loops>"
-  "$<$<AND:$<CONFIG:GENERIC>,$<COMPILE_LANG_AND_ID:C,GNU>>:-O3;-mtune=generic;-funroll-loops>"
+  "$<$<AND:$<CONFIG:GENERIC>,$<COMPILE_LANG_AND_ID:Fortran,GNU>>:-O3;${_CP2K_GNU_GENERIC_TUNE};-funroll-loops>"
+  "$<$<AND:$<CONFIG:GENERIC>,$<COMPILE_LANG_AND_ID:CXX,GNU>>:-O3;${_CP2K_GNU_GENERIC_TUNE};-funroll-loops>"
+  "$<$<AND:$<CONFIG:GENERIC>,$<COMPILE_LANG_AND_ID:C,GNU>>:-O3;${_CP2K_GNU_GENERIC_TUNE};-funroll-loops>"
 )
 
 # Debug

--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -9,6 +9,8 @@ set(CP2K_C_COMPILER_LIST
     "GNU;Intel;IntelLLVM;NAG;Cray;PGI;NVHPC;Clang;AppleClang")
 set(CP2K_Fortran_COMPILER_LIST "GNU;Intel;IntelLLVM;NAG;Cray;PGI;NVHPC")
 
+include(CheckCompilerFlag)
+
 if(NOT CMAKE_C_COMPILER_ID IN_LIST CP2K_C_COMPILER_LIST)
   message(
     WARNING
@@ -50,20 +52,24 @@ add_compile_options(
   "$<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-deprecated-declarations;-Wno-vla-parameter>"
 )
 
-# -- Apple Silicon + GCC: -march=native expands internally to -march=apple-m1
-# (invalid). Use -mcpu=native instead.
-set(_CP2K_GNU_NATIVE_TUNE "-march=native;-mtune=native")
-set(_CP2K_GNU_GENERIC_TUNE "-mtune=generic")
-if(APPLE
-   AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64"
-   AND (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU"
-        OR CMAKE_C_COMPILER_ID STREQUAL "GNU"
-        OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
-  set(_CP2K_GNU_NATIVE_TUNE "-mcpu=native")
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|ppc64le")
-  set(_CP2K_GNU_NATIVE_TUNE "-mcpu=native")
-  set(_CP2K_GNU_GENERIC_TUNE "")
+# Detect CPU native/generic tunes
+set(_CP2K_GNU_NATIVE_TUNE "")
+set(_CP2K_GNU_GENERIC_TUNE "")
+check_compiler_flag(Fortran "-mtune=generic" CP2K_HAS_MTUNE_GENERIC)
+if(CP2K_HAS_MTUNE_GENERIC)
+  set(_CP2K_GNU_GENERIC_TUNE "-mtune=generic")
 endif()
+if(CP2K_ENABLE_NATIVE_OPTIMIZATION AND NOT CMAKE_CROSSCOMPILING)
+  foreach(_flag IN ITEMS -march=native -mcpu=native)
+    string(MAKE_C_IDENTIFIER "CP2K_HAS_${_flag}" _var)
+    check_compiler_flag(Fortran "${_flag}" ${_var})
+    if(${_var})
+      set(_CP2K_GNU_NATIVE_TUNE "${_flag}")
+      break()
+    endif()
+  endforeach()
+endif()
+
 if(APPLE)
   add_definitions(-D__MACOSX)
 endif()

--- a/docs/getting-started/build-from-source.md
+++ b/docs/getting-started/build-from-source.md
@@ -216,7 +216,8 @@ Here are some other important general options you may want to know:
   generator, which is also used by `make_cp2k.sh`; in this case, please ensure that Ninja is
   installed on your host system.
 - `-DCMAKE_BUILD_TYPE` Valid vaules are `Release` (default) and `Debug` (enables debug settings and
-  generates `pdbg` or `sdbg` instead of `psmp` or `ssmp`; recommended for development).
+  generates `pdbg` or `sdbg` instead of `psmp` or `ssmp`; recommended for development). CP2K also
+  supports setting `Generic` and `Coverage`.
 - `-DCMAKE_INSTALL_PREFIX` Specifies the installation path of CP2K. Assuming it is set to
   `/path/to/installation`, there will be several subdirectories: `bin` for binaries like
   `cp2k.psmp`, `include` for module files and headers, `lib` or `lib64` for libraries, and `share`
@@ -227,6 +228,9 @@ Here are some other important general options you may want to know:
 
 Along with some options with CP2K:
 
+- `-DCP2K_ENABLE_NATIVE_OPTIMIZATION` Decide if native flag (`-march=native` or `-mcpu-native`) is
+  used to trigger native optimization for the build host CPU. Only available when `CMAKE_BUILD_TYPE`
+  is not `Generic`.
 - `-DCP2K_USE_EVERYTHING` Enables all dependencies or not.
 - `-DCP2K_DATA_DIR` Specifies the location of the data of basis and potentials. Default is
   `/path/to/installation/share/cp2k/data`.

--- a/tools/toolchain/build_cp2k.sh
+++ b/tools/toolchain/build_cp2k.sh
@@ -29,13 +29,16 @@ source "${TOOLCHAIN_SCRIPTS_DIR}/tool_kit.sh"
 # ====================== Parameter parsing ======================
 CP2K_ROOT=$(cd "${TOOLCHAIN_ROOTDIR}/../.." && pwd)
 CMAKE_INSTALL_PREFIX=${CP2K_ROOT}/install
-DEBUG_BUILD="__FALSE__"
+CMAKE_BUILD_TYPE="Release"
+CP2K_ENABLE_NATIVE_OPTIMIZATION="OFF"
 BUILD_JOBS="$(get_nprocs)"
 BUILD_SHARED_LIBS="ON"
 DRY_RUN="__FALSE__"
 REBUILD_ONLY="__FALSE__"
 PREFIX_SET="__FALSE__"
-DEBUG_SET="__FALSE__"
+TYPE_SET="__FALSE__"
+TYPE_VALUE=""
+NATIVE_SET="__FALSE__"
 BUILD_STATIC_SET="__FALSE__"
 
 show_help() {
@@ -47,9 +50,14 @@ Generate CMake options from the toolchain configuration and build CP2K.
 Options:
   -h, --help            Show this help message and exit
   -j N, -jN             Number of parallel build jobs
-  --prefix              Set CMAKE_INSTALL_PREFIX (default is ${CP2K_ROOT}/install)
+  --type=<option>       Set CMAKE_BUILD_TYPE
+                        Available options: Release, Generic, Debug
+                        Default: Release
+  --native              Enable native CPU optimization. Cannot be used together
+                        with "--type=generic".
+  --prefix=<path>       Set CMAKE_INSTALL_PREFIX
+                        (default is ${CP2K_ROOT}/install)
   --dry-run             Show generated CMake options only and then exit
-  --debug               Build debug version of CP2K (-DCMAKE_BUILD_TYPE=Debug)
   --build-static        Set -DBUILD_SHARED_LIBS=OFF (default is ON)
   --rebuild-only        Skip CMake configuration and only rebuild/install CP2K
                         from the existing build directory. This requires a
@@ -73,17 +81,37 @@ while [ $# -ge 1 ]; do
     -j[0-9]*)
       BUILD_JOBS="${1#-j}"
       ;;
-    --prefix)
+    --type=*)
+      TYPE_SET="__TRUE__"
+      case "${1#*=}" in
+        Release | release)
+          TYPE_VALUE="Release"
+          ;;
+        Generic | generic)
+          TYPE_VALUE="Generic"
+          ;;
+        Debug | debug)
+          TYPE_VALUE="Debug"
+          ;;
+        *)
+          echo "ERROR: Invalid build type: ${1#*=}"
+          echo "Available options are: Release, Generic, Debug."
+          exit 1
+          ;;
+      esac
+      CMAKE_BUILD_TYPE="${TYPE_VALUE}"
+      ;;
+    --native)
+      NATIVE_SET="__TRUE__"
+      CP2K_ENABLE_NATIVE_OPTIMIZATION="ON"
+      ;;
+    --prefix=*)
       PREFIX_SET="__TRUE__"
-      if [[ "${2}" != /* ]]; then
+      if [[ "${1#*=}" != /* ]]; then
         report_error "The path for --prefix must be an absolute path."
       fi
-      CMAKE_INSTALL_PREFIX="${2}"
+      CMAKE_INSTALL_PREFIX="${1#*=}"
       shift
-      ;;
-    --debug)
-      DEBUG_SET="__TRUE__"
-      DEBUG_BUILD="__TRUE__"
       ;;
     --build-static)
       BUILD_STATIC_SET="__TRUE__"
@@ -102,10 +130,18 @@ while [ $# -ge 1 ]; do
   shift
 done
 
+if [ "${CMAKE_BUILD_TYPE}" = "Generic" ] && [ "${NATIVE_SET}" = "__TRUE__" ]; then
+  cat << EOF
+ERROR: "--native" cannot be used together with "--type=Generic".
+EOF
+  exit 1
+fi
+
 if [ "${REBUILD_ONLY}" = "__TRUE__" ]; then
   if [ "${DRY_RUN}" = "__TRUE__" ] ||
     [ "${PREFIX_SET}" = "__TRUE__" ] ||
-    [ "${DEBUG_SET}" = "__TRUE__" ] ||
+    [ "${TYPE_SET}" = "__TRUE__" ] ||
+    [ "${NATIVE_SET}" = "__TRUE__" ] ||
     [ "${BUILD_STATIC_SET}" = "__TRUE__" ]; then
     cat << EOF
 ERROR: "--rebuild-only" cannot be used together with options that affect CMake configuration.
@@ -177,14 +213,26 @@ fi
 source "${TOOLCHAIN_INSTALL_DIR}/setup"
 source "${TOOLCHAIN_INSTALL_DIR}/toolchain.conf"
 
+if [ "${mpi_mode}" = "no" ]; then
+  if [ "${CMAKE_BUILD_TYPE}" = "Debug" ]; then
+    CP2K_EXECUTABLE_SUFFIX="sdbg"
+  else
+    CP2K_EXECUTABLE_SUFFIX="ssmp"
+  fi
+else
+  if [ "${CMAKE_BUILD_TYPE}" = "Debug" ]; then
+    CP2K_EXECUTABLE_SUFFIX="pdbg"
+  else
+    CP2K_EXECUTABLE_SUFFIX="psmp"
+  fi
+fi
+
 # Generate cmake options for compiling cp2k
 CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
-CMAKE_OPTIONS+=" -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}"
+CMAKE_OPTIONS+=" -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+CMAKE_OPTIONS+=" -DCP2K_ENABLE_NATIVE_OPTIMIZATION=${CP2K_ENABLE_NATIVE_OPTIMIZATION}"
 if [[ ${CMAKE_INSTALL_PREFIX} == ${CP2K_ROOT}/* ]]; then
   CMAKE_OPTIONS+=" -DCP2K_DATA_DIR=${CP2K_ROOT}/data"
-fi
-if [ ${DEBUG_BUILD} == "__TRUE__" ]; then
-  CMAKE_OPTIONS+=" -DCMAKE_BUILD_TYPE=Debug"
 fi
 if [ -n "$(grep -- "--install-all" "${TOOLCHAIN_ROOTDIR}/toolchain_settings")" ]; then
   CMAKE_OPTIONS+=" -DCP2K_USE_EVERYTHING=ON -DCP2K_USE_DLAF=OFF -DCP2K_USE_PEXSI=OFF -DCP2K_USE_OPENPMD=OFF"
@@ -333,6 +381,8 @@ EOF
     log_cmake "Source dir : ${CP2K_ROOT}"
     log_cmake "Build  dir : ${BUILD_DIR}"
     log_cmake "Install dir: ${CMAKE_INSTALL_PREFIX}"
+    log_cmake "Build type : ${CMAKE_BUILD_TYPE}"
+    log_cmake "Native opt.: ${CP2K_ENABLE_NATIVE_OPTIMIZATION}"
     log_cmake "Shared libs: ${BUILD_SHARED_LIBS}"
 
     set -o pipefail
@@ -376,7 +426,7 @@ Please always source this script to load CP2K environment before running CP2K:
   source ${CMAKE_INSTALL_PREFIX}/cp2k_env
 
 It's suggested to run regtests after installation:
-  ${CP2K_ROOT}/tests/do_regtest.py ${CMAKE_INSTALL_PREFIX}/bin psmp
+  ${CP2K_ROOT}/tests/do_regtest.py ${CMAKE_INSTALL_PREFIX}/bin ${CP2K_EXECUTABLE_SUFFIX}
 Run \`${CP2K_ROOT}/tests/do_regtest.py --help\` for help message.
 
 If you want to clean the build cache (except cached CMake files) after


### PR DESCRIPTION
Downstream Fedora RPM-build project has been enabling ppc64le build, which currently doesn't work because ppc64le does not know `-mtune=` flag. See https://src.fedoraproject.org/rpms/cp2k/pull-request/12.

This PR uses `-mcpu=native` as native flag for ppc64le, and drops `-mtune=generic` for ppc64le to use GCC default.