### PR TITLE
Improve SKALA Torch startup and multi-GPU execution

### DIFF
--- a/src/skala_gpw_features.F
+++ b/src/skala_gpw_features.F
@@ -39,8 +39,9 @@ MODULE skala_gpw_features
                                            skala_gpw_atom_partition_smooth = 2
    REAL(KIND=dp), PARAMETER, PRIVATE    :: smooth_partition_eps = 1.0E-12_dp
 
-   PUBLIC :: skala_gpw_atom_subchunk_count, skala_gpw_feature_build, &
-             skala_gpw_feature_build_atom_subchunk, skala_gpw_feature_release, &
+   PUBLIC :: skala_gpw_atom_subchunk_count, skala_gpw_atom_subchunk_layout, &
+             skala_gpw_feature_build, skala_gpw_feature_build_atom_subchunk, &
+             skala_gpw_feature_build_atom_subchunk_bounds, skala_gpw_feature_release, &
              skala_gpw_feature_type, skala_gpw_smooth_partition_derivatives
 
    TYPE skala_gpw_layout_cache_type
@@ -1682,6 +1683,67 @@ CONTAINS
    END FUNCTION skala_gpw_atom_subchunk_count
 
 ! **************************************************************************************************
+!> \brief Build atom and row bounds for all atom-contiguous subchunks in one pass.
+!> \param max_rows ...
+!> \param atom_begin ...
+!> \param atom_count ...
+!> \param row_begin ...
+!> \param row_count ...
+! **************************************************************************************************
+   SUBROUTINE skala_gpw_atom_subchunk_layout(max_rows, atom_begin, atom_count, row_begin, &
+                                             row_count)
+      INTEGER, INTENT(IN)                                :: max_rows
+      INTEGER, ALLOCATABLE, DIMENSION(:), INTENT(OUT)    :: atom_begin, atom_count, row_begin, &
+                                                            row_count
+
+      INTEGER                                            :: atom_rows, iatom, nsubchunks, rows, &
+                                                            subchunk
+
+      nsubchunks = skala_gpw_atom_subchunk_count(max_rows)
+      ALLOCATE (atom_begin(nsubchunks), atom_count(nsubchunks), row_begin(nsubchunks), &
+                row_count(nsubchunks))
+      IF (nsubchunks == 0) RETURN
+
+      CPASSERT(cached_layout%active)
+      CPASSERT(cached_layout%chunk_natom > 0)
+
+      atom_begin = 0
+      atom_count = 0
+      row_begin = 0
+      row_count = 0
+
+      IF (max_rows <= 0) THEN
+         atom_begin(1) = 1
+         atom_count(1) = cached_layout%chunk_natom
+         row_begin(1) = 1
+         row_count(1) = cached_layout%chunk_feature_count
+         RETURN
+      END IF
+
+      subchunk = 1
+      atom_begin(subchunk) = 1
+      row_begin(subchunk) = 1
+      rows = 0
+      DO iatom = 1, cached_layout%chunk_natom
+         atom_rows = INT(cached_layout%chunk_atomic_grid_sizes(iatom))
+         IF (rows > 0 .AND. rows + atom_rows > max_rows) THEN
+            atom_count(subchunk) = iatom - atom_begin(subchunk)
+            row_count(subchunk) = rows
+            subchunk = subchunk + 1
+            atom_begin(subchunk) = iatom
+            row_begin(subchunk) = row_begin(subchunk - 1) + row_count(subchunk - 1)
+            rows = 0
+         END IF
+         rows = rows + atom_rows
+      END DO
+      atom_count(subchunk) = cached_layout%chunk_natom - atom_begin(subchunk) + 1
+      row_count(subchunk) = rows
+
+      CPASSERT(subchunk == nsubchunks)
+
+   END SUBROUTINE skala_gpw_atom_subchunk_layout
+
+! **************************************************************************************************
 !> \brief Build an atom-contiguous subchunk feature bundle from a rank-local atom chunk.
 !> \param parent ...
 !> \param features ...
@@ -1696,16 +1758,42 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: subchunk_index, max_rows
       LOGICAL, INTENT(IN)                                :: requires_grad
 
-      INTEGER                                            :: atom_begin, atom_count, atom_end, &
-                                                            max_grid_size, row_begin, row_count, &
-                                                            row_end
+      INTEGER                                            :: atom_begin, atom_end, row_begin, row_end
 
-      CALL skala_gpw_feature_release(features)
       CPASSERT(parent%uses_atom_chunks)
       CALL atom_subchunk_bounds(subchunk_index, max_rows, atom_begin, atom_end, &
                                 row_begin, row_end)
-      atom_count = atom_end - atom_begin + 1
-      row_count = row_end - row_begin + 1
+      CALL skala_gpw_feature_build_atom_subchunk_bounds(parent, features, atom_begin, &
+                                                        atom_end - atom_begin + 1, row_begin, &
+                                                        row_end - row_begin + 1, requires_grad)
+
+   END SUBROUTINE skala_gpw_feature_build_atom_subchunk
+
+! **************************************************************************************************
+!> \brief Build an atom-contiguous subchunk feature bundle from precomputed bounds.
+!> \param parent ...
+!> \param features ...
+!> \param atom_begin ...
+!> \param atom_count ...
+!> \param row_begin ...
+!> \param row_count ...
+!> \param requires_grad ...
+! **************************************************************************************************
+   SUBROUTINE skala_gpw_feature_build_atom_subchunk_bounds(parent, features, atom_begin, &
+                                                           atom_count, row_begin, row_count, &
+                                                           requires_grad)
+      TYPE(skala_gpw_feature_type), INTENT(IN)           :: parent
+      TYPE(skala_gpw_feature_type), INTENT(INOUT)        :: features
+      INTEGER, INTENT(IN)                                :: atom_begin, atom_count, row_begin, &
+                                                            row_count
+      LOGICAL, INTENT(IN)                                :: requires_grad
+
+      INTEGER                                            :: atom_end, max_grid_size, row_end
+
+      CALL skala_gpw_feature_release(features)
+      CPASSERT(parent%uses_atom_chunks)
+      atom_end = atom_begin + atom_count - 1
+      row_end = row_begin + row_count - 1
       CPASSERT(atom_count > 0)
       CPASSERT(row_count > 0)
       MARK_USED(requires_grad)
@@ -1724,7 +1812,7 @@ CONTAINS
                                         row_count)
       features%active = .TRUE.
 
-   END SUBROUTINE skala_gpw_feature_build_atom_subchunk
+   END SUBROUTINE skala_gpw_feature_build_atom_subchunk_bounds
 
 ! **************************************************************************************************
 !> \brief Return atom and row bounds for an atom-contiguous rank-local subchunk.

--- a/src/skala_gpw_functional.F
+++ b/src/skala_gpw_functional.F
@@ -31,14 +31,11 @@ MODULE skala_gpw_functional
    USE pw_types,                        ONLY: pw_c1d_gs_type,&
                                               pw_r3d_rs_type
    USE qs_grid_atom,                    ONLY: grid_atom_type
-   USE skala_gpw_features,              ONLY: skala_gpw_atom_partition_hard,&
-                                              skala_gpw_atom_partition_smooth,&
-                                              skala_gpw_atom_subchunk_count,&
-                                              skala_gpw_feature_build,&
-                                              skala_gpw_feature_build_atom_subchunk,&
-                                              skala_gpw_feature_release,&
-                                              skala_gpw_feature_type,&
-                                              skala_gpw_smooth_partition_derivatives
+   USE skala_gpw_features,              ONLY: &
+        skala_gpw_atom_partition_hard, skala_gpw_atom_partition_smooth, &
+        skala_gpw_atom_subchunk_count, skala_gpw_atom_subchunk_layout, skala_gpw_feature_build, &
+        skala_gpw_feature_build_atom_subchunk_bounds, skala_gpw_feature_release, &
+        skala_gpw_feature_type, skala_gpw_smooth_partition_derivatives
    USE skala_torch_api,                 ONLY: skala_torch_model_get_exc,&
                                               skala_torch_model_get_exc_density,&
                                               skala_torch_model_load,&
@@ -1139,7 +1136,11 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: route_grad_return_recv_counts, &
                                                             route_grad_return_recv_displs, &
                                                             route_grad_return_send_counts, &
-                                                            route_grad_return_send_displs
+                                                            route_grad_return_send_displs, &
+                                                            subchunk_atom_begin, &
+                                                            subchunk_atom_count, &
+                                                            subchunk_row_begin, &
+                                                            subchunk_row_count
       REAL(KIND=dp)                                      :: subchunk_exc
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: recv_grad_buffer, send_grad_buffer
       TYPE(skala_gpw_feature_type)                       :: subchunk
@@ -1148,7 +1149,9 @@ CONTAINS
       CPASSERT(features%uses_atom_chunks)
       CPASSERT(max_rows > 0)
       nflat_local = features%nflat_local
-      nsubchunks = skala_gpw_atom_subchunk_count(max_rows)
+      CALL skala_gpw_atom_subchunk_layout(max_rows, subchunk_atom_begin, subchunk_atom_count, &
+                                          subchunk_row_begin, subchunk_row_count)
+      nsubchunks = SIZE(subchunk_atom_begin)
 
       exc = 0.0_dp
       IF (compute_grads) THEN
@@ -1177,8 +1180,12 @@ CONTAINS
       CALL timeset("skala_gpw_atom_subchunks", phase_handle)
       DO isubchunk = 1, nsubchunks
          CALL timeset("skala_gpw_atom_subchunk_build", subphase_handle)
-         CALL skala_gpw_feature_build_atom_subchunk(features, subchunk, isubchunk, &
-                                                    max_rows, compute_grads)
+         CALL skala_gpw_feature_build_atom_subchunk_bounds(features, subchunk, &
+                                                           subchunk_atom_begin(isubchunk), &
+                                                           subchunk_atom_count(isubchunk), &
+                                                           subchunk_row_begin(isubchunk), &
+                                                           subchunk_row_count(isubchunk), &
+                                                           compute_grads)
          CALL timestop(subphase_handle)
          CALL timeset("skala_gpw_atom_subchunk_forward", subphase_handle)
          CALL skala_torch_model_get_exc(cached_model, subchunk%inputs, &
@@ -1255,6 +1262,7 @@ CONTAINS
                      route_grad_return_recv_displs, route_grad_return_send_counts, &
                      route_grad_return_send_displs, send_grad_buffer)
       END IF
+      DEALLOCATE (subchunk_atom_begin, subchunk_atom_count, subchunk_row_begin, subchunk_row_count)
 
    END SUBROUTINE evaluate_atom_subchunks
 

--- a/src/skala_torch_api.F
+++ b/src/skala_torch_api.F
@@ -18,8 +18,8 @@ MODULE skala_torch_api
                     dp
    USE string_utilities, ONLY: uppercase
    USE torch_api, ONLY: &
-      torch_dict_type, torch_model_forward_mol_tensor, torch_model_load, &
-      torch_model_read_metadata, torch_model_release, torch_model_type, &
+      torch_dict_type, torch_model_forward_mol_tensor, torch_model_load_with_metadata, &
+      torch_model_release, torch_model_remap_device_constants, torch_model_type, &
       torch_tensor_item_double, torch_tensor_release, torch_tensor_type, &
       torch_tensor_weighted_sum
 #include "./base/base_uses.f90"
@@ -56,9 +56,10 @@ CONTAINS
       CHARACTER(:), ALLOCATABLE                          :: features_json, protocol_string
       INTEGER                                            :: ios
 
-      CALL torch_model_load(model%torch_model, filename)
-      protocol_string = torch_model_read_metadata(filename, "protocol_version")
-      features_json = torch_model_read_metadata(filename, "features")
+      CALL torch_model_load_with_metadata(model%torch_model, filename, &
+                                          "protocol_version", protocol_string, &
+                                          "features", features_json)
+      CALL torch_model_remap_device_constants(model%torch_model)
       READ (protocol_string, *, IOSTAT=ios) model%protocol_version
       IF (ios /= 0) CPABORT("Could not parse SKALA TorchScript protocol_version metadata")
       IF (model%protocol_version /= 2) THEN

--- a/src/torch_api.F
+++ b/src/torch_api.F
@@ -83,8 +83,9 @@ MODULE torch_api
    PUBLIC :: torch_tensor_item_double, torch_tensor_weighted_sum
    PUBLIC :: torch_dict_type, torch_dict_clone, torch_dict_create, torch_dict_insert
    PUBLIC :: torch_dict_get, torch_dict_release
-   PUBLIC :: torch_model_type, torch_model_load, torch_model_forward, torch_model_release
-   PUBLIC :: torch_model_forward_mol_tensor
+   PUBLIC :: torch_model_type, torch_model_load, torch_model_load_with_metadata, &
+             torch_model_forward, torch_model_release
+   PUBLIC :: torch_model_forward_mol_tensor, torch_model_remap_device_constants
    PUBLIC :: torch_model_get_attr, torch_model_read_metadata
    PUBLIC :: torch_cuda_device_count, torch_cuda_is_available
    PUBLIC :: torch_allow_tf32, torch_model_freeze, torch_use_cuda
@@ -713,6 +714,81 @@ CONTAINS
       MARK_USED(filename)
 #endif
    END SUBROUTINE torch_model_load
+
+! **************************************************************************************************
+!> \brief Loads a Torch model and reads two metadata entries in the same archive pass.
+! **************************************************************************************************
+   SUBROUTINE torch_model_load_with_metadata(model, filename, key1, value1, key2, value2)
+      TYPE(torch_model_type), INTENT(INOUT)              :: model
+      CHARACTER(len=*), INTENT(IN)                       :: filename, key1, key2
+      CHARACTER(:), ALLOCATABLE, INTENT(OUT)             :: value1, value2
+
+#if defined(__LIBTORCH)
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'torch_model_load_with_metadata'
+      INTEGER                                            :: handle, length1, length2
+      TYPE(C_PTR)                                        :: content1_c, content2_c
+
+      INTERFACE
+         SUBROUTINE torch_c_model_load_with_metadata(model, filename, key1, key2, &
+                                                     content1, length1, content2, length2) &
+            BIND(C, name="torch_c_model_load_with_metadata")
+            IMPORT :: C_CHAR, C_INT, C_PTR
+            TYPE(C_PTR)                                  :: model
+            CHARACTER(kind=C_CHAR), DIMENSION(*)         :: filename, key1, key2
+            TYPE(C_PTR)                                  :: content1, content2
+            INTEGER(kind=C_INT)                          :: length1, length2
+         END SUBROUTINE torch_c_model_load_with_metadata
+      END INTERFACE
+
+      CALL timeset(routineN, handle)
+      CPASSERT(.NOT. C_ASSOCIATED(model%c_ptr))
+      content1_c = C_NULL_PTR
+      content2_c = C_NULL_PTR
+      length1 = -1
+      length2 = -1
+      CALL torch_c_model_load_with_metadata(model=model%c_ptr, &
+                                            filename=TRIM(filename)//C_NULL_CHAR, &
+                                            key1=TRIM(key1)//C_NULL_CHAR, &
+                                            key2=TRIM(key2)//C_NULL_CHAR, &
+                                            content1=content1_c, length1=length1, &
+                                            content2=content2_c, length2=length2)
+      CPASSERT(C_ASSOCIATED(model%c_ptr))
+      CALL c_string_to_allocatable(content1_c, length1, value1)
+      CALL c_string_to_allocatable(content2_c, length2, value2)
+      CALL timestop(handle)
+#else
+      CPABORT("CP2K was compiled without Torch library.")
+      MARK_USED(model)
+      MARK_USED(filename)
+      MARK_USED(key1)
+      MARK_USED(value1)
+      MARK_USED(key2)
+      MARK_USED(value2)
+#endif
+   END SUBROUTINE torch_model_load_with_metadata
+
+! **************************************************************************************************
+!> \brief Maps serialized TorchScript device constants to the active Torch device.
+! **************************************************************************************************
+   SUBROUTINE torch_model_remap_device_constants(model)
+      TYPE(torch_model_type), INTENT(INOUT)              :: model
+
+#if defined(__LIBTORCH)
+      INTERFACE
+         SUBROUTINE torch_c_model_remap_device_constants(model) &
+            BIND(C, name="torch_c_model_remap_device_constants")
+            IMPORT :: C_PTR
+            TYPE(C_PTR), VALUE                           :: model
+         END SUBROUTINE torch_c_model_remap_device_constants
+      END INTERFACE
+
+      CPASSERT(C_ASSOCIATED(model%c_ptr))
+      CALL torch_c_model_remap_device_constants(model=model%c_ptr)
+#else
+      CPABORT("CP2K was compiled without Torch library.")
+      MARK_USED(model)
+#endif
+   END SUBROUTINE torch_model_remap_device_constants
 
 ! **************************************************************************************************
 !> \brief Evaluates the given Torch model.

--- a/src/torch_c_api.cpp
+++ b/src/torch_c_api.cpp
@@ -122,14 +122,46 @@ static bool can_load_directly_to_device(const torch::Device &device) {
          torch::cuda::device_count() == 1;
 }
 
-static torch::jit::Module load_module_for_device(const char *filename,
-                                                 const torch::Device &device) {
+static torch::jit::Module load_module_for_device(
+    const char *filename, const torch::Device &device,
+    std::unordered_map<std::string, std::string> *extra_files = nullptr) {
   if (can_load_directly_to_device(device)) {
+    if (extra_files != nullptr) {
+      return torch::jit::load(filename, device, *extra_files);
+    }
     return torch::jit::load(filename, device);
   }
-  auto model = torch::jit::load(filename, torch::kCPU);
+  auto model = (extra_files != nullptr)
+                   ? torch::jit::load(filename, torch::kCPU, *extra_files)
+                   : torch::jit::load(filename, torch::kCPU);
   model.to(device);
   return model;
+}
+
+static void remap_device_constants(torch::jit::Block *block,
+                                   const torch::Device &device) {
+  for (torch::jit::Node *node : block->nodes()) {
+    if (node->kind() == torch::jit::prim::Constant &&
+        node->outputs().size() == 1 &&
+        node->output()->type()->kind() == c10::TypeKind::DeviceObjType &&
+        node->hasAttribute(torch::jit::attr::value) &&
+        node->kindOf(torch::jit::attr::value) == torch::jit::AttributeKind::s) {
+      node->s_(torch::jit::attr::value, device.str());
+    }
+    for (torch::jit::Block *nested_block : node->blocks()) {
+      remap_device_constants(nested_block, device);
+    }
+  }
+}
+
+static void remap_model_device_constants(torch::jit::Module &model,
+                                         const torch::Device &device) {
+  for (const auto &method : model.get_methods()) {
+    remap_device_constants(method.graph()->block(), device);
+  }
+  for (auto child : model.children()) {
+    remap_model_device_constants(child, device);
+  }
 }
 
 /*******************************************************************************
@@ -467,6 +499,39 @@ void torch_c_model_load(torch_c_model_t **model_out, const char *filename) {
   *model = load_module_for_device(filename, device);
   model->eval(); // Set to evaluation mode to disable gradients, drop-out, etc.
   *model_out = model;
+}
+
+/*******************************************************************************
+ * \brief Loads a Torch model and reads two metadata entries.
+ ******************************************************************************/
+void torch_c_model_load_with_metadata(torch_c_model_t **model_out,
+                                      const char *filename, const char *key1,
+                                      const char *key2, char **content1,
+                                      int *length1, char **content2,
+                                      int *length2) {
+  assert(*model_out == NULL);
+  c10::OptionalDeviceGuard guard;
+  const auto device = get_device_with_guard(guard);
+  std::unordered_map<std::string, std::string> extra_files = {{key1, ""},
+                                                              {key2, ""}};
+  set_jit_fusion_strategy();
+  torch::jit::Module *model = new torch::jit::Module();
+  *model = load_module_for_device(filename, device, &extra_files);
+  model->eval(); // Set to evaluation mode to disable gradients, drop-out, etc.
+  *model_out = model;
+  copy_string_to_c_buffer(extra_files[key1], content1, length1);
+  copy_string_to_c_buffer(extra_files[key2], content2, length2);
+}
+
+/*******************************************************************************
+ * \brief Maps serialized TorchScript device constants to the active device.
+ ******************************************************************************/
+void torch_c_model_remap_device_constants(torch_c_model_t *model) {
+  c10::OptionalDeviceGuard guard;
+  const auto device = get_device_with_guard(guard);
+  if (device.is_cuda()) {
+    remap_model_device_constants(*model, device);
+  }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
## Summary

This PR improves the performance and GPU portability of the native SKALA Torch path.

- Precompute atom-subchunk bounds once per evaluation instead of repeatedly scanning the atom layout.
- Load the TorchScript model and both SKALA metadata entries in a single archive pass.
- Remap serialized TorchScript device constants to the CUDA device selected by CP2K.
- Allow portable CPU models and models exported for `cuda:0` to run on the GPU assigned to each MPI rank.

The changes do not depend on pending external GauXC or SKALA changes.

## Performance

On a single NVIDIA GB10, using the same CUDA-exported model and input for both revisions (median of three runs):

| Timing | master | this PR |
|---|---:|---:|
| Torch model and metadata loading | 1.192 s | 0.435 s |
| SKALA atom subchunks | 1.762 s | 1.722 s |
| CP2K total | 3.075 s | 2.267 s |

This reduces model startup time by 63.5% and total time for this small startup-sensitive test by 26.3%.

On two NVIDIA A40 GPUs, using two MPI ranks and a portable SKALA model:

| GPUs | CP2K total | SKALA atom subchunks |
|---|---:|---:|
| 1 | 3.743 s | 2.817 s |
| 2 | 1.680 s | 0.660 s |

Both ranks see both GPUs and select the expected devices (`0:0`, `1:1`) without rank-specific `CUDA_VISIBLE_DEVICES` wrappers. The total runtime speed-up is 2.23x for this atom-subchunk stress test.

## Validation

- CP2K precommit checks passed for all five modified files.
- Built and tested on:
  - NVIDIA GB10, AArch64, PyTorch 2.12.0+cu130
  - NVIDIA A40, x86-64, PyTorch 2.6.0+cu124
- Portable model tested on CPU and CUDA.
- Single-GPU and two-rank/two-GPU executions completed normally.
- 29/29 relevant CPU regression-test checks passed.
- Six existing CUDA GPW/GAPW inputs were compared directly against master: energies and stresses agree exactly at printed precision; force differences are limited to the last printed digit.
