### PR TITLE
Fix CSCS Spack build and regression runtime

### DIFF
--- a/ci/cscs_daint_spack_psmp.yaml
+++ b/ci/cscs_daint_spack_psmp.yaml
@@ -95,7 +95,7 @@ regression test cp2k daint:
   timeout: 6h
   script:
     - git --no-pager log -1 --pretty="%nCommitSHA:%x20%H%nCommitTime:%x20%ci%nCommitAuthor:%x20%an%nCommitSubject:%x20%s%n"
-    - podman run --shm-size=1g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks ${SLURM_NTASKS} --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
+    - podman run --shm-size=8g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks ${SLURM_NTASKS} --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
   variables:
     SLURM_DEBUG: 1
     SLURM_HINT: nomultithread

--- a/ci/docker/build_cp2k_spack.Dockerfile
+++ b/ci/docker/build_cp2k_spack.Dockerfile
@@ -28,6 +28,7 @@ COPY ./data ./data
 COPY ./tools/build_utils ./tools/build_utils
 COPY ./cmake ./cmake
 COPY ./CMakeLists.txt .
+COPY ./CMakePresets.json .
 
 RUN ./make_cp2k.sh -cray -cv ${CP2K_VERSION} -uc no -j${NUM_PROCS} ${FEATURE_FLAGS}
 


### PR DESCRIPTION
## Summary

- Copy `CMakePresets.json` into the CSCS Spack build image so `make_cp2k.sh` can use its default CMake preset.
- Increase shared memory for the 288-task Daint regression container from 1 GiB to 8 GiB.

## Context

#5643 made a named CMake preset the default for `make_cp2k.sh`, but the CSCS build image copied only `CMakeLists.txt` and `cmake/`. Consequently, all CSCS Spack builds stopped during CMake configuration because `/opt/cp2k/CMakePresets.json` was missing.

After the build-context fix was exercised successfully, the Daint regression run completed 5461 tests correctly with zero wrong results, then 55 tests failed in `mp_world_init` with `SIGBUS`. The regression runner can schedule 288 MPI tasks but restricted the container shared memory to 1 GiB. The [MPICH FAQ](https://github.com/pmodels/mpich/blob/main/doc/wiki/faq/Frequently_Asked_Questions.md#q-why-mpi_put-raises-sigbus-error-inside-docker) documents this failure mode and recommends increasing `--shm-size`. The larger value is applied only to the highly parallel regression job; it does not preallocate 8 GiB and the benchmark settings are unchanged.

Fresh CSCS dependency builds currently also hit the independent GNU Readline mirror outage tracked in [spack/spack-packages#5863](https://github.com/spack/spack-packages/pull/5863). The latest validation attempt failed before the CP2K build because `mirror.spack.io` returned 404 and `ftpmirror.gnu.org` returned 502 for `readline83-002`. An earlier retry passed this stage, but the full Daint validation of the shared-memory change is presently blocked by the upstream download failure.

#5657 is complementary: it adds a `none` preset and adjusts `make_cp2k.sh`; it does not replace the need to put `CMakePresets.json` into this image.

No tests or dependencies are disabled, and no numerical tolerances are changed.

## Verification

- `./make_pretty.sh ci/cscs_daint_spack_psmp.yaml ci/docker/build_cp2k_spack.Dockerfile`
- `git diff --check`
- parsed `ci/cscs_daint_spack_psmp.yaml` with Ruby Psych
- built the exact `build_cp2k` stage with Podman and verified `/opt/cp2k/CMakePresets.json`
- on AArch64 Spark, started the published Daint image with `--shm-size=8g` and ran a two-rank MPICH/CP2K smoke test successfully
- attempted the full Daint validation; currently blocked in the dependency stage by spack/spack-packages#5863