### PR TITLE
Enable automatic native SKALA CPU subchunks

### DIFF
--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -1528,8 +1528,8 @@ CONTAINS
                           description="Maximum number of atom-grid rows evaluated by one TorchScript "// &
                           "call in the experimental CP2K-native SKALA GPW atom-chunk path. A positive "// &
                           "value splits each rank-local atom chunk into contiguous atom subchunks to "// &
-                          "reduce peak CUDA memory use; zero disables subchunking; -1 selects an "// &
-                          "automatic CUDA-oriented row cap.", &
+                          "reduce peak CPU or CUDA memory use; zero disables subchunking; -1 selects "// &
+                          "an automatic row cap.", &
                           usage="NATIVE_GRID_ATOM_CHUNK_MAX_ROWS 250000", &
                           default_i_val=-1)
       CALL section_add_keyword(section, keyword)

--- a/src/skala_gpw_functional.F
+++ b/src/skala_gpw_functional.F
@@ -367,12 +367,8 @@ CONTAINS
       END IF
 
       IF (features%uses_atom_chunks .AND. native_grid_atom_chunk_max_rows == -1) THEN
-         IF (native_grid_use_cuda) THEN
-            native_grid_atom_chunk_max_rows = auto_atom_chunk_max_rows(features, &
-                                                                       rho_r(1)%pw_grid%para%group)
-         ELSE
-            native_grid_atom_chunk_max_rows = 0
-         END IF
+         native_grid_atom_chunk_max_rows = auto_atom_chunk_max_rows(features, &
+                                                                    rho_r(1)%pw_grid%para%group)
       END IF
       IF (native_grid_diagnostics .AND. features%uses_atom_chunks .AND. &
           rho_r(1)%pw_grid%para%group%mepos == 0) THEN
@@ -1229,7 +1225,7 @@ CONTAINS
    END SUBROUTINE evaluate_atom_subchunks
 
 ! **************************************************************************************************
-!> \brief Select an automatic CUDA atom-subchunk row cap.
+!> \brief Select an automatic atom-subchunk row cap.
 !> \param features ...
 !> \param group ...
 !> \return ...


### PR DESCRIPTION
## Summary

- apply the existing automatic native SKALA atom-subchunk row cap to CPU execution as well as CUDA
- retain the existing explicit controls: zero disables subchunking and a positive value selects an exact cap
- update the input keyword description to cover CPU and CUDA memory use

## Motivation

`NATIVE_GRID_ATOM_CHUNK_MAX_ROWS` defaults to `-1`, but the automatic cap was previously enabled only for CUDA. CPU execution therefore evaluated the entire rank-local atom chunk in one TorchScript call by default. Large chunks retain a correspondingly large autograd graph and can consume much more host memory than necessary.

The existing automatic policy already derives a common cap from the largest rank-local chunk. Reusing it on CPU preserves atom-contiguous evaluation and MPI consistency while bounding the per-call graph size.

This is a focused performance and memory improvement toward #5439.

## Performance

On Terok with two MPI ranks, CPU-only native SKALA, and the 18-atom H2O6 case, the same current-master binary was compared with the previous unlimited default and an explicit 400,000-row cap selected by the proposed automatic policy:

| setting | CP2K time | maximum RSS |
|---|---:|---:|
| unlimited | 205.395 s | 38,860,868 KiB |
| 400,000 rows | 114.720 s | 7,001,612 KiB |

This is a 44.1% time reduction and an 82.0% reduction in maximum RSS. The total-energy difference was `5.96e-9 Ha`. The proposed build selects 400,000 rows automatically for this case and reproduces the explicitly capped result.

On Spark, the capped H2O6 workload also completed with two and eight MPI ranks; the CP2K time improved from 137.175 s to 47.748 s (2.87x for four times as many ranks), with identical reported total energies.

## Validation

- CP2K precommit checks for both changed files
- clean GCC 13 CMake build with MPI and LibTorch on Terok, rebased onto current `master`
- focused two-rank native SKALA CPU runs for RKS H2O, UKS OH, and Ar4 against their existing references
- large H2O6 automatic-cap run and explicit-cap comparison

No regression inputs or benchmark artifacts are added by this PR.
