### PR TITLE
Stabilize RTP electric-field ramp energy

### DIFF
--- a/tests/QS/regtest-ls-rtp/TEST_FILES.toml
+++ b/tests/QS/regtest-ls-rtp/TEST_FILES.toml
@@ -39,7 +39,7 @@
   { matcher = "E_total", tol = 3e-13, ref = -0.53624161700164 },
 ]
 "H2O-ls-emd-mixing.inp" = [
-  { matcher = "E_total", tol = 2e-11, ref = -17.08894042167865 },
+  { matcher = "E_total", tol = 3e-11, ref = -17.08894042167865 },
 ]
 "Ar_mixed_aa_planar-rtp-osc-field.inp" = [
   { matcher = "E_total", tol = 8e-13, ref = -21.07372556817139 },

--- a/tests/QS/regtest-rtp-2/TEST_FILES.toml
+++ b/tests/QS/regtest-rtp-2/TEST_FILES.toml
@@ -11,7 +11,7 @@
 "H2-rtp-efield-vg.inp"                  = [{matcher="E_total", tol=2e-10, ref=-0.83550227784861}]
 "H2-rtp-efield-vg-restart.inp"          = [{matcher="E_total", tol=2e-10, ref=-0.79589429986106}]
 "H2-emd-efield.inp"                     = [{matcher="M002", tol=4e-11, ref=-0.8760125223}]
-"H2-emd-efield-ramp.inp"                = [{matcher="M002", tol=5e-12, ref=-0.8704554332}]
+"H2-emd-efield-ramp.inp"                = [{matcher="M002", tol=3e-11, ref=-0.870455433182}]
 "H2-emd-efield-custom.inp"              = [{matcher="M002", tol=1e-10, ref=-0.8805787785}]
 "H2-rtp_ETRS_ARNOLDI.inp"               = [{matcher="E_total", tol=3e-10, ref=-0.8805676355}]
 "H2-emd_ETRS_ARNOLDI.inp"               = [{matcher="E_total", tol=1e-10, ref=-17.08579286}]


### PR DESCRIPTION
# Summary

Two Ehrenfest/RTP energy matchers sat just below their observed cross-build numerical variation after #5755 corrected diagonal second derivatives of overlap integrals.

- Update the `H2-emd-efield-ramp.inp` reference to the corrected serial-debug value, `-0.870455433182`, and use a `3e-11` relative tolerance.
- Raise only the tolerance of `H2O-ls-emd-mixing.inp` from `2e-11` to `3e-11`; its reference remains unchanged. The optimized GNU `ssmp` CI result differed by `2.10e-11`, just beyond the former limit.

These are matcher-only changes. No source code or regtest input is changed.

# Validation

- Reproduced `-0.870455433182` for the field-ramp test with a current `psmp` build.
- Built current master as GNU `ssmp` on Spark and ran `H2O-ls-emd-mixing.inp` five times each with 1, 2, and 4 OpenMP threads. All 15 runs remained within `1.3e-11` of the retained reference; the last digits vary slightly with threaded reductions.
- `./make_pretty.sh`
- `git diff --check`

## Current CI status

The two RTP tests changed here pass in the targeted `sdbg` and `ssmp` runs. The remaining failures are outside this patch:

- the platform-sensitive GFN2 modified-Broyden test added on `master`, addressed by #5810
- one borderline `TDDFPT_Check_Osc_Strength` result in `ssmp` (`1.01e-5` versus a `1.0e-5` tolerance), which passed unchanged in a subsequent `ssmp` run

No reported failure is attributable to the RTP matcher changes.
