### PR TITLE
Use portable CBLAS type aliases in LibTorch wrappers

### DIFF
--- a/src/torch_c_api.cpp
+++ b/src/torch_c_api.cpp
@@ -37,12 +37,13 @@
 #if defined(__OPENBLAS)
 // PyTorch's oneMKL batch ABI is not compatible with OpenBLAS's same-named
 // entry points. Expand grouped GEMMs into the portable CBLAS interface.
-extern "C" void cblas_sgemm_batch(
-    const enum CBLAS_ORDER order, const enum CBLAS_TRANSPOSE *trans_a,
-    const enum CBLAS_TRANSPOSE *trans_b, const int *m, const int *n,
-    const int *k, const float *alpha, const float **a, const int *lda,
-    const float **b, const int *ldb, const float *beta, float **c,
-    const int *ldc, const int group_count, const int *group_size) {
+extern "C" void
+cblas_sgemm_batch(const CBLAS_ORDER order, const CBLAS_TRANSPOSE *trans_a,
+                  const CBLAS_TRANSPOSE *trans_b, const int *m, const int *n,
+                  const int *k, const float *alpha, const float **a,
+                  const int *lda, const float **b, const int *ldb,
+                  const float *beta, float **c, const int *ldc,
+                  const int group_count, const int *group_size) {
   int offset = 0;
   for (int group = 0; group < group_count; ++group) {
     for (int operation = 0; operation < group_size[group]; ++operation) {
@@ -55,12 +56,13 @@ extern "C" void cblas_sgemm_batch(
   }
 }
 
-extern "C" void cblas_dgemm_batch(
-    const enum CBLAS_ORDER order, const enum CBLAS_TRANSPOSE *trans_a,
-    const enum CBLAS_TRANSPOSE *trans_b, const int *m, const int *n,
-    const int *k, const double *alpha, const double **a, const int *lda,
-    const double **b, const int *ldb, const double *beta, double **c,
-    const int *ldc, const int group_count, const int *group_size) {
+extern "C" void
+cblas_dgemm_batch(const CBLAS_ORDER order, const CBLAS_TRANSPOSE *trans_a,
+                  const CBLAS_TRANSPOSE *trans_b, const int *m, const int *n,
+                  const int *k, const double *alpha, const double **a,
+                  const int *lda, const double **b, const int *ldb,
+                  const double *beta, double **c, const int *ldc,
+                  const int group_count, const int *group_size) {
   int offset = 0;
   for (int group = 0; group < group_count; ++group) {
     for (int operation = 0; operation < group_size[group]; ++operation) {


### PR DESCRIPTION
## Summary

This uses the public `CBLAS_ORDER` and `CBLAS_TRANSPOSE` typedef names in CP2K's LibTorch grouped-GEMM wrappers.

FlexiBLAS exposes these CBLAS types as typedef aliases rather than C++ enum tags. Consequently, declarations using `enum CBLAS_ORDER` and `enum CBLAS_TRANSPOSE` fail to compile with FlexiBLAS even though they happen to compile with OpenBLAS. Using the standard typedef names is portable across both implementations and does not change runtime behavior.

## Validation

- CP2K precommit checks for `src/torch_c_api.cpp`
- Full `cp2k.psmp` build with FlexiBLAS and LibTorch on a GB200/B200 node
- Four-rank/four-GPU native-Skala GAPW/GTH smoke calculation including energy, forces, and stress

