### PR TITLE
Limit CSCS H100 regtest concurrency

### DIFF
--- a/ci/cscs_daint_spack_psmp_h100.yaml
+++ b/ci/cscs_daint_spack_psmp_h100.yaml
@@ -95,7 +95,7 @@ regression test cp2k daint:
   timeout: 6h
   script:
     - git --no-pager log -1 --pretty="%nCommitSHA:%x20%H%nCommitTime:%x20%ci%nCommitAuthor:%x20%an%nCommitSubject:%x20%s%n"
-    - podman run --device nvidia.com/gpu=all --shm-size=1g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks ${SLURM_NTASKS} --ompthreads 1 --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
+    - podman run --device nvidia.com/gpu=all --shm-size=1g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks ${SLURM_NTASKS} --ompthreads 1 --timeout 300 --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
   variables:
     SLURM_DEBUG: 1
     SLURM_HINT: nomultithread

--- a/ci/cscs_daint_spack_psmp_h100.yaml
+++ b/ci/cscs_daint_spack_psmp_h100.yaml
@@ -95,13 +95,14 @@ regression test cp2k daint:
   timeout: 6h
   script:
     - git --no-pager log -1 --pretty="%nCommitSHA:%x20%H%nCommitTime:%x20%ci%nCommitAuthor:%x20%an%nCommitSubject:%x20%s%n"
-    - podman run --device nvidia.com/gpu=all --shm-size=1g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks ${SLURM_NTASKS} --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
+    - podman run --device nvidia.com/gpu=all --shm-size=1g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks ${SLURM_NTASKS} --ompthreads 1 --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
   variables:
     SLURM_DEBUG: 1
     SLURM_HINT: nomultithread
     SLURM_JOB_NUM_NODES: 1
-    # Limit concurrent 2x2 regtest workers to avoid device contention.
-    SLURM_NTASKS: 64
+    # Run eight two-rank workers to limit device contention. SIRIUS full-
+    # potential tests are unstable with multiple OpenMP threads.
+    SLURM_NTASKS: 16
     SLURM_TIMELIMIT: 60
     USE_MPI: YES
 

--- a/ci/cscs_daint_spack_psmp_h100.yaml
+++ b/ci/cscs_daint_spack_psmp_h100.yaml
@@ -95,7 +95,7 @@ regression test cp2k daint:
   timeout: 6h
   script:
     - git --no-pager log -1 --pretty="%nCommitSHA:%x20%H%nCommitTime:%x20%ci%nCommitAuthor:%x20%an%nCommitSubject:%x20%s%n"
-    - podman run --device nvidia.com/gpu=all --shm-size=1g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks ${SLURM_NTASKS} --ompthreads 1 --timeout 300 --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
+    - podman run --device nvidia.com/gpu=all --shm-size=1g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks ${SLURM_NTASKS} --ompthreads 1 --timeout 400 --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
   variables:
     SLURM_DEBUG: 1
     SLURM_HINT: nomultithread

--- a/ci/cscs_daint_spack_psmp_h100.yaml
+++ b/ci/cscs_daint_spack_psmp_h100.yaml
@@ -100,10 +100,10 @@ regression test cp2k daint:
     SLURM_DEBUG: 1
     SLURM_HINT: nomultithread
     SLURM_JOB_NUM_NODES: 1
-    # Run eight two-rank workers to limit device contention. SIRIUS full-
-    # potential tests are unstable with multiple OpenMP threads.
+    # Run eight two-rank, single-threaded workers to limit device contention
+    # while retaining sufficient throughput on this four-GPU runner.
     SLURM_NTASKS: 16
-    SLURM_TIMELIMIT: 60
+    SLURM_TIMELIMIT: 90
     USE_MPI: YES
 
 benchmark cp2k 1 daint node:

--- a/ci/cscs_daint_spack_psmp_h100.yaml
+++ b/ci/cscs_daint_spack_psmp_h100.yaml
@@ -100,7 +100,8 @@ regression test cp2k daint:
     SLURM_DEBUG: 1
     SLURM_HINT: nomultithread
     SLURM_JOB_NUM_NODES: 1
-    SLURM_NTASKS: 224
+    # Limit concurrent 2x2 regtest workers to avoid device contention.
+    SLURM_NTASKS: 64
     SLURM_TIMELIMIT: 60
     USE_MPI: YES
 


### PR DESCRIPTION
## Summary

- run eight concurrent two-rank, single-threaded H100 regtest workers instead of 56
- allow up to 400 seconds for slower ARM/GH200 SIRIUS cases
- extend the SLURM allocation safeguard to 90 minutes
- keep every test, matcher, dependency, and GPU backend enabled

## Root cause

The H100 dashboard consistently failed with about 49-51 timed-out tests. Its allocation launched 56 concurrent regression-test directories on four GPUs, placing 28 simultaneous MPI ranks on each GPU.

The first revision reduced this to 16 workers and cut the failures from 51 to 12. The second revision switched to eight single-threaded workers and reduced the result further to three timeouts in a 37-minute run. The earlier SIRIUS full-potential Cholesky failure did not recur. Because worker concurrency and OpenMP thread count changed together, this observation does not establish a SIRIUS/OpenMP defect.

A subsequent run with a 300-second process timeout passed 5949 of 5950 tests in 38 minutes. The only remaining failure was `SIRIUS/regtest-1/Au.inp`, which continued normal SCF iterations until it was terminated after 302.62 seconds.

PR #5721 lowered the current global regtest timeout from the former 400 seconds to 150 seconds. This H100 runner now explicitly uses the former 400-second threshold. With `--ompthreads 1` and 16 task slots, `do_regtest.py` creates eight two-rank workers, or two workers per GPU. The 90-minute SLURM limit remains a protective bound and leaves headroom for the slower test. The separate H100 benchmark jobs still exercise hybrid MPI/OpenMP execution.

## Validation

- `./make_pretty.sh ci/cscs_daint_spack_psmp_h100.yaml`
- YAML parsing and worker/rank/timeout check
- `git diff --check`
- CP2K pre-push hook