### PR TITLE
Limit ASan regtest concurrency

### DIFF
--- a/tools/docker/Dockerfile.test_asan-psmp
+++ b/tools/docker/Dockerfile.test_asan-psmp
@@ -72,7 +72,7 @@ COPY ./tools/docker/scripts/build_cp2k.sh ./tools/docker/scripts/cmake_cp2k.sh .
 RUN ./build_cp2k.sh toolchain_asan psmp
 
 # Run regression tests.
-ARG TESTOPTS=""
+ARG TESTOPTS="--maxtasks=24"
 COPY ./tests ./tests
 COPY ./tools/docker/scripts/test_regtest.sh ./
 RUN /bin/bash -o pipefail -c " \

--- a/tools/docker/generate_dockerfiles.py
+++ b/tools/docker/generate_dockerfiles.py
@@ -275,7 +275,7 @@ def main() -> None:
 
     with OutputFile(f"Dockerfile.test_asan-psmp", args.check) as f:
         f.write(install_deps_toolchain())
-        f.write(regtest("toolchain_asan", "psmp"))
+        f.write(regtest("toolchain_asan", "psmp", testopts="--maxtasks=24"))
 
     with OutputFile(f"Dockerfile.test_coverage", args.check) as f:
         f.write(install_deps_toolchain())


### PR DESCRIPTION
The latest Address Sanitizer dashboard report stops abruptly partway through the regression suite. It contains no sanitizer finding, test failure, summary, final status, or `EndDate`, which is consistent with the worker being terminated externally under load. The previous complete ASan run used eight concurrent 2-rank x 2-thread jobs on a 32-CPU node.

Set `--maxtasks=24` for this runner, reducing it to six concurrent jobs. This is a 25% reduction in process and memory pressure; all tests, sanitizer checks, and dependencies remain enabled. The last complete run took about 80 minutes, so the reduced concurrency should remain within the dashboard timeout.

Checks performed:
- `python3 tools/docker/generate_dockerfiles.py --check`
- `./make_pretty.sh`
- `git diff --check`

A targeted `asan-psmp` run is required. If it still ends without a report footer or sanitizer finding, the remaining problem is likely in the runner or GCP pool rather than CP2K.