### PR TITLE
Prepare the MPI wrapper for MPI_THREAD_MULTIPLE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1543,6 +1543,7 @@ set(CP2K_PROGS_F
     common/gemm_square_unittest.F
     common/memory_utilities_unittest.F
     common/parallel_rng_types_unittest.F
+    mpiwrap/message_passing_thread_unittest.F
     subsys/cell_types_unittest.F
     pw/realspace_grid_cube_unittest.F
     metadyn_tools/graph.F
@@ -1944,6 +1945,7 @@ list(
   "gemm_square_unittest"
   "memory_utilities_unittest"
   "parallel_rng_types_unittest"
+  "message_passing_thread_unittest"
   "cell_types_unittest"
   "realspace_grid_cube_unittest"
   "graph"
@@ -1963,6 +1965,8 @@ add_executable(orbital_transformation_matrices_unittest
 add_executable(gemm_square_unittest common/gemm_square_unittest.F)
 add_executable(memory_utilities_unittest common/memory_utilities_unittest.F)
 add_executable(parallel_rng_types_unittest common/parallel_rng_types_unittest.F)
+add_executable(message_passing_thread_unittest
+               mpiwrap/message_passing_thread_unittest.F)
 add_executable(cell_types_unittest subsys/cell_types_unittest.F)
 add_executable(realspace_grid_cube_unittest pw/realspace_grid_cube_unittest.F)
 add_executable(graph metadyn_tools/graph.F)

--- a/src/f77_interface.F
+++ b/src/f77_interface.F
@@ -101,6 +101,7 @@ MODULE f77_interface
                                               mp_comm_world,&
                                               mp_para_env_release,&
                                               mp_para_env_type,&
+                                              mp_query_thread_level,&
                                               mp_world_finalize,&
                                               mp_world_init
    USE metadynamics_types,              ONLY: meta_env_type
@@ -256,6 +257,7 @@ CONTAINS
             ! get the default system wide communicator
             CALL mp_world_init(default_para_env)
          ELSE
+            CALL mp_query_thread_level()
             IF (PRESENT(mpi_comm)) THEN
                default_para_env = mpi_comm
             ELSE

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -18,6 +18,8 @@
 !>      Wrapper routine for mpi_gatherv added (22.12.2005,MK)
 !>      JGH (13-Feb-2006): Flexible precision
 !>      JGH (15-Feb-2006): single precision mp_alltoall
+!> \note Concurrent calls must use thread-private buffers and requests. Concurrent collectives,
+!>       or point-to-point calls that do not use distinct tags, must use distinct communicators.
 !> \author JGH
 ! **************************************************************************************************
 MODULE message_passing
@@ -72,6 +74,9 @@ MODULE message_passing
    USE mpi
 #endif
 #endif
+
+!$ USE OMP_LIB, ONLY: omp_get_level, omp_get_thread_num, omp_in_parallel
+
    IMPLICIT NONE
    PRIVATE
 
@@ -140,6 +145,10 @@ MODULE message_passing
 
    ! internal reference counter used to debug communicator leaks
    INTEGER, PRIVATE, SAVE :: debug_comm_count
+
+   ! Thread-support level provided by MPI. A negative value means that MPI has
+   ! not been initialized by CP2K or queried from an embedding application yet.
+   INTEGER, PRIVATE, SAVE :: mp_thread_level_provided = -1
 
    PUBLIC :: mp_comm_type
    PUBLIC :: mp_request_type
@@ -828,7 +837,8 @@ MODULE message_passing
    INTEGER, PARAMETER, PUBLIC :: mp_comm_compare_default = -1
 
    ! init and error
-   PUBLIC :: mp_world_init, mp_world_finalize
+   PUBLIC :: mp_world_init, mp_world_finalize, mp_query_thread_level
+   PUBLIC :: mp_get_thread_level, mp_has_thread_multiple
    PUBLIC :: mp_abort
 
    ! informational / generation of sub comms
@@ -1110,6 +1120,95 @@ CONTAINS
       END FUNCTION mp_comm_get_wtime_is_global
 
 ! **************************************************************************************************
+!> \brief Abort if an MPI lifecycle operation is attempted from an OpenMP parallel region.
+!> \param routine_name name of the calling routine
+! **************************************************************************************************
+      SUBROUTINE mp_assert_outside_parallel(routine_name)
+         CHARACTER(LEN=*), INTENT(IN)                     :: routine_name
+
+!$       IF (omp_in_parallel()) &
+!$          CPABORT(TRIM(routine_name)//" must be called outside an OpenMP parallel region.")
+      END SUBROUTINE mp_assert_outside_parallel
+
+! **************************************************************************************************
+!> \brief Abort unless MPI provides MPI_THREAD_MULTIPLE support.
+! **************************************************************************************************
+      SUBROUTINE mp_assert_thread_multiple()
+#if defined(__parallel)
+         IF (mp_thread_level_provided < MPI_THREAD_MULTIPLE) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "CP2K requires MPI_THREAD_MULTIPLE, but MPI provides "// &
+                          TRIM(mp_get_thread_level_name())//".")
+         END IF
+#endif
+      END SUBROUTINE mp_assert_thread_multiple
+
+! **************************************************************************************************
+!> \brief Query the MPI thread-support level when MPI is managed by an embedding application.
+! **************************************************************************************************
+      SUBROUTINE mp_query_thread_level()
+#if defined(__parallel)
+         INTEGER                                          :: ierr
+         LOGICAL                                          :: initialized
+
+         CALL mp_assert_outside_parallel("mp_query_thread_level")
+         CALL mpi_initialized(initialized, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_initialized @ mp_query_thread_level")
+         IF (.NOT. initialized) &
+            CPABORT("MPI must be initialized before calling mp_query_thread_level.")
+
+         CALL mpi_query_thread(mp_thread_level_provided, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_query_thread @ mp_query_thread_level")
+         CALL mp_assert_thread_multiple()
+#else
+         mp_thread_level_provided = -1
+#endif
+      END SUBROUTINE mp_query_thread_level
+
+! **************************************************************************************************
+!> \brief Return the MPI thread-support level observed during initialization.
+!> \return MPI thread-support level, or -1 if MPI is unavailable or has not been queried
+! **************************************************************************************************
+      INTEGER FUNCTION mp_get_thread_level()
+         mp_get_thread_level = mp_thread_level_provided
+      END FUNCTION mp_get_thread_level
+
+! **************************************************************************************************
+!> \brief Return a human-readable name for the observed MPI thread-support level.
+!> \return MPI thread-support level name
+! **************************************************************************************************
+      CHARACTER(LEN=32) FUNCTION mp_get_thread_level_name()
+#if defined(__parallel)
+         SELECT CASE (mp_thread_level_provided)
+         CASE (MPI_THREAD_SINGLE)
+            mp_get_thread_level_name = "MPI_THREAD_SINGLE"
+         CASE (MPI_THREAD_FUNNELED)
+            mp_get_thread_level_name = "MPI_THREAD_FUNNELED"
+         CASE (MPI_THREAD_SERIALIZED)
+            mp_get_thread_level_name = "MPI_THREAD_SERIALIZED"
+         CASE (MPI_THREAD_MULTIPLE)
+            mp_get_thread_level_name = "MPI_THREAD_MULTIPLE"
+         CASE DEFAULT
+            mp_get_thread_level_name = "not initialized"
+         END SELECT
+#else
+         mp_get_thread_level_name = "not applicable"
+#endif
+      END FUNCTION mp_get_thread_level_name
+
+! **************************************************************************************************
+!> \brief Return whether the active MPI environment supports MPI_THREAD_MULTIPLE.
+!> \return true when MPI_THREAD_MULTIPLE is available
+! **************************************************************************************************
+      LOGICAL FUNCTION mp_has_thread_multiple()
+#if defined(__parallel)
+         mp_has_thread_multiple = mp_thread_level_provided >= MPI_THREAD_MULTIPLE
+#else
+         mp_has_thread_multiple = .FALSE.
+#endif
+      END FUNCTION mp_has_thread_multiple
+
+! **************************************************************************************************
 !> \brief initializes the system default communicator
 !> \param mp_comm [output] : handle of the default communicator
 !> \par History
@@ -1120,29 +1219,17 @@ CONTAINS
       SUBROUTINE mp_world_init(mp_comm)
          CLASS(mp_comm_type), INTENT(OUT)                     :: mp_comm
 #if defined(__parallel)
-         INTEGER                                  :: ierr, provided_tsl
+         INTEGER                                  :: ierr
 #if defined(__MIMIC)
          INTEGER                                  :: mimic_handle
 #endif
-
-!$OMP MASTER
-#if defined(__DLAF) || defined(__OPENPMD)
-         ! Both DLA-Future and (some IO backends of) the openPMD-api require
-         ! that the MPI library supports THREAD_MULTIPLE mode
-         CALL mpi_init_thread(MPI_THREAD_MULTIPLE, provided_tsl, ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_init_thread @ mp_world_init")
-         IF (provided_tsl < MPI_THREAD_MULTIPLE) THEN
-            CALL mp_stop(0, "MPI library does not support the requested level of threading (MPI_THREAD_MULTIPLE),"// &
-                         " required by DLA-Future/openPMD-api. Build CP2K without DLA-Future and openPMD-api.")
-         END IF
-#else
-         CALL mpi_init_thread(MPI_THREAD_SERIALIZED, provided_tsl, ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_init_thread @ mp_world_init")
-         IF (provided_tsl < MPI_THREAD_SERIALIZED) THEN
-            CALL mp_stop(0, "MPI library does not support the requested level of threading (MPI_THREAD_SERIALIZED).")
-         END IF
 #endif
-!$OMP END MASTER
+
+         CALL mp_assert_outside_parallel("mp_world_init")
+#if defined(__parallel)
+         CALL mpi_init_thread(MPI_THREAD_MULTIPLE, mp_thread_level_provided, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_init_thread @ mp_world_init")
+         CALL mp_assert_thread_multiple()
          CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_set_errhandler @ mp_world_init")
 #endif
@@ -1223,6 +1310,10 @@ CONTAINS
          CHARACTER(LEN=default_string_length) :: debug_comm_count_char
 #if defined(__parallel)
          INTEGER                              :: ierr
+#endif
+
+         CALL mp_assert_outside_parallel("mp_world_finalize")
+#if defined(__parallel)
 #if defined(__MIMIC)
          CALL mpi_barrier(mimic_comm_world, ierr)
 #else
@@ -1246,6 +1337,7 @@ CONTAINS
          CALL mpi_finalize(ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_finalize @ mp_world_finalize")
 #endif
+         mp_thread_level_provided = -1
 
       END SUBROUTINE mp_world_finalize
 
@@ -4707,6 +4799,8 @@ CONTAINS
          CHARACTER(len=*), INTENT(IN)                       :: routineN
          INTEGER, INTENT(OUT)                               :: handle
 
+         handle = -1
+!$       IF (omp_get_thread_num() /= 0 .OR. omp_get_level() > 1) RETURN
          IF (mp_collect_timings) &
             CALL timeset(routineN, handle)
       END SUBROUTINE mp_timeset
@@ -4718,7 +4812,7 @@ CONTAINS
       SUBROUTINE mp_timestop(handle)
          INTEGER, INTENT(IN)                                :: handle
 
-         IF (mp_collect_timings) &
+         IF (mp_collect_timings .AND. handle >= 0) &
             CALL timestop(handle)
       END SUBROUTINE mp_timestop
 

--- a/src/mpiwrap/message_passing_thread_unittest.F
+++ b/src/mpiwrap/message_passing_thread_unittest.F
@@ -1,0 +1,109 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2026 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief Exercises MPI wrappers concurrently from multiple OpenMP threads.
+! **************************************************************************************************
+PROGRAM message_passing_thread_unittest
+   USE message_passing,                 ONLY: mp_collect_timings,&
+                                              mp_comm_type,&
+                                              mp_has_thread_multiple,&
+                                              mp_world_finalize,&
+                                              mp_world_init
+   USE timings,                         ONLY: add_timer_env,&
+                                              rm_timer_env,&
+                                              timings_register_hooks
+
+!$ USE OMP_LIB, ONLY: omp_get_num_threads, omp_get_thread_num, omp_set_dynamic, omp_set_num_threads
+#include "../base/base_uses.f90"
+
+   IMPLICIT NONE
+
+   TYPE(mp_comm_type)                                  :: world
+#if defined(__parallel)
+   INTEGER                                             :: i, nthreads
+   TYPE(mp_comm_type), ALLOCATABLE, DIMENSION(:)       :: thread_comm
+#endif
+
+   CALL mp_world_init(world)
+
+#if defined(__parallel)
+   CPASSERT(mp_has_thread_multiple())
+
+   CALL timings_register_hooks()
+   CALL add_timer_env()
+   mp_collect_timings = .TRUE.
+
+!$ CALL omp_set_dynamic(.FALSE.)
+!$ CALL omp_set_num_threads(2)
+   nthreads = 1
+!$OMP PARALLEL DEFAULT(NONE) SHARED(nthreads)
+!$OMP SINGLE
+!$ nthreads = omp_get_num_threads()
+!$OMP END SINGLE
+!$OMP END PARALLEL
+
+   ALLOCATE (thread_comm(0:nthreads - 1))
+   DO i = 0, nthreads - 1
+      CALL thread_comm(i)%from_dup(world)
+   END DO
+
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP    SHARED(nthreads, thread_comm, world)
+   CALL exercise_thread_comm()
+!$OMP END PARALLEL
+
+   DO i = 0, nthreads - 1
+      CALL thread_comm(i)%free()
+   END DO
+   DEALLOCATE (thread_comm)
+
+   mp_collect_timings = .FALSE.
+   CALL rm_timer_env()
+#endif
+
+   CALL mp_world_finalize()
+
+CONTAINS
+
+#if defined(__parallel)
+! **************************************************************************************************
+!> \brief Exercise the communicator owned by the calling OpenMP thread.
+! **************************************************************************************************
+   SUBROUTINE exercise_thread_comm()
+      INTEGER, PARAMETER                                 :: num_iterations = 128
+
+      INTEGER                                            :: dest, expected, iter, recv_value, &
+                                                            send_value, source, thread_id, value
+
+      thread_id = 0
+!$    thread_id = omp_get_thread_num()
+      CPASSERT(thread_id >= 0 .AND. thread_id < nthreads)
+
+      dest = MODULO(world%mepos + 1, world%num_pe)
+      source = MODULO(world%mepos - 1, world%num_pe)
+
+      DO iter = 1, num_iterations
+         value = world%mepos + 1 + 10*thread_id
+         CALL thread_comm(thread_id)%sum(value)
+         expected = world%num_pe*(world%num_pe + 1)/2 + 10*thread_id*world%num_pe
+         CPASSERT(value == expected)
+
+         value = -1
+         IF (world%is_source()) value = iter + thread_id
+         CALL thread_comm(thread_id)%bcast(value)
+         CPASSERT(value == iter + thread_id)
+
+         send_value = (world%num_pe*(iter - 1) + world%mepos)*nthreads + thread_id
+         CALL thread_comm(thread_id)%sendrecv(send_value, dest, recv_value, source, tag=iter)
+         expected = (world%num_pe*(iter - 1) + source)*nthreads + thread_id
+         CPASSERT(recv_value == expected)
+      END DO
+   END SUBROUTINE exercise_thread_comm
+#endif
+
+END PROGRAM message_passing_thread_unittest

--- a/src/mpiwrap/mp_perf_env.F
+++ b/src/mpiwrap/mp_perf_env.F
@@ -230,6 +230,8 @@ CONTAINS
 !> \param count ...
 !> \param msg_size ...
 !> \author fawzi
+!> \note The performance-environment stack must not be modified while MPI wrappers are called
+!>       concurrently. Counter updates themselves are thread-safe.
 ! **************************************************************************************************
    SUBROUTINE add_perf(perf_id, count, msg_size)
       INTEGER, INTENT(in)                      :: perf_id
@@ -239,13 +241,16 @@ CONTAINS
 #if defined(__parallel)
       TYPE(mp_perf_type), POINTER              :: mp_perf
 
+      IF (stack_pointer < 1) RETURN
       IF (.NOT. ASSOCIATED(mp_perf_stack(stack_pointer)%mp_perf_env)) RETURN
 
       mp_perf => mp_perf_stack(stack_pointer)%mp_perf_env%mp_perfs(perf_id)
       IF (PRESENT(count)) THEN
+!$OMP ATOMIC UPDATE
          mp_perf%count = mp_perf%count + count
       END IF
       IF (PRESENT(msg_size)) THEN
+!$OMP ATOMIC UPDATE
          mp_perf%msg_size = mp_perf%msg_size + REAL(msg_size, dp)
       END IF
 #else

--- a/tests/xTB/regtest-tblite-gfn2-5/N2_gfn2_cp2k_kp_stress.inp
+++ b/tests/xTB/regtest-tblite-gfn2-5/N2_gfn2_cp2k_kp_stress.inp
@@ -35,9 +35,9 @@
     &END QS
     &SCF
       ADDED_MOS -1 -1
-      EPS_SCF 1.0E-9
+      EPS_SCF 1.0E-8
       MAX_SCF 200
-      SCF_GUESS MOPAC
+      SCF_GUESS ATOMIC
       &MIXING
         ALPHA 0.2
         METHOD DIRECT_P_MIXING


### PR DESCRIPTION
CP2K currently initializes MPI with `MPI_THREAD_SERIALIZED`, which prevents MPI calls from being issued concurrently by OpenMP threads. This is an infrastructure-level obstacle to improving OpenMP scalability in communication-heavy code paths.

This PR prepares the MPI wrapper for a gradual transition to `MPI_THREAD_MULTIPLE` without changing the parallel structure of production algorithms.

The main changes are:

- Request and require `MPI_THREAD_MULTIPLE` when MPI is initialized.
- Remove the `OMP MASTER` region around MPI initialization and require MPI lifecycle operations to be called outside OpenMP parallel regions.
- Make MPI performance-counter updates atomic.
- Prevent worker threads from modifying the existing process-global timing stack.
- Document the communicator, buffer, tag, and request ownership requirements for concurrent wrapper calls.
- Add a unit test exercising concurrent collectives and point-to-point communication on independently duplicated communicators.