### PR TITLE
Reduce CSCS H100 regtest concurrency

### DIFF
--- a/ci/cscs_daint_spack_psmp_h100.yaml
+++ b/ci/cscs_daint_spack_psmp_h100.yaml
@@ -95,12 +95,12 @@ regression test cp2k daint:
   timeout: 6h
   script:
     - git --no-pager log -1 --pretty="%nCommitSHA:%x20%H%nCommitTime:%x20%ci%nCommitAuthor:%x20%an%nCommitSubject:%x20%s%n"
-    - podman run --device nvidia.com/gpu=all --shm-size=1g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks ${SLURM_NTASKS} --ompthreads 1 --timeout 400 --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
+    - podman run --device nvidia.com/gpu=all --shm-size=1g -v ${PWD}:/mnt ${DOCKERHUB_IMAGE_NAME} /opt/cp2k/tests/do_regtest.py --cp2kdatadir /opt/cp2k/install/share/cp2k/data --maxtasks 8 --ompthreads 1 --timeout 400 --mpiexec "mpiexec -bind-to none" --keepalive /opt/cp2k/install/bin ${VERSION} 2>&1 || true
   variables:
     SLURM_DEBUG: 1
     SLURM_HINT: nomultithread
     SLURM_JOB_NUM_NODES: 1
-    # Run eight two-rank, single-threaded workers to limit device contention
+    # Run four two-rank, single-threaded workers to limit resource contention
     # while retaining sufficient throughput on this four-GPU runner.
     SLURM_NTASKS: 16
     SLURM_TIMELIMIT: 90


### PR DESCRIPTION
## Summary

- cap the CSCS Daint H100 regtest runner at eight concurrent MPI ranks
- run four two-rank, single-threaded regtests at a time while retaining the 16-task allocation
- keep every regtest, reference, matcher tolerance, and the 400-second per-test timeout unchanged

## Motivation

The latest completed H100 run passed 5953 of 5954 tests. Its only failure was `SIRIUS/regtest-1/Au_GTH_SOC.inp`, which timed out after 403.27 seconds. The same test completed in about 254 seconds in the preceding successful run, indicating resource-contention sensitivity rather than a numerical regression.

PR #5763 already reduced the original excessive concurrency, but eight simultaneous two-rank workers can still make this CPU-only SIRIUS test exceed the timeout. Limiting the runner to four such workers gives each test more consistent CPU and memory-bandwidth access without weakening test coverage. The 16-task allocation is retained, and the expected total regtest duration remains within the 90-minute Slurm limit.

## Verification

- `./make_pretty.sh ci/cscs_daint_spack_psmp_h100.yaml`
- parsed the updated file with Ruby/Psych and verified `--maxtasks 8` with `SLURM_NTASKS: 16`

The runtime effect requires the CSCS Daint runner for final verification.