### PR TITLE
Misc docs edits and a bug fix for "mentions" links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ git clone -b support/vx.y --recursive https://github.com/cp2k/cp2k.git cp2k
 
 ## Install CP2K
 
-The [installation instructions](https://manual.cp2k.org/trunk/getting-started/installation.md) in
+The [installation instructions](https://manual.cp2k.org/trunk/getting-started/installation.html) in
 the CP2K manual provide several methods for installing CP2K with dependencies:
 
 - [Build from Source](https://manual.cp2k.org/trunk/getting-started/build-from-source.html)
@@ -64,7 +64,7 @@ the CP2K manual provide several methods for installing CP2K with dependencies:
 - [`data`](./data): Simulation parameters e.g. basis sets and pseudopotentials
 - [`docs`](./docs/): The markdown source pages for documentations that is rendered as the manual
 - [`tests`](./tests): Inputs for tests and regression tests
-- [`tools`](./tools): Mixed collection of useful scripts related to cp2k
+- [`tools`](./tools): Mixed collection of useful scripts related to CP2K
 - [`benchmarks`](./benchmarks): Inputs for benchmarks
 
 [conda-badge]: https://img.shields.io/conda/vn/conda-forge/cp2k

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,13 +87,15 @@ For a all typography options see the
   - This requires adding the citation to the [bibliography.F](../src/common/bibliography.F) and is
     rendered as a link to the [bibliography page](https://manual.cp2k.org/trunk/bibliography.html);
     ⚠️ always use the auto-generated key on the bibliography page for documentation, which may or
-    may not match the customizable key in `CALL add_reference(key=...)` invocations for source codes
+    may not match the name of the variable `key` passed to fortran `CALL add_reference(key=...)`
+    invocations for source codes
 - Another page: `[](../optical/tddft)`
   - Use the relative path, where the `.md` suffix for file extension can be specified or omitted
 - Subsection in the current page: `[](#problems-and-solutions)`
 - Subsection in another page: `[](../optical/tddft.md#periodic-systems)`
-  - ⚠️ Also use the relative path, but the `.md` suffix must be present before the `#` sign; see
-    also [](#cross-references) below
+  - ⚠️ Also use the relative path, but the `.md` suffix must be present before the `#` sign, and
+    only the first three levels of headings have these anchors auto-generated on the final page
+    ready for use; see [](#cross-references) below for an alternative
 - Input section: `[FORCE_EVAL](#CP2K_INPUT.FORCE_EVAL)`
   - This will also generate a "mentions" backlink in the input reference for the section
 - Input keyword: `[STRESS_TENSOR](#CP2K_INPUT.FORCE_EVAL.STRESS_TENSOR)`
@@ -220,7 +222,8 @@ plain display. Details can be found at
 ## Cross References
 
 Apart from using the title or header of a section as introduced in [](#links) above, it is also
-possible to define an explicit target for linking purposes. With the following target
+possible to define an explicit target for linking purposes. The identifier enclosed in parentheses
+is globally active and can be linked internally or externally. For instance, defined in one page,
 
 ```
 (build-gromacs-cp2k)=
@@ -230,7 +233,7 @@ possible to define an explicit target for linking purposes. With the following t
 The latest supported GROMACS release...
 ```
 
-the section can be linked like
+the section can be linked in another page without the need for full relative path.
 
 ```
 Build GROMACS with CP2K QM/MM support following instructions from [](#build-gromacs-cp2k) and ...

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ support. The following gives a quick overview of the syntax:
 ```
 **bold text**
 
-_italic text_
+_italic text_ (alternatively, *italic text*)
 
 ~~strikethrough text~~
 
@@ -81,30 +81,74 @@ For a all typography options see the
 ## Links
 
 - Acronym: `` {term}`ADMM` ``
-- Publication: `[](#Wilhelm2018)` ⚠️ see note below
+  - This requires adding the definition to the [acronyms.md](./acronyms.md) and is rendered as a
+    link to the [acronyms page](https://manual.cp2k.org/trunk/acronyms.html)
+- Publication: `[](#Wilhelm2018)`
+  - This requires adding the citation to the [bibliography.F](../src/common/bibliography.F) and is
+    rendered as a link to the [bibliography page](https://manual.cp2k.org/trunk/bibliography.html);
+    ⚠️ always use the auto-generated key on the bibliography page for documentation, which may or
+    may not match the customizable key in `CALL add_reference(key=...)` invocations for source codes
 - Another page: `[](../optical/tddft)`
-- Subsection in another page: `[](../optical/tddft.md#periodic-systems)` ⚠️ with file extension
+  - Use the relative path, where the `.md` suffix for file extension can be specified or omitted
+- Subsection in the current page: `[](#problems-and-solutions)`
+- Subsection in another page: `[](../optical/tddft.md#periodic-systems)`
+  - ⚠️ Also use the relative path, but the `.md` suffix must be present before the `#` sign; see
+    also [](#cross-references) below
 - Input section: `[FORCE_EVAL](#CP2K_INPUT.FORCE_EVAL)`
+  - This will also generate a "mentions" backlink in the input reference for the section
 - Input keyword: `[STRESS_TENSOR](#CP2K_INPUT.FORCE_EVAL.STRESS_TENSOR)`
+  - This will also highlight the keyword in the list and generate a "mentions" backlink following
+    the description in the input reference
+  - In case there is a name conflit, append `_SECTION` to the link to the section and keep the link
+    to the keyword as-is: use `[POTENTIAL](#CP2K_INPUT.FORCE_EVAL.SUBSYS.KIND.POTENTIAL_SECTION)`
+    for the section `&POTENTIAL` and `[POTENTIAL](#CP2K_INPUT.FORCE_EVAL.SUBSYS.KIND.POTENTIAL)` for
+    the keyword `POTENTIAL`
 - External URL: `<https://www.gromacs.org>`
 - External URL with label:
   `[click here](https://github.com/cp2k/cp2k-examples/blob/master/qm_mm/Protein.pdb)`
 
-> [!NOTE]
->
-> The variable names in [bibliography.F](../src/common/bibliography.F) only _mostly coincide_ with
-> the citation keys in the docs. The best place to look up citation keys is the
-> [bibliography page](https://manual.cp2k.org/trunk/bibliography.html).
-
 ## Lists
+
+For a numbered list:
 
 ```
 1. First enumerated item
 1. Second enumerated item
+1. And the third item
+```
 
+> [!NOTE]
+>
+> Every item uses `1.` intentionally in the markdown source file, and the formatting tool in the
+> precommit check will apply this style if detected. The list will still be rendered with the
+> intended numbers as indices on github and the final HTML documentation page, but there is no
+> longer the need to track and edit the numbers manually. For more information, see `mdformat` docs
+> on [ordered lists](https://mdformat.readthedocs.io/en/stable/users/style.html#ordered-lists).
 
+For an unordered list:
+
+```
 - A bullet point
 - Another bullet point
+  - Indented bullet point
+- Yet another bullet point
+* An asterisk is also okay
+```
+
+When nesting levels of lists, watch out for indentations and newlines.
+
+```
+1. 3D periodicity
+  - XYZ
+1. 2D periodicity
+  - XY
+  - YZ
+  - XZ
+1. 1D periodicity
+  - X
+  - Y
+  - Z
+1. non-periodic
 ```
 
 ## Tables
@@ -115,7 +159,7 @@ For a all typography options see the
 | baz | bim |
 ```
 
-For a all table options see the
+For more table formatting options, see the
 [MyST documentation](https://myst-parser.readthedocs.io/en/latest/syntax/tables.html).
 
 ## Math
@@ -157,6 +201,51 @@ for i in range(10):
   print("Hello World")
 ```
 ````
+
+````
+```text
+&GLOBAL
+  PRINT_LEVEL LOW
+  PROJECT_NAME h2o-512
+  RUN_TYPE MD
+  SEED 12345678
+&END GLOBAL
+```
+````
+
+The language identifiers like `python` determine syntax highlighting; `text` is the choice for a
+plain display. Details can be found at
+[MyST documentation](https://myst-parser.readthedocs.io/en/latest/syntax/code_and_apis.html).
+
+## Cross References
+
+Apart from using the title or header of a section as introduced in [](#links) above, it is also
+possible to define an explicit target for linking purposes. With the following target
+
+```
+(build-gromacs-cp2k)=
+
+#### GROMACS/CP2K QM/MM
+
+The latest supported GROMACS release...
+```
+
+the section can be linked like
+
+```
+Build GROMACS with CP2K QM/MM support following instructions from [](#build-gromacs-cp2k) and ...
+```
+
+There is another syntax for external links, convenient for repeated mentions. The main text use a
+label with square brackets, then at the end of the document the link is defined.
+
+```
+CP2K can be built and installed with [Spack]. [Spack] is a package manager designed ...
+
+[Spack]: https://spack.readthedocs.io
+```
+
+See also [MyST docs](https://myst-parser.readthedocs.io/en/latest/syntax/cross-referencing.html).
 
 ## Diagrams
 

--- a/docs/generate_input_reference.py
+++ b/docs/generate_input_reference.py
@@ -404,7 +404,8 @@ def find_all_mentions() -> Dict[str, Set[Path]]:
     mentions = defaultdict(set)
     for subdir in "getting-started", "methods", "technologies":
         for fn in (root_dir / subdir).glob("**/*.md"):
-            for xref in re.findall(r"\(#(CP2K_INPUT\..*)\)", fn.read_text()):
+            # Non-greedy match permits multiple links on the same line
+            for xref in re.findall(r"\(#(CP2K_INPUT\..*?)\)", fn.read_text()):
                 mentions[xref].add(fn.relative_to(root_dir))
     return mentions
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,9 +48,9 @@ implied for most of the documentation.
      seen in one environment may need to be explicitly activated in another via submission scripts.
    - **No** (assumed): optimization against native (host) CPU is appropriate, and environment setup
      is easier.
-1. Does the machine have some workstation GPU? (A "workstation GPU" focuses on the double-precision
-   float-point arithmetic and is suitable for professional computing, in contrast to a "gaming GPU"
-   with less optimized performance in this regard.)
+1. Does the machine have some workstation GPU? (A "workstation GPU" or "professional GPU" focuses on
+   the double-precision float-point arithmetic and is suitable for scientific computing, in contrast
+   to a "gaming GPU" or "consumer GPU" with less optimized double-precision performance.)
    - **Yes**: some of the [eigensolvers](../technologies/eigensolvers/index),
      [accelerators](../technologies/accelerators/index) and other
      [libraries](../technologies/libraries) have GPU acceleration support ready or under development

--- a/docs/technologies/libraries.md
+++ b/docs/technologies/libraries.md
@@ -26,14 +26,17 @@ On the Mac, BLAS and LAPACK can be provided by either OpenBLAS or Apple's Accele
 
 ## DBCSR (required, block-sparse matrix operations)
 
-{term}`DBCSR` is a standalone library for block-sparse matrix operations. It is maintained at the
+DBCSR is a standalone library for block-sparse matrix operations. It is maintained at the
 [cp2k/dbcsr](https://github.com/cp2k/dbcsr/) repository, with links to reference materials on
 <https://www.cp2k.org/dbcsr> and documentation on <https://cp2k.github.io/dbcsr/develop/index.html>.
 
 CP2K requires DBCSR as a hard dependency, which can be prepared with the CP2K toolchain or Spack
 build, and will be found automatically by CMake during configuration.
 
-For MPI builds, DBCSR must also have been built with MPI support.
+The MPI configuration should be consistent between CP2K and DBCSR. For a MPI build (`psmp`/`pdbg`)
+of CP2K, DBCSR must also have been built with MPI support using the CMake flag `-DUSE_MPI=ON`, and
+`-DUSE_MPI_F08=ON` if `mpi_f08` is available. Likewise, a serial build (`ssmp`/`sdbg`) of CP2K must
+use a DBCSR configured with `-DUSE_MPI=OFF`.
 
 ## MPI and ScaLAPACK (required for MPI parallel builds)
 

--- a/docs/technologies/libraries.md
+++ b/docs/technologies/libraries.md
@@ -20,16 +20,20 @@ Examples are the sequential or thread variant of the Intel MKL, the Cray libsci,
 variant and the reference BLAS/LAPACK packages. Usually the CMake step of CP2K will auto-detect the
 type of BLAS and SCALAPACK and then use the right configuration to ensure the code is thread-safe;
 however, if detection is ambiguous, `-DCP2K_BLAS_VENDOR=MKL` and `-DCP2K_SCALAPACK_VENDOR=MKL` can
-be used for a oneMKL installation
+be used for a oneMKL installation.
 
 On the Mac, BLAS and LAPACK can be provided by either OpenBLAS or Apple's Accelerate framework.
 
 ## DBCSR (required, block-sparse matrix operations)
 
-CP2K requires [DBCSR](https://github.com/cp2k/dbcsr/) for block-sparse matrix operations. It is
-found automatically by CMake. For MPI builds, DBCSR must also have been built with MPI support. The
-CP2K toolchain, Spack, and a compatible external DBCSR installation are supported ways to provide
-it.
+{term}`DBCSR` is a standalone library for block-sparse matrix operations. It is maintained at the
+[cp2k/dbcsr](https://github.com/cp2k/dbcsr/) repository, with links to reference materials on
+<https://www.cp2k.org/dbcsr> and documentation on <https://cp2k.github.io/dbcsr/develop/index.html>.
+
+CP2K requires DBCSR as a hard dependency, which can be prepared with the CP2K toolchain or Spack
+build, and will be found automatically by CMake during configuration.
+
+For MPI builds, DBCSR must also have been built with MPI support.
 
 ## MPI and ScaLAPACK (required for MPI parallel builds)
 
@@ -42,9 +46,12 @@ Note that the MPI installation must match the used Fortran compiler.
 
 If your computing platform does not provide MPI, there are several freely available implementations:
 
-- MPICH: <https://www.mpich.org/> (may require `-fallow-argument-mismatch` when building with GCC
-  10\)
+- MPICH: <https://www.mpich.org/>
 - OpenMPI: <http://www.open-mpi.org/>
+
+```{hint}
+When building MPICH with GCC 10, the `-fallow-argument-mismatch` compiler flag may be needed.
+```
 
 ```{note}
 Open MPI applies process binding by default. This can affect hybrid MPI+OpenMP runs because the
@@ -117,15 +124,21 @@ Hartree--Fock exchange and related methods.
 
 ## LIBXS (improved performance for matrix multiplication)
 
-- A library for matrix operations and deep learning primitives: <https://github.com/hfp/libxs/>.
-- [LIBXS](https://github.com/hfp/libxs/) provides optimized matrix operations used by CP2K and is
-  required when using CP2K's OpenCL backend.
+LIBXS is a C library for memory operations, numerics, synchronization, and more. It is originally
+developed as part of [LIBXSMM](#libxsmm-jit-kernel-provider-of-libxs). For more information, refer
+to <https://libxs.readthedocs.io/>. The source code is available at <https://github.com/hfp/libxs>.
+
+- LIBXS provides optimized matrix operations used by CP2K and is required when using CP2K's OpenCL
+  backend.
 - Pass `-DCP2K_USE_LIBXS=ON` to CMake to enable it.
 
 ## LIBXSTREAM (OpenCL offload runtime)
 
-- [LIBXSTREAM](https://github.com/hfp/libxstream) provides the stream and memory-management layer
-  used by CP2K's OpenCL offload backend.
+LIBXSTREAM is an accelerator backend library for GPU offloading. For more information, refer to
+<https://libxstream.readthedocs.io/>. The source code is available at
+<https://github.com/hfp/libxstream>.
+
+- LIBXSTREAM provides the stream and memory-management layer used by CP2K's OpenCL offload backend.
 - It is required automatically when configuring OpenCL acceleration with `-DCP2K_USE_ACCEL=OPENCL`;
   there is no separate `CP2K_USE_LIBXSTREAM` option.
 - OpenCL builds also require LIBXS. For a manual build, make both LIBXSTREAM and the OpenCL
@@ -134,7 +147,10 @@ Hartree--Fock exchange and related methods.
 
 ## LIBXSMM (JIT-kernel provider of libXS)
 
-- A library that provide a JIT-kernel for LibXS: <https://github.com/libxsmm/libxsmm/>.
+LIBXSMM is a library for specialized dense and sparse matrix operations that provides just-in-time
+kernels (JIT-kernels) for LibXS. For more information, refer to <https://libxsmm.readthedocs.io/>.
+The source code is available at <https://github.com/libxsmm/libxsmm/>.
+
 - Pass `-DCP2K_USE_LIBXSMM=ON` to CMake to enable it; this is only valid when `-DCP2K_USE_LIBXS=ON`
   is passed.
 - The integration of LIBXS and LIBXSMM is done through `libxs_jit.F` that is provided by LIBXS but
@@ -143,13 +159,15 @@ Hartree--Fock exchange and related methods.
 
 ## LIBXC (wider choice of xc functionals)
 
-LIBXC is a library that provides wider choice of XC functionals.
+LIBXC is a library that provides wider choice of XC functionals. For more information, refer to
+<https://libxc.gitlab.io>.
 
-- The latest version of LIBXC can be downloaded from <https://gitlab.com/libxc/libxc/-/releases>
+- The latest version of LIBXC can be downloaded from <https://gitlab.com/libxc/libxc/-/releases>.
+- CP2K input reference for the [DFT/XC/XC_FUNCTIONAL](#CP2K_INPUT.FORCE_EVAL.DFT.XC.XC_FUNCTIONAL)
+  section lists the LIBXC functionals as well as built-in ones.
 - CP2K makes use of third derivates but does not use fourth derivates, so LIBXC may be configured
   with `cmake .. -DDISABLE_KXC=OFF <other LIBXC configuration flags>`.
 - Pass `-DCP2K_USE_LIBXC=ON` to CMake.
-- [LIBXSMM](https://github.com/libxsmm/libxsmm/) provides just-in-time kernels for LIBXS.
 
 ## GauXC (xc integration library)
 
@@ -178,15 +196,20 @@ typically SuperLU_DIST together with ParMETIS or PT-Scotch.
 
 ## PLUMED (enables various enhanced sampling methods)
 
+PLUMED is a plugin library for enhanced sampling and free energy algorithms in molecular dynamics.
+For more information, refer to <https://www.plumed.org/>. The source code and release tarballs are
+available at <https://github.com/plumed/plumed2>.
+
 CP2K can be compiled with PLUMED 2.x by passing `-DCP2K_USE_PLUMED=ON` to CMake.
 
 See <https://cp2k.org/howto:install_with_plumed> for full instructions.
 
 ## spglib (crystal symmetries tools)
 
-Spglib is a library for finding and handling crystal symmetries.
+Spglib is a library for finding and handling crystal symmetries. For more information, refer to
+<https://spglib.readthedocs.io/>.
 
-- The library can be downloaded from <https://github.com/atztogo/spglib>
+- The library can be downloaded from <https://github.com/spglib/spglib>
 - For building CP2K with the spglib pass `-DCP2K_USE_SPGLIB=ON` to CMake.
 
 ## SIRIUS (plane wave calculations)
@@ -196,7 +219,9 @@ SIRIUS is a domain specific library for electronic structure calculations with p
 - The code is available at <https://github.com/electronic-structure/SIRIUS>.
 - SIRIUS support requires an MPI build. Pass `-DCP2K_USE_SIRIUS=ON` to CMake to enable it.
 - SIRIUS has its own dependency stack, commonly including HDF5, SpFFT, SPLA, and eigensolver
-  libraries. It's recommended to build SIRIUS through Spack to get all features enabled.
+  libraries. It is recommended to build SIRIUS through Spack to get all features enabled.
+- The CP2K input reference for the [PW_DFT](#CP2K_INPUT.FORCE_EVAL.PW_DFT) section is composed by
+  SIRIUS itself, and thus is absent from the `.xml` dumped by a CP2K binary not built with SIRIUS.
 - Pass `-DCP2K_USE_LIBVDWXC=ON` when the selected SIRIUS build provides libvdwxc support.
 - Pass `-DCP2K_USE_SIRIUS_DFTD3=ON` when SIRIUS was built with DFT-D3 support.
 - Pass `-DCP2K_USE_SIRIUS_DFTD4=ON` when SIRIUS was built with DFT-D4 support.
@@ -260,7 +285,7 @@ DeePMD-kit provides Deep Potential models. Support for its C interface can be en
 
 - DeePMD-kit C interface can be downloaded from
   <https://docs.deepmodeling.com/projects/deepmd/en/master/install/install-from-c-library.html>
-- For more information see <https://github.com/deepmodeling/deepmd-kit.git>.
+- For more information see <https://github.com/deepmodeling/deepmd-kit>.
 
 ## ACE (atomic cluster expansion ML potentials)
 
@@ -275,10 +300,16 @@ potentials support can be enabled by passing `-DCP2K_USE_ACE=ON` to CMake.
 
 ## DFTD4 (dispersion correction)
 
-DFTD4 provides the Generally Applicable Atomic-Charge Dependent London Dispersion Correction.
+DFTD4 provides the Generally Applicable Atomic-Charge Dependent London Dispersion Correction. For
+more information, see <https://www.chemie.uni-bonn.de/grimme/de/software/dft-d4>. The source code
+and release tarballs are available at <https://github.com/dftd4/dftd4>.
 
-- Please use the CMake-built dftd4 package rather than the Meson-built one for CP2K.
-- For more information, see <https://github.com/dftd4/dftd4>
+- Please use the CMake-built dftd4 package rather than the Meson-built one for CP2K at the moment;
+  the ability to export CMake configurations from Meson build has yet to be included in a release.
+- The CP2K 2026.2 release would be the last one to have interfaces to legacy versions of the DFTD4
+  code down to version 3; due to compatibility issues in development, these have since been dropped
+  in [pull request #5641](https://github.com/cp2k/cp2k/pull/5641).
+- DFTD4 is also part of the [TBLITE](#tblite-semiempirical-method) package as noted below.
 - Pass `-DCP2K_USE_DFTD4=ON` to CMake.
 
 ## libsmeagol (electron transport calculation with current-induced forces)
@@ -319,11 +350,13 @@ enabled by passing `-DCP2K_USE_GREENX=ON` to CMake.
 
 TBLITE is a lightweight tight-binding framework that provides the GFN2-xTB method.
 
-- Please always use the CMake-built tblite package rather than the Meson-built one for CP2K.
+- Please always use the CMake-built tblite package rather than the Meson-built one for CP2K at the
+  moment; the ability to export CMake configurations from Meson build has yet to be validated.
 - A CMake build of tblite from source also installs DFT-D4 and s-dftd3. Therefore, no separate DFTD4
   installation is needed when tblite is enabled; s-dftd3 also provides parameters for additional XC
   functionals.
-- For more information see <https://github.com/tblite/tblite>
+- The source code and release tarballs are available at <https://github.com/tblite/tblite>.
+- For more information see <https://tblite.readthedocs.io>.
 - Pass `-DCP2K_USE_TBLITE=ON` to CMake.
 
 ## openPMD (structured output)
@@ -349,7 +382,7 @@ as part of DFLAGS may or may not work.
 MiMiC - Multiscale simulation framework
 
 - Its interface is realized through the MCL library, which can be downloaded from
-  <https://https://mimic-project.org>
+  <https://gitlab.com/mimic-project/>
 - For more information about the framework and supported programs see <https://mimic-project.org>
 - Pass `-DCP2K_USE_MIMIC=ON` to CMake
 
@@ -360,4 +393,4 @@ libGint - A library for the calculation of the Hartree Fock exchange on GPUs
 - Compared to a regular XF calculation, the changes needed in the input file are :
 - &FORCE_EVAL &DFT &XC &HF HFX_LIBRARY libGint
 - &FORCE_EVAL &DFT &XC &HF &MEMORY MAX_MEMORY X
-- pass -DCP2K_USE_LIBGINT=ON\` to CMake.
+- pass `-DCP2K_USE_LIBGINT=ON` to CMake.


### PR DESCRIPTION
This PR:
- Expands `docs/README.md` with recent experience in formatting;
- Expands `docs/technologies/libraries.md` with some links and content;
- Also fixes other typos and rephrases a bit.