### PR TITLE
Add Gaussian QM/MM coupling for DFTB and xTB

### DIFF
--- a/src/input_cp2k_qmmm.F
+++ b/src/input_cp2k_qmmm.F
@@ -110,7 +110,7 @@ CONTAINS
                           enum_desc=s2a("Mechanical coupling (i.e. classical point charge based)", &
                                         "Using analytical 1/r potential (Coulomb) - not available for GPW/GAPW", &
                                         "Using fast Gaussian expansion of the electrostatic potential (Erf(r/rc)/r) "// &
-                                        "- not available for DFTB.", &
+                                        "for GPW/GAPW and Gaussian MM charges for DFTB/xTB.", &
                                         "Using fast Gaussian expansion of the s-wave electrostatic potential", &
                                         "Using quantum mechanics derived point charges interacting with MM charges"), &
                           default_i_val=do_qmmm_none)

--- a/src/input_cp2k_qmmm.F
+++ b/src/input_cp2k_qmmm.F
@@ -110,7 +110,7 @@ CONTAINS
                           enum_desc=s2a("Mechanical coupling (i.e. classical point charge based)", &
                                         "Using analytical 1/r potential (Coulomb) - not available for GPW/GAPW", &
                                         "Using fast Gaussian expansion of the electrostatic potential (Erf(r/rc)/r) "// &
-                                        "for GPW/GAPW and Gaussian MM charges for DFTB/xTB.", &
+                                        "for GPW/GAPW and Gaussian MM charges for DFTB/xTB with NOCOMPATIBILITY.", &
                                         "Using fast Gaussian expansion of the s-wave electrostatic potential", &
                                         "Using quantum mechanics derived point charges interacting with MM charges"), &
                           default_i_val=do_qmmm_none)

--- a/src/qmmm_gpw_energy.F
+++ b/src/qmmm_gpw_energy.F
@@ -52,6 +52,7 @@ MODULE qmmm_gpw_energy
                                               qmmm_gaussian_type
    USE qmmm_se_energy,                  ONLY: build_se_qmmm_matrix
    USE qmmm_tb_methods,                 ONLY: build_tb_qmmm_matrix,&
+                                              build_tb_qmmm_matrix_gauss,&
                                               build_tb_qmmm_matrix_pc,&
                                               build_tb_qmmm_matrix_zero
    USE qmmm_types_low,                  ONLY: qmmm_env_qm_type,&
@@ -160,8 +161,10 @@ CONTAINS
             CALL build_tb_qmmm_matrix(qs_env, qmmm_env, mm_particles, mm_cell, para_env)
          CASE (do_qmmm_pcharge)
             CALL build_tb_qmmm_matrix_pc(qs_env, qmmm_env, mm_particles, mm_cell, para_env)
-         CASE (do_qmmm_gauss, do_qmmm_swave)
-            CPABORT("GAUSS or SWAVE QM/MM electrostatic coupling not implemented for DFTB.")
+         CASE (do_qmmm_gauss)
+            CALL build_tb_qmmm_matrix_gauss(qs_env, qmmm_env, mm_particles, mm_cell, para_env)
+         CASE (do_qmmm_swave)
+            CPABORT("SWAVE QM/MM electrostatic coupling not implemented for tight-binding methods.")
          CASE DEFAULT
             CPABORT("Unknown QM/MM coupling")
          END SELECT

--- a/src/qmmm_gpw_forces.F
+++ b/src/qmmm_gpw_forces.F
@@ -58,6 +58,7 @@ MODULE qmmm_gpw_forces
                                               qmmm_elec_with_gaussian_LR
    USE qmmm_se_forces,                  ONLY: deriv_se_qmmm_matrix
    USE qmmm_tb_methods,                 ONLY: deriv_tb_qmmm_matrix,&
+                                              deriv_tb_qmmm_matrix_gauss,&
                                               deriv_tb_qmmm_matrix_pc
    USE qmmm_types_low,                  ONLY: qmmm_env_qm_type,&
                                               qmmm_per_pot_p_type,&
@@ -188,8 +189,11 @@ CONTAINS
          CASE (do_qmmm_pcharge)
             CALL deriv_tb_qmmm_matrix_pc(qs_env, qmmm_env, mm_particles, mm_cell, para_env, &
                                          need_f, Forces, Forces_added_charges)
-         CASE (do_qmmm_gauss, do_qmmm_swave)
-            CPABORT("GAUSS or SWAVE QM/MM electrostatic coupling not yet implemented for DFTB.")
+         CASE (do_qmmm_gauss)
+            CALL deriv_tb_qmmm_matrix_gauss(qs_env, qmmm_env, mm_particles, mm_cell, para_env, &
+                                            need_f, Forces, Forces_added_charges)
+         CASE (do_qmmm_swave)
+            CPABORT("SWAVE QM/MM electrostatic coupling not implemented for tight-binding methods.")
          CASE DEFAULT
             CPABORT("Unknown QM/MM coupling")
          END SELECT

--- a/src/qmmm_per_elpot.F
+++ b/src/qmmm_per_elpot.F
@@ -370,10 +370,10 @@ CONTAINS
       SELECT CASE (qmmm_coupl_type)
       CASE (do_qmmm_coulomb)
          CPABORT("QM-QM long range correction not possible with COULOMB coupling")
-      CASE (do_qmmm_pcharge)
+      CASE (do_qmmm_pcharge, do_qmmm_gauss)
          ! OK
-      CASE (do_qmmm_gauss, do_qmmm_swave)
-         CPABORT("QM-QM long range correction not possible with GAUSS/SWAVE coupling")
+      CASE (do_qmmm_swave)
+         CPABORT("QM-QM long range correction not possible with SWAVE coupling")
       CASE DEFAULT
          ! We should never get to this point
          CPABORT("Unknown QM/MM coupling type")

--- a/src/qmmm_tb_methods.F
+++ b/src/qmmm_tb_methods.F
@@ -36,6 +36,7 @@ MODULE qmmm_tb_methods
    USE input_section_types,             ONLY: section_vals_get_subs_vals,&
                                               section_vals_type
    USE kinds,                           ONLY: dp
+   USE mathconstants,                   ONLY: rootpi
    USE message_passing,                 ONLY: mp_para_env_type
    USE mulliken,                        ONLY: mulliken_charges
    USE particle_types,                  ONLY: allocate_particle_set,&
@@ -78,13 +79,18 @@ MODULE qmmm_tb_methods
    REAL(dp), PARAMETER                    :: eta_mm = 0.47_dp
    ! step size for qmmm finite difference
    REAL(dp), PARAMETER                    :: ddrmm = 0.0001_dp
+   INTEGER, PARAMETER                     :: pot_tb_nonperiodic = 0
+   INTEGER, PARAMETER                     :: pot_tb_short_range = 1
+   INTEGER, PARAMETER                     :: pot_ewald_short_range = 2
+   INTEGER, PARAMETER                     :: pot_gauss_nonperiodic = 3
+   INTEGER, PARAMETER                     :: pot_gauss_short_range = 4
 
    PRIVATE
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qmmm_tb_methods'
 
-   PUBLIC :: build_tb_qmmm_matrix, build_tb_qmmm_matrix_zero, &
-             build_tb_qmmm_matrix_pc, deriv_tb_qmmm_matrix, &
+   PUBLIC :: build_tb_qmmm_matrix, build_tb_qmmm_matrix_gauss, build_tb_qmmm_matrix_zero, &
+             build_tb_qmmm_matrix_pc, deriv_tb_qmmm_matrix, deriv_tb_qmmm_matrix_gauss, &
              deriv_tb_qmmm_matrix_pc
 
 CONTAINS
@@ -187,12 +193,14 @@ CONTAINS
          END IF
          DO i = 1, SIZE(list)
             iatom = list(i)
-            CALL build_mm_pot(qpot(iatom), 0, eta_a(0), qmmm_env%Potentials, particles_mm, &
+            CALL build_mm_pot(qpot(iatom), pot_tb_nonperiodic, eta_a(0), &
+                              qmmm_env%Potentials, particles_mm, &
                               qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, mm_cell, iatom, &
                               qmmm_env%spherical_cutoff, particles_qm)
             ! Possibly added charges
             IF (qmmm_env%move_mm_charges .OR. qmmm_env%add_mm_charges) THEN
-               CALL build_mm_pot(qpot(iatom), 0, eta_a(0), qmmm_env%added_charges%potentials, &
+               CALL build_mm_pot(qpot(iatom), pot_tb_nonperiodic, eta_a(0), &
+                                 qmmm_env%added_charges%potentials, &
                                  qmmm_env%added_charges%added_particles, &
                                  qmmm_env%added_charges%mm_atom_chrg, &
                                  qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, &
@@ -314,11 +322,54 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: mm_cell
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'build_tb_qmmm_matrix_pc'
+      CALL build_tb_qmmm_matrix_smeared(qs_env, qmmm_env, particles_mm, mm_cell, para_env, &
+                                        gaussian=.FALSE.)
 
-      INTEGER                                            :: do_ipol, ewald_type, handle, i, iatom, &
-                                                            ikind, imm, imp, indmm, ipot, jatom, &
-                                                            natom, natorb, nkind, nmm
+   END SUBROUTINE build_tb_qmmm_matrix_pc
+
+! **************************************************************************************************
+!> \brief Constructs the tight-binding QM/MM Hamiltonian for Gaussian MM charges
+!> \param qs_env ...
+!> \param qmmm_env ...
+!> \param particles_mm ...
+!> \param mm_cell ...
+!> \param para_env ...
+! **************************************************************************************************
+   SUBROUTINE build_tb_qmmm_matrix_gauss(qs_env, qmmm_env, particles_mm, mm_cell, para_env)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particles_mm
+      TYPE(cell_type), POINTER                           :: mm_cell
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+
+      CALL build_tb_qmmm_matrix_smeared(qs_env, qmmm_env, particles_mm, mm_cell, para_env, &
+                                        gaussian=.TRUE.)
+
+   END SUBROUTINE build_tb_qmmm_matrix_gauss
+
+! **************************************************************************************************
+!> \brief Constructs the tight-binding QM/MM Hamiltonian for smeared electrostatic coupling
+!> \param qs_env ...
+!> \param qmmm_env ...
+!> \param particles_mm ...
+!> \param mm_cell ...
+!> \param para_env ...
+!> \param gaussian Use Gaussian MM charges instead of the tight-binding point-charge regularization
+! **************************************************************************************************
+   SUBROUTINE build_tb_qmmm_matrix_smeared(qs_env, qmmm_env, particles_mm, mm_cell, para_env, gaussian)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particles_mm
+      TYPE(cell_type), POINTER                           :: mm_cell
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      LOGICAL, INTENT(IN)                                :: gaussian
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'build_tb_qmmm_matrix_smeared'
+
+      INTEGER :: do_ipol, ewald_type, handle, i, iatom, ikind, imm, imp, indmm, ipot, jatom, &
+         natom, natorb, nkind, nmm, nonperiodic_pot_type, short_range_pot_type
       INTEGER, DIMENSION(:), POINTER                     :: list
       LOGICAL                                            :: defined, do_dftb, do_multipoles, do_xtb, &
                                                             found
@@ -349,6 +400,14 @@ CONTAINS
       TYPE(xtb_control_type), POINTER                    :: xtb_control
 
       CALL timeset(routineN, handle)
+
+      IF (gaussian) THEN
+         nonperiodic_pot_type = pot_gauss_nonperiodic
+         short_range_pot_type = pot_gauss_short_range
+      ELSE
+         nonperiodic_pot_type = pot_tb_nonperiodic
+         short_range_pot_type = pot_tb_short_range
+      END IF
 
       CALL get_qs_env(qs_env=qs_env, &
                       dft_control=dft_control, &
@@ -452,7 +511,7 @@ CONTAINS
             END DO
          END IF
          CALL para_env%sum(qpot)
-         ! Add Ewald and TB short range corrections
+         ! Add the Ewald real-space term and the method-specific short-range correction
          ! This is effectively using a minimum image convention!
          ! Set rcutoff to values compatible with alpha Ewald
          CALL ewald_env_get(ewald_env, rcut=rcutoff(1), alpha=alpha)
@@ -477,20 +536,24 @@ CONTAINS
             END IF
             DO i = 1, SIZE(list)
                iatom = list(i)
-               CALL build_mm_pot(qpot(iatom), 1, eta_a(0), qmmm_env%Potentials, particles_mm, &
+               CALL build_mm_pot(qpot(iatom), short_range_pot_type, eta_a(0), &
+                                 qmmm_env%Potentials, particles_mm, &
                                  qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, mm_cell, iatom, rcutoff, &
                                  particles_qm)
-               CALL build_mm_pot(qpot(iatom), 2, alpha, qmmm_env%Potentials, particles_mm, &
+               CALL build_mm_pot(qpot(iatom), pot_ewald_short_range, alpha, &
+                                 qmmm_env%Potentials, particles_mm, &
                                  qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, mm_cell, iatom, rcutoff, &
                                  particles_qm)
                ! Possibly added charges
                IF (qmmm_env%move_mm_charges .OR. qmmm_env%add_mm_charges) THEN
-                  CALL build_mm_pot(qpot(iatom), 1, eta_a(0), qmmm_env%added_charges%potentials, &
+                  CALL build_mm_pot(qpot(iatom), short_range_pot_type, eta_a(0), &
+                                    qmmm_env%added_charges%potentials, &
                                     qmmm_env%added_charges%added_particles, &
                                     qmmm_env%added_charges%mm_atom_chrg, &
                                     qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, rcutoff, &
                                     particles_qm)
-                  CALL build_mm_pot(qpot(iatom), 2, alpha, qmmm_env%added_charges%potentials, &
+                  CALL build_mm_pot(qpot(iatom), pot_ewald_short_range, alpha, &
+                                    qmmm_env%added_charges%potentials, &
                                     qmmm_env%added_charges%added_particles, &
                                     qmmm_env%added_charges%mm_atom_chrg, &
                                     qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, rcutoff, &
@@ -500,7 +563,7 @@ CONTAINS
             END DO
          END DO
       CASE (do_ewald_none)
-         ! Simply summing up charges with 1/R (DFTB corrected)
+         ! Directly sum the nonperiodic regularized electrostatic potential
          nkind = SIZE(atomic_kind_set)
          DO ikind = 1, nkind
             CALL get_atomic_kind(atomic_kind_set(ikind), atom_list=list)
@@ -520,12 +583,14 @@ CONTAINS
             END IF
             DO i = 1, SIZE(list)
                iatom = list(i)
-               CALL build_mm_pot(qpot(iatom), 0, eta_a(0), qmmm_env%Potentials, particles_mm, &
+               CALL build_mm_pot(qpot(iatom), nonperiodic_pot_type, eta_a(0), &
+                                 qmmm_env%Potentials, particles_mm, &
                                  qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, mm_cell, iatom, &
                                  qmmm_env%spherical_cutoff, particles_qm)
                ! Possibly added charges
                IF (qmmm_env%move_mm_charges .OR. qmmm_env%add_mm_charges) THEN
-                  CALL build_mm_pot(qpot(iatom), 0, eta_a(0), qmmm_env%added_charges%potentials, &
+                  CALL build_mm_pot(qpot(iatom), nonperiodic_pot_type, eta_a(0), &
+                                    qmmm_env%added_charges%potentials, &
                                     qmmm_env%added_charges%added_particles, &
                                     qmmm_env%added_charges%mm_atom_chrg, &
                                     qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, &
@@ -574,7 +639,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE build_tb_qmmm_matrix_pc
+   END SUBROUTINE build_tb_qmmm_matrix_smeared
 
 ! **************************************************************************************************
 !> \brief Constructs the derivative w.r.t. 1-el DFTB hamiltonian QMMM terms
@@ -709,22 +774,26 @@ CONTAINS
             DO i = 1, SIZE(list)
                iatom = list(i)
                iqm = iqm + 1
-               CALL build_mm_pot(qpot(iatom), 0, eta_a(0), qmmm_env%Potentials, particles_mm, &
+               CALL build_mm_pot(qpot(iatom), pot_tb_nonperiodic, eta_a(0), &
+                                 qmmm_env%Potentials, particles_mm, &
                                  qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, mm_cell, iatom, &
                                  qmmm_env%spherical_cutoff, particles_qm)
-               CALL build_mm_dpot(mcharge(iatom), 0, eta_a(0), qmmm_env%Potentials, particles_mm, &
+               CALL build_mm_dpot(mcharge(iatom), pot_tb_nonperiodic, eta_a(0), &
+                                  qmmm_env%Potentials, particles_mm, &
                                   qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, &
                                   mm_cell, iatom, Forces, Forces_QM(:, iqm), &
                                   qmmm_env%spherical_cutoff, particles_qm)
                ! Possibly added charges
                IF (qmmm_env%move_mm_charges .OR. qmmm_env%add_mm_charges) THEN
-                  CALL build_mm_pot(qpot(iatom), 0, eta_a(0), qmmm_env%added_charges%potentials, &
+                  CALL build_mm_pot(qpot(iatom), pot_tb_nonperiodic, eta_a(0), &
+                                    qmmm_env%added_charges%potentials, &
                                     qmmm_env%added_charges%added_particles, &
                                     qmmm_env%added_charges%mm_atom_chrg, &
                                     qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, &
                                     qmmm_env%spherical_cutoff, &
                                     particles_qm)
-                  CALL build_mm_dpot(mcharge(iatom), 0, eta_a(0), qmmm_env%added_charges%potentials, &
+                  CALL build_mm_dpot(mcharge(iatom), pot_tb_nonperiodic, eta_a(0), &
+                                     qmmm_env%added_charges%potentials, &
                                      qmmm_env%added_charges%added_particles, &
                                      qmmm_env%added_charges%mm_atom_chrg, &
                                      qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, &
@@ -833,13 +902,70 @@ CONTAINS
       TYPE(particle_type), DIMENSION(:), POINTER         :: particles_mm
       TYPE(cell_type), POINTER                           :: mm_cell
       TYPE(mp_para_env_type), POINTER                    :: para_env
-      LOGICAL, INTENT(in), OPTIONAL                      :: calc_force
+      LOGICAL, INTENT(IN), OPTIONAL                      :: calc_force
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: Forces, Forces_added_charges
 
-      CHARACTER(len=*), PARAMETER :: routineN = 'deriv_tb_qmmm_matrix_pc'
+      CALL deriv_tb_qmmm_matrix_smeared(qs_env, qmmm_env, particles_mm, mm_cell, para_env, &
+                                        calc_force, Forces, Forces_added_charges, gaussian=.FALSE.)
+
+   END SUBROUTINE deriv_tb_qmmm_matrix_pc
+
+! **************************************************************************************************
+!> \brief Constructs tight-binding QM/MM derivatives for Gaussian MM charges
+!> \param qs_env ...
+!> \param qmmm_env ...
+!> \param particles_mm ...
+!> \param mm_cell ...
+!> \param para_env ...
+!> \param calc_force ...
+!> \param Forces ...
+!> \param Forces_added_charges ...
+! **************************************************************************************************
+   SUBROUTINE deriv_tb_qmmm_matrix_gauss(qs_env, qmmm_env, particles_mm, mm_cell, para_env, &
+                                         calc_force, Forces, Forces_added_charges)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particles_mm
+      TYPE(cell_type), POINTER                           :: mm_cell
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      LOGICAL, INTENT(IN), OPTIONAL                      :: calc_force
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: Forces, Forces_added_charges
+
+      CALL deriv_tb_qmmm_matrix_smeared(qs_env, qmmm_env, particles_mm, mm_cell, para_env, &
+                                        calc_force, Forces, Forces_added_charges, gaussian=.TRUE.)
+
+   END SUBROUTINE deriv_tb_qmmm_matrix_gauss
+
+! **************************************************************************************************
+!> \brief Constructs tight-binding QM/MM derivatives for smeared electrostatic coupling
+!> \param qs_env ...
+!> \param qmmm_env ...
+!> \param particles_mm ...
+!> \param mm_cell ...
+!> \param para_env ...
+!> \param calc_force ...
+!> \param Forces ...
+!> \param Forces_added_charges ...
+!> \param gaussian Use Gaussian MM charges instead of the tight-binding point-charge regularization
+! **************************************************************************************************
+   SUBROUTINE deriv_tb_qmmm_matrix_smeared(qs_env, qmmm_env, particles_mm, mm_cell, para_env, &
+                                           calc_force, Forces, Forces_added_charges, gaussian)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(qmmm_env_qm_type), POINTER                    :: qmmm_env
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particles_mm
+      TYPE(cell_type), POINTER                           :: mm_cell
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      LOGICAL, INTENT(in), OPTIONAL                      :: calc_force
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: Forces, Forces_added_charges
+      LOGICAL, INTENT(IN)                                :: gaussian
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'deriv_tb_qmmm_matrix_smeared'
 
       INTEGER :: atom_a, do_ipol, ewald_type, handle, i, iatom, ikind, imm, imp, indmm, ipot, iqm, &
-         jatom, natom, natorb, nkind, nmm, nspins, number_qm_atoms
+         jatom, natom, natorb, nkind, nmm, nonperiodic_pot_type, nspins, number_qm_atoms, &
+         short_range_pot_type
       INTEGER, DIMENSION(:), POINTER                     :: list
       LOGICAL                                            :: defined, do_dftb, do_multipoles, do_xtb, &
                                                             found
@@ -871,6 +997,13 @@ CONTAINS
       TYPE(xtb_control_type), POINTER                    :: xtb_control
 
       CALL timeset(routineN, handle)
+      IF (gaussian) THEN
+         nonperiodic_pot_type = pot_gauss_nonperiodic
+         short_range_pot_type = pot_gauss_short_range
+      ELSE
+         nonperiodic_pot_type = pot_tb_nonperiodic
+         short_range_pot_type = pot_tb_short_range
+      END IF
       IF (calc_force) THEN
          NULLIFY (rho, atomic_kind_set, qs_kind_set, particles_qm)
          CALL get_qs_env(qs_env=qs_env, &
@@ -1036,7 +1169,7 @@ CONTAINS
             END IF
             CALL para_env%sum(qpot)
             CALL para_env%sum(Forces_QM)
-            ! Add Ewald and DFTB short range corrections
+            ! Add the Ewald real-space term and the method-specific short-range correction
             ! This is effectively using a minimum image convention!
             ! Set rcutoff to values compatible with alpha Ewald
             CALL ewald_env_get(ewald_env, rcut=rcutoff(1), alpha=alpha)
@@ -1060,40 +1193,48 @@ CONTAINS
                DO i = 1, SIZE(list)
                   iatom = list(i)
                   iqm = iqm + 1
-                  CALL build_mm_pot(qpot(iatom), 1, eta_a(0), qmmm_env%Potentials, particles_mm, &
+                  CALL build_mm_pot(qpot(iatom), short_range_pot_type, eta_a(0), &
+                                    qmmm_env%Potentials, particles_mm, &
                                     qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, &
                                     mm_cell, iatom, rcutoff, particles_qm)
-                  CALL build_mm_dpot(mcharge(iatom), 1, eta_a(0), qmmm_env%Potentials, particles_mm, &
+                  CALL build_mm_dpot(mcharge(iatom), short_range_pot_type, eta_a(0), &
+                                     qmmm_env%Potentials, particles_mm, &
                                      qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, &
                                      mm_cell, iatom, Forces, Forces_QM(:, iqm), &
                                      rcutoff, particles_qm)
-                  CALL build_mm_pot(qpot(iatom), 2, alpha, qmmm_env%Potentials, particles_mm, &
+                  CALL build_mm_pot(qpot(iatom), pot_ewald_short_range, alpha, &
+                                    qmmm_env%Potentials, particles_mm, &
                                     qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, &
                                     mm_cell, iatom, rcutoff, particles_qm)
-                  CALL build_mm_dpot(mcharge(iatom), 2, alpha, qmmm_env%Potentials, particles_mm, &
+                  CALL build_mm_dpot(mcharge(iatom), pot_ewald_short_range, alpha, &
+                                     qmmm_env%Potentials, particles_mm, &
                                      qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, &
                                      mm_cell, iatom, Forces, Forces_QM(:, iqm), &
                                      rcutoff, particles_qm)
                   ! Possibly added charges
                   IF (qmmm_env%move_mm_charges .OR. qmmm_env%add_mm_charges) THEN
-                     CALL build_mm_pot(qpot(iatom), 1, eta_a(0), qmmm_env%added_charges%potentials, &
+                     CALL build_mm_pot(qpot(iatom), short_range_pot_type, eta_a(0), &
+                                       qmmm_env%added_charges%potentials, &
                                        qmmm_env%added_charges%added_particles, &
                                        qmmm_env%added_charges%mm_atom_chrg, &
                                        qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, rcutoff, &
                                        particles_qm)
                      CALL build_mm_dpot( &
-                        mcharge(iatom), 1, eta_a(0), qmmm_env%added_charges%potentials, &
+                        mcharge(iatom), short_range_pot_type, eta_a(0), &
+                        qmmm_env%added_charges%potentials, &
                         qmmm_env%added_charges%added_particles, qmmm_env%added_charges%mm_atom_chrg, &
                         qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, &
                         Forces_added_charges, Forces_QM(:, iqm), &
                         rcutoff, particles_qm)
-                     CALL build_mm_pot(qpot(iatom), 2, alpha, qmmm_env%added_charges%potentials, &
+                     CALL build_mm_pot(qpot(iatom), pot_ewald_short_range, alpha, &
+                                       qmmm_env%added_charges%potentials, &
                                        qmmm_env%added_charges%added_particles, &
                                        qmmm_env%added_charges%mm_atom_chrg, &
                                        qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, rcutoff, &
                                        particles_qm)
                      CALL build_mm_dpot( &
-                        mcharge(iatom), 2, alpha, qmmm_env%added_charges%potentials, &
+                        mcharge(iatom), pot_ewald_short_range, alpha, &
+                        qmmm_env%added_charges%potentials, &
                         qmmm_env%added_charges%added_particles, qmmm_env%added_charges%mm_atom_chrg, &
                         qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, &
                         Forces_added_charges, Forces_QM(:, iqm), &
@@ -1103,7 +1244,7 @@ CONTAINS
             END DO
 
          CASE (do_ewald_none)
-            ! Simply summing up charges with 1/R (DFTB corrected)
+            ! Directly sum the nonperiodic regularized electrostatic potential
             ! calculate potential and forces from classical charges
             iqm = 0
             DO ikind = 1, nkind
@@ -1122,22 +1263,26 @@ CONTAINS
                DO i = 1, SIZE(list)
                   iatom = list(i)
                   iqm = iqm + 1
-                  CALL build_mm_pot(qpot(iatom), 0, eta_a(0), qmmm_env%Potentials, particles_mm, &
+                  CALL build_mm_pot(qpot(iatom), nonperiodic_pot_type, eta_a(0), &
+                                    qmmm_env%Potentials, particles_mm, &
                                     qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, mm_cell, iatom, &
                                     qmmm_env%spherical_cutoff, particles_qm)
-                  CALL build_mm_dpot(mcharge(iatom), 0, eta_a(0), qmmm_env%Potentials, particles_mm, &
+                  CALL build_mm_dpot(mcharge(iatom), nonperiodic_pot_type, eta_a(0), &
+                                     qmmm_env%Potentials, particles_mm, &
                                      qmmm_env%mm_atom_chrg, qmmm_env%mm_atom_index, &
                                      mm_cell, iatom, Forces, Forces_QM(:, iqm), &
                                      qmmm_env%spherical_cutoff, particles_qm)
                   ! Possibly added charges
                   IF (qmmm_env%move_mm_charges .OR. qmmm_env%add_mm_charges) THEN
-                     CALL build_mm_pot(qpot(iatom), 0, eta_a(0), qmmm_env%added_charges%potentials, &
+                     CALL build_mm_pot(qpot(iatom), nonperiodic_pot_type, eta_a(0), &
+                                       qmmm_env%added_charges%potentials, &
                                        qmmm_env%added_charges%added_particles, &
                                        qmmm_env%added_charges%mm_atom_chrg, &
                                        qmmm_env%added_charges%mm_atom_index, &
                                        mm_cell, iatom, qmmm_env%spherical_cutoff, &
                                        particles_qm)
-                     CALL build_mm_dpot(mcharge(iatom), 0, eta_a(0), qmmm_env%added_charges%potentials, &
+                     CALL build_mm_dpot(mcharge(iatom), nonperiodic_pot_type, eta_a(0), &
+                                        qmmm_env%added_charges%potentials, &
                                         qmmm_env%added_charges%added_particles, &
                                         qmmm_env%added_charges%mm_atom_chrg, &
                                         qmmm_env%added_charges%mm_atom_index, mm_cell, iatom, &
@@ -1234,7 +1379,7 @@ CONTAINS
 
       CALL timestop(handle)
 
-   END SUBROUTINE deriv_tb_qmmm_matrix_pc
+   END SUBROUTINE deriv_tb_qmmm_matrix_smeared
 
 ! **************************************************************************************************
 !> \brief ...
@@ -1298,18 +1443,26 @@ CONTAINS
             END IF
             IF (ABS(qeff) <= qsmall) CYCLE LoopMM
             IF (dr > rtiny) THEN
-               IF (pot_type == 0) THEN
+               IF (pot_type == pot_tb_nonperiodic) THEN
                   sr = gamma_rab_sr(dr, qm_alpha, eta_mm, 0.0_dp)
                   qpot = qpot + qeff*(1.0_dp/dr - sr)
-               ELSE IF (pot_type == 1) THEN
+               ELSE IF (pot_type == pot_tb_short_range) THEN
                   sr = gamma_rab_sr(dr, qm_alpha, eta_mm, 0.0_dp)
                   qpot = qpot - qeff*sr
-               ELSE IF (pot_type == 2) THEN
+               ELSE IF (pot_type == pot_ewald_short_range) THEN
                   sr = erfc(qm_alpha*dr)/dr
                   qpot = qpot + qeff*sr
+               ELSE IF (pot_type == pot_gauss_nonperiodic) THEN
+                  sr = erf(dr/Pot%Rc)/dr
+                  qpot = qpot + qeff*sr
+               ELSE IF (pot_type == pot_gauss_short_range) THEN
+                  sr = erfc(dr/Pot%Rc)/dr
+                  qpot = qpot - qeff*sr
                ELSE
                   CPABORT("Unknown pot_type for dr > rtiny")
                END IF
+            ELSE IF (pot_type == pot_gauss_nonperiodic) THEN
+               qpot = qpot + qeff*2.0_dp/(rootpi*Pot%Rc)
             END IF
          END DO LoopMM
       END DO MainLoopPot
@@ -1385,17 +1538,23 @@ CONTAINS
             IF (dr > rtiny) THEN
                drp = dr + ddrmm
                drm = dr - ddrmm
-               IF (pot_type == 0) THEN
+               IF (pot_type == pot_tb_nonperiodic) THEN
                   dsr = 0.5_dp*(gamma_rab_sr(drp, qm_alpha, eta_mm, 0.0_dp) - &
                                 gamma_rab_sr(drm, qm_alpha, eta_mm, 0.0_dp))/ddrmm
                   fsr = qeff*qcharge*(-1.0_dp/(dr*dr) - dsr)
-               ELSE IF (pot_type == 1) THEN
+               ELSE IF (pot_type == pot_tb_short_range) THEN
                   dsr = 0.5_dp*(gamma_rab_sr(drp, qm_alpha, eta_mm, 0.0_dp) - &
                                 gamma_rab_sr(drm, qm_alpha, eta_mm, 0.0_dp))/ddrmm
                   fsr = -qeff*qcharge*dsr
-               ELSE IF (pot_type == 2) THEN
+               ELSE IF (pot_type == pot_ewald_short_range) THEN
                   dsr = 0.5_dp*(erfc(qm_alpha*drp)/drp - erfc(qm_alpha*drm)/drm)/ddrmm
                   fsr = qeff*qcharge*dsr
+               ELSE IF (pot_type == pot_gauss_nonperiodic) THEN
+                  fsr = qeff*qcharge*(2.0_dp*EXP(-(dr/Pot%Rc)**2)/(rootpi*Pot%Rc*dr) - &
+                                      erf(dr/Pot%Rc)/dr**2)
+               ELSE IF (pot_type == pot_gauss_short_range) THEN
+                  fsr = qeff*qcharge*(2.0_dp*EXP(-(dr/Pot%Rc)**2)/(rootpi*Pot%Rc*dr) + &
+                                      erfc(dr/Pot%Rc)/dr**2)
                ELSE
                   CPABORT("Unknown pot_type for dr > rtiny")
                END IF
@@ -1415,4 +1574,3 @@ CONTAINS
    END SUBROUTINE build_mm_dpot
 
 END MODULE qmmm_tb_methods
-

--- a/src/qmmm_tb_methods.F
+++ b/src/qmmm_tb_methods.F
@@ -343,6 +343,9 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: mm_cell
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
+      IF (qmmm_env%compatibility) THEN
+         CPABORT("Gaussian QM/MM coupling for tight-binding methods requires NOCOMPATIBILITY.")
+      END IF
       CALL build_tb_qmmm_matrix_smeared(qs_env, qmmm_env, particles_mm, mm_cell, para_env, &
                                         gaussian=.TRUE.)
 

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -313,6 +313,7 @@ CONTAINS
       IF (.NOT. ASSOCIATED(subsys_section)) THEN
          subsys_section => section_vals_get_subs_vals(force_env_section, "SUBSYS")
       END IF
+      CALL section_vals_val_get(force_env_section, "DFT%QS%METHOD", i_val=method_id)
 
       ! QMMM
       my_qmmm = .FALSE.
@@ -322,14 +323,14 @@ CONTAINS
          IF (qmmm_env_qm%qmmm_coupl_type == do_qmmm_gauss .OR. &
              qmmm_env_qm%qmmm_coupl_type == do_qmmm_swave) THEN
             ! For GAUSS/SWAVE methods there could be a DDAPC decoupling requested
-            qmmm_decoupl = my_qmmm .AND. qmmm_env_qm%periodic .AND. qmmm_env_qm%multipole
+            qmmm_decoupl = my_qmmm .AND. qmmm_env_qm%periodic .AND. qmmm_env_qm%multipole .AND. &
+                           method_id /= do_method_dftb .AND. method_id /= do_method_xtb
          END IF
          qs_env%qmmm_env_qm => qmmm_env_qm
       END IF
       CALL set_qs_env(qs_env=qs_env, qmmm=my_qmmm)
 
       ! Possibly initialize arrays for SE
-      CALL section_vals_val_get(force_env_section, "DFT%QS%METHOD", i_val=method_id)
       SELECT CASE (method_id)
       CASE (do_method_rm1, do_method_am1, do_method_mndo, do_method_pdg, &
             do_method_pm3, do_method_pm6, do_method_pm6fm, do_method_mndod, do_method_pnnl)
@@ -530,7 +531,9 @@ CONTAINS
       END IF
 
       IF (my_qmmm .AND. PRESENT(qmmm_env_qm) .AND. .NOT. dft_control%qs_control%commensurate_mgrids) THEN
-         IF (qmmm_env_qm%qmmm_coupl_type == do_qmmm_gauss .OR. qmmm_env_qm%qmmm_coupl_type == do_qmmm_swave) THEN
+         IF ((qmmm_env_qm%qmmm_coupl_type == do_qmmm_gauss .OR. &
+              qmmm_env_qm%qmmm_coupl_type == do_qmmm_swave) .AND. &
+             method_id /= do_method_dftb .AND. method_id /= do_method_xtb) THEN
             CALL cp_abort(__LOCATION__, "QM/MM with coupling GAUSS or S-WAVE requires "// &
                           "keyword FORCE_EVAL/DFT/MGRID/COMMENSURATE to be enabled.")
          END IF

--- a/tests/QMMM/DFTB/regtest/TEST_FILES.toml
+++ b/tests/QMMM/DFTB/regtest/TEST_FILES.toml
@@ -19,4 +19,5 @@
 "fdeb_5.inp"                            = []
 "fdeb_6.inp"                            = []
 "fdeb_7.inp"                            = []
+"gauss_1.inp"                           = []
 #EOF

--- a/tests/QMMM/DFTB/regtest/gauss_1.inp
+++ b/tests/QMMM/DFTB/regtest/gauss_1.inp
@@ -1,0 +1,124 @@
+&GLOBAL
+  PRINT_LEVEL LOW
+  PROJECT gauss_dftb
+  RUN_TYPE DEBUG
+&END GLOBAL
+
+&DEBUG
+  DEBUG_FORCES T
+  DEBUG_STRESS_TENSOR F
+  DX 0.0001
+  EPS_NO_ERROR_CHECK 5.E-4
+&END DEBUG
+
+&FORCE_EVAL
+  METHOD QMMM
+  &DFT
+    &QS
+      METHOD DFTB
+      &DFTB
+        DISPERSION F
+        DO_EWALD F
+        SELF_CONSISTENT T
+        &PARAMETER
+          PARAM_FILE_NAME scc_parameter
+          PARAM_FILE_PATH DFTB/scc
+        &END PARAMETER
+      &END DFTB
+    &END QS
+    &SCF
+      EPS_SCF 1.E-8
+      SCF_GUESS MOPAC
+      &PRINT
+        &RESTART OFF
+        &END RESTART
+      &END PRINT
+    &END SCF
+  &END DFT
+  &MM
+    &FORCEFIELD
+      &BEND
+        ATOMS H O H
+        K 0.
+        THETA0 1.8
+      &END BEND
+      &BOND
+        ATOMS O H
+        K 0.
+        R0 1.8
+      &END BOND
+      &CHARGE
+        ATOM O
+        CHARGE -0.8476
+      &END CHARGE
+      &CHARGE
+        ATOM H
+        CHARGE 0.4238
+      &END CHARGE
+      &NONBONDED
+        &LENNARD-JONES
+          ATOMS O O
+          EPSILON 78.198
+          RCUT 11.4
+          SIGMA 3.166
+        &END LENNARD-JONES
+        &LENNARD-JONES
+          ATOMS O H
+          EPSILON 0.0
+          RCUT 11.4
+          SIGMA 3.6705
+        &END LENNARD-JONES
+        &LENNARD-JONES
+          ATOMS H H
+          EPSILON 0.0
+          RCUT 11.4
+          SIGMA 3.30523
+        &END LENNARD-JONES
+      &END NONBONDED
+    &END FORCEFIELD
+    &POISSON
+      &EWALD
+        EWALD_TYPE NONE
+      &END EWALD
+    &END POISSON
+  &END MM
+  &QMMM
+    CENTER SETUP_ONLY
+    ECOUPL GAUSS
+    NOCOMPATIBILITY
+    USE_GEEP_LIB 10
+    &CELL
+      ABC 8.0 8.0 8.0
+    &END CELL
+    &MM_KIND H
+      RADIUS 0.44
+    &END MM_KIND
+    &MM_KIND O
+      RADIUS 0.78
+    &END MM_KIND
+    &QM_KIND H
+      MM_INDEX 2 3
+    &END QM_KIND
+    &QM_KIND O
+      MM_INDEX 1
+    &END QM_KIND
+  &END QMMM
+  &SUBSYS
+    &CELL
+      ABC 24.955 24.955 24.955
+    &END CELL
+    &COORD
+      O     0.000000     0.000000     0.000000    H2O1
+      H     0.000000     0.000000     1.000000    H2O1
+      H     0.942809     0.000000    -0.333333    H2O1
+      O    -1.617979    -0.948062    -2.341650    H2O2
+      H    -2.529195    -1.296822    -2.122437    H2O2
+      H    -1.534288    -0.833088    -3.331486    H2O2
+      O    -1.507990     2.117783     1.555094    H2O3
+      H    -1.501128     2.645178     2.403050    H2O3
+      H    -2.090603     1.352766     1.597519    H2O3
+    &END COORD
+    &TOPOLOGY
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QMMM/xTB/regtest/TEST_FILES.toml
+++ b/tests/QMMM/xTB/regtest/TEST_FILES.toml
@@ -19,4 +19,5 @@
 "fdeb_5.inp"                            = []
 "fdeb_6.inp"                            = []
 "fdeb_7.inp"                            = []
+"gauss_1.inp"                           = []
 #EOF

--- a/tests/QMMM/xTB/regtest/gauss_1.inp
+++ b/tests/QMMM/xTB/regtest/gauss_1.inp
@@ -1,0 +1,135 @@
+&GLOBAL
+  PRINT_LEVEL LOW
+  PROJECT gauss_xtb_periodic
+  RUN_TYPE DEBUG
+&END GLOBAL
+
+&DEBUG
+  DEBUG_FORCES T
+  DEBUG_STRESS_TENSOR F
+  DX 0.0001
+  EPS_NO_ERROR_CHECK 5.E-4
+  MAX_RELATIVE_ERROR 0.5
+&END DEBUG
+
+&FORCE_EVAL
+  METHOD QMMM
+  &DFT
+    &QS
+      METHOD xTB
+      &XTB
+        GFN_TYPE TBLITE
+        SCC_MIXER TBLITE
+        &TBLITE
+          METHOD GFN2
+        &END TBLITE
+      &END XTB
+    &END QS
+    &SCF
+      EPS_SCF 1.E-10
+      MAX_SCF 200
+      SCF_GUESS MOPAC
+      &PRINT
+        &RESTART OFF
+        &END RESTART
+      &END PRINT
+    &END SCF
+  &END DFT
+  &MM
+    &FORCEFIELD
+      &BEND
+        ATOMS H O H
+        K 0.
+        THETA0 1.8
+      &END BEND
+      &BOND
+        ATOMS O H
+        K 0.
+        R0 1.8
+      &END BOND
+      &CHARGE
+        ATOM O
+        CHARGE -0.8476
+      &END CHARGE
+      &CHARGE
+        ATOM H
+        CHARGE 0.4238
+      &END CHARGE
+      &NONBONDED
+        &LENNARD-JONES
+          ATOMS O O
+          EPSILON 78.198
+          RCUT 11.4
+          SIGMA 3.166
+        &END LENNARD-JONES
+        &LENNARD-JONES
+          ATOMS O H
+          EPSILON 0.0
+          RCUT 11.4
+          SIGMA 3.6705
+        &END LENNARD-JONES
+        &LENNARD-JONES
+          ATOMS H H
+          EPSILON 0.0
+          RCUT 11.4
+          SIGMA 3.30523
+        &END LENNARD-JONES
+      &END NONBONDED
+    &END FORCEFIELD
+    &POISSON
+      &EWALD
+        ALPHA .44
+        EWALD_TYPE SPME
+        GMAX 21
+      &END EWALD
+    &END POISSON
+  &END MM
+  &QMMM
+    CENTER SETUP_ONLY
+    ECOUPL GAUSS
+    NOCOMPATIBILITY
+    USE_GEEP_LIB 10
+    &CELL
+      ABC 8.0 8.0 8.0
+    &END CELL
+    &MM_KIND H
+      RADIUS 0.44
+    &END MM_KIND
+    &MM_KIND O
+      RADIUS 0.78
+    &END MM_KIND
+    &PERIODIC
+      &POISSON
+        &EWALD
+          ALPHA .44
+          EWALD_TYPE SPME
+          GMAX 21
+        &END EWALD
+      &END POISSON
+    &END PERIODIC
+    &QM_KIND H
+      MM_INDEX 2 3
+    &END QM_KIND
+    &QM_KIND O
+      MM_INDEX 1
+    &END QM_KIND
+  &END QMMM
+  &SUBSYS
+    &CELL
+      ABC 24.955 24.955 24.955
+    &END CELL
+    &COORD
+      O     0.000000     0.000000     0.000000    H2O1
+      H     0.000000     0.000000     1.000000    H2O1
+      H     0.942809     0.000000    -0.333333    H2O1
+      O    -1.617979    -0.948062    -2.341650    H2O2
+      H    -2.529195    -1.296822    -2.122437    H2O2
+      H    -1.534288    -0.833088    -3.331486    H2O2
+      O    -1.507990     2.117783     1.555094    H2O3
+      H    -1.501128     2.645178     2.403050    H2O3
+      H    -2.090603     1.352766     1.597519    H2O3
+    &END COORD
+    &TOPOLOGY
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL


### PR DESCRIPTION
## Summary

- Add Gaussian MM-charge embedding for DFTB and xTB QM/MM energies and forces.
- Use the exact nonperiodic potential `q erf(r/R) / r`, including its finite coincident-point limit.
- For periodic SPME, combine the point-charge Ewald potential with the local correction `-q erfc(r/R) / r` and reuse the existing tight-binding QM-QM long-range correction.
- Keep S-WAVE unsupported for tight-binding methods and require `NOCOMPATIBILITY`, so the historical CPMD correction term cannot be silently ignored.
- Add force-debug regression coverage for nonperiodic SCC-DFTB and periodic TBLITE/GFN2-xTB.

## Motivation

The existing tight-binding `POINT_CHARGE` coupling uses a DFTB-specific short-range gamma regularization. That is physically different from `GAUSS`, where each MM charge is represented by the radius-dependent Gaussian potential selected through `MM_KIND/RADIUS`. Previously, selecting `GAUSS` with DFTB or xTB aborted before constructing the Hamiltonian.

This change preserves the existing overlap-weighted tight-binding Hamiltonian form while supplying the Gaussian electrostatic potential consistently to its electronic, core, and force contributions. The periodic decomposition is equivalent to replacing every SPME point charge by its Gaussian charge distribution.

## Validation

- Built `cp2k.psmp` with CMake, MPI, OpenMP, and TBLITE enabled.
- CP2K precommit checks pass for all changed source and test files.
- Nonperiodic SCC-DFTB force debug passes with a sum of absolute force differences of `1.0e-8` a.u.
- Periodic TBLITE/GFN2-xTB force debug passes in serial and with two MPI ranks with a sum of absolute force differences of `3.096e-5` a.u. and a maximum relative error of `0.41%` for a small force component.
- For comparison, the existing periodic native-GFN1 `POINT_CHARGE` force test gives a larger sum of absolute differences of `8.777e-5` a.u. with the same SPME setup.
