### PR TITLE
Reduce duplicate GFN2 finite-difference checks

### DIFF
--- a/tests/xTB/regtest-tblite-gfn2-2/Ar_fcc_gfn2_kp_debug.inp
+++ b/tests/xTB/regtest-tblite-gfn2-2/Ar_fcc_gfn2_kp_debug.inp
@@ -5,7 +5,8 @@
 &END GLOBAL
 
 &DEBUG
-  DEBUG_FORCES T
+  # The SPGLIB companion covers force finite differences.
+  DEBUG_FORCES F
   DEBUG_STRESS_TENSOR T
   DX 0.0001
   MAX_RELATIVE_ERROR 0.5

--- a/tests/xTB/regtest-tblite-gfn2-2/Ar_fcc_gfn2_kp_spglib_backend_debug.inp
+++ b/tests/xTB/regtest-tblite-gfn2-2/Ar_fcc_gfn2_kp_spglib_backend_debug.inp
@@ -6,7 +6,8 @@
 
 &DEBUG
   DEBUG_FORCES T
-  DEBUG_STRESS_TENSOR T
+  # The default-backend companion covers stress finite differences.
+  DEBUG_STRESS_TENSOR F
   DX 0.0001
   MAX_RELATIVE_ERROR 0.5
   STOP_ON_MISMATCH F

--- a/tests/xTB/regtest-tblite-gfn2-2/TEST_FILES.toml
+++ b/tests/xTB/regtest-tblite-gfn2-2/TEST_FILES.toml
@@ -10,9 +10,7 @@
 "Ar_fcc_gfn2_force.inp"                  = [{matcher="M082", tol=1.0E-5, ref=0.0000000}]
 "Ar_fcc_gfn2_stress.inp"                 = [{matcher="M042", tol=1.0E-5, ref=0.0000000}]
 "Ar_fcc_gfn2_kp_debug.inp"               = [{matcher="DEBUG_stress_sum", tol=1.0E-5, ref=0.0000000},
-                                             {matcher="DEBUG_force_sum", tol=1.0E-5, ref=0.0000000},
                                              {matcher="N_special_kpoints", tol=0.0, ref=4}]
-"Ar_fcc_gfn2_kp_spglib_backend_debug.inp" = [{matcher="DEBUG_stress_sum", tol=1.0E-5, ref=0.0000000},
-                                             {matcher="DEBUG_force_sum", tol=1.0E-5, ref=0.0000000},
+"Ar_fcc_gfn2_kp_spglib_backend_debug.inp" = [{matcher="DEBUG_force_sum", tol=1.0E-5, ref=0.0000000},
                                              {matcher="N_special_kpoints", tol=0.0, ref=4}]
 #EOF


### PR DESCRIPTION
The Rawhide toolchain dashboard currently has 5,928/5,928 numerically correct tests, but fails because `Ar_fcc_gfn2_kp_spglib_backend_debug.inp` is marginally classified as slow (22.86 s versus a 22.00 s threshold).

The GFN2 Ar-fcc tests currently run both numerical force and stress finite differences with both the default and SPGLIB k-point symmetry backends. This PR removes that duplicate cross-product while retaining the relevant coverage:

- the default-backend test keeps the numerical GFN2 stress check;
- the SPGLIB test keeps the numerical GFN2 force check, including symmetry recomputation for displaced atoms;
- both tests still verify reduction to four special k-points;
- the GFN1 companion tests continue to exercise force and stress finite differences with both backends.

No test is suppressed, and no numerical tolerance or reference value is changed.

Validation:

- `./make_pretty.sh`
- `TEST_FILES.toml` parse check
- two 2-rank/1-thread Spark runs per input:
  - default backend: 4.59/4.54 s -> 2.30/2.24 s
  - SPGLIB backend: 4.49/4.46 s -> 2.89/2.93 s
- retained matcher results:
  - default backend stress difference sum: `1.76368e-7`
  - SPGLIB force difference sum: `0.0`
  - special k-points: `4` for both