### PR TITLE
BUILD: Make FindLapack honor user-provided CP2K_LAPACK_LINK_LIBRARIES

### DIFF
--- a/cmake/modules/FindLapack.cmake
+++ b/cmake/modules/FindLapack.cmake
@@ -31,18 +31,32 @@ if(NOT CP2K_CONFIG_PACKAGE)
       get_target_property(CP2K_LAPACK_LINK_LIBRARIES cp2k::BLAS::blas
                           INTERFACE_LINK_LIBRARIES)
     else()
-      # we might get lucky to find a pkgconfig package for lapack (fedora
-      # provides one for instance)
-      if(PKG_CONFIG_FOUND)
-        pkg_check_modules(CP2K_LAPACK lapack)
+      if(CP2K_BLAS_VENDOR MATCHES "CUSTOM" AND NOT DEFINED
+                                               CP2K_LAPACK_LINK_LIBRARIES)
+        message(
+          FATAL_ERROR
+            "Setting CP2K_BLAS_VENDOR=CUSTOM imply setting CP2K_LAPACK_LINK_LIBRARIES to the right libraries."
+        )
       endif()
 
-      if(NOT CP2K_LAPACK_FOUND)
-        find_library(
-          CP2K_LAPACK_LINK_LIBRARIES
-          NAMES "lapack" "lapack64"
-          PATH_SUFFIXES "openblas" "openblas64" "openblas-pthread"
-                        "openblas-openmp" "lib" "lib64")
+      if(DEFINED CP2K_LAPACK_LINK_LIBRARIES)
+        # the user provided the libraries (CP2K_BLAS_VENDOR=CUSTOM), do not
+        # search
+        set(CP2K_LAPACK_FOUND TRUE)
+      else()
+        # we might get lucky to find a pkgconfig package for lapack (fedora
+        # provides one for instance)
+        if(PKG_CONFIG_FOUND)
+          pkg_check_modules(CP2K_LAPACK lapack)
+        endif()
+
+        if(NOT CP2K_LAPACK_FOUND)
+          find_library(
+            CP2K_LAPACK_LINK_LIBRARIES
+            NAMES "lapack" "lapack64"
+            PATH_SUFFIXES "openblas" "openblas64" "openblas-pthread"
+                          "openblas-openmp" "lib" "lib64")
+        endif()
       endif()
     endif()
   endif()


### PR DESCRIPTION
## Bug
`cmake/modules/FindLapack.cmake` ignores a user-provided
`CP2K_LAPACK_LINK_LIBRARIES` when `CP2K_BLAS_VENDOR` is `CUSTOM`.
`CUSTOM` is the standard setting for spack builds.
The module calls `pkg_check_modules(CP2K_LAPACK lapack)` without a guard.
On hosts that provide a system `lapack.pc`, for example Debian or Ubuntu installed
`libopenblas-dev` using apt, pkg-config writes plain variables. CMake reads a
plain variable before a cache variable of the same name, so the
pkg-config result hides the user value.

The link line contains the spack OpenBLAS for the BLAS target and the
system `/usr/lib/x86_64-linux-gnu/openblas-pthread/liblapack.so` for the
LAPACK target. `libcp2k.so` then records `NEEDED libopenblas.so.0` and
`NEEDED liblapack.so.3`. At run time the process loads two complete
OpenBLAS runtimes. BLAS then crash at random lines.

## Fix

FindBlas.cmake already treats a 
defined CP2K_BLAS_LINK_LIBRARIES as authoritative, and its own FATAL_ERROR 
message names both variables. This extends the same rule to the LAPACK half.

The new FATAL_ERROR guard stops a CUSTOM build without CP2K_LAPACK_LINK_LIBRARIES 
with a clear message instead of a silent system search. 
The DEFINED guard accepts a user value and skips the search.

_Note: the new FATAL_ERROR changes behavior for CUSTOM builds that
set only CP2K_BLAS_LINK_LIBRARIES and relied on the silent search. 
I mirrored the FindBlas.cmake wording intentionally, but I am happy to 
downgrade it to a warning if you prefer._

<details>
<summary>How to reproduce</summary>

```text

prerequisite: libopenblas-dev installed via apt (Debian/Ubuntu)

$ spack spec    # trimmed to the relevant nodes
  cp2k@master ~cosma ~cuda +dbm_gpu ~dlaf +elpa +grid_gpu +libint +libxc +mpi
              ~mpi_f08 +openmp ~shared ~sirius ...        %gcc@14.2.0
  ^openblas@0.3.30 +fortran +pic +shared threads=openmp   %gcc@14.2.0
  ^openmpi@5.0.10                                         %gcc@14.2.0
  ^elpa@2026.02.002 +openmp
  ^netlib-scalapack@2.2.3 +shared

$ mpirun -np 2 cp2k.psmp <regtest>
  SIGSEGV in unrelated code paths, for example atom_operators.F:317

$ ldd cp2k.psmp | grep -iE 'lapack|openblas'
  liblapack.so.3   => /usr/lib/x86_64-linux-gnu/openblas-pthread/liblapack.so.3
  libopenblas.so.0 => <spack>/openblas-0.3.30-.../lib/libopenblas.so.0

$ readelf -d libcp2k.so.2026.2 | grep NEEDED
  NEEDED liblapack.so.3
  NEEDED libopenblas.so.0

$ patchelf --replace-needed liblapack.so.3 libopenblas.so.0 libcp2k.so.2026.2
  ->  crashes gone, energies bit-identical
```
</details>