### PR TITLE
Tighten SCF convergence in Becke CDFT regtest

### DIFF
--- a/tests/QS/regtest-cdft-gapw/H2He_becke_molecular.inp
+++ b/tests/QS/regtest-cdft-gapw/H2He_becke_molecular.inp
@@ -41,14 +41,14 @@
       &END CDFT
     &END QS
     &SCF
-      EPS_SCF 1.0E-7
+      EPS_SCF 1.0E-8
       MAX_SCF 80
       &OT
         MINIMIZER CG
         PRECONDITIONER FULL_ALL
       &END OT
       &OUTER_SCF
-        EPS_SCF 1.0E-7
+        EPS_SCF 1.0E-8
         MAX_SCF 2
       &END OUTER_SCF
     &END SCF


### PR DESCRIPTION
## Summary

- tighten both inner and outer SCF convergence from `1e-7` to `1e-8` in `H2He_becke_molecular.inp`
- keep the M071 reference value and matcher tolerance unchanged

## Rationale

The Ubuntu GCC 9 (`ssmp`) dashboard produced `0.848418134297` for M071, just outside the existing relative tolerance (`1.04e-7 > 1e-7`). Repeated two-thread runs show that the final Becke constraint value varies at roughly the same scale as the input SCF stopping criterion. Tightening the SCF threshold reduces this OpenMP-sensitive spread instead of weakening the regression matcher.

A looser `5e-8` compromise was also tested, but 2 of 8 concurrent four-thread runs still exceeded the unchanged matcher tolerance (`1.10e-7` and `1.23e-7` relative differences). It therefore does not reliably address the failure.

The test took 35 rather than 16 SCF steps in the slowest validation run, increasing its runtime from 2.48 to 5.85 seconds. On the current serial-debug dashboard the original test takes 5.98 seconds and the slow-test threshold is 29.48 seconds, leaving comfortable headroom for the tighter convergence.

## Validation

- 16 repeated runs with two OpenMP threads pass the unchanged M071 and M072 matchers
- 8 repeated runs with four OpenMP threads pass the unchanged matchers
- the two-thread M071 span decreased from about `1.0e-7` to `3.1e-8`
- `make_pretty.sh` and `git diff --check` pass