### PR TITLE
Backport OpenMPI shared-memory progress fix

### DIFF
--- a/tools/docker/Dockerfile.test_spack_openmpi-pdbg
+++ b/tools/docker/Dockerfile.test_spack_openmpi-pdbg
@@ -92,7 +92,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests  || echo "ERROR: Regression test run failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --timeout 400 || echo "ERROR: Regression test run failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -158,7 +158,7 @@ def main() -> None:
                 version="pdbg",
                 mpi_mode="openmpi",
                 feature_flags="",
-                testopts="",
+                testopts="--timeout 400",
                 image_tag=f.image_tag,
             )
         )

--- a/tools/spack/spack_repo/cp2k_dev/packages/openmpi/package.py
+++ b/tools/spack/spack_repo/cp2k_dev/packages/openmpi/package.py
@@ -1,0 +1,12 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.packages.openmpi.package import Openmpi as BuiltinOpenmpi
+
+from spack.package import *
+
+
+class Openmpi(BuiltinOpenmpi):
+    # Avoid orphaned FIN/ACK packets when the shared-memory BTL goes idle.
+    patch("pml-ob1-pending.patch", when="@5.0.10")

--- a/tools/spack/spack_repo/cp2k_dev/packages/openmpi/pml-ob1-pending.patch
+++ b/tools/spack/spack_repo/cp2k_dev/packages/openmpi/pml-ob1-pending.patch
@@ -1,0 +1,43 @@
+# Backports the OpenMPI sm-BTL hang fix from open-mpi/ompi#13939.
+# Merged upstream as commit 8849c01 and backported to v5.0.x as 14b5272.
+diff --git a/ompi/mca/pml/ob1/pml_ob1.h b/ompi/mca/pml/ob1/pml_ob1.h
+--- a/ompi/mca/pml/ob1/pml_ob1.h
++++ b/ompi/mca/pml/ob1/pml_ob1.h
+@@ -257,0 +258,6 @@ do {                                                            \
++/**
++ * A thread-safe function that should be called every time we need the OB1
++ * progress to be turned (or kept) on.
++ */
++int mca_pml_ob1_enable_progress(int32_t count);
++
+@@ -272,0 +279,4 @@ static inline void mca_pml_ob1_add_to_pending (ompi_proc_t *proc, mca_bml_base_b
++    /* Drive mca_pml_ob1_progress() so the queue is retried from opal_progress()
++     * even if no further BTL completion fires to call
++     * MCA_PML_OB1_PROGRESS_PENDING. */
++    mca_pml_ob1_enable_progress(1);
+@@ -414,6 +423,0 @@ mca_pml_ob1_calc_weighted_length( mca_pml_ob1_com_btl_t *btls, int num_btls, siz
+-/**
+- * A thread-safe function that should be called every time we need the OB1
+- * progress to be turned (or kept) on.
+- */
+-int mca_pml_ob1_enable_progress(int32_t count);
+-
+diff --git a/ompi/mca/pml/ob1/pml_ob1_progress.c b/ompi/mca/pml/ob1/pml_ob1_progress.c
+--- a/ompi/mca/pml/ob1/pml_ob1_progress.c
++++ b/ompi/mca/pml/ob1/pml_ob1_progress.c
+@@ -73,0 +74,15 @@ int mca_pml_ob1_progress(void)
++    /* Drain the FIN/ACK control-packet retry queue. It is otherwise drained
++     * only as a side effect of BTL completion callbacks (see
++     * MCA_PML_OB1_PROGRESS_PENDING). If the BTL goes idle while packets are
++     * still queued -- e.g. the tail of an incast where btl_sendi() repeatedly
++     * returned OPAL_ERR_OUT_OF_RESOURCE -- no further completion fires, the
++     * queue is never revisited, and every peer waiting on those FINs hangs
++     * forever. Retrying it here, driven by mca_pml_ob1_progress_needed (which
++     * mca_pml_ob1_add_to_pending() bumps via mca_pml_ob1_enable_progress()),
++     * guarantees the queue makes progress even with no BTL traffic in flight. */
++    if( opal_list_get_size(&mca_pml_ob1.pckt_pending) ) {
++        int pckt_before = (int) opal_list_get_size(&mca_pml_ob1.pckt_pending);
++        mca_pml_ob1_process_pending_packets(NULL);
++        completed_requests += pckt_before - (int) opal_list_get_size(&mca_pml_ob1.pckt_pending);
++    }
++

--- a/tools/toolchain/scripts/stage1/install_openmpi.sh
+++ b/tools/toolchain/scripts/stage1/install_openmpi.sh
@@ -39,6 +39,10 @@ case "${with_openmpi}" in
       patch -l -p1 < "${SCRIPT_DIR}/stage1/openmpi-${openmpi_ver}-op-module-lifetime.patch" \
         > openmpi_op_module_lifetime.patch.log 2>&1 ||
         tail_excerpt openmpi_op_module_lifetime.patch.log
+      # Backport the OB1 progress fix scheduled for OpenMPI 5.0.11.
+      patch -l -p1 < "${SCRIPT_DIR}/stage1/openmpi-${openmpi_ver}-pml-ob1-pending.patch" \
+        > openmpi_pml_ob1_pending.patch.log 2>&1 ||
+        tail_excerpt openmpi_pml_ob1_pending.patch.log
       if [ "${OPENBLAS_ARCH}" = "x86_64" ]; then
         # can have issue with older glibc libraries, in which case
         # we need to add the -fgnu89-inline to CFLAGS. We can check
@@ -64,7 +68,8 @@ case "${with_openmpi}" in
       cd ..
       write_checksums "${install_lock_file}" \
         "${SCRIPT_DIR}/stage1/$(basename ${SCRIPT_NAME})" \
-        "${SCRIPT_DIR}/stage1/openmpi-${openmpi_ver}-op-module-lifetime.patch"
+        "${SCRIPT_DIR}/stage1/openmpi-${openmpi_ver}-op-module-lifetime.patch" \
+        "${SCRIPT_DIR}/stage1/openmpi-${openmpi_ver}-pml-ob1-pending.patch"
     fi
     check_dir "${pkg_install_dir}/bin"
     check_dir "${pkg_install_dir}/lib"

--- a/tools/toolchain/scripts/stage1/openmpi-5.0.10-pml-ob1-pending.patch
+++ b/tools/toolchain/scripts/stage1/openmpi-5.0.10-pml-ob1-pending.patch
@@ -1,0 +1,43 @@
+# Backports the OpenMPI sm-BTL hang fix from open-mpi/ompi#13939.
+# Merged upstream as commit 8849c01 and backported to v5.0.x as 14b5272.
+diff --git a/ompi/mca/pml/ob1/pml_ob1.h b/ompi/mca/pml/ob1/pml_ob1.h
+--- a/ompi/mca/pml/ob1/pml_ob1.h
++++ b/ompi/mca/pml/ob1/pml_ob1.h
+@@ -257,0 +258,6 @@ do {                                                            \
++/**
++ * A thread-safe function that should be called every time we need the OB1
++ * progress to be turned (or kept) on.
++ */
++int mca_pml_ob1_enable_progress(int32_t count);
++
+@@ -272,0 +279,4 @@ static inline void mca_pml_ob1_add_to_pending (ompi_proc_t *proc, mca_bml_base_b
++    /* Drive mca_pml_ob1_progress() so the queue is retried from opal_progress()
++     * even if no further BTL completion fires to call
++     * MCA_PML_OB1_PROGRESS_PENDING. */
++    mca_pml_ob1_enable_progress(1);
+@@ -414,6 +423,0 @@ mca_pml_ob1_calc_weighted_length( mca_pml_ob1_com_btl_t *btls, int num_btls, siz
+-/**
+- * A thread-safe function that should be called every time we need the OB1
+- * progress to be turned (or kept) on.
+- */
+-int mca_pml_ob1_enable_progress(int32_t count);
+-
+diff --git a/ompi/mca/pml/ob1/pml_ob1_progress.c b/ompi/mca/pml/ob1/pml_ob1_progress.c
+--- a/ompi/mca/pml/ob1/pml_ob1_progress.c
++++ b/ompi/mca/pml/ob1/pml_ob1_progress.c
+@@ -73,0 +74,15 @@ int mca_pml_ob1_progress(void)
++    /* Drain the FIN/ACK control-packet retry queue. It is otherwise drained
++     * only as a side effect of BTL completion callbacks (see
++     * MCA_PML_OB1_PROGRESS_PENDING). If the BTL goes idle while packets are
++     * still queued -- e.g. the tail of an incast where btl_sendi() repeatedly
++     * returned OPAL_ERR_OUT_OF_RESOURCE -- no further completion fires, the
++     * queue is never revisited, and every peer waiting on those FINs hangs
++     * forever. Retrying it here, driven by mca_pml_ob1_progress_needed (which
++     * mca_pml_ob1_add_to_pending() bumps via mca_pml_ob1_enable_progress()),
++     * guarantees the queue makes progress even with no BTL traffic in flight. */
++    if( opal_list_get_size(&mca_pml_ob1.pckt_pending) ) {
++        int pckt_before = (int) opal_list_get_size(&mca_pml_ob1.pckt_pending);
++        mca_pml_ob1_process_pending_packets(NULL);
++        completed_requests += pckt_before - (int) opal_list_get_size(&mca_pml_ob1.pckt_pending);
++    }
++


### PR DESCRIPTION
The OpenMPI toolchain and Spack/OpenMPI dashboard runs intermittently hang in otherwise fast tests. The affected test changes between runs, while the failures consistently use OpenMPI 5.0.10 with the `sm` BTL and OB1 PML; one run also crashed in `mca_btl_sm_frag_complete`.

OpenMPI identified a matching `sm`/OB1 defect in open-mpi/ompi#12979: a FIN/ACK packet can be queued after `btl_sendi()` reports resource exhaustion, but the queue was retried only by later BTL completions. If the BTL becomes idle, no completion arrives and peers remain blocked indefinitely. The fix from open-mpi/ompi#13939 is in the stable branches and is expected in OpenMPI 5.0.11.

This PR backports that upstream fix to the OpenMPI 5.0.10 builds used by CP2K:

- applies it in the CP2K toolchain and includes it in the installation checksum;
- adds a small local Spack OpenMPI extension so Spack-based OpenMPI testers receive the same patch;
- keeps the patch restricted to OpenMPI 5.0.10;
- raises only the Spack OpenMPI `pdbg` per-test timeout from 150 to 400 seconds after full-suite validation exposed four slow debug tests.

No CP2K source, regtest input, suppression, numerical tolerance, or test parallelism is changed.

Validation:

- `./make_pretty.sh`
- `python3 tools/docker/generate_dockerfiles.py --check`
- patch applies cleanly to pristine OpenMPI 5.0.10
- complete patched OpenMPI 5.0.10 build
- 1,200 concurrent repetitions of `DFTB/regtest-scc-1-3/c_kp1.inp` with 2 MPI ranks and 2 OpenMP threads
- 320 concurrent mixed runs covering `c_kp1.inp`, `HF-ec2.inp`, `h2o_gks_p.inp`, and `h2_linrtbse_tda_static_pol_shift_enforce_dt.inp`
- fresh Spack concretization includes patch `576f58d`, and `spack patch openmpi@5.0.10` applies it successfully
- full Spack OpenMPI `pdbg` run: 5,925 of 5,929 tests correct, no wrong numerical results, and the remaining four tests stopped only at the former 150-second limit