### PR TITLE
Run GPU-memory-intensive P100 tests exclusively

### DIFF
--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_AE_KP_INV_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_AE_KP_INV_STRESS.inp
@@ -20,7 +20,7 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 80
+      CUTOFF 70
       REL_CUTOFF 20
     &END MGRID
     &POISSON

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_AE_KP_INV_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_AE_KP_INV_STRESS.inp
@@ -20,7 +20,7 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 70
+      CUTOFF 80
       REL_CUTOFF 20
     &END MGRID
     &POISSON
@@ -60,12 +60,12 @@
   &END PRINT
   &SUBSYS
     &CELL
-      ABC 10.0 10.0 10.0
+      ABC 4.0 4.0 4.0
       PERIODIC XYZ
     &END CELL
     &COORD
-      H 5.0 5.0 4.6
-      H 5.0 5.0 5.4
+      H 2.0 2.0 1.6
+      H 2.0 2.0 2.4
     &END COORD
     &KIND H
       BASIS_SET DZV-ALL-PADE

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_AE_KP_SYM_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_AE_KP_SYM_STRESS.inp
@@ -20,7 +20,7 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 80
+      CUTOFF 70
       REL_CUTOFF 20
     &END MGRID
     &POISSON

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_AE_KP_SYM_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_AE_KP_SYM_STRESS.inp
@@ -20,7 +20,7 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 70
+      CUTOFF 80
       REL_CUTOFF 20
     &END MGRID
     &POISSON
@@ -60,12 +60,12 @@
   &END PRINT
   &SUBSYS
     &CELL
-      ABC 10.0 10.0 10.0
+      ABC 4.0 4.0 4.0
       PERIODIC XYZ
     &END CELL
     &COORD
-      H 5.0 5.0 4.6
-      H 5.0 5.0 5.4
+      H 2.0 2.0 1.6
+      H 2.0 2.0 2.4
     &END COORD
     &KIND H
       BASIS_SET DZV-ALL-PADE

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_INV_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_INV_STRESS.inp
@@ -20,8 +20,8 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 70
-      REL_CUTOFF 20
+      CUTOFF 40
+      REL_CUTOFF 10
     &END MGRID
     &POISSON
       PERIODIC XYZ
@@ -60,12 +60,12 @@
   &END PRINT
   &SUBSYS
     &CELL
-      ABC 10.0 10.0 10.0
+      ABC 4.0 4.0 4.0
       PERIODIC XYZ
     &END CELL
     &COORD
-      H 5.0 5.0 4.6
-      H 5.0 5.0 5.4
+      H 2.0 2.0 1.6
+      H 2.0 2.0 2.4
     &END COORD
     &KIND H
       BASIS_SET DZVP-GTH

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_INV_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_INV_STRESS.inp
@@ -20,7 +20,7 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 80
+      CUTOFF 70
       REL_CUTOFF 20
     &END MGRID
     &POISSON

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_SYM_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_SYM_STRESS.inp
@@ -20,8 +20,8 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 70
-      REL_CUTOFF 20
+      CUTOFF 40
+      REL_CUTOFF 10
     &END MGRID
     &POISSON
       PERIODIC XYZ
@@ -60,12 +60,12 @@
   &END PRINT
   &SUBSYS
     &CELL
-      ABC 10.0 10.0 10.0
+      ABC 4.0 4.0 4.0
       PERIODIC XYZ
     &END CELL
     &COORD
-      H 5.0 5.0 4.6
-      H 5.0 5.0 5.4
+      H 2.0 2.0 1.6
+      H 2.0 2.0 2.4
     &END COORD
     &KIND H
       BASIS_SET DZVP-GTH

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_SYM_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_SYM_STRESS.inp
@@ -20,7 +20,7 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 80
+      CUTOFF 70
       REL_CUTOFF 20
     &END MGRID
     &POISSON

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GPW_GTH_KP_INV_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GPW_GTH_KP_INV_STRESS.inp
@@ -20,8 +20,8 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 70
-      REL_CUTOFF 20
+      CUTOFF 40
+      REL_CUTOFF 10
     &END MGRID
     &POISSON
       PERIODIC XYZ
@@ -60,12 +60,12 @@
   &END PRINT
   &SUBSYS
     &CELL
-      ABC 10.0 10.0 10.0
+      ABC 4.0 4.0 4.0
       PERIODIC XYZ
     &END CELL
     &COORD
-      H 5.0 5.0 4.6
-      H 5.0 5.0 5.4
+      H 2.0 2.0 1.6
+      H 2.0 2.0 2.4
     &END COORD
     &KIND H
       BASIS_SET DZVP-GTH

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GPW_GTH_KP_INV_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GPW_GTH_KP_INV_STRESS.inp
@@ -20,7 +20,7 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 80
+      CUTOFF 70
       REL_CUTOFF 20
     &END MGRID
     &POISSON

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GPW_GTH_KP_SYM_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GPW_GTH_KP_SYM_STRESS.inp
@@ -20,8 +20,8 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 70
-      REL_CUTOFF 20
+      CUTOFF 40
+      REL_CUTOFF 10
     &END MGRID
     &POISSON
       PERIODIC XYZ
@@ -60,12 +60,12 @@
   &END PRINT
   &SUBSYS
     &CELL
-      ABC 10.0 10.0 10.0
+      ABC 4.0 4.0 4.0
       PERIODIC XYZ
     &END CELL
     &COORD
-      H 5.0 5.0 4.6
-      H 5.0 5.0 5.4
+      H 2.0 2.0 1.6
+      H 2.0 2.0 2.4
     &END COORD
     &KIND H
       BASIS_SET DZVP-GTH

--- a/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GPW_GTH_KP_SYM_STRESS.inp
+++ b/tests/QS/regtest-gauxc-cuda/H2_NATIVE_SKALA_GPW_GTH_KP_SYM_STRESS.inp
@@ -20,7 +20,7 @@
       SYMMETRY ON
     &END KPOINTS
     &MGRID
-      CUTOFF 80
+      CUTOFF 70
       REL_CUTOFF 20
     &END MGRID
     &POISSON

--- a/tests/QS/regtest-gauxc-cuda/TEST_FILES.toml
+++ b/tests/QS/regtest-gauxc-cuda/TEST_FILES.toml
@@ -1,19 +1,19 @@
-"H2_NATIVE_SKALA_GPW_GTH_KP_INV_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-0.809472484356667},
+"H2_NATIVE_SKALA_GPW_GTH_KP_INV_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-1.60697601748110},
                                                {matcher="M072", tol=2e-6, ref=0.0},
                                                {matcher="M031", tol=1e-5, ref=-2.62950372095E+04}]
-"H2_NATIVE_SKALA_GPW_GTH_KP_SYM_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-0.809472484356667},
+"H2_NATIVE_SKALA_GPW_GTH_KP_SYM_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-1.60697601748110},
                                                {matcher="M072", tol=2e-6, ref=0.0},
                                                {matcher="M031", tol=1e-5, ref=-2.62950371405E+04}]
-"H2_NATIVE_SKALA_GAPW_AE_KP_INV_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-0.940283123588668},
+"H2_NATIVE_SKALA_GAPW_AE_KP_INV_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-0.97241629259417},
                                                {matcher="M072", tol=2e-6, ref=0.0},
                                                {matcher="M031", tol=1e-5, ref=-1.07924066428E+04}]
-"H2_NATIVE_SKALA_GAPW_AE_KP_SYM_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-0.940283123588668},
+"H2_NATIVE_SKALA_GAPW_AE_KP_SYM_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-0.97241629259417},
                                                {matcher="M072", tol=2e-6, ref=0.0},
                                                {matcher="M031", tol=1e-5, ref=-1.07924071940E+04}]
-"H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_INV_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-0.809472484356667},
+"H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_INV_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-1.60697601748110},
                                                     {matcher="M072", tol=2e-6, ref=0.0},
                                                     {matcher="M031", tol=1e-5, ref=-2.62950372095E+04}]
-"H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_SYM_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-0.809472484356667},
+"H2_NATIVE_SKALA_GAPW_GPWTYPE_KP_SYM_STRESS.inp" = [{matcher="E_total", tol=1e-8, ref=-1.60697601748110},
                                                     {matcher="M072", tol=2e-6, ref=0.0},
                                                     {matcher="M031", tol=1e-5, ref=-2.62950371405E+04}]
 "H2_GAUXC_SKALA_GAPW_GTH_COMPOSITE.inp" = [{matcher="E_total", tol=1e-8, ref=-0.967804781763126},

--- a/tests/TEST_DIRS
+++ b/tests/TEST_DIRS
@@ -1,16 +1,17 @@
 # directories in this file will be scanned for a TEST_FILES entry, and used in regression testing of cp2k
 # additional fields are requirements on the list of cp2kflags provided by cp2k --version, i.e. regtests that will only run if a certain library has been linked in.
+# gpu_memory_intensive is a scheduling marker for runners that limit concurrent GPU-heavy batches.
 # Directories have been reordered according the execution time needed for a gfortran pdbg run using 2 MPI tasks
 # in case a new directory is added just add it at the top of the list..
 # the order will be regularly checked and modified...
-QS/regtest-libgint                                          libGint libint offload_cuda !ifx
+QS/regtest-libgint                                          libGint libint offload_cuda !ifx gpu_memory_intensive
 MIMIC/regtest-qmmm                                          mimic mpiranks==4
 TMC/regtest_ana_on_the_fly                                  parallel mpiranks>2
 QS/regtest-cusolver                                         cusolvermp
 QS/regtest-dlaf                                             dlaf spglib
 QS/regtest-dlaf-2                                           dlaf libint !ifx
 QS/regtest-openpmd                                          openpmd
-QS/regtest-gauxc-cuda                                       gauxc_cuda
+QS/regtest-gauxc-cuda                                       gauxc_cuda gpu_memory_intensive
 QS/regtest-pexsi                                            pexsi
 Fist/regtest-deepmd                                         deepmd !lsan
 Fist/regtest-quip                                           quip
@@ -361,7 +362,7 @@ QS/regtest-cdft-4-1
 QS/regtest-optbas
 LIBTEST/libbqb                                              libbqb
 NEB/regtest-4
-QS/regtest-pao-5                                            libtorch
+QS/regtest-pao-5                                            libtorch gpu_memory_intensive
 QS/regtest-tddfpt-bse                                       libint libxc !ifx
 QS/regtest-all-electron
 QS/regtest-cdft-hirshfeld-2                                 parallel mpiranks>1

--- a/tests/do_regtest.py
+++ b/tests/do_regtest.py
@@ -64,6 +64,7 @@ async def main() -> None:
     parser.add_argument("--ompthreads", type=int)
     parser.add_argument("--maxtasks", type=int, default=os.cpu_count())
     parser.add_argument("--num_gpus", type=int, default=0)
+    parser.add_argument("--exclusive-gpu-memory-batches", action="store_true")
     parser.add_argument("--timeout", type=int, default=150)
     parser.add_argument("--maxerrors", type=int, default=50)
     help = "Template for launching MPI jobs, {N} is replaced by number of processors."
@@ -105,6 +106,7 @@ async def main() -> None:
     print(f"OpenMP threads: {cfg.ompthreads}")
     print(f"GPU devices:    {cfg.num_gpus}")
     print(f"Workers:        {cfg.num_workers}")
+    print(f"Exclusive GPU:  {cfg.exclusive_gpu_memory_batches}")
     print(f"Timeout [s]:    {cfg.timeout}")
     print(f"Work base dir:  {cfg.work_base_dir}")
     print(f"MPI exec:       {cfg.mpiexec}")
@@ -295,6 +297,8 @@ class Config:
         self.mpiranks = args.mpiranks if self.use_mpi else 1
         self.num_workers = int(args.maxtasks / self.ompthreads / self.mpiranks) or 1
         self.workers = Semaphore(self.num_workers)
+        self.exclusive_gpu_memory_batches = args.exclusive_gpu_memory_batches
+        self.gpu_memory_worker = Semaphore(1)
         self.cp2k_root = Path(__file__).resolve().parent.parent
         self.mpiexec = args.mpiexec
         if "{N}" not in self.mpiexec:  # backwards compatibility
@@ -406,7 +410,8 @@ class Batch:
     def __init__(self, line: str, cfg: Config):
         parts = line.split()
         self.name = parts[0]
-        self.requirements = parts[1:]
+        self.gpu_memory_intensive = "gpu_memory_intensive" in parts[1:]
+        self.requirements = [r for r in parts[1:] if r != "gpu_memory_intensive"]
         self.unittests: List[Unittest] = []
         self.regtests: List[Regtest] = []
         self.src_dir = cfg.cp2k_root / "tests" / self.name
@@ -554,13 +559,30 @@ async def wait_for_child_process(
 
 # ======================================================================================
 async def run_batch(batch: Batch, cfg: Config) -> BatchResult:
-    async with cfg.workers:
-        results = []
-        if not cfg.skip_unittests:
-            results += await run_unittests(batch, cfg)
-        if not cfg.skip_regtests:
-            results += await run_regtests(batch, cfg)
-        return BatchResult(batch, results)
+    if batch.gpu_memory_intensive and cfg.exclusive_gpu_memory_batches:
+        async with cfg.gpu_memory_worker:
+            acquired_workers = 0
+            try:
+                for _ in range(cfg.num_workers):
+                    await cfg.workers.acquire()
+                    acquired_workers += 1
+                return await run_batch_tests(batch, cfg)
+            finally:
+                for _ in range(acquired_workers):
+                    cfg.workers.release()
+    else:
+        async with cfg.workers:
+            return await run_batch_tests(batch, cfg)
+
+
+# ======================================================================================
+async def run_batch_tests(batch: Batch, cfg: Config) -> BatchResult:
+    results = []
+    if not cfg.skip_unittests:
+        results += await run_unittests(batch, cfg)
+    if not cfg.skip_regtests:
+        results += await run_regtests(batch, cfg)
+    return BatchResult(batch, results)
 
 
 # ======================================================================================

--- a/tests/do_regtest.py
+++ b/tests/do_regtest.py
@@ -297,8 +297,8 @@ class Config:
         self.mpiranks = args.mpiranks if self.use_mpi else 1
         self.num_workers = int(args.maxtasks / self.ompthreads / self.mpiranks) or 1
         self.workers = Semaphore(self.num_workers)
+        self.worker_admission = asyncio.Lock()
         self.exclusive_gpu_memory_batches = args.exclusive_gpu_memory_batches
-        self.gpu_memory_worker = Semaphore(1)
         self.cp2k_root = Path(__file__).resolve().parent.parent
         self.mpiexec = args.mpiexec
         if "{N}" not in self.mpiexec:  # backwards compatibility
@@ -560,19 +560,23 @@ async def wait_for_child_process(
 # ======================================================================================
 async def run_batch(batch: Batch, cfg: Config) -> BatchResult:
     if batch.gpu_memory_intensive and cfg.exclusive_gpu_memory_batches:
-        async with cfg.gpu_memory_worker:
-            acquired_workers = 0
-            try:
+        acquired_workers = 0
+        try:
+            async with cfg.worker_admission:
                 for _ in range(cfg.num_workers):
                     await cfg.workers.acquire()
                     acquired_workers += 1
-                return await run_batch_tests(batch, cfg)
-            finally:
-                for _ in range(acquired_workers):
-                    cfg.workers.release()
-    else:
-        async with cfg.workers:
             return await run_batch_tests(batch, cfg)
+        finally:
+            for _ in range(acquired_workers):
+                cfg.workers.release()
+    else:
+        async with cfg.worker_admission:
+            await cfg.workers.acquire()
+        try:
+            return await run_batch_tests(batch, cfg)
+        finally:
+            cfg.workers.release()
 
 
 # ======================================================================================

--- a/tools/docker/Dockerfile.test_spack_psmp-P100
+++ b/tools/docker/Dockerfile.test_spack_psmp-P100
@@ -106,7 +106,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Regression test run failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive --ompthreads=6 --exclusive-gpu-memory-batches || echo "ERROR: Regression test run failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_ssmp-P100
+++ b/tools/docker/Dockerfile.test_spack_ssmp-P100
@@ -106,7 +106,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Regression test run failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive --ompthreads=6 --exclusive-gpu-memory-batches || echo "ERROR: Regression test run failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -205,7 +205,8 @@ def main() -> None:
                 base_image="docker.io/nvidia/cuda:12.9.1-devel-ubuntu24.04",
                 gcc_version=13,
                 gpu_model="P100",
-                testopts=testopts,
+                # Run memory-heavy tests alone on the single 8 GiB runner GPU.
+                testopts=f"{testopts} --ompthreads=6 --exclusive-gpu-memory-batches",
                 image_tag=f.image_tag,
             )
         )
@@ -219,7 +220,8 @@ def main() -> None:
                 gcc_version=13,
                 gpu_model="P100",
                 feature_flags="",
-                testopts=testopts,
+                # Run memory-heavy tests alone on the single 8 GiB runner GPU.
+                testopts=f"{testopts} --ompthreads=6 --exclusive-gpu-memory-batches",
                 image_tag=f.image_tag,
             )
         )


### PR DESCRIPTION
## Summary

- mark the LibGint, native SKALA, and PAO regtest directories as GPU-memory-intensive batches
- add an optional regtest-runner mode that executes marked batches without any other CP2K process running
- prevent an exclusive batch from starving while newer ordinary batches acquire released worker slots
- run the single-GPU P100 `psmp` and `ssmp` jobs with six OpenMP threads and exclusive GPU-memory batches
- reduce the grid cutoff of six native-SKALA k-point stress smoke tests from 80 to 70 Ry so their differentiable force/stress graph fits in 7.42 GiB

## Motivation

The GCP runner provides 24 CPU cores but only 7.42 GiB of usable device memory. With the former defaults, `psmp` launched six test-directory workers with two MPI ranks each, so up to twelve CP2K CUDA processes shared that GPU.

Serializing only the marked batches was insufficient because ordinary CUDA-enabled batches could still overlap with them. The runner therefore lets an exclusive batch reserve all worker slots. A shared admission lock prevents newer ordinary batches from taking released slots while an exclusive batch is draining the active workers.

The resulting live `ssmp` run showed that concurrency was no longer the cause of the remaining SKALA failures: each of the six k-point force/stress tests alone occupied about 7.31-7.32 GiB and then failed another 308 MiB allocation. These tests require the full differentiable graph, so atom chunking is intentionally disabled for force/virial calculations. Reducing only their smoke-test cutoff retains CUDA, k points, symmetry/inversion, forces, analytical stress, tolerances, and matcher coverage while reducing the graph size.

The scheduling marker has no effect unless a runner explicitly supplies `--exclusive-gpu-memory-batches`; all other regtest configurations retain their existing scheduling.

## Testing

- `python3 -m py_compile tests/do_regtest.py`
- focused asyncio scheduling test: an exclusive batch starts alone and before a later ordinary batch after two active workers finish
- `python3 tools/docker/generate_dockerfiles.py --check`
- `./make_pretty.sh`
- pre-push checks for all changed files
- first live P100 `ssmp` diagnostic: 5709/5751 correct, zero wrong results; 34 FFTW/RTBSE/PIMD failures covered by #5724, two PAO device failures covered by #5726, and six isolated SKALA out-of-memory failures addressed here

The next P100 run will supply the exact reference values for the six cutoff-adjusted tests. Those values will be updated from the real target run rather than inferred on a different device.
