### PR TITLE
Keep native SKALA CUDA inputs in FP32

### DIFF
--- a/src/skala_gpw_features.F
+++ b/src/skala_gpw_features.F
@@ -189,11 +189,12 @@ CONTAINS
 !> \param use_atom_chunks ...
 !> \param route_atom_chunks ...
 !> \param atom_partition ...
+!> \param use_float32_dynamic Store dynamic CUDA inputs in single precision.
 ! **************************************************************************************************
    SUBROUTINE skala_gpw_feature_build(features, rho_set, rho_r, particle_set, cell, &
                                       requires_grad, weights, requires_coordinate_grad, &
                                       requires_stress_grad, use_atom_chunks, route_atom_chunks, &
-                                      atom_partition)
+                                      atom_partition, use_float32_dynamic)
       TYPE(skala_gpw_feature_type), INTENT(INOUT)        :: features
       TYPE(xc_rho_set_type), INTENT(IN)                  :: rho_set
       TYPE(pw_r3d_rs_type), DIMENSION(:), INTENT(IN)     :: rho_r
@@ -205,13 +206,14 @@ CONTAINS
                                                             requires_stress_grad, use_atom_chunks, &
                                                             route_atom_chunks
       INTEGER, INTENT(IN), OPTIONAL                      :: atom_partition
+      LOGICAL, INTENT(IN), OPTIONAL                      :: use_float32_dynamic
 
       INTEGER :: handle, i, ipt, ispin, j, k, local_row, my_atom_partition, &
          ndynamic_local_per_point, nflat, nflat_local, nspins, phase_handle, real_base, row
       INTEGER, DIMENSION(2, 3)                           :: bo
       LOGICAL :: collapse_spin_dynamics, my_requires_coordinate_grad, my_requires_grad, &
          my_requires_stress_grad, my_route_atom_chunks, my_use_atom_chunks, &
-         use_atom_chunk_protocol, use_atom_chunk_routing
+         my_use_float32_dynamic, use_atom_chunk_protocol, use_atom_chunk_routing
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: global_dynamic, local_dynamic
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: rho, rhoa, rhob, tau_a, tau_b, tau_total
       TYPE(cp_3d_r_cp_type), DIMENSION(3)                :: drho, drhoa, drhob
@@ -231,6 +233,8 @@ CONTAINS
       IF (PRESENT(use_atom_chunks)) my_use_atom_chunks = use_atom_chunks
       my_route_atom_chunks = .FALSE.
       IF (PRESENT(route_atom_chunks)) my_route_atom_chunks = route_atom_chunks
+      my_use_float32_dynamic = .FALSE.
+      IF (PRESENT(use_float32_dynamic)) my_use_float32_dynamic = use_float32_dynamic
       my_atom_partition = skala_gpw_atom_partition_hard
       IF (PRESENT(atom_partition)) my_atom_partition = atom_partition
       IF (my_atom_partition /= skala_gpw_atom_partition_hard .AND. &
@@ -403,6 +407,7 @@ CONTAINS
          CALL add_feature_tensors(features, my_requires_grad, my_requires_coordinate_grad, &
                                   my_requires_stress_grad, &
                                   features%uses_atom_chunks, &
+                                  use_float32_dynamic=my_use_float32_dynamic, &
                                   requires_weight_grad= &
                                   (my_atom_partition == skala_gpw_atom_partition_smooth .AND. &
                                    (my_requires_coordinate_grad .OR. my_requires_stress_grad)))
@@ -2198,18 +2203,23 @@ CONTAINS
 !> \param requires_stress_grad ...
 !> \param use_atom_chunks ...
 !> \param requires_weight_grad ...
+!> \param use_float32_dynamic Store dynamic CUDA inputs in single precision.
 ! **************************************************************************************************
    SUBROUTINE add_feature_tensors(features, requires_grad, requires_coordinate_grad, &
-                                  requires_stress_grad, use_atom_chunks, requires_weight_grad)
+                                  requires_stress_grad, use_atom_chunks, requires_weight_grad, &
+                                  use_float32_dynamic)
       TYPE(skala_gpw_feature_type), INTENT(INOUT)        :: features
       LOGICAL, INTENT(IN)                                :: requires_grad, requires_coordinate_grad, &
                                                             requires_stress_grad, use_atom_chunks
-      LOGICAL, INTENT(IN), OPTIONAL                      :: requires_weight_grad
+      LOGICAL, INTENT(IN), OPTIONAL                      :: requires_weight_grad, use_float32_dynamic
 
-      LOGICAL                                            :: my_requires_weight_grad
+      LOGICAL                                            :: my_requires_weight_grad, &
+                                                            my_use_float32_dynamic
 
       my_requires_weight_grad = .FALSE.
       IF (PRESENT(requires_weight_grad)) my_requires_weight_grad = requires_weight_grad
+      my_use_float32_dynamic = .FALSE.
+      IF (PRESENT(use_float32_dynamic)) my_use_float32_dynamic = use_float32_dynamic
 
       features%owns_static_tensors = .FALSE.
       features%owns_coordinate_tensor = .FALSE.
@@ -2245,13 +2255,16 @@ CONTAINS
          END IF
 
          CALL torch_tensor_reset_from_array(cached_layout%chunk_density_t, &
-                                            features%chunk_density, requires_grad=requires_grad)
+                                            features%chunk_density, requires_grad=requires_grad, &
+                                            use_float32=my_use_float32_dynamic)
          features%density_t = cached_layout%chunk_density_t
          CALL torch_tensor_reset_from_array(cached_layout%chunk_grad_t, features%chunk_grad, &
-                                            requires_grad=requires_grad)
+                                            requires_grad=requires_grad, &
+                                            use_float32=my_use_float32_dynamic)
          features%grad_t = cached_layout%chunk_grad_t
          CALL torch_tensor_reset_from_array(cached_layout%chunk_kin_t, features%chunk_kin, &
-                                            requires_grad=requires_grad)
+                                            requires_grad=requires_grad, &
+                                            use_float32=my_use_float32_dynamic)
          features%kin_t = cached_layout%chunk_kin_t
          cached_layout%chunk_dynamic_tensors_active = .TRUE.
 
@@ -2308,13 +2321,16 @@ CONTAINS
          features%local_feature_indices_t = cached_layout%local_feature_indices_t
 
          CALL torch_tensor_reset_from_array(cached_layout%density_t, features%density, &
-                                            requires_grad=requires_grad)
+                                            requires_grad=requires_grad, &
+                                            use_float32=my_use_float32_dynamic)
          features%density_t = cached_layout%density_t
          CALL torch_tensor_reset_from_array(cached_layout%grad_t, features%grad, &
-                                            requires_grad=requires_grad)
+                                            requires_grad=requires_grad, &
+                                            use_float32=my_use_float32_dynamic)
          features%grad_t = cached_layout%grad_t
          CALL torch_tensor_reset_from_array(cached_layout%kin_t, features%kin, &
-                                            requires_grad=requires_grad)
+                                            requires_grad=requires_grad, &
+                                            use_float32=my_use_float32_dynamic)
          features%kin_t = cached_layout%kin_t
          cached_layout%dynamic_tensors_active = .TRUE.
 

--- a/src/skala_gpw_functional.F
+++ b/src/skala_gpw_functional.F
@@ -360,7 +360,8 @@ CONTAINS
                                    requires_stress_grad=compute_virial, &
                                    use_atom_chunks=native_grid_atom_chunks, &
                                    route_atom_chunks=native_grid_atom_chunk_routing, &
-                                   atom_partition=native_grid_atom_partition)
+                                   atom_partition=native_grid_atom_partition, &
+                                   use_float32_dynamic=native_grid_use_cuda)
       CALL section_vals_val_get(gauxc_section, "NATIVE_GRID_DIAGNOSTICS", l_val=native_grid_diagnostics)
       IF (native_grid_diagnostics) THEN
          CALL print_native_grid_diagnostics(features, rho_r(1)%pw_grid%para%group%mepos == 0)

--- a/src/torch_api.F
+++ b/src/torch_api.F
@@ -206,19 +206,22 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief Reuses or creates a device leaf tensor and copies data into it.
 !>        The source must be an ALLOCATABLE to prevent passing a temporary array.
+!>        When requested, CUDA destinations use FP32 while CPU destinations remain FP64.
 ! **************************************************************************************************
-      SUBROUTINE torch_tensor_reset_from_array_double_${ndims}$d(tensor, source, requires_grad)
+      SUBROUTINE torch_tensor_reset_from_array_double_${ndims}$d(tensor, source, requires_grad, use_float32)
          TYPE(torch_tensor_type), INTENT(INOUT)             :: tensor
          #:set arraydims = ", ".join(":" for i in range(ndims))
          REAL(dp), DIMENSION(${arraydims}$), ALLOCATABLE, INTENT(IN)  :: source
          LOGICAL, OPTIONAL, INTENT(IN)                      :: requires_grad
+         LOGICAL, OPTIONAL, INTENT(IN)                      :: use_float32
 
 #if defined(__LIBTORCH)
          INTEGER(kind=int_8), DIMENSION(${ndims}$)          :: sizes_c
-         LOGICAL                                            :: my_req_grad
+         LOGICAL                                            :: my_req_grad, my_use_float32
 
          INTERFACE
-            SUBROUTINE torch_c_tensor_reset_from_array_double(tensor, req_grad, ndims, sizes, source) &
+            SUBROUTINE torch_c_tensor_reset_from_array_double(tensor, req_grad, ndims, sizes, source, &
+                                                              use_float32) &
                BIND(C, name="torch_c_tensor_reset_from_array_double")
                IMPORT :: C_PTR, C_INT, C_INT64_T, C_DOUBLE, C_BOOL
                TYPE(C_PTR)                                  :: tensor
@@ -226,11 +229,14 @@ CONTAINS
                INTEGER(kind=C_INT), VALUE                   :: ndims
                INTEGER(kind=C_INT64_T), DIMENSION(*)        :: sizes
                REAL(kind=C_DOUBLE), DIMENSION(*)            :: source
+               LOGICAL(kind=C_BOOL), VALUE                  :: use_float32
             END SUBROUTINE torch_c_tensor_reset_from_array_double
          END INTERFACE
 
          my_req_grad = .FALSE.
          IF (PRESENT(requires_grad)) my_req_grad = requires_grad
+         my_use_float32 = .FALSE.
+         IF (PRESENT(use_float32)) my_use_float32 = use_float32
 
          #:for axis in range(ndims)
             sizes_c(${axis + 1}$) = SIZE(source, ${ndims - axis}$) ! C arrays are stored row-major.
@@ -240,13 +246,15 @@ CONTAINS
                                                      req_grad=LOGICAL(my_req_grad, C_BOOL), &
                                                      ndims=${ndims}$, &
                                                      sizes=sizes_c, &
-                                                     source=source)
+                                                     source=source, &
+                                                     use_float32=LOGICAL(my_use_float32, C_BOOL))
          CPASSERT(C_ASSOCIATED(tensor%c_ptr))
 #else
          CPABORT("CP2K compiled without the Torch library.")
          MARK_USED(tensor)
          MARK_USED(source)
          MARK_USED(requires_grad)
+         MARK_USED(use_float32)
 #endif
       END SUBROUTINE torch_tensor_reset_from_array_double_${ndims}$d
 

--- a/src/torch_c_api.cpp
+++ b/src/torch_c_api.cpp
@@ -229,14 +229,16 @@ static bool tensor_matches(const torch_c_tensor_t *tensor,
 static void reset_tensor_from_array_double(torch_c_tensor_t **tensor,
                                            const bool req_grad, const int ndims,
                                            const int64_t sizes[],
-                                           double source[]) {
+                                           double source[],
+                                           const bool use_float32) {
   c10::OptionalDeviceGuard guard;
   const auto device = get_device_with_guard(guard);
+  const auto dtype =
+      (use_float32 && device.is_cuda()) ? torch::kFloat32 : torch::kFloat64;
   const auto sizes_ref = c10::IntArrayRef(sizes, ndims);
-  if (!tensor_matches(*tensor, torch::kFloat64, device, ndims, sizes)) {
+  if (!tensor_matches(*tensor, dtype, device, ndims, sizes)) {
     delete (*tensor);
-    const auto opts =
-        torch::TensorOptions().dtype(torch::kFloat64).device(device);
+    const auto opts = torch::TensorOptions().dtype(dtype).device(device);
     *tensor = new torch_c_tensor_t(torch::empty(sizes_ref, opts).detach());
   }
   const auto source_tensor = torch::from_blob(
@@ -320,14 +322,14 @@ void torch_c_tensor_from_array_double(torch_c_tensor_t **tensor,
 void torch_c_free_string(char *content) { free(content); }
 
 /*******************************************************************************
- * \brief Reuses or creates a device tensor and copies double data into it.
+ * \brief Reuses or creates a device tensor and copies double data into it,
+ *        optionally converting CUDA destinations to float.
  ******************************************************************************/
-void torch_c_tensor_reset_from_array_double(torch_c_tensor_t **tensor,
-                                            const bool req_grad,
-                                            const int ndims,
-                                            const int64_t sizes[],
-                                            double source[]) {
-  reset_tensor_from_array_double(tensor, req_grad, ndims, sizes, source);
+void torch_c_tensor_reset_from_array_double(
+    torch_c_tensor_t **tensor, const bool req_grad, const int ndims,
+    const int64_t sizes[], double source[], const bool use_float32) {
+  reset_tensor_from_array_double(tensor, req_grad, ndims, sizes, source,
+                                 use_float32);
 }
 
 /*******************************************************************************
@@ -463,7 +465,7 @@ void torch_c_tensor_grad(const torch_c_tensor_t *tensor,
 }
 
 /*******************************************************************************
- * \brief Copies three autograd gradients to CPU memory.
+ * \brief Copies three autograd gradients to double-precision CPU memory.
  ******************************************************************************/
 void torch_c_tensor_grad_batch3(const torch_c_tensor_t *tensor1,
                                 const torch_c_tensor_t *tensor2,
@@ -482,15 +484,13 @@ void torch_c_tensor_grad_batch3(const torch_c_tensor_t *tensor1,
   assert(source1.device() == source2.device());
   assert(source1.device() == source3.device());
   if (use_batched_gradient_readback(source1)) {
-    auto host1 =
-        torch::empty(source1.sizes(),
-                     source1.options().device(torch::kCPU).pinned_memory(true));
-    auto host2 =
-        torch::empty(source2.sizes(),
-                     source2.options().device(torch::kCPU).pinned_memory(true));
-    auto host3 =
-        torch::empty(source3.sizes(),
-                     source3.options().device(torch::kCPU).pinned_memory(true));
+    const auto host_options = torch::TensorOptions()
+                                  .dtype(torch::kFloat64)
+                                  .device(torch::kCPU)
+                                  .pinned_memory(true);
+    auto host1 = torch::empty(source1.sizes(), host_options);
+    auto host2 = torch::empty(source2.sizes(), host_options);
+    auto host3 = torch::empty(source3.sizes(), host_options);
     host1.copy_(source1, true);
     host2.copy_(source2, true);
     host3.copy_(source3, true);
@@ -499,9 +499,11 @@ void torch_c_tensor_grad_batch3(const torch_c_tensor_t *tensor1,
     *grad2 = new torch_c_tensor_t(std::move(host2));
     *grad3 = new torch_c_tensor_t(std::move(host3));
   } else {
-    *grad1 = new torch_c_tensor_t(source1.cpu().contiguous());
-    *grad2 = new torch_c_tensor_t(source2.cpu().contiguous());
-    *grad3 = new torch_c_tensor_t(source3.cpu().contiguous());
+    const auto host_options =
+        torch::TensorOptions().dtype(torch::kFloat64).device(torch::kCPU);
+    *grad1 = new torch_c_tensor_t(source1.to(host_options).contiguous());
+    *grad2 = new torch_c_tensor_t(source2.to(host_options).contiguous());
+    *grad3 = new torch_c_tensor_t(source3.to(host_options).contiguous());
   }
 }
 


### PR DESCRIPTION
## Summary

- keep dynamic native SKALA density, density-gradient, and kinetic-energy tensors in FP32 on CUDA
- preserve the existing FP64 CPU path
- reuse cached leaf tensors only when their shape, device, and requested dtype match
- convert autograd gradients back to FP64 CPU tensors before they are consumed by CP2K

## Motivation

The CUDA path previously copied CP2K's FP64 feature arrays into FP64 CUDA leaf tensors even when the exported SKALA model evaluated its learned operations in FP32. This increased dynamic-tensor storage and memory traffic without adding useful model precision.

The change performs the FP64-to-FP32 conversion while resetting the cached CUDA leaf tensors. Static layout tensors, direct exchange-correlation-density output, CP2K potentials, and CPU execution retain their existing precision. Gradient readback is explicitly converted to FP64 so the Fortran interface and downstream accumulation remain unchanged.

This is a focused GPU performance and memory improvement toward #5439.

## Performance

With the CUDA-exported SKALA model on Spark (GB10), one GPU, and H2O32:

- total CP2K time: 1.7% lower
- native SKALA forward time: 3.1% lower
- sampled GPU time: 4.5% lower
- host memory: unchanged within measurement noise

The total-energy difference relative to the FP64-input CUDA path was `4.18e-8 Ha`. For H2O6, combining the current model export with this input change reduced total time by 5.6% and sampled GPU time by 24.4% relative to the previously published Rev1 path; the incremental FP32-input effect itself was approximately neutral in total time while reducing sampled GPU use by 6.7%.

## Validation

- CP2K precommit checks for all four changed files
- clean CMake build with MPI, CUDA LibTorch, and GauXC disabled on Spark, rebased onto current `master`
- single-GPU H2O6 and H2O32 energy/performance runs
- native SKALA H2 energy, forces, and analytical stress smoke tests
- published Rev1 CUDA model compatibility smoke test

No paper, regression-result, or benchmark-script changes are included.
