### PR TITLE
Fix uninitialized lfomo/homo in set_mo_occupation_3

### DIFF
--- a/src/qs_mo_occupation.F
+++ b/src/qs_mo_occupation.F
@@ -179,6 +179,11 @@ CONTAINS
       nelec_a = accurate_sum(occ_a(:))
       nelec_b = accurate_sum(occ_b(:))
 
+      lfomo_a = nmo_a + 1
+      lfomo_b = nmo_b + 1
+      homo_a = 0
+      homo_b = 0
+
       DO i = 1, nmo_a
          IF (occ_a(i) < 1.0_dp) THEN
             lfomo_a = i


### PR DESCRIPTION
In UKS with GFN2-xTB and smearing, when all occupation numbers are exactly 1.0 (no fractional occupations), the lfomo and homo detection loops never execute EXIT, leaving lfomo_b and homo_b uninitialized. These garbage values propagate to calculate_dm_sparse and cause a crash in dbcsr_multiply ('Invalid last k specified').

Fix by initializing lfomo_a/b = nmo + 1 and homo_a/b = 0 before the detection loops, ensuring safe defaults when no fractional occupation is found.

fixes #5595