### PR TITLE
Use the FFTW3 Fortran execution interface in fftw31dm

### DIFF
--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -1117,7 +1117,8 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE fftw31dm(plan, zin, zout, scale, stat)
       TYPE(fft_plan_type), INTENT(IN)                    :: plan
-      COMPLEX(KIND=dp), DIMENSION(*), INTENT(IN), TARGET :: zin
+      COMPLEX(KIND=dp), DIMENSION(*), INTENT(INOUT), &
+         TARGET                                          :: zin
       COMPLEX(KIND=dp), DIMENSION(*), INTENT(INOUT), &
          TARGET                                          :: zout
       REAL(KIND=dp), INTENT(IN)                          :: scale
@@ -1126,10 +1127,6 @@ CONTAINS
       INTEGER                                            :: in_offset, my_id, num_rows, out_offset, &
                                                             scal_offset
       TYPE(C_PTR)                                        :: fftw_plan
-#if defined(__FFTW3)
-      COMPLEX(KIND=dp), DIMENSION(:), POINTER            :: zin_slice, zout_slice
-#endif
-
 !------------------------------------------------------------------------------
 
       my_id = 0
@@ -1138,9 +1135,7 @@ CONTAINS
 #if defined(__FFTW3)
       IF (plan%m <= 1) THEN
          stat = 1
-         CALL C_F_POINTER(C_LOC(zin(1)), zin_slice, [plan%n*plan%m])
-         CALL C_F_POINTER(C_LOC(zout(1)), zout_slice, [plan%n*plan%m])
-         CALL dfftw_execute_dft(plan%fftw_plan, zin_slice, zout_slice)
+         CALL fftw_execute_dft(plan%fftw_plan, zin(1), zout(1))
          IF (scale /= 1.0_dp) CALL zdscal(plan%n*plan%m, scale, zout, 1)
          RETURN
       END IF
@@ -1179,7 +1174,7 @@ CONTAINS
 !$OMP MASTER
          stat = 1
 !$OMP END MASTER
-         CALL dfftw_execute_dft(fftw_plan, zin(in_offset:in_offset), zout(out_offset:out_offset))
+         CALL fftw_execute_dft(fftw_plan, zin(in_offset), zout(out_offset))
 !$    end if
 ! all threads need to meet at this barrier
 !$OMP BARRIER


### PR DESCRIPTION
## Summary

- replace the legacy `dfftw_execute_dft` calls in `fftw31dm` with FFTW3's explicit Fortran 2003 interface
- pass the first array element at each FFT offset instead of one-element array sections
- declare the input array `INTENT(INOUT)`, as required by `fftw_execute_dft`

## Motivation

The CSCS Daint H100 psmp regtests consistently segfault in the OpenMP part of `fftw31dm`. The legacy call has no explicit Fortran interface and receives one-element array sections. Using the `fftw3.f03` interface gives the compiler the correct `C_PTR` and assumed-size array contract and avoids array descriptor or temporary handling at the call site.

This keeps the existing FFT plans, work sharing, results, and test tolerances unchanged.

## Testing

- `./make_pretty.sh src/pw/fft/fftw3_lib.F`
- Spark, 2 MPI ranks x 2 OpenMP threads: all five `tests/LIBTEST/misc/test_pw*.inp` inputs passed
- Spark, 2 MPI ranks x 2 OpenMP threads: `w512_pint_qtb_fp0.inp` and `w512_pint_qtb_fp1.inp` passed
- CSCS Daint H100: all `QS/regtest-rtbse-linearized` inputs and matchers passed in the combined stack run

## Follow-up

The four remaining legacy `dfftw_plan_many_dft` planning calls in this file should be converted separately with dedicated coverage, as suggested in review.