### PR TITLE
Write effective charges to additional GPW cube files

### DIFF
--- a/src/pw/realspace_grid_cube.F
+++ b/src/pw/realspace_grid_cube.F
@@ -121,8 +121,10 @@ CONTAINS
       IF (PRESENT(mpi_io)) parallel_write = mpi_io
       IF (PRESENT(max_file_size_mb)) my_max_file_size_mb = max_file_size_mb
       CPASSERT(my_max_file_size_mb >= 0)
-      CPWARN_IF(.NOT. parallel_write .AND. PRESENT(particles_z) .AND. .NOT. PRESENT(particles_zeff), &
-                missing_zeff_warning)
+      IF (.NOT. parallel_write .AND. PRESENT(particles_z) .AND. &
+          .NOT. PRESENT(particles_zeff)) THEN
+         CPWARN(missing_zeff_warning)
+      END IF
 
       my_stride = 1
       IF (PRESENT(stride)) THEN
@@ -706,7 +708,9 @@ CONTAINS
       !get rs grids and parallel envnment
       gid = grid%pw_grid%para%group
       my_rank = grid%pw_grid%para%group%mepos
-      CPWARN_IF(PRESENT(particles_z) .AND. .NOT. PRESENT(particles_zeff), missing_zeff_warning)
+      IF (PRESENT(particles_z) .AND. .NOT. PRESENT(particles_zeff)) THEN
+         CPWARN(missing_zeff_warning)
+      END IF
 
       ! Shortcut
       lbounds = grid%pw_grid%bounds(1, :)

--- a/src/pw/realspace_grid_cube.F
+++ b/src/pw/realspace_grid_cube.F
@@ -34,6 +34,9 @@ MODULE realspace_grid_cube
    INTEGER, PARAMETER, PRIVATE          :: cube_line_len = cube_entry_len*cube_num_entries_line
    CHARACTER(len=*), PARAMETER          :: cube_value_format = '(1X,ES12.4E3)', &
                                            cube_values_format = '(6(1X,ES12.4E3))'
+   CHARACTER(len=*), PARAMETER, PRIVATE :: missing_zeff_warning = &
+                                           "Effective nuclear charges were not supplied; "// &
+                                           "zeros will be written to the Cube atom records."
    LOGICAL, PARAMETER, PRIVATE          :: debug_this_module = .FALSE.
 
 CONTAINS
@@ -118,6 +121,8 @@ CONTAINS
       IF (PRESENT(mpi_io)) parallel_write = mpi_io
       IF (PRESENT(max_file_size_mb)) my_max_file_size_mb = max_file_size_mb
       CPASSERT(my_max_file_size_mb >= 0)
+      CPWARN_IF(.NOT. parallel_write .AND. PRESENT(particles_z) .AND. .NOT. PRESENT(particles_zeff), &
+                missing_zeff_warning)
 
       my_stride = 1
       IF (PRESENT(stride)) THEN
@@ -701,6 +706,7 @@ CONTAINS
       !get rs grids and parallel envnment
       gid = grid%pw_grid%para%group
       my_rank = grid%pw_grid%para%group%mepos
+      CPWARN_IF(PRESENT(particles_z) .AND. .NOT. PRESENT(particles_zeff), missing_zeff_warning)
 
       ! Shortcut
       lbounds = grid%pw_grid%bounds(1, :)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -278,6 +278,34 @@ MODULE qs_scf_post_gpw
 CONTAINS
 
 ! **************************************************************************************************
+!> \brief Collects the effective core charge for every atom in a QS environment
+!> \param qs_env the QS environment
+!> \param zcharge effective core charges ordered by atom index
+! **************************************************************************************************
+   SUBROUTINE get_effective_core_charges(qs_env, zcharge)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: zcharge
+
+      INTEGER                                            :: iat, iatom, ikind, nat, natom, nkind
+      REAL(KIND=dp)                                      :: zeff
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
+                      nkind=nkind, natom=natom)
+      ALLOCATE (zcharge(natom))
+      DO ikind = 1, nkind
+         CALL get_qs_kind(qs_kind_set(ikind), zeff=zeff)
+         CALL get_atomic_kind(atomic_kind_set(ikind), natom=nat)
+         DO iatom = 1, nat
+            iat = atomic_kind_set(ikind)%atom_list(iatom)
+            zcharge(iat) = zeff
+         END DO
+      END DO
+   END SUBROUTINE get_effective_core_charges
+
+! **************************************************************************************************
 !> \brief Append `extend_by` to the absolute path of the base section.
 !> \param self ...
 !> \param extend_by ...
@@ -1417,6 +1445,7 @@ CONTAINS
                                                             nlist, unit_nr
       INTEGER, DIMENSION(:), POINTER                     :: list, list_index
       LOGICAL                                            :: append_cube, mpi_io
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1435,6 +1464,7 @@ CONTAINS
 
       IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, mo_section%relative_section_key) &
  , cp_p_file) .AND. section_get_lval(dft_section, mo_section%concat_to_relative(section_key_do_write(mo_section%grid_output)))) THEN
+         CALL get_effective_core_charges(qs_env, zcharge)
          nhomo = section_get_ival(dft_section, mo_section%concat_to_relative("%NHOMO"))
          ! For openPMD, refer to access modes instead of APPEND key
          IF (mo_section%grid_output == grid_output_cubes) THEN
@@ -1495,13 +1525,14 @@ CONTAINS
                       openpmd_unit_si=openpmd_unit_si_wavefunction, &
                       sim_time=qs_env%sim_time)
             WRITE (title, *) "WAVEFUNCTION ", ivector, " spin ", ispin, " i.e. HOMO - ", ivector - homo
-            CALL mo_section%write_pw(wf_r, unit_nr, title, particles=particles, &
+            CALL mo_section%write_pw(wf_r, unit_nr, title, particles=particles, zeff=zcharge, &
                                      stride=section_get_ivals(dft_section, mo_section%concat_to_relative("%STRIDE")), &
                                      max_file_size_mb=section_get_rval(dft_section, "PRINT%MO_CUBES%MAX_FILE_SIZE_MB"), &
                                      mpi_io=mpi_io)
             CALL mo_section%print_key_finished_output(unit_nr, logger, input, mo_section%absolute_section_key, mpi_io=mpi_io)
          END DO
          IF (ASSOCIATED(list_index)) DEALLOCATE (list_index)
+         DEALLOCATE (zcharge)
       END IF
 
       CALL timestop(handle)
@@ -1546,6 +1577,7 @@ CONTAINS
       INTEGER                                            :: handle, ifirst, index_mo, ivector, &
                                                             unit_nr
       LOGICAL                                            :: append_cube, mpi_io
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1562,6 +1594,7 @@ CONTAINS
 
       IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, mo_section%relative_section_key), cp_p_file) &
           .AND. section_get_lval(dft_section, mo_section%concat_to_relative(section_key_do_write(mo_section%grid_output)))) THEN
+         CALL get_effective_core_charges(qs_env, zcharge)
          NULLIFY (qs_kind_set, particle_set, pw_env, cell)
          ! For openPMD, refer to access modes instead of APPEND key
          IF (mo_section%grid_output == grid_output_cubes) THEN
@@ -1605,13 +1638,14 @@ CONTAINS
                       openpmd_unit_si=openpmd_unit_si_wavefunction, &
                       sim_time=qs_env%sim_time)
             WRITE (title, *) "WAVEFUNCTION ", index_mo, " spin ", ispin, " i.e. LUMO + ", ifirst + ivector - 2
-            CALL mo_section%write_pw(wf_r, unit_nr, title, particles=particles, &
+            CALL mo_section%write_pw(wf_r, unit_nr, title, particles=particles, zeff=zcharge, &
                                      stride=section_get_ivals(dft_section, mo_section%concat_to_relative("%STRIDE")), &
                                      max_file_size_mb=section_get_rval(dft_section, "PRINT%MO_CUBES%MAX_FILE_SIZE_MB"), &
                                      mpi_io=mpi_io)
             CALL mo_section%print_key_finished_output(unit_nr, logger, input, mo_section%absolute_section_key, mpi_io=mpi_io)
 
          END DO
+         DEALLOCATE (zcharge)
       END IF
 
       CALL timestop(handle)
@@ -1971,6 +2005,7 @@ CONTAINS
       INTEGER                                            :: handle, ispin, output_unit, unit_nr
       LOGICAL                                            :: append_cube, gapw, mpi_io
       REAL(dp)                                           :: rho_cutoff
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(cp_section_key)                               :: elf_section_key
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
@@ -2010,6 +2045,7 @@ CONTAINS
             END IF
             rho_cutoff = section_get_rval(elf_section, "density_cutoff")
             CALL qs_elf_calc(qs_env, elf_r, rho_cutoff)
+            CALL get_effective_core_charges(qs_env, zcharge)
 
             ! write ELF into cube file
 
@@ -2051,7 +2087,7 @@ CONTAINS
                      TRIM(filename)
                END IF
 
-               CALL elf_section_key%write_pw(elf_r(ispin), unit_nr, title, particles=particles, &
+               CALL elf_section_key%write_pw(elf_r(ispin), unit_nr, title, particles=particles, zeff=zcharge, &
                                              stride=section_get_ivals(elf_section, "STRIDE"), mpi_io=mpi_io)
                CALL elf_section_key%print_key_finished_output( &
                   unit_nr, &
@@ -2064,7 +2100,7 @@ CONTAINS
             END DO
 
             ! deallocate
-            DEALLOCATE (elf_r)
+            DEALLOCATE (elf_r, zcharge)
 
          ELSE
             ! not implemented
@@ -2561,14 +2597,14 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename, mpi_filename, my_pos_cube, &
                                                             my_pos_voro
       CHARACTER(LEN=default_string_length)               :: name, print_density
-      INTEGER :: after, handle, i, iat, iatom, id, ikind, img, iso, ispin, iw, l, n_rep_hf, nat, &
-         natom, nd(3), ngto, niso, nkind, np, nr, output_unit, print_level, should_print_bqb, &
-         should_print_voro, unit_nr, unit_nr_voro
+      INTEGER :: after, handle, i, iat, id, ikind, img, iso, ispin, iw, l, n_rep_hf, natom, nd(3), &
+         ngto, niso, nkind, np, nr, output_unit, print_level, should_print_bqb, should_print_voro, &
+         unit_nr, unit_nr_voro
       LOGICAL :: append_cube, append_voro, do_hfx, do_kpoints, mpi_io, omit_headers, print_it, &
          rho_r_valid, voro_print_txt, write_ks, write_xc, xrd_interface
       REAL(KIND=dp)                                      :: norm_factor, q_max, rho_hard, rho_soft, &
                                                             rho_total, rho_total_rspace, udvol, &
-                                                            volume, zeff
+                                                            volume
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: bfun
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: aedens, ccdens, ppdens
@@ -2619,6 +2655,8 @@ CONTAINS
       CALL get_qs_env(qs_env, &
                       atomic_kind_set=atomic_kind_set, &
                       qs_kind_set=qs_kind_set, &
+                      nkind=nkind, &
+                      natom=natom, &
                       particle_set=particle_set, &
                       cell=cell, &
                       para_env=para_env, &
@@ -2632,16 +2670,7 @@ CONTAINS
       CALL get_qs_env(qs_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r)
 
-      CALL get_qs_env(qs_env, nkind=nkind, natom=natom)
-      ALLOCATE (zcharge(natom))
-      DO ikind = 1, nkind
-         CALL get_qs_kind(qs_kind_set(ikind), zeff=zeff)
-         CALL get_atomic_kind(atomic_kind_set(ikind), natom=nat)
-         DO iatom = 1, nat
-            iat = atomic_kind_set(ikind)%atom_list(iatom)
-            zcharge(iat) = zeff
-         END DO
-      END DO
+      CALL get_effective_core_charges(qs_env, zcharge)
 
       ! Print the total density (electronic + core charge)
       IF (BTEST(cp_print_key_should_output(logger%iter_info, input, &
@@ -3785,6 +3814,7 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename, my_pos_cube
       INTEGER                                            :: handle, io_unit, natom, unit_nr
       LOGICAL                                            :: append_cube, gapw, gapw_xc, mpi_io
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
@@ -3807,6 +3837,7 @@ CONTAINS
          CALL auxbas_pw_pool%create_pw(eden)
          !
          CALL qs_local_energy(qs_env, eden)
+         CALL get_effective_core_charges(qs_env, zcharge)
          !
          append_cube = section_get_lval(input, "DFT%PRINT%LOCAL_ENERGY_CUBE%APPEND")
          IF (append_cube) THEN
@@ -3818,7 +3849,7 @@ CONTAINS
          unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%LOCAL_ENERGY_CUBE", &
                                         extension=".cube", middle_name="local_energy", &
                                         file_position=my_pos_cube, mpi_io=mpi_io)
-         CALL cp_pw_to_cube(eden, unit_nr, "LOCAL ENERGY", particles=particles, &
+         CALL cp_pw_to_cube(eden, unit_nr, "LOCAL ENERGY", particles=particles, zeff=zcharge, &
                             stride=section_get_ivals(dft_section, "PRINT%LOCAL_ENERGY_CUBE%STRIDE"), &
                             max_file_size_mb=section_get_rval(dft_section, "PRINT%LOCAL_ENERGY_CUBE%MAX_FILE_SIZE_MB"), &
                             mpi_io=mpi_io)
@@ -3836,6 +3867,7 @@ CONTAINS
                                            "DFT%PRINT%LOCAL_ENERGY_CUBE", mpi_io=mpi_io)
          !
          CALL auxbas_pw_pool%give_back_pw(eden)
+         DEALLOCATE (zcharge)
       END IF
       CALL timestop(handle)
 
@@ -3861,6 +3893,7 @@ CONTAINS
       INTEGER                                            :: handle, io_unit, natom, unit_nr
       LOGICAL                                            :: append_cube, gapw, gapw_xc, mpi_io
       REAL(KIND=dp)                                      :: beta
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
@@ -3887,6 +3920,7 @@ CONTAINS
          ! use beta=0: kinetic energy density in symmetric form
          beta = 0.0_dp
          CALL qs_local_stress(qs_env, beta=beta)
+         CALL get_effective_core_charges(qs_env, zcharge)
          !
          append_cube = section_get_lval(input, "DFT%PRINT%LOCAL_STRESS_CUBE%APPEND")
          IF (append_cube) THEN
@@ -3898,7 +3932,7 @@ CONTAINS
          unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%LOCAL_STRESS_CUBE", &
                                         extension=".cube", middle_name="local_stress", &
                                         file_position=my_pos_cube, mpi_io=mpi_io)
-         CALL cp_pw_to_cube(stress, unit_nr, "LOCAL STRESS", particles=particles, &
+         CALL cp_pw_to_cube(stress, unit_nr, "LOCAL STRESS", particles=particles, zeff=zcharge, &
                             stride=section_get_ivals(dft_section, "PRINT%LOCAL_STRESS_CUBE%STRIDE"), &
                             max_file_size_mb=section_get_rval(dft_section, "PRINT%LOCAL_STRESS_CUBE%MAX_FILE_SIZE_MB"), &
                             mpi_io=mpi_io)
@@ -3917,6 +3951,7 @@ CONTAINS
                                            "DFT%PRINT%LOCAL_STRESS_CUBE", mpi_io=mpi_io)
          !
          CALL auxbas_pw_pool%give_back_pw(stress)
+         DEALLOCATE (zcharge)
       END IF
 
       CALL timestop(handle)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -3988,6 +3988,7 @@ CONTAINS
                                                             n_cstr, n_tiles, unit_nr
       LOGICAL :: append_cube, do_cstr_charge_cube, do_dielectric_cube, do_dirichlet_bc_cube, &
          has_dirichlet_bc, has_implicit_ps, mpi_io, tile_cubes
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
@@ -4014,6 +4015,7 @@ CONTAINS
       do_dielectric_cube = BTEST(cp_print_key_should_output(logger%iter_info, input, &
                                                             "DFT%PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE"), cp_p_file)
       IF (has_implicit_ps .AND. do_dielectric_cube) THEN
+         IF (.NOT. ALLOCATED(zcharge)) CALL get_effective_core_charges(qs_env, zcharge)
          append_cube = section_get_lval(input, "DFT%PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE%APPEND")
          my_pos_cube = "REWIND"
          IF (append_cube) THEN
@@ -4038,7 +4040,7 @@ CONTAINS
                            poisson_env%implicit_env%dielectric%eps, aux_r)
          END SELECT
 
-         CALL cp_pw_to_cube(aux_r, unit_nr, "DIELECTRIC CONSTANT", particles=particles, &
+         CALL cp_pw_to_cube(aux_r, unit_nr, "DIELECTRIC CONSTANT", particles=particles, zeff=zcharge, &
                             stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE%STRIDE"), &
                         max_file_size_mb=section_get_rval(dft_section, "PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE%MAX_FILE_SIZE_MB"), &
                             mpi_io=mpi_io)
@@ -4061,6 +4063,7 @@ CONTAINS
       END IF
 
       IF (has_implicit_ps .AND. do_cstr_charge_cube .AND. has_dirichlet_bc) THEN
+         IF (.NOT. ALLOCATED(zcharge)) CALL get_effective_core_charges(qs_env, zcharge)
          append_cube = section_get_lval(input, &
                                         "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE%APPEND")
          my_pos_cube = "REWIND"
@@ -4087,7 +4090,7 @@ CONTAINS
                            poisson_env%implicit_env%cstr_charge, aux_r)
          END SELECT
 
-         CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET CONSTRAINT CHARGE", particles=particles, &
+         CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET CONSTRAINT CHARGE", particles=particles, zeff=zcharge, &
                             stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE%STRIDE"), &
              max_file_size_mb=section_get_rval(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE%MAX_FILE_SIZE_MB"), &
                             mpi_io=mpi_io)
@@ -4109,6 +4112,7 @@ CONTAINS
       END IF
 
       IF (has_implicit_ps .AND. has_dirichlet_bc .AND. do_dirichlet_bc_cube) THEN
+         IF (.NOT. ALLOCATED(zcharge)) CALL get_effective_core_charges(qs_env, zcharge)
          append_cube = section_get_lval(input, "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%APPEND")
          my_pos_cube = "REWIND"
          IF (append_cube) THEN
@@ -4135,7 +4139,7 @@ CONTAINS
 
                   CALL pw_copy(poisson_env%implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw, aux_r)
 
-                  CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, &
+                  CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, zeff=zcharge, &
                                      stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%STRIDE"), &
                       max_file_size_mb=section_get_rval(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%MAX_FILE_SIZE_MB"), &
                                      mpi_io=mpi_io)
@@ -4163,7 +4167,7 @@ CONTAINS
                END DO
             END DO
 
-            CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, &
+            CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, zeff=zcharge, &
                                stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%STRIDE"), &
                       max_file_size_mb=section_get_rval(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%MAX_FILE_SIZE_MB"), &
                                mpi_io=mpi_io)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -279,6 +279,34 @@ MODULE qs_scf_post_gpw
 CONTAINS
 
 ! **************************************************************************************************
+!> \brief Collects the effective core charge for every atom in a QS environment
+!> \param qs_env the QS environment
+!> \param zcharge effective core charges ordered by atom index
+! **************************************************************************************************
+   SUBROUTINE get_effective_core_charges(qs_env, zcharge)
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
+         INTENT(OUT)                                     :: zcharge
+
+      INTEGER                                            :: iat, iatom, ikind, nat, natom, nkind
+      REAL(KIND=dp)                                      :: zeff
+      TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+
+      CALL get_qs_env(qs_env, atomic_kind_set=atomic_kind_set, qs_kind_set=qs_kind_set, &
+                      nkind=nkind, natom=natom)
+      ALLOCATE (zcharge(natom))
+      DO ikind = 1, nkind
+         CALL get_qs_kind(qs_kind_set(ikind), zeff=zeff)
+         CALL get_atomic_kind(atomic_kind_set(ikind), natom=nat)
+         DO iatom = 1, nat
+            iat = atomic_kind_set(ikind)%atom_list(iatom)
+            zcharge(iat) = zeff
+         END DO
+      END DO
+   END SUBROUTINE get_effective_core_charges
+
+! **************************************************************************************************
 !> \brief Append `extend_by` to the absolute path of the base section.
 !> \param self ...
 !> \param extend_by ...
@@ -1418,6 +1446,7 @@ CONTAINS
                                                             nlist, unit_nr
       INTEGER, DIMENSION(:), POINTER                     :: list, list_index
       LOGICAL                                            :: append_cube, mpi_io
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1436,6 +1465,7 @@ CONTAINS
 
       IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, mo_section%relative_section_key) &
  , cp_p_file) .AND. section_get_lval(dft_section, mo_section%concat_to_relative(section_key_do_write(mo_section%grid_output)))) THEN
+         CALL get_effective_core_charges(qs_env, zcharge)
          nhomo = section_get_ival(dft_section, mo_section%concat_to_relative("%NHOMO"))
          ! For openPMD, refer to access modes instead of APPEND key
          IF (mo_section%grid_output == grid_output_cubes) THEN
@@ -1496,13 +1526,14 @@ CONTAINS
                       openpmd_unit_si=openpmd_unit_si_wavefunction, &
                       sim_time=qs_env%sim_time)
             WRITE (title, *) "WAVEFUNCTION ", ivector, " spin ", ispin, " i.e. HOMO - ", ivector - homo
-            CALL mo_section%write_pw(wf_r, unit_nr, title, particles=particles, &
+            CALL mo_section%write_pw(wf_r, unit_nr, title, particles=particles, zeff=zcharge, &
                                      stride=section_get_ivals(dft_section, mo_section%concat_to_relative("%STRIDE")), &
                                      max_file_size_mb=section_get_rval(dft_section, "PRINT%MO_CUBES%MAX_FILE_SIZE_MB"), &
                                      mpi_io=mpi_io)
             CALL mo_section%print_key_finished_output(unit_nr, logger, input, mo_section%absolute_section_key, mpi_io=mpi_io)
          END DO
          IF (ASSOCIATED(list_index)) DEALLOCATE (list_index)
+         DEALLOCATE (zcharge)
       END IF
 
       CALL timestop(handle)
@@ -1547,6 +1578,7 @@ CONTAINS
       INTEGER                                            :: handle, ifirst, index_mo, ivector, &
                                                             unit_nr
       LOGICAL                                            :: append_cube, mpi_io
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
@@ -1563,6 +1595,7 @@ CONTAINS
 
       IF (BTEST(cp_print_key_should_output(logger%iter_info, dft_section, mo_section%relative_section_key), cp_p_file) &
           .AND. section_get_lval(dft_section, mo_section%concat_to_relative(section_key_do_write(mo_section%grid_output)))) THEN
+         CALL get_effective_core_charges(qs_env, zcharge)
          NULLIFY (qs_kind_set, particle_set, pw_env, cell)
          ! For openPMD, refer to access modes instead of APPEND key
          IF (mo_section%grid_output == grid_output_cubes) THEN
@@ -1606,13 +1639,14 @@ CONTAINS
                       openpmd_unit_si=openpmd_unit_si_wavefunction, &
                       sim_time=qs_env%sim_time)
             WRITE (title, *) "WAVEFUNCTION ", index_mo, " spin ", ispin, " i.e. LUMO + ", ifirst + ivector - 2
-            CALL mo_section%write_pw(wf_r, unit_nr, title, particles=particles, &
+            CALL mo_section%write_pw(wf_r, unit_nr, title, particles=particles, zeff=zcharge, &
                                      stride=section_get_ivals(dft_section, mo_section%concat_to_relative("%STRIDE")), &
                                      max_file_size_mb=section_get_rval(dft_section, "PRINT%MO_CUBES%MAX_FILE_SIZE_MB"), &
                                      mpi_io=mpi_io)
             CALL mo_section%print_key_finished_output(unit_nr, logger, input, mo_section%absolute_section_key, mpi_io=mpi_io)
 
          END DO
+         DEALLOCATE (zcharge)
       END IF
 
       CALL timestop(handle)
@@ -1972,6 +2006,7 @@ CONTAINS
       INTEGER                                            :: handle, ispin, output_unit, unit_nr
       LOGICAL                                            :: append_cube, gapw, mpi_io
       REAL(dp)                                           :: rho_cutoff
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(cp_section_key)                               :: elf_section_key
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
@@ -2011,6 +2046,7 @@ CONTAINS
             END IF
             rho_cutoff = section_get_rval(elf_section, "density_cutoff")
             CALL qs_elf_calc(qs_env, elf_r, rho_cutoff)
+            CALL get_effective_core_charges(qs_env, zcharge)
 
             ! write ELF into cube file
 
@@ -2052,7 +2088,7 @@ CONTAINS
                      TRIM(filename)
                END IF
 
-               CALL elf_section_key%write_pw(elf_r(ispin), unit_nr, title, particles=particles, &
+               CALL elf_section_key%write_pw(elf_r(ispin), unit_nr, title, particles=particles, zeff=zcharge, &
                                              stride=section_get_ivals(elf_section, "STRIDE"), mpi_io=mpi_io)
                CALL elf_section_key%print_key_finished_output( &
                   unit_nr, &
@@ -2065,7 +2101,7 @@ CONTAINS
             END DO
 
             ! deallocate
-            DEALLOCATE (elf_r)
+            DEALLOCATE (elf_r, zcharge)
 
          ELSE
             ! not implemented
@@ -2562,14 +2598,14 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename, mpi_filename, my_pos_cube, &
                                                             my_pos_voro
       CHARACTER(LEN=default_string_length)               :: name, print_density
-      INTEGER :: after, handle, i, iat, iatom, id, ikind, img, iso, ispin, iw, l, n_rep_hf, nat, &
-         natom, nd(3), ngto, niso, nkind, np, nr, output_unit, print_level, should_print_bqb, &
-         should_print_voro, unit_nr, unit_nr_voro
+      INTEGER :: after, handle, i, iat, id, ikind, img, iso, ispin, iw, l, n_rep_hf, natom, nd(3), &
+         ngto, niso, nkind, np, nr, output_unit, print_level, should_print_bqb, should_print_voro, &
+         unit_nr, unit_nr_voro
       LOGICAL :: append_cube, append_voro, do_hfx, do_kpoints, mpi_io, omit_headers, print_it, &
          rho_r_valid, voro_print_txt, write_ks, write_xc, xrd_interface
       REAL(KIND=dp)                                      :: norm_factor, q_max, rho_hard, rho_soft, &
                                                             rho_total, rho_total_rspace, udvol, &
-                                                            volume, zeff
+                                                            volume
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: bfun
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: aedens, ccdens, ppdens
@@ -2620,6 +2656,8 @@ CONTAINS
       CALL get_qs_env(qs_env, &
                       atomic_kind_set=atomic_kind_set, &
                       qs_kind_set=qs_kind_set, &
+                      nkind=nkind, &
+                      natom=natom, &
                       particle_set=particle_set, &
                       cell=cell, &
                       para_env=para_env, &
@@ -2633,16 +2671,7 @@ CONTAINS
       CALL get_qs_env(qs_env, rho=rho)
       CALL qs_rho_get(rho, rho_r=rho_r)
 
-      CALL get_qs_env(qs_env, nkind=nkind, natom=natom)
-      ALLOCATE (zcharge(natom))
-      DO ikind = 1, nkind
-         CALL get_qs_kind(qs_kind_set(ikind), zeff=zeff)
-         CALL get_atomic_kind(atomic_kind_set(ikind), natom=nat)
-         DO iatom = 1, nat
-            iat = atomic_kind_set(ikind)%atom_list(iatom)
-            zcharge(iat) = zeff
-         END DO
-      END DO
+      CALL get_effective_core_charges(qs_env, zcharge)
 
       ! Print the total density (electronic + core charge)
       IF (BTEST(cp_print_key_should_output(logger%iter_info, input, &
@@ -3794,6 +3823,7 @@ CONTAINS
       CHARACTER(LEN=default_path_length)                 :: filename, my_pos_cube
       INTEGER                                            :: handle, io_unit, natom, unit_nr
       LOGICAL                                            :: append_cube, gapw, gapw_xc, mpi_io
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
@@ -3816,6 +3846,7 @@ CONTAINS
          CALL auxbas_pw_pool%create_pw(eden)
          !
          CALL qs_local_energy(qs_env, eden)
+         CALL get_effective_core_charges(qs_env, zcharge)
          !
          append_cube = section_get_lval(input, "DFT%PRINT%LOCAL_ENERGY_CUBE%APPEND")
          IF (append_cube) THEN
@@ -3827,7 +3858,7 @@ CONTAINS
          unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%LOCAL_ENERGY_CUBE", &
                                         extension=".cube", middle_name="local_energy", &
                                         file_position=my_pos_cube, mpi_io=mpi_io)
-         CALL cp_pw_to_cube(eden, unit_nr, "LOCAL ENERGY", particles=particles, &
+         CALL cp_pw_to_cube(eden, unit_nr, "LOCAL ENERGY", particles=particles, zeff=zcharge, &
                             stride=section_get_ivals(dft_section, "PRINT%LOCAL_ENERGY_CUBE%STRIDE"), &
                             max_file_size_mb=section_get_rval(dft_section, "PRINT%LOCAL_ENERGY_CUBE%MAX_FILE_SIZE_MB"), &
                             mpi_io=mpi_io)
@@ -3845,6 +3876,7 @@ CONTAINS
                                            "DFT%PRINT%LOCAL_ENERGY_CUBE", mpi_io=mpi_io)
          !
          CALL auxbas_pw_pool%give_back_pw(eden)
+         DEALLOCATE (zcharge)
       END IF
       CALL timestop(handle)
 
@@ -3870,6 +3902,7 @@ CONTAINS
       INTEGER                                            :: handle, io_unit, natom, unit_nr
       LOGICAL                                            :: append_cube, gapw, gapw_xc, mpi_io
       REAL(KIND=dp)                                      :: beta
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(dft_control_type), POINTER                    :: dft_control
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
@@ -3896,6 +3929,7 @@ CONTAINS
          ! use beta=0: kinetic energy density in symmetric form
          beta = 0.0_dp
          CALL qs_local_stress(qs_env, beta=beta)
+         CALL get_effective_core_charges(qs_env, zcharge)
          !
          append_cube = section_get_lval(input, "DFT%PRINT%LOCAL_STRESS_CUBE%APPEND")
          IF (append_cube) THEN
@@ -3907,7 +3941,7 @@ CONTAINS
          unit_nr = cp_print_key_unit_nr(logger, input, "DFT%PRINT%LOCAL_STRESS_CUBE", &
                                         extension=".cube", middle_name="local_stress", &
                                         file_position=my_pos_cube, mpi_io=mpi_io)
-         CALL cp_pw_to_cube(stress, unit_nr, "LOCAL STRESS", particles=particles, &
+         CALL cp_pw_to_cube(stress, unit_nr, "LOCAL STRESS", particles=particles, zeff=zcharge, &
                             stride=section_get_ivals(dft_section, "PRINT%LOCAL_STRESS_CUBE%STRIDE"), &
                             max_file_size_mb=section_get_rval(dft_section, "PRINT%LOCAL_STRESS_CUBE%MAX_FILE_SIZE_MB"), &
                             mpi_io=mpi_io)
@@ -3926,6 +3960,7 @@ CONTAINS
                                            "DFT%PRINT%LOCAL_STRESS_CUBE", mpi_io=mpi_io)
          !
          CALL auxbas_pw_pool%give_back_pw(stress)
+         DEALLOCATE (zcharge)
       END IF
 
       CALL timestop(handle)

--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -3979,6 +3979,7 @@ CONTAINS
                                                             n_cstr, n_tiles, unit_nr
       LOGICAL :: append_cube, do_cstr_charge_cube, do_dielectric_cube, do_dirichlet_bc_cube, &
          has_dirichlet_bc, has_implicit_ps, mpi_io, tile_cubes
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       TYPE(particle_list_type), POINTER                  :: particles
       TYPE(pw_env_type), POINTER                         :: pw_env
       TYPE(pw_poisson_type), POINTER                     :: poisson_env
@@ -4005,6 +4006,7 @@ CONTAINS
       do_dielectric_cube = BTEST(cp_print_key_should_output(logger%iter_info, input, &
                                                             "DFT%PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE"), cp_p_file)
       IF (has_implicit_ps .AND. do_dielectric_cube) THEN
+         IF (.NOT. ALLOCATED(zcharge)) CALL get_effective_core_charges(qs_env, zcharge)
          append_cube = section_get_lval(input, "DFT%PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE%APPEND")
          my_pos_cube = "REWIND"
          IF (append_cube) THEN
@@ -4029,7 +4031,7 @@ CONTAINS
                            poisson_env%implicit_env%dielectric%eps, aux_r)
          END SELECT
 
-         CALL cp_pw_to_cube(aux_r, unit_nr, "DIELECTRIC CONSTANT", particles=particles, &
+         CALL cp_pw_to_cube(aux_r, unit_nr, "DIELECTRIC CONSTANT", particles=particles, zeff=zcharge, &
                             stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE%STRIDE"), &
                         max_file_size_mb=section_get_rval(dft_section, "PRINT%IMPLICIT_PSOLVER%DIELECTRIC_CUBE%MAX_FILE_SIZE_MB"), &
                             mpi_io=mpi_io)
@@ -4052,6 +4054,7 @@ CONTAINS
       END IF
 
       IF (has_implicit_ps .AND. do_cstr_charge_cube .AND. has_dirichlet_bc) THEN
+         IF (.NOT. ALLOCATED(zcharge)) CALL get_effective_core_charges(qs_env, zcharge)
          append_cube = section_get_lval(input, &
                                         "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE%APPEND")
          my_pos_cube = "REWIND"
@@ -4078,7 +4081,7 @@ CONTAINS
                            poisson_env%implicit_env%cstr_charge, aux_r)
          END SELECT
 
-         CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET CONSTRAINT CHARGE", particles=particles, &
+         CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET CONSTRAINT CHARGE", particles=particles, zeff=zcharge, &
                             stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE%STRIDE"), &
              max_file_size_mb=section_get_rval(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_CSTR_CHARGE_CUBE%MAX_FILE_SIZE_MB"), &
                             mpi_io=mpi_io)
@@ -4100,6 +4103,7 @@ CONTAINS
       END IF
 
       IF (has_implicit_ps .AND. has_dirichlet_bc .AND. do_dirichlet_bc_cube) THEN
+         IF (.NOT. ALLOCATED(zcharge)) CALL get_effective_core_charges(qs_env, zcharge)
          append_cube = section_get_lval(input, "DFT%PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%APPEND")
          my_pos_cube = "REWIND"
          IF (append_cube) THEN
@@ -4126,7 +4130,7 @@ CONTAINS
 
                   CALL pw_copy(poisson_env%implicit_env%contacts(j)%dirichlet_bc%tiles(i)%tile%tile_pw, aux_r)
 
-                  CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, &
+                  CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, zeff=zcharge, &
                                      stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%STRIDE"), &
                       max_file_size_mb=section_get_rval(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%MAX_FILE_SIZE_MB"), &
                                      mpi_io=mpi_io)
@@ -4154,7 +4158,7 @@ CONTAINS
                END DO
             END DO
 
-            CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, &
+            CALL cp_pw_to_cube(aux_r, unit_nr, "DIRICHLET TYPE CONSTRAINT", particles=particles, zeff=zcharge, &
                                stride=section_get_ivals(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%STRIDE"), &
                       max_file_size_mb=section_get_rval(dft_section, "PRINT%IMPLICIT_PSOLVER%DIRICHLET_BC_CUBE%MAX_FILE_SIZE_MB"), &
                                mpi_io=mpi_io)

--- a/tests/QS/regtest-gpw-8/TEST_FILES.toml
+++ b/tests/QS/regtest-gpw-8/TEST_FILES.toml
@@ -24,6 +24,11 @@
 "mao_5.inp"                             = [{matcher="E_total", tol=1e-10, ref=-17.154246373196706}]
 #
 "local_energy.inp"                      = [{matcher="E_total", tol=1e-10, ref=-34.301659959649530}]
-"local_stress.inp"                      = [{matcher="E_total", tol=1e-10, ref=-31.065602427106100}]
+"local_stress.inp"                      = [{matcher="E_total", tol=1e-10, ref=-31.065602427106100},
+                                           {matcher="Cube_Si_effective_charge", file="si8_stress-WFN_00016_1-1_0.cube", tol=0.0, ref=4.0},
+                                           {matcher="Cube_Si_effective_charge", file="si8_stress-WFN_00017_1-1_0.cube", tol=0.0, ref=4.0},
+                                           {matcher="Cube_Si_effective_charge", file="si8_stress-ELF_S1-1_0.cube", tol=0.0, ref=4.0},
+                                           {matcher="Cube_Si_effective_charge", file="si8_stress-local_energy-1_0.cube", tol=0.0, ref=4.0},
+                                           {matcher="Cube_Si_effective_charge", file="si8_stress-local_stress-1_0.cube", tol=0.0, ref=4.0}]
 "H2-spline3.inp"                        = [{matcher="E_total", tol=1e-12, ref=-1.064646119848720}]
 #EOF

--- a/tests/QS/regtest-gpw-8/local_stress.inp
+++ b/tests/QS/regtest-gpw-8/local_stress.inp
@@ -14,10 +14,20 @@
       CUTOFF 200
     &END MGRID
     &PRINT
+      &ELF_CUBE
+        STRIDE 2 2 2
+      &END ELF_CUBE
       &LOCAL_ENERGY_CUBE
+        STRIDE 2 2 2
       &END LOCAL_ENERGY_CUBE
       &LOCAL_STRESS_CUBE
+        STRIDE 2 2 2
       &END LOCAL_STRESS_CUBE
+      &MO_CUBES
+        NHOMO 1
+        NLUMO 1
+        STRIDE 2 2 2
+      &END MO_CUBES
     &END PRINT
     &QS
       METHOD GPW

--- a/tests/QS/regtest-ps-implicit-2-1/H2O_dbl_cstr_otcg.inp
+++ b/tests/QS/regtest-ps-implicit-2-1/H2O_dbl_cstr_otcg.inp
@@ -68,15 +68,15 @@
     &END POISSON
     &PRINT
       &IMPLICIT_PSOLVER
-        &DIELECTRIC_CUBE off
-          STRIDE 1 1 1
+        &DIELECTRIC_CUBE on
+          STRIDE 4 4 4
         &END DIELECTRIC_CUBE
-        &DIRICHLET_BC_CUBE off
-          STRIDE 1 1 1
+        &DIRICHLET_BC_CUBE on
+          STRIDE 4 4 4
           TILE_CUBES .false.
         &END DIRICHLET_BC_CUBE
-        &DIRICHLET_CSTR_CHARGE_CUBE off
-          STRIDE 1 1 1
+        &DIRICHLET_CSTR_CHARGE_CUBE on
+          STRIDE 4 4 4
         &END DIRICHLET_CSTR_CHARGE_CUBE
       &END IMPLICIT_PSOLVER
       &V_HARTREE_CUBE off

--- a/tests/QS/regtest-ps-implicit-2-1/TEST_FILES.toml
+++ b/tests/QS/regtest-ps-implicit-2-1/TEST_FILES.toml
@@ -2,5 +2,8 @@
 "H2O_periodic.inp"                      = [{matcher="E_total", tol=1e-12, ref=-17.23756105673132}]
 "H2plus2_implicit_md.inp"               = [{matcher="M011", tol=1e-12, ref=-0.480570779548886}]
 "Hplus_dbl_cstr_md.inp"                 = [{matcher="M011", tol=2e-12, ref=-0.240556884153805}]
-"H2O_dbl_cstr_otcg.inp"                 = [{matcher="E_total", tol=1e-12, ref=-17.21986588953466}]
+"H2O_dbl_cstr_otcg.inp"                 = [{matcher="E_total", tol=1e-12, ref=-17.21986588953466},
+                                           {matcher="Cube_O_effective_charge", file="H2O_dbl_cstr_otcg-DIELECTRIC_CONSTANT-1_0.cube", tol=0.0, ref=6.0},
+                                           {matcher="Cube_O_effective_charge", file="H2O_dbl_cstr_otcg-dirichlet_cstr_charge-1_0.cube", tol=0.0, ref=6.0},
+                                           {matcher="Cube_O_effective_charge", file="H2O_dbl_cstr_otcg-DIRICHLET_CSTR-1_0.cube", tol=0.0, ref=6.0}]
 #EOF

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -26,6 +26,9 @@ registry = MatcherRegistry()
 
 # Total energy in Hartree
 registry["E_total"] = GenericMatcher(r"Total energy:", col=3)
+registry["Cube_Si_effective_charge"] = GenericMatcher(
+    r"^\s*14\s+([-+0-9.EeDd]+)\s+", col=1, regex=True, first=True
+)
 
 registry["M002"] = GenericMatcher(r"MD| Potential energy", col=5)
 registry["M003"] = GenericMatcher(r"Total energy [eV]:", col=4)

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -29,6 +29,9 @@ registry["E_total"] = GenericMatcher(r"Total energy:", col=3)
 registry["Cube_Si_effective_charge"] = GenericMatcher(
     r"^\s*14\s+([-+0-9.EeDd]+)\s+", col=1, regex=True, first=True
 )
+registry["Cube_O_effective_charge"] = GenericMatcher(
+    r"^\s*8\s+([-+0-9.EeDd]+)\s+", col=1, regex=True, first=True
+)
 
 registry["M002"] = GenericMatcher(r"MD| Potential energy", col=5)
 registry["M003"] = GenericMatcher(r"Total energy [eV]:", col=4)

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -32,6 +32,9 @@ registry["COMMUTATOR_HR_Z"] = GenericMatcher(r"COMMUTATOR_HR| CheckSum Z =", col
 registry["Cube_Si_effective_charge"] = GenericMatcher(
     r"^\s*14\s+([-+0-9.EeDd]+)\s+", col=1, regex=True, first=True
 )
+registry["Cube_O_effective_charge"] = GenericMatcher(
+    r"^\s*8\s+([-+0-9.EeDd]+)\s+", col=1, regex=True, first=True
+)
 
 registry["M002"] = GenericMatcher(r"MD| Potential energy", col=5)
 registry["M003"] = GenericMatcher(r"Total energy [eV]:", col=4)

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -29,6 +29,9 @@ registry["E_total"] = GenericMatcher(r"Total energy:", col=3)
 registry["COMMUTATOR_HR_X"] = GenericMatcher(r"COMMUTATOR_HR| CheckSum X =", col=5)
 registry["COMMUTATOR_HR_Y"] = GenericMatcher(r"COMMUTATOR_HR| CheckSum Y =", col=5)
 registry["COMMUTATOR_HR_Z"] = GenericMatcher(r"COMMUTATOR_HR| CheckSum Z =", col=5)
+registry["Cube_Si_effective_charge"] = GenericMatcher(
+    r"^\s*14\s+([-+0-9.EeDd]+)\s+", col=1, regex=True, first=True
+)
 
 registry["M002"] = GenericMatcher(r"MD| Potential energy", col=5)
 registry["M003"] = GenericMatcher(r"Total energy [eV]:", col=4)


### PR DESCRIPTION
## Summary

- factor the existing GPW effective-core-charge lookup into a shared helper
- write effective charges to occupied and unoccupied MO, ELF, local-energy, local-stress, dielectric, and Dirichlet cube files
- extend the existing local-stress and implicit-Poisson regressions to validate the affected cube headers

## Root cause

#4584 taught the Cube writer to accept effective charges and enabled them for most GPW outputs. These post-SCF call sites still supplied only the particles, so the Cube writer fell back to zero for the charge field.

The shared helper reuses the same `get_qs_kind(..., zeff=...)` logic already used by the other GPW Cube outputs, including the existing potential-specific handling. Passing the charges at the GPW call sites also avoids adding a generic warning for the optional low-level argument, which would affect method-specific callers that do not expose the same charge information.

## Verification

- reproduced the five original missing charges with the existing Si8 local-stress setup: each header contained `0.000000` on current `master`
- confirmed those five headers contain the GTH-PBE-q4 effective charge `4.000000` after the fix
- added coverage for the three implicit-Poisson cube variants and confirmed the O header contains the GTH-PBE-q6 effective charge `6.000000`
- reproduced the implicit-Poisson reference energy `-17.219865889534653` Ha
- built `cp2k.psmp` with GCC 16 and OpenMPI on macOS
- passed the full two-rank `QS/regtest-gpw-8` suite (`26/26`)
- passed all CP2K pre-push checks on the changed files

Closes #4518
