### PR TITLE
Enable Spglib in CUDA toolchain builds

### DIFF
--- a/tools/docker/scripts/cmake_cp2k.sh
+++ b/tools/docker/scripts/cmake_cp2k.sh
@@ -160,7 +160,6 @@ elif [[ "${PROFILE}" == "toolchain_cuda_"* ]] && [[ "${VERSION}" == "psmp" ]]; t
     -DCP2K_USE_LIBSMEAGOL=OFF \
     -DCP2K_USE_LIBTORCH=OFF \
     -DCP2K_USE_GREENX=OFF \
-    -DCP2K_USE_SPGLIB=OFF \
     -DCP2K_USE_VORI=OFF \
     -DCP2K_USE_TREXIO=OFF \
     -DCP2K_USE_MIMIC=OFF \


### PR DESCRIPTION
## Summary

- enable Spglib in `toolchain_cuda_*` builds
- restore Spglib-backed symmetry handling and the corresponding regression-test coverage

## Motivation

The CUDA Pascal dashboard currently fails
`QS/regtest-kp-hfx-ri/diamond_gpw_extRI_kpsym.inp`. The total energy
matches the reference, but the build reports three special k-points instead
of the expected two.

The CUDA toolchain already installs Spglib 2.7.0 and CMake finds LibSPG.
However, `cmake_cp2k.sh` explicitly sets `CP2K_USE_SPGLIB=OFF` for all CUDA
toolchain profiles. This also causes the Spglib-specific regression-test
directories to be skipped.

Removing that override lets the existing `CP2K_USE_EVERYTHING=ON` setting
enable the dependency that is already present in the image. No test input,
reference value, tolerance, or test suppression is changed.

## Validation

- `./make_pretty.sh tools/docker/scripts/cmake_cp2k.sh`
- configured and built current `master` with Spglib 2.7.0 enabled
- ran `diamond_gpw_extRI_kpsym.inp` with two MPI ranks
- obtained `Number of Special K-points: 2`
- obtained the expected energy: `-8.128239211227610 Ha`
- verified that the CUDA-P100 Docker configuration includes Spglib and proceeds to CP2K compilation