### PR TITLE
MTLR: Fix runtime errors

### DIFF
--- a/src/atom_kind_orbitals.F
+++ b/src/atom_kind_orbitals.F
@@ -108,7 +108,8 @@ CONTAINS
          OPTIONAL, POINTER                               :: ao_coef
 
       INTEGER                                            :: i, ii, j, k, k1, k2, l, ll, m, mb, mo, &
-                                                            nr, nset, nsgf, valence_n, z
+                                                            nr, nset, nsgf, projector_index, &
+                                                            valence_n, z
       INTEGER, DIMENSION(0:lmat)                         :: nbb
       INTEGER, DIMENSION(0:lmat, 10)                     :: ncalc, ncore, nelem
       INTEGER, DIMENSION(0:lmat, 100)                    :: set_index, shell_index
@@ -523,10 +524,15 @@ CONTAINS
          CPASSERT(PRESENT(which_n))
          CPASSERT(which_l >= 0 .AND. which_l <= lmat)
          valence_n = COUNT(ncore(which_l, :) > 0) + which_l + 1
-         CPASSERT(which_n >= valence_n)
+         projector_index = which_n - valence_n + 1
+         IF (projector_index < 1 .OR. projector_index > SIZE(atom%orbitals%wfn, 2)) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "The requested tensorial atomic projector N is outside "// &
+                          "the available orbital range for the selected L.")
+         END IF
          IF (ASSOCIATED(ao_coef)) DEALLOCATE (ao_coef)
          ALLOCATE (ao_coef(SIZE(atom%orbitals%wfn(:, 1, which_l))))
-         ao_coef(:) = atom%orbitals%wfn(:, which_n - valence_n + 1, which_l)
+         ao_coef(:) = atom%orbitals%wfn(:, projector_index, which_l)
          IF (MAXVAL(ABS(ao_coef)) <= 100.0_dp*EPSILON(1.0_dp)) THEN
             CALL cp_abort(__LOCATION__, &
                           "The requested atomic projector is zero. Check the "// &

--- a/src/cp_control_utils.F
+++ b/src/cp_control_utils.F
@@ -2399,10 +2399,10 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'write_dft_control'
 
       CHARACTER(LEN=20)                                  :: tmpStr
-      INTEGER                                            :: handle, i, i_rep, n_rep, output_unit
+      INTEGER                                            :: handle, i, i_rep, max_mtlr_iter, n_rep, &
+                                                            output_unit
       REAL(kind=dp)                                      :: density_cut, density_smooth_cut_range, &
-                                                            eps_u_j_loop, gradient_cut, &
-                                                            max_mtlr_iter, tau_cut
+                                                            eps_u_j_loop, gradient_cut, tau_cut
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(enumeration_type), POINTER                    :: enum
       TYPE(keyword_type), POINTER                        :: keyword
@@ -2514,7 +2514,7 @@ CONTAINS
                CALL section_vals_val_get(dft_section, "EPS_U_J_LOOP", r_val=eps_u_j_loop)
                WRITE (UNIT=output_unit, FMT="(T2,A,T67,ES14.7E3)") &
                   "MTLR U J| EPS_U_J_LOOP", eps_u_j_loop
-               CALL section_vals_val_get(dft_section, "MAX_MTLR_LOOP", r_val=max_mtlr_iter)
+               CALL section_vals_val_get(dft_section, "MAX_MTLR_LOOP", i_val=max_mtlr_iter)
                WRITE (UNIT=output_unit, FMT="(T2,A,T67,I10)") &
                   "MTLR U J| MAX_MTLR_LOOP", max_mtlr_iter
             END IF

--- a/src/dft_plus_u.F
+++ b/src/dft_plus_u.F
@@ -292,6 +292,14 @@ CONTAINS
 
       nspin = dft_control%nspins
       nimg = dft_control%nimages
+      IF (dft_control%mtlr_dft_with_perturbation) THEN
+         IF (.NOT. ASSOCIATED(matrix_vhxc)) THEN
+            CPABORT("MTLR requires the projected Hxc matrix for every spin channel.")
+         END IF
+         IF (SIZE(matrix_vhxc) /= nspin) THEN
+            CPABORT("The number of projected Hxc matrices does not match the spin channels.")
+         END IF
+      END IF
 
       IF (nspin == 2) THEN
          fspin = 1.0_dp
@@ -418,7 +426,9 @@ CONTAINS
          IF (dft_control%mtlr_dft_with_perturbation) THEN
             IF (ispin == 1) perturbation_strength = 0.9_dp*dft_control%perturbation_strength
             IF (ispin == 2) perturbation_strength = 1.1_dp*dft_control%perturbation_strength
-            CPASSERT(ASSOCIATED(matrix_vhxc(ispin)%matrix))
+            IF (.NOT. ASSOCIATED(matrix_vhxc(ispin)%matrix)) THEN
+               CPABORT("MTLR projected Hxc matrix is not initialized.")
+            END IF
             sm_vhxc => matrix_vhxc(ispin)%matrix
          END IF
 
@@ -2255,6 +2265,7 @@ CONTAINS
       NULLIFY (first_sgf)
       NULLIFY (matrix_p)
       NULLIFY (matrix_s)
+      NULLIFY (matrix_vhxc)
       NULLIFY (l)
       NULLIFY (last_sgf)
       NULLIFY (nshell)
@@ -2321,6 +2332,14 @@ CONTAINS
       energy%dft_plus_u = 0.0_dp
 
       nspin = dft_control%nspins
+      IF (dft_control%mtlr_dft_with_perturbation) THEN
+         IF (.NOT. ASSOCIATED(matrix_vhxc)) THEN
+            CPABORT("MTLR requires the projected Hxc matrix for every spin channel.")
+         END IF
+         IF (SIZE(matrix_vhxc) /= nspin) THEN
+            CPABORT("The number of projected Hxc matrices does not match the spin channels.")
+         END IF
+      END IF
 
       IF (nspin == 2) THEN
          fspin = 1.0_dp
@@ -2439,7 +2458,9 @@ CONTAINS
          IF (dft_control%mtlr_dft_with_perturbation) THEN
             IF (ispin == 1) perturbation_strength = 0.9_dp*dft_control%perturbation_strength
             IF (ispin == 2) perturbation_strength = 1.1_dp*dft_control%perturbation_strength
-            CPASSERT(ASSOCIATED(matrix_vhxc(ispin)%matrix))
+            IF (.NOT. ASSOCIATED(matrix_vhxc(ispin)%matrix)) THEN
+               CPABORT("MTLR projected Hxc matrix is not initialized.")
+            END IF
             sm_vhxc => matrix_vhxc(ispin)%matrix
          END IF
 

--- a/src/mtlr_u_j_methods.F
+++ b/src/mtlr_u_j_methods.F
@@ -67,11 +67,12 @@ CONTAINS
       LOGICAL                                            :: any_dft_plus_u, any_mtlr_kind, &
                                                             converged, do_reference_scf, &
                                                             wfn_restart_file_explicit
+      LOGICAL, ALLOCATABLE, DIMENSION(:)                 :: mtlr_kind
       REAL(KIND=dp) :: delta_j, delta_u, denominator_minus, denominator_plus, eps_u_j_loop, &
-         fhxc_minus, fhxc_plus, intercept_minus, intercept_plus, l, std_j, std_minus, std_plus, &
-         std_u, sum_trq_minus, sum_trq_minus_x_trq_minus, sum_trq_minus_x_vhxc_minus, &
-         sum_trq_plus, sum_trq_plus_x_trq_plus, sum_trq_plus_x_vhxc_plus, sum_vhxc_minus, &
-         sum_vhxc_plus
+         fhxc_minus, fhxc_plus, intercept_minus, intercept_plus, l, max_delta_j, max_delta_u, &
+         std_j, std_minus, std_plus, std_u, sum_trq_minus, sum_trq_minus_x_trq_minus, &
+         sum_trq_minus_x_vhxc_minus, sum_trq_plus, sum_trq_plus_x_trq_plus, &
+         sum_trq_plus_x_vhxc_plus, sum_vhxc_minus, sum_vhxc_plus
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: j_new, j_old, perturbation_strength, &
                                                             trq_minus, trq_plus, u_new, u_old, &
                                                             vhxc_minus, vhxc_plus
@@ -98,13 +99,24 @@ CONTAINS
                       scf_control=scf_control, &
                       atomic_kind_set=atomic_kind_set)
 
+      CPASSERT(ASSOCIATED(atomic_kind_set))
+      CPASSERT(ASSOCIATED(dft_control))
+      CPASSERT(ASSOCIATED(qs_kind_set))
+      CPASSERT(ASSOCIATED(scf_control))
+
       nkind = SIZE(atomic_kind_set)
+      IF (SIZE(qs_kind_set) /= nkind) THEN
+         CPABORT("The atomic-kind and Quickstep-kind arrays have inconsistent sizes.")
+      END IF
+      ALLOCATE (mtlr_kind(nkind))
+      mtlr_kind(:) = .FALSE.
       any_dft_plus_u = .FALSE.
       any_mtlr_kind = .FALSE.
       DO ikind = 1, nkind
          IF (.NOT. ASSOCIATED(qs_kind_set(ikind)%dft_plus_u)) CYCLE
          any_dft_plus_u = .TRUE.
          IF (qs_kind_set(ikind)%dft_plus_u%do_mtlr) THEN
+            mtlr_kind(ikind) = .TRUE.
             any_mtlr_kind = .TRUE.
          END IF
       END DO
@@ -173,13 +185,20 @@ CONTAINS
       converged = .FALSE.
       eps_u_j_loop = dft_control%eps_u_j_loop
       max_mtlr_iter = dft_control%max_mtlr_iter
+      IF (dft_control%nspins /= 2) THEN
+         CPABORT("Unrestricted KS has to be used (the number of spin channels should be 2).")
+      END IF
+      IF (max_mtlr_iter < 1) THEN
+         CPABORT("MAX_MTLR_LOOP must be at least one.")
+      END IF
+      IF (eps_u_j_loop <= 0.0_dp) THEN
+         CPABORT("EPS_U_J_LOOP must be positive.")
+      END IF
 
       ! Ensure that the DFT+U+J machinery remains active during the
       ! initial MTLR calculation, even when a parameter starts from zero.
       DO ikind = 1, nkind
-         IF (ASSOCIATED(qs_kind_set(ikind)%dft_plus_u)) THEN
-            IF (.NOT. qs_kind_set(ikind)%dft_plus_u%do_mtlr) CYCLE
-         END IF
+         IF (.NOT. mtlr_kind(ikind)) CYCLE
          IF (qs_kind_set(ikind)%dft_plus_u%u_minus_j == 0.0_dp) THEN
             qs_kind_set(ikind)%dft_plus_u%u_minus_j = EPSILON(1.0_dp)
          END IF
@@ -192,10 +211,6 @@ CONTAINS
       END DO
 
       DO u_iter = 1, max_mtlr_iter
-
-         IF (dft_control%nspins /= 2) THEN
-            CPABORT("Unrestriced KS has to be used (the number of spin channels should be 2).")
-         END IF
 
          dft_control%mtlr_dft_with_perturbation = .FALSE.
 
@@ -213,8 +228,7 @@ CONTAINS
 
          DO ikind = 1, nkind
 
-            IF (.NOT. ASSOCIATED(qs_kind_set(ikind)%dft_plus_u)) CYCLE
-            IF (.NOT. qs_kind_set(ikind)%dft_plus_u%do_mtlr) CYCLE
+            IF (.NOT. mtlr_kind(ikind)) CYCLE
             CALL get_atomic_kind(atomic_kind_set(ikind), atom_list=atom_list)
             IF (.NOT. ANY(atom_list == qs_kind_set(ikind)%dft_plus_u%lr_atom)) THEN
                CPABORT("INDEX_PERTURBED_ATOM does not belong to the KIND containing the MTLR section.")
@@ -227,6 +241,9 @@ CONTAINS
             dft_control%mtlr_ikind = ikind
 
             n = SIZE(qs_kind_set(ikind)%dft_plus_u%perturbation_strength)
+            IF (n < 3) THEN
+               CPABORT("MTLR linear regression requires at least three perturbation strengths.")
+            END IF
             l = REAL(n, dp)
             ALLOCATE (perturbation_strength(n))
             ALLOCATE (trq_plus(n))
@@ -271,9 +288,7 @@ CONTAINS
                dft_control%perturbation_strength = perturbation_strength(p_iter)
                dft_control%mtlr_dft_with_perturbation = .TRUE.
 
-               IF (do_reference_scf) THEN
-                  CALL force_env_calc_energy_force(force_env, calc_force=.FALSE.)
-               END IF
+               CALL force_env_calc_energy_force(force_env, calc_force=.FALSE.)
 
                trq_plus(p_iter) = dft_control%trq(1) + dft_control%trq(2)
                trq_minus(p_iter) = dft_control%trq(1) - dft_control%trq(2)
@@ -423,12 +438,14 @@ CONTAINS
          END DO
 
          DO ikind = 1, nkind
+            IF (.NOT. mtlr_kind(ikind)) CYCLE
             qs_kind_set(ikind)%dft_plus_u%u_minus_j = u_new(ikind) - j_new(ikind)
             qs_kind_set(ikind)%dft_plus_u%hund_j = j_new(ikind)
          END DO
 
-         IF (MAXVAL(ABS(u_new(:) - u_old(:))) < eps_u_j_loop .AND. &
-             MAXVAL(ABS(j_new(:) - j_old(:))) < eps_u_j_loop) THEN
+         max_delta_u = MAXVAL(ABS(PACK(u_new(:) - u_old(:), mtlr_kind)))
+         max_delta_j = MAXVAL(ABS(PACK(j_new(:) - j_old(:), mtlr_kind)))
+         IF (max_delta_u < eps_u_j_loop .AND. max_delta_j < eps_u_j_loop) THEN
             converged = .TRUE.
          END IF
 
@@ -443,11 +460,11 @@ CONTAINS
 
             WRITE (UNIT=output_unit, FMT="(T2,A,ES16.8,A)") &
                "MTLR| Maximum change in U:          ", &
-               MAXVAL(ABS(u_new(:) - u_old(:)))*evolt, " eV"
+               max_delta_u*evolt, " eV"
 
             WRITE (UNIT=output_unit, FMT="(T2,A,ES16.8,A)") &
                "MTLR| Maximum change in J:          ", &
-               MAXVAL(ABS(j_new(:) - j_old(:)))*evolt, " eV"
+               max_delta_j*evolt, " eV"
 
             WRITE (UNIT=output_unit, FMT="(T2,A,ES16.8,A)") &
                "MTLR| Convergence threshold:        ", &
@@ -505,17 +522,16 @@ CONTAINS
                WRITE (UNIT=output_unit, FMT="(/,T2,78('*'))")
                WRITE (UNIT=output_unit, FMT="(T2,A,ES16.8,A)") &
                   "MTLR| Maximum change in U:          ", &
-                  MAXVAL(ABS(u_new(:) - u_old(:)))*evolt, " eV"
+                  max_delta_u*evolt, " eV"
                WRITE (UNIT=output_unit, FMT="(T2,A,ES16.8,A)") &
                   "MTLR| Maximum change in J:          ", &
-                  MAXVAL(ABS(j_new(:) - j_old(:)))*evolt, " eV"
+                  max_delta_j*evolt, " eV"
                WRITE (UNIT=output_unit, FMT="(T2,A,ES16.8,A)") &
                   "MTLR| Maximum change over U and J: ", &
-                  MAX(MAXVAL(ABS(u_new(:) - u_old(:))), &
-                      MAXVAL(ABS(j_new(:) - j_old(:))))*evolt, " eV"
+                  MAX(max_delta_u, max_delta_j)*evolt, " eV"
                WRITE (UNIT=output_unit, FMT="(T2,78('*'))")
                DO ikind = 1, nkind
-                  IF (.NOT. qs_kind_set(ikind)%dft_plus_u%do_mtlr) CYCLE
+                  IF (.NOT. mtlr_kind(ikind)) CYCLE
                   WRITE (UNIT=output_unit, FMT="(/,T2,A,I0,A)") &
                      "MTLR| Final parameters for KIND ", ikind, ":"
                   WRITE (UNIT=output_unit, FMT="(T2,A,F16.8,A)") &
@@ -547,7 +563,7 @@ CONTAINS
       END DO
 
       DO ikind = 1, nkind
-         IF (.NOT. qs_kind_set(ikind)%dft_plus_u%do_mtlr) CYCLE
+         IF (.NOT. mtlr_kind(ikind)) CYCLE
          qs_kind_set(ikind)%dft_plus_u%u_minus_j = u_new(ikind) - j_new(ikind)
          qs_kind_set(ikind)%dft_plus_u%hund_j = j_new(ikind)
       END DO
@@ -560,6 +576,7 @@ CONTAINS
       DEALLOCATE (j_new)
       DEALLOCATE (u_old)
       DEALLOCATE (j_old)
+      DEALLOCATE (mtlr_kind)
 
       CALL timestop(handle)
 

--- a/src/qs_kind_types.F
+++ b/src/qs_kind_types.F
@@ -2356,7 +2356,8 @@ CONTAINS
                END IF
                ALLOCATE (qs_kind%dft_plus_u%perturbation_strength(SIZE(tmp_perturbation_strength)))
                qs_kind%dft_plus_u%perturbation_strength(:) = tmp_perturbation_strength(:)
-               DEALLOCATE (tmp_perturbation_strength)
+               ! section_vals_val_get returns a pointer to storage owned by the
+               ! input tree. Only the copied component above is owned here.
                NULLIFY (tmp_perturbation_strength)
             END IF
          END IF ! section enabled

--- a/src/qs_ks_methods.F
+++ b/src/qs_ks_methods.F
@@ -477,14 +477,6 @@ CONTAINS
       END IF
       CALL auxbas_pw_pool%give_back_pw(v_hartree_gspace)
 
-      IF (dft_control%mtlr_dft_with_perturbation) THEN
-         DO ispin = 1, nspins
-            CALL auxbas_pw_pool%create_pw(v_hxc_rspace(ispin))
-            CALL pw_zero(v_hxc_rspace(ispin))
-            CALL pw_axpy(v_hartree_rspace, v_hxc_rspace(ispin))
-         END DO
-      END IF
-
       IF (dft_control%correct_surf_dip) THEN
          IF (dft_control%surf_dip_correct_switch) THEN
             CALL calc_dipsurf_potential(qs_env, energy)
@@ -779,7 +771,10 @@ CONTAINS
          END IF
       END IF
 
-      IF (dft_control%mtlr_dft_with_perturbation) THEN
+      IF (dft_control%mtlr_dft_with_perturbation .AND. .NOT. just_energy) THEN
+         IF (do_adiabatic_rescaling .OR. use_gauxc_matrix) THEN
+            CPABORT("MTLR requires an XC potential on the real-space grid.")
+         END IF
          IF (.NOT. ASSOCIATED(matrix_vhxc)) THEN
             ALLOCATE (matrix_vhxc(nspins))
             DO ispin = 1, nspins
@@ -798,9 +793,14 @@ CONTAINS
             END DO
          END IF
          DO ispin = 1, nspins
-            CALL pw_axpy(v_rspace_new(ispin), &
-                         v_hxc_rspace(ispin), &
-                         v_rspace_new(ispin)%pw_grid%dvol)
+            CALL auxbas_pw_pool%create_pw(v_hxc_rspace(ispin))
+            CALL pw_zero(v_hxc_rspace(ispin))
+            CALL pw_axpy(v_hartree_rspace, v_hxc_rspace(ispin))
+            IF (ASSOCIATED(v_rspace_new)) THEN
+               CALL pw_axpy(v_rspace_new(ispin), &
+                            v_hxc_rspace(ispin), &
+                            v_rspace_new(ispin)%pw_grid%dvol)
+            END IF
             CALL dbcsr_set(matrix_vhxc(ispin)%matrix, 0.0_dp)
             CALL integrate_v_rspace(v_hxc_rspace(ispin), &
                                     hmat=matrix_vhxc(ispin), &


### PR DESCRIPTION
Fixes several runtime errors in the MTLR implementation and adds validation for invalid or incomplete configurations. Most notably:

- Avoid a double-free of `PERTURBATION_STRENGTH`. The pointer returned by `section_vals_val_get` refers to storage owned by the input tree and must not be deallocated by `qs_kind_types`.
- Restrict all MTLR operations to KINDs with an enabled `&MTLR` section. This prevents dereferencing an unassociated `dft_plus_u` pointer and removes the need to add dummy `DFT_PLUS_U` sections to unrelated KINDs.
- Always run the perturbed SCF calculations. Previously, `SCF_GUESS ATOMIC` disabled both the reference SCF and the perturbed SCFs, producing identical response data and eventually a singular regression. A failed `RESTART` appeared to work only because it retained the restart control path after falling back to an atomic guess.
- Read `MAX_MTLR_LOOP` as an integer when writing the DFT summary.
- Validate the number of perturbation strengths and the initialization of the projected Hxc matrices.
- Validate tensorial atomic-projector indices before accessing the orbital array.
- Apply convergence checks only to MTLR-enabled KINDs.

These changes make MTLR fail early with a clear diagnostic for invalid input and prevent the observed null-pointer access, double-free, out-of-bounds access, and formatted-I/O errors.