### PR TITLE
Expose D4 smooth cutoff widths as input

### DIFF
--- a/src/input_cp2k_xc.F
+++ b/src/input_cp2k_xc.F
@@ -973,6 +973,21 @@ CONTAINS
                           unit_str="angstrom")
       CALL section_add_keyword(subsection, keyword)
       CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="D4_CUTOFF_WIDTH", &
+                          variants=["D4_2B_CUTOFF_WIDTH"], &
+                          description="Width of the smooth cutoff for the 2-body term of D4. "// &
+                          "A value of zero disables smoothing.", &
+                          usage="D4_CUTOFF_WIDTH 0.05", default_r_val=0.05_dp, &
+                          unit_str="bohr")
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
+      CALL keyword_create(keyword, __LOCATION__, name="D4_3B_CUTOFF_WIDTH", &
+                          description="Width of the smooth cutoff for the 3-body term of D4. "// &
+                          "A value of zero disables smoothing.", &
+                          usage="D4_3B_CUTOFF_WIDTH 0.0", default_r_val=0.0_dp, &
+                          unit_str="bohr")
+      CALL section_add_keyword(subsection, keyword)
+      CALL keyword_release(keyword)
       CALL keyword_create(keyword, __LOCATION__, name="D4_CN_CUTOFF", &
                           description="Coordination number cutoff for D4", &
                           usage="D4_CN_CUTOFF 30.0", default_r_val=-1.0_dp, &

--- a/src/qs_dispersion_d4.F
+++ b/src/qs_dispersion_d4.F
@@ -75,39 +75,6 @@ CONTAINS
 
 #if defined(__DFTD4)
 ! **************************************************************************************************
-!> \brief Read smooth-cutoff width override from environment.
-!> \param primary primary environment variable name
-!> \param fallback fallback environment variable name
-!> \param cutoff real-space cutoff used to validate the width
-!> \param width smooth-cutoff width to update
-! **************************************************************************************************
-   SUBROUTINE d4_smooth_width_from_env(primary, fallback, cutoff, width)
-      CHARACTER(LEN=*), INTENT(IN)                       :: primary, fallback
-      REAL(KIND=dp), INTENT(IN)                          :: cutoff
-      REAL(KIND=dp), INTENT(INOUT)                       :: width
-
-      CHARACTER(LEN=64)                                  :: env
-      INTEGER                                            :: io, stat
-      REAL(KIND=dp)                                      :: env_width
-
-      CALL GET_ENVIRONMENT_VARIABLE(primary, env, STATUS=stat)
-      IF (stat /= 0 .OR. LEN_TRIM(env) == 0) THEN
-         CALL GET_ENVIRONMENT_VARIABLE(fallback, env, STATUS=stat)
-      END IF
-      IF (stat == 0 .AND. LEN_TRIM(env) > 0) THEN
-         READ (env, *, IOSTAT=io) env_width
-         IF (io == 0) THEN
-            IF (env_width > 0.0_dp .AND. env_width < cutoff) THEN
-               width = env_width
-            ELSE
-               width = 0.0_dp
-            END IF
-         END IF
-      END IF
-
-   END SUBROUTINE d4_smooth_width_from_env
-
-! **************************************************************************************************
 !> \brief ...
 !> \param qs_env ...
 !> \param dispersion_env ...
@@ -272,14 +239,14 @@ CONTAINS
       IF (cutoff%disp3 > cutoff%disp2) THEN
          CPABORT("D4: Three-body cutoff should be smaller than two-body cutoff")
       END IF
-      ! DFTD4 4.2 introduced explicit smooth-cutoff widths.
-      ! Keep the same narrow two-body smoothing used by the toolchain patch.
-      cutoff%width2 = 0.05_dp
-      cutoff%width3 = 0.0_dp
-      CALL d4_smooth_width_from_env("DFTD4_DISP2_SMOOTH_WIDTH", "TBLITE_D4_DISP2_SMOOTH_WIDTH", &
-                                    cutoff%disp2, cutoff%width2)
-      CALL d4_smooth_width_from_env("DFTD4_DISP3_SMOOTH_WIDTH", "TBLITE_D4_DISP3_SMOOTH_WIDTH", &
-                                    cutoff%disp3, cutoff%width3)
+      cutoff%width2 = dispersion_env%d4_cutoff_width
+      cutoff%width3 = dispersion_env%d4_3b_cutoff_width
+      IF (cutoff%width2 < 0.0_dp .OR. cutoff%width2 >= cutoff%disp2) THEN
+         CPABORT("D4: Two-body cutoff width must be non-negative and smaller than the cutoff")
+      END IF
+      IF (cutoff%width3 < 0.0_dp .OR. cutoff%width3 >= cutoff%disp3) THEN
+         CPABORT("D4: Three-body cutoff width must be non-negative and smaller than the cutoff")
+      END IF
 
       IF (calculate_forces) THEN
          grad = .TRUE.

--- a/src/qs_dispersion_types.F
+++ b/src/qs_dispersion_types.F
@@ -40,6 +40,8 @@ MODULE qs_dispersion_types
       REAL(KIND=dp)                          :: rc_disp = -1.0_dp
       REAL(KIND=dp)                          :: rc_d4 = -1.0_dp
       REAL(KIND=dp)                          :: rc_cn = -1.0_dp
+      REAL(KIND=dp)                          :: d4_cutoff_width = 0.05_dp
+      REAL(KIND=dp)                          :: d4_3b_cutoff_width = 0.0_dp
       REAL(KIND=dp)                          :: exp_pre = -1.0_dp
       TYPE(section_vals_type), POINTER       :: dftd_section => NULL()
       LOGICAL                                :: verbose = .FALSE. !extended output
@@ -213,4 +215,3 @@ CONTAINS
    END SUBROUTINE qs_dispersion_release
 
 END MODULE qs_dispersion_types
-

--- a/src/qs_dispersion_utils.F
+++ b/src/qs_dispersion_utils.F
@@ -365,6 +365,10 @@ CONTAINS
             CALL section_vals_val_get(pp_section, "D3_REFERENCE_CODE", &
                                       l_val=dispersion_env%d3_reference_code)
             CALL section_vals_val_get(pp_section, "D4_CUTOFF", r_val=dispersion_env%rc_d4)
+            CALL section_vals_val_get(pp_section, "D4_CUTOFF_WIDTH", &
+                                      r_val=dispersion_env%d4_cutoff_width)
+            CALL section_vals_val_get(pp_section, "D4_3B_CUTOFF_WIDTH", &
+                                      r_val=dispersion_env%d4_3b_cutoff_width)
             CALL section_vals_val_get(pp_section, "D4_CN_CUTOFF", r_val=dispersion_env%rc_cn)
             CALL section_vals_val_get(pp_section, "FACTOR_S9_TERM", r_val=dispersion_env%s9)
             !C9 term default=T for D4

--- a/tests/QS/regtest-dft-vdw-corr-4/pbe_dftd4_sparse.inp
+++ b/tests/QS/regtest-dft-vdw-corr-4/pbe_dftd4_sparse.inp
@@ -40,6 +40,8 @@
         &PAIR_POTENTIAL
           REFERENCE_FUNCTIONAL PBE
           TYPE DFTD4
+          D4_CUTOFF_WIDTH [bohr] 0.05
+          D4_3B_CUTOFF_WIDTH [bohr] 0.0
           &EEQ
             EPS_DIIS 1.0E-12
             SPARSE

--- a/tests/QS/regtest-dft-vdw-corr-4/pbe_dftd4_sparse.inp
+++ b/tests/QS/regtest-dft-vdw-corr-4/pbe_dftd4_sparse.inp
@@ -38,10 +38,10 @@
       &VDW_POTENTIAL
         DISPERSION_FUNCTIONAL PAIR_POTENTIAL
         &PAIR_POTENTIAL
+          D4_3B_CUTOFF_WIDTH [bohr] 0.0
+          D4_CUTOFF_WIDTH [bohr] 0.05
           REFERENCE_FUNCTIONAL PBE
           TYPE DFTD4
-          D4_CUTOFF_WIDTH [bohr] 0.05
-          D4_3B_CUTOFF_WIDTH [bohr] 0.0
           &EEQ
             EPS_DIIS 1.0E-12
             SPARSE


### PR DESCRIPTION
## Summary

- add `D4_CUTOFF_WIDTH` (alias `D4_2B_CUTOFF_WIDTH`) and `D4_3B_CUTOFF_WIDTH` to `&VDW_POTENTIAL / &PAIR_POTENTIAL`
- remove the DFTD4/tblite environment-variable overrides from the CP2K D4 interface
- validate that configured widths are non-negative and smaller than their cutoffs
- cover both keywords in the sparse periodic D4 regression input

This follows up the post-merge discussion on #5143. The numerical defaults remain unchanged: the two-body width is `0.05` bohr, while three-body smoothing is disabled by default. The original stress discontinuity was isolated to the two-body D4 term; enabling three-body smoothing by default would change behavior beyond that fix. It can now be enabled explicitly through the input.

## Validation

- precommit checks for all changed Fortran files
- GCC 16 / OpenMPI build of `cp2k.psmp` with tblite/DFTD4
- `pbe_dftd4_sparse.inp` with two MPI ranks
