### PR TITLE
Molden: allow writing cell information for vibrations

### DIFF
--- a/src/mode_selective.F
+++ b/src/mode_selective.F
@@ -18,6 +18,7 @@
 !> \author Florian Schiffmann 08.2006
 ! **************************************************************************************************
 MODULE mode_selective
+   USE cell_types,                      ONLY: cell_type
    USE cp_files,                        ONLY: close_file,&
                                               open_file
    USE cp_log_handling,                 ONLY: cp_get_default_logger,&
@@ -96,10 +97,11 @@ CONTAINS
 !> \param dx ...
 !> \param output_unit ...
 !> \param logger ...
+!> \param cell simulation cell
 !> \author Teodoro Laino 08.2006
 ! **************************************************************************************************
    SUBROUTINE ms_vb_anal(input, rep_env, para_env, globenv, particles, &
-                         nrep, calc_intens, dx, output_unit, logger)
+                         nrep, calc_intens, dx, output_unit, logger, cell)
       TYPE(section_vals_type), POINTER                   :: input
       TYPE(replica_env_type), POINTER                    :: rep_env
       TYPE(mp_para_env_type), POINTER                    :: para_env
@@ -110,6 +112,7 @@ CONTAINS
       REAL(KIND=dp)                                      :: dx
       INTEGER                                            :: output_unit
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(cell_type), POINTER                           :: cell
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'ms_vb_anal'
 
@@ -203,7 +206,7 @@ CONTAINS
                                   mass, &
                                   converged, &
                                   dx, calc_intens, &
-                                  output_unit, logger)
+                                  output_unit, logger, cell)
          IF (converged) EXIT
          IF (calc_intens) THEN
             ALLOCATE (tmp_deriv(3, ms_vib%mat_size))
@@ -822,13 +825,14 @@ CONTAINS
 !> \param calc_intens ...
 !> \param output_unit_ms ...
 !> \param logger ...
+!> \param cell simulation cell
 !> \author Florian Schiffmann 11.2007
 ! **************************************************************************************************
    SUBROUTINE evaluate_H_update_b(rep_env, ms_vib, input, nrep, &
                                   particles, &
                                   mass, &
                                   converged, dx, &
-                                  calc_intens, output_unit_ms, logger)
+                                  calc_intens, output_unit_ms, logger, cell)
       TYPE(replica_env_type), POINTER                    :: rep_env
       TYPE(ms_vib_type)                                  :: ms_vib
       TYPE(section_vals_type), POINTER                   :: input
@@ -840,6 +844,7 @@ CONTAINS
       LOGICAL                                            :: calc_intens
       INTEGER                                            :: output_unit_ms
       TYPE(cp_logger_type), POINTER                      :: logger
+      TYPE(cell_type), POINTER                           :: cell
 
       INTEGER                                            :: i, j, jj, k, natoms, ncoord
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: ind
@@ -970,7 +975,7 @@ CONTAINS
          END IF
          dump_only_positive = ms_vib%low_freq > 0.0_dp
          CALL write_vibrations_molden(input, particles, eigenval, tmp_b, intensities, calc_intens, &
-                                      dump_only_positive=dump_only_positive, logger=logger)
+                                      dump_only_positive=dump_only_positive, logger=logger, cell=cell)
          IF (calc_intens) THEN
             DEALLOCATE (intensities)
          END IF

--- a/src/molden_utils.F
+++ b/src/molden_utils.F
@@ -68,6 +68,34 @@ MODULE molden_utils
 CONTAINS
 
 ! **************************************************************************************************
+!> \brief Write the CP2K [Cell] extension to a MOLDEN file
+!> \param iw output unit
+!> \param cell simulation cell
+!> \param unit_choice 1 for atomic units, 2 for Angstrom
+! **************************************************************************************************
+   SUBROUTINE write_cell_molden(iw, cell, unit_choice)
+      INTEGER, INTENT(IN)                                :: iw
+      TYPE(cell_type), INTENT(IN)                        :: cell
+      INTEGER, INTENT(IN)                                :: unit_choice
+
+      REAL(KIND=dp)                                      :: scale_factor
+
+      IF (unit_choice == 2) THEN
+         scale_factor = angstrom
+         WRITE (iw, '(T2,A)') "[Cell] Angs"
+      ELSE
+         scale_factor = 1.0_dp
+         WRITE (iw, '(T2,A)') "[Cell] AU"
+      END IF
+      WRITE (iw, '(T2,3(F12.6,3X))') &
+         cell%hmat(1, 1)*scale_factor, cell%hmat(2, 1)*scale_factor, cell%hmat(3, 1)*scale_factor
+      WRITE (iw, '(T2,3(F12.6,3X))') &
+         cell%hmat(1, 2)*scale_factor, cell%hmat(2, 2)*scale_factor, cell%hmat(3, 2)*scale_factor
+      WRITE (iw, '(T2,3(F12.6,3X))') &
+         cell%hmat(1, 3)*scale_factor, cell%hmat(2, 3)*scale_factor, cell%hmat(3, 3)*scale_factor
+   END SUBROUTINE write_cell_molden
+
+! **************************************************************************************************
 !> \brief Write out the MOs in molden format for visualisation
 !> \param mos the set of MOs (both spins, if UKS)
 !> \param qs_kind_set for basis set info
@@ -161,17 +189,9 @@ CONTAINS
          IF (iw > 0) THEN
             WRITE (iw, '(T2,A)') "[Molden Format]"
             IF (write_cell) THEN
-               IF (unit_choice == 2) THEN
-                  WRITE (iw, '(T2,A)') "[Cell] Angs"
-               ELSE
-                  WRITE (iw, '(T2,A)') "[Cell] AU"
-               END IF
-               WRITE (iw, '(T2,3(F12.6,3X))') &
-                  cell%hmat(1, 1)*scale_factor, cell%hmat(2, 1)*scale_factor, cell%hmat(3, 1)*scale_factor
-               WRITE (iw, '(T2,3(F12.6,3X))') &
-                  cell%hmat(1, 2)*scale_factor, cell%hmat(2, 2)*scale_factor, cell%hmat(3, 2)*scale_factor
-               WRITE (iw, '(T2,3(F12.6,3X))') &
-                  cell%hmat(1, 3)*scale_factor, cell%hmat(2, 3)*scale_factor, cell%hmat(3, 3)*scale_factor
+               CPASSERT(PRESENT(cell))
+               CPASSERT(ASSOCIATED(cell))
+               CALL write_cell_molden(iw, cell, unit_choice)
             END IF
             IF (unit_choice == 2) THEN
                WRITE (iw, '(T2,A)') "[Atoms] Angs"
@@ -598,10 +618,11 @@ CONTAINS
 !> \param dump_only_positive ...
 !> \param logger ...
 !> \param list array of mobile atom indices
+!> \param cell optional simulation cell for the CP2K [Cell] extension
 !> \author Florian Schiffmann 11.2007
 ! **************************************************************************************************
    SUBROUTINE write_vibrations_molden(input, particles, freq, eigen_vec, intensities, calc_intens, &
-                                      dump_only_positive, logger, list)
+                                      dump_only_positive, logger, list, cell)
 
       TYPE(section_vals_type), POINTER                   :: input
       TYPE(particle_type), DIMENSION(:), POINTER         :: particles
@@ -611,12 +632,14 @@ CONTAINS
       LOGICAL, INTENT(in)                                :: calc_intens, dump_only_positive
       TYPE(cp_logger_type), POINTER                      :: logger
       INTEGER, DIMENSION(:), OPTIONAL, POINTER           :: list
+      TYPE(cell_type), OPTIONAL, POINTER                 :: cell
 
       CHARACTER(len=*), PARAMETER :: routineN = 'write_vibrations_molden'
 
       CHARACTER(LEN=2)                                   :: element_symbol
       INTEGER                                            :: handle, i, iw, j, k, l, z
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: my_list
+      LOGICAL                                            :: write_cell
       REAL(KIND=dp)                                      :: fint
 
       CALL timeset(routineN, handle)
@@ -642,6 +665,13 @@ CONTAINS
             END DO
          END IF
          WRITE (iw, '(T2,A)') "[Molden Format]"
+         CALL section_vals_val_get(input, "VIBRATIONAL_ANALYSIS%PRINT%MOLDEN_VIB%WRITE_CELL", &
+                                   l_val=write_cell)
+         IF (write_cell) THEN
+            CPASSERT(PRESENT(cell))
+            CPASSERT(ASSOCIATED(cell))
+            CALL write_cell_molden(iw, cell, 1)
+         END IF
          WRITE (iw, '(T2,A)') "[Atoms] AU"
          DO i = 1, SIZE(particles)
             CALL get_atomic_kind(atomic_kind=particles(i)%atomic_kind, &

--- a/src/motion/input_cp2k_vib.F
+++ b/src/motion/input_cp2k_vib.F
@@ -180,6 +180,13 @@ CONTAINS
       CALL cp_print_key_section_create(print_key, __LOCATION__, "MOLDEN_VIB", &
                                        description="Controls the printing for visualization in molden format", &
                                        print_level=low_print_level, add_last=add_last_numeric, filename="VIBRATIONS")
+      CALL keyword_create(keyword, __LOCATION__, name="WRITE_CELL", &
+                          description="Controls whether the CP2K [Cell] extension is written to the MOLDEN file. "// &
+                          "The cell vectors are written in atomic units to match the vibrational coordinates.", &
+                          usage="WRITE_CELL T", &
+                          default_l_val=.FALSE., lone_keyword_l_val=.TRUE.)
+      CALL section_add_keyword(print_key, keyword)
+      CALL keyword_release(keyword)
       CALL section_add_subsection(section, print_key)
       CALL section_release(print_key)
 

--- a/src/motion/vibrational_analysis.F
+++ b/src/motion/vibrational_analysis.F
@@ -19,6 +19,7 @@
 ! **************************************************************************************************
 MODULE vibrational_analysis
    USE atomic_kind_types,               ONLY: get_atomic_kind
+   USE cell_types,                      ONLY: cell_type
    USE cp_blacs_env,                    ONLY: cp_blacs_env_create,&
                                               cp_blacs_env_release,&
                                               cp_blacs_env_type
@@ -128,6 +129,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: D, Dfull, dip_deriv, RotTrM
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER         :: polar_deriv, tmp_dip
       REAL(KIND=dp), DIMENSION(:, :, :, :), POINTER      :: tmp_polar
+      TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_logger_type), POINTER                      :: logger
       TYPE(cp_subsys_type), POINTER                      :: subsys
       TYPE(f_env_type), POINTER                          :: f_env
@@ -138,7 +140,7 @@ CONTAINS
                                                             vib_section
 
       CALL timeset(routineN, handle)
-      NULLIFY (D, RotTrM, logger, subsys, f_env, particles, rep_env, intensities_d, intensities_p, &
+      NULLIFY (D, RotTrM, cell, logger, subsys, f_env, particles, rep_env, intensities_d, intensities_p, &
                vib_section, print_section, depol_p, depol_u)
       logger => cp_get_default_logger()
       vib_section => section_vals_get_subs_vals(input, "VIBRATIONAL_ANALYSIS")
@@ -190,11 +192,12 @@ CONTAINS
       IF (ASSOCIATED(rep_env)) THEN
          CALL f_env_add_defaults(f_env_id=rep_env%f_env_id, f_env=f_env)
          CALL force_env_get(f_env%force_env, subsys=subsys)
+         CALL cp_subsys_get(subsys, cell=cell)
          particles => subsys%particles%els
          ! Decide which kind of Vibrational Analysis to perform
          IF (do_mode_tracking) THEN
             CALL ms_vb_anal(input, rep_env, para_env, globenv, particles, &
-                            nrep, calc_intens, dx, output_unit, logger)
+                            nrep, calc_intens, dx, output_unit, logger, cell)
             CALL f_env_rm_defaults(f_env, ierr)
          ELSE
             CALL get_moving_atoms(force_env=f_env%force_env, Ilist=Mlist)
@@ -712,7 +715,7 @@ CONTAINS
                   CALL get_thch_values(H_eigval2, iw, mass, nvib, inertia, 1, minimum_energy, tc_temp, tc_press)
                END IF
                CALL write_vibrations_molden(input, particles, H_eigval2, D, intensities_d, calc_intens, &
-                                            dump_only_positive=.FALSE., logger=logger, list=Mlist)
+                                            dump_only_positive=.FALSE., logger=logger, list=Mlist, cell=cell)
             ELSE
                IF (output_unit > 0) THEN
                   WRITE (output_unit, '(T2,"VIB| No further vibrational info. Detected a single atom")')


### PR DESCRIPTION
This PR abstracts the writing of the CP2K-specific Molden `[Cell]` section and reuses it for vibrational Molden output.

`MOLDEN_VIB` gains an optional `WRITE_CELL` keyword, allowing periodic vibrational Molden files to retain the simulation cell in addition to the atomic coordinates, frequencies, and normal modes. The cell is written in atomic units to be consistent with the vibrational Molden coordinates; using Angstrom as unit is not available.

This makes the output more self-contained for periodic normal-mode visualization and downstream analysis, similarly to the existing use of `[Cell]` in Molden files containing molecular-orbital information.