### PR TITLE
Add missing features to the 2026.2 changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -45,10 +45,8 @@
   ([#5467](https://github.com/cp2k/cp2k/pull/5467))
 - Planar counter charge model for grand canonical SCF
   ([#5064](https://github.com/cp2k/cp2k/pull/5064))
-- New Pulay mixing for grand canonical SCF
-  ([#5407](https://github.com/cp2k/cp2k/pull/5407))
-- Solvent aware SCCS method
-  ([#5495](https://github.com/cp2k/cp2k/pull/5495))
+- New Pulay mixing for grand canonical SCF ([#5407](https://github.com/cp2k/cp2k/pull/5407))
+- Solvent aware SCCS method ([#5495](https://github.com/cp2k/cp2k/pull/5495))
 
 ### New Libraries
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,14 @@
 - Per-thermal-region function for rescaling temperatures in MD (independent of thermostats)
   ([#5002](https://github.com/cp2k/cp2k/pull/5002))
 - Cell optimization with fixed volume ([#5086](https://github.com/cp2k/cp2k/pull/5086))
+- Constant potential (work function) grand canonical SCF for 3d-periodic slab models
+  ([#5467](https://github.com/cp2k/cp2k/pull/5467))
+- Planar counter charge model for grand canonical SCF
+  ([#5064](https://github.com/cp2k/cp2k/pull/5064))
+- New Pulay mixing for grand canonical SCF
+  ([#5407](https://github.com/cp2k/cp2k/pull/5407))
+- Solvent aware SCCS method
+  ([#5495](https://github.com/cp2k/cp2k/pull/5495))
 
 ### New Libraries
 


### PR DESCRIPTION
This adds the grand canonical SCF and solvent aware SCCS developments that were missing from the CP2K 2026.2 changelog.
Related pull requests: #5064, #5407, #5467, and #5495.