### PR TITLE
Align STRUCTURE_DATA dihedral signs with torsion COLVARs

### DIFF
--- a/src/particle_methods.F
+++ b/src/particle_methods.F
@@ -1036,8 +1036,9 @@ CONTAINS
                                particle_set(atomic_indices(3))%r(:), cell)
                   rcd(:) = pbc(particle_set(atomic_indices(3))%r(:), &
                                particle_set(atomic_indices(4))%r(:), cell)
+                  ! Match the sign convention of the TORSION collective variable.
                   WRITE (UNIT=iw, FMT="(T3,A,T26,A,F9.3)") &
-                     "d"//TRIM(string), "=", dihedral_angle(rab, rbc, rcd)*degree
+                     "d"//TRIM(string), "=", -dihedral_angle(rab, rbc, rcd)*degree
                ELSE
                   WRITE (UNIT=iw, FMT="(T3,A)") &
                      "Invalid atomic indices "//TRIM(string)//" specified. Print request is ignored."

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -387,4 +387,9 @@ registry["REFTRAJ_last_frame_index"] = GenericMatcher(
     r"i\s*=\s*(\d+)", col=1, regex=True
 )
 registry["REFTRAJ_force_file"] = TextPresenceMatcher("ATOMIC FORCES")
+
+# STRUCTURE_DATA uses the same torsion sign convention as the TORSION COLVAR.
+registry["STRUCTURE_DATA_dihedral_angle"] = GenericMatcher(
+    r"d\(1,2,3,4\)\s*=\s*([-+0-9.]+)", col=1, regex=True
+)
 # EOF

--- a/tests/xTB/regtest-3/TEST_FILES.toml
+++ b/tests/xTB/regtest-3/TEST_FILES.toml
@@ -21,4 +21,5 @@
 "graphite-stm.inp"                      = [{matcher="E_total", tol=1.0E-12, ref=-7.91403223193017}]
 "si_dos.inp"                            = [{matcher="E_total", tol=1.0E-12, ref=-14.73033123463482}]
 "h2o_reaction_path_kinds.inp"           = [{matcher="M002", tol=1.0E-12, ref=-5.42961342279}]
+"h4_torsion_structure_data.inp"         = [{matcher="STRUCTURE_DATA_dihedral_angle", tol=1.0E-12, ref=90.0}]
 #EOF

--- a/tests/xTB/regtest-3/h4_torsion_structure_data.inp
+++ b/tests/xTB/regtest-3/h4_torsion_structure_data.inp
@@ -1,0 +1,69 @@
+&GLOBAL
+  PRINT_LEVEL LOW
+  PROJECT h4_torsion_structure_data
+  RUN_TYPE MD
+&END GLOBAL
+
+&MOTION
+  &FREE_ENERGY
+    &METADYN
+      DO_HILLS FALSE
+      &METAVAR
+        COLVAR 1
+        SCALE 1.0
+      &END METAVAR
+      &PRINT
+        &COLVAR
+          COMMON_ITERATION_LEVELS 2
+          &EACH
+            MD 1
+          &END EACH
+        &END COLVAR
+      &END PRINT
+    &END METADYN
+  &END FREE_ENERGY
+  &MD
+    ENSEMBLE NVE
+    STEPS 0
+  &END MD
+  &PRINT
+    &STRUCTURE_DATA LOW
+      DIHEDRAL_ANGLE 1 2 3 4
+      &EACH
+        MD 1
+      &END EACH
+    &END STRUCTURE_DATA
+  &END PRINT
+&END MOTION
+
+&FORCE_EVAL
+  METHOD QUICKSTEP
+  &DFT
+    &QS
+      METHOD XTB
+    &END QS
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 8.0 8.0 8.0
+      PERIODIC NONE
+    &END CELL
+    &COLVAR
+      &TORSION
+        ATOMS 1 2 3 4
+      &END TORSION
+    &END COLVAR
+    &COORD
+      H 0.0 0.0 0.0
+      H 1.0 0.0 0.0
+      H 1.0 1.0 0.0
+      H 1.0 1.0 1.0
+    &END COORD
+    &VELOCITY
+      0.0 0.0 0.0
+      0.0 0.0 0.0
+      0.0 0.0 0.0
+      0.0 0.0 0.0
+    &END VELOCITY
+  &END SUBSYS
+&END FORCE_EVAL


### PR DESCRIPTION
## Summary

- align `STRUCTURE_DATA/DIHEDRAL_ANGLE` with the sign convention used by the `TORSION` collective variable
- add a regression covering a positive 90-degree torsion

## Root cause

`STRUCTURE_DATA` passed the three bond vectors directly to `dihedral_angle()`, whose orientation is opposite to the established `TORSION` COLVAR convention. The same atom ordering therefore produced values with equal magnitude and opposite signs.

The correction is applied in the structure-data print path because the shared geometry helper is also used by TMC moves; changing it globally would alter existing TMC behavior outside this issue.

## Verification

- reproduced the issue on a four-atom geometry: `TORSION` reported `+1.57080 rad`, while `STRUCTURE_DATA` printed `-90.000 deg`
- confirmed both report the positive orientation after the fix: `+1.57080 rad` and `+90.000 deg`
- built `cp2k.pdbg` with a fresh GCC 16 MPI Debug configuration
- passed the new two-rank xTB regression (`1/1`)
- passed all CP2K precommit checks

Closes #3405