### PR TITLE
Limit P100 psmp regtest concurrency

### DIFF
--- a/tools/docker/Dockerfile.test_spack_psmp-P100
+++ b/tools/docker/Dockerfile.test_spack_psmp-P100
@@ -106,7 +106,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive --timeout 400 || echo "ERROR: Regression test run failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --keepalive --timeout 400 --maxtasks=16 || echo "ERROR: Regression test run failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -219,7 +219,7 @@ def main() -> None:
                 gcc_version=13,
                 gpu_model="P100",
                 feature_flags="",
-                testopts=f"{testopts} --timeout 400",
+                testopts=f"{testopts} --timeout 400 --maxtasks=16",
                 image_tag=f.image_tag,
             )
         )


### PR DESCRIPTION
The targeted Spack psmp P100 run for #5792 completed 5941/5952 tests. Its remaining failures were one post-run segmentation fault and ten SIRIUS tests that timed out together, while the same SIRIUS input succeeds both classically and through the CP2K shell on an independent SIRIUS-enabled build. This points to node-level resource or process-teardown contention rather than incorrect test results.

Reduce the P100 psmp runner from six to four concurrent regtest workers by setting `--maxtasks=16` for its 2-MPI-rank, 2-OpenMP-thread jobs. All tests and dependencies remain enabled, and the existing per-test timeout stays unchanged.

Checks performed:
- `python3 tools/docker/generate_dockerfiles.py --check`
- `./make_pretty.sh`
- `git diff --check`

A targeted `spack-psmp-p100` run is needed to confirm the dashboard behavior.