### PR TITLE
Deduplicate native SKALA MPI grid routes

### DIFF
--- a/src/skala_gpw_features.F
+++ b/src/skala_gpw_features.F
@@ -64,7 +64,9 @@ MODULE skala_gpw_features
                                                             route_grad_return_recv_displs, &
                                                             route_grad_return_send_counts, &
                                                             route_grad_return_send_displs, &
-                                                            route_local_positions, chunk_return_positions, &
+                                                            chunk_return_positions, route_chunk_offsets, &
+                                                            route_chunk_rows, route_row_offsets, &
+                                                            route_row_positions, route_send_local_rows, &
                                                             route_point_recv_counts, &
                                                             route_point_recv_displs, &
                                                             route_point_send_counts, &
@@ -142,7 +144,6 @@ MODULE skala_gpw_features
       INTEGER, ALLOCATABLE, DIMENSION(:)                :: chunk_grad_counts, chunk_grad_displs, &
                                                            local_feature_counts, local_feature_offsets, &
                                                            local_feature_rows, &
-                                                           chunk_return_positions, &
                                                            route_grad_return_recv_counts, &
                                                            route_grad_return_recv_displs, &
                                                            route_grad_return_send_counts, &
@@ -151,7 +152,9 @@ MODULE skala_gpw_features
                                                            route_point_recv_displs, &
                                                            route_point_send_counts, &
                                                            route_point_send_displs, &
-                                                           route_local_positions
+                                                           route_chunk_offsets, route_chunk_rows, &
+                                                           route_row_offsets, route_row_positions, &
+                                                           route_send_local_rows
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)          :: feature_index
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:)    :: atomic_grid_sizes
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :) :: atomic_grid_size_bound_shape
@@ -1020,7 +1023,11 @@ CONTAINS
                 features%route_point_recv_displs(cached_layout%nproc), &
                 features%route_point_send_counts(cached_layout%nproc), &
                 features%route_point_send_displs(cached_layout%nproc), &
-                features%route_local_positions(SIZE(cached_layout%route_local_positions)))
+                features%route_chunk_offsets(SIZE(cached_layout%route_chunk_offsets)), &
+                features%route_chunk_rows(SIZE(cached_layout%route_chunk_rows)), &
+                features%route_row_offsets(SIZE(cached_layout%route_row_offsets)), &
+                features%route_row_positions(SIZE(cached_layout%route_row_positions)), &
+                features%route_send_local_rows(SIZE(cached_layout%route_send_local_rows)))
       features%chunk_grad_counts(:) = cached_layout%chunk_grad_counts
       features%chunk_grad_displs(:) = cached_layout%chunk_grad_displs
       features%route_grad_return_recv_counts(:) = cached_layout%route_grad_return_recv_counts
@@ -1031,7 +1038,11 @@ CONTAINS
       features%route_point_recv_displs(:) = cached_layout%route_point_recv_displs
       features%route_point_send_counts(:) = cached_layout%route_point_send_counts
       features%route_point_send_displs(:) = cached_layout%route_point_send_displs
-      features%route_local_positions(:) = cached_layout%route_local_positions
+      features%route_chunk_offsets(:) = cached_layout%route_chunk_offsets
+      features%route_chunk_rows(:) = cached_layout%route_chunk_rows
+      features%route_row_offsets(:) = cached_layout%route_row_offsets
+      features%route_row_positions(:) = cached_layout%route_row_positions
+      features%route_send_local_rows(:) = cached_layout%route_send_local_rows
       IF (needs_coordinate_array) THEN
          ALLOCATE (features%coarse_0_atomic_coords(3, cached_layout%natom))
          features%coarse_0_atomic_coords(:, :) = cached_layout%coarse_0_atomic_coords
@@ -1203,52 +1214,143 @@ CONTAINS
 
       CLASS(mp_comm_type), INTENT(IN)                    :: group
 
-      INTEGER                                            :: chunk_row, dest, local_feature, point_pos, row
-      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: cursor, recv_meta, route_local_dest, send_meta
+      INTEGER                                            :: chunk_row, dest, feature_begin, feature_end, &
+                                                            feature_pos, local_feature, local_row, meta_pos, &
+                                                            nflat_local, nproc, nrecv, nsend, pe, point_pos, &
+                                                            route_index, row, row_position
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: chunk_cursor, chunk_route_counts, &
+                                                            feature_cursor, feature_recv_counts, &
+                                                            feature_recv_displs, feature_send_counts, &
+                                                            feature_send_displs, meta_recv_counts, &
+                                                            meta_recv_displs, meta_send_counts, &
+                                                            meta_send_displs, recv_meta, route_cursor, &
+                                                            route_feature_dest, route_last_row, &
+                                                            route_last_position, send_meta
 
-      ALLOCATE (route_local_dest(SIZE(local_to_global)), &
-                cache%route_local_positions(SIZE(local_to_global)), &
-                cache%chunk_return_positions(cache%chunk_feature_count), &
-                cursor(SIZE(cache%route_point_send_counts)))
+      nflat_local = SIZE(cache%local_feature_offsets) - 1
+      nproc = SIZE(cache%route_point_send_counts)
+      ALLOCATE (route_feature_dest(SIZE(local_to_global)), &
+                feature_send_counts(nproc), feature_send_displs(nproc), &
+                feature_recv_counts(nproc), feature_recv_displs(nproc), &
+                route_last_row(nproc), route_last_position(nproc))
       cache%route_point_send_counts = 0
-      cache%route_local_positions = 0
-      cache%chunk_return_positions = 0
-      DO local_feature = 1, SIZE(local_to_global)
-         dest = feature_row_chunk_owner(local_to_global(local_feature), &
-                                        cache%chunk_feature_counts, &
-                                        cache%chunk_feature_displs)
-         CPASSERT(dest > 0)
-         route_local_dest(local_feature) = dest
-         cache%route_point_send_counts(dest) = cache%route_point_send_counts(dest) + 1
+      feature_send_counts = 0
+      route_feature_dest = 0
+      route_last_row = 0
+      ! Route each local grid row only once to each atom-chunk owner.
+      DO local_row = 1, nflat_local
+         feature_begin = cache%local_feature_offsets(local_row)
+         feature_end = cache%local_feature_offsets(local_row + 1) - 1
+         DO local_feature = feature_begin, feature_end
+            dest = feature_row_chunk_owner(local_to_global(local_feature), &
+                                           cache%chunk_feature_counts, &
+                                           cache%chunk_feature_displs)
+            CPASSERT(dest > 0)
+            route_feature_dest(local_feature) = dest
+            feature_send_counts(dest) = feature_send_counts(dest) + 1
+            IF (route_last_row(dest) /= local_row) THEN
+               cache%route_point_send_counts(dest) = cache%route_point_send_counts(dest) + 1
+               route_last_row(dest) = local_row
+            END IF
+         END DO
       END DO
       CALL counts_to_displs(cache%route_point_send_counts, cache%route_point_send_displs)
-      cursor(:) = cache%route_point_send_displs + 1
-      DO local_feature = 1, SIZE(local_to_global)
-         dest = route_local_dest(local_feature)
-         point_pos = cursor(dest)
-         cursor(dest) = cursor(dest) + 1
-         cache%route_local_positions(local_feature) = point_pos
-      END DO
+      CALL counts_to_displs(feature_send_counts, feature_send_displs)
       CALL group%alltoall(cache%route_point_send_counts, cache%route_point_recv_counts, 1)
       CALL counts_to_displs(cache%route_point_recv_counts, cache%route_point_recv_displs)
+      CALL group%alltoall(feature_send_counts, feature_recv_counts, 1)
+      CALL counts_to_displs(feature_recv_counts, feature_recv_displs)
 
-      ALLOCATE (send_meta(SIZE(local_to_global)), recv_meta(cache%chunk_feature_count))
-      cursor(:) = cache%route_point_send_displs + 1
-      DO local_feature = 1, SIZE(local_to_global)
-         dest = route_local_dest(local_feature)
-         point_pos = cursor(dest)
-         cursor(dest) = cursor(dest) + 1
-         send_meta(point_pos) = local_to_global(local_feature)
+      nsend = SUM(cache%route_point_send_counts)
+      nrecv = SUM(cache%route_point_recv_counts)
+      ALLOCATE (cache%route_send_local_rows(nsend), &
+                cache%route_row_offsets(nflat_local + 1), &
+                cache%route_row_positions(nsend), &
+                route_cursor(nproc), feature_cursor(nproc), &
+                send_meta(2*SIZE(local_to_global)), &
+                recv_meta(2*cache%chunk_feature_count), &
+                meta_send_counts(nproc), meta_send_displs(nproc), &
+                meta_recv_counts(nproc), meta_recv_displs(nproc))
+      cache%route_send_local_rows = 0
+      cache%route_row_positions = 0
+      send_meta = 0
+      route_cursor(:) = cache%route_point_send_displs + 1
+      feature_cursor(:) = feature_send_displs + 1
+      route_last_row = 0
+      route_last_position = 0
+      cache%route_row_offsets(1) = 1
+      row_position = 1
+      DO local_row = 1, nflat_local
+         feature_begin = cache%local_feature_offsets(local_row)
+         feature_end = cache%local_feature_offsets(local_row + 1) - 1
+         DO local_feature = feature_begin, feature_end
+            dest = route_feature_dest(local_feature)
+            IF (route_last_row(dest) /= local_row) THEN
+               point_pos = route_cursor(dest)
+               route_cursor(dest) = route_cursor(dest) + 1
+               route_last_row(dest) = local_row
+               route_last_position(dest) = point_pos
+               cache%route_send_local_rows(point_pos) = local_row
+               cache%route_row_positions(row_position) = point_pos
+               row_position = row_position + 1
+            ELSE
+               point_pos = route_last_position(dest)
+            END IF
+            feature_pos = feature_cursor(dest)
+            feature_cursor(dest) = feature_cursor(dest) + 1
+            send_meta(2*feature_pos - 1) = local_to_global(local_feature)
+            send_meta(2*feature_pos) = point_pos - cache%route_point_send_displs(dest)
+         END DO
+         cache%route_row_offsets(local_row + 1) = row_position
       END DO
-      CALL group%alltoall(send_meta, cache%route_point_send_counts, &
-                          cache%route_point_send_displs, recv_meta, &
-                          cache%route_point_recv_counts, &
-                          cache%route_point_recv_displs)
-      DO point_pos = 1, cache%chunk_feature_count
-         row = recv_meta(point_pos)
-         chunk_row = row - cache%chunk_feature_begin + 1
-         CPASSERT(chunk_row >= 1 .AND. chunk_row <= cache%chunk_feature_count)
-         cache%chunk_return_positions(chunk_row) = point_pos
+      CPASSERT(row_position == nsend + 1)
+
+      ! Tell each chunk owner which feature rows share a compressed route point.
+      meta_send_counts(:) = 2*feature_send_counts
+      meta_send_displs(:) = 2*feature_send_displs
+      meta_recv_counts(:) = 2*feature_recv_counts
+      meta_recv_displs(:) = 2*feature_recv_displs
+      CALL group%alltoall(send_meta, meta_send_counts, meta_send_displs, recv_meta, &
+                          meta_recv_counts, meta_recv_displs)
+
+      ! Store the route-to-feature expansion in CSR form for gradient reduction.
+      ALLOCATE (cache%chunk_return_positions(cache%chunk_feature_count), &
+                cache%route_chunk_offsets(nrecv + 1), &
+                cache%route_chunk_rows(cache%chunk_feature_count), &
+                chunk_route_counts(nrecv), chunk_cursor(nrecv))
+      cache%chunk_return_positions = 0
+      cache%route_chunk_rows = 0
+      chunk_route_counts = 0
+      DO pe = 1, nproc
+         DO feature_pos = feature_recv_displs(pe) + 1, &
+            feature_recv_displs(pe) + feature_recv_counts(pe)
+            meta_pos = 2*feature_pos
+            row = recv_meta(meta_pos - 1)
+            route_index = recv_meta(meta_pos)
+            point_pos = cache%route_point_recv_displs(pe) + route_index
+            CPASSERT(point_pos >= 1 .AND. point_pos <= nrecv)
+            chunk_row = row - cache%chunk_feature_begin + 1
+            CPASSERT(chunk_row >= 1 .AND. chunk_row <= cache%chunk_feature_count)
+            cache%chunk_return_positions(chunk_row) = point_pos
+            chunk_route_counts(point_pos) = chunk_route_counts(point_pos) + 1
+         END DO
+      END DO
+      cache%route_chunk_offsets(1) = 1
+      DO point_pos = 1, nrecv
+         cache%route_chunk_offsets(point_pos + 1) = &
+            cache%route_chunk_offsets(point_pos) + chunk_route_counts(point_pos)
+      END DO
+      chunk_cursor(:) = cache%route_chunk_offsets(1:nrecv)
+      DO pe = 1, nproc
+         DO feature_pos = feature_recv_displs(pe) + 1, &
+            feature_recv_displs(pe) + feature_recv_counts(pe)
+            meta_pos = 2*feature_pos
+            row = recv_meta(meta_pos - 1)
+            chunk_row = row - cache%chunk_feature_begin + 1
+            point_pos = cache%chunk_return_positions(chunk_row)
+            cache%route_chunk_rows(chunk_cursor(point_pos)) = chunk_row
+            chunk_cursor(point_pos) = chunk_cursor(point_pos) + 1
+         END DO
       END DO
 
       cache%route_grad_return_send_counts(:) = ngrad_per_point*cache%route_point_recv_counts
@@ -1256,12 +1358,20 @@ CONTAINS
       cache%route_grad_return_recv_counts(:) = ngrad_per_point*cache%route_point_send_counts
       cache%route_grad_return_recv_displs(:) = ngrad_per_point*cache%route_point_send_displs
 
-      CPASSERT(SUM(cache%route_point_send_counts) == SIZE(local_to_global))
-      CPASSERT(SUM(cache%route_point_recv_counts) == cache%chunk_feature_count)
-      CPASSERT(ALL(cache%route_local_positions > 0))
+      CPASSERT(SUM(feature_send_counts) == SIZE(local_to_global))
+      CPASSERT(SUM(feature_recv_counts) == cache%chunk_feature_count)
+      CPASSERT(SUM(cache%route_point_send_counts) == nsend)
+      CPASSERT(SUM(cache%route_point_recv_counts) == nrecv)
       CPASSERT(ALL(cache%chunk_return_positions > 0))
+      CPASSERT(ALL(cache%route_chunk_rows > 0))
+      CPASSERT(ALL(cache%route_row_positions > 0))
+      CPASSERT(ALL(cache%route_send_local_rows > 0))
 
-      DEALLOCATE (cursor, recv_meta, route_local_dest, send_meta)
+      DEALLOCATE (chunk_cursor, chunk_route_counts, feature_cursor, feature_recv_counts, &
+                  feature_recv_displs, feature_send_counts, feature_send_displs, &
+                  meta_recv_counts, meta_recv_displs, meta_send_counts, meta_send_displs, &
+                  recv_meta, route_cursor, route_feature_dest, route_last_position, route_last_row, &
+                  send_meta)
 
    END SUBROUTINE build_atom_chunk_routes
 
@@ -1315,16 +1425,15 @@ CONTAINS
       CLASS(mp_comm_type), INTENT(IN)                    :: group
       LOGICAL, INTENT(IN)                                :: collapse_spin_dynamics
 
-      INTEGER                                            :: chunk_row, dyn_base, local_feature, local_row, &
+      INTEGER                                            :: chunk_row, dyn_base, local_row, &
                                                             ndynamic_route_per_point, nrecv, nsend, &
                                                             point_pos, src_base
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: recv_counts, recv_displs, send_counts, send_displs
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: recv_dynamic, send_dynamic
 
-      nsend = SIZE(cached_layout%route_local_positions)
+      nsend = SIZE(cached_layout%route_send_local_rows)
       nrecv = SUM(cached_layout%route_point_recv_counts)
-      CPASSERT(nsend == SIZE(cached_layout%local_feature_rows))
-      CPASSERT(nrecv == cached_layout%chunk_feature_count)
+      CPASSERT(nsend == SUM(cached_layout%route_point_send_counts))
       ndynamic_route_per_point = ndynamic_per_point
       IF (collapse_spin_dynamics) ndynamic_route_per_point = nrks_dynamic_per_point
 
@@ -1339,11 +1448,10 @@ CONTAINS
       recv_displs(:) = ndynamic_route_per_point*cached_layout%route_point_recv_displs
 !$OMP PARALLEL DO DEFAULT(NONE) &
 !$OMP SHARED(cached_layout, local_dynamic, ndynamic_route_per_point, nsend, send_dynamic) &
-!$OMP PRIVATE(dyn_base, local_feature, local_row, point_pos, src_base)
-      DO local_feature = 1, nsend
-         point_pos = cached_layout%route_local_positions(local_feature)
+!$OMP PRIVATE(dyn_base, local_row, point_pos, src_base)
+      DO point_pos = 1, nsend
          dyn_base = ndynamic_route_per_point*(point_pos - 1)
-         local_row = cached_layout%local_feature_points(local_feature)
+         local_row = cached_layout%route_send_local_rows(point_pos)
          src_base = ndynamic_route_per_point*(local_row - 1)
          send_dynamic(dyn_base + 1:dyn_base + ndynamic_route_per_point) = &
             local_dynamic(src_base + 1:src_base + ndynamic_route_per_point)
@@ -1358,22 +1466,19 @@ CONTAINS
          IF (collapse_spin_dynamics) THEN
             ALLOCATE (features%chunk_density(cached_layout%chunk_feature_count, 1), &
                       features%chunk_grad(cached_layout%chunk_feature_count, 3, 1), &
-                      features%chunk_kin(cached_layout%chunk_feature_count, 1), &
-                      features%chunk_return_positions(cached_layout%chunk_feature_count))
+                      features%chunk_kin(cached_layout%chunk_feature_count, 1))
          ELSE
             ALLOCATE (features%chunk_density(cached_layout%chunk_feature_count, 2), &
                       features%chunk_grad(cached_layout%chunk_feature_count, 3, 2), &
-                      features%chunk_kin(cached_layout%chunk_feature_count, 2), &
-                      features%chunk_return_positions(cached_layout%chunk_feature_count))
+                      features%chunk_kin(cached_layout%chunk_feature_count, 2))
          END IF
-         features%chunk_return_positions(:) = cached_layout%chunk_return_positions
 
 !$OMP PARALLEL DO DEFAULT(NONE) &
-!$OMP SHARED(cached_layout, collapse_spin_dynamics, features, ndynamic_route_per_point, recv_dynamic) &
+!$OMP SHARED(cached_layout, collapse_spin_dynamics, features, ndynamic_route_per_point, nrecv, recv_dynamic) &
 !$OMP PRIVATE(chunk_row, dyn_base, point_pos)
          DO chunk_row = 1, cached_layout%chunk_feature_count
             point_pos = cached_layout%chunk_return_positions(chunk_row)
-            CPASSERT(point_pos >= 1 .AND. point_pos <= cached_layout%chunk_feature_count)
+            CPASSERT(point_pos >= 1 .AND. point_pos <= nrecv)
             dyn_base = ndynamic_route_per_point*(point_pos - 1)
             IF (collapse_spin_dynamics) THEN
                features%chunk_density(chunk_row, 1) = recv_dynamic(dyn_base + 1)
@@ -1393,7 +1498,6 @@ CONTAINS
             END IF
          END DO
 !$OMP END PARALLEL DO
-         CPASSERT(ALL(features%chunk_return_positions > 0))
       END IF
 
       DEALLOCATE (recv_counts, recv_displs, recv_dynamic, send_counts, send_displs, send_dynamic)
@@ -1523,12 +1627,16 @@ CONTAINS
       IF (ALLOCATED(cache%route_grad_return_send_displs)) THEN
          DEALLOCATE (cache%route_grad_return_send_displs)
       END IF
-      IF (ALLOCATED(cache%route_local_positions)) DEALLOCATE (cache%route_local_positions)
       IF (ALLOCATED(cache%chunk_return_positions)) DEALLOCATE (cache%chunk_return_positions)
+      IF (ALLOCATED(cache%route_chunk_offsets)) DEALLOCATE (cache%route_chunk_offsets)
+      IF (ALLOCATED(cache%route_chunk_rows)) DEALLOCATE (cache%route_chunk_rows)
       IF (ALLOCATED(cache%route_point_recv_counts)) DEALLOCATE (cache%route_point_recv_counts)
       IF (ALLOCATED(cache%route_point_recv_displs)) DEALLOCATE (cache%route_point_recv_displs)
       IF (ALLOCATED(cache%route_point_send_counts)) DEALLOCATE (cache%route_point_send_counts)
       IF (ALLOCATED(cache%route_point_send_displs)) DEALLOCATE (cache%route_point_send_displs)
+      IF (ALLOCATED(cache%route_row_offsets)) DEALLOCATE (cache%route_row_offsets)
+      IF (ALLOCATED(cache%route_row_positions)) DEALLOCATE (cache%route_row_positions)
+      IF (ALLOCATED(cache%route_send_local_rows)) DEALLOCATE (cache%route_send_local_rows)
       IF (ALLOCATED(cache%dynamic_counts)) DEALLOCATE (cache%dynamic_counts)
       IF (ALLOCATED(cache%dynamic_displs)) DEALLOCATE (cache%dynamic_displs)
       IF (ALLOCATED(cache%feature_counts)) DEALLOCATE (cache%feature_counts)
@@ -1650,7 +1758,6 @@ CONTAINS
       IF (ALLOCATED(features%kin)) DEALLOCATE (features%kin)
       IF (ALLOCATED(features%chunk_grad_counts)) DEALLOCATE (features%chunk_grad_counts)
       IF (ALLOCATED(features%chunk_grad_displs)) DEALLOCATE (features%chunk_grad_displs)
-      IF (ALLOCATED(features%chunk_return_positions)) DEALLOCATE (features%chunk_return_positions)
       IF (ALLOCATED(features%route_grad_return_recv_counts)) THEN
          DEALLOCATE (features%route_grad_return_recv_counts)
       END IF
@@ -1675,7 +1782,11 @@ CONTAINS
       IF (ALLOCATED(features%route_point_send_displs)) THEN
          DEALLOCATE (features%route_point_send_displs)
       END IF
-      IF (ALLOCATED(features%route_local_positions)) DEALLOCATE (features%route_local_positions)
+      IF (ALLOCATED(features%route_chunk_offsets)) DEALLOCATE (features%route_chunk_offsets)
+      IF (ALLOCATED(features%route_chunk_rows)) DEALLOCATE (features%route_chunk_rows)
+      IF (ALLOCATED(features%route_row_offsets)) DEALLOCATE (features%route_row_offsets)
+      IF (ALLOCATED(features%route_row_positions)) DEALLOCATE (features%route_row_positions)
+      IF (ALLOCATED(features%route_send_local_rows)) DEALLOCATE (features%route_send_local_rows)
       IF (ALLOCATED(features%feature_index)) DEALLOCATE (features%feature_index)
       IF (ALLOCATED(features%local_feature_counts)) DEALLOCATE (features%local_feature_counts)
       IF (ALLOCATED(features%local_feature_offsets)) DEALLOCATE (features%local_feature_offsets)

--- a/src/skala_gpw_features.F
+++ b/src/skala_gpw_features.F
@@ -60,10 +60,6 @@ MODULE skala_gpw_features
                                                             feature_source_points, global_to_feature, &
                                                             local_feature_counts, local_feature_offsets, &
                                                             local_feature_points, local_feature_rows, &
-                                                            route_grad_return_recv_counts, &
-                                                            route_grad_return_recv_displs, &
-                                                            route_grad_return_send_counts, &
-                                                            route_grad_return_send_displs, &
                                                             chunk_return_positions, route_chunk_offsets, &
                                                             route_chunk_rows, route_row_offsets, &
                                                             route_row_positions, route_send_local_rows, &
@@ -143,18 +139,16 @@ MODULE skala_gpw_features
       TYPE(torch_tensor_type)                           :: local_feature_indices_t
       INTEGER, ALLOCATABLE, DIMENSION(:)                :: chunk_grad_counts, chunk_grad_displs, &
                                                            local_feature_counts, local_feature_offsets, &
-                                                           local_feature_rows, &
-                                                           route_grad_return_recv_counts, &
-                                                           route_grad_return_recv_displs, &
-                                                           route_grad_return_send_counts, &
-                                                           route_grad_return_send_displs, &
-                                                           route_point_recv_counts, &
-                                                           route_point_recv_displs, &
-                                                           route_point_send_counts, &
-                                                           route_point_send_displs, &
-                                                           route_chunk_offsets, route_chunk_rows, &
-                                                           route_row_offsets, route_row_positions, &
-                                                           route_send_local_rows
+                                                           local_feature_rows
+      INTEGER, POINTER, DIMENSION(:)                    :: route_point_recv_counts => NULL(), &
+                                                           route_point_recv_displs => NULL(), &
+                                                           route_point_send_counts => NULL(), &
+                                                           route_point_send_displs => NULL(), &
+                                                           route_chunk_offsets => NULL(), &
+                                                           route_chunk_rows => NULL(), &
+                                                           route_row_offsets => NULL(), &
+                                                           route_row_positions => NULL(), &
+                                                           route_send_local_rows => NULL()
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :)          :: feature_index
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:)    :: atomic_grid_sizes
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:, :) :: atomic_grid_size_bound_shape
@@ -177,7 +171,7 @@ MODULE skala_gpw_features
                                                             uses_collapsed_rks_dynamic = .FALSE.
    END TYPE skala_gpw_feature_type
 
-   TYPE(skala_gpw_layout_cache_type), SAVE               :: cached_layout
+   TYPE(skala_gpw_layout_cache_type), SAVE, TARGET       :: cached_layout
 
 CONTAINS
 
@@ -757,10 +751,6 @@ CONTAINS
                 cached_layout%chunk_grad_counts(nproc), cached_layout%chunk_grad_displs(nproc), &
                 cached_layout%feature_counts(nproc), cached_layout%feature_displs(nproc), &
                 cached_layout%dynamic_counts(nproc), cached_layout%dynamic_displs(nproc), &
-                cached_layout%route_grad_return_recv_counts(nproc), &
-                cached_layout%route_grad_return_recv_displs(nproc), &
-                cached_layout%route_grad_return_send_counts(nproc), &
-                cached_layout%route_grad_return_send_displs(nproc), &
                 cached_layout%route_point_recv_counts(nproc), &
                 cached_layout%route_point_recv_displs(nproc), &
                 cached_layout%route_point_send_counts(nproc), &
@@ -1024,35 +1014,20 @@ CONTAINS
          features%atomic_grid_weights(:) = cached_layout%atomic_grid_weights
       END IF
       ALLOCATE (features%chunk_grad_counts(cached_layout%nproc), &
-                features%chunk_grad_displs(cached_layout%nproc), &
-                features%route_grad_return_recv_counts(cached_layout%nproc), &
-                features%route_grad_return_recv_displs(cached_layout%nproc), &
-                features%route_grad_return_send_counts(cached_layout%nproc), &
-                features%route_grad_return_send_displs(cached_layout%nproc), &
-                features%route_point_recv_counts(cached_layout%nproc), &
-                features%route_point_recv_displs(cached_layout%nproc), &
-                features%route_point_send_counts(cached_layout%nproc), &
-                features%route_point_send_displs(cached_layout%nproc), &
-                features%route_chunk_offsets(SIZE(cached_layout%route_chunk_offsets)), &
-                features%route_chunk_rows(SIZE(cached_layout%route_chunk_rows)), &
-                features%route_row_offsets(SIZE(cached_layout%route_row_offsets)), &
-                features%route_row_positions(SIZE(cached_layout%route_row_positions)), &
-                features%route_send_local_rows(SIZE(cached_layout%route_send_local_rows)))
+                features%chunk_grad_displs(cached_layout%nproc))
       features%chunk_grad_counts(:) = cached_layout%chunk_grad_counts
       features%chunk_grad_displs(:) = cached_layout%chunk_grad_displs
-      features%route_grad_return_recv_counts(:) = cached_layout%route_grad_return_recv_counts
-      features%route_grad_return_recv_displs(:) = cached_layout%route_grad_return_recv_displs
-      features%route_grad_return_send_counts(:) = cached_layout%route_grad_return_send_counts
-      features%route_grad_return_send_displs(:) = cached_layout%route_grad_return_send_displs
-      features%route_point_recv_counts(:) = cached_layout%route_point_recv_counts
-      features%route_point_recv_displs(:) = cached_layout%route_point_recv_displs
-      features%route_point_send_counts(:) = cached_layout%route_point_send_counts
-      features%route_point_send_displs(:) = cached_layout%route_point_send_displs
-      features%route_chunk_offsets(:) = cached_layout%route_chunk_offsets
-      features%route_chunk_rows(:) = cached_layout%route_chunk_rows
-      features%route_row_offsets(:) = cached_layout%route_row_offsets
-      features%route_row_positions(:) = cached_layout%route_row_positions
-      features%route_send_local_rows(:) = cached_layout%route_send_local_rows
+      IF (use_atom_chunk_routing) THEN
+         features%route_point_recv_counts => cached_layout%route_point_recv_counts
+         features%route_point_recv_displs => cached_layout%route_point_recv_displs
+         features%route_point_send_counts => cached_layout%route_point_send_counts
+         features%route_point_send_displs => cached_layout%route_point_send_displs
+         features%route_chunk_offsets => cached_layout%route_chunk_offsets
+         features%route_chunk_rows => cached_layout%route_chunk_rows
+         features%route_row_offsets => cached_layout%route_row_offsets
+         features%route_row_positions => cached_layout%route_row_positions
+         features%route_send_local_rows => cached_layout%route_send_local_rows
+      END IF
       IF (needs_coordinate_array) THEN
          ALLOCATE (features%coarse_0_atomic_coords(3, cached_layout%natom))
          features%coarse_0_atomic_coords(:, :) = cached_layout%coarse_0_atomic_coords
@@ -1363,11 +1338,6 @@ CONTAINS
          END DO
       END DO
 
-      cache%route_grad_return_send_counts(:) = ngrad_per_point*cache%route_point_recv_counts
-      cache%route_grad_return_send_displs(:) = ngrad_per_point*cache%route_point_recv_displs
-      cache%route_grad_return_recv_counts(:) = ngrad_per_point*cache%route_point_send_counts
-      cache%route_grad_return_recv_displs(:) = ngrad_per_point*cache%route_point_send_displs
-
       CPASSERT(SUM(feature_send_counts) == SIZE(local_to_global))
       CPASSERT(SUM(feature_recv_counts) == cache%chunk_feature_count)
       CPASSERT(SUM(cache%route_point_send_counts) == nsend)
@@ -1625,18 +1595,6 @@ CONTAINS
       IF (ALLOCATED(cache%chunk_feature_displs)) DEALLOCATE (cache%chunk_feature_displs)
       IF (ALLOCATED(cache%chunk_grad_counts)) DEALLOCATE (cache%chunk_grad_counts)
       IF (ALLOCATED(cache%chunk_grad_displs)) DEALLOCATE (cache%chunk_grad_displs)
-      IF (ALLOCATED(cache%route_grad_return_recv_counts)) THEN
-         DEALLOCATE (cache%route_grad_return_recv_counts)
-      END IF
-      IF (ALLOCATED(cache%route_grad_return_recv_displs)) THEN
-         DEALLOCATE (cache%route_grad_return_recv_displs)
-      END IF
-      IF (ALLOCATED(cache%route_grad_return_send_counts)) THEN
-         DEALLOCATE (cache%route_grad_return_send_counts)
-      END IF
-      IF (ALLOCATED(cache%route_grad_return_send_displs)) THEN
-         DEALLOCATE (cache%route_grad_return_send_displs)
-      END IF
       IF (ALLOCATED(cache%chunk_return_positions)) DEALLOCATE (cache%chunk_return_positions)
       IF (ALLOCATED(cache%route_chunk_offsets)) DEALLOCATE (cache%route_chunk_offsets)
       IF (ALLOCATED(cache%route_chunk_rows)) DEALLOCATE (cache%route_chunk_rows)
@@ -1768,35 +1726,11 @@ CONTAINS
       IF (ALLOCATED(features%kin)) DEALLOCATE (features%kin)
       IF (ALLOCATED(features%chunk_grad_counts)) DEALLOCATE (features%chunk_grad_counts)
       IF (ALLOCATED(features%chunk_grad_displs)) DEALLOCATE (features%chunk_grad_displs)
-      IF (ALLOCATED(features%route_grad_return_recv_counts)) THEN
-         DEALLOCATE (features%route_grad_return_recv_counts)
-      END IF
-      IF (ALLOCATED(features%route_grad_return_recv_displs)) THEN
-         DEALLOCATE (features%route_grad_return_recv_displs)
-      END IF
-      IF (ALLOCATED(features%route_grad_return_send_counts)) THEN
-         DEALLOCATE (features%route_grad_return_send_counts)
-      END IF
-      IF (ALLOCATED(features%route_grad_return_send_displs)) THEN
-         DEALLOCATE (features%route_grad_return_send_displs)
-      END IF
-      IF (ALLOCATED(features%route_point_recv_counts)) THEN
-         DEALLOCATE (features%route_point_recv_counts)
-      END IF
-      IF (ALLOCATED(features%route_point_recv_displs)) THEN
-         DEALLOCATE (features%route_point_recv_displs)
-      END IF
-      IF (ALLOCATED(features%route_point_send_counts)) THEN
-         DEALLOCATE (features%route_point_send_counts)
-      END IF
-      IF (ALLOCATED(features%route_point_send_displs)) THEN
-         DEALLOCATE (features%route_point_send_displs)
-      END IF
-      IF (ALLOCATED(features%route_chunk_offsets)) DEALLOCATE (features%route_chunk_offsets)
-      IF (ALLOCATED(features%route_chunk_rows)) DEALLOCATE (features%route_chunk_rows)
-      IF (ALLOCATED(features%route_row_offsets)) DEALLOCATE (features%route_row_offsets)
-      IF (ALLOCATED(features%route_row_positions)) DEALLOCATE (features%route_row_positions)
-      IF (ALLOCATED(features%route_send_local_rows)) DEALLOCATE (features%route_send_local_rows)
+      NULLIFY (features%route_point_recv_counts, features%route_point_recv_displs, &
+               features%route_point_send_counts, features%route_point_send_displs, &
+               features%route_chunk_offsets, features%route_chunk_rows, &
+               features%route_row_offsets, features%route_row_positions, &
+               features%route_send_local_rows)
       IF (ALLOCATED(features%feature_index)) DEALLOCATE (features%feature_index)
       IF (ALLOCATED(features%local_feature_counts)) DEALLOCATE (features%local_feature_counts)
       IF (ALLOCATED(features%local_feature_offsets)) DEALLOCATE (features%local_feature_offsets)

--- a/src/skala_gpw_features.F
+++ b/src/skala_gpw_features.F
@@ -323,7 +323,8 @@ CONTAINS
       CALL timestop(phase_handle)
 
       CALL timeset("skala_gpw_copy_layout", phase_handle)
-      CALL copy_cached_layout(features, my_requires_coordinate_grad .OR. my_requires_stress_grad, &
+      CALL copy_cached_layout(features, use_atom_chunk_routing, &
+                              my_requires_coordinate_grad .OR. my_requires_stress_grad, &
                               my_requires_stress_grad .OR. &
                               (my_atom_partition == skala_gpw_atom_partition_smooth .AND. &
                                (my_requires_coordinate_grad .OR. my_requires_stress_grad)))
@@ -391,7 +392,11 @@ CONTAINS
          features%spin_moment = SUM((features%density(:, 1) - features%density(:, 2))* &
                                     features%grid_weights)
       END IF
-      features%grid_weight_sum = SUM(features%grid_weights)
+      IF (use_atom_chunk_routing) THEN
+         features%grid_weight_sum = SUM(cached_layout%grid_weights)
+      ELSE
+         features%grid_weight_sum = SUM(features%grid_weights)
+      END IF
       CALL timestop(phase_handle)
 
       CALL timeset("skala_gpw_tensor_update", phase_handle)
@@ -975,32 +980,37 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief Copy static cached layout arrays into a feature bundle.
 !> \param features ...
+!> \param use_atom_chunk_routing ...
 !> \param needs_coordinate_array ...
 !> \param needs_grid_coordinate_array ...
 ! **************************************************************************************************
-   SUBROUTINE copy_cached_layout(features, needs_coordinate_array, needs_grid_coordinate_array)
+   SUBROUTINE copy_cached_layout(features, use_atom_chunk_routing, needs_coordinate_array, &
+                                 needs_grid_coordinate_array)
       TYPE(skala_gpw_feature_type), INTENT(INOUT)        :: features
-      LOGICAL, INTENT(IN)                                :: needs_coordinate_array, &
+      LOGICAL, INTENT(IN)                                :: use_atom_chunk_routing, &
+                                                            needs_coordinate_array, &
                                                             needs_grid_coordinate_array
 
       CPASSERT(cached_layout%active)
 
-      ALLOCATE (features%feature_index(LBOUND(cached_layout%feature_index, 1): &
-                                       UBOUND(cached_layout%feature_index, 1), &
-                                       LBOUND(cached_layout%feature_index, 2): &
-                                       UBOUND(cached_layout%feature_index, 2), &
-                                       LBOUND(cached_layout%feature_index, 3): &
-                                       UBOUND(cached_layout%feature_index, 3)))
-      ALLOCATE (features%grid_weights(cached_layout%nflat))
-      ALLOCATE (features%local_feature_counts(cached_layout%nflat_local), &
-                features%local_feature_offsets(cached_layout%nflat_local + 1), &
-                features%local_feature_rows(SIZE(cached_layout%local_feature_rows)))
+      IF (.NOT. use_atom_chunk_routing) THEN
+         ALLOCATE (features%feature_index(LBOUND(cached_layout%feature_index, 1): &
+                                          UBOUND(cached_layout%feature_index, 1), &
+                                          LBOUND(cached_layout%feature_index, 2): &
+                                          UBOUND(cached_layout%feature_index, 2), &
+                                          LBOUND(cached_layout%feature_index, 3): &
+                                          UBOUND(cached_layout%feature_index, 3)))
+         ALLOCATE (features%grid_weights(cached_layout%nflat))
+         ALLOCATE (features%local_feature_counts(cached_layout%nflat_local), &
+                   features%local_feature_offsets(cached_layout%nflat_local + 1), &
+                   features%local_feature_rows(SIZE(cached_layout%local_feature_rows)))
 
-      features%feature_index(:, :, :) = cached_layout%feature_index
-      features%grid_weights(:) = cached_layout%grid_weights
-      features%local_feature_counts(:) = cached_layout%local_feature_counts
-      features%local_feature_offsets(:) = cached_layout%local_feature_offsets
-      features%local_feature_rows(:) = cached_layout%local_feature_rows
+         features%feature_index(:, :, :) = cached_layout%feature_index
+         features%grid_weights(:) = cached_layout%grid_weights
+         features%local_feature_counts(:) = cached_layout%local_feature_counts
+         features%local_feature_offsets(:) = cached_layout%local_feature_offsets
+         features%local_feature_rows(:) = cached_layout%local_feature_rows
+      END IF
       features%nflat = cached_layout%nflat
       features%nflat_local = cached_layout%nflat_local
       features%chunk_feature_count = cached_layout%chunk_feature_count

--- a/src/skala_gpw_functional.F
+++ b/src/skala_gpw_functional.F
@@ -1128,9 +1128,9 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
          INTENT(OUT)                                     :: grad_grad
 
-      INTEGER                                            :: isubchunk, nroute_grad_per_point, nroute_points, &
-                                                            nsubchunks, phase_handle, &
-                                                            subphase_handle
+      INTEGER                                            :: isubchunk, nroute_grad_per_point, &
+                                                            nroute_recv_points, nroute_send_points, &
+                                                            nsubchunks, phase_handle, subphase_handle
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: route_grad_return_recv_counts, &
                                                             route_grad_return_recv_displs, &
                                                             route_grad_return_send_counts, &
@@ -1153,13 +1153,14 @@ CONTAINS
       exc = 0.0_dp
       IF (compute_grads) THEN
          CPASSERT(features%uses_atom_chunk_routing)
-         CPASSERT(SUM(features%route_point_recv_counts) == features%chunk_feature_count)
-         nroute_points = SIZE(features%route_local_positions)
-         CPASSERT(SUM(features%route_point_send_counts) == nroute_points)
+         nroute_recv_points = SUM(features%route_point_recv_counts)
+         nroute_send_points = SIZE(features%route_send_local_rows)
+         CPASSERT(SUM(features%route_point_send_counts) == nroute_send_points)
+         CPASSERT(SIZE(features%route_chunk_offsets) == nroute_recv_points + 1)
          nroute_grad_per_point = ngrad_per_point
          IF (collapse_spin_grads) nroute_grad_per_point = ncollapsed_grad_per_point
-         ALLOCATE (send_grad_buffer(MAX(1, nroute_grad_per_point*features%chunk_feature_count)), &
-                   recv_grad_buffer(MAX(1, nroute_grad_per_point*nroute_points)), &
+         ALLOCATE (send_grad_buffer(MAX(1, nroute_grad_per_point*nroute_recv_points)), &
+                   recv_grad_buffer(MAX(1, nroute_grad_per_point*nroute_send_points)), &
                    route_grad_return_send_counts(SIZE(features%route_point_recv_counts)), &
                    route_grad_return_send_displs(SIZE(features%route_point_recv_displs)), &
                    route_grad_return_recv_counts(SIZE(features%route_point_send_counts)), &
@@ -1341,8 +1342,9 @@ CONTAINS
       LOGICAL, INTENT(IN)                                :: route_to_return_positions
       LOGICAL, INTENT(IN), OPTIONAL                      :: collapse_spin_grads
 
-      INTEGER                                            :: base, irow, ngrad_buffer_per_point, &
-                                                            point_pos, target_points
+      INTEGER                                            :: base, feature_pos, irow, &
+                                                            ngrad_buffer_per_point, point_pos, &
+                                                            target_points
       LOGICAL                                            :: my_collapse_spin_grads
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: chunk_density_grad, chunk_kin_grad
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: chunk_grad_grad
@@ -1358,7 +1360,6 @@ CONTAINS
                                   chunk_density_grad, chunk_grad_grad, chunk_kin_grad)
       CPASSERT(MOD(SIZE(TARGET), ngrad_buffer_per_point) == 0)
       target_points = SIZE(TARGET)/ngrad_buffer_per_point
-      CPASSERT(target_points >= features%chunk_feature_count)
       CPASSERT(SIZE(chunk_density_grad, 1) == features%chunk_feature_count)
       CPASSERT(SIZE(chunk_grad_grad, 1) == features%chunk_feature_count)
       CPASSERT(SIZE(chunk_grad_grad, 2) == 3)
@@ -1374,49 +1375,103 @@ CONTAINS
          CPASSERT(SIZE(chunk_kin_grad, 2) == 2)
       END IF
 
+      IF (route_to_return_positions) THEN
+         CPASSERT(target_points == SIZE(features%route_chunk_offsets) - 1)
 !$OMP PARALLEL DO DEFAULT(NONE) &
 !$OMP SHARED(chunk_density_grad, chunk_grad_grad, chunk_kin_grad, features, &
-!$OMP        my_collapse_spin_grads, ngrad_buffer_per_point, route_to_return_positions, &
-!$OMP        TARGET, target_points) &
-!$OMP PRIVATE(base, irow, point_pos)
-      DO irow = 1, features%chunk_feature_count
-         IF (route_to_return_positions) THEN
-            point_pos = features%chunk_return_positions(irow)
-            CPASSERT(point_pos >= 1 .AND. point_pos <= target_points)
-         ELSE
-            point_pos = irow
-         END IF
-         base = ngrad_buffer_per_point*(point_pos - 1)
-         IF (my_collapse_spin_grads) THEN
-            IF (features%uses_collapsed_rks_dynamic) THEN
-               TARGET(base + 1) = 0.5_dp*chunk_density_grad(irow, 1)
-               TARGET(base + 2) = 0.5_dp*chunk_grad_grad(irow, 1, 1)
-               TARGET(base + 3) = 0.5_dp*chunk_grad_grad(irow, 2, 1)
-               TARGET(base + 4) = 0.5_dp*chunk_grad_grad(irow, 3, 1)
-               TARGET(base + 5) = 0.5_dp*chunk_kin_grad(irow, 1)
-            ELSE
-               TARGET(base + 1) = 0.5_dp*(chunk_density_grad(irow, 1) + &
-                                          chunk_density_grad(irow, 2))
-               TARGET(base + 2) = 0.5_dp*(chunk_grad_grad(irow, 1, 1) + &
-                                          chunk_grad_grad(irow, 1, 2))
-               TARGET(base + 3) = 0.5_dp*(chunk_grad_grad(irow, 2, 1) + &
-                                          chunk_grad_grad(irow, 2, 2))
-               TARGET(base + 4) = 0.5_dp*(chunk_grad_grad(irow, 3, 1) + &
-                                          chunk_grad_grad(irow, 3, 2))
-               TARGET(base + 5) = 0.5_dp*(chunk_kin_grad(irow, 1) + chunk_kin_grad(irow, 2))
-            END IF
-         ELSE
-            TARGET(base + 1:base + 2) = chunk_density_grad(irow, :)
-            TARGET(base + 3) = chunk_grad_grad(irow, 1, 1)
-            TARGET(base + 4) = chunk_grad_grad(irow, 2, 1)
-            TARGET(base + 5) = chunk_grad_grad(irow, 3, 1)
-            TARGET(base + 6) = chunk_grad_grad(irow, 1, 2)
-            TARGET(base + 7) = chunk_grad_grad(irow, 2, 2)
-            TARGET(base + 8) = chunk_grad_grad(irow, 3, 2)
-            TARGET(base + 9:base + 10) = chunk_kin_grad(irow, :)
-         END IF
-      END DO
+!$OMP        my_collapse_spin_grads, ngrad_buffer_per_point, TARGET, target_points) &
+!$OMP PRIVATE(base, feature_pos, irow, point_pos)
+         DO point_pos = 1, target_points
+            base = ngrad_buffer_per_point*(point_pos - 1)
+            TARGET(base + 1:base + ngrad_buffer_per_point) = 0.0_dp
+            DO feature_pos = features%route_chunk_offsets(point_pos), &
+               features%route_chunk_offsets(point_pos + 1) - 1
+               irow = features%route_chunk_rows(feature_pos)
+               CPASSERT(irow >= 1 .AND. irow <= features%chunk_feature_count)
+               IF (my_collapse_spin_grads) THEN
+                  IF (features%uses_collapsed_rks_dynamic) THEN
+                     TARGET(base + 1) = TARGET(base + 1) + &
+                                        0.5_dp*chunk_density_grad(irow, 1)
+                     TARGET(base + 2) = TARGET(base + 2) + &
+                                        0.5_dp*chunk_grad_grad(irow, 1, 1)
+                     TARGET(base + 3) = TARGET(base + 3) + &
+                                        0.5_dp*chunk_grad_grad(irow, 2, 1)
+                     TARGET(base + 4) = TARGET(base + 4) + &
+                                        0.5_dp*chunk_grad_grad(irow, 3, 1)
+                     TARGET(base + 5) = TARGET(base + 5) + &
+                                        0.5_dp*chunk_kin_grad(irow, 1)
+                  ELSE
+                     TARGET(base + 1) = TARGET(base + 1) + &
+                                        0.5_dp*(chunk_density_grad(irow, 1) + &
+                                                chunk_density_grad(irow, 2))
+                     TARGET(base + 2) = TARGET(base + 2) + &
+                                        0.5_dp*(chunk_grad_grad(irow, 1, 1) + &
+                                                chunk_grad_grad(irow, 1, 2))
+                     TARGET(base + 3) = TARGET(base + 3) + &
+                                        0.5_dp*(chunk_grad_grad(irow, 2, 1) + &
+                                                chunk_grad_grad(irow, 2, 2))
+                     TARGET(base + 4) = TARGET(base + 4) + &
+                                        0.5_dp*(chunk_grad_grad(irow, 3, 1) + &
+                                                chunk_grad_grad(irow, 3, 2))
+                     TARGET(base + 5) = TARGET(base + 5) + &
+                                        0.5_dp*(chunk_kin_grad(irow, 1) + &
+                                                chunk_kin_grad(irow, 2))
+                  END IF
+               ELSE
+                  TARGET(base + 1:base + 2) = TARGET(base + 1:base + 2) + &
+                                              chunk_density_grad(irow, :)
+                  TARGET(base + 3) = TARGET(base + 3) + chunk_grad_grad(irow, 1, 1)
+                  TARGET(base + 4) = TARGET(base + 4) + chunk_grad_grad(irow, 2, 1)
+                  TARGET(base + 5) = TARGET(base + 5) + chunk_grad_grad(irow, 3, 1)
+                  TARGET(base + 6) = TARGET(base + 6) + chunk_grad_grad(irow, 1, 2)
+                  TARGET(base + 7) = TARGET(base + 7) + chunk_grad_grad(irow, 2, 2)
+                  TARGET(base + 8) = TARGET(base + 8) + chunk_grad_grad(irow, 3, 2)
+                  TARGET(base + 9:base + 10) = TARGET(base + 9:base + 10) + &
+                                               chunk_kin_grad(irow, :)
+               END IF
+            END DO
+         END DO
 !$OMP END PARALLEL DO
+      ELSE
+         CPASSERT(target_points >= features%chunk_feature_count)
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP SHARED(chunk_density_grad, chunk_grad_grad, chunk_kin_grad, features, &
+!$OMP        my_collapse_spin_grads, ngrad_buffer_per_point, TARGET) &
+!$OMP PRIVATE(base, irow)
+         DO irow = 1, features%chunk_feature_count
+            base = ngrad_buffer_per_point*(irow - 1)
+            IF (my_collapse_spin_grads) THEN
+               IF (features%uses_collapsed_rks_dynamic) THEN
+                  TARGET(base + 1) = 0.5_dp*chunk_density_grad(irow, 1)
+                  TARGET(base + 2) = 0.5_dp*chunk_grad_grad(irow, 1, 1)
+                  TARGET(base + 3) = 0.5_dp*chunk_grad_grad(irow, 2, 1)
+                  TARGET(base + 4) = 0.5_dp*chunk_grad_grad(irow, 3, 1)
+                  TARGET(base + 5) = 0.5_dp*chunk_kin_grad(irow, 1)
+               ELSE
+                  TARGET(base + 1) = 0.5_dp*(chunk_density_grad(irow, 1) + &
+                                             chunk_density_grad(irow, 2))
+                  TARGET(base + 2) = 0.5_dp*(chunk_grad_grad(irow, 1, 1) + &
+                                             chunk_grad_grad(irow, 1, 2))
+                  TARGET(base + 3) = 0.5_dp*(chunk_grad_grad(irow, 2, 1) + &
+                                             chunk_grad_grad(irow, 2, 2))
+                  TARGET(base + 4) = 0.5_dp*(chunk_grad_grad(irow, 3, 1) + &
+                                             chunk_grad_grad(irow, 3, 2))
+                  TARGET(base + 5) = 0.5_dp*(chunk_kin_grad(irow, 1) + &
+                                             chunk_kin_grad(irow, 2))
+               END IF
+            ELSE
+               TARGET(base + 1:base + 2) = chunk_density_grad(irow, :)
+               TARGET(base + 3) = chunk_grad_grad(irow, 1, 1)
+               TARGET(base + 4) = chunk_grad_grad(irow, 2, 1)
+               TARGET(base + 5) = chunk_grad_grad(irow, 3, 1)
+               TARGET(base + 6) = chunk_grad_grad(irow, 1, 2)
+               TARGET(base + 7) = chunk_grad_grad(irow, 2, 2)
+               TARGET(base + 8) = chunk_grad_grad(irow, 3, 2)
+               TARGET(base + 9:base + 10) = chunk_kin_grad(irow, :)
+            END IF
+         END DO
+!$OMP END PARALLEL DO
+      END IF
 
       CALL torch_tensor_release(density_grad_t)
       CALL torch_tensor_release(grad_grad_t)
@@ -1445,12 +1500,12 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(OUT)                                     :: kin_grad
 
-      INTEGER                                            :: base, local_feature, local_row, &
-                                                            nflat_local, nroute_grad_per_point, &
-                                                            nroute_points, point_pos
+      INTEGER                                            :: base, local_row, nflat_local, &
+                                                            nroute_grad_per_point, nroute_points, &
+                                                            point_pos, row_route_pos
 
       nflat_local = features%nflat_local
-      nroute_points = SIZE(features%route_local_positions)
+      nroute_points = SIZE(features%route_send_local_rows)
       nroute_grad_per_point = ngrad_per_point
       IF (collapse_spin_grads) nroute_grad_per_point = ncollapsed_grad_per_point
       CPASSERT(SIZE(recv_grad_buffer) >= nroute_grad_per_point*nroute_points)
@@ -1460,14 +1515,14 @@ CONTAINS
 !$OMP PARALLEL DO DEFAULT(NONE) &
 !$OMP SHARED(collapse_spin_grads, density_grad, features, grad_grad, kin_grad, nflat_local, &
 !$OMP        nroute_grad_per_point, nroute_points, recv_grad_buffer) &
-!$OMP PRIVATE(base, local_feature, local_row, point_pos)
+!$OMP PRIVATE(base, local_row, point_pos, row_route_pos)
       DO local_row = 1, nflat_local
          density_grad(local_row, :) = 0.0_dp
          grad_grad(local_row, :, :) = 0.0_dp
          kin_grad(local_row, :) = 0.0_dp
-         DO local_feature = features%local_feature_offsets(local_row), &
-            features%local_feature_offsets(local_row + 1) - 1
-            point_pos = features%route_local_positions(local_feature)
+         DO row_route_pos = features%route_row_offsets(local_row), &
+            features%route_row_offsets(local_row + 1) - 1
+            point_pos = features%route_row_positions(row_route_pos)
             CPASSERT(point_pos >= 1 .AND. point_pos <= nroute_points)
             base = nroute_grad_per_point*(point_pos - 1)
             IF (collapse_spin_grads) THEN
@@ -1551,7 +1606,8 @@ CONTAINS
 
       INTEGER                                            :: base, feature_pos, i, j, k, local_row, &
                                                             nflat_local, nroute_grad_per_point, &
-                                                            nroute_points, phase_handle, row
+                                                            nroute_recv_points, nroute_send_points, &
+                                                            phase_handle, row
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: route_grad_return_recv_counts, &
                                                             route_grad_return_recv_displs, &
                                                             route_grad_return_send_counts, &
@@ -1563,16 +1619,17 @@ CONTAINS
 
       nflat_local = features%nflat_local
       IF (features%uses_atom_chunk_routing) THEN
-         CPASSERT(SUM(features%route_point_recv_counts) == features%chunk_feature_count)
-         nroute_points = SIZE(features%route_local_positions)
-         CPASSERT(SUM(features%route_point_send_counts) == nroute_points)
+         nroute_recv_points = SUM(features%route_point_recv_counts)
+         nroute_send_points = SIZE(features%route_send_local_rows)
+         CPASSERT(SUM(features%route_point_send_counts) == nroute_send_points)
+         CPASSERT(SIZE(features%route_chunk_offsets) == nroute_recv_points + 1)
 
          nroute_grad_per_point = ngrad_per_point
          IF (features%uses_collapsed_rks_dynamic) THEN
             nroute_grad_per_point = ncollapsed_grad_per_point
          END IF
-         ALLOCATE (send_grad_buffer(MAX(1, nroute_grad_per_point*features%chunk_feature_count)), &
-                   recv_grad_buffer(MAX(1, nroute_grad_per_point*nroute_points)), &
+         ALLOCATE (send_grad_buffer(MAX(1, nroute_grad_per_point*nroute_recv_points)), &
+                   recv_grad_buffer(MAX(1, nroute_grad_per_point*nroute_send_points)), &
                    route_grad_return_send_counts(SIZE(features%route_point_recv_counts)), &
                    route_grad_return_send_displs(SIZE(features%route_point_recv_displs)), &
                    route_grad_return_recv_counts(SIZE(features%route_point_send_counts)), &


### PR DESCRIPTION
## Summary

- route each local GPW grid row only once per destination rank
- retain CSR mappings from compressed route points to all atom-chunk rows
- accumulate gradient contributions before returning them to the grid owner
- avoid unused layout-array copies on the routed atom-chunk path
- reuse cached route metadata across SCF evaluations

## Motivation

The native SKALA atom-chunk path previously sent identical dynamic grid features once for every atom feature referencing a grid row. This increased MPI buffer sizes, communication volume, gradient packing work, and temporary layout allocations.

This change compresses the communication routes while preserving the full feature expansion on the receiving rank. It is incremental progress toward #5439.

## Validation

- CP2K pre-push hook
- CPU LibTorch with 2 and 8 MPI ranks, including idle atom-chunk ranks
- CUDA LibTorch with 1 and 2 GPUs
- RKS and UKS energies
- analytical forces and stress
- builds on aarch64/sm_121 and x86_64/sm_86

For an H2O32 five-SCF benchmark, the median wall time improves from 135.92 s to 129.57 s on one GB10 and from 120.91 s to 116.15 s on two A40 GPUs. GPU memory usage is unchanged.
