### PR TITLE
Unify MPI lifecycle handling for MPI_THREAD_MULTIPLE

### DIFF
--- a/src/grid/grid_unittest.c
+++ b/src/grid/grid_unittest.c
@@ -4,6 +4,7 @@
 /*                                                                            */
 /*  SPDX-License-Identifier: BSD-3-Clause                                     */
 /*----------------------------------------------------------------------------*/
+#include "../mpiwrap/cp_mpi.h"
 #include "../offload/offload_library.h"
 #include "../offload/offload_mempool.h"
 #include "common/grid_library.h"
@@ -12,11 +13,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-// Only used to call MPI_Init and MPI_Finalize to avoid spurious MPI error.
-#if defined(__parallel)
-#include <mpi.h>
-#endif
 
 /*******************************************************************************
  * \brief Wrapper for printf, passed to grid_library_print_stats.
@@ -64,12 +60,11 @@ static int run_test(const char cp2k_root_dir[], const char task_file[]) {
 }
 
 int main(int argc, char *argv[]) {
-#if defined(__parallel)
-  MPI_Init(&argc, &argv);
-#endif
+  cp_mpi_init(&argc, &argv);
 
   if (argc != 2) {
     printf("Usage: grid_unittest.x <cp2k-root-dir>\n");
+    cp_mpi_finalize();
     return 1;
   }
 
@@ -101,9 +96,7 @@ int main(int argc, char *argv[]) {
     printf("\nFound %i errors :-(\n", errors);
   }
 
-#if defined(__parallel)
-  MPI_Finalize();
-#endif
+  cp_mpi_finalize();
 
   return errors;
 }

--- a/src/mpiwrap/cp_mpi.c
+++ b/src/mpiwrap/cp_mpi.c
@@ -13,6 +13,9 @@
 #include <string.h>
 
 #if defined(__parallel)
+static bool mpi_initialized_by_cp2k = false;
+static bool mpi_attached_by_cp2k = false;
+
 /*******************************************************************************
  * \brief Check given MPI status and upon failure abort with a nice message.
  * \author Ole Schuett
@@ -25,15 +28,77 @@
       MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);                                 \
     }                                                                          \
   } while (0)
+
+/*******************************************************************************
+ * \brief Abort if an MPI lifecycle operation is called from a parallel region.
+ ******************************************************************************/
+static void assert_outside_parallel(const char *routine_name) {
+  if (omp_in_parallel()) {
+    fprintf(stderr, "%s must be called outside an OpenMP parallel region.\n",
+            routine_name);
+    abort();
+  }
+}
+
+/*******************************************************************************
+ * \brief Return a human-readable MPI thread-support level.
+ ******************************************************************************/
+static const char *thread_level_name(const int level) {
+  switch (level) {
+  case MPI_THREAD_SINGLE:
+    return "MPI_THREAD_SINGLE";
+  case MPI_THREAD_FUNNELED:
+    return "MPI_THREAD_FUNNELED";
+  case MPI_THREAD_SERIALIZED:
+    return "MPI_THREAD_SERIALIZED";
+  case MPI_THREAD_MULTIPLE:
+    return "MPI_THREAD_MULTIPLE";
+  default:
+    return "unknown";
+  }
+}
+
+/*******************************************************************************
+ * \brief Abort unless MPI provides MPI_THREAD_MULTIPLE support.
+ ******************************************************************************/
+static void require_thread_multiple(const int provided) {
+  if (provided < MPI_THREAD_MULTIPLE) {
+    fprintf(stderr, "CP2K requires MPI_THREAD_MULTIPLE, but MPI provides %s.\n",
+            thread_level_name(provided));
+    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    abort();
+  }
+}
 #endif
 
 /*******************************************************************************
- * \brief Wrapper around MPI_Init.
+ * \brief Initialize MPI with MPI_THREAD_MULTIPLE or attach to an active MPI.
  * \author Ole Schuett
  ******************************************************************************/
 void cp_mpi_init(int *argc, char ***argv) {
 #if defined(__parallel)
-  CHECK(MPI_Init(argc, argv));
+  assert_outside_parallel("cp_mpi_init");
+  if (mpi_attached_by_cp2k) {
+    fprintf(stderr, "cp_mpi_init must only be called once per lifecycle.\n");
+    abort();
+  }
+
+  int finalized, initialized, provided;
+  CHECK(MPI_Finalized(&finalized));
+  if (finalized) {
+    fprintf(stderr, "cp_mpi_init cannot be called after MPI_Finalize.\n");
+    abort();
+  }
+
+  CHECK(MPI_Initialized(&initialized));
+  if (initialized) {
+    CHECK(MPI_Query_thread(&provided));
+  } else {
+    CHECK(MPI_Init_thread(argc, argv, MPI_THREAD_MULTIPLE, &provided));
+    mpi_initialized_by_cp2k = true;
+  }
+  require_thread_multiple(provided);
+  mpi_attached_by_cp2k = true;
 #else
   (void)argc; // mark used
   (void)argv;
@@ -41,12 +106,28 @@ void cp_mpi_init(int *argc, char ***argv) {
 }
 
 /*******************************************************************************
- * \brief Wrapper around MPI_Finalize.
+ * \brief Detach from MPI and finalize it only if cp_mpi_init initialized it.
  * \author Ole Schuett
  ******************************************************************************/
 void cp_mpi_finalize(void) {
 #if defined(__parallel)
-  CHECK(MPI_Finalize());
+  assert_outside_parallel("cp_mpi_finalize");
+  if (!mpi_attached_by_cp2k) {
+    fprintf(stderr, "cp_mpi_finalize called without a matching cp_mpi_init.\n");
+    abort();
+  }
+
+  int finalized;
+  CHECK(MPI_Finalized(&finalized));
+  if (finalized) {
+    fprintf(stderr, "MPI was finalized before cp_mpi_finalize.\n");
+    abort();
+  }
+  if (mpi_initialized_by_cp2k) {
+    CHECK(MPI_Finalize());
+    mpi_initialized_by_cp2k = false;
+  }
+  mpi_attached_by_cp2k = false;
 #endif
 }
 
@@ -146,6 +227,7 @@ cp_mpi_comm_t cp_mpi_cart_create(const cp_mpi_comm_t comm_old, const int ndims,
                                  const int dims[], const int periods[],
                                  const int reorder) {
 #if defined(__parallel)
+  assert_outside_parallel("cp_mpi_cart_create");
   cp_mpi_comm_t comm_cart;
   CHECK(MPI_Cart_create(comm_old, ndims, dims, periods, reorder, &comm_cart));
   return comm_cart;
@@ -200,6 +282,7 @@ int cp_mpi_cart_rank(const cp_mpi_comm_t comm, const int coords[]) {
 cp_mpi_comm_t cp_mpi_cart_sub(const cp_mpi_comm_t comm,
                               const int remain_dims[]) {
 #if defined(__parallel)
+  assert_outside_parallel("cp_mpi_cart_sub");
   cp_mpi_comm_t newcomm;
   CHECK(MPI_Cart_sub(comm, remain_dims, &newcomm));
   return newcomm;
@@ -216,6 +299,7 @@ cp_mpi_comm_t cp_mpi_cart_sub(const cp_mpi_comm_t comm,
  ******************************************************************************/
 void cp_mpi_comm_free(cp_mpi_comm_t *comm) {
 #if defined(__parallel)
+  assert_outside_parallel("cp_mpi_comm_free");
   CHECK(MPI_Comm_free(comm));
 #else
   (void)comm; // mark used

--- a/src/mpiwrap/cp_mpi.h
+++ b/src/mpiwrap/cp_mpi.h
@@ -19,13 +19,18 @@ typedef int cp_mpi_comm_t;
 #endif
 
 /*******************************************************************************
- * \brief Wrapper around MPI_Init.
+ * \brief Initialize MPI with MPI_THREAD_MULTIPLE or attach to an active MPI.
+ *
+ * Must be called outside OpenMP parallel regions and paired with
+ * cp_mpi_finalize.
  * \author Ole Schuett
  ******************************************************************************/
 void cp_mpi_init(int *argc, char ***argv);
 
 /*******************************************************************************
- * \brief Wrapper around MPI_Finalize.
+ * \brief Detach from MPI and finalize it only if cp_mpi_init initialized it.
+ *
+ * Must be called outside OpenMP parallel regions.
  * \author Ole Schuett
  ******************************************************************************/
 void cp_mpi_finalize(void);

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -20,6 +20,8 @@
 !>      JGH (15-Feb-2006): single precision mp_alltoall
 !> \note Concurrent calls must use thread-private buffers and requests. Concurrent collectives,
 !>       or point-to-point calls that do not use distinct tags, must use distinct communicators.
+!>       Communicator creation, duplication, splitting, ownership changes, and destruction must
+!>       happen outside OpenMP parallel regions.
 !> \author JGH
 ! **************************************************************************************************
 MODULE message_passing
@@ -29,6 +31,7 @@ MODULE message_passing
       real_8_size, default_string_length
    USE machine, ONLY: m_abort
    USE mp_perf_env, ONLY: add_perf, add_mp_perf_env, rm_mp_perf_env
+   USE OMP_LIB, ONLY: omp_get_level, omp_get_thread_num, omp_in_parallel
 #if defined(__MIMIC)
    USE mcl, ONLY: mcl_initialize, mcl_is_initialized, mcl_abort
 #endif
@@ -74,8 +77,6 @@ MODULE message_passing
    USE mpi
 #endif
 #endif
-
-!$ USE OMP_LIB, ONLY: omp_get_level, omp_get_thread_num, omp_in_parallel
 
    IMPLICIT NONE
    PRIVATE
@@ -149,6 +150,13 @@ MODULE message_passing
    ! Thread-support level provided by MPI. A negative value means that MPI has
    ! not been initialized by CP2K or queried from an embedding application yet.
    INTEGER, PRIVATE, SAVE :: mp_thread_level_provided = -1
+
+   ! MPI can be initialized by CP2K or by an embedding application. Only the
+   ! component that initialized MPI is allowed to finalize it.
+#if defined(__parallel)
+   LOGICAL, PRIVATE, SAVE :: mp_mpi_initialized_by_cp2k = .FALSE.
+#endif
+   LOGICAL, PRIVATE, SAVE :: mp_world_is_initialized = .FALSE.
 
    PUBLIC :: mp_comm_type
    PUBLIC :: mp_request_type
@@ -838,7 +846,6 @@ MODULE message_passing
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize, mp_query_thread_level
-   PUBLIC :: mp_get_thread_level, mp_has_thread_multiple
    PUBLIC :: mp_abort
 
    ! informational / generation of sub comms
@@ -1126,8 +1133,10 @@ CONTAINS
       SUBROUTINE mp_assert_outside_parallel(routine_name)
          CHARACTER(LEN=*), INTENT(IN)                     :: routine_name
 
-!$       IF (omp_in_parallel()) &
-!$          CPABORT(TRIM(routine_name)//" must be called outside an OpenMP parallel region.")
+         IF (omp_in_parallel()) THEN
+            CALL cp_abort(__LOCATION__, &
+                          TRIM(routine_name)//" must be called outside an OpenMP parallel region.")
+         END IF
       END SUBROUTINE mp_assert_outside_parallel
 
 ! **************************************************************************************************
@@ -1144,34 +1153,49 @@ CONTAINS
       END SUBROUTINE mp_assert_thread_multiple
 
 ! **************************************************************************************************
+!> \brief Initialize MPI or attach to an MPI environment provided by an embedding application.
+!> \param initialize_mpi whether CP2K should initialize MPI when it is not active yet
+! **************************************************************************************************
+      SUBROUTINE mp_initialize_thread_support(initialize_mpi)
+         LOGICAL, INTENT(IN)                              :: initialize_mpi
+#if defined(__parallel)
+         INTEGER                                          :: ierr
+         LOGICAL                                          :: finalized, initialized
+
+         CALL mpi_finalized(finalized, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_finalized @ mp_initialize_thread_support")
+         IF (finalized) THEN
+            CALL cp_abort(__LOCATION__, "MPI has already been finalized.")
+         END IF
+
+         CALL mpi_initialized(initialized, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_initialized @ mp_initialize_thread_support")
+         IF (.NOT. initialized) THEN
+            IF (.NOT. initialize_mpi) THEN
+               CALL cp_abort(__LOCATION__, &
+                             "MPI must be initialized by the embedding application before CP2K.")
+            END IF
+            CALL mpi_init_thread(MPI_THREAD_MULTIPLE, mp_thread_level_provided, ierr)
+            IF (ierr /= 0) CALL mp_stop(ierr, "mpi_init_thread @ mp_initialize_thread_support")
+            mp_mpi_initialized_by_cp2k = .TRUE.
+         ELSE
+            CALL mpi_query_thread(mp_thread_level_provided, ierr)
+            IF (ierr /= 0) CALL mp_stop(ierr, "mpi_query_thread @ mp_initialize_thread_support")
+         END IF
+         CALL mp_assert_thread_multiple()
+#else
+         MARK_USED(initialize_mpi)
+         mp_thread_level_provided = -1
+#endif
+      END SUBROUTINE mp_initialize_thread_support
+
+! **************************************************************************************************
 !> \brief Query the MPI thread-support level when MPI is managed by an embedding application.
 ! **************************************************************************************************
       SUBROUTINE mp_query_thread_level()
-#if defined(__parallel)
-         INTEGER                                          :: ierr
-         LOGICAL                                          :: initialized
-
          CALL mp_assert_outside_parallel("mp_query_thread_level")
-         CALL mpi_initialized(initialized, ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_initialized @ mp_query_thread_level")
-         IF (.NOT. initialized) &
-            CPABORT("MPI must be initialized before calling mp_query_thread_level.")
-
-         CALL mpi_query_thread(mp_thread_level_provided, ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_query_thread @ mp_query_thread_level")
-         CALL mp_assert_thread_multiple()
-#else
-         mp_thread_level_provided = -1
-#endif
+         CALL mp_initialize_thread_support(.FALSE.)
       END SUBROUTINE mp_query_thread_level
-
-! **************************************************************************************************
-!> \brief Return the MPI thread-support level observed during initialization.
-!> \return MPI thread-support level, or -1 if MPI is unavailable or has not been queried
-! **************************************************************************************************
-      INTEGER FUNCTION mp_get_thread_level()
-         mp_get_thread_level = mp_thread_level_provided
-      END FUNCTION mp_get_thread_level
 
 ! **************************************************************************************************
 !> \brief Return a human-readable name for the observed MPI thread-support level.
@@ -1197,24 +1221,13 @@ CONTAINS
       END FUNCTION mp_get_thread_level_name
 
 ! **************************************************************************************************
-!> \brief Return whether the active MPI environment supports MPI_THREAD_MULTIPLE.
-!> \return true when MPI_THREAD_MULTIPLE is available
-! **************************************************************************************************
-      LOGICAL FUNCTION mp_has_thread_multiple()
-#if defined(__parallel)
-         mp_has_thread_multiple = mp_thread_level_provided >= MPI_THREAD_MULTIPLE
-#else
-         mp_has_thread_multiple = .FALSE.
-#endif
-      END FUNCTION mp_has_thread_multiple
-
-! **************************************************************************************************
 !> \brief initializes the system default communicator
 !> \param mp_comm [output] : handle of the default communicator
 !> \par History
 !>      2.2004 created [Joost VandeVondele ]
 !> \note
-!>      should only be called once
+!>      While active, this routine may only be called once. If MPI is already initialized,
+!>      CP2K validates MPI_THREAD_MULTIPLE and attaches without taking ownership.
 ! **************************************************************************************************
       SUBROUTINE mp_world_init(mp_comm)
          CLASS(mp_comm_type), INTENT(OUT)                     :: mp_comm
@@ -1226,10 +1239,11 @@ CONTAINS
 #endif
 
          CALL mp_assert_outside_parallel("mp_world_init")
+         IF (mp_world_is_initialized) THEN
+            CALL cp_abort(__LOCATION__, "mp_world_init called while already initialized.")
+         END IF
+         CALL mp_initialize_thread_support(.TRUE.)
 #if defined(__parallel)
-         CALL mpi_init_thread(MPI_THREAD_MULTIPLE, mp_thread_level_provided, ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_init_thread @ mp_world_init")
-         CALL mp_assert_thread_multiple()
          CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_set_errhandler @ mp_world_init")
 #endif
@@ -1247,6 +1261,7 @@ CONTAINS
 #endif
          CALL mp_comm%init()
          CALL add_mp_perf_env()
+         mp_world_is_initialized = .TRUE.
       END SUBROUTINE mp_world_init
 
 ! **************************************************************************************************
@@ -1272,6 +1287,7 @@ CONTAINS
          MPI_GROUP_TYPE                                  :: newgroup, oldgroup
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
          ierr = 0
 #if defined(__parallel)
@@ -1301,7 +1317,7 @@ CONTAINS
       END SUBROUTINE mp_reordering
 
 ! **************************************************************************************************
-!> \brief finalizes the system default communicator
+!> \brief Finalize the system default communicator and MPI when CP2K owns MPI.
 !> \par History
 !>      2.2004 created [Joost VandeVondele]
 ! **************************************************************************************************
@@ -1313,6 +1329,10 @@ CONTAINS
 #endif
 
          CALL mp_assert_outside_parallel("mp_world_finalize")
+         IF (.NOT. mp_world_is_initialized) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "mp_world_finalize called without a matching mp_world_init.")
+         END IF
 #if defined(__parallel)
 #if defined(__MIMIC)
          CALL mpi_barrier(mimic_comm_world, ierr)
@@ -1334,10 +1354,16 @@ CONTAINS
                           " leaking communicators "//ADJUSTL(TRIM(debug_comm_count_char)))
          END IF
 #if defined(__parallel)
-         CALL mpi_finalize(ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_finalize @ mp_world_finalize")
+         IF (mp_mpi_initialized_by_cp2k) THEN
+            CALL mpi_finalize(ierr)
+            IF (ierr /= 0) CALL mp_stop(ierr, "mpi_finalize @ mp_world_finalize")
+         END IF
 #endif
          mp_thread_level_provided = -1
+#if defined(__parallel)
+         mp_mpi_initialized_by_cp2k = .FALSE.
+#endif
+         mp_world_is_initialized = .FALSE.
 
       END SUBROUTINE mp_world_finalize
 
@@ -1585,6 +1611,7 @@ CONTAINS
 #endif
 
          ierr = 0
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
          comm_cart%handle = comm_old%handle
@@ -1708,6 +1735,7 @@ CONTAINS
          INTEGER :: ierr
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
@@ -1741,6 +1769,7 @@ CONTAINS
          INTEGER :: ierr
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          free_comm = .TRUE.
          SELECT TYPE (comm)
          CLASS IS (mp_para_env_type)
@@ -1798,9 +1827,10 @@ CONTAINS
 !> \brief increase the reference counter but ensure that you free it later
 !> \param para_env ...
 ! **************************************************************************************************
-      ELEMENTAL SUBROUTINE mp_para_env_retain(para_env)
+      ELEMENTAL IMPURE SUBROUTINE mp_para_env_retain(para_env)
          CLASS(mp_para_env_type), INTENT(INOUT) :: para_env
 
+         CALL mp_assert_outside_parallel("mp_para_env_retain")
          para_env%ref_count = para_env%ref_count + 1
 
       END SUBROUTINE mp_para_env_retain
@@ -1821,9 +1851,10 @@ CONTAINS
 !> \brief increase the reference counter, don't forget to free it later
 !> \param cart ...
 ! **************************************************************************************************
-      ELEMENTAL SUBROUTINE mp_para_cart_retain(cart)
+      ELEMENTAL IMPURE SUBROUTINE mp_para_cart_retain(cart)
          CLASS(mp_para_cart_type), INTENT(INOUT) :: cart
 
+         CALL mp_assert_outside_parallel("mp_para_cart_retain")
          cart%ref_count = cart%ref_count + 1
 
       END SUBROUTINE mp_para_cart_retain
@@ -1845,6 +1876,7 @@ CONTAINS
          INTEGER :: ierr
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
@@ -1895,6 +1927,14 @@ CONTAINS
          CLASS(mp_comm_type), INTENT(INOUT) :: comm
          LOGICAL, INTENT(IN), OPTIONAL :: owns_group
 
+         ! Only reference-counted communicators update ownership state during initialization.
+         SELECT TYPE (comm)
+         CLASS IS (mp_para_env_type)
+            CALL mp_assert_outside_parallel("mp_comm_init")
+         CLASS IS (mp_para_cart_type)
+            CALL mp_assert_outside_parallel("mp_comm_init")
+         END SELECT
+
          IF (comm%handle MPI_GET_COMP /= mp_comm_null_handle MPI_GET_COMP) THEN
             comm%source = 0
             CALL comm%get_size(comm%num_pe)
@@ -1944,6 +1984,7 @@ CONTAINS
          TYPE(mp_para_env_type), POINTER        :: para_env
          CLASS(mp_comm_type), INTENT(in)        :: group
 
+         CALL mp_assert_outside_parallel("mp_para_env_create")
          IF (ASSOCIATED(para_env)) &
             CPABORT("The passed para_env must not be associated!")
          ALLOCATE (para_env)
@@ -1965,6 +2006,7 @@ CONTAINS
       SUBROUTINE mp_para_env_release(para_env)
          TYPE(mp_para_env_type), POINTER                    :: para_env
 
+         CALL mp_assert_outside_parallel("mp_para_env_release")
          IF (ASSOCIATED(para_env)) THEN
             CALL para_env%free()
             IF (.NOT. para_env%is_valid()) DEALLOCATE (para_env)
@@ -1982,6 +2024,7 @@ CONTAINS
          TYPE(mp_para_cart_type), POINTER, INTENT(OUT)      :: cart
          CLASS(mp_comm_type), INTENT(in)                    :: group
 
+         CALL mp_assert_outside_parallel("mp_para_cart_create")
          IF (ASSOCIATED(cart)) &
             CPABORT("The passed para_cart must not be associated!")
          ALLOCATE (cart)
@@ -1998,6 +2041,7 @@ CONTAINS
       SUBROUTINE mp_para_cart_release(cart)
          TYPE(mp_para_cart_type), POINTER                   :: cart
 
+         CALL mp_assert_outside_parallel("mp_para_cart_release")
          IF (ASSOCIATED(cart)) THEN
             CALL cart%free()
             IF (.NOT. cart%is_valid()) DEALLOCATE (cart)
@@ -2455,6 +2499,7 @@ CONTAINS
          INTEGER :: ierr, my_key
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
@@ -2495,6 +2540,7 @@ CONTAINS
          INTEGER :: ierr, my_key
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
@@ -2560,6 +2606,7 @@ CONTAINS
          INTEGER, DIMENSION(:), ALLOCATABLE       :: rank_permutation
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
          ! actual number of groups
@@ -4800,9 +4847,10 @@ CONTAINS
          INTEGER, INTENT(OUT)                               :: handle
 
          handle = -1
-!$       IF (omp_get_thread_num() /= 0 .OR. omp_get_level() > 1) RETURN
-         IF (mp_collect_timings) &
-            CALL timeset(routineN, handle)
+         IF (.NOT. mp_collect_timings) RETURN
+         IF (omp_get_thread_num() /= 0) RETURN
+         IF (omp_get_level() > 1) RETURN
+         CALL timeset(routineN, handle)
       END SUBROUTINE mp_timeset
 
 ! **************************************************************************************************
@@ -4812,7 +4860,7 @@ CONTAINS
       SUBROUTINE mp_timestop(handle)
          INTEGER, INTENT(IN)                                :: handle
 
-         IF (mp_collect_timings .AND. handle >= 0) &
+         IF (handle >= 0) &
             CALL timestop(handle)
       END SUBROUTINE mp_timestop
 

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -29,8 +29,8 @@ MODULE message_passing
    USE kinds, ONLY: &
       dp, int_4, int_4_size, int_8, int_8_size, real_4, real_4_size, real_8, &
       real_8_size, default_string_length
-   USE machine, ONLY: m_abort
-   USE mp_perf_env, ONLY: add_perf, add_mp_perf_env, rm_mp_perf_env
+   USE machine, ONLY: m_abort, m_walltime
+   USE mp_perf_env, ONLY: add_mp_perf_env, add_mp_worker_timing, add_perf, rm_mp_perf_env
    USE OMP_LIB, ONLY: omp_get_level, omp_get_max_threads, omp_get_num_threads, &
                       omp_get_thread_num, omp_in_parallel
 #if defined(__MIMIC)
@@ -158,6 +158,17 @@ MODULE message_passing
    LOGICAL, PRIVATE, SAVE :: mp_mpi_initialized_by_cp2k = .FALSE.
 #endif
    LOGICAL, PRIVATE, SAVE :: mp_world_is_initialized = .FALSE.
+
+   INTEGER, PARAMETER, PRIVATE :: mp_no_timer_handle = -1
+   INTEGER, PARAMETER, PRIVATE :: mp_worker_timer_handle = -2
+   INTEGER, PARAMETER, PRIVATE :: mp_worker_timer_max_depth = 16
+
+   TYPE, PRIVATE :: mp_worker_timer_type
+      INTEGER :: depth = 0
+      REAL(KIND=dp), DIMENSION(mp_worker_timer_max_depth) :: start = 0.0_dp
+   END TYPE mp_worker_timer_type
+
+   TYPE(mp_worker_timer_type), ALLOCATABLE, DIMENSION(:), PRIVATE, SAVE :: mp_worker_timers
 
    PUBLIC :: mp_comm_type
    PUBLIC :: mp_thread_comm_pool_type
@@ -1251,6 +1262,8 @@ CONTAINS
 !> \note
 !>      While active, this routine may only be called once. If MPI is already initialized,
 !>      CP2K validates MPI_THREAD_MULTIPLE and attaches without taking ownership.
+!>      When MPI timing is enabled, the OpenMP maximum thread count must not increase before
+!>      mp_world_finalize is called.
 ! **************************************************************************************************
       SUBROUTINE mp_world_init(mp_comm)
          CLASS(mp_comm_type), INTENT(OUT)                     :: mp_comm
@@ -1266,6 +1279,7 @@ CONTAINS
             CALL cp_abort(__LOCATION__, "mp_world_init called while already initialized.")
          END IF
          CALL mp_initialize_thread_support(.TRUE.)
+         ALLOCATE (mp_worker_timers(0:omp_get_max_threads() - 1))
 #if defined(__parallel)
          CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_set_errhandler @ mp_world_init")
@@ -1363,6 +1377,11 @@ CONTAINS
          CALL mpi_barrier(MPI_COMM_WORLD, ierr) ! call mpi directly to avoid 0 stack pointer
 #endif
 #endif
+         IF (ANY(mp_worker_timers%depth /= 0)) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "Unmatched MPI wrapper timer on an OpenMP worker thread.")
+         END IF
+         DEALLOCATE (mp_worker_timers)
          CALL rm_mp_perf_env()
 
          debug_comm_count = debug_comm_count - 1
@@ -4980,14 +4999,37 @@ CONTAINS
 !> \brief Starts a timer region
 !> \param routineN ...
 !> \param handle ...
+!> \note Worker-thread timers must be stopped by the same OpenMP thread that started them.
 ! **************************************************************************************************
       SUBROUTINE mp_timeset(routineN, handle)
          CHARACTER(len=*), INTENT(IN)                       :: routineN
          INTEGER, INTENT(OUT)                               :: handle
 
-         handle = -1
+         INTEGER                                            :: thread_num
+
+         handle = mp_no_timer_handle
          IF (.NOT. mp_collect_timings) RETURN
-         IF (omp_get_thread_num() /= 0) RETURN
+         thread_num = omp_get_thread_num()
+         IF (omp_get_level() == 1 .AND. thread_num /= 0) THEN
+            IF (.NOT. ALLOCATED(mp_worker_timers)) THEN
+               CALL cp_abort(__LOCATION__, "MPI worker timers are not initialized.")
+            END IF
+            IF (thread_num > UBOUND(mp_worker_timers, 1)) THEN
+               CALL cp_abort(__LOCATION__, &
+                             "OpenMP team exceeds the size recorded by mp_world_init.")
+            END IF
+            ASSOCIATE (timer => mp_worker_timers(thread_num))
+               IF (timer%depth >= mp_worker_timer_max_depth) THEN
+                  CALL cp_abort(__LOCATION__, &
+                                "MPI wrapper timer stack overflow on an OpenMP worker thread.")
+               END IF
+               timer%depth = timer%depth + 1
+               timer%start(timer%depth) = m_walltime()
+            END ASSOCIATE
+            handle = mp_worker_timer_handle
+            RETURN
+         END IF
+         IF (thread_num /= 0) RETURN
          IF (omp_get_level() > 1) RETURN
          CALL timeset(routineN, handle)
       END SUBROUTINE mp_timeset
@@ -4999,8 +5041,22 @@ CONTAINS
       SUBROUTINE mp_timestop(handle)
          INTEGER, INTENT(IN)                                :: handle
 
-         IF (handle >= 0) &
+         INTEGER                                            :: depth, thread_num
+
+         IF (handle == mp_worker_timer_handle) THEN
+            thread_num = omp_get_thread_num()
+            ASSOCIATE (timer => mp_worker_timers(thread_num))
+               depth = timer%depth
+               IF (depth <= 0) THEN
+                  CALL cp_abort(__LOCATION__, &
+                                "Unmatched MPI wrapper timer on an OpenMP worker thread.")
+               END IF
+               CALL add_mp_worker_timing(m_walltime() - timer%start(depth))
+               timer%depth = depth - 1
+            END ASSOCIATE
+         ELSE IF (handle >= 0) THEN
             CALL timestop(handle)
+         END IF
       END SUBROUTINE mp_timestop
 
       #:include 'message_passing.fypp'

--- a/src/mpiwrap/message_passing.F
+++ b/src/mpiwrap/message_passing.F
@@ -20,6 +20,8 @@
 !>      JGH (15-Feb-2006): single precision mp_alltoall
 !> \note Concurrent calls must use thread-private buffers and requests. Concurrent collectives,
 !>       or point-to-point calls that do not use distinct tags, must use distinct communicators.
+!>       Communicator creation, duplication, splitting, ownership changes, and destruction must
+!>       happen outside OpenMP parallel regions.
 !> \author JGH
 ! **************************************************************************************************
 MODULE message_passing
@@ -29,6 +31,8 @@ MODULE message_passing
       real_8_size, default_string_length
    USE machine, ONLY: m_abort
    USE mp_perf_env, ONLY: add_perf, add_mp_perf_env, rm_mp_perf_env
+   USE OMP_LIB, ONLY: omp_get_level, omp_get_max_threads, omp_get_num_threads, &
+                      omp_get_thread_num, omp_in_parallel
 #if defined(__MIMIC)
    USE mcl, ONLY: mcl_initialize, mcl_is_initialized, mcl_abort
 #endif
@@ -74,8 +78,6 @@ MODULE message_passing
    USE mpi
 #endif
 #endif
-
-!$ USE OMP_LIB, ONLY: omp_get_level, omp_get_thread_num, omp_in_parallel
 
    IMPLICIT NONE
    PRIVATE
@@ -150,7 +152,15 @@ MODULE message_passing
    ! not been initialized by CP2K or queried from an embedding application yet.
    INTEGER, PRIVATE, SAVE :: mp_thread_level_provided = -1
 
+   ! MPI can be initialized by CP2K or by an embedding application. Only the
+   ! component that initialized MPI is allowed to finalize it.
+#if defined(__parallel)
+   LOGICAL, PRIVATE, SAVE :: mp_mpi_initialized_by_cp2k = .FALSE.
+#endif
+   LOGICAL, PRIVATE, SAVE :: mp_world_is_initialized = .FALSE.
+
    PUBLIC :: mp_comm_type
+   PUBLIC :: mp_thread_comm_pool_type
    PUBLIC :: mp_request_type
    PUBLIC :: mp_win_type
    PUBLIC :: mp_file_type
@@ -616,6 +626,27 @@ MODULE message_passing
       GENERIC, PUBLIC :: get_wtime_is_global => mp_comm_get_wtime_is_global
    END TYPE
 
+! **************************************************************************************************
+!> \brief Pool of duplicated communicators, one for each thread in an OpenMP team.
+!> \note Initialize and free the pool outside OpenMP parallel regions. The number of lanes must match
+!>       the size of every team using the pool. The returned communicator is owned by the pool and
+!>       must not be freed by the caller. Matching collectives must be issued in the same order by
+!>       corresponding lanes on every MPI rank.
+! **************************************************************************************************
+   TYPE mp_thread_comm_pool_type
+      PRIVATE
+      TYPE(mp_comm_type), DIMENSION(:), POINTER :: comms => NULL()
+      INTEGER :: num_lanes = 0
+   CONTAINS
+      PROCEDURE, PUBLIC, PASS(pool), NON_OVERRIDABLE :: init => mp_thread_comm_pool_init
+      PROCEDURE, PUBLIC, PASS(pool), NON_OVERRIDABLE :: free => mp_thread_comm_pool_free
+      PROCEDURE, PUBLIC, PASS(pool), NON_OVERRIDABLE :: get_comm => mp_thread_comm_pool_get_comm
+      PROCEDURE, PUBLIC, PASS(pool), NON_OVERRIDABLE :: &
+         get_num_lanes => mp_thread_comm_pool_get_num_lanes
+      PROCEDURE, PUBLIC, PASS(pool), NON_OVERRIDABLE :: &
+         is_initialized => mp_thread_comm_pool_is_initialized
+   END TYPE mp_thread_comm_pool_type
+
    TYPE mp_request_type
       PRIVATE
       MPI_REQUEST_TYPE :: handle = mp_request_null_handle
@@ -838,7 +869,6 @@ MODULE message_passing
 
    ! init and error
    PUBLIC :: mp_world_init, mp_world_finalize, mp_query_thread_level
-   PUBLIC :: mp_get_thread_level, mp_has_thread_multiple
    PUBLIC :: mp_abort
 
    ! informational / generation of sub comms
@@ -1126,8 +1156,10 @@ CONTAINS
       SUBROUTINE mp_assert_outside_parallel(routine_name)
          CHARACTER(LEN=*), INTENT(IN)                     :: routine_name
 
-!$       IF (omp_in_parallel()) &
-!$          CPABORT(TRIM(routine_name)//" must be called outside an OpenMP parallel region.")
+         IF (omp_in_parallel()) THEN
+            CALL cp_abort(__LOCATION__, &
+                          TRIM(routine_name)//" must be called outside an OpenMP parallel region.")
+         END IF
       END SUBROUTINE mp_assert_outside_parallel
 
 ! **************************************************************************************************
@@ -1144,34 +1176,49 @@ CONTAINS
       END SUBROUTINE mp_assert_thread_multiple
 
 ! **************************************************************************************************
+!> \brief Initialize MPI or attach to an MPI environment provided by an embedding application.
+!> \param initialize_mpi whether CP2K should initialize MPI when it is not active yet
+! **************************************************************************************************
+      SUBROUTINE mp_initialize_thread_support(initialize_mpi)
+         LOGICAL, INTENT(IN)                              :: initialize_mpi
+#if defined(__parallel)
+         INTEGER                                          :: ierr
+         LOGICAL                                          :: finalized, initialized
+
+         CALL mpi_finalized(finalized, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_finalized @ mp_initialize_thread_support")
+         IF (finalized) THEN
+            CALL cp_abort(__LOCATION__, "MPI has already been finalized.")
+         END IF
+
+         CALL mpi_initialized(initialized, ierr)
+         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_initialized @ mp_initialize_thread_support")
+         IF (.NOT. initialized) THEN
+            IF (.NOT. initialize_mpi) THEN
+               CALL cp_abort(__LOCATION__, &
+                             "MPI must be initialized by the embedding application before CP2K.")
+            END IF
+            CALL mpi_init_thread(MPI_THREAD_MULTIPLE, mp_thread_level_provided, ierr)
+            IF (ierr /= 0) CALL mp_stop(ierr, "mpi_init_thread @ mp_initialize_thread_support")
+            mp_mpi_initialized_by_cp2k = .TRUE.
+         ELSE
+            CALL mpi_query_thread(mp_thread_level_provided, ierr)
+            IF (ierr /= 0) CALL mp_stop(ierr, "mpi_query_thread @ mp_initialize_thread_support")
+         END IF
+         CALL mp_assert_thread_multiple()
+#else
+         MARK_USED(initialize_mpi)
+         mp_thread_level_provided = -1
+#endif
+      END SUBROUTINE mp_initialize_thread_support
+
+! **************************************************************************************************
 !> \brief Query the MPI thread-support level when MPI is managed by an embedding application.
 ! **************************************************************************************************
       SUBROUTINE mp_query_thread_level()
-#if defined(__parallel)
-         INTEGER                                          :: ierr
-         LOGICAL                                          :: initialized
-
          CALL mp_assert_outside_parallel("mp_query_thread_level")
-         CALL mpi_initialized(initialized, ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_initialized @ mp_query_thread_level")
-         IF (.NOT. initialized) &
-            CPABORT("MPI must be initialized before calling mp_query_thread_level.")
-
-         CALL mpi_query_thread(mp_thread_level_provided, ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_query_thread @ mp_query_thread_level")
-         CALL mp_assert_thread_multiple()
-#else
-         mp_thread_level_provided = -1
-#endif
+         CALL mp_initialize_thread_support(.FALSE.)
       END SUBROUTINE mp_query_thread_level
-
-! **************************************************************************************************
-!> \brief Return the MPI thread-support level observed during initialization.
-!> \return MPI thread-support level, or -1 if MPI is unavailable or has not been queried
-! **************************************************************************************************
-      INTEGER FUNCTION mp_get_thread_level()
-         mp_get_thread_level = mp_thread_level_provided
-      END FUNCTION mp_get_thread_level
 
 ! **************************************************************************************************
 !> \brief Return a human-readable name for the observed MPI thread-support level.
@@ -1197,24 +1244,13 @@ CONTAINS
       END FUNCTION mp_get_thread_level_name
 
 ! **************************************************************************************************
-!> \brief Return whether the active MPI environment supports MPI_THREAD_MULTIPLE.
-!> \return true when MPI_THREAD_MULTIPLE is available
-! **************************************************************************************************
-      LOGICAL FUNCTION mp_has_thread_multiple()
-#if defined(__parallel)
-         mp_has_thread_multiple = mp_thread_level_provided >= MPI_THREAD_MULTIPLE
-#else
-         mp_has_thread_multiple = .FALSE.
-#endif
-      END FUNCTION mp_has_thread_multiple
-
-! **************************************************************************************************
 !> \brief initializes the system default communicator
 !> \param mp_comm [output] : handle of the default communicator
 !> \par History
 !>      2.2004 created [Joost VandeVondele ]
 !> \note
-!>      should only be called once
+!>      While active, this routine may only be called once. If MPI is already initialized,
+!>      CP2K validates MPI_THREAD_MULTIPLE and attaches without taking ownership.
 ! **************************************************************************************************
       SUBROUTINE mp_world_init(mp_comm)
          CLASS(mp_comm_type), INTENT(OUT)                     :: mp_comm
@@ -1226,10 +1262,11 @@ CONTAINS
 #endif
 
          CALL mp_assert_outside_parallel("mp_world_init")
+         IF (mp_world_is_initialized) THEN
+            CALL cp_abort(__LOCATION__, "mp_world_init called while already initialized.")
+         END IF
+         CALL mp_initialize_thread_support(.TRUE.)
 #if defined(__parallel)
-         CALL mpi_init_thread(MPI_THREAD_MULTIPLE, mp_thread_level_provided, ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_init_thread @ mp_world_init")
-         CALL mp_assert_thread_multiple()
          CALL mpi_comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN, ierr)
          IF (ierr /= 0) CALL mp_stop(ierr, "mpi_comm_set_errhandler @ mp_world_init")
 #endif
@@ -1247,6 +1284,7 @@ CONTAINS
 #endif
          CALL mp_comm%init()
          CALL add_mp_perf_env()
+         mp_world_is_initialized = .TRUE.
       END SUBROUTINE mp_world_init
 
 ! **************************************************************************************************
@@ -1272,6 +1310,7 @@ CONTAINS
          MPI_GROUP_TYPE                                  :: newgroup, oldgroup
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
          ierr = 0
 #if defined(__parallel)
@@ -1301,7 +1340,7 @@ CONTAINS
       END SUBROUTINE mp_reordering
 
 ! **************************************************************************************************
-!> \brief finalizes the system default communicator
+!> \brief Finalize the system default communicator and MPI when CP2K owns MPI.
 !> \par History
 !>      2.2004 created [Joost VandeVondele]
 ! **************************************************************************************************
@@ -1313,6 +1352,10 @@ CONTAINS
 #endif
 
          CALL mp_assert_outside_parallel("mp_world_finalize")
+         IF (.NOT. mp_world_is_initialized) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "mp_world_finalize called without a matching mp_world_init.")
+         END IF
 #if defined(__parallel)
 #if defined(__MIMIC)
          CALL mpi_barrier(mimic_comm_world, ierr)
@@ -1334,10 +1377,16 @@ CONTAINS
                           " leaking communicators "//ADJUSTL(TRIM(debug_comm_count_char)))
          END IF
 #if defined(__parallel)
-         CALL mpi_finalize(ierr)
-         IF (ierr /= 0) CALL mp_stop(ierr, "mpi_finalize @ mp_world_finalize")
+         IF (mp_mpi_initialized_by_cp2k) THEN
+            CALL mpi_finalize(ierr)
+            IF (ierr /= 0) CALL mp_stop(ierr, "mpi_finalize @ mp_world_finalize")
+         END IF
 #endif
          mp_thread_level_provided = -1
+#if defined(__parallel)
+         mp_mpi_initialized_by_cp2k = .FALSE.
+#endif
+         mp_world_is_initialized = .FALSE.
 
       END SUBROUTINE mp_world_finalize
 
@@ -1585,6 +1634,7 @@ CONTAINS
 #endif
 
          ierr = 0
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
          comm_cart%handle = comm_old%handle
@@ -1708,6 +1758,7 @@ CONTAINS
          INTEGER :: ierr
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
@@ -1741,6 +1792,7 @@ CONTAINS
          INTEGER :: ierr
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          free_comm = .TRUE.
          SELECT TYPE (comm)
          CLASS IS (mp_para_env_type)
@@ -1798,9 +1850,10 @@ CONTAINS
 !> \brief increase the reference counter but ensure that you free it later
 !> \param para_env ...
 ! **************************************************************************************************
-      ELEMENTAL SUBROUTINE mp_para_env_retain(para_env)
+      ELEMENTAL IMPURE SUBROUTINE mp_para_env_retain(para_env)
          CLASS(mp_para_env_type), INTENT(INOUT) :: para_env
 
+         CALL mp_assert_outside_parallel("mp_para_env_retain")
          para_env%ref_count = para_env%ref_count + 1
 
       END SUBROUTINE mp_para_env_retain
@@ -1821,9 +1874,10 @@ CONTAINS
 !> \brief increase the reference counter, don't forget to free it later
 !> \param cart ...
 ! **************************************************************************************************
-      ELEMENTAL SUBROUTINE mp_para_cart_retain(cart)
+      ELEMENTAL IMPURE SUBROUTINE mp_para_cart_retain(cart)
          CLASS(mp_para_cart_type), INTENT(INOUT) :: cart
 
+         CALL mp_assert_outside_parallel("mp_para_cart_retain")
          cart%ref_count = cart%ref_count + 1
 
       END SUBROUTINE mp_para_cart_retain
@@ -1845,6 +1899,7 @@ CONTAINS
          INTEGER :: ierr
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
@@ -1860,6 +1915,123 @@ CONTAINS
          CALL mp_timestop(handle)
 
       END SUBROUTINE mp_comm_dup
+
+! **************************************************************************************************
+!> \brief Create a pool of duplicated communicators for use by an OpenMP team.
+!> \param pool communicator pool
+!> \param parent communicator to duplicate
+!> \param num_lanes number of communicators to create; defaults to the OpenMP maximum
+! **************************************************************************************************
+      SUBROUTINE mp_thread_comm_pool_init(pool, parent, num_lanes)
+         CLASS(mp_thread_comm_pool_type), INTENT(INOUT)    :: pool
+         CLASS(mp_comm_type), INTENT(IN)                   :: parent
+         INTEGER, INTENT(IN), OPTIONAL                     :: num_lanes
+
+         INTEGER, DIMENSION(2)                             :: lane_bounds
+         INTEGER                                           :: ilane, requested_lanes
+
+         CALL mp_assert_outside_parallel("mp_thread_comm_pool_init")
+         IF (ASSOCIATED(pool%comms)) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "The thread communicator pool is already initialized.")
+         END IF
+
+         requested_lanes = omp_get_max_threads()
+         IF (PRESENT(num_lanes)) requested_lanes = num_lanes
+         IF (requested_lanes <= 0) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "The thread communicator pool requires at least one lane.")
+         END IF
+
+         ! MPI_Comm_dup is collective, so every rank must create the same number of communicators.
+         lane_bounds = [requested_lanes, -requested_lanes]
+         CALL parent%max(lane_bounds)
+         IF (lane_bounds(1) /= -lane_bounds(2)) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "The thread communicator pool size must be identical on every MPI rank.")
+         END IF
+
+         pool%num_lanes = requested_lanes
+         ALLOCATE (pool%comms(0:pool%num_lanes - 1))
+         DO ilane = 0, pool%num_lanes - 1
+            CALL pool%comms(ilane)%from_dup(parent)
+         END DO
+      END SUBROUTINE mp_thread_comm_pool_init
+
+! **************************************************************************************************
+!> \brief Destroy a thread communicator pool.
+!> \param pool communicator pool
+! **************************************************************************************************
+      SUBROUTINE mp_thread_comm_pool_free(pool)
+         CLASS(mp_thread_comm_pool_type), INTENT(INOUT)    :: pool
+
+         INTEGER                                           :: ilane
+
+         CALL mp_assert_outside_parallel("mp_thread_comm_pool_free")
+         IF (.NOT. ASSOCIATED(pool%comms)) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "The thread communicator pool is not initialized.")
+         END IF
+
+         DO ilane = LBOUND(pool%comms, 1), UBOUND(pool%comms, 1)
+            CALL pool%comms(ilane)%free()
+         END DO
+         DEALLOCATE (pool%comms)
+         pool%num_lanes = 0
+      END SUBROUTINE mp_thread_comm_pool_free
+
+! **************************************************************************************************
+!> \brief Return the communicator assigned to the calling thread.
+!> \param pool communicator pool
+!> \param comm communicator assigned to the calling thread; owned by pool
+!> \note The team size must match the pool size. Communicator selection itself is local and does not
+!>       require every thread in the team to call this routine.
+! **************************************************************************************************
+      SUBROUTINE mp_thread_comm_pool_get_comm(pool, comm)
+         CLASS(mp_thread_comm_pool_type), INTENT(IN)       :: pool
+         TYPE(mp_comm_type), POINTER, INTENT(OUT)          :: comm
+
+         INTEGER                                           :: omp_level, thread_num
+
+         IF (.NOT. ASSOCIATED(pool%comms)) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "The thread communicator pool is not initialized.")
+         END IF
+         omp_level = omp_get_level()
+         IF (omp_level == 0) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "mp_thread_comm_pool_get_comm must be called from an OpenMP parallel region.")
+         END IF
+         IF (omp_level /= 1) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "mp_thread_comm_pool_get_comm does not support nested OpenMP parallel regions.")
+         END IF
+         IF (omp_get_num_threads() /= pool%num_lanes) THEN
+            CALL cp_abort(__LOCATION__, &
+                          "The OpenMP team size must match the thread communicator pool size.")
+         END IF
+
+         thread_num = omp_get_thread_num()
+         comm => pool%comms(thread_num)
+      END SUBROUTINE mp_thread_comm_pool_get_comm
+
+! **************************************************************************************************
+!> \brief Return the number of lanes in a thread communicator pool.
+! **************************************************************************************************
+      ELEMENTAL INTEGER FUNCTION mp_thread_comm_pool_get_num_lanes(pool)
+         CLASS(mp_thread_comm_pool_type), INTENT(IN)       :: pool
+
+         mp_thread_comm_pool_get_num_lanes = pool%num_lanes
+      END FUNCTION mp_thread_comm_pool_get_num_lanes
+
+! **************************************************************************************************
+!> \brief Return whether a thread communicator pool has been initialized.
+! **************************************************************************************************
+      ELEMENTAL LOGICAL FUNCTION mp_thread_comm_pool_is_initialized(pool)
+         CLASS(mp_thread_comm_pool_type), INTENT(IN)       :: pool
+
+         mp_thread_comm_pool_is_initialized = ASSOCIATED(pool%comms)
+      END FUNCTION mp_thread_comm_pool_is_initialized
 
 ! **************************************************************************************************
 !> \brief Implements a simple assignment function to overload the assignment operator
@@ -1894,6 +2066,13 @@ CONTAINS
       ELEMENTAL IMPURE SUBROUTINE mp_comm_init(comm, owns_group)
          CLASS(mp_comm_type), INTENT(INOUT) :: comm
          LOGICAL, INTENT(IN), OPTIONAL :: owns_group
+
+         SELECT TYPE (comm)
+         CLASS IS (mp_para_env_type)
+            CALL mp_assert_outside_parallel("mp_comm_init")
+         CLASS IS (mp_para_cart_type)
+            CALL mp_assert_outside_parallel("mp_comm_init")
+         END SELECT
 
          IF (comm%handle MPI_GET_COMP /= mp_comm_null_handle MPI_GET_COMP) THEN
             comm%source = 0
@@ -1944,6 +2123,7 @@ CONTAINS
          TYPE(mp_para_env_type), POINTER        :: para_env
          CLASS(mp_comm_type), INTENT(in)        :: group
 
+         CALL mp_assert_outside_parallel("mp_para_env_create")
          IF (ASSOCIATED(para_env)) &
             CPABORT("The passed para_env must not be associated!")
          ALLOCATE (para_env)
@@ -1965,6 +2145,7 @@ CONTAINS
       SUBROUTINE mp_para_env_release(para_env)
          TYPE(mp_para_env_type), POINTER                    :: para_env
 
+         CALL mp_assert_outside_parallel("mp_para_env_release")
          IF (ASSOCIATED(para_env)) THEN
             CALL para_env%free()
             IF (.NOT. para_env%is_valid()) DEALLOCATE (para_env)
@@ -1982,6 +2163,7 @@ CONTAINS
          TYPE(mp_para_cart_type), POINTER, INTENT(OUT)      :: cart
          CLASS(mp_comm_type), INTENT(in)                    :: group
 
+         CALL mp_assert_outside_parallel("mp_para_cart_create")
          IF (ASSOCIATED(cart)) &
             CPABORT("The passed para_cart must not be associated!")
          ALLOCATE (cart)
@@ -1998,6 +2180,7 @@ CONTAINS
       SUBROUTINE mp_para_cart_release(cart)
          TYPE(mp_para_cart_type), POINTER                   :: cart
 
+         CALL mp_assert_outside_parallel("mp_para_cart_release")
          IF (ASSOCIATED(cart)) THEN
             CALL cart%free()
             IF (.NOT. cart%is_valid()) DEALLOCATE (cart)
@@ -2455,6 +2638,7 @@ CONTAINS
          INTEGER :: ierr, my_key
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
@@ -2495,6 +2679,7 @@ CONTAINS
          INTEGER :: ierr, my_key
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
 #if defined(__parallel)
@@ -2560,6 +2745,7 @@ CONTAINS
          INTEGER, DIMENSION(:), ALLOCATABLE       :: rank_permutation
 #endif
 
+         CALL mp_assert_outside_parallel(routineN)
          CALL mp_timeset(routineN, handle)
 
          ! actual number of groups
@@ -4800,9 +4986,10 @@ CONTAINS
          INTEGER, INTENT(OUT)                               :: handle
 
          handle = -1
-!$       IF (omp_get_thread_num() /= 0 .OR. omp_get_level() > 1) RETURN
-         IF (mp_collect_timings) &
-            CALL timeset(routineN, handle)
+         IF (.NOT. mp_collect_timings) RETURN
+         IF (omp_get_thread_num() /= 0) RETURN
+         IF (omp_get_level() > 1) RETURN
+         CALL timeset(routineN, handle)
       END SUBROUTINE mp_timeset
 
 ! **************************************************************************************************
@@ -4812,7 +4999,7 @@ CONTAINS
       SUBROUTINE mp_timestop(handle)
          INTEGER, INTENT(IN)                                :: handle
 
-         IF (mp_collect_timings .AND. handle >= 0) &
+         IF (handle >= 0) &
             CALL timestop(handle)
       END SUBROUTINE mp_timestop
 

--- a/src/mpiwrap/message_passing_thread_unittest.F
+++ b/src/mpiwrap/message_passing_thread_unittest.F
@@ -6,104 +6,72 @@
 !--------------------------------------------------------------------------------------------------!
 
 ! **************************************************************************************************
-!> \brief Exercises MPI wrappers concurrently from multiple OpenMP threads.
+!> \brief Exercises point-to-point MPI wrappers concurrently from multiple OpenMP threads.
 ! **************************************************************************************************
 PROGRAM message_passing_thread_unittest
+   USE OMP_LIB,                         ONLY: omp_get_num_threads,&
+                                              omp_get_thread_num,&
+                                              omp_set_dynamic,&
+                                              omp_set_num_threads
    USE message_passing,                 ONLY: mp_collect_timings,&
                                               mp_comm_type,&
-                                              mp_has_thread_multiple,&
                                               mp_world_finalize,&
                                               mp_world_init
    USE timings,                         ONLY: add_timer_env,&
                                               rm_timer_env,&
                                               timings_register_hooks
-
-!$ USE OMP_LIB, ONLY: omp_get_num_threads, omp_get_thread_num, omp_set_dynamic, omp_set_num_threads
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
 
    TYPE(mp_comm_type)                                  :: world
-#if defined(__parallel)
-   INTEGER                                             :: i, nthreads
-   TYPE(mp_comm_type), ALLOCATABLE, DIMENSION(:)       :: thread_comm
-#endif
 
    CALL mp_world_init(world)
-
-#if defined(__parallel)
-   CPASSERT(mp_has_thread_multiple())
 
    CALL timings_register_hooks()
    CALL add_timer_env()
    mp_collect_timings = .TRUE.
 
-!$ CALL omp_set_dynamic(.FALSE.)
-!$ CALL omp_set_num_threads(2)
-   nthreads = 1
-!$OMP PARALLEL DEFAULT(NONE) SHARED(nthreads)
-!$OMP SINGLE
-!$ nthreads = omp_get_num_threads()
-!$OMP END SINGLE
+   CALL omp_set_dynamic(.FALSE.)
+   CALL omp_set_num_threads(2)
+!$OMP PARALLEL DEFAULT(NONE) SHARED(world)
+   CALL exercise_concurrent_point_to_point(world)
 !$OMP END PARALLEL
-
-   ALLOCATE (thread_comm(0:nthreads - 1))
-   DO i = 0, nthreads - 1
-      CALL thread_comm(i)%from_dup(world)
-   END DO
-
-!$OMP PARALLEL DEFAULT(NONE) &
-!$OMP    SHARED(nthreads, thread_comm, world)
-   CALL exercise_thread_comm()
-!$OMP END PARALLEL
-
-   DO i = 0, nthreads - 1
-      CALL thread_comm(i)%free()
-   END DO
-   DEALLOCATE (thread_comm)
 
    mp_collect_timings = .FALSE.
    CALL rm_timer_env()
-#endif
-
    CALL mp_world_finalize()
 
 CONTAINS
 
-#if defined(__parallel)
 ! **************************************************************************************************
-!> \brief Exercise the communicator owned by the calling OpenMP thread.
+!> \brief Exercise concurrent point-to-point communication on a shared communicator.
+!> \param comm communicator shared by all OpenMP threads
 ! **************************************************************************************************
-   SUBROUTINE exercise_thread_comm()
+   SUBROUTINE exercise_concurrent_point_to_point(comm)
+      TYPE(mp_comm_type), INTENT(IN)                     :: comm
+
       INTEGER, PARAMETER                                 :: num_iterations = 128
 
-      INTEGER                                            :: dest, expected, iter, recv_value, &
-                                                            send_value, source, thread_id, value
+      INTEGER                                            :: dest, expected, iter, nthreads, &
+                                                            recv_value, send_value, source, tag, &
+                                                            thread_id
 
-      thread_id = 0
-!$    thread_id = omp_get_thread_num()
+      thread_id = omp_get_thread_num()
+      nthreads = omp_get_num_threads()
+      CPASSERT(nthreads == 2)
       CPASSERT(thread_id >= 0 .AND. thread_id < nthreads)
 
-      dest = MODULO(world%mepos + 1, world%num_pe)
-      source = MODULO(world%mepos - 1, world%num_pe)
+      dest = MODULO(comm%mepos + 1, comm%num_pe)
+      source = MODULO(comm%mepos - 1, comm%num_pe)
 
       DO iter = 1, num_iterations
-         value = world%mepos + 1 + 10*thread_id
-         CALL thread_comm(thread_id)%sum(value)
-         expected = world%num_pe*(world%num_pe + 1)/2 + 10*thread_id*world%num_pe
-         CPASSERT(value == expected)
-
-         value = -1
-         IF (world%is_source()) value = iter + thread_id
-         CALL thread_comm(thread_id)%bcast(value)
-         CPASSERT(value == iter + thread_id)
-
-         send_value = (world%num_pe*(iter - 1) + world%mepos)*nthreads + thread_id
-         CALL thread_comm(thread_id)%sendrecv(send_value, dest, recv_value, source, tag=iter)
-         expected = (world%num_pe*(iter - 1) + source)*nthreads + thread_id
+         tag = (iter - 1)*nthreads + thread_id
+         send_value = (comm%num_pe*(iter - 1) + comm%mepos)*nthreads + thread_id
+         CALL comm%sendrecv(send_value, dest, recv_value, source, tag=tag)
+         expected = (comm%num_pe*(iter - 1) + source)*nthreads + thread_id
          CPASSERT(recv_value == expected)
       END DO
-   END SUBROUTINE exercise_thread_comm
-#endif
+   END SUBROUTINE exercise_concurrent_point_to_point
 
 END PROGRAM message_passing_thread_unittest

--- a/src/mpiwrap/message_passing_thread_unittest.F
+++ b/src/mpiwrap/message_passing_thread_unittest.F
@@ -9,79 +9,76 @@
 !> \brief Exercises MPI wrappers concurrently from multiple OpenMP threads.
 ! **************************************************************************************************
 PROGRAM message_passing_thread_unittest
+   USE OMP_LIB,                         ONLY: omp_get_num_threads,&
+                                              omp_get_thread_num,&
+                                              omp_set_dynamic,&
+                                              omp_set_num_threads
    USE message_passing,                 ONLY: mp_collect_timings,&
                                               mp_comm_type,&
-                                              mp_has_thread_multiple,&
+                                              mp_thread_comm_pool_type,&
                                               mp_world_finalize,&
                                               mp_world_init
    USE timings,                         ONLY: add_timer_env,&
                                               rm_timer_env,&
                                               timings_register_hooks
-
-!$ USE OMP_LIB, ONLY: omp_get_num_threads, omp_get_thread_num, omp_set_dynamic, omp_set_num_threads
 #include "../base/base_uses.f90"
 
    IMPLICIT NONE
 
    TYPE(mp_comm_type)                                  :: world
-#if defined(__parallel)
-   INTEGER                                             :: i, nthreads
-   TYPE(mp_comm_type), ALLOCATABLE, DIMENSION(:)       :: thread_comm
-#endif
+   TYPE(mp_comm_type), POINTER                         :: thread_comm => NULL()
+   TYPE(mp_thread_comm_pool_type)                      :: thread_comms
+   INTEGER                                             :: nthreads
 
    CALL mp_world_init(world)
-
-#if defined(__parallel)
-   CPASSERT(mp_has_thread_multiple())
 
    CALL timings_register_hooks()
    CALL add_timer_env()
    mp_collect_timings = .TRUE.
 
-!$ CALL omp_set_dynamic(.FALSE.)
-!$ CALL omp_set_num_threads(2)
-   nthreads = 1
+   CALL omp_set_dynamic(.FALSE.)
+   CALL omp_set_num_threads(2)
+   nthreads = 0
 !$OMP PARALLEL DEFAULT(NONE) SHARED(nthreads)
 !$OMP SINGLE
-!$ nthreads = omp_get_num_threads()
+   nthreads = omp_get_num_threads()
 !$OMP END SINGLE
 !$OMP END PARALLEL
+   CALL thread_comms%init(world, num_lanes=nthreads)
+   CPASSERT(thread_comms%is_initialized())
+   CPASSERT(thread_comms%get_num_lanes() == nthreads)
 
-   ALLOCATE (thread_comm(0:nthreads - 1))
-   DO i = 0, nthreads - 1
-      CALL thread_comm(i)%from_dup(world)
-   END DO
-
-!$OMP PARALLEL DEFAULT(NONE) &
-!$OMP    SHARED(nthreads, thread_comm, world)
-   CALL exercise_thread_comm()
+!$OMP PARALLEL DEFAULT(NONE) NUM_THREADS(nthreads) &
+!$OMP    PRIVATE(thread_comm) SHARED(thread_comms, world)
+   CALL thread_comms%get_comm(thread_comm)
+   CALL exercise_thread_comm(thread_comm, world)
 !$OMP END PARALLEL
 
-   DO i = 0, nthreads - 1
-      CALL thread_comm(i)%free()
-   END DO
-   DEALLOCATE (thread_comm)
+   CALL thread_comms%free()
+   CPASSERT(.NOT. thread_comms%is_initialized())
 
    mp_collect_timings = .FALSE.
    CALL rm_timer_env()
-#endif
-
    CALL mp_world_finalize()
 
 CONTAINS
 
-#if defined(__parallel)
 ! **************************************************************************************************
 !> \brief Exercise the communicator owned by the calling OpenMP thread.
+!> \param thread_comm ...
+!> \param world ...
 ! **************************************************************************************************
-   SUBROUTINE exercise_thread_comm()
+   SUBROUTINE exercise_thread_comm(thread_comm, world)
+      TYPE(mp_comm_type), INTENT(IN)                     :: thread_comm, world
+
       INTEGER, PARAMETER                                 :: num_iterations = 128
 
-      INTEGER                                            :: dest, expected, iter, recv_value, &
-                                                            send_value, source, thread_id, value
+      INTEGER                                            :: dest, expected, iter, nthreads, &
+                                                            recv_value, send_value, source, &
+                                                            thread_id, value
 
-      thread_id = 0
-!$    thread_id = omp_get_thread_num()
+      thread_id = omp_get_thread_num()
+      nthreads = omp_get_num_threads()
       CPASSERT(thread_id >= 0 .AND. thread_id < nthreads)
 
       dest = MODULO(world%mepos + 1, world%num_pe)
@@ -89,21 +86,20 @@ CONTAINS
 
       DO iter = 1, num_iterations
          value = world%mepos + 1 + 10*thread_id
-         CALL thread_comm(thread_id)%sum(value)
+         CALL thread_comm%sum(value)
          expected = world%num_pe*(world%num_pe + 1)/2 + 10*thread_id*world%num_pe
          CPASSERT(value == expected)
 
          value = -1
          IF (world%is_source()) value = iter + thread_id
-         CALL thread_comm(thread_id)%bcast(value)
+         CALL thread_comm%bcast(value)
          CPASSERT(value == iter + thread_id)
 
          send_value = (world%num_pe*(iter - 1) + world%mepos)*nthreads + thread_id
-         CALL thread_comm(thread_id)%sendrecv(send_value, dest, recv_value, source, tag=iter)
+         CALL thread_comm%sendrecv(send_value, dest, recv_value, source, tag=iter)
          expected = (world%num_pe*(iter - 1) + source)*nthreads + thread_id
          CPASSERT(recv_value == expected)
       END DO
    END SUBROUTINE exercise_thread_comm
-#endif
 
 END PROGRAM message_passing_thread_unittest

--- a/src/mpiwrap/message_passing_thread_unittest.F
+++ b/src/mpiwrap/message_passing_thread_unittest.F
@@ -30,14 +30,14 @@ PROGRAM message_passing_thread_unittest
    TYPE(mp_thread_comm_pool_type)                      :: thread_comms
    INTEGER                                             :: nthreads
 
+   CALL omp_set_dynamic(.FALSE.)
+   CALL omp_set_num_threads(2)
    CALL mp_world_init(world)
 
    CALL timings_register_hooks()
    CALL add_timer_env()
    mp_collect_timings = .TRUE.
 
-   CALL omp_set_dynamic(.FALSE.)
-   CALL omp_set_num_threads(2)
    nthreads = 0
 !$OMP PARALLEL DEFAULT(NONE) SHARED(nthreads)
 !$OMP SINGLE

--- a/src/mpiwrap/mp_perf_env.F
+++ b/src/mpiwrap/mp_perf_env.F
@@ -20,7 +20,7 @@ MODULE mp_perf_env
    PUBLIC :: mp_perf_env_type
    PUBLIC :: mp_perf_env_retain, mp_perf_env_release
    PUBLIC :: add_mp_perf_env, rm_mp_perf_env, get_mp_perf_env, describe_mp_perf_env
-   PUBLIC :: add_perf
+   PUBLIC :: add_mp_worker_timing, add_perf
 
    TYPE mp_perf_type
       CHARACTER(LEN=20) :: name = ""
@@ -35,6 +35,8 @@ MODULE mp_perf_env
       PRIVATE
       INTEGER :: ref_count = -1
       TYPE(mp_perf_type), DIMENSION(MAX_PERF) :: mp_perfs = mp_perf_type()
+      INTEGER :: worker_thread_calls = 0
+      REAL(KIND=dp) :: worker_thread_time = 0.0_dp
    CONTAINS
       PROCEDURE, PUBLIC, PASS(perf_env), NON_OVERRIDABLE :: retain => mp_perf_env_retain
    END TYPE mp_perf_env_type
@@ -180,6 +182,12 @@ CONTAINS
             END IF
 
          END DO
+         IF (perf_env%worker_thread_calls > 0) THEN
+            WRITE (iw, '(1X,A,T47,I10)') &
+               'ACCUMULATED WORKER-THREAD MPI CALLS', perf_env%worker_thread_calls
+            WRITE (iw, '(1X,A,T47,F10.3)') &
+               'ACCUMULATED WORKER-THREAD MPI TIME [s]', perf_env%worker_thread_time
+         END IF
          WRITE (iw, '( 1X, 79("-"), / )')
       END IF
 #else
@@ -260,5 +268,29 @@ CONTAINS
 #endif
 
    END SUBROUTINE add_perf
+
+! **************************************************************************************************
+!> \brief Add time spent in MPI wrappers by OpenMP worker threads.
+!> \param elapsed elapsed wall time in seconds
+!> \note The reported time is accumulated across worker threads and may therefore exceed wall time.
+! **************************************************************************************************
+   SUBROUTINE add_mp_worker_timing(elapsed)
+      REAL(KIND=dp), INTENT(IN)                :: elapsed
+
+#if defined(__parallel)
+      TYPE(mp_perf_env_type), POINTER          :: perf_env
+
+      IF (stack_pointer < 1) RETURN
+      IF (.NOT. ASSOCIATED(mp_perf_stack(stack_pointer)%mp_perf_env)) RETURN
+
+      perf_env => mp_perf_stack(stack_pointer)%mp_perf_env
+!$OMP ATOMIC UPDATE
+      perf_env%worker_thread_calls = perf_env%worker_thread_calls + 1
+!$OMP ATOMIC UPDATE
+      perf_env%worker_thread_time = perf_env%worker_thread_time + elapsed
+#else
+      MARK_USED(elapsed)
+#endif
+   END SUBROUTINE add_mp_worker_timing
 
 END MODULE mp_perf_env

--- a/src/start/libcp2k.h
+++ b/src/start/libcp2k.h
@@ -29,31 +29,33 @@ typedef int force_env_t;
 void cp2k_get_version(char *version_str, int str_length);
 
 /*******************************************************************************
- * \brief Initialize CP2K and MPI
+ * \brief Initialize CP2K, initializing or attaching to MPI as needed
  * \warning You are supposed to call cp2k_finalize() before exiting the program.
  ******************************************************************************/
 void cp2k_init(void);
 
 /*******************************************************************************
  * \brief Initialize CP2K without initializing MPI (on MPI_COMM_WORLD)
- * \warning You are supposed to call cp2k_finalize() before exiting the program.
+ * \warning You are supposed to call cp2k_finalize_without_mpi() before exiting
+ *          the program.
  ******************************************************************************/
 void cp2k_init_without_mpi(void);
 
 /*******************************************************************************
  * \brief Initialize CP2K without initializing MPI on the given comm
- * \warning You are supposed to call cp2k_finalize() before exiting the program.
+ * \warning You are supposed to call cp2k_finalize_without_mpi() before exiting
+ *          the program.
  * \param mpi_comm Fortran MPI communicator if MPI is not managed by CP2K
  ******************************************************************************/
 void cp2k_init_without_mpi_comm(int mpi_comm);
 
 /*******************************************************************************
- * \brief Finalize CP2K and MPI
+ * \brief Finalize CP2K and MPI if CP2K initialized it
  ******************************************************************************/
 void cp2k_finalize(void);
 
 /*******************************************************************************
- * \brief Finalize CP2K and without finalizing MPI
+ * \brief Finalize CP2K without finalizing MPI
  ******************************************************************************/
 void cp2k_finalize_without_mpi(void);
 


### PR DESCRIPTION
Follow-up to #5811.

This PR extends the `MPI_THREAD_MULTIPLE` groundwork by making MPI initialization and ownership explicit in both the Fortran and C wrappers, and by making MPI wrapper instrumentation safe when calls originate from OpenMP worker threads.

The main changes are:

- Initialize MPI with `MPI_THREAD_MULTIPLE` when CP2K owns MPI initialization.
- When MPI was initialized by an embedding application, attach without taking ownership, query the provided thread-support level, and require `MPI_THREAD_MULTIPLE`.
- Finalize MPI only when CP2K initialized it.
- Detect duplicate or unmatched initialization/finalization calls and reject lifecycle operations after MPI has been finalized.
- Require MPI lifecycle operations and communicator creation, duplication, splitting, reference-count changes, and destruction to take place outside OpenMP parallel regions.
- Add an MPI-only unit test that exercises concurrent point-to-point communication from two OpenMP threads on a shared communicator, using distinct tags to keep message matching unambiguous.
- Use the ownership-aware C MPI initialization and finalization wrappers in `grid_unittest`.