### PR TITLE
Declare NNP OpenMP data sharing

### DIFF
--- a/src/nnp_force.F
+++ b/src/nnp_force.F
@@ -177,7 +177,9 @@ CONTAINS
       ! my_force_t/my_cstress_t. SCHEDULE(STATIC) hands out contiguous atom
       ! blocks in thread order, so the ordered sum over threads after the
       ! region reproduces the serial summation order exactly.
-      !$OMP PARALLEL DEFAULT(SHARED) &
+      !$OMP PARALLEL DEFAULT(NONE) &
+      !$OMP          SHARED(calc_forces, calc_stress, istart, max_input_nodes, mecalc, &
+      !$OMP                 my_cstress_t, my_force_t, nnp) &
       !$OMP          PRIVATE(i, i_com, ind, ie, il, j, n_input_nodes, tid, my_arc, denergydsym, stress)
 
       tid = 1


### PR DESCRIPTION
# Summary

The atom-loop OpenMP region introduced by #5747 used `DEFAULT(SHARED)`, which violates CP2K convention C006 and made both convention dashboard testers fail.

Use `DEFAULT(NONE)` and explicitly declare the region shared data. The existing private list remains unchanged, so this is a scoping declaration rather than a behavioral change.

# Validation

- `./make_pretty.sh`
- `git diff --check`
- GNU 13 `ssmp` build on current master
- `NNP/regtest-1/H2O_C-NNP_MD.inp` with 1, 2, and 4 OpenMP threads; all three produced the unchanged final potential energy `0.586488095231E+02`
