### PR TITLE
Document standard diagonalization and virtual MO output

### DIFF
--- a/docs/methods/electronic_structure/molecular_orbitals.md
+++ b/docs/methods/electronic_structure/molecular_orbitals.md
@@ -61,9 +61,36 @@ Useful controls include:
 - [CARTESIAN_OVERLAP](#CP2K_INPUT.FORCE_EVAL.DFT.PRINT.MO.CARTESIAN_OVERLAP): print the Cartesian
   overlap matrix together with Cartesian MO coefficients.
 
-For diagonalization calculations, unoccupied orbitals must be available through
-[ADDED_MOS](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.ADDED_MOS). For OT calculations, CP2K can generate the
-requested virtual orbitals for printing through the OT eigensolver.
+For diagonalization calculations, an explicit positive `MO_INDEX_RANGE` or `-1` as its last index
+automatically makes the requested orbitals available, up to the AO basis size. Use
+[ADDED_MOS](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.ADDED_MOS) when virtual orbitals are needed independently
+of this print request, for example for smearing or a subsequent method. For OT calculations, CP2K
+can generate the requested virtual orbitals for printing through the OT eigensolver.
+
+### Standard diagonalization and the number of orbitals
+
+With [ALGORITHM STANDARD](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.DIAGONALIZATION.ALGORITHM), CP2K constructs
+the Kohn--Sham matrix $H$ and overlap matrix $S$ in the atomic-orbital (AO) basis and solves
+
+$$
+H C = S C \varepsilon.
+$$
+
+For a k-point calculation, CP2K solves this generalized eigenproblem separately at every k-point and
+spin channel. It is not a projection of $H$ onto the occupied-MO subspace. Depending on the selected
+diagonalization backend, CP2K either computes only the requested lowest eigenpairs or computes the
+complete spectrum and retains the requested part.
+
+The number of stored orbitals is normally the number needed for the occupied states plus
+`ADDED_MOS`, capped by the AO basis size. `ADDED_MOS -1` requests all available orbitals. At zero
+electronic temperature, virtual orbitals do not contribute to the density matrix, but calculating
+and storing more of them increases the cost.
+
+For Gamma-point calculations close to SCF convergence, `STANDARD` may use a block-Jacobi
+pseudo-diagonalization sweep controlled by
+[EPS_JACOBI](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.DIAGONALIZATION.EPS_JACOBI). This is distinct from the
+optional [DIAG_SUB_SCF](#CP2K_INPUT.FORCE_EVAL.DFT.SCF.DIAGONALIZATION.DIAG_SUB_SCF) inner loop,
+which keeps the MOs fixed while refining occupations and is not available with k-points.
 
 ### Interpreting MO energies and energy gaps
 

--- a/src/input_cp2k_print_dft.F
+++ b/src/input_cp2k_print_dft.F
@@ -541,8 +541,9 @@ CONTAINS
          print_key, __LOCATION__, "MO", &
          description="Controls the printing of the molecular orbital (MO) information. The requested MO information "// &
          "is printed for all occupied MOs by default. Use the MO_INDEX_RANGE keyword to restrict the number "// &
-         "of the MOs or to print the MO information for unoccupied MOs. With diagonalization, additional MOs "// &
-         "have to be made available for printout using the ADDED_MOS keyword in the SCF section. With OT, "// &
+         "of the MOs or to print the MO information for unoccupied MOs. With diagonalization, an explicit "// &
+         "positive range or -1 as its last index makes the requested MOs available automatically, up to the "// &
+         "AO basis size. ADDED_MOS can make extra MOs available independently of this print request. With OT, "// &
          "it is sufficient to specify the desired MO_INDEX_RANGE. The OT eigensolver can be controlled with "// &
          "the EPS_LUMO and MAX_ITER_LUMO keywords in the SCF section.", &
          print_level=high_print_level, filename="__STD_OUT__")
@@ -593,8 +594,9 @@ CONTAINS
                           name="MO_INDEX_RANGE", &
                           variants=s2a("MO_RANGE", "RANGE"), &
                           description="Print only the requested subset of MOs. The indices of the first and "// &
-                          "the last MO have to be specified to define the range. -1 as the last MO index "// &
-                          "prints all available orbitals with diagonalisation (ADDED_MOS) and all orbitals with OT.", &
+                          "the last MO have to be specified to define the range. A positive range makes the "// &
+                          "requested MOs available automatically. -1 as the last MO index makes and prints all "// &
+                          "available orbitals with diagonalization and all orbitals with OT.", &
                           repeats=.FALSE., &
                           n_var=2, &
                           type_of_var=integer_t, &

--- a/src/input_cp2k_scf.F
+++ b/src/input_cp2k_scf.F
@@ -963,7 +963,8 @@ CONTAINS
                           usage="ALGORITHM STANDARD", &
                           default_i_val=diag_standard, &
                           enum_c_vals=s2a("STANDARD", "OT", "LANCZOS", "DAVIDSON", "FILTER_MATRIX"), &
-                          enum_desc=s2a("Standard diagonalization: LAPACK methods or Jacobi.", &
+                          enum_desc=s2a("AO-basis Kohn-Sham diagonalization using LAPACK-compatible methods"// &
+                                        " or a late-SCF Jacobi sweep.", &
                                         "Iterative diagonalization using OT method", &
                                         "Block Krylov-space approach to self-consistent diagonalisation", &
                                         "Preconditioned blocked Davidson", &


### PR DESCRIPTION
## Summary

- document that an explicit positive `MO_INDEX_RANGE`, or `-1` as its last index, automatically makes the requested orbitals available for diagonalization calculations
- clarify when `ADDED_MOS` is still needed independently of an MO print request
- explain that `ALGORITHM STANDARD` solves the generalized Kohn-Sham eigenproblem in the AO basis rather than in the occupied-MO subspace
- distinguish standard diagonalization, late-SCF Jacobi sweeps, and `DIAG_SUB_SCF`
- update the generated input-reference descriptions accordingly

## Motivation

The documentation still states that virtual orbitals must always be made available explicitly with `ADDED_MOS`. This no longer matches the behavior introduced by commit [983a8784de](https://github.com/cp2k/cp2k/commit/983a8784de08474e9a2886adc0c8e52bba168087).

The discrepancy caused confusion in [CP2K:22133](https://groups.google.com/g/cp2k/c/sBNW-51oBLw), where `MO_INDEX_RANGE 0 -1` was expected to print the full available spectrum.

## Testing

- full CP2K CMake/Ninja build
- full Sphinx HTML build; no warning introduced by the changed pages
- official CP2K precommit checks: 3/3 files passed
- reproduced the attached periodic XTB silicon calculation with the unchanged input:
  - 8 k-points
  - 4 occupied orbitals
  - 18 total orbitals at every k-point
  - no explicit `ADDED_MOS`
- `git diff --check`
