### PR TITLE
Correct CMAKE_INSTALL_LIBDIR in Fedora SPEC

### DIFF
--- a/tools/fedora/cp2k.spec
+++ b/tools/fedora/cp2k.spec
@@ -154,6 +154,7 @@ for mpi in '' mpich openmpi; do
     module load mpi/${mpi}-%{_arch}
     cmake_mpi_args=(
       "-DCMAKE_INSTALL_PREFIX:PATH=${MPI_HOME}"
+      "-DCMAKE_INSTALL_LIBDIR:PATH=lib"
       "-DCMAKE_PREFIX_PATH:PATH=${MPI_HOME};%{_prefix}"
       "-DCMAKE_INSTALL_Fortran_MODULES:PATH=${MPI_FORTRAN_MOD_DIR}/cp2k"
       "-DCP2K_DATA_DIR:PATH=%{_datadir}/cp2k/data"
@@ -163,7 +164,6 @@ for mpi in '' mpich openmpi; do
   else
     cmake_mpi_args=(
       "-DCMAKE_INSTALL_Fortran_MODULES:PATH=%{_fmoddir}/cp2k"
-      "-DCMAKE_INSTALL_LIBDIR:PATH=lib64"
       "-DCP2K_USE_MPI:BOOL=OFF"
     )
   fi


### PR DESCRIPTION
Follow up to #5617.