### PR TITLE
Document constrained MD and blue-moon estimators

### DIFF
--- a/docs/methods/sampling/constrained_dynamics.md
+++ b/docs/methods/sampling/constrained_dynamics.md
@@ -1,0 +1,126 @@
+# Constrained molecular dynamics
+
+CP2K can constrain a collective variable during molecular dynamics with
+[MOTION/CONSTRAINT/COLLECTIVE](#CP2K_INPUT.MOTION.CONSTRAINT.COLLECTIVE). The collective variable is
+defined in [FORCE_EVAL/SUBSYS/COLVAR](#CP2K_INPUT.FORCE_EVAL.SUBSYS.COLVAR), and `COLVAR` in the
+constraint section selects it by input order. Use
+[INTERMOLECULAR](#CP2K_INPUT.MOTION.CONSTRAINT.COLLECTIVE.INTERMOLECULAR) for a collective variable
+whose atoms are not all in the same molecular object.
+
+A fixed-distance window can be set up as follows:
+
+```none
+&FORCE_EVAL
+  ...
+  &SUBSYS
+    ...
+    &COLVAR
+      &DISTANCE
+        ATOMS 1 2
+      &END DISTANCE
+    &END COLVAR
+  &END SUBSYS
+&END FORCE_EVAL
+
+&MOTION
+  &CONSTRAINT
+    &COLLECTIVE
+      COLVAR 1
+      INTERMOLECULAR TRUE
+      TARGET [angstrom] 2.0
+    &END COLLECTIVE
+    &LAGRANGE_MULTIPLIERS ON
+      FILENAME constraint_force
+      COMMON_ITERATION_LEVELS 1
+    &END LAGRANGE_MULTIPLIERS
+  &END CONSTRAINT
+  &MD
+    ...
+  &END MD
+&END MOTION
+```
+
+## Lagrange-multiplier output
+
+[LAGRANGE_MULTIPLIERS](#CP2K_INPUT.MOTION.CONSTRAINT.LAGRANGE_MULTIPLIERS) writes two records during
+a velocity-Verlet step:
+
+- `Shake Lagrangian Multipliers` contains the position-constraint multipliers. These are the values
+  relevant to a configurational constraint force and constrained thermodynamic integration.
+- `Rattle Lagrangian Multipliers` contains the velocity-constraint multipliers. They enforce the
+  time derivative of the constraint and are not a second configurational-force sample.
+
+The values are raw CP2K internal quantities; specifying `TARGET` in another unit does not convert
+the printed multipliers. A distance constraint therefore produces a multiplier in hartree/bohr,
+while an angular constraint uses the corresponding internal angular unit. The file contains the
+multipliers of all active constraints, first intramolecular constraints and then intermolecular
+constraints. The ordering within each group is collective-variable, 3-by-3, and 4-by-6 constraints.
+
+## Blue-moon ensemble correction
+
+The printed SHAKE multiplier is not, in general, a complete blue-moon estimator. For one constrained
+reaction coordinate $\xi$, define the scalar mass metric
+
+$$
+Z = \sum_i \frac{1}{m_i}\left|\nabla_i\xi\right|^2.
+$$
+
+With the CP2K convention that the constraint force is $-\lambda\nabla\xi$, the free-energy gradient
+contains a $Z^{-1/2}$ reweighting and, for a general coordinate, an additional metric-derivative
+term. CP2K currently writes $\lambda$ but does not evaluate or print the complete corrected
+blue-moon estimator. The required metric terms therefore have to be evaluated during postprocessing
+for the chosen reaction coordinate. See
+[Komeiji, Chem-Bio Informatics Journal 7, 12 (2007)](https://doi.org/10.1273/cbij.7.12) for the
+general expression and explicit algorithms for two common coordinates.
+
+For the distance between two atoms,
+
+$$
+\xi = |\mathbf r_i-\mathbf r_j|,
+\qquad
+Z = m_i^{-1}+m_j^{-1}.
+$$
+
+Here $Z$ is constant and the metric-derivative term is zero. The reweighting cancels, so the
+free-energy gradient reduces to $-\langle\lambda\rangle_\xi$ with the sign convention above.
+
+For the three-atom distance difference
+
+$$
+\xi = |\mathbf r_i-\mathbf r_j|-|\mathbf r_k-\mathbf r_j|,
+$$
+
+the metric-derivative term is also zero, but
+
+$$
+Z = m_i^{-1}+m_k^{-1}
+    +2m_j^{-1}\left(1-\boldsymbol\rho_{ij}\mathbin{\cdot}\boldsymbol\rho_{kj}\right)
+$$
+
+depends on the instantaneous angle. Consequently, the free-energy gradient is
+
+$$
+\frac{\mathrm d A}{\mathrm d\xi}
+=
+\frac{\left\langle Z^{-1/2}(-\lambda)\right\rangle_\xi}
+     {\left\langle Z^{-1/2}\right\rangle_\xi}.
+$$
+
+This simplification applies to this specific three-atom coordinate. It must not be assumed for an
+arbitrary [COMBINE_COLVAR](#CP2K_INPUT.FORCE_EVAL.SUBSYS.COLVAR.COMBINE_COLVAR), coordination
+number, or multiple simultaneous constraints.
+
+## Fixed windows and moving constraints
+
+For equilibrium constrained thermodynamic integration, run independently equilibrated trajectories
+at a series of fixed `TARGET` values, calculate the corrected free-energy gradient in every window,
+and integrate it over the reaction coordinate. Check the sampling length, correlation time, window
+spacing, integration direction, and unit conversion.
+
+[TARGET_GROWTH](#CP2K_INPUT.MOTION.CONSTRAINT.COLLECTIVE.TARGET_GROWTH) instead changes `TARGET`
+linearly by `TARGET_GROWTH * TIMESTEP` at every MD step, optionally stopping at
+[TARGET_LIMIT](#CP2K_INPUT.MOTION.CONSTRAINT.COLLECTIVE.TARGET_LIMIT). This is a moving-constraint
+or slow-growth protocol. CP2K does not integrate the work or turn the resulting trajectory into an
+equilibrium free-energy profile automatically. A finite pulling rate can cause lag, dissipation, and
+direction-dependent hysteresis, so such a trajectory must be analysed with a method appropriate to
+the intended nonequilibrium protocol.

--- a/docs/methods/sampling/index.md
+++ b/docs/methods/sampling/index.md
@@ -6,6 +6,7 @@ titlesonly:
 maxdepth: 2
 ---
 molecular_dynamics
+constrained_dynamics
 metadynamics
 path_integrals
 newton-x

--- a/src/input_cp2k_constraints.F
+++ b/src/input_cp2k_constraints.F
@@ -147,7 +147,10 @@ CONTAINS
 
       CALL cp_print_key_section_create( &
          print_key, __LOCATION__, "lagrange_multipliers", &
-         description="Prints out the lagrange multipliers of the specified constraints during an MD.", &
+         description="Prints the raw SHAKE position-constraint and RATTLE velocity-constraint"// &
+         " Lagrange multipliers during MD. Values use CP2K internal units and include all active"// &
+         " constraints. The output does not include mass-metric corrections required for a general"// &
+         " blue-moon free-energy estimator.", &
          print_level=high_print_level, filename="")
       CALL section_add_subsection(section, print_key)
       CALL section_release(print_key)
@@ -295,8 +298,10 @@ CONTAINS
       CALL keyword_release(keyword)
 
       CALL keyword_create(keyword, __LOCATION__, name="TARGET_GROWTH", &
-                          description="Specifies the growth speed of the target value of the constrained collective"// &
-                          " variable.", &
+                          description="Specifies the rate at which the target value of the constrained collective"// &
+                          " variable changes during MD. At every step, TARGET is incremented by"// &
+                          " TARGET_GROWTH times the MD time step, optionally up to TARGET_LIMIT."// &
+                          " This moves the constraint but does not integrate work or compute a free-energy profile.", &
                           usage="TARGET_GROWTH {real}", &
                           default_r_val=0.0_dp, unit_str="internal_cp2k")
       CALL section_add_keyword(section, keyword)


### PR DESCRIPTION
## Summary

- add a constrained molecular dynamics guide
- document SHAKE versus RATTLE multiplier semantics and internal units
- explain when a raw multiplier is sufficient for blue-moon thermodynamic integration
- give the mass-metric correction for a three-atom distance difference
- clarify that `TARGET_GROWTH` moves the constraint but does not integrate work or compute a PMF
- improve the generated input descriptions for `LAGRANGE_MULTIPLIERS` and `TARGET_GROWTH`

## Motivation

The input reference says that CP2K writes Lagrange multipliers, but it does not explain which of the SHAKE/RATTLE values enters configurational thermodynamic integration, when mass-metric reweighting is required, or what `TARGET_GROWTH` does and does not calculate.

This can lead to incorrect free-energy profiles for nonlinear or composite collective variables. The change was motivated by the unanswered Google Groups question [CP2K:22297](https://groups.google.com/g/cp2k/c/Dt1V92-egq0).

## Testing

- CP2K precommit on all changed files
- `git diff --check`
- Sphinx manual build with generated CP2K input references and warnings treated as errors
