### PR TITLE
Backport OpenMPI operation module lifetime fixes

### DIFF
--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -35,6 +35,10 @@ case "${with_openmpi}" in
       [ -d openmpi-${openmpi_ver} ] && rm -rf openmpi-${openmpi_ver}
       tar -xjf ${openmpi_pkg}
       cd openmpi-${openmpi_ver}
+      # Backport module lifetime fixes requested in open-mpi/ompi#13783.
+      patch -l -p1 < "${SCRIPT_DIR}/stage1/openmpi-${openmpi_ver}-op-module-lifetime.patch" \
+        > openmpi_op_module_lifetime.patch.log 2>&1 ||
+        tail_excerpt openmpi_op_module_lifetime.patch.log
       if [ "${OPENBLAS_ARCH}" = "x86_64" ]; then
         # can have issue with older glibc libraries, in which case
         # we need to add the -fgnu89-inline to CFLAGS. We can check
@@ -58,7 +62,9 @@ case "${with_openmpi}" in
       make -j $(get_nprocs) > make.log 2>&1 || tail_excerpt make.log
       make -j $(get_nprocs) install > install.log 2>&1 || tail_excerpt install.log
       cd ..
-      write_checksums "${install_lock_file}" "${SCRIPT_DIR}/stage1/$(basename ${SCRIPT_NAME})"
+      write_checksums "${install_lock_file}" \
+        "${SCRIPT_DIR}/stage1/$(basename ${SCRIPT_NAME})" \
+        "${SCRIPT_DIR}/stage1/openmpi-${openmpi_ver}-op-module-lifetime.patch"
     fi
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"

--- a/tools/toolchain/scripts/stage1/openmpi-5.0.10-op-module-lifetime.patch
+++ b/tools/toolchain/scripts/stage1/openmpi-5.0.10-op-module-lifetime.patch
@@ -1,0 +1,43 @@
+# Backports the OpenMPI fixes requested for CP2K in open-mpi/ompi#13783.
+# Merged upstream via open-mpi/ompi#13868 as commits 4f944b5 and 0517663.
+diff --git a/ompi/mca/op/base/op_base_op_select.c b/ompi/mca/op/base/op_base_op_select.c
+--- a/ompi/mca/op/base/op_base_op_select.c
++++ b/ompi/mca/op/base/op_base_op_select.c
+@@ -17 +17 @@
+- * Copyright (c) 2020      Research Organization for Information Science
++ * Copyright (c) 2020-2024 Research Organization for Information Science
+@@ -166 +166 @@ int ompi_op_base_op_select(ompi_op_t *op)
+-                OBJ_RELEASE(op->o_func.intrinsic.modules[i]);
++                OBJ_RELEASE(op->o_3buff_intrinsic.modules[i]);
+diff --git a/ompi/mca/op/aarch64/op_aarch64_component.c b/ompi/mca/op/aarch64/op_aarch64_component.c
+--- a/ompi/mca/op/aarch64/op_aarch64_component.c
++++ b/ompi/mca/op/aarch64/op_aarch64_component.c
+@@ -6,0 +7,2 @@
++ * Copyright (c) 2024      Research Organization for Information Science
++ *                         and Technology (RIST).  All rights reserved.
+@@ -168 +169,0 @@ static struct ompi_op_base_module_1_0_0_t *
+-    ompi_op_base_module_t *module = OBJ_NEW(ompi_op_base_module_t);
+@@ -174,0 +176,4 @@ static struct ompi_op_base_module_1_0_0_t *
++    ompi_op_base_module_t *module = OBJ_NEW(ompi_op_base_module_t);
++    if (NULL == module) {
++        return NULL;
++    }
+@@ -203,6 +207,0 @@ static struct ompi_op_base_module_1_0_0_t *
+-            if( NULL != module->opm_fns[i] ) {
+-                OBJ_RETAIN(module);
+-            }
+-            if( NULL != module->opm_3buff_fns[i] ) {
+-                OBJ_RETAIN(module);
+-            }
+@@ -211,0 +211 @@ static struct ompi_op_base_module_1_0_0_t *
++        OBJ_RELEASE(module);
+@@ -214,0 +215 @@ static struct ompi_op_base_module_1_0_0_t *
++        OBJ_RELEASE(module);
+@@ -217,0 +219 @@ static struct ompi_op_base_module_1_0_0_t *
++        OBJ_RELEASE(module);
+@@ -220,0 +223 @@ static struct ompi_op_base_module_1_0_0_t *
++        OBJ_RELEASE(module);
+@@ -223,0 +227 @@ static struct ompi_op_base_module_1_0_0_t *
++        OBJ_RELEASE(module);
+@@ -226,0 +231 @@ static struct ompi_op_base_module_1_0_0_t *
++        OBJ_RELEASE(module);


### PR DESCRIPTION
## Summary

- backport the two OpenMPI operation-module lifetime fixes requested for the CP2K CI failure in open-mpi/ompi#13783
- correct the three-buffer operation module release and remove excess AArch64 module retains
- include the patch in the OpenMPI toolchain install checksum

## Motivation

The OpenMPI psmp dashboard failure is not caused by intrinsically slow regtests. `H2O-periodic-dens-pulse-2.inp` crashed in OpenMPI 5.0.10 `mca_btl_sm_frag_complete`, while `ch2o_dip44.inp` subsequently timed out after 400 seconds even though it normally takes about 4-7 seconds.

OpenMPI issue open-mpi/ompi#13783 tracks this CP2K CI failure. The maintainers identified commits `4f944b5` and `0517663` as missing from the stable 5.x series; both were merged into v5.0.x via open-mpi/ompi#13868 but are not part of a release newer than the toolchain-pinned 5.0.10 yet.

No CP2K code, regtest input, tolerance, timeout, or MPI transport is changed.

## Testing

- CP2K precommit and pre-push checks
- patch application against the exact OpenMPI 5.0.10 source archive
- OpenMPI toolchain stage builds on x86_64 and AArch64
- fresh OpenMPI psmp Docker build and targeted regtests: 44/44 correct
- five additional repetitions of the affected regtest directories: 220/220 correct