### PR TITLE
Add COMMUTATOR_HR regtest matrix checksum

### DIFF
--- a/src/qs_scf_post_gpw.F
+++ b/src/qs_scf_post_gpw.F
@@ -31,6 +31,7 @@ MODULE qs_scf_post_gpw
    USE cp_dbcsr_api,                    ONLY: dbcsr_add,&
                                               dbcsr_p_type,&
                                               dbcsr_type
+   USE cp_dbcsr_contrib,                ONLY: dbcsr_checksum
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               dbcsr_deallocate_matrix_set
    USE cp_dbcsr_output,                 ONLY: cp_dbcsr_write_sparse_matrix
@@ -2572,7 +2573,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: zcharge
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: bfun
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: aedens, ccdens, ppdens
-      REAL(KIND=dp), DIMENSION(3)                        :: dr
+      REAL(KIND=dp), DIMENSION(3)                        :: checksum_hr, dr
       REAL(KIND=dp), DIMENSION(:), POINTER               :: my_Q0
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(atomic_kind_type), POINTER                    :: atomic_kind
@@ -3408,6 +3409,14 @@ CONTAINS
          CALL section_vals_val_get(input, "DFT%PRINT%AO_MATRICES%NDIGITS", i_val=after)
          NULLIFY (matrix_hr)
          CALL build_com_hr_matrix(qs_env, matrix_hr)
+         DO img = 1, 3
+            checksum_hr(img) = dbcsr_checksum(matrix_hr(img)%matrix)
+         END DO
+         IF (output_unit > 0) THEN
+            WRITE (output_unit, '(T2,A,E23.16)') 'COMMUTATOR_HR| CheckSum X =', checksum_hr(1)
+            WRITE (output_unit, '(T2,A,E23.16)') 'COMMUTATOR_HR| CheckSum Y =', checksum_hr(2)
+            WRITE (output_unit, '(T2,A,E23.16)') 'COMMUTATOR_HR| CheckSum Z =', checksum_hr(3)
+         END IF
          after = MIN(MAX(after, 1), 16)
          DO img = 1, 3
             CALL cp_dbcsr_write_sparse_matrix(matrix_hr(img)%matrix, 4, after, qs_env, &

--- a/tests/QS/regtest-gpw-1/TEST_FILES.toml
+++ b/tests/QS/regtest-gpw-1/TEST_FILES.toml
@@ -74,7 +74,10 @@
 #
 "He_PBE.inp"                            = [{matcher="E_total", tol=1.0E-13, ref=-1.14398524502663}]
 #
-"h2q.inp"                               = [{matcher="E_total", tol=1.0E-10, ref=-0.76162210587786}]
+"h2q.inp"                               = [{matcher="E_total",          tol=1.0E-10, ref=-0.76162210587786},
+                                           {matcher="COMMUTATOR_HR_X", tol=1.0E-8, ref=4.560125368089048},
+                                           {matcher="COMMUTATOR_HR_Y", tol=1.0E-8, ref=11.23984582788994},
+                                           {matcher="COMMUTATOR_HR_Z", tol=1.0E-8, ref=4.560125368089047}]
 # Mol Dipole Voronoi
 "moldip_voronoi.inp"                    = [{matcher="E_total", tol=1.0E-10, ref=-41.88176215391840}]
 # Test printing of cartesian overlap matrix with header

--- a/tests/QS/regtest-gpw-1/TEST_FILES.toml
+++ b/tests/QS/regtest-gpw-1/TEST_FILES.toml
@@ -74,7 +74,8 @@
 #
 "He_PBE.inp"                            = [{matcher="E_total", tol=1.0E-13, ref=-1.14398524502663}]
 #
-"h2q.inp"                               = [{matcher="E_total", tol=1.0E-10, ref=-0.76162210587786}]
+"h2q.inp"                               = [{matcher="E_total",      tol=1.0E-10, ref=-0.76162210587786},
+                                           {matcher="CP2K_MATRIX_CHECKSUM", title="COMMUTATOR", dimension=16, tol=1.0E-8, ref=[10.80033200738401, 118.25372370199796, 9.519705017376005]}]
 # Mol Dipole Voronoi
 "moldip_voronoi.inp"                    = [{matcher="E_total", tol=1.0E-10, ref=-41.88176215391840}]
 # Test printing of cartesian overlap matrix with header

--- a/tests/QS/regtest-gpw-1/h2q.inp
+++ b/tests/QS/regtest-gpw-1/h2q.inp
@@ -12,6 +12,12 @@
     &MGRID
       CUTOFF 100
     &END MGRID
+    &PRINT
+      &AO_MATRICES
+        COMMUTATOR_HR
+        NDIGITS 12
+      &END AO_MATRICES
+    &END PRINT
     &QS
       METHOD GPW
     &END QS

--- a/tests/matcher_classes.py
+++ b/tests/matcher_classes.py
@@ -2,7 +2,7 @@ import math
 import re
 import sys
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 if sys.version_info >= (3, 8):
     from typing import Literal, Protocol
@@ -82,6 +82,83 @@ class GenericMatcher(Matcher):
             return MatchResult("WRONG RESULT", error, value)
 
         return MatchResult("OK", error=None, value=value)  # passed
+
+
+# ======================================================================================
+class CP2KMatrixChecksumMatcher(Matcher):
+    def run(self, output: str, **kwargs: Any) -> MatchResult:
+        tol, ref = kwargs["tol"], kwargs["ref"]
+        title, dimension = kwargs["title"], kwargs.get("dimension", 16)
+        if (
+            not isinstance(tol, (float, int))
+            or not isinstance(ref, list)
+            or not ref
+            or not all(isinstance(value, (float, int)) for value in ref)
+            or not isinstance(title, str)
+            or not isinstance(dimension, int)
+            or dimension < 1
+        ):
+            return MatchResult(
+                "N/A", "Invalid CP2K matrix matcher arguments.\n", value=None
+            )
+
+        sections = re.split(rf"(?m)^\s+{re.escape(title)}\s*$", output)[1:]
+        if len(sections) != len(ref):
+            error = f"Expected {len(ref)} {title} matrices, found {len(sections)}.\n"
+            return MatchResult("WRONG RESULT", error, value=None)
+
+        values = []
+        for section in sections:
+            rows: List[List[float]] = [[] for _ in range(dimension)]
+            for line in section.splitlines():
+                fields = line.split()
+                if (
+                    len(fields) < 5
+                    or not fields[0].isdigit()
+                    or not fields[1].isdigit()
+                ):
+                    continue
+                try:
+                    row = int(fields[0])
+                    row_values = [
+                        float(value.replace("D", "E")) for value in fields[4:]
+                    ]
+                except ValueError:
+                    continue
+                if 1 <= row <= dimension and row_values:
+                    rows[row - 1].extend(row_values)
+                if all(len(row_values) == dimension for row_values in rows):
+                    break
+
+            if not all(len(row_values) == dimension for row_values in rows):
+                error = f"Could not parse a complete {dimension}x{dimension} {title} matrix.\n"
+                return MatchResult("WRONG RESULT", error, value=None)
+            values.append(
+                sum(
+                    (row + 1) * (col + 1) * value
+                    for row, row_values in enumerate(rows)
+                    for col, value in enumerate(row_values)
+                )
+            )
+
+        if not all(math.isfinite(value) for value in values):
+            return MatchResult("WRONG RESULT", "Checksum is not finite.\n", value=None)
+
+        errors = [
+            abs(value - reference) / abs(reference) if reference != 0.0 else abs(value)
+            for value, reference in zip(values, ref)
+        ]
+        if any(error > tol for error in errors):
+            checksums = ", ".join(
+                f"matrix {i + 1}: {value:.14g}" for i, value in enumerate(values)
+            )
+            return MatchResult(
+                "WRONG RESULT",
+                f"{title} checksum mismatch (relative errors: {errors}); values: {checksums}.\n",
+                value=None,
+            )
+
+        return MatchResult("OK", error=None, value=None)
 
 
 # ======================================================================================

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -26,6 +26,9 @@ registry = MatcherRegistry()
 
 # Total energy in Hartree
 registry["E_total"] = GenericMatcher(r"Total energy:", col=3)
+registry["COMMUTATOR_HR_X"] = GenericMatcher(r"COMMUTATOR_HR| CheckSum X =", col=5)
+registry["COMMUTATOR_HR_Y"] = GenericMatcher(r"COMMUTATOR_HR| CheckSum Y =", col=5)
+registry["COMMUTATOR_HR_Z"] = GenericMatcher(r"COMMUTATOR_HR| CheckSum Z =", col=5)
 
 registry["M002"] = GenericMatcher(r"MD| Potential energy", col=5)
 registry["M003"] = GenericMatcher(r"Total energy [eV]:", col=4)

--- a/tests/matchers.py
+++ b/tests/matchers.py
@@ -1,7 +1,13 @@
 import traceback
 from typing import Any, Dict
 
-from matcher_classes import Matcher, MatchResult, GenericMatcher, TextPresenceMatcher
+from matcher_classes import (
+    CP2KMatrixChecksumMatcher,
+    GenericMatcher,
+    MatchResult,
+    Matcher,
+    TextPresenceMatcher,
+)
 
 
 # ======================================================================================
@@ -26,6 +32,7 @@ registry = MatcherRegistry()
 
 # Total energy in Hartree
 registry["E_total"] = GenericMatcher(r"Total energy:", col=3)
+registry["CP2K_MATRIX_CHECKSUM"] = CP2KMatrixChecksumMatcher()
 
 registry["M002"] = GenericMatcher(r"MD| Potential energy", col=5)
 registry["M003"] = GenericMatcher(r"Total energy [eV]:", col=4)


### PR DESCRIPTION
Add regtest coverage for `DFT%PRINT%AO_MATRICES/COMMUTATOR_HR`. This follows #4694 and is a prerequisite for #5814 . The existing `regtest-gpw-1/h2q.inp` now enables `COMMUTATOR_HR` printing with 12 digits. CP2K now outputs checksums for the `COMMUTATOR_HR` matrix. 