### PR TITLE
make_cp2k.sh v2.2: add option for convention check

### DIFF
--- a/ci/docker/build_cp2k_spack.Dockerfile
+++ b/ci/docker/build_cp2k_spack.Dockerfile
@@ -23,12 +23,11 @@ ENV FEATURE_FLAGS=${FEATURE_FLAGS:-}
 
 # Build CP2K
 WORKDIR /opt/cp2k
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
 
 RUN ./make_cp2k.sh -cray -cv ${CP2K_VERSION} -uc no -j${NUM_PROCS} ${FEATURE_FLAGS}
 

--- a/ci/docker/build_deps_spack.Dockerfile
+++ b/ci/docker/build_deps_spack.Dockerfile
@@ -52,8 +52,8 @@ ENV FEATURE_FLAGS=${FEATURE_FLAGS:-}
 
 # Build CP2K dependencies
 WORKDIR /opt/cp2k
-COPY ./tools/spack ./tools/spack
-COPY ./tools/docker ./tools/docker
 COPY ./make_cp2k.sh .
+COPY ./tools/docker ./tools/docker
+COPY ./tools/spack ./tools/spack
 
 RUN ./make_cp2k.sh -bd_only -cray -cv ${CP2K_VERSION} -uc no -ue -j${NUM_PROCS} ${FEATURE_FLAGS}

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -50,7 +50,7 @@
 
 # Authors: Matthias Krack (MK)
 
-# Version: 2.1
+# Version: 2.2
 
 # Facilitate the deugging of this script
 set -uo pipefail
@@ -133,6 +133,7 @@ BENCHMARK_PROFILE=""
 BUILD_DEPS="if_needed"
 BUILD_DEPS_ONLY="no"
 BUILD_SHARED_LIBS="${BUILD_SHARED_LIBS:-ON}"
+CHECK_CONVENTIONS="no"
 CP2K_BUILD_TYPE="${CP2K_BUILD_TYPE:-Release}"
 DEPS_BUILD_TYPE="${DEPS_BUILD_TYPE:-Release}"
 CMAKE_FEATURE_FLAG_ALL="-DCP2K_USE_EVERYTHING=ON" # all features are activated by default
@@ -221,6 +222,10 @@ while [[ $# -gt 0 ]]; do
         ${EXIT_CMD} 1
       fi
       shift 2
+      ;;
+    -cc | --check_conventions)
+      CHECK_CONVENTIONS="yes"
+      shift 1
       ;;
     -cray)
       CRAY="yes"
@@ -720,10 +725,19 @@ if [[ ${TEST_GROMACS} == "yes" ]]; then
   GROMACS_VERSION=${GROMACS_VERSION:-v2026.3}
 fi
 
-export BENCHMARK_PROFILE BUILD_DEPS BUILD_DEPS_ONLY BUILD_SHARED_LIBS CMAKE_FEATURE_FLAGS CMAKE_FEATURE_FLAGS_GPU \
-  CP2K_BUILD_TYPE CRAY CUDA_SM_CODE DEPS_BUILD_TYPE GCC_VERSION GPU_MODEL GROMACS_VERSION IN_CONTAINER INSTALL_MESSAGE \
-  MPI_MODE NUM_PACKAGES NUM_PROCS REBUILD_CP2K RUN_BENCHMARK RUN_TEST TEST_GROMACS TESTOPTS USE_CACHE USE_OPENCL \
-  VERBOSE VERBOSE_FLAG VERBOSE_MAKEFILE VERBOSE_SPACK
+# Perform setup for coding conventions check
+if [[ "${CHECK_CONVENTIONS}" == "yes" ]]; then
+  CP2K_BUILD_TYPE="Conventions"
+  Fortran_COMPILER_LAUNCHER="${CP2K_ROOT}/tools/conventions/redirect_gfortran_output.py"
+else
+  Fortran_COMPILER_LAUNCHER=""
+fi
+
+export BENCHMARK_PROFILE BUILD_DEPS BUILD_DEPS_ONLY BUILD_SHARED_LIBS CHECK_CONVENTIONS CMAKE_FEATURE_FLAGS \
+  CMAKE_FEATURE_FLAGS_GPU CP2K_BUILD_TYPE CRAY CUDA_SM_CODE DEPS_BUILD_TYPE Fortran_COMPILER_LAUNCHER \
+  GCC_VERSION GPU_MODEL GROMACS_VERSION IN_CONTAINER INSTALL_MESSAGE MPI_MODE NUM_PACKAGES NUM_PROCS \
+  REBUILD_CP2K RUN_BENCHMARK RUN_TEST TEST_GROMACS TESTOPTS USE_CACHE USE_OPENCL VERBOSE VERBOSE_FLAG \
+  VERBOSE_MAKEFILE VERBOSE_SPACK
 
 # Show help if requested
 if [[ "${HELP}" == "yes" ]]; then
@@ -733,6 +747,7 @@ if [[ "${HELP}" == "yes" ]]; then
   echo "                    [-bp | --build_path PATH]"
   echo "                    [-bsl | --build_static_libcp2k]"
   echo "                    [-bt | --build_type (Debug | Release | RelWithDebInfo)]"
+  echo "                    [-cc | --check_conventions]"
   echo "                    [-cray]"
   echo "                    [-cv | --cp2k_version (pdbg | psmp | sdbg | ssmp | ssmp-static)]"
   echo "                    [-df | --disable | --disable_feature (all | FEATURE | PACKAGE | none)"
@@ -761,6 +776,7 @@ if [[ "${HELP}" == "yes" ]]; then
   echo " --build_path          : Define the CP2K build path (default: ${CP2K_ROOT})"
   echo " --build_static_libcp2k: Build a static CP2K library libcp2k.a instead of the default shared one libcp2k.so"
   echo " --build_type          : Set preferred CMake build type for CP2K (default: \"Release\")"
+  echo " --check_conventions   : Check compliance with CP2K's coding conventions"
   echo " --cp2k_version        : CP2K version to be built (default: \"psmp\")"
   echo " -cray                 : Use Cray specific spack configuration"
   echo " --enable_feature      : Enable feature or package (default: all)"
@@ -809,6 +825,7 @@ echo "BUILD_DEPS          = ${BUILD_DEPS}"
 echo "BUILD_DEPS_ONLY     = ${BUILD_DEPS_ONLY}"
 echo "BUILD_PATH          = ${BUILD_PATH}"
 echo "BUILD_SHARED_LIBS   = ${BUILD_SHARED_LIBS}"
+echo "CHECK_CONVENTIONS   = ${CHECK_CONVENTIONS}"
 echo "CP2K_BUILD_TYPE     = ${CP2K_BUILD_TYPE}"
 echo "CMAKE_PRESET        = ${CMAKE_PRESET}"
 echo "CP2K_VERSION        = ${CP2K_VERSION}"
@@ -901,7 +918,7 @@ esac
 
 # Check if a valid CMake build type is selected for CP2K
 case "${CP2K_BUILD_TYPE^}" in
-  Debug | Release | RelWithDebInfo)
+  Conventions | Debug | Release | RelWithDebInfo)
     true
     ;;
   *)
@@ -1089,11 +1106,11 @@ if [[ ! -f "${SPACK_BUILD_PATH}/BUILD_DEPENDENCIES_COMPLETED" ]]; then
   # also retains a partially downloaded release archive across interruptions.
   if [[ ! -d "${SPACK_ROOT}" ]]; then
     echo "Installing Spack ${SPACK_VERSION}"
-    if ! wget -q -c "https://github.com/spack/spack/archive/v${SPACK_VERSION}.tar.gz"; then
+    if ! wget -q -c "https://github.com/spack/spack/releases/download/v${SPACK_VERSION}/spack-${SPACK_VERSION}.tar.gz"; then
       echo "ERROR: Downloading Spack ${SPACK_VERSION} failed"
       ${EXIT_CMD} 1
     fi
-    if ! tar -xzf "v${SPACK_VERSION}.tar.gz"; then
+    if ! tar -xzf "spack-${SPACK_VERSION}.tar.gz"; then
       echo "ERROR: Extracting Spack ${SPACK_VERSION} failed"
       ${EXIT_CMD} 1
     fi
@@ -1471,6 +1488,7 @@ if [[ ! -d "${CMAKE_BUILD_PATH}" ]]; then
         -GNinja \
         -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} \
         -DCMAKE_BUILD_TYPE="${CP2K_BUILD_TYPE}" \
+        -DCMAKE_Fortran_COMPILER_LAUNCHER="${Fortran_COMPILER_LAUNCHER}" \
         -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
         -DCMAKE_INSTALL_LIBDIR="lib" \
         -DCMAKE_INSTALL_MESSAGE="${INSTALL_MESSAGE}" \
@@ -1489,6 +1507,7 @@ if [[ ! -d "${CMAKE_BUILD_PATH}" ]]; then
         -GNinja \
         -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} \
         -DCMAKE_BUILD_TYPE="${CP2K_BUILD_TYPE}" \
+        -DCMAKE_Fortran_COMPILER_LAUNCHER="${Fortran_COMPILER_LAUNCHER}" \
         -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
         -DCMAKE_INSTALL_LIBDIR="lib" \
         -DCMAKE_INSTALL_MESSAGE="${INSTALL_MESSAGE}" \
@@ -1720,6 +1739,15 @@ export GAUXC_SKALA_MODEL=${GAUXC_SKALA_MODEL}
 ${CP2K_ROOT}/tests/do_regtest.py ${TESTOPTS} \$* ${INSTALL_PREFIX}/bin ${VERSION}
 ***
 chmod 750 "${INSTALL_PREFIX}"/bin/run_tests
+
+# Collect information from coding convention checks
+if [[ "${CHECK_CONVENTIONS}" == "yes" ]]; then
+  "${CP2K_ROOT}"/tools/conventions/analyze_gfortran_ast.py "${CMAKE_BUILD_PATH}"/*.ast &> "${CMAKE_BUILD_PATH}"/ast.issues
+  ((VERBOSE > 0)) && cat "${CMAKE_BUILD_PATH}"/ast.issues
+  "${CP2K_ROOT}"/tools/conventions/analyze_gfortran_warnings.py "${CMAKE_BUILD_PATH}"/*.warn &> "${CMAKE_BUILD_PATH}"/warn.issues
+  ((VERBOSE > 0)) && cat "${CMAKE_BUILD_PATH}"/warn.issues
+  "${CP2K_ROOT}"/tools/conventions/summarize_issues.py --suppressions="${CP2K_ROOT}/tools/conventions/conventions.supp" "${CMAKE_BUILD_PATH}"/*.issues
+fi
 
 # Create script to run the CP2K benchmarks for psmp builds
 if [[ "${VERSION}" == "psmp" ]]; then

--- a/src/input/cp_output_handling_openpmd.F
+++ b/src/input/cp_output_handling_openpmd.F
@@ -16,6 +16,7 @@
 !>      handling: @see cp_log_handling
 ! **************************************************************************************************
 MODULE cp_output_handling_openpmd
+
    USE cp_output_handling, only: cp_print_key_should_output, cp_p_file
    USE cp_files, ONLY: close_file, &
                        open_file

--- a/src/openpmd_api.F
+++ b/src/openpmd_api.F
@@ -188,7 +188,7 @@ MODULE openpmd_api
       #:for dim in dimensions
          TYPE openpmd_dynamic_memory_view_type_${dim}$d
             PRIVATE
-            INTEGER, DIMENSION(${dim}$) :: chunk_extent
+            INTEGER, DIMENSION(${dim}$) :: chunk_extent = 0
             TYPE(C_PTR) :: c_ptr = C_NULL_PTR
 
          CONTAINS

--- a/src/pw/realspace_grid_openpmd.F
+++ b/src/pw/realspace_grid_openpmd.F
@@ -56,16 +56,14 @@ MODULE realspace_grid_openpmd
 
    PRIVATE
 
-   PUBLIC ::pw_to_openpmd
+   PUBLIC :: pw_to_openpmd
 
 #ifdef __OPENPMD
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'realspace_grid_openpmd'
    LOGICAL, PARAMETER, PRIVATE          :: debug_this_module = .FALSE.
-   LOGICAL, PRIVATE                     :: parses_linebreaks = .FALSE., &
-                                           parse_test = .TRUE.
 
    TYPE cp_openpmd_write_buffer_1d
-      REAL(KIND=dp), POINTER :: buffer(:)
+      REAL(KIND=dp), DIMENSION(:), POINTER :: buffer => NULL()
    END TYPE cp_openpmd_write_buffer_1d
 #endif
 

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -25,7 +25,6 @@ cp_fm_elpa.F: Module "elpa" USEd without ONLY clause or not PRIVATE https://cp2k
 cp_log_handling.F: Found WRITE statement with hardcoded unit in "cp_int_to_string" https://cp2k.org/conv#c012
 cp_log_handling.F: Found WRITE statement with hardcoded unit in "cp_logger_get_default_unit_nr" https://cp2k.org/conv#c012
 cp_log_handling.F: Found WRITE statement with hardcoded unit in "cp_real_dp_to_string" https://cp2k.org/conv#c012
-cp_output_handling_openpmd.F: Found type cp_openpmd_per_call_value_type without initializer https://cp2k.org/conv#c016
 cp_parser_inpp_methods.F: Found READ with unchecked STAT in "inpp_process_directive" https://cp2k.org/conv#c001
 cube_utils.F: Found WRITE statement with hardcoded unit in "return_cube_nonortho" https://cp2k.org/conv#c012
 d3_poly.F: Found CALL RANDOM_NUMBER in procedure "poly_random" https://cp2k.org/conv#c104
@@ -158,13 +157,9 @@ pwdft_environment_types.F: Module "sirius" USEd without ONLY clause or not PRIVA
 pw_grids.F: Found WRITE statement with hardcoded unit in "pw_grid_sort" https://cp2k.org/conv#c012
 qs_active_space_methods.F: Found type eri_fcidump_checksum without initializer https://cp2k.org/conv#c016
 qs_active_space_methods.F: Found type eri_fcidump_print without initializer https://cp2k.org/conv#c016
-qs_charge_mixing.F: Module "mctc_env" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 qs_dispersion_d4.F: Module "dftd4" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
-qs_dispersion_d4.F: Module "mctc_env" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 qs_dispersion_d4.F: Module "multicharge" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 qs_dispersion_s_dftd3.F: Module "dftd3_param" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
-qs_dispersion_s_dftd3.F: Module "mctc_data" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
-qs_dispersion_s_dftd3.F: Module "mctc_env" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 qs_external_density.F: Found WRITE statement with hardcoded unit in "external_read_density" https://cp2k.org/conv#c012
 qs_fb_env_methods.F: Found CALL cp_fm_gemm in procedure "fb_env_do_diag" https://cp2k.org/conv#c101
 qs_linres_atom_current.F: Found WRITE statement with hardcoded unit in "calculate_jrho_atom_rad" https://cp2k.org/conv#c012
@@ -218,10 +213,8 @@ tblite_interface.F: Found OPEN statement in procedure "tb_grad2force" https://cp
 tblite_interface.F: Found OPEN statement in procedure "tb_read_reference_grad" https://cp2k.org/conv#c203
 tblite_interface.F: Found OPEN statement in procedure "tb_update_charges" https://cp2k.org/conv#c203
 tblite_interface.F: Found OPEN statement in procedure "tb_write_reference_gen" https://cp2k.org/conv#c203
-tblite_interface.F: Module "mctc_env" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 tblite_interface.F: Module "tblite_container" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 tblite_scc_mixer.F: Found type cp2k_tblite_broyden_mixer_type without initializer https://cp2k.org/conv#c016
-tblite_scc_mixer.F: Module "mctc_env" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 tblite_scc_mixer.F: Module "tblite_lapack" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 tblite_types.F: Found type tblite_type without initializer https://cp2k.org/conv#c016
 tblite_types.F: Module "tblite_container" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -1,3 +1,4 @@
+
 al_system_dynamics.F: Found WRITE statement with hardcoded unit in "dump_vel" https://cp2k.org/conv#c012
 base_hooks.F: Found CALL m_abort in procedure "cp_abort" https://cp2k.org/conv#c102
 base_hooks.F: Found STOP statement in procedure "cp_abort" https://cp2k.org/conv#c205
@@ -25,6 +26,8 @@ cp_fm_elpa.F: Module "elpa" USEd without ONLY clause or not PRIVATE https://cp2k
 cp_log_handling.F: Found WRITE statement with hardcoded unit in "cp_int_to_string" https://cp2k.org/conv#c012
 cp_log_handling.F: Found WRITE statement with hardcoded unit in "cp_logger_get_default_unit_nr" https://cp2k.org/conv#c012
 cp_log_handling.F: Found WRITE statement with hardcoded unit in "cp_real_dp_to_string" https://cp2k.org/conv#c012
+cp_output_handling_openpmd.F: Found CLOSE statement in procedure "cp_openpmd_print_key_finished_output" https://cp2k.org/conv#c204
+cp_output_handling_openpmd.F: Found OPEN statement in procedure "cp_openpmd_print_key_unit_nr" https://cp2k.org/conv#c203
 cp_parser_inpp_methods.F: Found READ with unchecked STAT in "inpp_process_directive" https://cp2k.org/conv#c001
 cube_utils.F: Found WRITE statement with hardcoded unit in "return_cube_nonortho" https://cp2k.org/conv#c012
 d3_poly.F: Found CALL RANDOM_NUMBER in procedure "poly_random" https://cp2k.org/conv#c104
@@ -169,6 +172,7 @@ qs_linres_current.F: Found WRITE statement with hardcoded unit in "calculate_jrh
 qs_linres_current.F: Found WRITE statement with hardcoded unit in "collocate_gauge_new" https://cp2k.org/conv#c012
 qs_linres_issc_utils.F: Found WRITE statement with hardcoded unit in "issc_issc" https://cp2k.org/conv#c012
 qs_rho_atom_methods.F: Found WRITE statement with hardcoded unit in "init_rho_atom" https://cp2k.org/conv#c012
+realspace_grid_openpmd.F: Module "mpi_f08" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 se_core_matrix.F: Found WRITE statement with hardcoded unit in "aa" https://cp2k.org/conv#c012
 se_core_matrix.F: Found WRITE statement with hardcoded unit in "makeds" https://cp2k.org/conv#c012
 se_core_matrix.F: Found WRITE statement with hardcoded unit in "makes" https://cp2k.org/conv#c012

--- a/tools/dashboard/dashboard.conf
+++ b/tools/dashboard/dashboard.conf
@@ -41,6 +41,12 @@ host:        GCP
 report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_conventions_report.txt
 info_url:    http://www.cp2k.org/dev:codingconventions
 
+[spack-psmp-conventions]
+name:        Spack (psmp, conventions)
+host:        GCP
+report_url:  https://storage.googleapis.com/cp2k-ci/dashboard_spack-psmp-conventions_report.txt
+info_url:    http://www.cp2k.org/dev:codingconventions
+
 # ==============================================================================
 
 [current-pdbg]

--- a/tools/docker/Dockerfile.test_spack_conventions
+++ b/tools/docker/Dockerfile.test_spack_conventions
@@ -1,0 +1,64 @@
+#
+# This file was created by generate_dockerfiles.py.
+# Usage: ./spack_cache_start.sh; podman build --shm-size=1g -t spack_conventions -f ./Dockerfile.test_spack_conventions ../../
+#
+
+ARG BASE_IMAGE="ubuntu:26.04"
+
+###### Stage 1: Build CP2K dependencies ######
+
+FROM "${BASE_IMAGE}" AS build_deps
+
+RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
+    bzip2 \
+    ca-certificates \
+    cmake \
+    g++ gcc gfortran \
+    git \
+    gnupg \
+    libssh-dev \
+    libssl-dev \
+    libtool \
+    libtool-bin \
+    lsb-release \
+    make \
+    patch \
+    pkgconf \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    unzip \
+    wget \
+    xxd \
+    xz-utils \
+    zlib1g \
+    zlib1g-dev \
+    zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG IMAGE_TAG
+ENV IMAGE_TAG=${IMAGE_TAG:-spack_conventions}
+
+ARG SPACK_CACHE
+ENV SPACK_CACHE="${SPACK_CACHE:-s3://spack-cache --s3-endpoint-url=http://host.containers.internal:9000}"
+
+# Build CP2K dependencies
+WORKDIR /opt/cp2k
+COPY ./tools/spack ./tools/spack
+COPY ./tools/docker ./tools/docker
+COPY ./make_cp2k.sh .
+RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue --check_conventions
+
+###### Stage 2: Build CP2K ######
+
+FROM build_deps AS build_cp2k
+
+COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./cmake ./cmake
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
+
+RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich --check_conventions

--- a/tools/docker/Dockerfile.test_spack_conventions
+++ b/tools/docker/Dockerfile.test_spack_conventions
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue --check_conventio
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_gromacs
+++ b/tools/docker/Dockerfile.test_spack_gromacs
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue --test_gromacs
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_gromacs
+++ b/tools/docker/Dockerfile.test_spack_gromacs
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue --test_gromacs
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich --test_gromacs
 

--- a/tools/docker/Dockerfile.test_spack_openmpi-pdbg
+++ b/tools/docker/Dockerfile.test_spack_openmpi-pdbg
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi openmpi
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_openmpi-pdbg
+++ b/tools/docker/Dockerfile.test_spack_openmpi-pdbg
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi openmpi
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv pdbg  -gpu none -mpi openmpi 
 

--- a/tools/docker/Dockerfile.test_spack_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_spack_openmpi-psmp
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi openmpi
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi openmpi 
 

--- a/tools/docker/Dockerfile.test_spack_openmpi-psmp
+++ b/tools/docker/Dockerfile.test_spack_openmpi-psmp
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi openmpi
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_pdbg
+++ b/tools/docker/Dockerfile.test_spack_pdbg
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv pdbg  -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_pdbg
+++ b/tools/docker/Dockerfile.test_spack_pdbg
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_pdbg-P100
+++ b/tools/docker/Dockerfile.test_spack_pdbg-P100
@@ -61,7 +61,7 @@ RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu P100 -gv 13 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_pdbg-P100
+++ b/tools/docker/Dockerfile.test_spack_pdbg-P100
@@ -61,12 +61,12 @@ RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu P100 -gv 13 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv pdbg -gv 13 -gpu P100 -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_pdbg-rawhide
+++ b/tools/docker/Dockerfile.test_spack_pdbg-rawhide
@@ -45,12 +45,12 @@ RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv pdbg  -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_pdbg-rawhide
+++ b/tools/docker/Dockerfile.test_spack_pdbg-rawhide
@@ -45,7 +45,7 @@ RUN ./make_cp2k.sh -bd_only -cv pdbg -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_performance-openmp
+++ b/tools/docker/Dockerfile.test_spack_performance-openmp
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_performance-openmp
+++ b/tools/docker/Dockerfile.test_spack_performance-openmp
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-4x2
+++ b/tools/docker/Dockerfile.test_spack_psmp-4x2
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-4x2
+++ b/tools/docker/Dockerfile.test_spack_psmp-4x2
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-P100
+++ b/tools/docker/Dockerfile.test_spack_psmp-P100
@@ -61,12 +61,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu P100 -gv 13 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 13 -gpu P100 -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-P100
+++ b/tools/docker/Dockerfile.test_spack_psmp-P100
@@ -61,7 +61,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu P100 -gv 13 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-fedora
+++ b/tools/docker/Dockerfile.test_spack_psmp-fedora
@@ -45,12 +45,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp  -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-fedora
+++ b/tools/docker/Dockerfile.test_spack_psmp-fedora
@@ -45,7 +45,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none  -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc10
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc10
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 10 -mpi mpich -ue -df libtorc
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc10
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc10
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 10 -mpi mpich -ue -df libtorc
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 10 -gpu none -mpi mpich -df libtorch
 

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc11
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc11
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 11 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 11 -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc11
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc11
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 11 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc12
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc12
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 12 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc12
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc12
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 12 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 12 -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc13
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc13
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 13 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc13
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc13
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 13 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 13 -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc14
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc14
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 14 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc14
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc14
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 14 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 14 -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc15
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc15
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 15 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 15 -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc15
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc15
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 15 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc16
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc16
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 16 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-gcc16
+++ b/tools/docker/Dockerfile.test_spack_psmp-gcc16
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 16 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 16 -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-opensuse
+++ b/tools/docker/Dockerfile.test_spack_psmp-opensuse
@@ -50,7 +50,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 13 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_psmp-opensuse
+++ b/tools/docker/Dockerfile.test_spack_psmp-opensuse
@@ -50,12 +50,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 13 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 13 -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-rockylinux
+++ b/tools/docker/Dockerfile.test_spack_psmp-rockylinux
@@ -45,12 +45,12 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 14 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv psmp -gv 14 -gpu none -mpi mpich 
 

--- a/tools/docker/Dockerfile.test_spack_psmp-rockylinux
+++ b/tools/docker/Dockerfile.test_spack_psmp-rockylinux
@@ -45,7 +45,7 @@ RUN ./make_cp2k.sh -bd_only -cv psmp -gpu none -gv 14 -mpi mpich -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_sdbg
+++ b/tools/docker/Dockerfile.test_spack_sdbg
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv sdbg -gpu none  -mpi no -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_sdbg
+++ b/tools/docker/Dockerfile.test_spack_sdbg
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv sdbg -gpu none  -mpi no -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv sdbg  -gpu none -mpi no 
 

--- a/tools/docker/Dockerfile.test_spack_ssmp
+++ b/tools/docker/Dockerfile.test_spack_ssmp
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu none  -mpi no -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_ssmp
+++ b/tools/docker/Dockerfile.test_spack_ssmp
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu none  -mpi no -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv ssmp  -gpu none -mpi no 
 

--- a/tools/docker/Dockerfile.test_spack_ssmp-P100
+++ b/tools/docker/Dockerfile.test_spack_ssmp-P100
@@ -61,7 +61,7 @@ RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu P100 -gv 13 -mpi no -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_ssmp-P100
+++ b/tools/docker/Dockerfile.test_spack_ssmp-P100
@@ -61,12 +61,12 @@ RUN ./make_cp2k.sh -bd_only -cv ssmp -gpu P100 -gv 13 -mpi no -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv ssmp -gv 13 -gpu P100 -mpi no 
 

--- a/tools/docker/Dockerfile.test_spack_ssmp-static
+++ b/tools/docker/Dockerfile.test_spack_ssmp-static
@@ -54,7 +54,7 @@ RUN ./make_cp2k.sh -bd_only -cv ssmp-static -gpu none  -mpi no -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/Dockerfile.test_spack_ssmp-static
+++ b/tools/docker/Dockerfile.test_spack_ssmp-static
@@ -54,12 +54,12 @@ RUN ./make_cp2k.sh -bd_only -cv ssmp-static -gpu none  -mpi no -ue
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv ssmp-static  -gpu none -mpi no 
 

--- a/tools/docker/cp2k-ci.conf
+++ b/tools/docker/cp2k-ci.conf
@@ -53,6 +53,14 @@ cache_from:   pdbg
 build_path:   /
 dockerfile:   /tools/docker/Dockerfile.test_conventions
 
+[spack-psmp-conventions]
+display_name: Spack (psmp, conventions)
+tags:         daily
+cpu:          16
+nodepools:    pool-main
+build_path:   /
+dockerfile:   /tools/docker/Dockerfile.test_spack_conventions
+
 # ==============================================================================
 
 [pdbg]

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -786,7 +786,7 @@ RUN ./make_cp2k.sh -bd_only -cv {version} -gpu {gpu_model} {gcc_version_flag} -m
 
 FROM build_deps AS build_cp2k
 
-COPY ./CMakeLists.txt ./CMakePresets.json .
+COPY ./CMakeLists.txt ./CMakePresets.json ./
 COPY ./cmake ./cmake
 COPY ./data ./data
 COPY ./src ./src

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -260,6 +260,17 @@ def main() -> None:
             )
         )
 
+    with OutputFile(f"Dockerfile.test_spack_conventions", args.check) as f:
+        f.write(
+            install_cp2k_spack(
+                version="psmp",
+                mpi_mode="mpich",
+                feature_flags="--check_conventions",
+                image_tag=f.image_tag,
+                test_type="conventions",
+            )
+        )
+
     # End Spack/CMake based tester
 
     with OutputFile(f"Dockerfile.test_asan-psmp", args.check) as f:
@@ -775,16 +786,18 @@ RUN ./make_cp2k.sh -bd_only -cv {version} -gpu {gpu_model} {gcc_version_flag} -m
 
 FROM build_deps AS build_cp2k
 
-COPY ./src ./src
-COPY ./data ./data
-COPY ./tools/build_utils ./tools/build_utils
+COPY ./CMakeLists.txt ./CMakePresets.json .
 COPY ./cmake ./cmake
-COPY ./CMakeLists.txt .
-COPY ./CMakePresets.json .
+COPY ./data ./data
+COPY ./src ./src
+COPY ./tools/build_utils ./tools/build_utils
+COPY ./tools/conventions ./tools/conventions
 
 RUN ./make_cp2k.sh -cv {version} {gcc_version_flag} -gpu {gpu_model} -mpi {mpi_mode} {feature_flags}
 """
     )
+    if test_type == "conventions":
+        return output
     output += (
         install_base_image(
             base_image=rf"{base_image}",


### PR DESCRIPTION
- Usage: make_cp2k.sh --check_conventions or just -cc
- add Spack (psmp, conventions) tester
- the new tester detects 9 unsuppressed issues related to openpmd