### PR TITLE
Avoid SKALA model parameter gradients

### DIFF
--- a/src/skala_torch_api.F
+++ b/src/skala_torch_api.F
@@ -18,8 +18,9 @@ MODULE skala_torch_api
                     dp
    USE string_utilities, ONLY: uppercase
    USE torch_api, ONLY: &
-      torch_dict_type, torch_model_forward_mol_tensor, torch_model_load_with_metadata, &
-      torch_model_release, torch_model_remap_device_constants, torch_model_type, &
+      torch_dict_type, torch_model_disable_parameter_gradients, torch_model_forward_mol_tensor, &
+      torch_model_load_with_metadata, torch_model_release, torch_model_remap_device_constants, &
+      torch_model_type, &
       torch_tensor_item_double, torch_tensor_release, torch_tensor_type, &
       torch_tensor_weighted_sum
 #include "./base/base_uses.f90"
@@ -60,6 +61,7 @@ CONTAINS
                                           "protocol_version", protocol_string, &
                                           "features", features_json)
       CALL torch_model_remap_device_constants(model%torch_model)
+      CALL torch_model_disable_parameter_gradients(model%torch_model)
       READ (protocol_string, *, IOSTAT=ios) model%protocol_version
       IF (ios /= 0) CPABORT("Could not parse SKALA TorchScript protocol_version metadata")
       IF (model%protocol_version /= 2) THEN

--- a/src/torch_api.F
+++ b/src/torch_api.F
@@ -85,7 +85,8 @@ MODULE torch_api
    PUBLIC :: torch_dict_get, torch_dict_release
    PUBLIC :: torch_model_type, torch_model_load, torch_model_load_with_metadata, &
              torch_model_forward, torch_model_release
-   PUBLIC :: torch_model_forward_mol_tensor, torch_model_remap_device_constants
+   PUBLIC :: torch_model_disable_parameter_gradients, torch_model_forward_mol_tensor, &
+             torch_model_remap_device_constants
    PUBLIC :: torch_model_get_attr, torch_model_read_metadata
    PUBLIC :: torch_cuda_device_count, torch_cuda_is_available
    PUBLIC :: torch_allow_tf32, torch_model_freeze, torch_use_cuda
@@ -789,6 +790,29 @@ CONTAINS
       MARK_USED(model)
 #endif
    END SUBROUTINE torch_model_remap_device_constants
+
+! **************************************************************************************************
+!> \brief Disable gradients for inference-only model parameters.
+! **************************************************************************************************
+   SUBROUTINE torch_model_disable_parameter_gradients(model)
+      TYPE(torch_model_type), INTENT(INOUT)              :: model
+
+#if defined(__LIBTORCH)
+      INTERFACE
+         SUBROUTINE torch_c_model_disable_parameter_gradients(model) &
+            BIND(C, name="torch_c_model_disable_parameter_gradients")
+            IMPORT :: C_PTR
+            TYPE(C_PTR), VALUE                           :: model
+         END SUBROUTINE torch_c_model_disable_parameter_gradients
+      END INTERFACE
+
+      CPASSERT(C_ASSOCIATED(model%c_ptr))
+      CALL torch_c_model_disable_parameter_gradients(model=model%c_ptr)
+#else
+      CPABORT("CP2K was compiled without Torch library.")
+      MARK_USED(model)
+#endif
+   END SUBROUTINE torch_model_disable_parameter_gradients
 
 ! **************************************************************************************************
 !> \brief Evaluates the given Torch model.

--- a/src/torch_c_api.cpp
+++ b/src/torch_c_api.cpp
@@ -497,7 +497,7 @@ void torch_c_model_load(torch_c_model_t **model_out, const char *filename) {
   set_jit_fusion_strategy();
   torch::jit::Module *model = new torch::jit::Module();
   *model = load_module_for_device(filename, device);
-  model->eval(); // Set to evaluation mode to disable gradients, drop-out, etc.
+  model->eval(); // Set inference behavior for modules such as dropout.
   *model_out = model;
 }
 
@@ -517,7 +517,7 @@ void torch_c_model_load_with_metadata(torch_c_model_t **model_out,
   set_jit_fusion_strategy();
   torch::jit::Module *model = new torch::jit::Module();
   *model = load_module_for_device(filename, device, &extra_files);
-  model->eval(); // Set to evaluation mode to disable gradients, drop-out, etc.
+  model->eval(); // Set inference behavior for modules such as dropout.
   *model_out = model;
   copy_string_to_c_buffer(extra_files[key1], content1, length1);
   copy_string_to_c_buffer(extra_files[key2], content2, length2);
@@ -531,6 +531,16 @@ void torch_c_model_remap_device_constants(torch_c_model_t *model) {
   const auto device = get_device_with_guard(guard);
   if (device.is_cuda()) {
     remap_model_device_constants(*model, device);
+  }
+}
+
+/*******************************************************************************
+ * \brief Disables gradients for inference-only model parameters.
+ ******************************************************************************/
+void torch_c_model_disable_parameter_gradients(torch_c_model_t *model) {
+  torch::NoGradGuard no_grad;
+  for (auto parameter : model->parameters()) {
+    parameter.set_requires_grad(false);
   }
 }
 


### PR DESCRIPTION
## Summary

- mark loaded SKALA TorchScript model parameters as non-differentiable
- keep autograd enabled for density inputs used to construct the XC potential
- clarify that `Module::eval()` changes inference behavior but does not disable parameter gradients

## Motivation

Native-grid SKALA differentiates the XC energy with respect to its density features, but it never optimizes the model weights. `Module::eval()` does not change the weights' `requires_grad` state, so LibTorch was constructing and evaluating unused parameter gradients during every SKALA call.

## Performance

Median of three H2O6 runs with three KS builds on Terok (A40, 8 OpenMP threads per rank), comparing current master with this change:

| configuration | CP2K | native SKALA | Torch backward |
| --- | ---: | ---: | ---: |
| 1 GPU | 17.470 -> 16.608 s (-4.9%) | 12.827 -> 11.888 s (-7.3%) | 2.606 -> 2.213 s (-15.1%) |
| 2 MPI ranks / 2 GPUs | 12.342 -> 12.084 s (-2.1%) | 8.023 -> 7.627 s (-4.9%) | 1.914 -> 1.718 s (-10.2%) |

## Validation

- CP2K precommit checks for all changed files
- CUDA/LibTorch/GauXC `cp2k.psmp` build on Terok
- native-grid SKALA smokes with one GPU and two MPI ranks on two GPUs
- paired A/B runs reproduced the same energy within `1e-14` Ha; final one- and two-GPU smokes differed by `2.2e-11` Ha
