### PR TITLE
Parallelize k-point calculations with OpenMP for single-rank runs

### DIFF
--- a/src/fm/cp_cfm_diag.F
+++ b/src/fm/cp_cfm_diag.F
@@ -57,7 +57,8 @@ MODULE cp_cfm_diag
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'cp_cfm_diag'
 
-   PUBLIC :: cp_cfm_heevd, cp_cfm_geeig, cp_cfm_geeig_canon
+   PUBLIC :: cp_cfm_heevd, cp_cfm_geeig, cp_cfm_geeig_canon, &
+             cp_cfm_geeig_local, cp_cfm_geeig_canon_local
 
 CONTAINS
 
@@ -603,5 +604,198 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE cp_cfm_geeig_canon
+
+! **************************************************************************************************
+!> \brief Solve a generalized complex eigenproblem using the local LAPACK backend.
+!>        This routine is restricted to a one-rank BLACS grid.  It deliberately
+!>        avoids ScaLAPACK so independent k-points can be evaluated concurrently
+!>        without making overlapping MPI calls from OpenMP worker threads.
+!> \param amatrix Hamiltonian, overwritten
+!> \param bmatrix overlap matrix, overwritten
+!> \param eigenvectors eigenvectors
+!> \param eigenvalues eigenvalues
+! **************************************************************************************************
+   SUBROUTINE cp_cfm_geeig_local(amatrix, bmatrix, eigenvectors, eigenvalues)
+
+      TYPE(cp_cfm_type), INTENT(IN)                      :: amatrix, bmatrix, eigenvectors
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
+
+      CHARACTER(len=*), PARAMETER                        :: routineN = 'cp_cfm_geeig_local'
+
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: work
+      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: a, b, z
+      INTEGER                                            :: handle, info, liwork, lrwork, lwork, &
+                                                            n, nmo
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iwork
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: evals, rwork
+#if defined (__HAS_IEEE_EXCEPTIONS)
+      LOGICAL, DIMENSION(5)                              :: halt
+#endif
+
+      CALL timeset(routineN, handle)
+
+      CPASSERT(PRODUCT(amatrix%matrix_struct%context%num_pe) == 1)
+      n = amatrix%matrix_struct%nrow_global
+      nmo = MIN(n, SIZE(eigenvalues))
+      a => amatrix%local_data
+      b => bmatrix%local_data
+      z => eigenvectors%local_data
+
+      ALLOCATE (evals(n), iwork(1), rwork(1), work(1))
+      lwork = -1
+      lrwork = -1
+      liwork = -1
+      CALL zhegvd(1, 'V', 'U', n, a(1, 1), SIZE(a, 1), b(1, 1), SIZE(b, 1), evals(1), &
+                  work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
+      IF (info /= 0) CPABORT("Local ZHEGVD workspace query failed, info="//TRIM(cp_to_string(info)))
+      lwork = MAX(1, CEILING(REAL(work(1), KIND=dp)))
+      lrwork = MAX(1, CEILING(rwork(1)))
+      liwork = MAX(1, iwork(1))
+      DEALLOCATE (iwork, rwork, work)
+      ALLOCATE (iwork(liwork), rwork(lrwork), work(lwork))
+
+#if defined (__HAS_IEEE_EXCEPTIONS)
+      CALL ieee_get_halting_mode(IEEE_ALL, halt)
+      CALL ieee_set_halting_mode(IEEE_ALL, .FALSE.)
+#endif
+      CALL zhegvd(1, 'V', 'U', n, a(1, 1), SIZE(a, 1), b(1, 1), SIZE(b, 1), evals(1), &
+                  work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
+#if defined (__HAS_IEEE_EXCEPTIONS)
+      CALL ieee_set_halting_mode(IEEE_ALL, halt)
+#endif
+      IF (info /= 0) CPABORT("Local ZHEGVD failed, info="//TRIM(cp_to_string(info)))
+
+      eigenvalues(1:nmo) = evals(1:nmo)
+      z(1:n, 1:nmo) = a(1:n, 1:nmo)
+
+      DEALLOCATE (evals, iwork, rwork, work)
+      CALL timestop(handle)
+
+   END SUBROUTINE cp_cfm_geeig_local
+
+! **************************************************************************************************
+!> \brief Canonical generalized complex diagonalization on a one-rank BLACS grid.
+!> \param amatrix Hamiltonian, overwritten
+!> \param bmatrix overlap matrix, overwritten and used as work storage
+!> \param eigenvectors eigenvectors
+!> \param eigenvalues eigenvalues
+!> \param work work matrix
+!> \param epseig overlap eigenvalue threshold
+! **************************************************************************************************
+   SUBROUTINE cp_cfm_geeig_canon_local(amatrix, bmatrix, eigenvectors, eigenvalues, work, epseig)
+
+      TYPE(cp_cfm_type), INTENT(IN)                      :: amatrix, bmatrix, eigenvectors
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
+      TYPE(cp_cfm_type), INTENT(IN)                      :: work
+      REAL(KIND=dp), INTENT(IN)                          :: epseig
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'cp_cfm_geeig_canon_local'
+
+      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: a, b, u, z
+      INTEGER                                            :: handle, i, info, n, nc, nmo, nx
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: evals
+
+      CALL timeset(routineN, handle)
+
+      CPASSERT(PRODUCT(amatrix%matrix_struct%context%num_pe) == 1)
+      n = amatrix%matrix_struct%nrow_global
+      nmo = MIN(n, SIZE(eigenvalues))
+      a => amatrix%local_data
+      b => bmatrix%local_data
+      u => work%local_data
+      z => eigenvectors%local_data
+      ALLOCATE (evals(n))
+
+      b(1:n, 1:n) = -b(1:n, 1:n)
+      CALL cp_cfm_heevd_local(b, u, evals, info)
+      IF (info /= 0) CPABORT("Local overlap ZHEEVD failed, info="//TRIM(cp_to_string(info)))
+      evals(:) = -evals(:)
+      nc = n
+      DO i = 1, n
+         IF (evals(i) < epseig) THEN
+            nc = i - 1
+            EXIT
+         END IF
+      END DO
+      CPASSERT(nc /= 0)
+
+      IF (nc < n) THEN
+         IF (nc < nmo) z(1:n, nc + 1:nmo) = u(1:n, nc + 1:nmo)
+         u(1:n, nc + 1:n) = z_zero
+         evals(nc + 1:n) = 1.0_dp
+      END IF
+      DO i = 1, n
+         u(1:n, i) = u(1:n, i)/SQRT(evals(i))
+      END DO
+
+      CALL zgemm('C', 'N', n, n, n, z_one, u(1, 1), SIZE(u, 1), a(1, 1), SIZE(a, 1), &
+                 z_zero, b(1, 1), SIZE(b, 1))
+      CALL zgemm('N', 'N', n, n, n, z_one, b(1, 1), SIZE(b, 1), u(1, 1), SIZE(u, 1), &
+                 z_zero, a(1, 1), SIZE(a, 1))
+      IF (nc < n) THEN
+         DO i = nc + 1, n
+            a(i, i) = CMPLX(10000.0_dp, 0.0_dp, KIND=dp)
+         END DO
+      END IF
+
+      CALL cp_cfm_heevd_local(a, b, evals, info)
+      IF (info /= 0) CPABORT("Local Hamiltonian ZHEEVD failed, info="//TRIM(cp_to_string(info)))
+      eigenvalues(1:nmo) = evals(1:nmo)
+      nx = MIN(nc, nmo)
+      CALL zgemm('N', 'N', n, nx, nc, z_one, u(1, 1), SIZE(u, 1), b(1, 1), SIZE(b, 1), &
+                 z_zero, z(1, 1), SIZE(z, 1))
+
+      DEALLOCATE (evals)
+      CALL timestop(handle)
+
+   END SUBROUTINE cp_cfm_geeig_canon_local
+
+! **************************************************************************************************
+!> \brief Local LAPACK ZHEEVD helper. The eigenvectors are copied to vectors.
+!> \param matrix ...
+!> \param vectors ...
+!> \param eigenvalues ...
+!> \param info ...
+! **************************************************************************************************
+   SUBROUTINE cp_cfm_heevd_local(matrix, vectors, eigenvalues, info)
+
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(INOUT)  :: matrix, vectors
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: eigenvalues
+      INTEGER, INTENT(OUT)                               :: info
+
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: work
+      INTEGER                                            :: liwork, lrwork, lwork, n
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iwork
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: rwork
+#if defined (__HAS_IEEE_EXCEPTIONS)
+      LOGICAL, DIMENSION(5)                              :: halt
+#endif
+
+      n = SIZE(eigenvalues)
+      ALLOCATE (iwork(1), rwork(1), work(1))
+      lwork = -1
+      lrwork = -1
+      liwork = -1
+      CALL zheevd('V', 'U', n, matrix(1, 1), SIZE(matrix, 1), eigenvalues(1), &
+                  work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
+      IF (info /= 0) CPABORT("Local ZHEEVD workspace query failed, info="//TRIM(cp_to_string(info)))
+      lwork = MAX(1, CEILING(REAL(work(1), KIND=dp)))
+      lrwork = MAX(1, CEILING(rwork(1)))
+      liwork = MAX(1, iwork(1))
+      DEALLOCATE (iwork, rwork, work)
+      ALLOCATE (iwork(liwork), rwork(lrwork), work(lwork))
+#if defined (__HAS_IEEE_EXCEPTIONS)
+      CALL ieee_get_halting_mode(IEEE_ALL, halt)
+      CALL ieee_set_halting_mode(IEEE_ALL, .FALSE.)
+#endif
+      CALL zheevd('V', 'U', n, matrix(1, 1), SIZE(matrix, 1), eigenvalues(1), &
+                  work(1), lwork, rwork(1), lrwork, iwork(1), liwork, info)
+#if defined (__HAS_IEEE_EXCEPTIONS)
+      CALL ieee_set_halting_mode(IEEE_ALL, halt)
+#endif
+      vectors(1:n, 1:n) = matrix(1:n, 1:n)
+      DEALLOCATE (iwork, rwork, work)
+
+   END SUBROUTINE cp_cfm_heevd_local
 
 END MODULE cp_cfm_diag

--- a/src/kpoint_methods.F
+++ b/src/kpoint_methods.F
@@ -29,10 +29,10 @@ MODULE kpoint_methods
    USE cp_dbcsr_api,                    ONLY: &
         dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_distribute, &
         dbcsr_distribution_get, dbcsr_distribution_type, dbcsr_get_block_p, dbcsr_get_info, &
-        dbcsr_get_stored_coordinates, dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, &
-        dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_p_type, &
-        dbcsr_replicate_all, dbcsr_set, dbcsr_type, dbcsr_type_antisymmetric, &
-        dbcsr_type_no_symmetry, dbcsr_type_symmetric
+        dbcsr_get_readonly_block_p, dbcsr_get_stored_coordinates, dbcsr_iterator_blocks_left, &
+        dbcsr_iterator_next_block, dbcsr_iterator_readonly_start, dbcsr_iterator_start, &
+        dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_p_type, dbcsr_replicate_all, dbcsr_set, &
+        dbcsr_type, dbcsr_type_antisymmetric, dbcsr_type_no_symmetry, dbcsr_type_symmetric
    USE cp_dbcsr_contrib,                ONLY: dbcsr_dot
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: copy_fm_to_dbcsr
@@ -98,7 +98,11 @@ MODULE kpoint_methods
    USE scf_control_types,               ONLY: smear_type
    USE smearing_utils,                  ONLY: Smearkp,&
                                               Smearkp2
-   USE util,                            ONLY: get_limit
+   USE util,                            ONLY: get_limit,&
+                                              sort
+
+!$ USE OMP_LIB, ONLY: omp_get_max_threads, &
+!$                    omp_get_thread_num
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -107,9 +111,18 @@ MODULE kpoint_methods
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'kpoint_methods'
 
+   TYPE, PUBLIC :: kp_transform_plan_type
+      INTEGER :: nentry = 0, ngroup = 0
+      LOGICAL :: symmetric = .FALSE.
+      INTEGER, ALLOCATABLE, DIMENSION(:) :: col, col_offset, group_start, image, row, row_offset
+      INTEGER, ALLOCATABLE, DIMENSION(:, :) :: cell
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:) :: symmetry_sign
+   END TYPE kp_transform_plan_type
+
    PUBLIC :: kpoint_initialize, kpoint_env_initialize, kpoint_initialize_mos, kpoint_initialize_mo_set
    PUBLIC :: kpoint_init_cell_index, kpoint_set_mo_occupation
    PUBLIC :: kpoint_density_matrices, kpoint_density_transform
+   PUBLIC :: kp_transform_plan_create, kp_transform_plan_release
    PUBLIC :: rskp_transform, lowdin_kp_trans, lowdin_kp_mo_coeff
    PUBLIC :: rskp_grid_type, rskp_transform_grid_prepare, rskp_transform_grid_extract, &
              rskp_transform_grid_release
@@ -1764,7 +1777,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_density_matrices'
 
       INTEGER                                            :: handle, ikpgr, ispin, kplocal, nao, nmo, &
-                                                            nspin
+                                                            nspin, omp_threads
       INTEGER, DIMENSION(2)                              :: kp_range
       LOGICAL                                            :: aux_fit, wtype
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation
@@ -1801,10 +1814,25 @@ CONTAINS
       END IF
       CALL get_mo_set(mo_set, nao=nao, nmo=nmo)
       CALL cp_fm_get_info(mo_set%mo_coeff, matrix_struct=matrix_struct)
-      CALL cp_fm_create(fwork, matrix_struct)
 
       CALL get_kpoint_info(kpoint, kp_range=kp_range)
       kplocal = kp_range(2) - kp_range(1) + 1
+      IF (aux_fit) THEN
+         kp => kpoint%kp_aux_env(1)%kpoint_env
+      ELSE
+         kp => kpoint%kp_env(1)%kpoint_env
+      END IF
+      nspin = SIZE(kp%mos, 2)
+      omp_threads = 1
+!$    omp_threads = omp_get_max_threads()
+      IF (kpoint%blacs_env_all%para_env%num_pe == 1 .AND. omp_threads > 1 .AND. &
+          kplocal*nspin > 1) THEN
+         CALL kpoint_density_matrices_omp(kpoint, wtype, aux_fit, nao, nmo, kplocal, nspin)
+         CALL timestop(handle)
+         RETURN
+      END IF
+
+      CALL cp_fm_create(fwork, matrix_struct)
       DO ikpgr = 1, kplocal
          IF (aux_fit) THEN
             kp => kpoint%kp_aux_env(ikpgr)%kpoint_env
@@ -1867,6 +1895,129 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE kpoint_density_matrices
+
+! **************************************************************************************************
+!> \brief Thread k-point density-matrix construction on a one-rank BLACS grid.
+!>        The local BLAS path avoids concurrent ScaLAPACK calls and gives every
+!>        worker a private column-scaled MO buffer.
+!> \param kpoint ...
+!> \param wtype ...
+!> \param aux_fit ...
+!> \param nao ...
+!> \param nmo ...
+!> \param kplocal ...
+!> \param nspin ...
+! **************************************************************************************************
+   SUBROUTINE kpoint_density_matrices_omp(kpoint, wtype, aux_fit, nao, nmo, kplocal, nspin)
+
+      TYPE(kpoint_type), POINTER                         :: kpoint
+      LOGICAL, INTENT(IN)                                :: wtype, aux_fit
+      INTEGER, INTENT(IN)                                :: nao, nmo, kplocal, nspin
+
+      INTEGER                                            :: ikpgr, ispin, nworkers, thread
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: work
+
+      nworkers = 1
+!$    nworkers = MIN(omp_get_max_threads(), kplocal*nspin)
+      ALLOCATE (work(nao, nmo, nworkers))
+
+!$OMP PARALLEL DO COLLAPSE(2) DEFAULT(NONE) SCHEDULE(DYNAMIC, 1) NUM_THREADS(nworkers) &
+!$OMP SHARED(kpoint,wtype,aux_fit,nao,nmo,kplocal,nspin,nworkers,work) PRIVATE(ikpgr,ispin,thread)
+      DO ikpgr = 1, kplocal
+         DO ispin = 1, nspin
+            thread = 1
+!$          thread = omp_get_thread_num() + 1
+            CALL kpoint_density_matrix_job(kpoint, ikpgr, ispin, wtype, aux_fit, nao, nmo, &
+                                           work(:, :, thread))
+         END DO
+      END DO
+!$OMP END PARALLEL DO
+
+      DEALLOCATE (work)
+
+   END SUBROUTINE kpoint_density_matrices_omp
+
+! **************************************************************************************************
+!> \brief Construct one (k-point,spin) density matrix using local BLAS.
+!> \param kpoint ...
+!> \param ikpgr ...
+!> \param ispin ...
+!> \param wtype ...
+!> \param aux_fit ...
+!> \param nao ...
+!> \param nmo ...
+!> \param work ...
+! **************************************************************************************************
+   SUBROUTINE kpoint_density_matrix_job(kpoint, ikpgr, ispin, wtype, aux_fit, nao, nmo, work)
+
+      TYPE(kpoint_type), POINTER                         :: kpoint
+      INTEGER, INTENT(IN)                                :: ikpgr, ispin
+      LOGICAL, INTENT(IN)                                :: wtype, aux_fit
+      INTEGER, INTENT(IN)                                :: nao, nmo
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(INOUT)      :: work
+
+      INTEGER                                            :: imo
+      REAL(KIND=dp)                                      :: scale
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: ci, cmat, cr, rmat
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation
+      TYPE(cp_fm_type), POINTER                          :: cpmat, rpmat
+      TYPE(kpoint_env_type), POINTER                     :: kp
+      TYPE(mo_set_type), POINTER                         :: mo_set
+
+      IF (aux_fit) THEN
+         kp => kpoint%kp_aux_env(ikpgr)%kpoint_env
+      ELSE
+         kp => kpoint%kp_env(ikpgr)%kpoint_env
+      END IF
+      mo_set => kp%mos(1, ispin)
+      IF (wtype) THEN
+         CALL get_mo_set(mo_set, occupation_numbers=occupation, eigenvalues=eigenvalues)
+      ELSE
+         CALL get_mo_set(mo_set, occupation_numbers=occupation)
+      END IF
+      CALL cp_fm_get_info(mo_set%mo_coeff, local_data=cr)
+
+      IF (wtype) THEN
+         rpmat => kp%wmat(1, ispin)
+      ELSE
+         rpmat => kp%pmat(1, ispin)
+      END IF
+      CALL cp_fm_get_info(rpmat, local_data=rmat)
+
+      DO imo = 1, nmo
+         scale = occupation(imo)
+         IF (wtype) scale = scale*eigenvalues(imo)
+         work(1:nao, imo) = scale*cr(1:nao, imo)
+      END DO
+      CALL dgemm('N', 'T', nao, nao, nmo, 1.0_dp, cr, SIZE(cr, 1), &
+                 work, SIZE(work, 1), 0.0_dp, rmat, SIZE(rmat, 1))
+
+      IF (.NOT. kpoint%use_real_wfn) THEN
+         mo_set => kp%mos(2, ispin)
+         CALL cp_fm_get_info(mo_set%mo_coeff, local_data=ci)
+         IF (wtype) THEN
+            cpmat => kp%wmat(2, ispin)
+         ELSE
+            cpmat => kp%pmat(2, ispin)
+         END IF
+         CALL cp_fm_get_info(cpmat, local_data=cmat)
+
+         CALL dgemm('N', 'T', nao, nao, nmo, 1.0_dp, ci, SIZE(ci, 1), &
+                    work, SIZE(work, 1), 0.0_dp, cmat, SIZE(cmat, 1))
+         CALL dgemm('N', 'T', nao, nao, nmo, -1.0_dp, work, SIZE(work, 1), &
+                    ci, SIZE(ci, 1), 1.0_dp, cmat, SIZE(cmat, 1))
+
+         DO imo = 1, nmo
+            scale = occupation(imo)
+            IF (wtype) scale = scale*eigenvalues(imo)
+            work(1:nao, imo) = scale*ci(1:nao, imo)
+         END DO
+         CALL dgemm('N', 'T', nao, nao, nmo, 1.0_dp, ci, SIZE(ci, 1), &
+                    work, SIZE(work, 1), 1.0_dp, rmat, SIZE(rmat, 1))
+      END IF
+
+   END SUBROUTINE kpoint_density_matrix_job
 
 ! **************************************************************************************************
 !> \brief Calculate Lowdin transformation of density matrix S^1/2 P S^1/2
@@ -2051,20 +2202,18 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_density_transform'
 
-      INTEGER                                            :: handle, ic, ik, ikk, indx, ir, ira, is, &
-                                                            ispin, jr, nc, nimg, nkp, nspin
+      INTEGER                                            :: handle, ic, ik, ikk, indx, ispin, nc, &
+                                                            nimg, nkp, nspin, omp_threads
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: aux_fit, do_ext, do_symmetric, my_kpgrp, &
-                                                            real_only, reverse_phase
-      REAL(KIND=dp)                                      :: wkpx
+                                                            real_only
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
       TYPE(copy_info_type), ALLOCATABLE, DIMENSION(:)    :: info
       TYPE(cp_fm_type)                                   :: fmdummy
       TYPE(dbcsr_type), POINTER                          :: cpmat, rpmat, scpmat, srpmat
-      TYPE(kind_rotmat_type), DIMENSION(:), POINTER      :: kind_rot
+      TYPE(kp_transform_plan_type)                       :: transform_plan
       TYPE(kpoint_env_type), POINTER                     :: kp
-      TYPE(kpoint_sym_type), POINTER                     :: kpsym
       TYPE(mp_para_env_type), POINTER                    :: para_env
 
       CALL timeset(routineN, handle)
@@ -2121,8 +2270,27 @@ CONTAINS
       nc = SIZE(kp%mos, 1)
       nimg = SIZE(denmat, 2)
       real_only = (nc == 1)
+      CALL kp_transform_plan_create(transform_plan, sab_nl, cell_to_index, nimg, &
+                                    group_entries=.TRUE.)
 
       para_env => kpoint%blacs_env_all%para_env
+      omp_threads = 1
+!$    omp_threads = omp_get_max_threads()
+      IF (para_env%num_pe == 1 .AND. omp_threads > 1) THEN
+         CALL kpoint_density_transform_local(kpoint, denmat, wtype, aux_fit, do_ext, pmat_ext, &
+                                             rpmat, cpmat, srpmat, scpmat, real_only, nspin, nimg, &
+                                             nkp, xkp, wkp, transform_plan)
+         CALL kp_transform_plan_release(transform_plan)
+         CALL dbcsr_deallocate_matrix(rpmat)
+         CALL dbcsr_deallocate_matrix(cpmat)
+         IF (.NOT. kpoint%full_grid) THEN
+            CALL dbcsr_deallocate_matrix(srpmat)
+            CALL dbcsr_deallocate_matrix(scpmat)
+         END IF
+         CALL timestop(handle)
+         RETURN
+      END IF
+
       ALLOCATE (info(nspin*nkp*nc))
 
       ! Start all the communication
@@ -2186,34 +2354,9 @@ CONTAINS
                CALL copy_fm_to_dbcsr(fmwork(2), cpmat, keep_sparsity=.TRUE.)
             END IF
 
-            ! symmetrization
-            kpsym => kpoint%kp_sym(ik)%kpoint_sym
-            CPASSERT(ASSOCIATED(kpsym))
-
-            IF (kpsym%apply_symmetry) THEN
-               wkpx = wkp(ik)/REAL(kpsym%nwght, KIND=dp)
-               DO is = 1, kpsym%nwght
-                  ir = ABS(kpsym%rotp(is))
-                  ira = 0
-                  DO jr = 1, SIZE(kpoint%ibrot)
-                     IF (ir == kpoint%ibrot(jr)) ira = jr
-                  END DO
-                  CPASSERT(ira > 0)
-                  kind_rot => kpoint%kind_rotmat(ira, :)
-                  CPASSERT(kpsym%phase_mode(is) > 0)
-                  reverse_phase = kpsym%phase_mode(is) == 2
-                  CALL symtrans_phase(srpmat, scpmat, rpmat, cpmat, real_only, kind_rot, &
-                                      kpsym%rot(1:3, 1:3, is), kpsym%f0(:, is), &
-                                      kpsym%fcell_gauge(:, :, is), kpoint%atype, &
-                                      kpsym%xkp(1:3, is), kpsym%rotp(is) < 0, reverse_phase)
-                  CALL transform_dmat(denmat, srpmat, scpmat, ispin, real_only, sab_nl, &
-                                      cell_to_index, kpsym%xkp(1:3, is), wkpx)
-               END DO
-            ELSE
-               ! transformation
-               CALL transform_dmat(denmat, rpmat, cpmat, ispin, real_only, sab_nl, &
-                                   cell_to_index, xkp(1:3, ik), wkp(ik))
-            END IF
+            CALL kp_transform_density_matrix(kpoint, denmat, rpmat, cpmat, srpmat, scpmat, &
+                                             ispin, real_only, ik, xkp(1:3, ik), wkp(ik), &
+                                             transform_plan)
          END DO
       END DO
 
@@ -2243,6 +2386,7 @@ CONTAINS
       END DO
 
       ! All done
+      CALL kp_transform_plan_release(transform_plan)
       DEALLOCATE (info)
 
       CALL dbcsr_deallocate_matrix(rpmat)
@@ -2257,89 +2401,384 @@ CONTAINS
    END SUBROUTINE kpoint_density_transform
 
 ! **************************************************************************************************
+!> \brief One-rank K-to-R density transform without full-matrix redistribution.
+!>        MPI communication remains on the generic path; this routine is called
+!>        only when every k-point is local to the current rank.
+!> \param kpoint ...
+!> \param denmat ...
+!> \param wtype ...
+!> \param aux_fit ...
+!> \param do_ext ...
+!> \param pmat_ext ...
+!> \param rpmat ...
+!> \param cpmat ...
+!> \param srpmat ...
+!> \param scpmat ...
+!> \param real_only ...
+!> \param nspin ...
+!> \param nimg ...
+!> \param nkp ...
+!> \param xkp ...
+!> \param wkp ...
+!> \param plan ...
+! **************************************************************************************************
+   SUBROUTINE kpoint_density_transform_local(kpoint, denmat, wtype, aux_fit, do_ext, pmat_ext, &
+                                             rpmat, cpmat, srpmat, scpmat, real_only, nspin, nimg, &
+                                             nkp, xkp, wkp, plan)
+
+      TYPE(kpoint_type), POINTER                         :: kpoint
+      TYPE(dbcsr_p_type), DIMENSION(:, :)                :: denmat
+      LOGICAL, INTENT(IN)                                :: wtype, aux_fit, do_ext
+      TYPE(cp_fm_type), DIMENSION(:, :, :), INTENT(IN), &
+         OPTIONAL                                        :: pmat_ext
+      TYPE(dbcsr_type), POINTER                          :: rpmat, cpmat, srpmat, scpmat
+      LOGICAL, INTENT(IN)                                :: real_only
+      INTEGER, INTENT(IN)                                :: nspin, nimg, nkp
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
+      TYPE(kp_transform_plan_type), INTENT(IN)           :: plan
+
+      INTEGER                                            :: ic, ik, ispin
+      TYPE(cp_fm_type), POINTER                          :: source_c, source_r
+      TYPE(kpoint_env_type), POINTER                     :: kp
+
+      CPASSERT(kpoint%kp_range(1) == 1 .AND. kpoint%kp_range(2) == nkp)
+      CPASSERT(.NOT. do_ext .OR. PRESENT(pmat_ext))
+
+      DO ispin = 1, nspin
+         DO ic = 1, nimg
+            CALL dbcsr_set(denmat(ispin, ic)%matrix, 0.0_dp)
+         END DO
+
+         DO ik = 1, nkp
+            IF (aux_fit) THEN
+               kp => kpoint%kp_aux_env(ik)%kpoint_env
+            ELSE
+               kp => kpoint%kp_env(ik)%kpoint_env
+            END IF
+
+            IF (do_ext) THEN
+               CALL kp_copy_fm_to_dbcsr_local(pmat_ext(ik, 1, ispin), rpmat)
+               IF (.NOT. real_only) CALL kp_copy_fm_to_dbcsr_local(pmat_ext(ik, 2, ispin), cpmat)
+            ELSE
+               IF (wtype) THEN
+                  source_r => kp%wmat(1, ispin)
+                  IF (.NOT. real_only) source_c => kp%wmat(2, ispin)
+               ELSE
+                  source_r => kp%pmat(1, ispin)
+                  IF (.NOT. real_only) source_c => kp%pmat(2, ispin)
+               END IF
+               CALL kp_copy_fm_to_dbcsr_local(source_r, rpmat)
+               IF (.NOT. real_only) CALL kp_copy_fm_to_dbcsr_local(source_c, cpmat)
+            END IF
+
+            CALL kp_transform_density_matrix(kpoint, denmat, rpmat, cpmat, srpmat, scpmat, &
+                                             ispin, real_only, ik, xkp(1:3, ik), wkp(ik), plan)
+         END DO
+      END DO
+
+   END SUBROUTINE kpoint_density_transform_local
+
+! **************************************************************************************************
+!> \brief Apply k-point symmetry and accumulate one reciprocal-space density matrix in real space.
+!> \param kpoint ...
+!> \param denmat ...
+!> \param rpmat ...
+!> \param cpmat ...
+!> \param srpmat ...
+!> \param scpmat ...
+!> \param ispin ...
+!> \param real_only ...
+!> \param ik ...
+!> \param xkp ...
+!> \param wkp ...
+!> \param plan ...
+! **************************************************************************************************
+   SUBROUTINE kp_transform_density_matrix(kpoint, denmat, rpmat, cpmat, srpmat, scpmat, &
+                                          ispin, real_only, ik, xkp, wkp, plan)
+
+      TYPE(kpoint_type), POINTER                         :: kpoint
+      TYPE(dbcsr_p_type), DIMENSION(:, :)                :: denmat
+      TYPE(dbcsr_type), POINTER                          :: rpmat, cpmat, srpmat, scpmat
+      INTEGER, INTENT(IN)                                :: ispin
+      LOGICAL, INTENT(IN)                                :: real_only
+      INTEGER, INTENT(IN)                                :: ik
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: xkp
+      REAL(KIND=dp), INTENT(IN)                          :: wkp
+      TYPE(kp_transform_plan_type), INTENT(IN)           :: plan
+
+      INTEGER                                            :: ir, ira, is, jr
+      LOGICAL                                            :: reverse_phase
+      REAL(KIND=dp)                                      :: symmetry_weight
+      TYPE(kind_rotmat_type), DIMENSION(:), POINTER      :: kind_rot
+      TYPE(kpoint_sym_type), POINTER                     :: kpsym
+
+      kpsym => kpoint%kp_sym(ik)%kpoint_sym
+      CPASSERT(ASSOCIATED(kpsym))
+      IF (kpsym%apply_symmetry) THEN
+         symmetry_weight = wkp/REAL(kpsym%nwght, KIND=dp)
+         DO is = 1, kpsym%nwght
+            ir = ABS(kpsym%rotp(is))
+            ira = 0
+            DO jr = 1, SIZE(kpoint%ibrot)
+               IF (ir == kpoint%ibrot(jr)) ira = jr
+            END DO
+            CPASSERT(ira > 0)
+            kind_rot => kpoint%kind_rotmat(ira, :)
+            CPASSERT(kpsym%phase_mode(is) > 0)
+            reverse_phase = kpsym%phase_mode(is) == 2
+            CALL symtrans_phase(srpmat, scpmat, rpmat, cpmat, real_only, kind_rot, &
+                                kpsym%rot(1:3, 1:3, is), kpsym%f0(:, is), &
+                                kpsym%fcell_gauge(:, :, is), kpoint%atype, &
+                                kpsym%xkp(1:3, is), kpsym%rotp(is) < 0, reverse_phase)
+            CALL transform_dmat(denmat, srpmat, scpmat, ispin, real_only, plan, &
+                                kpsym%xkp(1:3, is), symmetry_weight)
+         END DO
+      ELSE
+         CALL transform_dmat(denmat, rpmat, cpmat, ispin, real_only, plan, xkp, wkp)
+      END IF
+
+   END SUBROUTINE kp_transform_density_matrix
+
+! **************************************************************************************************
+!> \brief Copy a one-rank full matrix directly into existing DBCSR blocks.
+!> \param fm ...
+!> \param matrix ...
+! **************************************************************************************************
+   SUBROUTINE kp_copy_fm_to_dbcsr_local(fm, matrix)
+
+      TYPE(cp_fm_type), INTENT(IN)                       :: fm
+      TYPE(dbcsr_type), POINTER                          :: matrix
+
+      INTEGER                                            :: col_offset, row_offset
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: full
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: block
+      TYPE(dbcsr_iterator_type)                          :: iterator
+
+      CALL cp_fm_get_info(fm, local_data=full)
+      CALL dbcsr_iterator_start(iterator, matrix, shared=.FALSE.)
+      DO WHILE (dbcsr_iterator_blocks_left(iterator))
+         CALL dbcsr_iterator_next_block(iterator, block=block, row_offset=row_offset, &
+                                        col_offset=col_offset)
+         block(:, :) = full(row_offset:row_offset + SIZE(block, 1) - 1, &
+                            col_offset:col_offset + SIZE(block, 2) - 1)
+      END DO
+      CALL dbcsr_iterator_stop(iterator)
+
+   END SUBROUTINE kp_copy_fm_to_dbcsr_local
+
+! **************************************************************************************************
+!> \brief Build the immutable neighbor-list traversal shared by R-to-K and K-to-R transforms.
+!> \param plan ...
+!> \param sab_nl ...
+!> \param cell_to_index ...
+!> \param nimg ...
+!> \param block_template ...
+!> \param group_entries ...
+! **************************************************************************************************
+   SUBROUTINE kp_transform_plan_create(plan, sab_nl, cell_to_index, nimg, block_template, group_entries)
+
+      TYPE(kp_transform_plan_type), INTENT(OUT)          :: plan
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_nl
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      INTEGER, INTENT(IN)                                :: nimg
+      TYPE(dbcsr_type), INTENT(IN), OPTIONAL             :: block_template
+      LOGICAL, INTENT(IN), OPTIONAL                      :: group_entries
+
+      INTEGER                                            :: i, iatom, icell, icol, igroup, irow, &
+                                                            jatom, nblock
+      INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:)     :: key
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: order
+      INTEGER, DIMENSION(3)                              :: cell
+      INTEGER, DIMENSION(:), POINTER                     :: col_offsets, row_offsets
+      LOGICAL                                            :: do_grouping, do_symmetric, store_offsets
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: iterator
+
+      CALL get_neighbor_list_set_p(neighbor_list_sets=sab_nl, symmetric=do_symmetric)
+      plan%symmetric = do_symmetric
+      do_grouping = .FALSE.
+      IF (PRESENT(group_entries)) do_grouping = group_entries
+      store_offsets = PRESENT(block_template)
+      IF (store_offsets) THEN
+         CALL dbcsr_get_info(block_template, row_blk_offset=row_offsets, col_blk_offset=col_offsets)
+      END IF
+      plan%nentry = 0
+      plan%ngroup = 0
+      CALL neighbor_list_iterator_create(iterator, sab_nl)
+      DO WHILE (neighbor_list_iterate(iterator) == 0)
+         CALL get_iterator_info(iterator, cell=cell)
+         icell = cell_to_index(cell(1), cell(2), cell(3))
+         IF (icell >= 1 .AND. icell <= nimg) plan%nentry = plan%nentry + 1
+      END DO
+      CALL neighbor_list_iterator_release(iterator)
+
+      ALLOCATE (plan%row(plan%nentry), plan%col(plan%nentry), plan%image(plan%nentry), &
+                plan%cell(3, plan%nentry), plan%symmetry_sign(plan%nentry))
+      IF (store_offsets) THEN
+         ALLOCATE (plan%row_offset(plan%nentry), plan%col_offset(plan%nentry))
+      END IF
+
+      i = 0
+      CALL neighbor_list_iterator_create(iterator, sab_nl)
+      DO WHILE (neighbor_list_iterate(iterator) == 0)
+         CALL get_iterator_info(iterator, iatom=iatom, jatom=jatom, cell=cell)
+         icell = cell_to_index(cell(1), cell(2), cell(3))
+         IF (icell < 1 .OR. icell > nimg) CYCLE
+         i = i + 1
+         irow = iatom
+         icol = jatom
+         plan%symmetry_sign(i) = 1.0_dp
+         IF (do_symmetric .AND. iatom > jatom) THEN
+            irow = jatom
+            icol = iatom
+            plan%symmetry_sign(i) = -1.0_dp
+         END IF
+         plan%row(i) = irow
+         plan%col(i) = icol
+         IF (store_offsets) THEN
+            plan%row_offset(i) = row_offsets(irow)
+            plan%col_offset(i) = col_offsets(icol)
+         END IF
+         plan%image(i) = icell
+         plan%cell(:, i) = cell
+      END DO
+      CALL neighbor_list_iterator_release(iterator)
+      CPASSERT(i == plan%nentry)
+
+      IF (do_grouping .AND. plan%nentry > 0) THEN
+         nblock = MAX(MAXVAL(plan%row), MAXVAL(plan%col))
+         ALLOCATE (key(plan%nentry), order(plan%nentry))
+         DO i = 1, plan%nentry
+            key(i) = INT(plan%image(i), KIND=int_8) + INT(nimg, KIND=int_8)* &
+                     (INT(plan%row(i) - 1, KIND=int_8) + INT(nblock, KIND=int_8)* &
+                      INT(plan%col(i) - 1, KIND=int_8))
+         END DO
+         CALL sort(key, plan%nentry, order)
+         plan%row(:) = plan%row(order)
+         plan%col(:) = plan%col(order)
+         IF (store_offsets) THEN
+            plan%row_offset(:) = plan%row_offset(order)
+            plan%col_offset(:) = plan%col_offset(order)
+         END IF
+         plan%image(:) = plan%image(order)
+         plan%cell(:, :) = plan%cell(:, order)
+         plan%symmetry_sign(:) = plan%symmetry_sign(order)
+
+         plan%ngroup = 1
+         DO i = 2, plan%nentry
+            IF (key(i) /= key(i - 1)) plan%ngroup = plan%ngroup + 1
+         END DO
+         ALLOCATE (plan%group_start(plan%ngroup + 1))
+         igroup = 1
+         plan%group_start(igroup) = 1
+         DO i = 2, plan%nentry
+            IF (key(i) /= key(i - 1)) THEN
+               igroup = igroup + 1
+               plan%group_start(igroup) = i
+            END IF
+         END DO
+         plan%group_start(plan%ngroup + 1) = plan%nentry + 1
+         DEALLOCATE (key, order)
+      END IF
+
+   END SUBROUTINE kp_transform_plan_create
+
+! **************************************************************************************************
+!> \brief Release a K-to-R traversal plan.
+!> \param plan ...
+! **************************************************************************************************
+   SUBROUTINE kp_transform_plan_release(plan)
+
+      TYPE(kp_transform_plan_type), INTENT(INOUT)        :: plan
+
+      DEALLOCATE (plan%row, plan%col, plan%image, plan%cell, plan%symmetry_sign)
+      IF (ALLOCATED(plan%row_offset)) DEALLOCATE (plan%row_offset, plan%col_offset)
+      IF (ALLOCATED(plan%group_start)) DEALLOCATE (plan%group_start)
+      plan%nentry = 0
+      plan%ngroup = 0
+      plan%symmetric = .FALSE.
+
+   END SUBROUTINE kp_transform_plan_release
+
+! **************************************************************************************************
 !> \brief real space density matrices in DBCSR format
 !> \param denmat  Real space (DBCSR) density matrix
 !> \param rpmat ...
 !> \param cpmat ...
 !> \param ispin ...
 !> \param real_only ...
-!> \param sab_nl ...
-!> \param cell_to_index ...
+!> \param plan precomputed neighbor-list traversal
 !> \param xkp ...
 !> \param wkp ...
 ! **************************************************************************************************
-   SUBROUTINE transform_dmat(denmat, rpmat, cpmat, ispin, real_only, sab_nl, cell_to_index, xkp, wkp)
+   SUBROUTINE transform_dmat(denmat, rpmat, cpmat, ispin, real_only, plan, xkp, wkp)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :)                :: denmat
       TYPE(dbcsr_type), POINTER                          :: rpmat, cpmat
       INTEGER, INTENT(IN)                                :: ispin
       LOGICAL, INTENT(IN)                                :: real_only
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_nl
-      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      TYPE(kp_transform_plan_type), INTENT(IN)           :: plan
       REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: xkp
       REAL(KIND=dp), INTENT(IN)                          :: wkp
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'transform_dmat'
 
-      INTEGER                                            :: handle, iatom, icell, icol, irow, jatom, &
-                                                            nimg
-      INTEGER, DIMENSION(3)                              :: cell
-      LOGICAL                                            :: do_symmetric, found
-      REAL(KIND=dp)                                      :: arg, coskl, fc, sinkl
+      INTEGER                                            :: handle, i, ifirst, igroup, ilast, &
+                                                            nthreads
+      LOGICAL                                            :: found
+      REAL(KIND=dp)                                      :: arg, coskl, sinkl
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: cblock, dblock, rblock
-      TYPE(neighbor_list_iterator_p_type), &
-         DIMENSION(:), POINTER                           :: nl_iterator
 
       CALL timeset(routineN, handle)
 
-      nimg = SIZE(denmat, 2)
-
-      ! transformation
-      CALL get_neighbor_list_set_p(neighbor_list_sets=sab_nl, symmetric=do_symmetric)
-      CALL neighbor_list_iterator_create(nl_iterator, sab_nl)
-      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
-         CALL get_iterator_info(nl_iterator, iatom=iatom, jatom=jatom, cell=cell)
+      nthreads = 1
+!$    nthreads = MAX(1, MIN(omp_get_max_threads(), plan%ngroup))
+      ! Entries are grouped by (image,row-block,col-block), hence workers
+      ! update disjoint DBCSR blocks without atomics or false sharing.
+!$OMP PARALLEL DO DEFAULT(NONE) SCHEDULE(DYNAMIC, 4) NUM_THREADS(nthreads) &
+!$OMP SHARED(plan,denmat,rpmat,cpmat,ispin,real_only,xkp,wkp,nthreads) &
+!$OMP PRIVATE(igroup,ifirst,ilast,i,arg,coskl,sinkl,found,dblock,rblock,cblock)
+      DO igroup = 1, plan%ngroup
+         ifirst = plan%group_start(igroup)
+         ilast = plan%group_start(igroup + 1) - 1
 
          !We have a FT from KP to real-space: S(R) = sum_k S(k)*exp(-i*k*R), with S(k) a complex number
          !Therefore, we have: S(R) = sum_k Re(S(k))*cos(k*R) -i^2*Im(S(k))*sin(k*R)
          !                         = sum_k Re(S(k))*cos(k*R) + Im(S(k))*sin(k*R)
          !fc = +- 1 is due to the usual non-symmetric real-space matrices stored as symmetric ones
+         coskl = 0.0_dp
+         sinkl = 0.0_dp
+         DO i = ifirst, ilast
+            arg = DOT_PRODUCT(REAL(plan%cell(:, i), KIND=dp), xkp)
+            coskl = coskl + wkp*COS(twopi*arg)
+            sinkl = sinkl + wkp*plan%symmetry_sign(i)*SIN(twopi*arg)
+         END DO
 
-         irow = iatom
-         icol = jatom
-         fc = 1.0_dp
-         IF (do_symmetric .AND. iatom > jatom) THEN
-            irow = jatom
-            icol = iatom
-            fc = -1.0_dp
-         END IF
-
-         icell = cell_to_index(cell(1), cell(2), cell(3))
-         IF (icell < 1 .OR. icell > nimg) CYCLE
-
-         arg = REAL(cell(1), dp)*xkp(1) + REAL(cell(2), dp)*xkp(2) + REAL(cell(3), dp)*xkp(3)
-         coskl = wkp*COS(twopi*arg)
-         sinkl = wkp*fc*SIN(twopi*arg)
-
-         CALL dbcsr_get_block_p(matrix=denmat(ispin, icell)%matrix, row=irow, col=icol, &
+         CALL dbcsr_get_block_p(matrix=denmat(ispin, plan%image(ifirst))%matrix, &
+                                row=plan%row(ifirst), col=plan%col(ifirst), &
                                 block=dblock, found=found)
          IF (.NOT. found) CYCLE
 
          IF (real_only) THEN
-            CALL dbcsr_get_block_p(matrix=rpmat, row=irow, col=icol, block=rblock, found=found)
+            CALL dbcsr_get_readonly_block_p(matrix=rpmat, row=plan%row(ifirst), col=plan%col(ifirst), &
+                                            block=rblock, found=found)
             IF (.NOT. found) CYCLE
             dblock = dblock + coskl*rblock
          ELSE
-            CALL dbcsr_get_block_p(matrix=rpmat, row=irow, col=icol, block=rblock, found=found)
+            CALL dbcsr_get_readonly_block_p(matrix=rpmat, row=plan%row(ifirst), col=plan%col(ifirst), &
+                                            block=rblock, found=found)
             IF (.NOT. found) CYCLE
-            CALL dbcsr_get_block_p(matrix=cpmat, row=irow, col=icol, block=cblock, found=found)
+            CALL dbcsr_get_readonly_block_p(matrix=cpmat, row=plan%row(ifirst), col=plan%col(ifirst), &
+                                            block=cblock, found=found)
             IF (.NOT. found) CYCLE
             dblock = dblock + coskl*rblock
             dblock = dblock + sinkl*cblock
          END IF
       END DO
-      CALL neighbor_list_iterator_release(nl_iterator)
+!$OMP END PARALLEL DO
 
       CALL timestop(handle)
 
@@ -2521,9 +2960,10 @@ CONTAINS
 
       INTEGER                                            :: handle, iatom, icol, ikind, ip, irow, &
                                                             jcol, jkind, jp, jrow, mynode, natom, &
-                                                            numnodes, owner
+                                                            nthreads, numnodes, owner
       INTEGER, DIMENSION(3)                              :: shift
-      LOGICAL                                            :: dorot, found, has_phase, perm, trans
+      LOGICAL                                            :: byrows, dorot, found, has_phase, perm, &
+                                                            trans
       REAL(KIND=dp)                                      :: arg, coskl, dr, sinkl
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: cwork, rwork, twork
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: cblock, kroti, krotj, rblock, scblock, &
@@ -2564,7 +3004,15 @@ CONTAINS
       CALL dbcsr_set(srpmat, 0.0_dp)
       IF (.NOT. real_only) CALL dbcsr_set(scpmat, 0.0_dp)
 
-      CALL dbcsr_iterator_start(iter, rpmat)
+      nthreads = 1
+!$    nthreads = omp_get_max_threads()
+      byrows = nthreads <= natom
+!$OMP PARALLEL DEFAULT(NONE) NUM_THREADS(nthreads) &
+!$OMP SHARED(rpmat,cpmat,srpmat,scpmat,real_only,kmat,rot,f0,fcell,atype,xkp,time_reversal, &
+!$OMP        reverse_phase,natom,perm,dorot,has_phase,mynode,numnodes,nthreads,byrows) &
+!$OMP PRIVATE(iter,irow,icol,rblock,rwork,cwork,twork,ikind,jkind,kroti,krotj,shift,arg,coskl, &
+!$OMP         sinkl,cblock,found,ip,jp,jrow,jcol,trans,srblock,scblock,owner)
+      CALL dbcsr_iterator_readonly_start(iter, rpmat, dynamic=.TRUE., dynamic_byrows=byrows)
       DO WHILE (dbcsr_iterator_blocks_left(iter))
          CALL dbcsr_iterator_next_block(iter, irow, icol, rblock)
          IF (.NOT. ALLOCATED(rwork)) THEN
@@ -2602,7 +3050,7 @@ CONTAINS
             END IF
             rwork(:, :) = coskl*rblock
          ELSE
-            CALL dbcsr_get_block_p(matrix=cpmat, row=irow, col=icol, block=cblock, found=found)
+            CALL dbcsr_get_readonly_block_p(matrix=cpmat, row=irow, col=icol, block=cblock, found=found)
             rwork(:, :) = coskl*rblock
             IF (time_reversal) THEN
                cwork(:, :) = -sinkl*rblock
@@ -2678,6 +3126,7 @@ CONTAINS
          END IF
       END DO
       CALL dbcsr_iterator_stop(iter)
+!$OMP END PARALLEL
       IF (numnodes /= 1 .AND. (perm .OR. has_phase)) THEN
          CALL dbcsr_distribute(rpmat)
          IF (.NOT. real_only) CALL dbcsr_distribute(cpmat)

--- a/src/qs_diis.F
+++ b/src/qs_diis.F
@@ -84,6 +84,7 @@ MODULE qs_diis
              qs_diis_b_create_sparse, &
              qs_diis_b_step_4lscf
    PUBLIC :: qs_diis_b_clear_kp, &
+             qs_diis_b_check_i_alloc_kp, &
              qs_diis_b_create_kp, &
              qs_diis_b_step_kp, &
              qs_diis_b_calc_err_kp, &

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -19,6 +19,8 @@ MODULE qs_scf_diagonalization
                                               cp_cfm_scale_and_add_fm
    USE cp_cfm_diag,                     ONLY: cp_cfm_geeig,&
                                               cp_cfm_geeig_canon,&
+                                              cp_cfm_geeig_canon_local,&
+                                              cp_cfm_geeig_local,&
                                               cp_cfm_heevd
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_release,&
@@ -29,9 +31,9 @@ MODULE qs_scf_diagonalization
    USE cp_control_types,                ONLY: dft_control_type,&
                                               hairy_probes_type
    USE cp_dbcsr_api,                    ONLY: &
-        dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_desymmetrize, dbcsr_p_type, &
-        dbcsr_set, dbcsr_type, dbcsr_type_antisymmetric, dbcsr_type_no_symmetry, &
-        dbcsr_type_symmetric
+        dbcsr_copy, dbcsr_create, dbcsr_deallocate_matrix, dbcsr_desymmetrize, &
+        dbcsr_get_readonly_block_p, dbcsr_p_type, dbcsr_set, dbcsr_type, dbcsr_type_antisymmetric, &
+        dbcsr_type_no_symmetry, dbcsr_type_symmetric
    USE cp_dbcsr_cp2k_link,              ONLY: cp_dbcsr_alloc_block_from_nbl
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               copy_fm_to_dbcsr,&
@@ -42,13 +44,10 @@ MODULE qs_scf_diagonalization
                                               cp_fm_uplo_to_full
    USE cp_fm_cholesky,                  ONLY: cp_fm_cholesky_reduce,&
                                               cp_fm_cholesky_restore
-   USE cp_fm_diag,                      ONLY: FM_DIAG_TYPE_CUSOLVER,&
-                                              choose_eigv_solver,&
-                                              cp_fm_geeig,&
-                                              cp_fm_geeig_canon,&
-                                              cusolver_n_min,&
-                                              diag_type,&
-                                              direct_generalized_diagonalization
+   USE cp_fm_diag,                      ONLY: &
+        FM_DIAG_TYPE_CUSOLVER, FM_DIAG_TYPE_DLAF, choose_eigv_solver, cp_fm_geeig, &
+        cp_fm_geeig_canon, cusolver_n_min, diag_check_requested, diag_type, &
+        direct_generalized_diagonalization
    USE cp_fm_pool_types,                ONLY: cp_fm_pool_p_type,&
                                               fm_pool_create_fm,&
                                               fm_pool_give_back_fm
@@ -73,20 +72,18 @@ MODULE qs_scf_diagonalization
                                               section_vals_type
    USE kinds,                           ONLY: dp,&
                                               int_8
-   USE kpoint_methods,                  ONLY: kpoint_density_matrices,&
-                                              kpoint_density_transform,&
-                                              kpoint_set_mo_occupation,&
-                                              rskp_grid_type,&
-                                              rskp_transform,&
-                                              rskp_transform_grid_extract,&
-                                              rskp_transform_grid_prepare,&
-                                              rskp_transform_grid_release
+   USE kpoint_methods,                  ONLY: &
+        kp_transform_plan_create, kp_transform_plan_release, kp_transform_plan_type, &
+        kpoint_density_matrices, kpoint_density_transform, kpoint_set_mo_occupation, &
+        rskp_grid_type, rskp_transform, rskp_transform_grid_extract, rskp_transform_grid_prepare, &
+        rskp_transform_grid_release
    USE kpoint_types,                    ONLY: get_kpoint_info,&
                                               kpoint_env_type,&
                                               kpoint_type
    USE machine,                         ONLY: m_flush,&
                                               m_walltime
    USE mathconstants,                   ONLY: gaussi,&
+                                              twopi,&
                                               z_one,&
                                               z_zero
    USE message_passing,                 ONLY: mp_para_env_type
@@ -97,6 +94,7 @@ MODULE qs_scf_diagonalization
    USE qs_density_mixing_types,         ONLY: direct_mixing_nr,&
                                               gspace_mixing_nr
    USE qs_diis,                         ONLY: qs_diis_b_calc_err_kp,&
+                                              qs_diis_b_check_i_alloc_kp,&
                                               qs_diis_b_info_kp,&
                                               qs_diis_b_step,&
                                               qs_diis_b_step_kp
@@ -137,6 +135,9 @@ MODULE qs_scf_diagonalization
    USE qs_scf_types,                    ONLY: qs_scf_env_type,&
                                               subspace_env_type
    USE scf_control_types,               ONLY: scf_control_type
+
+!$ USE OMP_LIB, ONLY: omp_get_max_threads, &
+!$                    omp_get_thread_num
 #include "./base/base_uses.f90"
 
    IMPLICIT NONE
@@ -144,6 +145,10 @@ MODULE qs_scf_diagonalization
    PRIVATE
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_scf_diagonalization'
+
+   TYPE, PRIVATE :: kp_diag_omp_workspace_type
+      TYPE(cp_cfm_type) :: cksmat, cmos, csmat, csmat_base, cwork
+   END TYPE kp_diag_omp_workspace_type
 
    PUBLIC :: do_general_diag, do_general_diag_kp, do_roks_diag, &
              do_special_diag, do_ot_diag, do_block_davidson_diag, &
@@ -468,13 +473,14 @@ CONTAINS
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: coeffs
       INTEGER                                            :: handle, ib, igroup, ik, ikp, indx, &
                                                             ispin, jb, kplocal, lattice_fft, nb, &
-                                                            nkp, nkp_groups, nspin
+                                                            nkp, nkp_groups, nspin, omp_threads
       INTEGER, DIMENSION(2)                              :: kp_range
       INTEGER, DIMENSION(3)                              :: nkp_grid
       INTEGER, DIMENSION(:, :), POINTER                  :: kp_dist
       INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
       LOGICAL                                            :: do_diis, my_kpgrp, spin_grid_fft, &
-                                                            use_grid_fft, use_real_wfn
+                                                            use_grid_fft, use_omp_kpoints, &
+                                                            use_real_wfn
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
       TYPE(copy_info_type), ALLOCATABLE, DIMENSION(:, :) :: info
@@ -507,6 +513,27 @@ CONTAINS
       do_diis = .FALSE.
       IF (scf_env%iter_count > 1 .AND. .NOT. scf_env%skip_diis .AND. .NOT. use_real_wfn &
           .AND. PRESENT(diis_error) .AND. PRESENT(qs_env)) do_diis = .TRUE.
+
+      para_env => kpoints%blacs_env_all%para_env
+      nspin = SIZE(matrix_ks, 1)
+      omp_threads = 1
+!$    omp_threads = omp_get_max_threads()
+      ! The local executor operates on the complex k-point representation.
+      use_omp_kpoints = para_env%num_pe == 1 .AND. omp_threads > 1 .AND. kplocal > 1 .AND. &
+                        .NOT. use_real_wfn
+      ! Keep accelerator and distributed eigensolver selections on their existing paths.
+      IF (diag_type == FM_DIAG_TYPE_CUSOLVER .OR. diag_type == FM_DIAG_TYPE_DLAF) THEN
+         use_omp_kpoints = .FALSE.
+      END IF
+      IF (diag_check_requested()) use_omp_kpoints = .FALSE.
+
+      IF (use_omp_kpoints) THEN
+         CALL do_general_diag_kp_omp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, update_p, &
+                                     diis_step, do_diis, qs_env, diis_error, probe, sab_nl, &
+                                     cell_to_index, xkp)
+         CALL timestop(handle)
+         RETURN
+      END IF
 
       ! allocate some work matrices
       ALLOCATE (rmatrix, cmatrix, tmpmat)
@@ -850,6 +877,431 @@ CONTAINS
       CALL timestop(handle)
 
    END SUBROUTINE do_general_diag_kp
+
+! **************************************************************************************************
+!> \brief OpenMP executor for k-points whose BLACS grid contains one MPI rank.
+!>        Each worker owns all dense temporary matrices and reads the shared
+!>        DBCSR inputs without mutation. MPI-backed full-matrix operations are
+!>        replaced by local LAPACK calls.
+!> \param matrix_ks ...
+!> \param matrix_s ...
+!> \param kpoints ...
+!> \param scf_env ...
+!> \param scf_control ...
+!> \param update_p ...
+!> \param diis_step ...
+!> \param do_diis ...
+!> \param qs_env ...
+!> \param diis_error ...
+!> \param probe ...
+!> \param sab_nl ...
+!> \param cell_to_index ...
+!> \param xkp ...
+! **************************************************************************************************
+   SUBROUTINE do_general_diag_kp_omp(matrix_ks, matrix_s, kpoints, scf_env, scf_control, update_p, &
+                                     diis_step, do_diis, qs_env, diis_error, probe, sab_nl, &
+                                     cell_to_index, xkp)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks, matrix_s
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(qs_scf_env_type), POINTER                     :: scf_env
+      TYPE(scf_control_type), POINTER                    :: scf_control
+      LOGICAL, INTENT(IN)                                :: update_p
+      LOGICAL, INTENT(INOUT)                             :: diis_step
+      LOGICAL, INTENT(IN)                                :: do_diis
+      TYPE(qs_environment_type), OPTIONAL, POINTER       :: qs_env
+      REAL(dp), INTENT(INOUT), OPTIONAL                  :: diis_error
+      TYPE(hairy_probes_type), DIMENSION(:), OPTIONAL, &
+         POINTER                                         :: probe
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_nl
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+
+      CHARACTER(len=*), PARAMETER :: routineN = 'do_general_diag_kp_omp'
+
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: coeffs
+      INTEGER                                            :: handle, ib, ikp, kplocal, nb, nspin, &
+                                                            nworkers, thread
+      TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct, mo_struct
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
+      TYPE(kp_diag_omp_workspace_type), ALLOCATABLE, &
+         DIMENSION(:)                                    :: workspace
+      TYPE(kp_transform_plan_type)                       :: transform_plan
+      TYPE(kpoint_env_type), POINTER                     :: kp
+      TYPE(mp_para_env_type), POINTER                    :: para_env_global
+      TYPE(section_vals_type), POINTER                   :: scf_section
+
+      CALL timeset(routineN, handle)
+      NULLIFY (matrix_struct, mo_struct, mo_coeff, kp, para_env_global, scf_section)
+
+      kplocal = SIZE(xkp, 2)
+      nspin = SIZE(matrix_ks, 1)
+      nworkers = 1
+!$    nworkers = MIN(omp_get_max_threads(), kplocal)
+      CALL cp_fm_get_info(scf_env%scf_work1(1), matrix_struct=matrix_struct)
+      kp => kpoints%kp_env(1)%kpoint_env
+      CALL get_mo_set(kp%mos(1, 1), mo_coeff=mo_coeff)
+      CALL cp_fm_get_info(mo_coeff, matrix_struct=mo_struct)
+      CALL kp_diag_omp_workspaces_create(workspace, nworkers, matrix_struct, mo_struct)
+      CALL kp_transform_plan_create(transform_plan, sab_nl, cell_to_index, SIZE(matrix_ks, 2), &
+                                    matrix_ks(1, 1)%matrix)
+
+      IF (do_diis) THEN
+         CALL get_qs_env(qs_env, para_env=para_env_global)
+         scf_section => section_vals_get_subs_vals(qs_env%input, "DFT%SCF")
+         CALL qs_diis_b_info_kp(kpoints%scf_diis_buffer, ib, nb)
+         CALL qs_diis_b_check_i_alloc_kp(kpoints%scf_diis_buffer, matrix_struct, nspin, kplocal, &
+                                         scf_section)
+
+!$OMP PARALLEL DO DEFAULT(NONE) SCHEDULE(DYNAMIC, 1) NUM_THREADS(nworkers) &
+!$OMP SHARED(workspace,matrix_ks,matrix_s,kpoints,ib,transform_plan,xkp,kplocal,nspin,nworkers) &
+!$OMP PRIVATE(ikp,thread)
+         DO ikp = 1, kplocal
+            thread = 1
+!$          thread = omp_get_thread_num() + 1
+            CALL kp_diis_error_job_local(ikp, workspace(thread), matrix_ks, matrix_s, kpoints, &
+                                         ib, transform_plan, xkp, nspin)
+         END DO
+!$OMP END PARALLEL DO
+
+         ALLOCATE (coeffs(nb))
+         CALL qs_diis_b_step_kp(kpoints%scf_diis_buffer, coeffs, ib, nb, scf_env%iter_delta, diis_error, &
+                                diis_step, scf_control%eps_diis, nspin, kplocal, kplocal, &
+                                scf_control%nmixing, &
+                                scf_section, para_env_global)
+
+!$OMP PARALLEL DO DEFAULT(NONE) SCHEDULE(DYNAMIC, 1) NUM_THREADS(nworkers) &
+!$OMP SHARED(workspace,kpoints,coeffs,nb,scf_env,scf_control,kplocal,nspin,nworkers) PRIVATE(ikp,thread)
+         DO ikp = 1, kplocal
+            thread = 1
+!$          thread = omp_get_thread_num() + 1
+            CALL kp_diis_diag_job(ikp, workspace(thread), kpoints, coeffs, nb, scf_env, &
+                                  scf_control, nspin)
+         END DO
+!$OMP END PARALLEL DO
+         DEALLOCATE (coeffs)
+      ELSE
+         diis_step = .FALSE.
+!$OMP PARALLEL DO DEFAULT(NONE) SCHEDULE(DYNAMIC, 1) NUM_THREADS(nworkers) &
+!$OMP SHARED(workspace,matrix_ks,matrix_s,kpoints,scf_env,scf_control,transform_plan,xkp,kplocal,nspin,nworkers) &
+!$OMP PRIVATE(ikp,thread)
+         DO ikp = 1, kplocal
+            thread = 1
+!$          thread = omp_get_thread_num() + 1
+            CALL kp_diag_job(ikp, workspace(thread), matrix_ks, matrix_s, kpoints, scf_env, scf_control, &
+                             transform_plan, xkp, nspin)
+         END DO
+!$OMP END PARALLEL DO
+      END IF
+
+      IF (update_p) THEN
+         IF (PRESENT(probe)) THEN
+            scf_control%smear%do_smear = .FALSE.
+            CALL kpoint_set_mo_occupation(kpoints, scf_control%smear, probe=probe)
+         ELSE
+            CALL kpoint_set_mo_occupation(kpoints, scf_control%smear)
+         END IF
+         CALL kpoint_density_matrices(kpoints)
+         CALL kpoint_density_transform(kpoints, scf_env%p_mix_new, .FALSE., &
+                                       matrix_s(1, 1)%matrix, sab_nl, scf_env%scf_work1, &
+                                       overlap_rs=matrix_s)
+      END IF
+
+      CALL kp_transform_plan_release(transform_plan)
+      CALL kp_diag_omp_workspaces_release(workspace)
+      CALL timestop(handle)
+
+   END SUBROUTINE do_general_diag_kp_omp
+
+! **************************************************************************************************
+!> \brief Create one independent dense workspace per OpenMP worker.
+!> \param workspace ...
+!> \param nworkers ...
+!> \param matrix_struct ...
+!> \param mo_struct ...
+! **************************************************************************************************
+   SUBROUTINE kp_diag_omp_workspaces_create(workspace, nworkers, matrix_struct, mo_struct)
+
+      TYPE(kp_diag_omp_workspace_type), ALLOCATABLE, &
+         DIMENSION(:), INTENT(OUT)                       :: workspace
+      INTEGER, INTENT(IN)                                :: nworkers
+      TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct, mo_struct
+
+      INTEGER                                            :: i
+
+      ALLOCATE (workspace(nworkers))
+      DO i = 1, nworkers
+         CALL cp_cfm_create(workspace(i)%cksmat, matrix_struct)
+         CALL cp_cfm_create(workspace(i)%csmat, matrix_struct)
+         CALL cp_cfm_create(workspace(i)%csmat_base, matrix_struct)
+         CALL cp_cfm_create(workspace(i)%cwork, matrix_struct)
+         CALL cp_cfm_create(workspace(i)%cmos, mo_struct)
+      END DO
+
+   END SUBROUTINE kp_diag_omp_workspaces_create
+
+! **************************************************************************************************
+!> \brief Release OpenMP k-point workspaces.
+!> \param workspace ...
+! **************************************************************************************************
+   SUBROUTINE kp_diag_omp_workspaces_release(workspace)
+
+      TYPE(kp_diag_omp_workspace_type), ALLOCATABLE, &
+         DIMENSION(:), INTENT(INOUT)                     :: workspace
+
+      INTEGER                                            :: i
+
+      DO i = 1, SIZE(workspace)
+         CALL cp_cfm_release(workspace(i)%cksmat)
+         CALL cp_cfm_release(workspace(i)%csmat)
+         CALL cp_cfm_release(workspace(i)%csmat_base)
+         CALL cp_cfm_release(workspace(i)%cwork)
+         CALL cp_cfm_release(workspace(i)%cmos)
+      END DO
+      DEALLOCATE (workspace)
+
+   END SUBROUTINE kp_diag_omp_workspaces_release
+
+! **************************************************************************************************
+!> \brief Fuse the real-space Fourier transform and DBCSR-to-dense expansion.
+!>        The target is private to one worker and the source blocks are read-only.
+!> \param source ...
+!> \param ispin ...
+!> \param xkp ...
+!> \param plan ...
+!> \param TARGET ...
+! **************************************************************************************************
+   SUBROUTINE kp_build_cfm(source, ispin, xkp, plan, TARGET)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: source
+      INTEGER, INTENT(IN)                                :: ispin
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: xkp
+      TYPE(kp_transform_plan_type), INTENT(IN)           :: plan
+      TYPE(cp_cfm_type), INTENT(IN)                      :: target
+
+      COMPLEX(KIND=dp)                                   :: phase
+      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: full
+      INTEGER                                            :: col_offset, i, row_offset
+      LOGICAL                                            :: found
+      REAL(KIND=dp)                                      :: arg
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: block
+
+      full => target%local_data
+      full = z_zero
+      DO i = 1, plan%nentry
+         CALL dbcsr_get_readonly_block_p(source(ispin, plan%image(i))%matrix, &
+                                         plan%row(i), plan%col(i), block, found)
+         IF (.NOT. found) CYCLE
+         row_offset = plan%row_offset(i)
+         col_offset = plan%col_offset(i)
+         arg = DOT_PRODUCT(REAL(plan%cell(:, i), KIND=dp), xkp)
+         phase = CMPLX(COS(twopi*arg), plan%symmetry_sign(i)*SIN(twopi*arg), KIND=dp)
+         full(row_offset:row_offset + SIZE(block, 1) - 1, &
+              col_offset:col_offset + SIZE(block, 2) - 1) = &
+            full(row_offset:row_offset + SIZE(block, 1) - 1, &
+                 col_offset:col_offset + SIZE(block, 2) - 1) + phase*block
+         IF (plan%symmetric .AND. plan%row(i) /= plan%col(i)) THEN
+            full(col_offset:col_offset + SIZE(block, 2) - 1, &
+                 row_offset:row_offset + SIZE(block, 1) - 1) = &
+               full(col_offset:col_offset + SIZE(block, 2) - 1, &
+                    row_offset:row_offset + SIZE(block, 1) - 1) + CONJG(phase)*TRANSPOSE(block)
+         END IF
+      END DO
+
+   END SUBROUTINE kp_build_cfm
+
+! **************************************************************************************************
+!> \brief Transform and diagonalize one k-point without DIIS.
+!> \param ikp ...
+!> \param workspace ...
+!> \param matrix_ks ...
+!> \param matrix_s ...
+!> \param kpoints ...
+!> \param scf_env ...
+!> \param scf_control ...
+!> \param transform_plan ...
+!> \param xkp ...
+!> \param nspin ...
+! **************************************************************************************************
+   SUBROUTINE kp_diag_job(ikp, workspace, matrix_ks, matrix_s, kpoints, scf_env, scf_control, &
+                          transform_plan, xkp, nspin)
+
+      INTEGER, INTENT(IN)                                :: ikp
+      TYPE(kp_diag_omp_workspace_type), INTENT(INOUT)    :: workspace
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks, matrix_s
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(qs_scf_env_type), POINTER                     :: scf_env
+      TYPE(scf_control_type), POINTER                    :: scf_control
+      TYPE(kp_transform_plan_type), INTENT(IN)           :: transform_plan
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      INTEGER, INTENT(IN)                                :: nspin
+
+      INTEGER                                            :: ispin
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues
+      TYPE(cp_fm_type), POINTER                          :: imos, rmos
+      TYPE(kpoint_env_type), POINTER                     :: kp
+
+      kp => kpoints%kp_env(ikp)%kpoint_env
+      CALL kp_build_cfm(matrix_s, 1, xkp(1:3, ikp), transform_plan, workspace%csmat_base)
+      DO ispin = 1, nspin
+         CALL kp_build_cfm(matrix_ks, ispin, xkp(1:3, ikp), transform_plan, workspace%cksmat)
+         CALL cp_cfm_to_cfm(workspace%csmat_base, workspace%csmat)
+         CALL get_mo_set(kp%mos(1, ispin), mo_coeff=rmos, eigenvalues=eigenvalues)
+         CALL get_mo_set(kp%mos(2, ispin), mo_coeff=imos)
+         IF (scf_env%cholesky_method == cholesky_off) THEN
+            CALL cp_cfm_geeig_canon_local(workspace%cksmat, workspace%csmat, workspace%cmos, &
+                                          eigenvalues, workspace%cwork, scf_control%eps_eigval)
+         ELSE
+            CALL cp_cfm_geeig_local(workspace%cksmat, workspace%csmat, workspace%cmos, eigenvalues)
+         END IF
+         kp%mos(2, ispin)%eigenvalues = eigenvalues
+         CALL cp_cfm_to_fm(workspace%cmos, rmos, imos)
+      END DO
+
+   END SUBROUTINE kp_diag_job
+
+! **************************************************************************************************
+!> \brief Build the DIIS error for one k-point after the shared buffer has
+!>        already been allocated.  All products use local BLAS, so worker
+!>        threads never enter ScaLAPACK or MPI.
+!> \param ikp ...
+!> \param workspace ...
+!> \param matrix_ks ...
+!> \param matrix_s ...
+!> \param kpoints ...
+!> \param ib ...
+!> \param transform_plan ...
+!> \param xkp ...
+!> \param nspin ...
+! **************************************************************************************************
+   SUBROUTINE kp_diis_error_job_local(ikp, workspace, matrix_ks, matrix_s, kpoints, ib, &
+                                      transform_plan, xkp, nspin)
+
+      INTEGER, INTENT(IN)                                :: ikp
+      TYPE(kp_diag_omp_workspace_type), INTENT(INOUT)    :: workspace
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_ks, matrix_s
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      INTEGER, INTENT(IN)                                :: ib
+      TYPE(kp_transform_plan_type), INTENT(IN)           :: transform_plan
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
+      INTEGER, INTENT(IN)                                :: nspin
+
+      INTEGER                                            :: ispin
+      TYPE(kpoint_env_type), POINTER                     :: kp
+
+      kp => kpoints%kp_env(ikp)%kpoint_env
+      CALL kp_build_cfm(matrix_s, 1, xkp(1:3, ikp), transform_plan, &
+                        workspace%csmat_base)
+      DO ispin = 1, nspin
+         CALL kp_build_cfm(matrix_ks, ispin, xkp(1:3, ikp), transform_plan, &
+                           workspace%cksmat)
+         CALL cp_cfm_to_cfm(workspace%csmat_base, workspace%csmat)
+         CALL kp_diis_calc_err_local(kpoints, kp, workspace, ib, ispin, ikp)
+      END DO
+
+   END SUBROUTINE kp_diis_error_job_local
+
+! **************************************************************************************************
+!> \brief Local-BLAS equivalent of qs_diis_b_calc_err_kp for an allocated buffer.
+!> \param kpoints ...
+!> \param kp ...
+!> \param workspace ...
+!> \param ib ...
+!> \param ispin ...
+!> \param ikp ...
+! **************************************************************************************************
+   SUBROUTINE kp_diis_calc_err_local(kpoints, kp, workspace, ib, ispin, ikp)
+
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(kpoint_env_type), POINTER                     :: kp
+      TYPE(kp_diag_omp_workspace_type), INTENT(INOUT)    :: workspace
+      INTEGER, INTENT(IN)                                :: ib, ispin, ikp
+
+      COMPLEX(KIND=dp), DIMENSION(:, :), POINTER         :: c, error, h, kc, s, sc
+      INTEGER                                            :: homo, nao, nmo
+      REAL(KIND=dp)                                      :: maxocc
+      REAL(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: ci, cr
+      TYPE(cp_fm_type), POINTER                          :: imos, rmos
+
+      CALL get_mo_set(kp%mos(1, ispin), nao=nao, nmo=nmo, homo=homo, &
+                      mo_coeff=rmos, maxocc=maxocc)
+      CALL get_mo_set(kp%mos(2, ispin), mo_coeff=imos)
+      CALL cp_fm_get_info(rmos, local_data=cr)
+      CALL cp_fm_get_info(imos, local_data=ci)
+
+      c => workspace%cmos%local_data
+      c(1:nao, 1:nmo) = CMPLX(cr(1:nao, 1:nmo), ci(1:nao, 1:nmo), KIND=dp)
+
+      h => kpoints%scf_diis_buffer%param(ib, ispin, ikp)%local_data
+      s => kpoints%scf_diis_buffer%smat(ikp)%local_data
+      h(:, :) = workspace%cksmat%local_data(:, :)
+      s(:, :) = workspace%csmat%local_data(:, :)
+
+      kc => workspace%cksmat%local_data
+      sc => workspace%csmat%local_data
+      CALL zgemm('N', 'N', nao, homo, nao, CMPLX(maxocc, 0.0_dp, KIND=dp), &
+                 h(1, 1), SIZE(h, 1), c(1, 1), SIZE(c, 1), z_zero, kc(1, 1), SIZE(kc, 1))
+      CALL zgemm('N', 'N', nao, homo, nao, CMPLX(2.0_dp, 0.0_dp, KIND=dp), &
+                 s(1, 1), SIZE(s, 1), c(1, 1), SIZE(c, 1), z_zero, sc(1, 1), SIZE(sc, 1))
+
+      error => kpoints%scf_diis_buffer%error(ib, ispin, ikp)%local_data
+      CALL zgemm('N', 'T', nao, nao, homo, z_one, sc(1, 1), SIZE(sc, 1), &
+                 kc(1, 1), SIZE(kc, 1), z_zero, error(1, 1), SIZE(error, 1))
+      CALL zgemm('N', 'T', nao, nao, homo, z_one, kc(1, 1), SIZE(kc, 1), &
+                 sc(1, 1), SIZE(sc, 1), -z_one, error(1, 1), SIZE(error, 1))
+
+   END SUBROUTINE kp_diis_calc_err_local
+
+! **************************************************************************************************
+!> \brief Form the DIIS Hamiltonian and diagonalize one k-point.
+!> \param ikp ...
+!> \param workspace ...
+!> \param kpoints ...
+!> \param coeffs ...
+!> \param nb ...
+!> \param scf_env ...
+!> \param scf_control ...
+!> \param nspin ...
+! **************************************************************************************************
+   SUBROUTINE kp_diis_diag_job(ikp, workspace, kpoints, coeffs, nb, scf_env, scf_control, nspin)
+
+      INTEGER, INTENT(IN)                                :: ikp
+      TYPE(kp_diag_omp_workspace_type), INTENT(INOUT)    :: workspace
+      TYPE(kpoint_type), POINTER                         :: kpoints
+      COMPLEX(KIND=dp), DIMENSION(:), INTENT(IN)         :: coeffs
+      INTEGER, INTENT(IN)                                :: nb
+      TYPE(qs_scf_env_type), POINTER                     :: scf_env
+      TYPE(scf_control_type), POINTER                    :: scf_control
+      INTEGER, INTENT(IN)                                :: nspin
+
+      INTEGER                                            :: ispin, jb
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues
+      TYPE(cp_fm_type), POINTER                          :: imos, rmos
+      TYPE(kpoint_env_type), POINTER                     :: kp
+
+      kp => kpoints%kp_env(ikp)%kpoint_env
+      DO ispin = 1, nspin
+         CALL cp_cfm_to_cfm(kpoints%scf_diis_buffer%smat(ikp), workspace%csmat)
+         CALL cp_cfm_set_all(workspace%cksmat, z_zero)
+         DO jb = 1, nb
+            CALL cp_cfm_scale_and_add(z_one, workspace%cksmat, coeffs(jb), &
+                                      kpoints%scf_diis_buffer%param(jb, ispin, ikp))
+         END DO
+         CALL get_mo_set(kp%mos(1, ispin), mo_coeff=rmos, eigenvalues=eigenvalues)
+         CALL get_mo_set(kp%mos(2, ispin), mo_coeff=imos)
+         IF (scf_env%cholesky_method == cholesky_off) THEN
+            CALL cp_cfm_geeig_canon_local(workspace%cksmat, workspace%csmat, workspace%cmos, &
+                                          eigenvalues, workspace%cwork, scf_control%eps_eigval)
+         ELSE
+            CALL cp_cfm_geeig_local(workspace%cksmat, workspace%csmat, workspace%cmos, eigenvalues)
+         END IF
+         kp%mos(2, ispin)%eigenvalues = eigenvalues
+         CALL cp_cfm_to_fm(workspace%cmos, rmos, imos)
+      END DO
+
+   END SUBROUTINE kp_diis_diag_job
 
 ! **************************************************************************************************
 !> \brief Kpoint diagonalization routine


### PR DESCRIPTION
This PR adds an OpenMP-parallel path for Quickstep k-point SCF calculations when CP2K is run with a single MPI rank.

Previously, the k-points handled by `do_general_diag_kp` and the subsequent density-matrix construction were processed mostly sequentially, even when multiple OpenMP threads were available. This left most CPU cores idle during a significant part of k-point calculations.

The new path parallelizes the independent `(k-point, spin)` work across OpenMP threads, including:

- the real-space to k-point transformation of the Hamiltonian and overlap matrices;
- local generalized diagonalization;
- k-point DIIS error construction and the diagonalization after mixing;
- construction of the k-point density matrices;
- the k-point to real-space density transformation; and
- symmetry transformations of the density matrices.

Each worker uses private dense matrices and scratch buffers. Immutable traversal plans are constructed before entering the parallel regions, and the real-space density transformation assigns each output block to a single thread to avoid data races and false sharing.

Hybrid MPI+OpenMP optimzation cannot work because of [`MPI_THREAD_SERIALIZED`](https://github.com/cp2k/cp2k/blob/2823083452d26bf0e93751c57ae6cbdd3f8ace63/src/mpiwrap/message_passing.F#L1139), so OpenMP workers do not enter MPI or ScaLAPACK. For diagonalization, the single-rank path uses local LAPACK and BLAS routines instead of invoking ScaLAPACK concurrently.