### PR TITLE
Scale declaration cleaner work limit

### DIFF
--- a/tools/precommit/format_fortran_test.py
+++ b/tools/precommit/format_fortran_test.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 
 from format_fortran import main
+from prettify_cp2k import normalizeFortranFile
 from prettify_cp2k import selftest
 
 interface_cpp_content = """\
@@ -50,6 +51,21 @@ class TestSingleFileFolder(unittest.TestCase):
             result = fhandle.read()
 
         self.assertEqual(result.splitlines(), selftest.content.splitlines())
+
+    def test_large_declaration_dependency_pass(self):
+        declarations = []
+        for idx in range(500):
+            declarations.append(
+                {
+                    "attributes": [],
+                    "parameters": None,
+                    "vars": [f"var_{idx:03d}"],
+                    "normalizedType": f"TYPE_{idx:03d}",
+                }
+            )
+
+        normalizeFortranFile.enforceDeclDependecies(declarations)
+        self.assertEqual(sum(len(d["vars"]) for d in declarations), 500)
 
 
 class TestInterfaceCppDirective(unittest.TestCase):

--- a/tools/precommit/prettify_cp2k/normalizeFortranFile.py
+++ b/tools/precommit/prettify_cp2k/normalizeFortranFile.py
@@ -529,7 +529,7 @@ def enforceDeclDependecies(declarations):
     """enforces the dependencies between the vars
     and compacts the declarations, returns the variables needed by other variables"""
     nvars = sum(len(d["vars"]) for d in declarations)
-    max_iterations = max(100000, 10 * nvars * max(1, nvars))
+    max_iterations = max(100000, 10 * nvars**2)
     idecl = 0
     ii = 0
     while idecl < len(declarations):

--- a/tools/precommit/prettify_cp2k/normalizeFortranFile.py
+++ b/tools/precommit/prettify_cp2k/normalizeFortranFile.py
@@ -528,6 +528,8 @@ def findWord(word, text, options=re.IGNORECASE):
 def enforceDeclDependecies(declarations):
     """enforces the dependencies between the vars
     and compacts the declarations, returns the variables needed by other variables"""
+    nvars = sum(len(d["vars"]) for d in declarations)
+    max_iterations = max(100000, 10 * nvars * max(1, nvars))
     idecl = 0
     ii = 0
     while idecl < len(declarations):
@@ -560,8 +562,8 @@ def enforceDeclDependecies(declarations):
                 for idecl2 in range(idecl + 1, len(declarations)):
                     for ivar2 in range(len(declarations[idecl2]["vars"])):
                         ii += 1
-                        if ii > 100000:
-                            raise Error("could not enforce all constraints")
+                        if ii > max_iterations:
+                            raise RuntimeError("could not enforce all constraints")
                         m = VAR_RE.match(declarations[idecl2]["vars"][ivar2])
                         if (
                             ivar == 0


### PR DESCRIPTION
## Summary

- scale the declaration dependency-pass work limit with the number of parsed variables
- raise a defined `RuntimeError` if the scaled limit is still exceeded
- add a regression covering 500 independent declarations

This keeps the existing algorithm and its small-input behavior unchanged while avoiding a fixed-size failure for generated or unusually declaration-heavy Fortran routines.

## Testing

- `python3 tools/precommit/format_fortran_test.py`
- `./tools/precommit/precommit.py tools/precommit/format_fortran_test.py tools/precommit/prettify_cp2k/normalizeFortranFile.py`