### PR TITLE
Select CUTLASS automatically for device SKALA

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1860,6 +1860,9 @@ target_compile_definitions(
     $<$<BOOL:${CP2K_USE_SIRIUS}>:__SIRIUS>
     $<$<BOOL:${CP2K_USE_LIBVDWXC}>:__LIBVDWXC>
     $<$<BOOL:${CP2K_USE_GAUXC}>:__GAUXC>
+    # GauXC's CMake package exports CUTLASS even when its Fortran config does
+    # not.
+    $<$<AND:$<BOOL:${CP2K_USE_GAUXC}>,$<BOOL:${GAUXC_HAS_CUTLASS}>>:GAUXC_HAS_CUTLASS>
     # GauXC feature flags GAUXC_HAS_MPI, GAUXC_HAS_ONEDFT, GAUXC_HAS_HOST,
     # GAUXC_HAS_DEVICE, GAUXC_HAS_CUDA, and GAUXC_HAS_HDF5 are provided by
     # gauxc/gauxc_config.f in the Fortran sources.

--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -131,6 +131,9 @@ CONTAINS
 #if defined(GAUXC_HAS_CUDA)
       flags = TRIM(flags)//" gauxc_cuda"
 #endif
+#if defined(GAUXC_HAS_CUTLASS)
+      flags = TRIM(flags)//" gauxc_cutlass"
+#endif
 #if defined(GAUXC_HAS_HDF5)
       flags = TRIM(flags)//" gauxc_hdf5"
 #endif

--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -1588,11 +1588,13 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="LWD_KERNEL", &
                           description="Local work driver kernel used by the GauXC integrator. "// &
-                          "DEFAULT uses GauXC's default for the selected execution space. "// &
+                          "AUTO uses SCHEME1-CUTLASS for device SKALA when GauXC provides it "// &
+                          "and otherwise uses GauXC's default for the selected execution space. "// &
+                          "DEFAULT always uses GauXC's default. "// &
                           "Device builds with CUTLASS support can use SCHEME1-CUTLASS to run "// &
                           "the grouped local potential update through CUTLASS.", &
-                          usage="LWD_KERNEL DEFAULT", &
-                          default_c_val="DEFAULT")
+                          usage="LWD_KERNEL AUTO", &
+                          default_c_val="AUTO")
       CALL section_add_keyword(section, keyword)
       CALL keyword_release(keyword)
 

--- a/src/xc/xc_gauxc_functional.F
+++ b/src/xc/xc_gauxc_functional.F
@@ -5,6 +5,10 @@
 !   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
 !--------------------------------------------------------------------------------------------------!
 
+#ifdef __GAUXC
+#include "gauxc/gauxc_config.f"
+#endif
+
 MODULE xc_gauxc_functional
    USE atomic_kind_types,               ONLY: atomic_kind_type,&
                                               get_atomic_kind
@@ -969,9 +973,8 @@ CONTAINS
       REAL(KIND=dp), PARAMETER :: gapw_fd_gradient_dx = 1.0E-4_dp
 
       CHARACTER(len=default_path_length)                 :: model_key, model_name, output_path
-      CHARACTER(len=default_string_length)               :: gradient_runtime, gradient_runtime_key, &
-                                                            grid_key, pruning_key, skala_runtime, &
-                                                            skala_runtime_key, xc_fun_key
+      CHARACTER(len=default_string_length) :: gradient_runtime, gradient_runtime_key, grid_key, &
+         lwd_kernel_key, pruning_key, skala_runtime, skala_runtime_key, xc_fun_key
       INTEGER                                            :: atom_chunk_size, env_status, img, ispin, &
                                                             nimages
       LOGICAL :: atom_chunk_size_explicit, do_kpoints, gapw_method, gapw_paw_pseudopotentials, &
@@ -1152,6 +1155,16 @@ CONTAINS
       params%use_gauxc_model = (TRIM(model_key) /= "" .AND. TRIM(model_key) /= "NONE" .AND. &
                                 TRIM(model_key) /= TRIM(xc_fun_key))
       use_skala_model = (INDEX(TRIM(model_key), "SKALA") > 0)
+      lwd_kernel_key = ADJUSTL(params%lwd_kernel)
+      CALL uppercase(lwd_kernel_key)
+      IF (TRIM(lwd_kernel_key) == "AUTO") THEN
+         params%lwd_kernel = "DEFAULT"
+#if defined(GAUXC_HAS_CUTLASS)
+         IF (use_skala_model .AND. TRIM(params%int_exec_space) == "DEVICE") THEN
+            params%lwd_kernel = "SCHEME1-CUTLASS"
+         END IF
+#endif
+      END IF
       params%model_eval_name = model_name
       IF (.NOT. params%use_gauxc_model) THEN
          ! MODEL NONE and MODEL equal to FUNCTIONAL select conventional GauXC.


### PR DESCRIPTION
## Summary

- make `LWD_KERNEL AUTO` the default for GauXC integration
- select `SCHEME1-CUTLASS` automatically for device SKALA when GauXC provides CUTLASS support
- retain GauXC's default kernel for host execution, conventional functionals, and builds without CUTLASS
- preserve `LWD_KERNEL DEFAULT` as an explicit opt-out
- report CUTLASS support through the `gauxc_cutlass` CP2K flag

## Motivation

GauXC's `SCHEME1-CUTLASS` local-work-driver kernel substantially accelerates the grouped local-potential update used by SKALA on CUDA devices. Until now users had to know about this implementation detail and select the kernel explicitly.

`AUTO` makes the optimized kernel the default only for the configuration that benefits from it: `MODEL SKALA` with `INT_EXECUTION_SPACE DEVICE` and a CUTLASS-enabled GauXC build. All other configurations continue to use GauXC's default kernel.

Explicitly requesting `LWD_KERNEL DEFAULT` preserves the previous behavior.

GauXC exports CUTLASS availability through its CMake package but not through the generated Fortran configuration header. CP2K therefore propagates this feature as `GAUXC_HAS_CUTLASS` and exposes it in the runtime build flags.

## Performance

On Terok with one NVIDIA A40, one MPI rank, eight OpenMP threads, the SKALA 1.1 Rev1 CUDA model, and a six-water molecular test, two alternating runs per configuration gave:

| Kernel | Mean wall time | Mean CP2K time | Mean peak host RSS | Peak GPU memory |
|---|---:|---:|---:|---:|
| `DEFAULT` | 6.445 s | 3.485 s | 1,469,452 KiB | 8,807 MiB |
| `AUTO` / CUTLASS | 5.351 s | 2.374 s | 1,455,084 KiB | 8,807 MiB |

This corresponds to a 17.0% wall-time reduction and a 31.9% reduction in CP2K time. Peak GPU memory is unchanged and mean peak host RSS is about 1.0% lower.

All runs produced the identical total energy `-102.465949637613207 Ha`.

## Compatibility

- builds without GauXC CUTLASS support map `AUTO` to `DEFAULT`
- host SKALA execution continues to use `DEFAULT`
- conventional GauXC functionals continue to use `DEFAULT`
- users can retain the old behavior explicitly with `LWD_KERNEL DEFAULT`

## Validation

- CP2K precommit checks for all four changed files
- GauXC CUDA/CUTLASS/LibTorch build on Terok
- alternating `AUTO`/`DEFAULT` one-GPU timing and memory measurements
- identical energies for both kernel selections
- empty stderr output for all benchmark runs
- conventional GauXC PBE fallback smoke test

Related to #5439.
