### PR TITLE
Post-process nested reaction path COLVARs

### DIFF
--- a/src/colvar_utils.F
+++ b/src/colvar_utils.F
@@ -563,7 +563,7 @@ CONTAINS
 !>     10.2014 Moved out of colvar_types.F [Ole Schuett]
 !> \author Teodoro Laino - 07.2007
 ! **************************************************************************************************
-   SUBROUTINE post_process_colvar(colvar, particles)
+   RECURSIVE SUBROUTINE post_process_colvar(colvar, particles)
       TYPE(colvar_type), POINTER                         :: colvar
       TYPE(particle_type), DIMENSION(:), OPTIONAL, &
          POINTER                                         :: particles
@@ -786,6 +786,11 @@ CONTAINS
                              rotate=.TRUE.)
                END DO
             END IF
+         ELSE
+            DO i = 1, SIZE(colvar%reaction_path_param%colvar_p)
+               CALL post_process_colvar(colvar%reaction_path_param%colvar_p(i)%colvar, particles)
+            END DO
+            CALL colvar_setup(colvar)
          END IF
       END IF
 

--- a/tests/xTB/regtest-3/TEST_FILES.toml
+++ b/tests/xTB/regtest-3/TEST_FILES.toml
@@ -20,4 +20,5 @@
 "H2O-geo-pdos.inp"                      = [{matcher="E_total", tol=1.0E-12, ref=-5.76872484352614}]
 "graphite-stm.inp"                      = [{matcher="E_total", tol=1.0E-12, ref=-7.91403223193017}]
 "si_dos.inp"                            = [{matcher="E_total", tol=1.0E-12, ref=-14.73033123463482}]
+"h2o_reaction_path_kinds.inp"           = [{matcher="M002", tol=1.0E-12, ref=-5.42961342279}]
 #EOF

--- a/tests/xTB/regtest-3/h2o_reaction_path_kinds.inp
+++ b/tests/xTB/regtest-3/h2o_reaction_path_kinds.inp
@@ -1,0 +1,91 @@
+&GLOBAL
+  PRINT_LEVEL LOW
+  PROJECT h2o_reaction_path_kinds
+  RUN_TYPE MD
+&END GLOBAL
+
+&MOTION
+  &FREE_ENERGY
+    &METADYN
+      DO_HILLS FALSE
+      &METAVAR
+        COLVAR 1
+        SCALE 1.0
+        &WALL
+          POSITION 0.5
+          TYPE QUADRATIC
+          &QUADRATIC
+            DIRECTION WALL_PLUS
+            K 1.0
+          &END QUADRATIC
+        &END WALL
+      &END METAVAR
+      &METAVAR
+        COLVAR 2
+        SCALE 1.0
+        &WALL
+          POSITION 0.5
+          TYPE QUADRATIC
+          &QUADRATIC
+            DIRECTION WALL_PLUS
+            K 1.0
+          &END QUADRATIC
+        &END WALL
+      &END METAVAR
+    &END METADYN
+  &END FREE_ENERGY
+  &MD
+    STEPS 1
+  &END MD
+&END MOTION
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    &QS
+      METHOD XTB
+    &END QS
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 5.0 5.0 5.0
+      PERIODIC NONE
+    &END CELL
+    &COLVAR
+      &REACTION_PATH
+        FUNCTION T
+        RANGE 0.0 1.0
+        VARIABLE T
+        &COLVAR
+          &COORDINATION
+            ATOMS_FROM 1
+            ATOMS_TO 2 3
+          &END COORDINATION
+        &END COLVAR
+      &END REACTION_PATH
+    &END COLVAR
+    &COLVAR
+      &REACTION_PATH
+        FUNCTION T
+        RANGE 0.0 1.0
+        VARIABLE T
+        &COLVAR
+          &COORDINATION
+            ATOMS_FROM 1
+            KINDS_TO H
+          &END COORDINATION
+        &END COLVAR
+      &END REACTION_PATH
+    &END COLVAR
+    &COORD
+      O -1.37631 0.79033 0.00000
+      H -0.40631 0.79033 0.00000
+      H -1.69964 1.04112 -0.87947
+    &END COORD
+    &VELOCITY
+      0.0 0.0 0.0
+      0.0 0.0 0.0
+      0.0 0.0 0.0
+    &END VELOCITY
+  &END SUBSYS
+&END FORCE_EVAL


### PR DESCRIPTION
## Summary

- recursively post-process component COLVARs used by `REACTION_PATH` and `DISTANCE_FROM_PATH`
- rebuild the parent COLVAR mapping after kind names have been expanded to atom indices
- add an xTB regression covering a nested `COORDINATION` definition with `KINDS_TO`

## Root cause

Only top-level COLVARs were post-processed after particle kinds became available. A nested `COORDINATION` COLVAR using `KINDS_TO` therefore retained an empty atom list when its parent reaction path was initialized. Explicit `ATOMS_TO` definitions did not require this post-processing and worked correctly.

## Verification

- reproduced the issue: `ATOMS_TO` returned `0.91155`, while the equivalent nested `KINDS_TO` definition returned `0.24792`
- confirmed that both definitions return identical values after the fix, including `0.91155` in the first step
- built `cp2k.pdbg` with a fresh GCC 16 MPI Debug configuration
- passed the new two-rank xTB regression test (`1/1`)
- confirmed that the regression test produces a different potential energy on the unfixed code
- passed CP2K precommit checks for all changed files

Closes #2510
