### PR TITLE
Fix quartic metadynamics wall energy

### DIFF
--- a/src/input_cp2k_free_energy.F
+++ b/src/input_cp2k_free_energy.F
@@ -764,7 +764,8 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="K", &
-                          description="Specify the value of the quartic potential constant: K*(CV-(POS+/-(1/K^(1/4))))^4", &
+                          description="Specify the value of the quartic potential constant: "// &
+                          "K*(CV-(POS+/-(0.05/K^(1/4))))^4", &
                           usage="K <REAL>", unit_str='hartree', &
                           type_of_var=real_t)
       CALL section_add_keyword(subsection, keyword)

--- a/src/metadynamics_utils.F
+++ b/src/metadynamics_utils.F
@@ -932,7 +932,7 @@ CONTAINS
                      ! The difference of a periodic COLVAR is always within [-pi,pi]
                      diff_ss = SIGN(1.0_dp, ASIN(SIN(diff_ss)))*ACOS(COS(diff_ss))
                   END IF
-                  efunc = colvars(ih)%walls(iwall)%k_quartic*diff_ss*diff_ss**4
+                  efunc = colvars(ih)%walls(iwall)%k_quartic*diff_ss**4
                   dfunc = 4.0_dp*colvars(ih)%walls(iwall)%k_quartic*diff_ss**3
                   SELECT CASE (colvars(ih)%walls(iwall)%id_direction)
                   CASE (do_wall_p)

--- a/tests/Fist/regtest-15/TEST_FILES.toml
+++ b/tests/Fist/regtest-15/TEST_FILES.toml
@@ -1,7 +1,7 @@
 # metadyn
 "metadyn1.inp"                          = [{matcher="M002", tol=1.0E-14, ref=-0.465672945738E-02}]
 "metadyn2.inp"                          = [{matcher="M002", tol=1.0E-14, ref=-0.146726946152E-02}]
-"metadyn3.inp"                          = [{matcher="M002", tol=1e-14, ref=-0.465541396806E-02}]
+"metadyn3.inp"                          = [{matcher="M002", tol=1e-14, ref=-0.465539820679E-02}]
 "metadyn4.inp"                          = [{matcher="M002", tol=1e-14, ref=-0.466434098306E-02}]
 "metadyn5.inp"                          = [{matcher="M002", tol=1.0E-14, ref=0.260815657919E-02}]
 "metadyn6.inp"                          = [{matcher="M002", tol=1e-11, ref=-0.000190599068492}]


### PR DESCRIPTION
## Summary

- correct the quartic metadynamics wall energy to use `K * Δs^4`
- keep the energy consistent with the existing derivative `4 * K * Δs^3`
- document the actual `0.05 / K^(1/4)` offset used for quartic walls
- update the existing quartic-wall regression reference

## Root cause

The quartic wall energy multiplied `diff_ss` by `diff_ss**4`, effectively evaluating a fifth-order potential. The corresponding force already implemented the derivative of the intended fourth-order potential.

Besides making energy and force inconsistent, the odd exponent could produce a negative wall energy for `WALL_MINUS`.

The input description also omitted the `0.05` factor used when shifting the quartic wall position.

## Verification

- reproduced the previous result with the existing `metadyn3` regression
- completed a fresh GCC 16 MPI Debug build with LibXC
- ran `Fist/regtest-15` with two MPI ranks: `14 / 14` tests passed
- ran CP2K precommit checks for all three changed files
- `git diff --check`

Closes #318
