### PR TITLE
Stabilize remaining Pascal dashboard runs

### DIFF
--- a/tools/docker/Dockerfile.test_cuda_P100
+++ b/tools/docker/Dockerfile.test_cuda_P100
@@ -87,7 +87,7 @@ COPY ./tools/docker/scripts/build_cp2k.sh ./tools/docker/scripts/cmake_cp2k.sh .
 RUN ./build_cp2k.sh toolchain_cuda_P100 psmp
 
 # Run regression tests.
-ARG TESTOPTS=""
+ARG TESTOPTS="--timeout 400"
 COPY ./tests ./tests
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -o pipefail -c " \

--- a/tools/docker/Dockerfile.test_spack_psmp-P100
+++ b/tools/docker/Dockerfile.test_spack_psmp-P100
@@ -106,7 +106,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Regression test run failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive --timeout 400 || echo "ERROR: Regression test run failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/Dockerfile.test_spack_ssmp-P100
+++ b/tools/docker/Dockerfile.test_spack_ssmp-P100
@@ -106,7 +106,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive || echo "ERROR: Regression test run failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive --timeout 400 || echo "ERROR: Regression test run failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -205,7 +205,7 @@ def main() -> None:
                 base_image="docker.io/nvidia/cuda:12.9.1-devel-ubuntu24.04",
                 gcc_version=13,
                 gpu_model="P100",
-                testopts=testopts,
+                testopts=f"{testopts} --timeout 400",
                 image_tag=f.image_tag,
             )
         )
@@ -299,7 +299,8 @@ def main() -> None:
     for gpu_ver in "P100", "V100", "A100":
         with OutputFile(f"Dockerfile.test_cuda_{gpu_ver}", args.check) as f:
             f.write(install_deps_toolchain_cuda(gpu_ver=gpu_ver))
-            f.write(regtest(f"toolchain_cuda_{gpu_ver}", "psmp"))
+            gpu_testopts = "--timeout 400" if gpu_ver == "P100" else ""
+            f.write(regtest(f"toolchain_cuda_{gpu_ver}", "psmp", gpu_testopts))
         with OutputFile(f"Dockerfile.test_performance_cuda_{gpu_ver}", args.check) as f:
             f.write(install_deps_toolchain_cuda(gpu_ver=gpu_ver))
             f.write(performance(f"toolchain_cuda_{gpu_ver}"))

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -219,7 +219,7 @@ def main() -> None:
                 gcc_version=13,
                 gpu_model="P100",
                 feature_flags="",
-                testopts=testopts,
+                testopts=f"{testopts} --timeout 400",
                 image_tag=f.image_tag,
             )
         )

--- a/tools/spack/cp2k_deps_p.yaml
+++ b/tools/spack/cp2k_deps_p.yaml
@@ -166,6 +166,7 @@ spack:
         - "+dlaf"
         - "+elpa"
         - "+fortran"
+        - "~memory_pool"
         - "+pugixml"
         - "+scalapack"
         - "+vdwxc"


### PR DESCRIPTION
## Summary

- raise the per-test timeout from 150 to 400 seconds for the legacy CUDA Pascal and both Spack `ssmp` and `psmp` P100 jobs
- build parallel Spack configurations with `SIRIUS ~memory_pool`, matching the working toolchain SIRIUS configuration
- keep the existing worker counts, all dependencies, all test directories, and all numerical tolerances unchanged

## Motivation

The CUDA Pascal and Spack P100 reports contain no wrong numerical results. Their failures are tests reaching the common 150-second timeout, plus restart or dependent tests that fail because a predecessor timed out.

The Spack `psmp` P100 report originally exposed an additional SIRIUS configuration difference. Its CUDA-enabled SIRIUS 7.11.1 build used the default `+memory_pool` variant and Umpire, whereas the working CUDA toolchain build explicitly uses `SIRIUS_USE_MEMORY_POOL=OFF`. Disabling the optional SIRIUS memory pool retains CUDA-enabled SIRIUS and its complete regtest coverage.

A follow-up full-suite run confirmed that `~memory_pool` was concretized and used. It had no wrong numerical results, but 15 tests still reached the 150-second limit and two dependent/restart tests consequently failed. Applying the same 400-second limit to the Spack `psmp` P100 job addresses that remaining inconsistency without reducing overall throughput.

This complements #5782. Its live report shows that `--maxtasks 8` lowers the `psmp` run from six to two directory workers and makes the complete suite several hours long, so that concurrency change is not carried over here.

## Testing

- `./make_pretty.sh`
- `python3 tools/docker/generate_dockerfiles.py --check`
- `python3 -m py_compile tools/docker/generate_dockerfiles.py`
- `git diff --check`
- CP2K pre-push hook for the files changed in both follow-up commits

Fixes part of #4849.