### PR TITLE
Install optimized SKALA 1.1 Rev1 models

### DIFF
--- a/docs/methods/dft/gauxc.md
+++ b/docs/methods/dft/gauxc.md
@@ -42,18 +42,23 @@ name. The underlying functional is optional in this case and defaults to `PBE`:
 ```
 
 The `.fun` format and available model checkpoints are defined by GauXC rather than CP2K. `.fun`
-files use TorchScript serialization. The official Skala 1.1 checkpoint can be downloaded together
-with GauXC in toolchain, or from Hugging Face with the `hf` command provided by the
+files use TorchScript serialization. The official Skala 1.1 Rev1 checkpoints can be downloaded
+together with GauXC in the toolchain, or from Hugging Face with the `hf` command provided by the
 `huggingface_hub` package:
 
 ```bash
-hf download microsoft/skala-1.1 skala-1.1.fun --local-dir .
+hf download microsoft/skala-1.1 skala-1.1-rev1.fun --local-dir .
+hf download microsoft/skala-1.1 skala-1.1-rev1-cuda.fun --local-dir .
 ```
 
-Select the downloaded checkpoint with `MODEL ./skala-1.1.fun`. Alternatively, set
-`GAUXC_SKALA_MODEL` to its path and use `MODEL SKALA`. See the
+Select a downloaded checkpoint explicitly with `MODEL ./skala-1.1-rev1.fun`. Alternatively, set
+`GAUXC_SKALA_MODEL` to the CPU checkpoint and use `MODEL SKALA` for host execution. For
+`INT_EXECUTION_SPACE DEVICE`, set `GAUXC_SKALA_CUDA_MODEL` to the CUDA checkpoint. CP2K falls back
+to `GAUXC_SKALA_MODEL` for compatibility with existing configurations where that variable already
+points to a device-compatible checkpoint; the CPU checkpoint itself is not device-compatible. For
+the model interface and available checkpoints, consult
 [GauXC/Skala model documentation](https://microsoft.github.io/skala/gauxc/c-library.html#download-checkpoint-from-huggingface)
-for the model interface and available checkpoints. Obtain `.fun` files only from trusted sources.
+and obtain `.fun` files only from trusted sources.
 
 The molecular-quadrature Skala path defaults to `GRID SUPERFINE` and `PRUNING_SCHEME UNPRUNED`
 unless these settings are provided explicitly. These settings are recommended for force checks;

--- a/src/xc/xc_gauxc_functional.F
+++ b/src/xc/xc_gauxc_functional.F
@@ -974,7 +974,8 @@ CONTAINS
 
       CHARACTER(len=default_path_length)                 :: model_key, model_name, output_path
       CHARACTER(len=default_string_length) :: gradient_runtime, gradient_runtime_key, grid_key, &
-         lwd_kernel_key, pruning_key, skala_runtime, skala_runtime_key, xc_fun_key
+         int_exec_space_key, lwd_kernel_key, pruning_key, skala_runtime, skala_runtime_key, &
+         xc_fun_key
       INTEGER                                            :: atom_chunk_size, env_status, img, ispin, &
                                                             nimages
       LOGICAL :: atom_chunk_size_explicit, do_kpoints, gapw_method, gapw_paw_pseudopotentials, &
@@ -1152,6 +1153,8 @@ CONTAINS
       CALL uppercase(skala_runtime_key)
       gradient_runtime_key = ADJUSTL(gradient_runtime)
       CALL uppercase(gradient_runtime_key)
+      int_exec_space_key = ADJUSTL(params%int_exec_space)
+      CALL uppercase(int_exec_space_key)
       params%use_gauxc_model = (TRIM(model_key) /= "" .AND. TRIM(model_key) /= "NONE" .AND. &
                                 TRIM(model_key) /= TRIM(xc_fun_key))
       use_skala_model = (INDEX(TRIM(model_key), "SKALA") > 0)
@@ -1233,9 +1236,23 @@ CONTAINS
                "Use GRID SUPERFINE and PRUNING_SCHEME UNPRUNED for quantitative force checks.")
          END IF
          IF (TRIM(model_key) == "SKALA") THEN
-            CALL GET_ENVIRONMENT_VARIABLE("GAUXC_SKALA_MODEL", model_name, STATUS=env_status)
+            model_name = ""
+            env_status = 1
+            IF (TRIM(int_exec_space_key) == "DEVICE") THEN
+               CALL GET_ENVIRONMENT_VARIABLE("GAUXC_SKALA_CUDA_MODEL", model_name, STATUS=env_status)
+            END IF
             IF (env_status /= 0 .OR. LEN_TRIM(model_name) == 0) THEN
-               CPABORT("MODEL SKALA requires the GAUXC_SKALA_MODEL environment variable")
+               CALL GET_ENVIRONMENT_VARIABLE("GAUXC_SKALA_MODEL", model_name, STATUS=env_status)
+            END IF
+            IF (env_status /= 0 .OR. LEN_TRIM(model_name) == 0) THEN
+               IF (TRIM(int_exec_space_key) == "DEVICE") THEN
+                  CALL cp_abort( &
+                     __LOCATION__, &
+                     "MODEL SKALA with DEVICE execution requires GAUXC_SKALA_CUDA_MODEL or "// &
+                     "GAUXC_SKALA_MODEL")
+               ELSE
+                  CPABORT("MODEL SKALA requires the GAUXC_SKALA_MODEL environment variable")
+               END IF
             END IF
             params%model_eval_name = model_name
          END IF

--- a/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/gauxc/package.py
@@ -52,16 +52,43 @@ class Gauxc(CMakePackage, CudaPackage, ROCmPackage):
     variant("pic", default=True, description="Build position independent code")
 
     # Skala resource file
-    SKALA_RESOURCES = {"1.1": "0c8432ac3f03c8f1276372df9aca5b7ee7f8939d47a8789eb158976e89aa0606"}
-    variant("skala_version", default="none", values=("none", *SKALA_RESOURCES.keys()), multi=False)
-    for skala_version, sha256 in SKALA_RESOURCES.items():
+    SKALA_RESOURCES = {
+        "1.1": {
+            "cpu": (
+                "skala-1.1-rev1.fun",
+                "7f3e8622e1eb520ccd88a55464c3e359ac4d7e5ccbd1fb77a26afa1e1c20a5cd",
+            ),
+            "cuda": (
+                "skala-1.1-rev1-cuda.fun",
+                "f848eae769dca91741a518ae7275d10caac398ab21db649f91bc1f136872f223",
+            ),
+        }
+    }
+    variant(
+        "skala_version",
+        default="none",
+        values=("none", *SKALA_RESOURCES.keys()),
+        multi=False,
+        description="SKALA model version to install",
+    )
+    for skala_version, artifacts in SKALA_RESOURCES.items():
+        cpu_file, cpu_sha256 = artifacts["cpu"]
         resource(
             name=f"skala_fun_{skala_version}",
-            url=f"https://huggingface.co/microsoft/skala-{skala_version}/resolve/main/skala-{skala_version}.fun",
-            sha256=sha256,
+            url=f"https://huggingface.co/microsoft/skala-{skala_version}/resolve/main/{cpu_file}",
+            sha256=cpu_sha256,
             expand=False,
-            placement="onedft_models",
+            placement={cpu_file: cpu_file},
             when=f"+skala skala_version={skala_version}",
+        )
+        cuda_file, cuda_sha256 = artifacts["cuda"]
+        resource(
+            name=f"skala_cuda_fun_{skala_version}",
+            url=f"https://huggingface.co/microsoft/skala-{skala_version}/resolve/main/{cuda_file}",
+            sha256=cuda_sha256,
+            expand=False,
+            placement={cuda_file: cuda_file},
+            when=f"+skala+cuda skala_version={skala_version}",
         )
 
     conflicts("+magma", when="~cuda ~rocm", msg="MAGMA requires CUDA or HIP")
@@ -75,7 +102,6 @@ class Gauxc(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("cmake@3.20:", type="build")
     depends_on("ninja@1.10:", type="build")
     depends_on("exchcxx~cuda", when="~cuda")
-    depends_on("exchcxx+cuda", when="+cuda")
     depends_on("integratorxx")
     depends_on("blas")
     depends_on("hdf5", when="+hdf5")
@@ -86,10 +112,14 @@ class Gauxc(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("gau2grid")
     depends_on("nlohmann-json", when="+skala")
     depends_on("py-torch@2:~cuda", when="+skala~cuda")
-    depends_on("py-torch@2:+cuda", when="+skala+cuda")
     depends_on("magma", when="+magma")
     depends_on("nccl", when="+nccl")
     depends_on("cutlass", when="+cutlass")
+
+    for arch in CudaPackage.cuda_arch_values:
+        cuda_spec = f"+cuda cuda_arch={arch}"
+        depends_on(f"exchcxx{cuda_spec}", when=cuda_spec)
+        depends_on(f"py-torch@2:{cuda_spec}", when=f"+skala {cuda_spec}")
 
     generator("ninja")
 
@@ -130,7 +160,21 @@ class Gauxc(CMakePackage, CudaPackage, ROCmPackage):
         super().install(spec, prefix)
         if spec.satisfies("+skala"):
             skala_version = spec.variants["skala_version"].value
-            skala_file = f"skala-{skala_version}.fun"
             target_dir = prefix.share.gauxc.join("onedft_models")
             mkdirp(target_dir)
-            install(join_path("onedft_models", skala_file), target_dir)
+            cpu_file = self.SKALA_RESOURCES[skala_version]["cpu"][0]
+            install(cpu_file, target_dir)
+            if spec.satisfies("+cuda"):
+                cuda_file = self.SKALA_RESOURCES[skala_version]["cuda"][0]
+                install(cuda_file, target_dir)
+
+    def setup_run_environment(self, env):
+        spec = self.spec
+        if spec.satisfies("+skala"):
+            skala_version = spec.variants["skala_version"].value
+            model_dir = self.prefix.share.gauxc.join("onedft_models")
+            cpu_file = self.SKALA_RESOURCES[skala_version]["cpu"][0]
+            env.set("GAUXC_SKALA_MODEL", model_dir.join(cpu_file))
+            if spec.satisfies("+cuda"):
+                cuda_file = self.SKALA_RESOURCES[skala_version]["cuda"][0]
+                env.set("GAUXC_SKALA_CUDA_MODEL", model_dir.join(cuda_file))

--- a/tools/toolchain/scripts/stage6/install_gauxc.sh
+++ b/tools/toolchain/scripts/stage6/install_gauxc.sh
@@ -14,8 +14,11 @@ nlohmann_json_pkg="nlohmann-json-3.12.0-include.zip"
 nlohmann_json_sha256="b8cb0ef2dd7f57f18933997c9934bb1fa962594f701cd5a8d3c2c80541559372"
 nlohmann_json_urlpath="https://github.com/nlohmann/json/releases/download/v3.12.0"
 skala_model_ver="1.1"
-skala_model_pkg="skala-${skala_model_ver}.fun"
-skala_model_sha256="0c8432ac3f03c8f1276372df9aca5b7ee7f8939d47a8789eb158976e89aa0606"
+skala_model_rev="rev1"
+skala_model_pkg="skala-${skala_model_ver}-${skala_model_rev}.fun"
+skala_model_sha256="7f3e8622e1eb520ccd88a55464c3e359ac4d7e5ccbd1fb77a26afa1e1c20a5cd"
+skala_cuda_model_pkg="skala-${skala_model_ver}-${skala_model_rev}-cuda.fun"
+skala_cuda_model_sha256="f848eae769dca91741a518ae7275d10caac398ab21db649f91bc1f136872f223"
 skala_model_urlpath="https://huggingface.co/microsoft/skala-${skala_model_ver}/resolve/main"
 
 source "${SCRIPT_DIR}"/common_vars.sh
@@ -61,8 +64,11 @@ case "${with_gauxc}" in
     echo "==================== Installing GauXC ===================="
     pkg_install_dir="${INSTALLDIR}/gauxc-${gauxc_ver}"
     install_lock_file="${pkg_install_dir}/install_successful"
+    installed_skala_model="${pkg_install_dir}/share/gauxc/onedft_models/${skala_model_pkg}"
+    installed_skala_cuda_model="${pkg_install_dir}/share/gauxc/onedft_models/${skala_cuda_model_pkg}"
 
-    if verify_checksums "${install_lock_file}"; then
+    if verify_checksums "${install_lock_file}" && [ -f "${installed_skala_model}" ] &&
+      { [ "${ENABLE_CUDA}" != "__TRUE__" ] || [ -f "${installed_skala_cuda_model}" ]; }; then
       echo "gauxc-${gauxc_ver} is already installed, skipping it."
     else
       retrieve_github_archive "${gauxc_sha256}" "${gauxc_rev}.tar.gz" \
@@ -74,6 +80,11 @@ case "${with_gauxc}" in
       retrieve_github_archive "${skala_model_sha256}" "${skala_model_pkg}" \
         "${skala_model_urlpath}" \
         "${skala_model_pkg}"
+      if [ "${ENABLE_CUDA}" = "__TRUE__" ]; then
+        retrieve_github_archive "${skala_cuda_model_sha256}" "${skala_cuda_model_pkg}" \
+          "${skala_model_urlpath}" \
+          "${skala_cuda_model_pkg}"
+      fi
       echo "Installing from scratch into ${pkg_install_dir}"
       rm -rf "GauXC-${gauxc_rev}" "${pkg_install_dir}"
       tar -xzf "${gauxc_pkg}"
@@ -157,11 +168,17 @@ case "${with_gauxc}" in
       mkdir -p "${pkg_install_dir}/share/gauxc/onedft_models"
       install -m 0644 "${BUILDDIR}/${skala_model_pkg}" \
         "${pkg_install_dir}/share/gauxc/onedft_models/${skala_model_pkg}"
+      skala_model_checksum_files=("${BUILDDIR}/${skala_model_pkg}")
+      if [ "${ENABLE_CUDA}" = "__TRUE__" ]; then
+        install -m 0644 "${BUILDDIR}/${skala_cuda_model_pkg}" \
+          "${pkg_install_dir}/share/gauxc/onedft_models/${skala_cuda_model_pkg}"
+        skala_model_checksum_files+=("${BUILDDIR}/${skala_cuda_model_pkg}")
+      fi
       write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage6/$(basename ${SCRIPT_NAME})" \
         "${SCRIPT_DIR}/stage6/gauxc-${gauxc_ver}.patch" \
         "${SCRIPT_DIR}/stage6/gauxc-libxc-only-exchcxx.patch" \
         "${SCRIPT_DIR}/stage6/exchcxx-disable-builtin.patch" "${BUILDDIR}/${gauxc_pkg}" \
-        "${BUILDDIR}/${nlohmann_json_pkg}" "${BUILDDIR}/${skala_model_pkg}"
+        "${BUILDDIR}/${nlohmann_json_pkg}" "${skala_model_checksum_files[@]}"
     fi
     ;;
   __SYSTEM__)
@@ -185,13 +202,21 @@ esac
 if [ "${with_gauxc}" != "__DONTUSE__" ]; then
   if [ -n "${pkg_install_dir:-}" ]; then
     gauxc_skala_model="${pkg_install_dir}/share/gauxc/onedft_models/${skala_model_pkg}"
+    if [ "${ENABLE_CUDA}" = "__TRUE__" ]; then
+      gauxc_skala_cuda_model="${pkg_install_dir}/share/gauxc/onedft_models/${skala_cuda_model_pkg}"
+      [ -f "${gauxc_skala_cuda_model}" ] || gauxc_skala_cuda_model=""
+    else
+      gauxc_skala_cuda_model=""
+    fi
   else
     gauxc_skala_model=""
+    gauxc_skala_cuda_model=""
   fi
   cat << EOF > "${BUILDDIR}/setup_gauxc"
 export GAUXC_VER="${gauxc_ver}"
 export GAUXC_ROOT="${pkg_install_dir}"
 export GAUXC_SKALA_MODEL="${gauxc_skala_model}"
+export GAUXC_SKALA_CUDA_MODEL="${gauxc_skala_cuda_model}"
 EOF
   if [ "${with_gauxc}" != "__SYSTEM__" ]; then
     cat << EOF >> "${BUILDDIR}/setup_gauxc"


### PR DESCRIPTION
## Summary

- install the official SKALA 1.1 Rev1 CPU checkpoint in the toolchain and Spack package
- install and export the CUDA-specific Rev1 checkpoint for CUDA builds
- prefer the CUDA checkpoint for `MODEL SKALA` with GauXC device execution, with a legacy-variable fallback
- propagate the selected Spack CUDA architecture to ExchCXX and PyTorch
- make toolchain install locks require the model artifacts needed by the current CPU/CUDA configuration

## Motivation

Microsoft SKALA PR microsoft/skala#92 replaced advanced indexing in the SKALA 1.1 tensor product with an explicit gather. The retraced Rev1 checkpoints preserve the functional while substantially reducing Torch backward cost. Microsoft SKALA PR microsoft/skala#94 made these Rev1 files the upstream defaults, but CP2K still installed the older Rev0 CPU checkpoint and did not install the CUDA checkpoint.

Inspection of the inlined TorchScript graphs confirms that the CUDA Rev1 artifact replaces six `aten::index` operations with six `aten::gather` operations compared with Rev0.

For `MODEL SKALA`, the molecular GauXC path now prefers `GAUXC_SKALA_CUDA_MODEL` when `INT_EXECUTION_SPACE DEVICE` is selected. It retains `GAUXC_SKALA_MODEL` as a fallback for existing installations where that variable already points to a device-compatible checkpoint. The documentation makes explicit that the official CPU checkpoint itself is not device-compatible.

The Spack `gauxc+skala+cuda` variant was also not concretizable because its `cuda_arch` value was not propagated to `py-torch+cuda`. This change passes the selected architecture to both PyTorch and ExchCXX.

## Performance

On Spark with one NVIDIA GB10 GPU, one MPI rank and eight OpenMP threads, two uncontended alternating runs of the 32-water SKALA GPU benchmark changed from a mean wall time of 43.052 s with Rev0 to 37.974 s with Rev1, an 11.8% reduction. Mean CP2K time decreased from 40.590 s to 35.555 s (12.4%). The atom-subchunk forward block decreased from 25.341 s to 19.565 s (22.8%), and the direct Torch model timer decreased from 4.021 s to 3.386 s (15.8%). Every overlap log was empty and all four runs exited successfully.

On Terok with two NVIDIA A40 GPUs, two MPI ranks and eight OpenMP threads per rank, the same benchmark changed from a mean CP2K time of 26.893 s with Rev0 to 23.380 s with Rev1, a 13.1% reduction. The launch used `--map-by ppr:2:node:PE=8 --bind-to core` and `OMP_PROC_BIND=false`.

The Rev1-minus-Rev0 energy difference was -2.69e-9 Ha in the Spark benchmark and approximately 2.1e-8 Ha on Terok. Small H2 checks on Spark showed differences of 8.4e-10 Ha on CPU and 2.1e-10 Ha on CUDA; force differences were a few 1e-9 Ha/bohr.

## Validation

- CP2K precommit checks for all changed files
- `bash -n` for `install_gauxc.sh`
- CPU Spack concretization with `+skala~cuda`
- CUDA Spack concretization on Spark with `+skala+cuda cuda_arch=121`
- Spack staging of both Rev1 resources with verified SHA-256 checksums
- Spack runtime environment exports for both model paths
- isolated toolchain CPU and CUDA install-lock/setup tests
- direct Rev0/Rev1 inlined TorchScript graph inspection
- SKALA energy, force and stress smoke tests on Spark
- GauXC device-model selection and legacy-variable fallback tests on Spark
- full Spark rebuild after rebasing onto CP2K master including #5659
- post-rebase HOST and DEVICE model-selection smokes with the unused model path deliberately invalid
- clean alternating one-GPU Rev0/Rev1 timing series on Spark
