### PR TITLE
Relax GAPW CDFT Hirshfeld regtest tolerance

### DIFF
--- a/tests/QS/regtest-cdft-gapw/TEST_FILES.toml
+++ b/tests/QS/regtest-cdft-gapw/TEST_FILES.toml
@@ -10,7 +10,7 @@
   {matcher="M072", tol=5e-5, ref=1.03364671e-4},
 ]
 "H2_hirshfeld_molecular.inp" = [
-  {matcher="M071", tol=2e-8, ref=0.860064537137},
+  {matcher="M071", tol=1e-7, ref=0.860064537137},
   {matcher="M072", tol=5e-5, ref=1.19391737e-2},
 ]
 # The atoms straddle the cell boundary to exercise minimum-image derivatives.


### PR DESCRIPTION
The molecular Hirshfeld GAPW CDFT regression test introduced in #5730
shows small compiler- and architecture-dependent numerical variations.

Across the affected dashboard testers, the M071 value ranges from
0.8600644855 to 0.8600645191, corresponding to a maximum deviation of
5.164e-8 from the existing reference value. The previous tolerance of
2e-8 was therefore too strict.

This change increases the tolerance to 1e-7. The reference value,
test input, and production code remain unchanged.

Validation:

- QS/regtest-cdft-gapw: 13 / 13 tests passed with four MPI ranks
- make_pretty.sh passed
- pre-push checks passed
- all observed dashboard values are within the updated tolerance

The other reported H100 and GROMACS dashboard failures are unrelated
to the GAPW CDFT regression test.