### PR TITLE
Limit OpenMPI debug regtest concurrency

### DIFF
--- a/tools/docker/Dockerfile.test_spack_openmpi-pdbg
+++ b/tools/docker/Dockerfile.test_spack_openmpi-pdbg
@@ -92,7 +92,7 @@ COPY --from=build_cp2k /etc/ld.so.conf.d/cp2k.conf /etc/ld.so.conf.d/cp2k.conf
 RUN ldconfig
 
 # Run CP2K regression test
-RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --timeout 400 || echo "ERROR: Regression test run failed"
+RUN /opt/cp2k/install/bin/launch /opt/cp2k/install/bin/run_tests --timeout 400 --maxtasks=16 || echo "ERROR: Regression test run failed"
 
 # Create entrypoint and finalise container build
 WORKDIR /mnt

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -158,7 +158,7 @@ def main() -> None:
                 version="pdbg",
                 mpi_mode="openmpi",
                 feature_flags="",
-                testopts="--timeout 400",
+                testopts="--timeout 400 --maxtasks=16",
                 image_tag=f.image_tag,
             )
         )


### PR DESCRIPTION
The Spack OpenMPI pdbg dashboard has failed on different tests in successive runs: the archived run timed out in `QS/regtest-acc-2/HF-ec2.inp` at 150 seconds, while the targeted run for #5787 timed out in `QS/regtest-stda-force-3/h2o_f20.inp` and `xTB/regtest-gfn1-d/ch2o_t08.inp` despite a 400-second limit. No incorrect numerical result was reported.

The runner currently starts 16 concurrent two-rank debug jobs on 32 CPUs. Cap it at eight concurrent jobs with `--maxtasks=16`. This keeps every test enabled and preserves the 400-second per-test timeout while reducing memory and process contention in the leak-sanitized debug build.

Checks performed:
- `python3 tools/docker/generate_dockerfiles.py --check`
- `./make_pretty.sh`
- `git diff --check`

A targeted `spack-openmpi-pdbg` run is needed to validate the change.