### PR TITLE
Parallelize native SKALA atom-chunk routing

### DIFF
--- a/src/skala_gpw_features.F
+++ b/src/skala_gpw_features.F
@@ -64,12 +64,11 @@ MODULE skala_gpw_features
                                                             route_grad_return_recv_displs, &
                                                             route_grad_return_send_counts, &
                                                             route_grad_return_send_displs, &
-                                                            route_local_dest, chunk_return_positions, &
+                                                            route_local_positions, chunk_return_positions, &
                                                             route_point_recv_counts, &
                                                             route_point_recv_displs, &
                                                             route_point_send_counts, &
-                                                            route_point_send_displs, &
-                                                            route_send_local_rows
+                                                            route_point_send_displs
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)           :: feature_index
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:)     :: atomic_grid_sizes, chunk_atomic_grid_sizes, &
                                                             chunk_feature_indices
@@ -152,7 +151,7 @@ MODULE skala_gpw_features
                                                            route_point_recv_displs, &
                                                            route_point_send_counts, &
                                                            route_point_send_displs, &
-                                                           route_send_local_rows
+                                                           route_local_positions
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)          :: feature_index
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:)    :: atomic_grid_sizes
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :) :: atomic_grid_size_bound_shape
@@ -1021,7 +1020,7 @@ CONTAINS
                 features%route_point_recv_displs(cached_layout%nproc), &
                 features%route_point_send_counts(cached_layout%nproc), &
                 features%route_point_send_displs(cached_layout%nproc), &
-                features%route_send_local_rows(SIZE(cached_layout%route_send_local_rows)))
+                features%route_local_positions(SIZE(cached_layout%route_local_positions)))
       features%chunk_grad_counts(:) = cached_layout%chunk_grad_counts
       features%chunk_grad_displs(:) = cached_layout%chunk_grad_displs
       features%route_grad_return_recv_counts(:) = cached_layout%route_grad_return_recv_counts
@@ -1032,7 +1031,7 @@ CONTAINS
       features%route_point_recv_displs(:) = cached_layout%route_point_recv_displs
       features%route_point_send_counts(:) = cached_layout%route_point_send_counts
       features%route_point_send_displs(:) = cached_layout%route_point_send_displs
-      features%route_send_local_rows(:) = cached_layout%route_send_local_rows
+      features%route_local_positions(:) = cached_layout%route_local_positions
       IF (needs_coordinate_array) THEN
          ALLOCATE (features%coarse_0_atomic_coords(3, cached_layout%natom))
          features%coarse_0_atomic_coords(:, :) = cached_layout%coarse_0_atomic_coords
@@ -1205,30 +1204,30 @@ CONTAINS
       CLASS(mp_comm_type), INTENT(IN)                    :: group
 
       INTEGER                                            :: chunk_row, dest, local_feature, point_pos, row
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cursor, recv_meta, send_meta
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cursor, recv_meta, route_local_dest, send_meta
 
-      ALLOCATE (cache%route_local_dest(SIZE(local_to_global)), &
-                cache%route_send_local_rows(SIZE(local_to_global)), &
+      ALLOCATE (route_local_dest(SIZE(local_to_global)), &
+                cache%route_local_positions(SIZE(local_to_global)), &
                 cache%chunk_return_positions(cache%chunk_feature_count), &
                 cursor(SIZE(cache%route_point_send_counts)))
       cache%route_point_send_counts = 0
-      cache%route_send_local_rows = 0
+      cache%route_local_positions = 0
       cache%chunk_return_positions = 0
       DO local_feature = 1, SIZE(local_to_global)
          dest = feature_row_chunk_owner(local_to_global(local_feature), &
                                         cache%chunk_feature_counts, &
                                         cache%chunk_feature_displs)
          CPASSERT(dest > 0)
-         cache%route_local_dest(local_feature) = dest
+         route_local_dest(local_feature) = dest
          cache%route_point_send_counts(dest) = cache%route_point_send_counts(dest) + 1
       END DO
       CALL counts_to_displs(cache%route_point_send_counts, cache%route_point_send_displs)
       cursor(:) = cache%route_point_send_displs + 1
       DO local_feature = 1, SIZE(local_to_global)
-         dest = cache%route_local_dest(local_feature)
+         dest = route_local_dest(local_feature)
          point_pos = cursor(dest)
          cursor(dest) = cursor(dest) + 1
-         cache%route_send_local_rows(point_pos) = cache%local_feature_points(local_feature)
+         cache%route_local_positions(local_feature) = point_pos
       END DO
       CALL group%alltoall(cache%route_point_send_counts, cache%route_point_recv_counts, 1)
       CALL counts_to_displs(cache%route_point_recv_counts, cache%route_point_recv_displs)
@@ -1236,7 +1235,7 @@ CONTAINS
       ALLOCATE (send_meta(SIZE(local_to_global)), recv_meta(cache%chunk_feature_count))
       cursor(:) = cache%route_point_send_displs + 1
       DO local_feature = 1, SIZE(local_to_global)
-         dest = cache%route_local_dest(local_feature)
+         dest = route_local_dest(local_feature)
          point_pos = cursor(dest)
          cursor(dest) = cursor(dest) + 1
          send_meta(point_pos) = local_to_global(local_feature)
@@ -1259,10 +1258,10 @@ CONTAINS
 
       CPASSERT(SUM(cache%route_point_send_counts) == SIZE(local_to_global))
       CPASSERT(SUM(cache%route_point_recv_counts) == cache%chunk_feature_count)
-      CPASSERT(ALL(cache%route_send_local_rows > 0))
+      CPASSERT(ALL(cache%route_local_positions > 0))
       CPASSERT(ALL(cache%chunk_return_positions > 0))
 
-      DEALLOCATE (cursor, recv_meta, send_meta)
+      DEALLOCATE (cursor, recv_meta, route_local_dest, send_meta)
 
    END SUBROUTINE build_atom_chunk_routes
 
@@ -1316,14 +1315,13 @@ CONTAINS
       CLASS(mp_comm_type), INTENT(IN)                    :: group
       LOGICAL, INTENT(IN)                                :: collapse_spin_dynamics
 
-      INTEGER                                            :: chunk_row, dest, dyn_base, local_feature, local_row, &
+      INTEGER                                            :: chunk_row, dyn_base, local_feature, local_row, &
                                                             ndynamic_route_per_point, nrecv, nsend, &
                                                             point_pos, src_base
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cursor, recv_counts, recv_displs, &
-                                                            send_counts, send_displs
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: recv_counts, recv_displs, send_counts, send_displs
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: recv_dynamic, send_dynamic
 
-      nsend = SIZE(cached_layout%route_local_dest)
+      nsend = SIZE(cached_layout%route_local_positions)
       nrecv = SUM(cached_layout%route_point_recv_counts)
       CPASSERT(nsend == SIZE(cached_layout%local_feature_rows))
       CPASSERT(nrecv == cached_layout%chunk_feature_count)
@@ -1332,24 +1330,25 @@ CONTAINS
 
       ALLOCATE (send_dynamic(MAX(1, ndynamic_route_per_point*nsend)), &
                 recv_dynamic(MAX(1, ndynamic_route_per_point*nrecv)), &
-                cursor(cached_layout%nproc), send_counts(cached_layout%nproc), &
-                send_displs(cached_layout%nproc), recv_counts(cached_layout%nproc), &
+                send_counts(cached_layout%nproc), send_displs(cached_layout%nproc), &
+                recv_counts(cached_layout%nproc), &
                 recv_displs(cached_layout%nproc))
       send_counts(:) = ndynamic_route_per_point*cached_layout%route_point_send_counts
       send_displs(:) = ndynamic_route_per_point*cached_layout%route_point_send_displs
       recv_counts(:) = ndynamic_route_per_point*cached_layout%route_point_recv_counts
       recv_displs(:) = ndynamic_route_per_point*cached_layout%route_point_recv_displs
-      cursor(:) = cached_layout%route_point_send_displs + 1
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP SHARED(cached_layout, local_dynamic, ndynamic_route_per_point, nsend, send_dynamic) &
+!$OMP PRIVATE(dyn_base, local_feature, local_row, point_pos, src_base)
       DO local_feature = 1, nsend
-         dest = cached_layout%route_local_dest(local_feature)
-         point_pos = cursor(dest)
-         cursor(dest) = cursor(dest) + 1
+         point_pos = cached_layout%route_local_positions(local_feature)
          dyn_base = ndynamic_route_per_point*(point_pos - 1)
          local_row = cached_layout%local_feature_points(local_feature)
          src_base = ndynamic_route_per_point*(local_row - 1)
          send_dynamic(dyn_base + 1:dyn_base + ndynamic_route_per_point) = &
             local_dynamic(src_base + 1:src_base + ndynamic_route_per_point)
       END DO
+!$OMP END PARALLEL DO
 
       CALL group%alltoall(send_dynamic, send_counts, send_displs, recv_dynamic, recv_counts, &
                           recv_displs)
@@ -1369,6 +1368,9 @@ CONTAINS
          END IF
          features%chunk_return_positions(:) = cached_layout%chunk_return_positions
 
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP SHARED(cached_layout, collapse_spin_dynamics, features, ndynamic_route_per_point, recv_dynamic) &
+!$OMP PRIVATE(chunk_row, dyn_base, point_pos)
          DO chunk_row = 1, cached_layout%chunk_feature_count
             point_pos = cached_layout%chunk_return_positions(chunk_row)
             CPASSERT(point_pos >= 1 .AND. point_pos <= cached_layout%chunk_feature_count)
@@ -1390,11 +1392,11 @@ CONTAINS
                features%chunk_kin(chunk_row, :) = recv_dynamic(dyn_base + 9:dyn_base + 10)
             END IF
          END DO
+!$OMP END PARALLEL DO
          CPASSERT(ALL(features%chunk_return_positions > 0))
       END IF
 
-      DEALLOCATE (cursor, recv_counts, recv_displs, recv_dynamic, send_counts, send_displs, &
-                  send_dynamic)
+      DEALLOCATE (recv_counts, recv_displs, recv_dynamic, send_counts, send_displs, send_dynamic)
 
    END SUBROUTINE route_atom_chunk_dynamics
 
@@ -1521,13 +1523,12 @@ CONTAINS
       IF (ALLOCATED(cache%route_grad_return_send_displs)) THEN
          DEALLOCATE (cache%route_grad_return_send_displs)
       END IF
-      IF (ALLOCATED(cache%route_local_dest)) DEALLOCATE (cache%route_local_dest)
+      IF (ALLOCATED(cache%route_local_positions)) DEALLOCATE (cache%route_local_positions)
       IF (ALLOCATED(cache%chunk_return_positions)) DEALLOCATE (cache%chunk_return_positions)
       IF (ALLOCATED(cache%route_point_recv_counts)) DEALLOCATE (cache%route_point_recv_counts)
       IF (ALLOCATED(cache%route_point_recv_displs)) DEALLOCATE (cache%route_point_recv_displs)
       IF (ALLOCATED(cache%route_point_send_counts)) DEALLOCATE (cache%route_point_send_counts)
       IF (ALLOCATED(cache%route_point_send_displs)) DEALLOCATE (cache%route_point_send_displs)
-      IF (ALLOCATED(cache%route_send_local_rows)) DEALLOCATE (cache%route_send_local_rows)
       IF (ALLOCATED(cache%dynamic_counts)) DEALLOCATE (cache%dynamic_counts)
       IF (ALLOCATED(cache%dynamic_displs)) DEALLOCATE (cache%dynamic_displs)
       IF (ALLOCATED(cache%feature_counts)) DEALLOCATE (cache%feature_counts)
@@ -1674,7 +1675,7 @@ CONTAINS
       IF (ALLOCATED(features%route_point_send_displs)) THEN
          DEALLOCATE (features%route_point_send_displs)
       END IF
-      IF (ALLOCATED(features%route_send_local_rows)) DEALLOCATE (features%route_send_local_rows)
+      IF (ALLOCATED(features%route_local_positions)) DEALLOCATE (features%route_local_positions)
       IF (ALLOCATED(features%feature_index)) DEALLOCATE (features%feature_index)
       IF (ALLOCATED(features%local_feature_counts)) DEALLOCATE (features%local_feature_counts)
       IF (ALLOCATED(features%local_feature_offsets)) DEALLOCATE (features%local_feature_offsets)

--- a/src/skala_gpw_functional.F
+++ b/src/skala_gpw_functional.F
@@ -1129,9 +1129,8 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(OUT)                                     :: grad_grad
 
-      INTEGER                                            :: base, isubchunk, local_row, nflat_local, &
-                                                            nroute_grad_per_point, nroute_points, &
-                                                            nsubchunks, phase_handle, point_pos, &
+      INTEGER                                            :: isubchunk, nroute_grad_per_point, nroute_points, &
+                                                            nsubchunks, phase_handle, &
                                                             subphase_handle
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: route_grad_return_recv_counts, &
                                                             route_grad_return_recv_displs, &
@@ -1148,7 +1147,6 @@ CONTAINS
 
       CPASSERT(features%uses_atom_chunks)
       CPASSERT(max_rows > 0)
-      nflat_local = features%nflat_local
       CALL skala_gpw_atom_subchunk_layout(max_rows, subchunk_atom_begin, subchunk_atom_count, &
                                           subchunk_row_begin, subchunk_row_count)
       nsubchunks = SIZE(subchunk_atom_begin)
@@ -1157,7 +1155,7 @@ CONTAINS
       IF (compute_grads) THEN
          CPASSERT(features%uses_atom_chunk_routing)
          CPASSERT(SUM(features%route_point_recv_counts) == features%chunk_feature_count)
-         nroute_points = SIZE(features%route_send_local_rows)
+         nroute_points = SIZE(features%route_local_positions)
          CPASSERT(SUM(features%route_point_send_counts) == nroute_points)
          nroute_grad_per_point = ngrad_per_point
          IF (collapse_spin_grads) nroute_grad_per_point = ncollapsed_grad_per_point
@@ -1218,44 +1216,8 @@ CONTAINS
          CALL timestop(phase_handle)
 
          CALL timeset("skala_gpw_grad_route_scatter", phase_handle)
-         ALLOCATE (density_grad(nflat_local, 2), grad_grad(nflat_local, 3, 2), &
-                   kin_grad(nflat_local, 2))
-         density_grad = 0.0_dp
-         grad_grad = 0.0_dp
-         kin_grad = 0.0_dp
-         DO point_pos = 1, nroute_points
-            local_row = features%route_send_local_rows(point_pos)
-            CPASSERT(local_row >= 1 .AND. local_row <= nflat_local)
-            base = nroute_grad_per_point*(point_pos - 1)
-            IF (collapse_spin_grads) THEN
-               density_grad(local_row, :) = density_grad(local_row, :) + &
-                                            recv_grad_buffer(base + 1)
-               grad_grad(local_row, 1, :) = grad_grad(local_row, 1, :) + &
-                                            recv_grad_buffer(base + 2)
-               grad_grad(local_row, 2, :) = grad_grad(local_row, 2, :) + &
-                                            recv_grad_buffer(base + 3)
-               grad_grad(local_row, 3, :) = grad_grad(local_row, 3, :) + &
-                                            recv_grad_buffer(base + 4)
-               kin_grad(local_row, :) = kin_grad(local_row, :) + recv_grad_buffer(base + 5)
-            ELSE
-               density_grad(local_row, :) = density_grad(local_row, :) + &
-                                            recv_grad_buffer(base + 1:base + 2)
-               grad_grad(local_row, 1, 1) = grad_grad(local_row, 1, 1) + &
-                                            recv_grad_buffer(base + 3)
-               grad_grad(local_row, 2, 1) = grad_grad(local_row, 2, 1) + &
-                                            recv_grad_buffer(base + 4)
-               grad_grad(local_row, 3, 1) = grad_grad(local_row, 3, 1) + &
-                                            recv_grad_buffer(base + 5)
-               grad_grad(local_row, 1, 2) = grad_grad(local_row, 1, 2) + &
-                                            recv_grad_buffer(base + 6)
-               grad_grad(local_row, 2, 2) = grad_grad(local_row, 2, 2) + &
-                                            recv_grad_buffer(base + 7)
-               grad_grad(local_row, 3, 2) = grad_grad(local_row, 3, 2) + &
-                                            recv_grad_buffer(base + 8)
-               kin_grad(local_row, :) = kin_grad(local_row, :) + &
-                                        recv_grad_buffer(base + 9:base + 10)
-            END IF
-         END DO
+         CALL scatter_routed_atom_chunk_grads(features, recv_grad_buffer, collapse_spin_grads, &
+                                              density_grad, grad_grad, kin_grad)
          CALL timestop(phase_handle)
 
          DEALLOCATE (recv_grad_buffer, route_grad_return_recv_counts, &
@@ -1413,6 +1375,11 @@ CONTAINS
          CPASSERT(SIZE(chunk_kin_grad, 2) == 2)
       END IF
 
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP SHARED(chunk_density_grad, chunk_grad_grad, chunk_kin_grad, features, &
+!$OMP        my_collapse_spin_grads, ngrad_buffer_per_point, route_to_return_positions, &
+!$OMP        TARGET, target_points) &
+!$OMP PRIVATE(base, irow, point_pos)
       DO irow = 1, features%chunk_feature_count
          IF (route_to_return_positions) THEN
             point_pos = features%chunk_return_positions(irow)
@@ -1450,12 +1417,93 @@ CONTAINS
             TARGET(base + 9:base + 10) = chunk_kin_grad(irow, :)
          END IF
       END DO
+!$OMP END PARALLEL DO
 
       CALL torch_tensor_release(density_grad_t)
       CALL torch_tensor_release(grad_grad_t)
       CALL torch_tensor_release(kin_grad_t)
 
    END SUBROUTINE pack_atom_chunk_grads
+
+! **************************************************************************************************
+!> \brief Scatter routed atom-chunk gradients into local grid-row order.
+!> \param features ...
+!> \param recv_grad_buffer ...
+!> \param collapse_spin_grads ...
+!> \param density_grad ...
+!> \param grad_grad ...
+!> \param kin_grad ...
+! **************************************************************************************************
+   SUBROUTINE scatter_routed_atom_chunk_grads(features, recv_grad_buffer, collapse_spin_grads, &
+                                              density_grad, grad_grad, kin_grad)
+      TYPE(skala_gpw_feature_type), INTENT(IN)           :: features
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: recv_grad_buffer
+      LOGICAL, INTENT(IN)                                :: collapse_spin_grads
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: density_grad
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
+         INTENT(OUT)                                     :: grad_grad
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
+         INTENT(OUT)                                     :: kin_grad
+
+      INTEGER                                            :: base, local_feature, local_row, &
+                                                            nflat_local, nroute_grad_per_point, &
+                                                            nroute_points, point_pos
+
+      nflat_local = features%nflat_local
+      nroute_points = SIZE(features%route_local_positions)
+      nroute_grad_per_point = ngrad_per_point
+      IF (collapse_spin_grads) nroute_grad_per_point = ncollapsed_grad_per_point
+      CPASSERT(SIZE(recv_grad_buffer) >= nroute_grad_per_point*nroute_points)
+      ALLOCATE (density_grad(nflat_local, 2), grad_grad(nflat_local, 3, 2), &
+                kin_grad(nflat_local, 2))
+
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP SHARED(collapse_spin_grads, density_grad, features, grad_grad, kin_grad, nflat_local, &
+!$OMP        nroute_grad_per_point, nroute_points, recv_grad_buffer) &
+!$OMP PRIVATE(base, local_feature, local_row, point_pos)
+      DO local_row = 1, nflat_local
+         density_grad(local_row, :) = 0.0_dp
+         grad_grad(local_row, :, :) = 0.0_dp
+         kin_grad(local_row, :) = 0.0_dp
+         DO local_feature = features%local_feature_offsets(local_row), &
+            features%local_feature_offsets(local_row + 1) - 1
+            point_pos = features%route_local_positions(local_feature)
+            CPASSERT(point_pos >= 1 .AND. point_pos <= nroute_points)
+            base = nroute_grad_per_point*(point_pos - 1)
+            IF (collapse_spin_grads) THEN
+               density_grad(local_row, :) = density_grad(local_row, :) + &
+                                            recv_grad_buffer(base + 1)
+               grad_grad(local_row, 1, :) = grad_grad(local_row, 1, :) + &
+                                            recv_grad_buffer(base + 2)
+               grad_grad(local_row, 2, :) = grad_grad(local_row, 2, :) + &
+                                            recv_grad_buffer(base + 3)
+               grad_grad(local_row, 3, :) = grad_grad(local_row, 3, :) + &
+                                            recv_grad_buffer(base + 4)
+               kin_grad(local_row, :) = kin_grad(local_row, :) + recv_grad_buffer(base + 5)
+            ELSE
+               density_grad(local_row, :) = density_grad(local_row, :) + &
+                                            recv_grad_buffer(base + 1:base + 2)
+               grad_grad(local_row, 1, 1) = grad_grad(local_row, 1, 1) + &
+                                            recv_grad_buffer(base + 3)
+               grad_grad(local_row, 2, 1) = grad_grad(local_row, 2, 1) + &
+                                            recv_grad_buffer(base + 4)
+               grad_grad(local_row, 3, 1) = grad_grad(local_row, 3, 1) + &
+                                            recv_grad_buffer(base + 5)
+               grad_grad(local_row, 1, 2) = grad_grad(local_row, 1, 2) + &
+                                            recv_grad_buffer(base + 6)
+               grad_grad(local_row, 2, 2) = grad_grad(local_row, 2, 2) + &
+                                            recv_grad_buffer(base + 7)
+               grad_grad(local_row, 3, 2) = grad_grad(local_row, 3, 2) + &
+                                            recv_grad_buffer(base + 8)
+               kin_grad(local_row, :) = kin_grad(local_row, :) + &
+                                        recv_grad_buffer(base + 9:base + 10)
+            END IF
+         END DO
+      END DO
+!$OMP END PARALLEL DO
+
+   END SUBROUTINE scatter_routed_atom_chunk_grads
 
 ! **************************************************************************************************
 !> \brief Return CPU views of autograd outputs for the SKALA dynamic feature tensors.
@@ -1505,7 +1553,7 @@ CONTAINS
 
       INTEGER                                            :: base, feature_pos, i, j, k, local_row, &
                                                             nflat_local, nroute_grad_per_point, &
-                                                            nroute_points, phase_handle, point_pos, row
+                                                            nroute_points, phase_handle, row
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: route_grad_return_recv_counts, &
                                                             route_grad_return_recv_displs, &
                                                             route_grad_return_send_counts, &
@@ -1518,7 +1566,7 @@ CONTAINS
       nflat_local = features%nflat_local
       IF (features%uses_atom_chunk_routing) THEN
          CPASSERT(SUM(features%route_point_recv_counts) == features%chunk_feature_count)
-         nroute_points = SIZE(features%route_send_local_rows)
+         nroute_points = SIZE(features%route_local_positions)
          CPASSERT(SUM(features%route_point_send_counts) == nroute_points)
 
          nroute_grad_per_point = ngrad_per_point
@@ -1554,44 +1602,9 @@ CONTAINS
          CALL timestop(phase_handle)
 
          CALL timeset("skala_gpw_grad_route_scatter", phase_handle)
-         ALLOCATE (density_grad(nflat_local, 2), grad_grad(nflat_local, 3, 2), &
-                   kin_grad(nflat_local, 2))
-         density_grad = 0.0_dp
-         grad_grad = 0.0_dp
-         kin_grad = 0.0_dp
-         DO point_pos = 1, nroute_points
-            local_row = features%route_send_local_rows(point_pos)
-            CPASSERT(local_row >= 1 .AND. local_row <= nflat_local)
-            base = nroute_grad_per_point*(point_pos - 1)
-            IF (features%uses_collapsed_rks_dynamic) THEN
-               density_grad(local_row, :) = density_grad(local_row, :) + &
-                                            recv_grad_buffer(base + 1)
-               grad_grad(local_row, 1, :) = grad_grad(local_row, 1, :) + &
-                                            recv_grad_buffer(base + 2)
-               grad_grad(local_row, 2, :) = grad_grad(local_row, 2, :) + &
-                                            recv_grad_buffer(base + 3)
-               grad_grad(local_row, 3, :) = grad_grad(local_row, 3, :) + &
-                                            recv_grad_buffer(base + 4)
-               kin_grad(local_row, :) = kin_grad(local_row, :) + recv_grad_buffer(base + 5)
-            ELSE
-               density_grad(local_row, :) = density_grad(local_row, :) + &
-                                            recv_grad_buffer(base + 1:base + 2)
-               grad_grad(local_row, 1, 1) = grad_grad(local_row, 1, 1) + &
-                                            recv_grad_buffer(base + 3)
-               grad_grad(local_row, 2, 1) = grad_grad(local_row, 2, 1) + &
-                                            recv_grad_buffer(base + 4)
-               grad_grad(local_row, 3, 1) = grad_grad(local_row, 3, 1) + &
-                                            recv_grad_buffer(base + 5)
-               grad_grad(local_row, 1, 2) = grad_grad(local_row, 1, 2) + &
-                                            recv_grad_buffer(base + 6)
-               grad_grad(local_row, 2, 2) = grad_grad(local_row, 2, 2) + &
-                                            recv_grad_buffer(base + 7)
-               grad_grad(local_row, 3, 2) = grad_grad(local_row, 3, 2) + &
-                                            recv_grad_buffer(base + 8)
-               kin_grad(local_row, :) = kin_grad(local_row, :) + &
-                                        recv_grad_buffer(base + 9:base + 10)
-            END IF
-         END DO
+         CALL scatter_routed_atom_chunk_grads(features, recv_grad_buffer, &
+                                              features%uses_collapsed_rks_dynamic, &
+                                              density_grad, grad_grad, kin_grad)
          CALL timestop(phase_handle)
 
          DEALLOCATE (recv_grad_buffer, route_grad_return_recv_counts, &


### PR DESCRIPTION
## Summary

- precompute the local-feature-to-send-buffer mapping in the native SKALA layout cache
- parallelize atom-chunk dynamic-feature packing and receive-buffer unpacking with OpenMP
- parallelize Torch gradient packing into return buffers
- scatter returned gradients by local grid row, avoiding atomics while retaining deterministic row-local accumulation
- remove the cached destination-rank array that is no longer needed after layout construction

## Motivation

Native-grid atom chunks distribute Torch evaluation across MPI ranks and GPUs, but the dynamic features and autograd results still have to be packed, exchanged, and scattered on the CPU during every SCF step. After parallelizing the static layout construction in #5654, these serial local routing loops became the next visible CPU bottleneck in the workflow discussed in #5439.

The send-buffer position of every local feature is static for the lifetime of the layout. This PR computes that mapping once and uses it to make the recurring pack and unpack loops conflict-free. Returned gradients are processed one local grid row per OpenMP iteration, so all contributions to a row remain local to one thread and no atomics or thread-private full-grid buffers are required.

The MPI message layout, communicated values, and Torch inputs are unchanged.

## Performance

Terok, NVIDIA A40, 96-atom H2O cluster, one SCF iteration, SMOOTH atom chunks, CUDA SKALA model, 8 OpenMP threads per MPI rank. Both sides include #5654 so that this table isolates the recurring routing change:

| Configuration | #5654 | this PR | reduction | speedup |
| --- | ---: | ---: | ---: | ---: |
| 1 MPI rank / 1 GPU | 37.550 s | 34.918 s | 7.0% | 1.08x |
| 2 MPI ranks / 2 GPUs | 22.528 s | 20.995 s | 6.8% | 1.07x |

Representative one-GPU phase timings:

| Phase | #5654 | this PR | speedup |
| --- | ---: | ---: | ---: |
| dynamic route | 1.264 s | 0.424 s | 2.98x |
| Torch gradient pack | 0.835 s | 0.407 s | 2.05x |
| returned-gradient scatter | 2.013 s | 0.341 s | 5.90x |

A two-rank CPU/LibTorch run of a two-water system improved from 23.240 s to 21.841 s (1.06x), so the change is not CUDA-specific.

## Numerical validation

- 96-atom RKS energy is unchanged at fixed rank count:
  - 1 rank: `-545.783212177163932` Ha
  - 2 ranks: `-545.783212177846167` Ha
- two-rank CPU/LibTorch energy is unchanged: `-34.081978687847609` Ha
- UKS CUDA runs with 1 and 8 OpenMP threads give the same energy: `-16.408065378767454` Ha

## Checks

- CP2K precommit checks
- Release MPI/OpenMP/GauXC/CUDA/LibTorch build on Terok
- RKS CUDA runs with 1 rank / 1 GPU and 2 ranks / 2 GPUs
- RKS CPU/LibTorch run with 2 MPI ranks
- UKS CUDA run with 1 and 8 OpenMP threads
