### PR TITLE
Guard LibXS JIT use against missing handles

### DIFF
--- a/tools/toolchain/scripts/stage4/install_libxs.sh
+++ b/tools/toolchain/scripts/stage4/install_libxs.sh
@@ -33,6 +33,8 @@ case "$with_libxs" in
 
       echo "Installing from scratch into ${pkg_install_dir}"
       cd libxs-${libxs_ver}
+      patch -l -p1 < "${SCRIPT_DIR}/stage4/libxs-${libxs_ver}-jit-handle.patch" \
+        > libxs_jit_handle.patch.log 2>&1 || tail_excerpt libxs_jit_handle.patch.log
       mkdir build && cd build
       cmake \
         -DCMAKE_INSTALL_PREFIX="${pkg_install_dir}" \
@@ -42,7 +44,8 @@ case "$with_libxs" in
         .. > configure.log 2>&1 || tail_excerpt configure.log
       make install -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
       cd ..
-      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage4/$(basename ${SCRIPT_NAME})"
+      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage4/$(basename ${SCRIPT_NAME})" \
+        "${SCRIPT_DIR}/stage4/libxs-${libxs_ver}-jit-handle.patch"
     fi
     ;;
   __SYSTEM__)

--- a/tools/toolchain/scripts/stage4/libxs-1.0.0-jit-handle.patch
+++ b/tools/toolchain/scripts/stage4/libxs-1.0.0-jit-handle.patch
@@ -20,3 +20,20 @@ index a567d3b..d5fd909 100644
            {
              void* fn = jgs(jitter);
              if (NULL != fn) LIBXS_FPTR_FROM_VPTR(libxs_gemm_sjit_t, config.sgemm_jit, fn);
+diff --git a/libxs/libxs_gemm.h b/libxs/libxs_gemm.h
+--- a/libxs/libxs_gemm.h
++++ b/libxs/libxs_gemm.h
+@@ -302,11 +302,9 @@ LIBXS_API_INLINE void libxs_gemm_call(
+ {
+   LIBXS_ASSERT(NULL != config);
+-  if (NULL != config->dgemm_jit) {
+-    LIBXS_ASSERT(NULL != config->jitter);
++  if (NULL != config->dgemm_jit && NULL != config->jitter) {
+     config->dgemm_jit(config->jitter, a, b, c);
+   }
+-  else if (NULL != config->sgemm_jit) {
+-    LIBXS_ASSERT(NULL != config->jitter);
++  else if (NULL != config->sgemm_jit && NULL != config->jitter) {
+     config->sgemm_jit(config->jitter, a, b, c);
+   }
+   else if (NULL != config->xgemm) {

--- a/tools/toolchain/scripts/stage4/libxs-1.0.0-jit-handle.patch
+++ b/tools/toolchain/scripts/stage4/libxs-1.0.0-jit-handle.patch
@@ -1,0 +1,22 @@
+diff --git a/src/libxs_gemm.c b/src/libxs_gemm.c
+index a567d3b..d5fd909 100644
+--- a/src/libxs_gemm.c
++++ b/src/libxs_gemm.c
+@@ -519,7 +519,7 @@ LIBXS_API libxs_gemm_config_t* libxs_gemm_dispatch_rt(
+           void* jitter = NULL;
+           if (2 != jcd(&jitter, 102, mkl_ta, mkl_tb,
+             km, kn, kk, kernel_shape->alpha, klda, kldb,
+-            kernel_shape->beta, kldc))
++            kernel_shape->beta, kldc) && NULL != jitter)
+           {
+             void* fn = jgd(jitter);
+             if (NULL != fn) LIBXS_FPTR_FROM_VPTR(libxs_gemm_djit_t, config.dgemm_jit, fn);
+@@ -535,7 +535,7 @@ LIBXS_API libxs_gemm_config_t* libxs_gemm_dispatch_rt(
+           void* jitter = NULL;
+           if (2 != jcs(&jitter, 102, mkl_ta, mkl_tb,
+             km, kn, kk, (float)kernel_shape->alpha, klda, kldb,
+-            (float)kernel_shape->beta, kldc))
++            (float)kernel_shape->beta, kldc) && NULL != jitter)
+           {
+             void* fn = jgs(jitter);
+             if (NULL != fn) LIBXS_FPTR_FROM_VPTR(libxs_gemm_sjit_t, config.sgemm_jit, fn);


### PR DESCRIPTION
## Summary

- patch bundled LibXS 1.0.0 to require a valid JIT handle before retrieving an MKL DGEMM or SGEMM kernel
- execute a JIT kernel only when both its function pointer and handle are present
- use the existing XGEMM/BLAS fallback for incomplete JIT configurations
- include the patch in the toolchain checksum so cached installations are invalidated correctly

## Motivation

The Intel oneAPI (ssmp, ifort) dashboard originally aborted in `G0W0_H2O_PBE0_30_pts.inp` at LibXS' `config->jitter` assertion. A JIT create callback can return without populating the handle, so dispatch must not request or store a kernel in that case.

After that dispatch guard, the ifort-psmp check exposed a second path in `diamond_gpw_stress.inp`: while the shared GEMM configuration is updated during JIT warm-up, an OpenMP consumer can observe a JIT function pointer without its handle. Treating the function pointer and handle as a pair at the call site selects LibXS' existing fallback for this incomplete state.

The complete fix and regression tests are submitted upstream as hfp/libxs#27 (tracking issue: hfp/libxs#26). This PR remains version-bound to bundled LibXS 1.0.0 and does not change CP2K sources, regtest references, or tolerances.

## Testing

- upstream LibXS mock tests cover missing handles during DGEMM/SGEMM dispatch and call, including fallback execution
- focused LibXS CMake test passes with Linux/GCC/OpenMP
- Intel 2024.2 ifort ssmp: `QS/regtest-gw-cubic`, 13/13 correct; the original failing test returns `15.6066`
- Intel 2024.2 ifort psmp, 2 MPI x 2 OpenMP, portable CPU target: `QS/regtest-kp-hfx-ri-2`, 6/6 correct
- the psmp CI reproducer `diamond_gpw_stress.inp` returns `-10.23639573` without the LibXS assertion
- patch applies cleanly to the bundled LibXS 1.0.0 tarball
- `make_pretty.sh` and `git diff --check`: pass