### PR TITLE
Move GCC 14 Spack test to morning window

### DIFF
--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -500,7 +500,7 @@ dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-gcc15
 
 [spack-psmp-gcc14]
 display_name: Spack (psmp, GCC 14)
-tags:         weekly-afternoon
+tags:         weekly-morning
 cpu:          32
 nodepools:    pool-main
 build_path:   /


### PR DESCRIPTION
## Summary

- Run `spack-psmp-gcc14` in the less congested `weekly-morning` window.
- Keep the compiler, dependencies, and regression coverage unchanged.

## Motivation

The 5 August run started at 16:46 UTC but its report was cut off without an `EndDate` at 17:03 UTC during the dependency build. Several late `weekly-afternoon` jobs were truncated at exactly the same time, whereas the morning batch completed with spare capacity.

The last archived regression failure predates #5646, which fixed the affected half-cell k-point gauge path.

## Validation

- `./make_pretty.sh tools/docker/cp2k-ci.conf`
- Parsed `cp2k-ci.conf` and verified the tester resolves to `weekly-morning`