### PR TITLE
Finalize keepalive regtest shells cleanly

### DIFF
--- a/tests/do_regtest.py
+++ b/tests/do_regtest.py
@@ -470,12 +470,20 @@ class Cp2kShell:
         self.workdir = workdir
         self._child: Optional[Process] = None
 
-    async def stop(self) -> None:
+    async def stop(self, force: bool = False) -> None:
         assert self._child
-        try:
-            self._child.terminate()  # Give mpiexec a chance to shutdown
-        except ProcessLookupError:
-            pass
+        if self._child.returncode is None:
+            if force:
+                try:
+                    self._child.terminate()
+                except ProcessLookupError:
+                    pass
+            else:
+                # Let CP2K finalize MPI and release launcher resources.
+                try:
+                    await self.sendline("EXIT")
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
         await self._child.communicate()  # Read output to prevent a zombie process.
         self._child = None
 
@@ -607,7 +615,7 @@ async def run_regtests_keepalive(batch: Batch, cfg: Config) -> List[TestResult]:
                 returncode = -9
 
         if returncode != 0:
-            await shell.stop()
+            await shell.stop(force=timed_out)
             await shell.start()
         duration = time.perf_counter() - start_time
         output_size = dirsize(batch.workdir) - start_dirsize


### PR DESCRIPTION
## Summary

- stop healthy keepalive CP2K shells through the shell `EXIT` protocol
- retain hard termination for timed-out calculations
- avoid sending shutdown commands to children that have already exited

## Motivation

The Spack psmp 4x2 dashboard starts failing abruptly with empty output and return code 7 around test directory 256.

The keepalive runner currently terminates `mpiexec` after every test directory. With MPICH 5.0.1 this leaves one 4,233,472-byte `mpich_shm_*` segment behind for each terminated shell. The dashboard container provides 1 GiB of `/dev/shm`, which is exhausted after roughly 254 shells. Subsequent MPI launches then fail immediately.

Using the CP2K shell's `EXIT` command lets CP2K finalize MPI normally and release the shared-memory segment. A timed-out calculation may still be busy, so that path keeps the existing hard termination behavior.

This does not change tests, references, tolerances, or dependencies.

## Testing

- exact Spack psmp 4x2 configuration: MPICH 5.0.1, 4 MPI ranks x 2 OpenMP threads, 4 workers, 1 GiB `/dev/shm`
- baseline: shared-memory usage grew to 250 segments; 52 tests then failed with empty output and return code 7
- patched: shared-memory usage remained at 3-4 active segments; 5904/5904 tests passed in 34 minutes
- focused shutdown-state checks for healthy, timed-out, and crashed children
- `python3 -m py_compile tests/do_regtest.py`
- `make_pretty.sh tests/do_regtest.py`
- `git diff --check`