### PR TITLE
Stabilize open-shell OH reference SCF

### DIFF
--- a/tests/QS/regtest-gauxc-gpw-mol/OH_NATIVE_GPW_PBE_UKS_REFERENCE.inp
+++ b/tests/QS/regtest-gauxc-gpw-mol/OH_NATIVE_GPW_PBE_UKS_REFERENCE.inp
@@ -24,14 +24,13 @@
       METHOD GPW
     &END QS
     &SCF
-      EPS_SCF 1.0E-3
+      EPS_SCF 1.0E-5
       MAX_SCF 80
       SCF_GUESS ATOMIC
-      &DIAGONALIZATION
-      &END DIAGONALIZATION
-      &MIXING
-        ALPHA 0.4
-      &END MIXING
+      &OT
+        MINIMIZER CG
+        PRECONDITIONER FULL_SINGLE_INVERSE
+      &END OT
     &END SCF
     &XC
       &XC_FUNCTIONAL

--- a/tests/QS/regtest-gauxc-gpw-mol/TEST_FILES.toml
+++ b/tests/QS/regtest-gauxc-gpw-mol/TEST_FILES.toml
@@ -3,7 +3,7 @@
 "H2O_NATIVE_SKALA_GPW.inp"     = [{matcher="E_total", tol=5e-6,  ref=-17.06733788},
                                   {matcher="SKALA_GPW_feature_electrons", tol=1e-8, ref=8.00008704097},
                                   {matcher="SKALA_GPW_feature_spin_moment", tol=1e-12, ref=0.0}]
-"OH_NATIVE_GPW_PBE_UKS_REFERENCE.inp" = [{matcher="E_total", tol=7e-6, ref=-16.524536848018680}]
+"OH_NATIVE_GPW_PBE_UKS_REFERENCE.inp" = [{matcher="E_total", tol=7e-6, ref=-16.525600111988442}]
 "OH_NATIVE_SKALA_GPW_UKS.inp"  = [{matcher="E_total", tol=5e-6,  ref=-16.4080654},
                                   {matcher="SKALA_GPW_feature_electrons", tol=1e-8, ref=7.00008702590},
                                   {matcher="SKALA_GPW_feature_spin_moment", tol=1e-8, ref=1.00001243227}]


### PR DESCRIPTION
# Summary

The Eiger `ssmp` dashboard selected `-16.52560011529644 Ha` for `OH_NATIVE_GPW_PBE_UKS_REFERENCE.inp`, while the test expected the higher-energy `-16.524536848018680 Ha` solution. The existing diagonalization SCF stops at `EPS_SCF 1e-3` and is sensitive to threaded reductions near that loose stopping point.

Use OT/CG with `FULL_SINGLE_INVERSE` and tighten `EPS_SCF` to `1e-5`. This consistently reaches the lower-energy state. Update the reference to that converged state while keeping the existing `7e-6` matcher tolerance unchanged.

# Validation

- GNU 13 `ssmp` build on current master
- Three runs each with 1, 2, and 4 OpenMP threads
- all nine OT runs converged to `-16.5256001119885 Ha` within about `6e-14 Ha`
- the failed Eiger result differs from the new reference by only about `3.3e-9 Ha`
- runtime of the focused test remained small: about `4.7 s` with one thread
- `./make_pretty.sh`
- `git diff --check`

## Current CI status

After #5810 and #5803 were merged, this branch was rebased onto current `master`. A fresh CSCS Eiger `ssmp` run passed all 5854 tests. The changed target test produced `-16.52560011 Ha` and completed successfully in 7.34 s, confirming that the earlier red jobs were caused by the now-merged GFN2 and RTP failures rather than this patch.
