### PR TITLE
Enable expandable LibTorch CUDA segments by default

### DIFF
--- a/src/torch_c_api.cpp
+++ b/src/torch_c_api.cpp
@@ -10,6 +10,7 @@
 #include <ATen/Parallel.h>
 #if defined(__LIBTORCH_CUDA)
 #include <ATen/cuda/CUDAContextLight.h>
+#include <c10/cuda/CUDAAllocatorConfig.h>
 #endif
 #include <c10/core/DeviceGuard.h>
 #include <torch/csrc/api/include/torch/cuda.h>
@@ -52,6 +53,22 @@ private:
  ******************************************************************************/
 static bool use_cuda_if_available = true;
 
+static void enable_expandable_cuda_segments_if_unconfigured() {
+#if defined(__LIBTORCH_CUDA)
+  static const bool initialized = []() {
+    const char *legacy_config = std::getenv("PYTORCH_CUDA_ALLOC_CONF");
+    const char *config = std::getenv("PYTORCH_ALLOC_CONF");
+    if ((legacy_config == nullptr || legacy_config[0] == '\0') &&
+        (config == nullptr || config[0] == '\0')) {
+      c10::cuda::CUDACachingAllocator::setAllocatorSettings(
+          "expandable_segments:True");
+    }
+    return true;
+  }();
+  (void)initialized;
+#endif
+}
+
 static bool get_positive_int_env(const char *name, int &value) {
   const char *raw = std::getenv(name);
   if (raw == nullptr || raw[0] == '\0') {
@@ -87,6 +104,7 @@ static torch::Device get_device() {
   if (!use_cuda_if_available || !torch::cuda::is_available()) {
     return torch::kCPU;
   }
+  enable_expandable_cuda_segments_if_unconfigured();
   const auto device_count = torch::cuda::device_count();
   if (device_count <= 0) {
     return torch::kCPU;


### PR DESCRIPTION
## Summary

Enable LibTorch's expandable CUDA memory segments by default when no allocator
configuration was provided by the user.

Expandable segments reduce CUDA memory fragmentation for workloads whose
tensor sizes vary between atom chunks and SCF steps.

Explicit user configuration through either `PYTORCH_ALLOC_CONF` or the legacy
`PYTORCH_CUDA_ALLOC_CONF` variable remains untouched. In particular, users can
restore the previous behavior with:

    PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False

## Implementation

The allocator is configured once, immediately before CP2K selects its first
LibTorch CUDA device.

A thread-safe static initializer ensures that the setting is applied only once
per MPI process. CPU-only LibTorch builds are unaffected.

## Benchmark

Terok, 2 x NVIDIA A40, H2O32 native SKALA, 3 SCF steps,
2 MPI ranks x 4 OpenMP threads:

| Allocator configuration | GPU 0 | GPU 1 | Total |
|---|---:|---:|---:|
| Explicitly disabled | 12,394 MiB | 10,292 MiB | 22,686 MiB |
| CP2K default | 8,926 MiB | 7,394 MiB | 16,320 MiB |
| Explicitly enabled | 8,926 MiB | 7,394 MiB | 16,320 MiB |

The default therefore reduces the measured LibTorch CUDA process peak by
6,366 MiB, or 28.1%.

Across four disabled and eight expandable-segment runs, median wall time was:

| Configuration | Wall time | CP2K timer |
|---|---:|---:|
| Disabled | 43.833 s | 40.907 s |
| Expandable segments | 43.959 s | 41.123 s |

The timing difference is about +0.3% wall time and +0.5% in the CP2K timer,
within the observed run-to-run variation. Host memory remained effectively
unchanged.

## Validation

- CP2K precommit checks pass.
- `torch_c_api.cpp` compiles with LibTorch 2.6.0 + CUDA 12.4.
- Default, explicitly disabled, and explicitly enabled allocator modes run
  successfully with two MPI ranks on two GPUs.
- Explicit allocator environment settings are preserved.
- Energies agree within the normal GPU run-to-run numerical variation.
