### PR TITLE
Reduce RTBSE restart regtest cell size

### DIFF
--- a/tests/QS/regtest-rtbse-linearized-open-shell/h2_linrtbse_tda_open_shell_restart.inp
+++ b/tests/QS/regtest-rtbse-linearized-open-shell/h2_linrtbse_tda_open_shell_restart.inp
@@ -87,7 +87,7 @@
   &END PROPERTIES
   &SUBSYS
     &CELL
-      ABC 10.0 10.0 10.0
+      ABC 8.0 8.0 8.0
       PERIODIC NONE
     &END CELL
     &COORD

--- a/tests/QS/regtest-rtbse-linearized-open-shell/h2_linrtbse_tda_open_shell_restart_cont.inp
+++ b/tests/QS/regtest-rtbse-linearized-open-shell/h2_linrtbse_tda_open_shell_restart_cont.inp
@@ -87,7 +87,7 @@
   &END PROPERTIES
   &SUBSYS
     &CELL
-      ABC 10.0 10.0 10.0
+      ABC 8.0 8.0 8.0
       PERIODIC NONE
     &END CELL
     &COORD


### PR DESCRIPTION
## Summary
- reduce the non-periodic H2 cell from 10 to 8 Angstrom in both RTBSE restart inputs
- keep the propagation lengths, physical methods, reference values, and matcher tolerances unchanged

## Motivation
The Current Toolchain (sdbg) dashboard flags `h2_linrtbse_tda_open_shell_restart.inp` as slow (about 40 s versus a 32 s threshold). Profiling shows that the initial GAPW SCF and its FFT grid dominate the runtime, while the RTBSE propagation itself is small.

The molecule is centered in a non-periodic cell with the WAVELET Poisson solver. An 8 Angstrom box retains ample vacuum for H2 while reducing the real-space grid volume.

## Validation
- `make_pretty.sh` passes for both modified inputs
- full `QS/regtest-rtbse-linearized-open-shell` run with current master, serial Debug, one OpenMP thread: 18/18 correct, 0 slow tests
- restart seed runtime: 8.35 s average at 10 Angstrom, 5.33 s at 8 Angstrom
- continuation runtime: 2.40 s
- all existing excitation-energy and static-polarizability matchers pass without reference or tolerance changes
