### PR TITLE
Clean up tblite SCC residual and debug handling

### DIFF
--- a/src/qs_charge_mixing.F
+++ b/src/qs_charge_mixing.F
@@ -40,9 +40,9 @@ MODULE qs_charge_mixing
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_charge_mixing'
 
-   PUBLIC :: charge_mixing, charge_mixing_scc_error
+   PUBLIC :: charge_mixing, charge_mixing_scc_error, tblite_scc_error_on_cp2k_scale
 
-   REAL(KIND=dp), PARAMETER, PRIVATE :: tblite_scc_pconv = 2.0E-5_dp
+   REAL(KIND=dp), PARAMETER, PUBLIC :: tblite_scc_pconv = 2.0E-5_dp
 
 CONTAINS
 
@@ -216,6 +216,25 @@ CONTAINS
    END SUBROUTINE charge_mixing
 
 ! **************************************************************************************************
+!> \brief Map a raw tblite SCC residual to CP2K's EPS_SCF reporting scale.
+!> \param raw_error raw tblite SCC residual
+!> \param eps_scf CP2K SCF convergence threshold
+!> \param pconv tblite SCC convergence reference
+!> \return residual on the CP2K convergence scale
+! **************************************************************************************************
+   PURE FUNCTION tblite_scc_error_on_cp2k_scale(raw_error, eps_scf, pconv) RESULT(scaled_error)
+      REAL(KIND=dp), INTENT(IN)                          :: raw_error, eps_scf, pconv
+      REAL(KIND=dp)                                      :: scaled_error
+
+      IF (eps_scf > 0.0_dp .AND. pconv > 0.0_dp) THEN
+         scaled_error = eps_scf*raw_error/pconv
+      ELSE
+         scaled_error = raw_error
+      END IF
+
+   END FUNCTION tblite_scc_error_on_cp2k_scale
+
+! **************************************************************************************************
 !> \brief Return the CP2K-side tblite SCC-mixer residual on the CP2K EPS_SCF scale.
 !> \param mixing_store ...
 !> \param eps_scf ...
@@ -230,11 +249,8 @@ CONTAINS
       IF (.NOT. ASSOCIATED(mixing_store)) RETURN
       IF (mixing_store%tb_scc_mixer_step <= 1) RETURN
 
-      IF (eps_scf > 0.0_dp) THEN
-         mixer_error = eps_scf*mixing_store%tb_scc_mixer_error/tblite_scc_pconv
-      ELSE
-         mixer_error = mixing_store%tb_scc_mixer_error
-      END IF
+      mixer_error = tblite_scc_error_on_cp2k_scale(mixing_store%tb_scc_mixer_error, &
+                                                   eps_scf, tblite_scc_pconv)
 
    END FUNCTION charge_mixing_scc_error
 

--- a/src/tblite_interface.F
+++ b/src/tblite_interface.F
@@ -86,7 +86,7 @@ MODULE tblite_interface
    USE mulliken, ONLY: ao_charges
    USE orbital_pointers, ONLY: ncoset
    USE particle_types, ONLY: particle_type
-   USE qs_charge_mixing, ONLY: charge_mixing
+   USE qs_charge_mixing, ONLY: charge_mixing, tblite_scc_error_on_cp2k_scale, tblite_scc_pconv
    USE qs_condnum, ONLY: overlap_condnum
    USE qs_density_mixing_types, ONLY: modified_broyden_mixing_nr
    USE qs_energy_types, ONLY: qs_energy_type
@@ -126,7 +126,6 @@ MODULE tblite_interface
    INTEGER, PARAMETER                                 :: dip_n = 3
    INTEGER, PARAMETER                                 :: quad_n = 6
    REAL(KIND=dp), PARAMETER                           :: same_atom = 0.00001_dp
-   REAL(KIND=dp), PARAMETER                           :: tblite_scc_pconv = 2.0E-5_dp
 
    PUBLIC :: tb_set_calculator, tb_init_geometry, tb_init_wf
    PUBLIC :: tb_get_basis, build_tblite_matrices
@@ -553,12 +552,9 @@ CONTAINS
       IF (.NOT. tb_native_scc_mixer_active(dft_control)) RETURN
       IF (ALLOCATED(tb%mixer)) THEN
          raw_error = REAL(tb%mixer%get_error(), KIND=dp)
-         IF (eps_scf > 0.0_dp) THEN
-            mixer_error = eps_scf*raw_error/ &
-                          (tblite_scc_pconv*dft_control%qs_control%xtb_control%tblite_accuracy)
-         ELSE
-            mixer_error = raw_error
-         END IF
+         mixer_error = tblite_scc_error_on_cp2k_scale( &
+                       raw_error, eps_scf, &
+                       tblite_scc_pconv*dft_control%qs_control%xtb_control%tblite_accuracy)
       END IF
 #else
       MARK_USED(dft_control)
@@ -1534,9 +1530,7 @@ CONTAINS
       LOGICAL                                            :: advance_native_mixer, discard_mixed_output, do_combined_mixing, &
                                                             do_dipole, do_quadrupole, native_sign_mixing, &
                                                             skip_charge_mixing, reuse_native_input, skip_scf_dispersion, &
-                                                            skip_scf_dispersion_energy, seed_native_from_rho, &
-                                                            skip_scf_dispersion_gradient, skip_scf_dispersion_potential, &
-                                                            use_native_mixer, use_no_mixer
+                                                            seed_native_from_rho, use_native_mixer, use_no_mixer
       REAL(KIND=dp)                                      :: native_seed_charge, norm, new_charge, pao
 #if defined(__TBLITE_DEBUG_DIAGNOSTICS)
       INTEGER                                            :: debug_status
@@ -1576,18 +1570,10 @@ CONTAINS
       skip_scf_dispersion = .FALSE.
 #if defined(__TBLITE_DEBUG_DIAGNOSTICS)
       CALL GET_ENVIRONMENT_VARIABLE("CP2K_TBLITE_DEBUG_SKIP_SCF_DISPERSION", debug_value, STATUS=debug_status)
-      IF (debug_status == 0) READ (debug_value, *, IOSTAT=debug_status) skip_scf_dispersion
-#endif
-      skip_scf_dispersion_energy = skip_scf_dispersion
-      skip_scf_dispersion_gradient = skip_scf_dispersion
-      skip_scf_dispersion_potential = skip_scf_dispersion
-#if defined(__TBLITE_DEBUG_DIAGNOSTICS)
-      CALL GET_ENVIRONMENT_VARIABLE("CP2K_TBLITE_DEBUG_SKIP_SCF_DISPERSION_ENERGY", debug_value, STATUS=debug_status)
-      IF (debug_status == 0) READ (debug_value, *, IOSTAT=debug_status) skip_scf_dispersion_energy
-      CALL GET_ENVIRONMENT_VARIABLE("CP2K_TBLITE_DEBUG_SKIP_SCF_DISPERSION_GRADIENT", debug_value, STATUS=debug_status)
-      IF (debug_status == 0) READ (debug_value, *, IOSTAT=debug_status) skip_scf_dispersion_gradient
-      CALL GET_ENVIRONMENT_VARIABLE("CP2K_TBLITE_DEBUG_SKIP_SCF_DISPERSION_POTENTIAL", debug_value, STATUS=debug_status)
-      IF (debug_status == 0) READ (debug_value, *) skip_scf_dispersion_potential
+      IF (debug_status == 0) THEN
+         READ (debug_value, *, IOSTAT=debug_status) skip_scf_dispersion
+         IF (debug_status /= 0) skip_scf_dispersion = .FALSE.
+      END IF
 #endif
       IF (dft_control%qs_control%do_ls_scf .OR. scf_control%use_ot) THEN
          use_native_mixer = .FALSE.
@@ -2128,10 +2114,8 @@ CONTAINS
          CALL tb%calc%coulomb%get_energy(tb%mol, tb%cache, tb%wfn, tb%e_es)
       END IF
       IF (ALLOCATED(tb%calc%dispersion)) THEN
-         IF (.NOT. skip_scf_dispersion_potential) THEN
+         IF (.NOT. skip_scf_dispersion) THEN
             CALL tb%calc%dispersion%get_potential(tb%mol, tb%dcache, tb%wfn, tb%pot)
-         END IF
-         IF (.NOT. skip_scf_dispersion_energy) THEN
             CALL tb%calc%dispersion%get_energy(tb%mol, tb%dcache, tb%wfn, tb%e_scd)
          END IF
       END IF
@@ -2148,7 +2132,7 @@ CONTAINS
             CALL tb_grad2force(qs_env, tb, para_env, 3)
          END IF
 
-         IF (ALLOCATED(tb%calc%dispersion) .AND. .NOT. skip_scf_dispersion_gradient) THEN
+         IF (ALLOCATED(tb%calc%dispersion) .AND. .NOT. skip_scf_dispersion) THEN
             tb%grad = 0.0_dp
             CALL tb%calc%dispersion%get_gradient(tb%mol, tb%dcache, tb%wfn, tb%grad, tb%sigma)
             CALL tb_dump_sigma_component("after_dispersion_scf", tb%sigma, para_env)


### PR DESCRIPTION
## Summary

- centralize conversion of raw tblite SCC residuals to the CP2K `EPS_SCF` reporting scale
- share the tblite SCC convergence reference instead of duplicating it in two modules
- replace the component-specific SCC-dispersion debug switches with one developer-only switch

This follows up the post-merge review comments on #5131. The large numbered `mp_test_mode` infrastructure was already removed in #5169. This change addresses the remaining duplicated residual conversion and consolidates the retained dispersion diagnostic.

The common `EPS_SCF` scale is retained because both residual paths contribute to the same CP2K `iter_delta`; only the conversion implementation is shared.

## Validation

- precommit checks for both changed Fortran files
- GCC 16 / OpenMPI build of `cp2k.psmp` with tblite
- `N2_gfn2_cp2k_kp_stress.inp` completed successfully
