### PR TITLE
Preserve interfaces before preprocessor directives

### DIFF
--- a/tools/precommit/format_fortran_test.py
+++ b/tools/precommit/format_fortran_test.py
@@ -9,6 +9,25 @@ import sys
 from format_fortran import main
 from prettify_cp2k import selftest
 
+interface_cpp_content = """\
+MODULE interface_cpp_test
+   IMPLICIT NONE
+
+CONTAINS
+
+   SUBROUTINE initialize()
+      INTERFACE
+         SUBROUTINE initialize_aux() BIND(C, name='initialize_aux')
+         END SUBROUTINE initialize_aux
+      END INTERFACE
+
+#if defined(__DLAF)
+      CALL initialize_aux()
+#endif
+   END SUBROUTINE initialize
+END MODULE interface_cpp_test
+"""
+
 
 class TestSingleFileFolder(unittest.TestCase):
     def setUp(self):
@@ -31,6 +50,21 @@ class TestSingleFileFolder(unittest.TestCase):
             result = fhandle.read()
 
         self.assertEqual(result.splitlines(), selftest.content.splitlines())
+
+
+class TestInterfaceCppDirective(unittest.TestCase):
+    def test_prettify_preserves_interface(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            fname = os.path.join(tempdir, "prettify_interface.F")
+            with open(fname, "w", encoding="utf8") as fhandle:
+                fhandle.write(interface_cpp_content)
+
+            self.assertEqual(main([fname]), 0)
+
+            with open(fname, encoding="utf8") as fhandle:
+                result = fhandle.read()
+
+        self.assertEqual(result, interface_cpp_content)
 
 
 if __name__ == "__main__":

--- a/tools/precommit/prettify_cp2k/normalizeFortranFile.py
+++ b/tools/precommit/prettify_cp2k/normalizeFortranFile.py
@@ -420,9 +420,11 @@ def parseRoutine(inFile, logger):
                 routine["parsedDeclarations"].append(decl)
             elif INTERFACE_START_RE.match(jline):
                 istart = lines
+                interface_lines = list(istart)
                 interfaceDeclFile = StringIO()
                 while True:
                     jline, _, lines = stream.nextFortranLine()
+                    interface_lines.extend(lines)
                     if INTERFACE_END_RE.match(jline):
                         iend = lines
                         break
@@ -453,6 +455,7 @@ def parseRoutine(inFile, logger):
                         "iend": iend,
                     }
                     routine["parsedDeclarations"].append(decl)
+                lines = interface_lines
             elif USE_PARSE_RE.match(jline):
                 routine["use"].append("".join(lines))
             else:


### PR DESCRIPTION
## Summary

- retain the complete raw `INTERFACE` block while parsing routine declarations
- preserve that block when a following preprocessor directive disables declaration cleanup
- add an integration regression test for `END INTERFACE` followed by `#if defined`

## Root cause

The parser represented an interface structurally for normal declaration rewriting, but its raw declaration fallback retained only the final `END INTERFACE` line. A following preprocessor directive makes `cleanDeclarations` deliberately keep the raw declarations. That fallback therefore discarded the interface start and contents and left the formatter to misindent the surrounding routine.

The parser now retains all source lines belonging to the interface. Normal declaration rewriting is unchanged; the complete copy is used when cleanup is skipped.

## Impact

Running the CP2K Fortran formatter no longer deletes interface declarations when a preprocessor block follows them.

Closes #3071

## Verification

- `python3 tools/precommit/format_fortran_test.py`
- `python3 tools/precommit/precommit.py -a tools/precommit/prettify_cp2k/normalizeFortranFile.py tools/precommit/format_fortran_test.py`
- `git diff --check`
- confirmed the new regression test fails without the parser fix and passes with it
