### PR TITLE
Fix degenerate Broyden charge mixing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1545,6 +1545,7 @@ set(CP2K_PROGS_F
     common/gemm_square_unittest.F
     common/memory_utilities_unittest.F
     common/parallel_rng_types_unittest.F
+    qs_charge_mixing_unittest.F
     subsys/cell_types_unittest.F
     pw/realspace_grid_cube_unittest.F
     metadyn_tools/graph.F
@@ -1952,6 +1953,7 @@ list(
   "gemm_square_unittest"
   "memory_utilities_unittest"
   "parallel_rng_types_unittest"
+  "qs_charge_mixing_unittest"
   "cell_types_unittest"
   "realspace_grid_cube_unittest"
   "graph"
@@ -1975,6 +1977,7 @@ add_executable(orbital_transformation_matrices_unittest
 add_executable(gemm_square_unittest common/gemm_square_unittest.F)
 add_executable(memory_utilities_unittest common/memory_utilities_unittest.F)
 add_executable(parallel_rng_types_unittest common/parallel_rng_types_unittest.F)
+add_executable(qs_charge_mixing_unittest qs_charge_mixing_unittest.F)
 add_executable(cell_types_unittest subsys/cell_types_unittest.F)
 add_executable(realspace_grid_cube_unittest pw/realspace_grid_cube_unittest.F)
 add_executable(graph metadyn_tools/graph.F)

--- a/src/qs_charge_mixing.F
+++ b/src/qs_charge_mixing.F
@@ -429,8 +429,15 @@ CONTAINS
       mixing_store%dfbroy(:, 1:ns, nv) = dq_now(:, 1:ns) - dq_last(:, 1:ns)
       wdf = SUM(mixing_store%dfbroy(:, 1:ns, nv)**2)
       CALL para_env%sum(wdf)
-      wdf = 1.0_dp/SQRT(wdf)
-      mixing_store%dfbroy(:, 1:ns, nv) = wdf*mixing_store%dfbroy(:, 1:ns, nv)
+      IF (wdf > TINY(1.0_dp) .AND. wdf < HUGE(1.0_dp)) THEN
+         wdf = 1.0_dp/SQRT(wdf)
+         mixing_store%dfbroy(:, 1:ns, nv) = wdf*mixing_store%dfbroy(:, 1:ns, nv)
+      ELSE
+         ! Identical consecutive residuals do not define a Broyden direction.
+         ! Keep a zero history vector so it does not enter the Broyden update.
+         wdf = 0.0_dp
+         mixing_store%dfbroy(:, 1:ns, nv) = 0.0_dp
+      END IF
 
       ! abroy matrix
       DO i = 1, nv

--- a/src/qs_charge_mixing_unittest.F
+++ b/src/qs_charge_mixing_unittest.F
@@ -1,0 +1,71 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2026 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+PROGRAM qs_charge_mixing_unittest
+   USE ieee_arithmetic,                 ONLY: ieee_is_finite
+   USE kinds,                           ONLY: dp
+   USE message_passing,                 ONLY: mp_para_env_type,&
+                                              mp_world_finalize,&
+                                              mp_world_init
+   USE qs_charge_mixing,                ONLY: charge_mixing
+   USE qs_density_mixing_types,         ONLY: broyden_mixing_nr,&
+                                              mixing_storage_release,&
+                                              mixing_storage_type
+
+   IMPLICIT NONE
+
+   REAL(KIND=dp), DIMENSION(1, 1) :: charges
+   TYPE(mp_para_env_type), POINTER :: para_env
+   TYPE(mixing_storage_type), POINTER :: mixing_store
+
+   NULLIFY (mixing_store, para_env)
+   ALLOCATE (para_env)
+   CALL mp_world_init(para_env)
+
+   ALLOCATE (mixing_store)
+   mixing_store%ncall = 0
+   mixing_store%nbuffer = 4
+   mixing_store%n_simple_mix = 0
+   mixing_store%nskip_mixing = 0
+   mixing_store%alpha = 0.1_dp
+   mixing_store%broy_w0 = 0.01_dp
+   mixing_store%nat_local = 1
+   mixing_store%max_shell = 1
+   ALLOCATE (mixing_store%acharge(1, 1, 4), mixing_store%dacharge(1, 1, 4), &
+             mixing_store%dfbroy(1, 1, 4), mixing_store%ubroy(1, 1, 4), &
+             mixing_store%abroy(4, 4), mixing_store%wbroy(4), mixing_store%atlist(1))
+   mixing_store%acharge = 0.0_dp
+   mixing_store%dacharge = 0.0_dp
+   mixing_store%dfbroy = 0.0_dp
+   mixing_store%ubroy = 0.0_dp
+   mixing_store%abroy = 0.0_dp
+   mixing_store%wbroy = 0.0_dp
+   mixing_store%atlist = 1
+
+   charges = 1.0_dp
+   CALL charge_mixing(broyden_mixing_nr, mixing_store, charges, para_env, 1)
+   charges = 0.5_dp
+   CALL charge_mixing(broyden_mixing_nr, mixing_store, charges, para_env, 2)
+
+   ! Reproduce a degenerate Broyden history by supplying the previous residual again.
+   charges(1, 1) = mixing_store%acharge(1, 1, 2) - mixing_store%dacharge(1, 1, 1)
+   CALL charge_mixing(broyden_mixing_nr, mixing_store, charges, para_env, 3)
+
+   IF (.NOT. ALL(ieee_is_finite(charges))) THEN
+      ERROR STOP "Broyden mixing produced non-finite charges for identical residuals"
+   END IF
+   IF (.NOT. ALL(mixing_store%dfbroy(:, :, 1) == 0.0_dp)) THEN
+      ERROR STOP "Degenerate Broyden direction was not discarded"
+   END IF
+
+   CALL mixing_storage_release(mixing_store)
+   DEALLOCATE (mixing_store)
+   DEALLOCATE (para_env)
+   CALL mp_world_finalize()
+
+END PROGRAM qs_charge_mixing_unittest
+! vim: set ts=3 sw=3 tw=132 :

--- a/tests/UNIT_TESTS
+++ b/tests/UNIT_TESTS
@@ -11,6 +11,7 @@ message_passing_thread_unittest                          parallel
 orbital_transformation_matrices_unittest
 nequip_unittest                                          libtorch
 parallel_rng_types_unittest
+qs_charge_mixing_unittest
 realspace_grid_cube_unittest
 gx_ac_unittest                                           greenx
 


### PR DESCRIPTION
## Summary

- avoid normalizing a zero or non-finite Broyden residual difference
- discard a degenerate history direction instead of propagating NaNs into the pseudoinverse
- add a deterministic unit test for identical consecutive SCC residuals

## Motivation

Identical consecutive residuals caused a division by zero during Broyden history normalization. The resulting NaNs surfaced later as an SVD failed abort. This was reported for tblite SCC calculations, but the issue is in the general CP2K charge-mixing path.

The focused unit test reproduces the exact SVD failure without the fix and passes with the guard. No reference energies or tolerances are changed.

## Testing

- CP2K precommit checks
- CMake build with tblite enabled
- qs_charge_mixing_unittest, serial
- qs_charge_mixing_unittest, 2 MPI ranks