### PR TITLE
CMake/Spack: Resolve OpenBLAS discovery

### DIFF
--- a/cmake/modules/FindBlas.cmake
+++ b/cmake/modules/FindBlas.cmake
@@ -127,13 +127,10 @@ endif()
 # cleanup list (regularly contains empty items)
 list(FILTER CP2K_BLAS_LINK_LIBRARIES EXCLUDE REGEX "^$")
 
-# we exclude the CP2K_BLAS_INCLUDE_DIRS from the list of mandatory variables as
-# having the fortran interface is usually enough. C, C++ and others languages
-# might require this information though
-
 find_package_handle_standard_args(
-  ${CMAKE_FIND_PACKAGE_NAME} REQUIRED_VARS CP2K_BLAS_LINK_LIBRARIES
-                                           CP2K_BLAS_VENDOR CP2K_BLAS_FOUND)
+  ${CMAKE_FIND_PACKAGE_NAME}
+  REQUIRED_VARS CP2K_BLAS_LINK_LIBRARIES CP2K_BLAS_VENDOR
+                CP2K_BLAS_INCLUDE_DIRS CP2K_BLAS_FOUND)
 
 if(NOT TARGET cp2k::BLAS::blas)
   add_library(cp2k::BLAS::blas INTERFACE IMPORTED)

--- a/cmake/modules/FindOpenBLAS.cmake
+++ b/cmake/modules/FindOpenBLAS.cmake
@@ -32,7 +32,9 @@ if(NOT CP2K_OPENBLAS_FOUND)
   cp2k_find_libraries(OPENBLAS_THREADS64 "openblas64_threads;openblas64_omp")
 endif()
 
-cp2k_include_dirs(OPENBLAS "cblas.h")
+if(NOT CP2K_OPENBLAS_INCLUDE_DIRS)
+  cp2k_include_dirs(openblas "cblas.h")
+endif()
 
 # check if found
 if(CP2K_OPENBLAS_INCLUDE_DIRS)

--- a/tools/spack/cp2k_deps_s-static.yaml
+++ b/tools/spack/cp2k_deps_s-static.yaml
@@ -53,6 +53,7 @@ spack:
       require:
         - "+fortran"
         - "threads=openmp"
+        - "build_system=makefile"
 
     # Libraries needed by CP2K
     dbcsr:

--- a/tools/spack/cp2k_deps_s.yaml
+++ b/tools/spack/cp2k_deps_s.yaml
@@ -60,6 +60,7 @@ spack:
       require:
         - "+fortran"
         - "threads=openmp"
+        - "build_system=makefile"
 
     # Libraries needed by CP2K
     dbcsr:


### PR DESCRIPTION
Since #5675 introduced [the inclusion of `cblas.h`](https://github.com/cp2k/cp2k/blob/852b9a412ddc30c10b4546cf9c8743185fdcc096/src/torch_c_api.cpp#L21-L23), we must treat `CP2K_BLAS_INCLUDE_DIRS` as a required variable.

The `FindOpenBLAS.cmake` seems to lose the include directory discovery when OpenBLAS is built with CMake, as OpenBLAS CMake installs include headers under `include/openblas` rather `include` (not consistent with Makefile build...). The unconditional `cp2k_include_dirs(OPENBLAS "cblas.h")` then overrides the correct value the `pkg-config` of OpenBLAS already provides, as it search for `<prefix>/include/cblas.h`, `<prefix>/include/OPENBLAS/cblas.h`, and `<prefix>/OPENBLAS/cblas.h`, but not `<prefix>/include/openblas/cblas.h`.

Since CMake is explicitly marked as "experimental" by upstream, I also make `build_system=makefile` the requirement for OpenBLAS in Spack `yaml` file.