### PR TITLE
CMake/Spack: Enhance OpenBLAS discovery

### DIFF
--- a/cmake/modules/FindOpenBLAS.cmake
+++ b/cmake/modules/FindOpenBLAS.cmake
@@ -33,7 +33,7 @@ if(NOT CP2K_OPENBLAS_FOUND)
 endif()
 
 if(NOT CP2K_OPENBLAS_INCLUDE_DIRS)
-  cp2k_include_dirs(openblas "cblas.h")
+  cp2k_include_dirs(OPENBLAS "cblas.h")
 endif()
 
 # check if found

--- a/cmake/modules/cp2k_utils.cmake
+++ b/cmake/modules/cp2k_utils.cmake
@@ -74,12 +74,15 @@ function(cp2k_find_libraries _package_name _library_name)
 endfunction()
 
 function(cp2k_include_dirs _package_name _library_include_file)
+  string(TOLOWER "${_package_name}" _package_name_lower)
   find_path(
     CP2K_${_package_name}_INCLUDE_DIRS_TMP
     NAMES ${_library_include_file}
     PATHS "${CP2K_${_package_name}_ROOT}"
     HINTS "${CP2K_${_package_name}_ROOT}"
-    PATH_SUFFIXES "include" "include/${_package_name}" "${_package_name}")
+    PATH_SUFFIXES
+      "include" "include/${_package_name}" "include/${_package_name_lower}"
+      "${_package_name}" "${_package_name_lower}")
 
   set(CP2K_${_package_name}_INCLUDE_DIRS
       "${CP2K_${_package_name}_INCLUDE_DIRS_TMP}"

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1433,6 +1433,9 @@ if [[ ! -d "${CMAKE_BUILD_PATH}" ]]; then
     ssmp-static)
       # Find some static libraries in advance
       LIBOPENBLAS=$(find -L "${SPACK_ROOT}"/opt/spack/view -name libopenblas.a)
+      OPENBLAS_INCLUDE_DIR="$(
+        dirname "$(find -L "${SPACK_ROOT}"/opt/spack/view -name cblas.h -print -quit)"
+      )"
       LIBM="$(find /usr -name libm.a 2> /dev/null)"
       # shellcheck disable=SC2086
       cmake -S "${CP2K_ROOT}" -B "${CMAKE_BUILD_PATH}" --preset "${CMAKE_PRESET}" \
@@ -1446,6 +1449,8 @@ if [[ ! -d "${CMAKE_BUILD_PATH}" ]]; then
         -DCMAKE_INSTALL_MESSAGE="${INSTALL_MESSAGE}" \
         -DCMAKE_SKIP_RPATH="ON" \
         -DCMAKE_VERBOSE_MAKEFILE="${VERBOSE_MAKEFILE}" \
+        -DCP2K_BLAS_VENDOR="OpenBLAS" \
+        -DCP2K_BLAS_INCLUDE_DIRS="${OPENBLAS_INCLUDE_DIR}" \
         -DCP2K_BLAS_LINK_LIBRARIES="${LIBOPENBLAS};${LIBM}" \
         -DCP2K_LAPACK_LINK_LIBRARIES="${LIBOPENBLAS};${LIBM}" \
         ${CMAKE_FEATURE_FLAGS} \


### PR DESCRIPTION
Using `cp2k_include_dirs(openblas "cblas.h")` is incorrect because it returns `CP2K_openblas_INCLUDE_DIRS` that cannot be used (CMake wants `CP2K_OPENBLAS_INCLUDE_DIRS`.

As simply reverting that change will again break the discovery of `include/openblas/cblas.h`, I modified the `cp2k_includr_dirs` function to make such discovery possible.

Follow up to #5694.