### PR TITLE
Stage COSMA MPI transfers through host memory

### DIFF
--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -1186,9 +1186,11 @@ if [[ ! -f "${SPACK_BUILD_PATH}/BUILD_DEPENDENCIES_COMPLETED" ]]; then
 
   # Activate CUDA in the spack configuration file if requested
   if ((CUDA_SM_CODE > 0)); then
+    # The generated MPI stack is not CUDA-aware, so COSMA has to stage MPI
+    # transfers through host memory instead of passing device pointers.
     sed -E \
       -e "0,/~cuda/s//+cuda cuda_arch=${CUDA_SM_CODE}/" \
-      -e 's/"~cuda\s+~gpu_direct"/"\+cuda \+gpu_direct"/' \
+      -e 's/"~cuda\s+~gpu_direct"/"\+cuda ~gpu_direct"/' \
       -e '/\s*#\s*-\s+"fabrics=efa,ucx"/ s/#/ /' \
       -i "${CP2K_CONFIG_FILE}"
     # Building libfabric with CUDA causes problems

--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -159,11 +159,6 @@ spack:
         - "~valgrind"
         - "~xnnpack"
 
-    # Libfabric's UCX provider is not compatible with UCX 1.22 yet.
-    ucx:
-      require:
-        - "@1.21.0"
-
     sirius:
       require:
         - "~apps"
@@ -182,6 +177,11 @@ spack:
     trexio:
       require:
         - "+hdf5"
+
+    # Libfabric's UCX provider is not compatible with UCX 1.22 yet.
+    ucx:
+      require:
+        - "@1.21.0"
 
   repos:
     builtin:

--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -159,6 +159,11 @@ spack:
         - "~valgrind"
         - "~xnnpack"
 
+    # Libfabric's UCX provider is not compatible with UCX 1.22 yet.
+    ucx:
+      require:
+        - "@1.21.0"
+
     sirius:
       require:
         - "~apps"


### PR DESCRIPTION
## Summary

- Keep CUDA acceleration enabled for COSMA in Spack CUDA builds.
- Disable COSMA's `gpu_direct` variant while the generated MPI stack cannot safely execute COSMA's device-buffer collectives, so MPI transfers are staged through host memory.
- Pin UCX to 1.21.0 until Libfabric's UCX provider supports the UCX 1.22 API.

## Motivation

The CSCS Daint H100 dashboard currently reports 49 runtime failures with nearly identical crashes in `cosma_pdgemm`. The published failing image concretized COSMA as `+cuda +gpu_direct`, while MPICH was built with `~cuda`. COSMA therefore passed device pointers to an MPI implementation that could not handle them.

The failure is reproducible with a single affected UO2 geometry-optimization test; increasing container shared memory from 1 GiB to 8 GiB does not change it. The same binary succeeds with ScaLAPACK, and a replacement COSMA 2.8.4 build using `+cuda ~gpu_direct` completes the test through COSMA.

Building CUDA-aware MPI is not sufficient for this stack. I additionally tested MPICH 5.0.1 `+cuda` with `ch4:ucx`, UCX `+cuda`, and COSMA 2.8.4 `+cuda +gpu_direct` on Spark. A direct CUDA-buffer `MPI_Allgather` succeeds, but the corresponding four-rank COSMA multiplication emits CUDA unpack errors from MPICH/Yaksa and produces a checksum of 262144 instead of 134217728. Disabling MPICH GPU support makes the same COSMA path segfault. Host staging is therefore the conservative correctness fix until the MPICH/COSMA GPU-direct interaction is resolved.

The first CI rebuild also exposed a dependency incompatibility: Libfabric 2.6.0 still calls `ucs_memtype_cache_update` with four arguments, while UCX 1.22 changed that API to require a fifth argument. Pinning UCX to 1.21.0 preserves the Libfabric UCX provider and fixes the dependency build.

No dependency or test is disabled, and no test input, reference value, or tolerance is changed.

## Verification

- `./make_pretty.sh make_cp2k.sh tools/spack/cp2k_deps_p.yaml`
- GNU Bash syntax check
- generated CUDA Spack configuration contains COSMA `+cuda ~gpu_direct`
- exact ARM64 Daint dependency build concretizes Libfabric with UCX 1.21.0
- Libfabric builds and installs successfully in that dependency build
- `Fist/regtest-7-2/UO2-2x2x2-cs-geo_opt-bfgs.inp` passes with four MPI ranks through COSMA
- `LIBTEST/misc/test_cp_fm_gemm_01.inp` and `test_cp_fm_gemm_02.inp` pass with four MPI ranks through COSMA
- CUDA-aware-MPI alternative tested with direct MPI and COSMA device-buffer collectives

## Independent CI follow-ups

The optional GPU jobs exposed unrelated failures that are being kept out of this focused COSMA change:

- #5724 fixes the Daint H100 FFTW execution crashes.
- #5726 fixes the Daint H100 PAO TorchScript CPU/CUDA device mismatch.
- #5725 reduces process concurrency on the single 8 GiB P100 runner to prevent CUDA OOM failures.
