### PR TITLE
build: drop UCC requirement for cuSOLVERMp 0.7+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1076,11 +1076,10 @@ if(CP2K_USE_CUSOLVER_MP)
   else()
     message("    - CAL Include directories: ${CP2K_CAL_INCLUDE_DIRS}\n"
             "    - CAL Libraries: ${CP2K_CAL_LINK_LIBRARIES}")
+    message("    - UCC Include directories: ${CP2K_UCC_INCLUDE_DIRS}\n"
+            "    - UCC Libraries: ${CP2K_UCC_LINK_LIBRARIES}\n"
+            "    - UCX Libraries: ${CP2K_UCX_LINK_LIBRARIES}\n")
   endif()
-
-  message("    - UCC Include directories: ${CP2K_UCC_INCLUDE_DIRS}\n"
-          "    - UCC Libraries: ${CP2K_UCC_LINK_LIBRARIES}\n"
-          "    - UCX Libraries: ${CP2K_UCX_LINK_LIBRARIES}\n")
 endif()
 
 if(CP2K_USE_LIBXC)

--- a/cmake/modules/FindCuSolverMP.cmake
+++ b/cmake/modules/FindCuSolverMP.cmake
@@ -12,8 +12,6 @@
 include(FindPackageHandleStandardArgs)
 include(cp2k_utils)
 
-find_package(ucc REQUIRED)
-
 # First, find CuSolverMP library and headers
 cp2k_set_default_paths(CUSOLVER_MP "CUSOLVER_MP")
 cp2k_find_libraries(CUSOLVER_MP "cusolverMp")
@@ -41,12 +39,13 @@ if(CP2K_CUSOLVER_MP_INCLUDE_DIRS)
     find_package(Nccl REQUIRED)
     set(CP2K_CUSOLVERMP_USE_NCCL
         ON
-        CACHE BOOL "CuSolverMP uses NCCL for communication")
+        CACHE BOOL "CuSolverMP uses NCCL for communication" FORCE)
   else()
     find_package(Cal REQUIRED)
+    find_package(ucc REQUIRED)
     set(CP2K_CUSOLVERMP_USE_NCCL
         OFF
-        CACHE BOOL "CuSolverMP uses Cal for communication")
+        CACHE BOOL "CuSolverMP uses Cal for communication" FORCE)
   endif()
 endif()
 
@@ -64,13 +63,13 @@ if(NOT TARGET cp2k::CUSOLVER_MP::cusolver_mp)
   if(CP2K_CUSOLVERMP_USE_NCCL)
     set(_comm_lib "cp2k::NCCL::nccl")
   else()
-    set(_comm_lib "cp2k::CAL::cal")
+    set(_comm_lib "cp2k::CAL::cal;cp2k::UCC::ucc")
   endif()
 
   set_target_properties(
     cp2k::CUSOLVER_MP::cusolver_mp
     PROPERTIES INTERFACE_LINK_LIBRARIES
-               "${CP2K_CUSOLVER_MP_LINK_LIBRARIES};${_comm_lib};cp2k::UCC::ucc")
+               "${CP2K_CUSOLVER_MP_LINK_LIBRARIES};${_comm_lib}")
   set_target_properties(
     cp2k::CUSOLVER_MP::cusolver_mp
     PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${CP2K_CUSOLVER_MP_INCLUDE_DIRS}")

--- a/docs/technologies/eigensolvers/cusolvermp.md
+++ b/docs/technologies/eigensolvers/cusolvermp.md
@@ -13,7 +13,6 @@ tools for the solution of dense linear systems and eigenvalue problems.
 [cuSOLVERmp] >= 0.7
 
 - [NCCL]: requires `libnccl.\*` in the `$PATH`
-- [UCC]: requires `libucc.\*` and `libucs.\*` in the `$PATH`
 
 ## CMake
 

--- a/tools/toolchain/scripts/stage4/install_cusolvermp.sh
+++ b/tools/toolchain/scripts/stage4/install_cusolvermp.sh
@@ -41,6 +41,10 @@ case "${with_cusolvermp}" in
 esac
 
 if [ "${with_cusolvermp}" != "__DONTUSE__" ]; then
+  # These values can be inherited from a previous toolchain run. Only export
+  # roots for the communication backend selected by the detected version.
+  unset NCCL_ROOT CAL_ROOT UCC_ROOT UCX_ROOT
+
   if [ "${cusolvermp_header}" = "__FALSE__" ] || ! [ -f "${cusolvermp_header}" ]; then
     report_error ${LINENO} "Could not find cusolverMp.h."
     exit 1
@@ -57,6 +61,7 @@ if [ "${with_cusolvermp}" != "__DONTUSE__" ]; then
   cusolvermp_minor="${cusolvermp_minor:-0}"
 
   if [ "${cusolvermp_major}" -gt 0 ] || [ "${cusolvermp_minor}" -ge 7 ]; then
+    cusolvermp_comm_backend="nccl"
     nccl_lib="$(find_in_paths "libnccl.*" $LIB_PATHS)"
     if [ "${nccl_lib}" = "__FALSE__" ]; then
       report_error ${LINENO} "Could not find NCCL required by cuSOLVERMp ${cusolvermp_major}.${cusolvermp_minor}."
@@ -64,43 +69,42 @@ if [ "${with_cusolvermp}" != "__DONTUSE__" ]; then
     fi
     NCCL_ROOT="$(dirname "$(dirname "${nccl_lib}")")"
   else
+    cusolvermp_comm_backend="cal"
     cal_lib="$(find_in_paths "libcal.*" $LIB_PATHS)"
     if [ "${cal_lib}" = "__FALSE__" ]; then
       report_error ${LINENO} "Could not find CAL required by cuSOLVERMp ${cusolvermp_major}.${cusolvermp_minor}."
       exit 1
     fi
     CAL_ROOT="$(dirname "$(dirname "${cal_lib}")")"
+    ucc_lib="$(find_in_paths "libucc.*" $LIB_PATHS)"
+    ucx_lib="$(find_in_paths "libucs.*" $LIB_PATHS)"
+    if [ "${ucc_lib}" = "__FALSE__" ] || [ "${ucx_lib}" = "__FALSE__" ]; then
+      report_error ${LINENO} "Could not find UCC/UCX required by cuSOLVERMp ${cusolvermp_major}.${cusolvermp_minor}."
+      exit 1
+    fi
+    UCC_ROOT="$(dirname "$(dirname "${ucc_lib}")")"
+    UCX_ROOT="$(dirname "$(dirname "${ucx_lib}")")"
   fi
-
-  ucc_lib="$(find_in_paths "libucc.*" $LIB_PATHS)"
-  ucx_lib="$(find_in_paths "libucs.*" $LIB_PATHS)"
-  if [ "${ucc_lib}" = "__FALSE__" ] || [ "${ucx_lib}" = "__FALSE__" ]; then
-    report_error ${LINENO} "Could not find UCC/UCX required by cuSOLVERMp."
-    exit 1
-  fi
-  UCC_ROOT="$(dirname "$(dirname "${ucc_lib}")")"
-  UCX_ROOT="$(dirname "$(dirname "${ucx_lib}")")"
 
   cat << EOF > "${BUILDDIR}/setup_cusolvermp"
 export CUSOLVERMP_VER="${cusolvermp_major}.${cusolvermp_minor}"
 export CUSOLVERMP_LIBS="${CUSOLVERMP_LIBS}"
 export CUSOLVER_MP_ROOT="${pkg_install_dir}"
-export UCC_ROOT="${UCC_ROOT}"
-export UCX_ROOT="${UCX_ROOT}"
 prepend_path CMAKE_PREFIX_PATH "${pkg_install_dir}"
-prepend_path CMAKE_PREFIX_PATH "${UCC_ROOT}"
-prepend_path CMAKE_PREFIX_PATH "${UCX_ROOT}"
 EOF
-  if [ -n "${NCCL_ROOT}" ]; then
+  if [ "${cusolvermp_comm_backend}" = "nccl" ]; then
     cat << EOF >> "${BUILDDIR}/setup_cusolvermp"
 export NCCL_ROOT="${NCCL_ROOT}"
 prepend_path CMAKE_PREFIX_PATH "${NCCL_ROOT}"
 EOF
-  fi
-  if [ -n "${CAL_ROOT}" ]; then
+  else
     cat << EOF >> "${BUILDDIR}/setup_cusolvermp"
 export CAL_ROOT="${CAL_ROOT}"
 prepend_path CMAKE_PREFIX_PATH "${CAL_ROOT}"
+export UCC_ROOT="${UCC_ROOT}"
+export UCX_ROOT="${UCX_ROOT}"
+prepend_path CMAKE_PREFIX_PATH "${UCC_ROOT}"
+prepend_path CMAKE_PREFIX_PATH "${UCX_ROOT}"
 EOF
   fi
   filter_setup "${BUILDDIR}/setup_cusolvermp" "${SETUPFILE}"


### PR DESCRIPTION
## Description

cuSOLVERMp 0.7 replaced the legacy CAL communication backend with NCCL, as already reflected by the version-dependent backend selection introduced in #4766. However, CP2K still found and linked UCC unconditionally in both the
CMake and toolchain paths. This prevented a current cuSOLVERMp installation from being used unless the unrelated legacy UCC/UCX stack was also installed.

This change completes the version-dependent dependency selection:

- cuSOLVERMp 0.7 and newer find and link NCCL only;
- older cuSOLVERMp releases continue to find and link CAL plus UCC/UCX;
- the CMake summary, toolchain setup, and documentation report the matching dependencies.

The backend cache value is forced to the detected result so that reconfiguring the same build directory with a different cuSOLVERMp version cannot retain a stale communication backend.

## Verification

A stacked integration branch, including the follow-up Spack support planned as a separate PR, was built and tested on two NVIDIA V100 GPUs:

https://github.com/Stardust0831/cp2k/actions/runs/29884688275

The successful run provides the following artifacts and checks:

- Spack installed `cusolvermp@0.7.2.888` and NCCL, with no `ucc` package in the environment.
- `cp2k.psmp --version` reports `cusolvermp cusolvermp_nccl`.
- `ldd libcusolverMp.so.0` contains NCCL and CUDA libraries, and no UCC or UCX  libraries.
- Two MPI ranks were bound to separate V100 devices: rank 0 to GPU 0 and rank 1 to GPU 1.
- The real regression case executed `cp_fm_general_cusolver` and produced  `-31.187602969867200 Ha`, differing from the reference by `1.421e-14 Ha`.
- The complex regression case executed `cp_cfm_general_cusolver` and produced  `-31.461089087225645 Ha`, differing from the reference by `7.105e-15 Ha`.

UCX is present in the complete CP2K process through MPICH's selected network transport. It is not a dependency of `libcusolverMp.so.0`, and UCC is absent.

The version split was also checked independently of the GPU run:

- minimal CMake configurations verified the exact interface link libraries for both a synthetic 0.7 header (`cuSOLVERMp;NCCL`) and a synthetic 0.6 header  (`cuSOLVERMp;CAL;UCC`);
- the actual toolchain installer was run through legacy-to-0.7, 0.7-to-legacy, and legacy-to-0.7 transitions. Each generated setup and persisted  `toolchain.env` contained only the roots for the selected backend.

The four changed files also pass the CP2K precommit service:

```text
Summary: Found 4, skipped 0, checked 4, and failed 0 files.
Status: OK
```
