### PR TITLE
Ban direct environment-variable queries

### DIFF
--- a/tools/conventions/analyze_gfortran_ast.py
+++ b/tools/conventions/analyze_gfortran_ast.py
@@ -159,6 +159,11 @@ def process_log_file(fhandle: TextIO) -> None:
                 msg(f'Found CALL RANDOM_SEED in procedure "{cur_proc}"', 105)
             elif tokens[1].lower().startswith("_gfortran_execute_command_line"):
                 msg(f'Found CALL EXECUTE_COMMAND_LINE in procedure "{cur_proc}"', 106)
+            elif tokens[1].lower().startswith("_gfortran_get_environment_variable"):
+                msg(
+                    f'Found CALL GET_ENVIRONMENT_VARIABLE in procedure "{cur_proc}"',
+                    107,
+                )
 
         elif line.startswith("GOTO"):
             msg(f'Found GOTO statement in procedure "{cur_proc}"', 201)

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -246,5 +246,17 @@ xyz2dcd.F: Found STOP statement in procedure "xyz2dcd" https://cp2k.org/conv#c20
 xyz2dcd.F: Found WRITE statement with hardcoded unit in "abort_program" https://cp2k.org/conv#c012
 xyz2dcd.F: Found WRITE statement with hardcoded unit in "print_help" https://cp2k.org/conv#c012
 xyz2dcd.F: Found WRITE statement with hardcoded unit in "xyz2dcd" https://cp2k.org/conv#c012
+# Existing environment queries audited in #5857. These provide runtime metadata,
+# external resource locations, warnings, or developer-only diagnostics.
+cp2k.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "cp2k" https://cp2k.org/conv#c107
+machine.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "m_getlog" https://cp2k.org/conv#c107
+machine.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "m_omp_get_stacksize" https://cp2k.org/conv#c107
+skala_gpw_functional.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "get_skala_model_path" https://cp2k.org/conv#c107
+tblite_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "tb_add_stress" https://cp2k.org/conv#c107
+tblite_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "tb_dump_sigma_component" https://cp2k.org/conv#c107
+tblite_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "tb_grad2force" https://cp2k.org/conv#c107
+tblite_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "tb_update_charges" https://cp2k.org/conv#c107
+xc_gauxc_functional.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "apply_gauxc" https://cp2k.org/conv#c107
+xc_gauxc_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "print_gauxc_status_message" https://cp2k.org/conv#c107
 # Suppression kept for toolchain based convention check
 cp_output_handling_openpmd.F: Found type cp_openpmd_per_call_value_type without initializer https://cp2k.org/conv#c016

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -246,16 +246,16 @@ xyz2dcd.F: Found STOP statement in procedure "xyz2dcd" https://cp2k.org/conv#c20
 xyz2dcd.F: Found WRITE statement with hardcoded unit in "abort_program" https://cp2k.org/conv#c012
 xyz2dcd.F: Found WRITE statement with hardcoded unit in "print_help" https://cp2k.org/conv#c012
 xyz2dcd.F: Found WRITE statement with hardcoded unit in "xyz2dcd" https://cp2k.org/conv#c012
+# Current GFortran AST false positives: the ELPA imports have ONLY clauses, and
+# the Libint engines in the Coulomb context are initialized explicitly.
+coulomb_integral_interface.F: Found type coulomb_integral_context_type without initializer https://cp2k.org/conv#c016
+cp_cfm_elpa.F: Module "elpa" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
+cp_cfm_elpa.F: Module "elpa_constants" USEd without ONLY clause or not PRIVATE https://cp2k.org/conv#c002
 # Existing environment queries audited in #5857. These provide runtime metadata,
-# external resource locations, warnings, or developer-only diagnostics.
-cp2k.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "cp2k" https://cp2k.org/conv#c107
+# external resource locations, or diagnostics.
 machine.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "m_getlog" https://cp2k.org/conv#c107
 machine.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "m_omp_get_stacksize" https://cp2k.org/conv#c107
 skala_gpw_functional.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "get_skala_model_path" https://cp2k.org/conv#c107
-tblite_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "tb_add_stress" https://cp2k.org/conv#c107
-tblite_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "tb_dump_sigma_component" https://cp2k.org/conv#c107
-tblite_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "tb_grad2force" https://cp2k.org/conv#c107
-tblite_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "tb_update_charges" https://cp2k.org/conv#c107
 xc_gauxc_functional.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "apply_gauxc" https://cp2k.org/conv#c107
 xc_gauxc_interface.F: Found CALL GET_ENVIRONMENT_VARIABLE in procedure "print_gauxc_status_message" https://cp2k.org/conv#c107
 # Suppression kept for toolchain based convention check


### PR DESCRIPTION
## Summary

- flag direct `GET_ENVIRONMENT_VARIABLE` calls in the GFortran AST conventions check
- explicitly suppress the currently audited calls that are present in the conventions build
- prevent new procedures from introducing hidden environment-controlled inputs
- account for three current-master GFortran AST false positives exposed by the conventions run

## Rationale

This follows the reproducibility discussion in #5842. Environment variables should not silently steer CP2K calculations.

The existing detected calls are retained as an explicit migration boundary so this conventions-only change has no runtime effect. Most provide runtime metadata, external resource locations, or diagnostics. Calls in the main program and developer-only tblite code are not emitted by the current conventions build and therefore do not need suppressions. In particular, removing the SKALA model-path aliases needs a separate focused change because toolchain, Spack, and regtest configurations currently rely on them.

The initial CI run also exposed three violations already present on master. The two ELPA imports have explicit `ONLY` clauses but are reported through imported derived-type metadata in the GFortran AST. The Libint engines in `coulomb_integral_context_type` cannot be default-constructed and are initialized explicitly by `coulomb_integral_init`. These three false positives are documented and suppressed.

## Validation

- `./make_pretty.sh`
- `python3 -m py_compile tools/conventions/analyze_gfortran_ast.py tools/conventions/summarize_issues.py`
- verified rule 107 using actual GFortran AST output from a small `GET_ENVIRONMENT_VARIABLE` call
- `git diff --check origin/master...HEAD`

Refs #5857
