### PR TITLE
Move Rocky Linux Spack test to morning window

### DIFF
--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -466,7 +466,7 @@ dockerfile:   /tools/docker/Dockerfile.test_spack_psmp-fedora
 
 [spack-psmp-rockylinux]
 display_name: Spack (psmp, rockylinux)
-tags:         weekly-afternoon
+tags:         weekly-morning
 cpu:          32
 nodepools:    pool-main
 build_path:   /


### PR DESCRIPTION
## Summary

- Run `spack-psmp-rockylinux` in the less congested `weekly-morning` window.
- Keep the tester configuration, dependencies, and regression coverage unchanged.

## Motivation

The 5 August run started at 16:24 UTC but its report was cut off without an `EndDate` at 17:03 UTC while Spack was still installing dependencies. Several late `weekly-afternoon` jobs were truncated at the same time, whereas the morning batch completed with spare capacity.

The last archived regression failure predates #5646, which fixed the affected half-cell k-point gauge path.

## Validation

- `./make_pretty.sh tools/docker/cp2k-ci.conf`
- Parsed `cp2k-ci.conf` and verified the tester resolves to `weekly-morning`