### PR TITLE
Guard DCDR regtests with LibXC

### DIFF
--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -309,7 +309,7 @@ QS/regtest-smeagol-1
 QS/regtest-smeagol-2                                        libsmeagol
 QS/regtest-mp2-admm-stress                                  libint !ifx
 QS/regtest-gpw-9                                            libxc
-QS/regtest-dcdr
+QS/regtest-dcdr                                             libxc
 QS/regtest-mp2-lr-stress                                    libint !ifx
 QS/regtest-cdft-5
 QS/regtest-polar


### PR DESCRIPTION
Follow-up to #5658.

## Summary

- declare the `libxc` requirement for `QS/regtest-dcdr` in `tests/TEST_DIRS`

## Rationale

The r2SCAN APT regression test introduced by #5658 uses LibXC. Without a directory guard, configurations built without LibXC can still schedule the DCDR test directory and then fail because the functional is unavailable.

## Testing

- `./make_pretty.sh tests/TEST_DIRS`
- `git diff --check`
- verified that the `QS/regtest-dcdr` entry is parsed as the directory plus the `libxc` requirement
