### PR TITLE
TRJANA: Add event and mode time-series analyses

### DIFF
--- a/tools/trajana/Makefile
+++ b/tools/trajana/Makefile
@@ -22,6 +22,7 @@ COMMON_OBJECTS = \
 
 ANALYSIS_OBJECTS = \
         geometry_analysis.o \
+        event_analysis.o \
         rdf_analysis.o \
         vacf_analysis.o \
         hbond_analysis.o \
@@ -61,6 +62,7 @@ cube_io.o: kinds.o
 time_series.o: kinds.o fft.o
 spectral_tools.o: kinds.o
 geometry_analysis.o: kinds.o text_utils.o trajectory_types.o trajectory_io.o cell_source.o command_line.o frame_controls.o geometry.o
+event_analysis.o: kinds.o text_utils.o trajectory_types.o trajectory_io.o cell_source.o command_line.o frame_controls.o geometry_analysis.o
 rdf_analysis.o: kinds.o trajectory_types.o trajectory_io.o cell_source.o command_line.o frame_controls.o geometry.o selections.o
 vacf_analysis.o: kinds.o text_utils.o trajectory_types.o trajectory_io.o command_line.o frame_controls.o selections.o time_series.o spectral_tools.o
 hbond_analysis.o: kinds.o trajectory_types.o trajectory_io.o cell_source.o command_line.o frame_controls.o geometry.o groups.o

--- a/tools/trajana/README.md
+++ b/tools/trajana/README.md
@@ -2,8 +2,8 @@
 
 This directory contains five standalone Fortran programs for post-processing CP2K trajectories:
 
-- `trajana.x` performs geometry, RDF, VACF, hydrogen-bond, scattering, and collective-current
-  analyses.
+- `trajana.x` performs geometry, hysteretic-event, RDF, VACF, hydrogen-bond, scattering, and
+  collective-current analyses.
 - `trajconvert.x` wraps, unwraps, converts, and reduces trajectories to group centers.
 - `twopt.x` evaluates conventional two-phase thermodynamics directly from CP2K trajectories.
 - `twopt3d.x` maps local solvent density and intermolecular 2PT entropy in three dimensions.
@@ -69,6 +69,41 @@ calculations:
 The action-file syntax remains `DISTANCE i j`, `ANGLE i j k`, and `TORSION i j k l`; only the first
 letter is significant. Geometry uses the minimum image when a cell is available. Distances are
 written in angstrom and angles in degrees.
+
+## Hysteretic events in geometric observables
+
+The `events` mode detects threshold-crossing episodes in the same distance, angle, or torsion
+actions used by `geometry`. Separate entry and exit values suppress rapid recrossings near a single
+threshold. For example, C--O elongation episodes that start at 1.70 angstrom and end below 1.65
+angstrom are obtained with:
+
+```console
+./trajana.x events \
+  --input PROJECT-pos-1.xyz \
+  --actions co-bonds.in \
+  --cell-file PROJECT-1.cell \
+  --dt-fs 0.5 \
+  --direction above \
+  --entry 1.70 \
+  --exit 1.65 \
+  --output co-events.dat \
+  --summary co-event-summary.dat
+```
+
+For `--direction above`, the exit value must be smaller than the entry value. With
+`--direction below`, the inequalities and required threshold order are reversed. All actions in one
+run use the same direction and thresholds; run observables with different units or definitions
+separately. Distances use angstrom, while angles and torsions use degrees. Periodic distances and
+angles use the same triclinic minimum-image implementation as `geometry`.
+
+The event output reports the first and last active sampled frames, sampled residence time, extremum,
+and whether the observable returned past the exit threshold. An event that remains active at the end
+of the selected trajectory is written with `returned_past_exit=0` and counted as open in the
+summary. Each active sample contributes the selected-frame time step to the residence time,
+including a one-sample event. Times start at zero for the first selected frame, and `--stride`
+multiplies the input `--dt-fs` automatically. The summary reports `first_entry_ps=-1` when no event
+occurred. Event counts and residence times are descriptive trajectory statistics; probabilities and
+rates require an independently sampled trajectory ensemble.
 
 ## Radial distribution function
 
@@ -145,7 +180,8 @@ chosen frequency without a harmonic or quasi-harmonic approximation.
   --mode-count 10 \
   --output fresean-eigenvalues.dat \
   --mode-file fresean-modes.xyz \
-  --mode-spectrum fresean-mode-spectra.dat
+  --mode-spectrum fresean-mode-spectra.dat \
+  --mode-timeseries fresean-mode-timeseries.dat
 ```
 
 The position and velocity files must contain synchronized frames with identical atom ordering.
@@ -170,6 +206,30 @@ effective number of selected degrees of freedom. `--mode-file` writes the leadin
 the closest sampled frequency to `--frequency-cm`; components are divided by the square root of the
 atomic mass so that they are suitable as displacement vectors. `--mode-spectrum` evaluates
 `q^T C(omega) q` for those fixed modes over the full spectrum.
+
+With synchronized positions, `--mode-timeseries` projects every aligned frame onto the fixed
+mass-weighted eigenvectors selected at `--frequency-cm`. For mode vector `e_k`, it writes
+
+```text
+q_k(t)    = e_k^T M^(1/2) [R_aligned(t) - R_reference]
+qdot_k(t) = e_k^T M^(1/2) V_aligned(t)
+E_k(t)    = 1/2 [qdot_k(t)^2 + omega^2 q_k(t)^2].
+```
+
+The time mean of each projected coordinate is removed before evaluating the energy. Coordinates,
+velocities, harmonic energy proxies in kJ/mol, energy-equivalent quanta, and instantaneous fractions
+normalized over the extracted modes are written for every selected frame. This output requires a
+positive `--frequency-cm` and `--position`; the latter ensures that coordinates are projected
+directly instead of being reconstructed by integrating velocities. The energies use the selected
+frequency for every extracted vector and are diagnostics rather than exact quantum populations.
+Individual vectors inside a degenerate subspace are not unique, although sums over a complete
+degenerate subspace are invariant.
+
+The output header also reports the first `1/e` time of the unbiased autocorrelation of the
+normalized complex phase vector `omega*q_k + i*qdot_k`. A value of `-1` means that no crossing
+occurred within half of the selected trajectory. Under continuous external or thermostatted driving
+this is an effective driven phase-correlation time, not a field-free
+intramolecular-vibrational-redistribution lifetime.
 
 The exact discrete procedure follows the equations and normalization demonstrated in the
 [FRESEAN tutorial](https://github.com/HeydenLabASU-collab/FRESEAN-tutorial), including the symmetric

--- a/tools/trajana/event_analysis.f90
+++ b/tools/trajana/event_analysis.f90
@@ -1,0 +1,287 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2026 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+MODULE trajana_event_analysis
+   USE trajana_cell_source,             ONLY: cell_source_type
+   USE trajana_command_line,            ONLY: fail,&
+                                              get_integer_option,&
+                                              get_option,&
+                                              get_real_option
+   USE trajana_frame_controls,          ONLY: frame_selected
+   USE trajana_geometry_analysis,       ONLY: action_type,&
+                                              evaluate_action,&
+                                              read_actions,&
+                                              validate_actions
+   USE trajana_kinds,                   ONLY: dp
+   USE trajana_text_utils,              ONLY: lower_case
+   USE trajana_trajectory_io,           ONLY: close_output,&
+                                              open_output,&
+                                              xyz_reader_type
+   USE trajana_trajectory_types,        ONLY: frame_type
+
+   IMPLICIT NONE
+   PRIVATE
+
+   TYPE :: event_state_type
+      LOGICAL :: active = .FALSE.
+      LOGICAL :: seen = .FALSE.
+      INTEGER :: active_samples = 0
+      INTEGER :: event_count = 0
+      INTEGER :: open_events = 0
+      INTEGER :: start_frame = 0
+      INTEGER :: last_frame = 0
+      INTEGER :: extremum_frame = 0
+      REAL(dp) :: start_ps = 0.0_dp
+      REAL(dp) :: last_ps = 0.0_dp
+      REAL(dp) :: extremum = 0.0_dp
+      REAL(dp) :: extremum_ps = 0.0_dp
+      REAL(dp) :: first_entry_ps = -1.0_dp
+      REAL(dp) :: total_residence_ps = 0.0_dp
+      REAL(dp) :: longest_residence_ps = 0.0_dp
+      REAL(dp) :: trajectory_extremum = 0.0_dp
+   END TYPE event_state_type
+
+   PUBLIC :: run_events
+
+CONTAINS
+
+   SUBROUTINE run_events()
+      CHARACTER(LEN=512)                                 :: message
+      CHARACTER(LEN=:), ALLOCATABLE                      :: action_path, cell_path, cell_text, &
+                                                            direction, input_path, output_path, &
+                                                            periodic_text, summary_path
+      INTEGER                                            :: expected_atoms, first, frame_count, &
+                                                            ierr, item, last, output_unit, stride, &
+                                                            summary_unit
+      LOGICAL                                            :: above, eof, found, summary_requested
+      REAL(dp)                                           :: dt_fs, effective_dt_ps, entry_value, &
+                                                            exit_value, time_ps
+      REAL(dp), ALLOCATABLE                              :: result(:)
+      TYPE(action_type), ALLOCATABLE                     :: actions(:)
+      TYPE(cell_source_type)                             :: cells
+      TYPE(event_state_type), ALLOCATABLE                :: states(:)
+      TYPE(frame_type)                                   :: frame
+      TYPE(xyz_reader_type)                              :: trajectory
+
+      CALL get_option("--input", input_path, found, "-")
+      CALL get_option("--output", output_path, found, "-")
+      CALL get_option("--summary", summary_path, summary_requested)
+      CALL get_option("--actions", action_path, found, "trajana.in")
+      CALL get_option("--cell", cell_text, found, "")
+      CALL get_option("--cell-file", cell_path, found, "")
+      CALL get_option("--periodic", periodic_text, found, "XYZ")
+      CALL get_option("--direction", direction, found, "above")
+      CALL get_real_option("--dt-fs", dt_fs, -1.0_dp)
+      CALL get_real_option("--entry", entry_value, HUGE(1.0_dp))
+      CALL get_real_option("--exit", exit_value, HUGE(1.0_dp))
+      CALL get_integer_option("--first", first, 1)
+      CALL get_integer_option("--last", last, HUGE(1))
+      CALL get_integer_option("--stride", stride, 1)
+
+      IF (dt_fs <= 0.0_dp) CALL fail("events requires a positive --dt-fs")
+      IF (entry_value > 0.5_dp*HUGE(1.0_dp)) CALL fail("events requires --entry")
+      IF (exit_value > 0.5_dp*HUGE(1.0_dp)) CALL fail("events requires --exit")
+      IF (first < 1 .OR. last < first .OR. stride < 1) CALL fail("Invalid frame range")
+      direction = lower_case(direction)
+      SELECT CASE (direction)
+      CASE ("above")
+         above = .TRUE.
+         IF (exit_value >= entry_value) CALL fail("For --direction above, --exit must be smaller than --entry")
+      CASE ("below")
+         above = .FALSE.
+         IF (exit_value <= entry_value) CALL fail("For --direction below, --exit must be larger than --entry")
+      CASE DEFAULT
+         CALL fail("--direction expects above or below")
+      END SELECT
+      effective_dt_ps = dt_fs*REAL(stride, dp)/1000.0_dp
+
+      CALL read_actions(action_path, actions, ierr, message)
+      IF (ierr /= 0) CALL fail(message)
+      CALL cells%configure(cell_text, cell_path, periodic_text, ierr, message)
+      IF (ierr /= 0) CALL fail(message)
+      CALL trajectory%open_file(input_path, ierr, message)
+      IF (ierr /= 0) CALL fail(message)
+      CALL open_output(output_path, output_unit, ierr, message)
+      IF (ierr /= 0) CALL fail(message)
+      WRITE (output_unit, "(A)") "# Hysteretic events in geometric trajectory observables"
+      WRITE (output_unit, "(A,A)") "# direction: ", TRIM(direction)
+      WRITE (output_unit, "(A,ES24.16)") "# entry: ", entry_value
+      WRITE (output_unit, "(A,ES24.16)") "# exit: ", exit_value
+      WRITE (output_unit, "(A,ES24.16)") "# selected_frame_time_step_ps: ", effective_dt_ps
+      WRITE (output_unit, "(A)") &
+         "# action event start_frame end_frame start_ps end_ps residence_ps extremum "// &
+         "extremum_frame extremum_ps returned_past_exit"
+
+      ALLOCATE (RESULT(SIZE(actions)), states(SIZE(actions)))
+      expected_atoms = -1
+      frame_count = 0
+      DO
+         CALL trajectory%read_frame(frame, eof, ierr, message)
+         IF (ierr /= 0) CALL fail(message)
+         IF (eof) EXIT
+         CALL cells%attach(frame, ierr, message)
+         IF (ierr /= 0) CALL fail(message)
+         IF (frame%number > last) EXIT
+         IF (.NOT. frame_selected(frame%number, first, last, stride)) CYCLE
+         IF (expected_atoms < 0) THEN
+            expected_atoms = frame%natoms
+            CALL validate_actions(actions, expected_atoms, ierr, message)
+            IF (ierr /= 0) CALL fail(message)
+         END IF
+         IF (frame%natoms /= expected_atoms) CALL fail("The atom count changes along the trajectory")
+
+         frame_count = frame_count + 1
+         time_ps = REAL(frame_count - 1, dp)*effective_dt_ps
+         DO item = 1, SIZE(actions)
+            CALL evaluate_action(actions(item), frame, RESULT(item), ierr)
+            IF (ierr /= 0) CALL fail("Degenerate geometry or singular cell in frame")
+            CALL update_state(states(item), RESULT(item), frame%number, time_ps, effective_dt_ps, &
+                              entry_value, exit_value, above, item, output_unit)
+         END DO
+      END DO
+      IF (frame_count == 0) CALL fail("No trajectory frames were selected")
+      DO item = 1, SIZE(actions)
+         IF (states(item)%active) THEN
+            states(item)%open_events = states(item)%open_events + 1
+            CALL write_event(states(item), item, effective_dt_ps, .FALSE., output_unit)
+            states(item)%active = .FALSE.
+         END IF
+      END DO
+
+      CALL close_output(output_unit)
+      CALL trajectory%close_file()
+      CALL cells%close()
+      IF (summary_requested) THEN
+         CALL open_output(summary_path, summary_unit, ierr, message)
+         IF (ierr /= 0) CALL fail(message)
+         CALL write_summary(summary_unit, actions, states, direction, entry_value, exit_value, frame_count, &
+                            effective_dt_ps)
+         CALL close_output(summary_unit)
+      END IF
+   END SUBROUTINE run_events
+
+   SUBROUTINE update_state(state, value, frame, time_ps, dt_ps, entry_value, exit_value, &
+                           above, action, output_unit)
+      TYPE(event_state_type), INTENT(INOUT)              :: state
+      REAL(dp), INTENT(IN)                               :: value
+      INTEGER, INTENT(IN)                                :: frame
+      REAL(dp), INTENT(IN)                               :: time_ps, dt_ps, entry_value, exit_value
+      LOGICAL, INTENT(IN)                                :: above
+      INTEGER, INTENT(IN)                                :: action, output_unit
+
+      LOGICAL                                            :: entered, exited
+
+      IF (.NOT. state%seen) THEN
+         state%trajectory_extremum = value
+         state%seen = .TRUE.
+      ELSE IF ((above .AND. value > state%trajectory_extremum) .OR. &
+               (.NOT. above .AND. value < state%trajectory_extremum)) THEN
+         state%trajectory_extremum = value
+      END IF
+      IF (above) THEN
+         entered = value >= entry_value
+         exited = value <= exit_value
+      ELSE
+         entered = value <= entry_value
+         exited = value >= exit_value
+      END IF
+
+      IF (.NOT. state%active) THEN
+         IF (entered) CALL start_event(state, value, frame, time_ps)
+      ELSE IF (exited) THEN
+         CALL write_event(state, action, dt_ps, .TRUE., output_unit)
+         state%active = .FALSE.
+      ELSE
+         state%active_samples = state%active_samples + 1
+         state%last_frame = frame
+         state%last_ps = time_ps
+         IF ((above .AND. value > state%extremum) .OR. (.NOT. above .AND. value < state%extremum)) THEN
+            state%extremum = value
+            state%extremum_frame = frame
+            state%extremum_ps = time_ps
+         END IF
+      END IF
+   END SUBROUTINE update_state
+
+   SUBROUTINE start_event(state, value, frame, time_ps)
+      TYPE(event_state_type), INTENT(INOUT)              :: state
+      REAL(dp), INTENT(IN)                               :: value
+      INTEGER, INTENT(IN)                                :: frame
+      REAL(dp), INTENT(IN)                               :: time_ps
+
+      state%active = .TRUE.
+      state%active_samples = 1
+      state%event_count = state%event_count + 1
+      state%start_frame = frame
+      state%last_frame = frame
+      state%extremum_frame = frame
+      state%start_ps = time_ps
+      state%last_ps = time_ps
+      state%extremum = value
+      state%extremum_ps = time_ps
+      IF (state%first_entry_ps < 0.0_dp) state%first_entry_ps = time_ps
+   END SUBROUTINE start_event
+
+   SUBROUTINE write_event(state, action, dt_ps, returned, unit)
+      TYPE(event_state_type), INTENT(INOUT)              :: state
+      INTEGER, INTENT(IN)                                :: action
+      REAL(dp), INTENT(IN)                               :: dt_ps
+      LOGICAL, INTENT(IN)                                :: returned
+      INTEGER, INTENT(IN)                                :: unit
+
+      REAL(dp)                                           :: residence_ps
+
+      residence_ps = REAL(state%active_samples, dp)*dt_ps
+      state%total_residence_ps = state%total_residence_ps + residence_ps
+      state%longest_residence_ps = MAX(state%longest_residence_ps, residence_ps)
+      WRITE (unit, "(2I8,2I12,4ES24.16,I12,ES24.16,I4)") action, state%event_count, &
+         state%start_frame, state%last_frame, state%start_ps, state%last_ps, residence_ps, state%extremum, &
+         state%extremum_frame, state%extremum_ps, MERGE(1, 0, returned)
+   END SUBROUTINE write_event
+
+   SUBROUTINE write_summary(unit, actions, states, direction, entry_value, exit_value, frames, dt_ps)
+      INTEGER, INTENT(IN)                                :: unit
+      TYPE(action_type), INTENT(IN)                      :: actions(:)
+      TYPE(event_state_type), INTENT(IN)                 :: states(:)
+      CHARACTER(LEN=*), INTENT(IN)                       :: direction
+      REAL(dp), INTENT(IN)                               :: entry_value, exit_value
+      INTEGER, INTENT(IN)                                :: frames
+      REAL(dp), INTENT(IN)                               :: dt_ps
+
+      INTEGER                                            :: item
+
+      WRITE (unit, "(A)") "# Summary of hysteretic events"
+      WRITE (unit, "(A,I0)") "# selected_frames: ", frames
+      WRITE (unit, "(A,ES24.16)") "# selected_frame_time_step_ps: ", dt_ps
+      WRITE (unit, "(A)") &
+         "# action kind atom1 atom2 atom3 atom4 direction entry exit events open_events first_entry_ps "// &
+         "total_residence_ps longest_residence_ps trajectory_extremum"
+      DO item = 1, SIZE(actions)
+         WRITE (unit, "(I8,1X,A,4I8,1X,A,2ES24.16,2I8,4ES24.16)") item, &
+            TRIM(action_name(actions(item)%kind)), actions(item)%atom, TRIM(direction), entry_value, exit_value, &
+            states(item)%event_count, states(item)%open_events, states(item)%first_entry_ps, &
+            states(item)%total_residence_ps, states(item)%longest_residence_ps, states(item)%trajectory_extremum
+      END DO
+   END SUBROUTINE write_summary
+
+   FUNCTION action_name(kind) RESULT(name)
+      INTEGER, INTENT(IN)                                :: kind
+      CHARACTER(LEN=8)                                   :: name
+
+      SELECT CASE (kind)
+      CASE (1)
+         name = "distance"
+      CASE (2)
+         name = "angle"
+      CASE (3)
+         name = "torsion"
+      CASE DEFAULT
+         name = "unknown"
+      END SELECT
+   END FUNCTION action_name
+
+END MODULE trajana_event_analysis

--- a/tools/trajana/fresean_analysis.f90
+++ b/tools/trajana/fresean_analysis.f90
@@ -6,7 +6,7 @@
 !--------------------------------------------------------------------------------------------------!
 
 MODULE trajana_fresean_analysis
-   USE trajana_alignment,              ONLY: center_positions,&
+   USE trajana_alignment,               ONLY: center_positions,&
                                               fit_rotation,&
                                               identity3
    USE trajana_command_line,            ONLY: fail,&
@@ -22,7 +22,8 @@ MODULE trajana_fresean_analysis
    USE trajana_linear_algebra,          ONLY: diagonalize_symmetric
    USE trajana_selections,              ONLY: build_selection
    USE trajana_text_utils,              ONLY: lower_case
-   USE trajana_time_series,             ONLY: remove_real_means
+   USE trajana_time_series,             ONLY: complex_autocorrelation_sum,&
+                                              remove_real_means
    USE trajana_trajectory_io,           ONLY: close_output,&
                                               open_output,&
                                               xyz_reader_type
@@ -32,34 +33,36 @@ MODULE trajana_fresean_analysis
    PRIVATE
 
    REAL(dp), PARAMETER :: bohr_per_atomic_time_to_angstrom_per_ps = 21876.91263641118_dp
+   REAL(dp), PARAMETER :: speed_of_light_cm_per_ps = 0.0299792458_dp
    REAL(dp), PARAMETER :: mass_velocity_to_j_mol = 10.0_dp
    REAL(dp), PARAMETER :: gas_constant_j_mol_k = 8.31446261815324_dp
    REAL(dp), PARAMETER :: thz_to_wavenumber = 33.3564095198152_dp
+   REAL(dp), PARAMETER :: wavenumber_to_kj_mol = 0.0119626565638697_dp
 
    PUBLIC :: print_fresean_help, run_fresean
 
 CONTAINS
 
    SUBROUTINE run_fresean()
-      CHARACTER(LEN=512)                                 :: message
-      CHARACTER(LEN=:), ALLOCATABLE                      :: mass_path, mode_path, mode_spectrum_path, &
-                                                            output_path, position_path, reference_path, &
-                                                            selection, velocity_path, velocity_unit
       CHARACTER(LEN=32), ALLOCATABLE                     :: labels(:)
-      INTEGER                                            :: atom, capacity, component, first, frames, ierr, item, &
-                                                            last, mode_count, &
-                                                            n_correlation, n_dof, n_selected, stride
+      CHARACTER(LEN=512)                                 :: message
+      CHARACTER(LEN=:), ALLOCATABLE :: mass_path, mode_path, mode_spectrum_path, &
+         mode_timeseries_path, output_path, position_path, reference_path, selection, &
+         velocity_path, velocity_unit
+      INTEGER                                            :: atom, capacity, component, first, &
+                                                            frames, ierr, item, last, mode_count, &
+                                                            n_correlation, n_dof, n_selected, &
+                                                            stride
       INTEGER, ALLOCATABLE                               :: selected_index(:)
-      LOGICAL                                            :: eof, found, mode_requested, mode_spectrum_requested, &
-                                                            position_eof, position_found, reference_eof, &
-                                                            reference_found, remove_mean
+      LOGICAL :: eof, found, mode_requested, mode_spectrum_requested, mode_timeseries_requested, &
+         position_eof, position_found, reference_eof, reference_found, remove_mean
       LOGICAL, ALLOCATABLE                               :: selected(:)
-      REAL(dp)                                           :: constraints, dt_fs, effective_dt_ps, frequency_cm, &
-                                                            sigma_cm, velocity_scale, velocity_scale_extra
-      REAL(dp)                                           :: rotation(3, 3), velocity(3)
-      REAL(dp), ALLOCATABLE                              :: current_positions(:, :), grown(:, :), masses(:), &
-                                                            reference_positions(:, :), series(:, :)
-      TYPE(frame_type)                                   :: position_frame, reference_frame, velocity_frame
+      REAL(dp) :: aligned_position(3), constraints, dt_fs, effective_dt_ps, frequency_cm, &
+         rotation(3, 3), sigma_cm, velocity(3), velocity_scale, velocity_scale_extra
+      REAL(dp), ALLOCATABLE :: current_positions(:, :), grown(:, :), grown_positions(:, :), &
+         masses(:), position_series(:, :), reference_positions(:, :), series(:, :)
+      TYPE(frame_type)                                   :: position_frame, reference_frame, &
+                                                            velocity_frame
       TYPE(mass_table_type)                              :: mass_table
       TYPE(xyz_reader_type)                              :: positions, reference, velocities
 
@@ -70,6 +73,7 @@ CONTAINS
       CALL get_option("--output", output_path, found, "-")
       CALL get_option("--mode-file", mode_path, mode_requested)
       CALL get_option("--mode-spectrum", mode_spectrum_path, mode_spectrum_requested)
+      CALL get_option("--mode-timeseries", mode_timeseries_path, mode_timeseries_requested)
       CALL get_option("--select", selection, found, "all")
       CALL get_option("--velocity-unit", velocity_unit, found, "cp2k")
       CALL get_real_option("--dt-fs", dt_fs, -1.0_dp)
@@ -95,6 +99,10 @@ CONTAINS
       IF (constraints < 0.0_dp) CALL fail("--constraints cannot be negative")
       IF (first < 1 .OR. last < first .OR. stride < 1) CALL fail("Invalid frame range")
       IF (reference_found .AND. .NOT. position_found) CALL fail("--reference requires --position")
+      IF (mode_timeseries_requested .AND. .NOT. position_found) &
+         CALL fail("--mode-timeseries requires --position")
+      IF (mode_timeseries_requested .AND. frequency_cm <= 0.0_dp) &
+         CALL fail("--mode-timeseries requires a positive --frequency-cm")
 
       velocity_unit = lower_case(velocity_unit)
       SELECT CASE (velocity_unit)
@@ -157,6 +165,11 @@ CONTAINS
             END DO
             capacity = 128
             ALLOCATE (series(n_dof, capacity))
+            IF (mode_timeseries_requested) THEN
+               ALLOCATE (position_series(n_dof, capacity))
+            ELSE
+               ALLOCATE (position_series(0, 0))
+            END IF
             IF (position_found) THEN
                CALL validate_position_frame(velocity_frame, position_frame)
                ALLOCATE (reference_positions(3, n_selected), current_positions(3, n_selected))
@@ -181,6 +194,11 @@ CONTAINS
             ALLOCATE (grown(n_dof, 2*capacity))
             grown(:, :capacity) = series
             CALL MOVE_ALLOC(grown, series)
+            IF (mode_timeseries_requested) THEN
+               ALLOCATE (grown_positions(n_dof, 2*capacity))
+               grown_positions(:, :capacity) = position_series
+               CALL MOVE_ALLOC(grown_positions, position_series)
+            END IF
             capacity = 2*capacity
          END IF
          frames = frames + 1
@@ -195,9 +213,13 @@ CONTAINS
          item = 0
          DO atom = 1, n_selected
             velocity = MATMUL(rotation, velocity_frame%value(:, selected_index(atom)))*velocity_scale
+            IF (mode_timeseries_requested) &
+               aligned_position = MATMUL(rotation, current_positions(:, atom)) - reference_positions(:, atom)
             DO component = 1, 3
                item = item + 1
                series(item, frames) = SQRT(masses(atom))*velocity(component)
+               IF (mode_timeseries_requested) &
+                  position_series(item, frames) = SQRT(masses(atom))*aligned_position(component)
             END DO
          END DO
       END DO
@@ -209,36 +231,47 @@ CONTAINS
          ALLOCATE (grown(3*n_selected, frames))
          grown = series(:, :frames)
          CALL MOVE_ALLOC(grown, series)
+         IF (mode_timeseries_requested) THEN
+            ALLOCATE (grown_positions(3*n_selected, frames))
+            grown_positions = position_series(:, :frames)
+            CALL MOVE_ALLOC(grown_positions, position_series)
+         END IF
       END IF
       IF (remove_mean) CALL remove_real_means(series)
 
       effective_dt_ps = dt_fs*REAL(stride, dp)/1000.0_dp
-      CALL analyze_series(series, masses, labels, selection, effective_dt_ps, sigma_cm, &
+      CALL analyze_series(series, position_series, masses, labels, selection, effective_dt_ps, sigma_cm, &
                           constraints, frequency_cm, n_correlation, mode_count, position_found, remove_mean, &
                           output_path, mode_path, mode_requested, mode_spectrum_path, &
-                          mode_spectrum_requested)
+                          mode_spectrum_requested, mode_timeseries_path, mode_timeseries_requested)
    END SUBROUTINE run_fresean
 
-   SUBROUTINE analyze_series(series, masses, labels, selection, dt_ps, sigma_cm, constraints, &
+   SUBROUTINE analyze_series(series, position_series, masses, labels, selection, dt_ps, sigma_cm, constraints, &
                              requested_frequency, n_correlation, requested_modes, aligned, mean_removed, output_path, &
-                             mode_path, mode_requested, mode_spectrum_path, mode_spectrum_requested)
-      REAL(dp), INTENT(IN)                               :: series(:, :), masses(:), dt_ps, sigma_cm, &
-                                                            constraints, requested_frequency
-      CHARACTER(LEN=*), INTENT(IN)                       :: labels(:), selection, output_path, mode_path, &
-                                                            mode_spectrum_path
+                             mode_path, mode_requested, mode_spectrum_path, mode_spectrum_requested, &
+                             mode_timeseries_path, mode_timeseries_requested)
+      REAL(dp), INTENT(IN)                               :: series(:, :), position_series(:, :), &
+                                                            masses(:)
+      CHARACTER(LEN=*), INTENT(IN)                       :: labels(:), selection
+      REAL(dp), INTENT(IN)                               :: dt_ps, sigma_cm, constraints, &
+                                                            requested_frequency
       INTEGER, INTENT(IN)                                :: n_correlation, requested_modes
-      LOGICAL, INTENT(IN)                                :: aligned, mean_removed, mode_requested, &
-                                                            mode_spectrum_requested
+      LOGICAL, INTENT(IN)                                :: aligned, mean_removed
+      CHARACTER(LEN=*), INTENT(IN)                       :: output_path, mode_path
+      LOGICAL, INTENT(IN)                                :: mode_requested
+      CHARACTER(LEN=*), INTENT(IN)                       :: mode_spectrum_path
+      LOGICAL, INTENT(IN)                                :: mode_spectrum_requested
+      CHARACTER(LEN=*), INTENT(IN)                       :: mode_timeseries_path
+      LOGICAL, INTENT(IN)                                :: mode_timeseries_requested
 
       CHARACTER(LEN=512)                                 :: message
-      INTEGER                                            :: frequency, ierr, mode, mode_count, mode_unit, &
-                                                            n_dof, output_unit, selected_frequency, &
-                                                            spectrum_unit
-      REAL(dp)                                           :: captured, df_cm, dof, kinetic_temperature, normalization, &
+      INTEGER :: frequency, ierr, mode, mode_count, mode_timeseries_unit, mode_unit, n_dof, &
+         output_unit, selected_frequency, spectrum_unit
+      REAL(dp)                                           :: captured, df_cm, dof, &
+                                                            kinetic_temperature, normalization, &
                                                             selected_wavenumber, total
-      REAL(dp), ALLOCATABLE                              :: eigenvalues(:), eigenvalue_table(:, :), &
-                                                            eigenvectors(:, :), matrices(:, :, :), mode_vectors(:, :), &
-                                                            trace(:)
+      REAL(dp), ALLOCATABLE :: eigenvalue_table(:, :), eigenvalues(:), eigenvectors(:, :), &
+         matrices(:, :, :), mode_vectors(:, :), trace(:)
 
       n_dof = SIZE(series, 1)
       dof = REAL(n_dof, dp) - constraints
@@ -314,16 +347,26 @@ CONTAINS
          CALL write_mode_spectra(spectrum_unit, df_cm, selected_wavenumber, trace, matrices, mode_vectors)
          CALL close_output(spectrum_unit)
       END IF
+      IF (mode_timeseries_requested) THEN
+         CALL open_output(mode_timeseries_path, mode_timeseries_unit, ierr, message)
+         IF (ierr /= 0) CALL fail(message)
+         CALL write_mode_timeseries(mode_timeseries_unit, dt_ps, selected_wavenumber, &
+                                    position_series, series, mode_vectors)
+         CALL close_output(mode_timeseries_unit)
+      END IF
    END SUBROUTINE analyze_series
 
    SUBROUTINE build_frequency_matrices(series, n_correlation, dt_ps, sigma_cm, matrices, df_cm)
-      REAL(dp), INTENT(IN)                               :: series(:, :), dt_ps, sigma_cm
+      REAL(dp), INTENT(IN)                               :: series(:, :)
       INTEGER, INTENT(IN)                                :: n_correlation
+      REAL(dp), INTENT(IN)                               :: dt_ps, sigma_cm
       REAL(dp), ALLOCATABLE, INTENT(OUT)                 :: matrices(:, :, :)
       REAL(dp), INTENT(OUT)                              :: df_cm
 
-      COMPLEX(dp), ALLOCATABLE                           :: transformed(:, :), work_long(:), work_short(:)
-      INTEGER                                            :: first, frames, frequency, lag, length, n_dof, second
+      COMPLEX(dp), ALLOCATABLE                           :: transformed(:, :), work_long(:), &
+                                                            work_short(:)
+      INTEGER                                            :: first, frames, frequency, lag, length, &
+                                                            n_dof, second
       REAL(dp)                                           :: gaussian_norm
       REAL(dp), ALLOCATABLE                              :: window(:)
 
@@ -341,7 +384,7 @@ CONTAINS
       gaussian_norm = 1.0_dp/SQRT(2.0_dp*ACOS(-1.0_dp)*sigma_cm*sigma_cm)
       DO frequency = 0, n_correlation - 1
          window(frequency + 1) = gaussian_norm* &
-            EXP(-0.5_dp*(REAL(frequency, dp)*df_cm/sigma_cm)**2)
+                                 EXP(-0.5_dp*(REAL(frequency, dp)*df_cm/sigma_cm)**2)
       END DO
       window(n_correlation + 1:) = window(n_correlation:2:-1)
       work_short = CMPLX(window, 0.0_dp, KIND=dp)
@@ -358,7 +401,7 @@ CONTAINS
             work_short(1) = CMPLX(window(1)*REAL(work_long(1), dp), 0.0_dp, KIND=dp)
             DO lag = 1, n_correlation - 1
                work_short(lag + 1) = CMPLX(window(lag + 1)*0.5_dp* &
-                  REAL(work_long(lag + 1) + work_long(frames - lag + 1), dp), 0.0_dp, KIND=dp)
+                                           REAL(work_long(lag + 1) + work_long(frames - lag + 1), dp), 0.0_dp, KIND=dp)
             END DO
             work_short(n_correlation + 1:) = work_short(n_correlation:2:-1)
             CALL fft_any_in_place(work_short, inverse=.FALSE.)
@@ -384,7 +427,8 @@ CONTAINS
    SUBROUTINE write_modes(unit, labels, masses, frequency_cm, eigenvalues, vectors)
       INTEGER, INTENT(IN)                                :: unit
       CHARACTER(LEN=*), INTENT(IN)                       :: labels(:)
-      REAL(dp), INTENT(IN)                               :: masses(:), frequency_cm, eigenvalues(:), vectors(:, :)
+      REAL(dp), INTENT(IN)                               :: masses(:), frequency_cm, eigenvalues(:), &
+                                                            vectors(:, :)
 
       INTEGER                                            :: atom, mode
       REAL(dp)                                           :: displacement(3)
@@ -402,8 +446,8 @@ CONTAINS
 
    SUBROUTINE write_mode_spectra(unit, df_cm, selected_frequency, trace, matrices, vectors)
       INTEGER, INTENT(IN)                                :: unit
-      REAL(dp), INTENT(IN)                               :: df_cm, selected_frequency, trace(:), matrices(:, :, :), &
-                                                            vectors(:, :)
+      REAL(dp), INTENT(IN)                               :: df_cm, selected_frequency, trace(:), &
+                                                            matrices(:, :, :), vectors(:, :)
 
       INTEGER                                            :: frequency, mode
       REAL(dp)                                           :: projection
@@ -424,6 +468,105 @@ CONTAINS
          WRITE (unit, "(A)") ""
       END DO
    END SUBROUTINE write_mode_spectra
+
+   SUBROUTINE write_mode_timeseries(unit, dt_ps, frequency_cm, positions, velocities, vectors)
+      INTEGER, INTENT(IN)                                :: unit
+      REAL(dp), INTENT(IN)                               :: dt_ps, frequency_cm, positions(:, :), &
+                                                            velocities(:, :), vectors(:, :)
+
+      INTEGER                                            :: frame, mode, mode_count
+      REAL(dp)                                           :: energy_quantum, omega_ps, total_energy
+      REAL(dp), ALLOCATABLE                              :: coordinate(:, :), energy(:, :), &
+                                                            energy_fraction(:, :), phase_time(:), &
+                                                            projected_velocity(:, :)
+
+      mode_count = SIZE(vectors, 2)
+      ALLOCATE (coordinate(mode_count, SIZE(positions, 2)), &
+                projected_velocity(mode_count, SIZE(velocities, 2)), &
+                energy(mode_count, SIZE(velocities, 2)), energy_fraction(mode_count, SIZE(velocities, 2)), &
+                phase_time(mode_count))
+      coordinate = MATMUL(TRANSPOSE(vectors), positions)
+      projected_velocity = MATMUL(TRANSPOSE(vectors), velocities)
+      DO mode = 1, mode_count
+         coordinate(mode, :) = coordinate(mode, :) - &
+                               SUM(coordinate(mode, :))/REAL(SIZE(coordinate, 2), dp)
+      END DO
+      omega_ps = 2.0_dp*ACOS(-1.0_dp)*speed_of_light_cm_per_ps*frequency_cm
+      energy = 0.5_dp*mass_velocity_to_j_mol* &
+               (projected_velocity**2 + (omega_ps*coordinate)**2)/1000.0_dp
+      energy_quantum = wavenumber_to_kj_mol*frequency_cm
+      energy_fraction = 0.0_dp
+      DO frame = 1, SIZE(energy, 2)
+         total_energy = SUM(energy(:, frame))
+         IF (total_energy > TINY(1.0_dp)) energy_fraction(:, frame) = energy(:, frame)/total_energy
+      END DO
+      DO mode = 1, mode_count
+         phase_time(mode) = phase_correlation_time(coordinate(mode, :), projected_velocity(mode, :), &
+                                                   omega_ps, dt_ps)
+      END DO
+
+      WRITE (unit, "(A)") "# Time-resolved projection onto fixed FRESEAN modes"
+      WRITE (unit, "(A,F16.8)") "# eigenvectors_selected_at_wavenumber_cm^-1: ", frequency_cm
+      WRITE (unit, "(A,F16.8)") "# harmonic_energy_quantum_kJ_mol^-1: ", energy_quantum
+      WRITE (unit, "(A)") "# mass_weighted_coordinate_unit: sqrt(g/mol)*angstrom"
+      WRITE (unit, "(A)") "# mass_weighted_velocity_unit: sqrt(g/mol)*angstrom/ps"
+      WRITE (unit, "(A)") "# projected_coordinate_means_removed: T"
+      WRITE (unit, "(A)") &
+         "# Energies are harmonic proxies; fractions are normalized over the extracted modes only."
+      WRITE (unit, "(A)") &
+         "# Phase-correlation times describe the continuously sampled trajectory, not an intrinsic IVR lifetime."
+      WRITE (unit, "(A)") "# A phase-correlation time of -1 means no 1/e crossing within half the trajectory."
+      DO mode = 1, mode_count
+         WRITE (unit, "(A,I0,A,ES24.16)") "# mode_", mode, "_phase_correlation_1e_ps: ", phase_time(mode)
+      END DO
+      WRITE (unit, "(A)", ADVANCE="no") "# time[ps]"
+      DO mode = 1, mode_count
+         WRITE (unit, "(A,I0,A,I0,A,I0,A,I0,A,I0)", ADVANCE="no") &
+            " q_", mode, " velocity_", mode, " energy_kJ_mol_", mode, " quanta_", mode, " fraction_", mode
+      END DO
+      WRITE (unit, "(A)") ""
+      DO frame = 1, SIZE(energy, 2)
+         WRITE (unit, "(ES24.16)", ADVANCE="no") REAL(frame - 1, dp)*dt_ps
+         DO mode = 1, mode_count
+            WRITE (unit, "(5ES24.16)", ADVANCE="no") coordinate(mode, frame), projected_velocity(mode, frame), &
+               energy(mode, frame), energy(mode, frame)/energy_quantum, energy_fraction(mode, frame)
+         END DO
+         WRITE (unit, "(A)") ""
+      END DO
+   END SUBROUTINE write_mode_timeseries
+
+   REAL(dp) FUNCTION phase_correlation_time(coordinate, velocity, omega_ps, dt_ps)
+      REAL(dp), INTENT(IN)                               :: coordinate(:), velocity(:), omega_ps, &
+                                                            dt_ps
+
+      COMPLEX(dp), ALLOCATABLE                           :: correlation(:), phase(:, :)
+      INTEGER                                            :: frame, lag, maximum_lag
+      REAL(dp)                                           :: amplitude, amplitude_cutoff, &
+                                                            maximum_amplitude
+
+      maximum_lag = SIZE(coordinate)/2
+      ALLOCATE (phase(1, SIZE(coordinate)))
+      maximum_amplitude = MAXVAL(SQRT((omega_ps*coordinate)**2 + velocity**2))
+      amplitude_cutoff = SQRT(EPSILON(1.0_dp))*maximum_amplitude
+      phase = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+      DO frame = 1, SIZE(coordinate)
+         amplitude = SQRT((omega_ps*coordinate(frame))**2 + velocity(frame)**2)
+         IF (amplitude > amplitude_cutoff) &
+            phase(1, frame) = CMPLX(omega_ps*coordinate(frame), velocity(frame), KIND=dp)/amplitude
+      END DO
+      CALL complex_autocorrelation_sum(phase, maximum_lag, correlation)
+      DO lag = 0, maximum_lag
+         correlation(lag) = correlation(lag)/REAL(SIZE(coordinate) - lag, dp)
+      END DO
+      phase_correlation_time = -1.0_dp
+      IF (ABS(correlation(0)) <= TINY(1.0_dp)) RETURN
+      DO lag = 1, maximum_lag
+         IF (ABS(correlation(lag)/correlation(0)) <= EXP(-1.0_dp)) THEN
+            phase_correlation_time = REAL(lag, dp)*dt_ps
+            RETURN
+         END IF
+      END DO
+   END FUNCTION phase_correlation_time
 
    SUBROUTINE validate_position_frame(velocity_frame, position_frame)
       TYPE(frame_type), INTENT(IN)                       :: velocity_frame, position_frame
@@ -469,6 +612,7 @@ CONTAINS
       WRITE (*, "(A)") "  --output FILE              VDoS and leading eigenvalues (default stdout)"
       WRITE (*, "(A)") "  --mode-file FILE           mass-unweighted displacement vectors in XYZ format"
       WRITE (*, "(A)") "  --mode-spectrum FILE       projected VDoS of the extracted modes"
+      WRITE (*, "(A)") "  --mode-timeseries FILE     time-resolved fixed-mode coordinates and energy proxies"
       WRITE (*, "(A)") ""
       WRITE (*, "(A)") "Alignment and conventions:"
       WRITE (*, "(A)") "  --position FILE            synchronized positions; enables rotational alignment"

--- a/tools/trajana/geometry_analysis.f90
+++ b/tools/trajana/geometry_analysis.f90
@@ -28,7 +28,7 @@ MODULE trajana_geometry_analysis
       INTEGER :: atom(4) = 0
    END TYPE action_type
 
-   PUBLIC :: run_geometry
+   PUBLIC :: action_type, evaluate_action, read_actions, run_geometry, validate_actions
 
 CONTAINS
 

--- a/tools/trajana/tests/test_trajana.py
+++ b/tools/trajana/tests/test_trajana.py
@@ -31,6 +31,13 @@ def run(*arguments):
         )
 
 
+def run_fails(*arguments):
+    completed = subprocess.run(arguments, cwd=TOOL_DIR, text=True, capture_output=True)
+    if completed.returncode == 0:
+        raise AssertionError(f"Command unexpectedly succeeded: {' '.join(arguments)}")
+    return completed
+
+
 def data_lines(path):
     return [
         [float(field) for field in line.split()]
@@ -507,6 +514,107 @@ class TrajectoryToolTests(unittest.TestCase):
             self.assertGreater(abs(components[0]), 0.999999)
             self.assertLess(max(abs(value) for value in components[1:]), 1.0e-8)
 
+    def test_fresean_writes_time_resolved_fixed_mode_projection(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            positions = root / "vibration-pos.xyz"
+            velocities = root / "vibration-vel.xyz"
+            reference = root / "reference.xyz"
+            frames = 64
+            dt_ps = 0.1
+            cycles = 4
+            amplitude = 0.05
+            angular_frequency = 2.0 * math.pi * cycles / (frames * dt_ps)
+            position_text = []
+            velocity_text = []
+            for frame in range(frames):
+                phase = 2.0 * math.pi * cycles * frame / frames
+                displacement = amplitude * math.sin(phase)
+                speed = amplitude * angular_frequency * math.cos(phase)
+                position_text.extend(
+                    (
+                        "3",
+                        f"frame {frame}",
+                        f"A {-1.0 - displacement:.16f} 0 0",
+                        f"B {1.0 + displacement:.16f} 0 0",
+                        "C 0 1 0",
+                    )
+                )
+                velocity_text.extend(
+                    (
+                        "3",
+                        f"frame {frame}",
+                        f"A {-speed:.16f} 0 0",
+                        f"B {speed:.16f} 0 0",
+                        "C 0 0 0",
+                    )
+                )
+            positions.write_text("\n".join(position_text) + "\n", encoding="utf8")
+            velocities.write_text("\n".join(velocity_text) + "\n", encoding="utf8")
+            reference.write_text(
+                "3\nreference\nA -1 0 0\nB 1 0 0\nC 0 1 0\n", encoding="utf8"
+            )
+            masses = root / "masses.dat"
+            masses.write_text("A 1\nB 1\nC 1\n", encoding="utf8")
+            timeseries = root / "mode-timeseries.dat"
+            run(
+                str(FRESEAN),
+                "--velocity",
+                str(velocities),
+                "--position",
+                str(positions),
+                "--reference",
+                str(reference),
+                "--velocity-unit",
+                "angstrom/ps",
+                "--mass-file",
+                str(masses),
+                "--dt-fs",
+                "100",
+                "--correlation-frames",
+                "16",
+                "--constraints",
+                "8",
+                "--frequency-cm",
+                "21.5",
+                "--mode-count",
+                "1",
+                "--output",
+                str(root / "fresean.dat"),
+                "--mode-timeseries",
+                str(timeseries),
+            )
+            values = data_lines(timeseries)
+            self.assertEqual(len(values), frames)
+            self.assertTrue(all(len(row) == 6 for row in values))
+            self.assertAlmostEqual(values[-1][0], (frames - 1) * dt_ps)
+            self.assertGreater(max(abs(row[1]) for row in values), 0.06)
+            self.assertGreater(max(abs(row[2]) for row in values), 0.25)
+            self.assertGreater(min(row[3] for row in values), 0.0)
+            self.assertTrue(all(abs(row[5] - 1.0) < 1.0e-12 for row in values))
+            phase_line = next(
+                line
+                for line in timeseries.read_text(encoding="utf8").splitlines()
+                if line.startswith("# mode_1_phase_correlation_1e_ps:")
+            )
+            self.assertEqual(float(phase_line.split(":", maxsplit=1)[1]), -1.0)
+
+    def test_fresean_mode_timeseries_requires_positions(self):
+        completed = run_fails(
+            str(FRESEAN),
+            "--velocity",
+            "unused.xyz",
+            "--mass-file",
+            "unused-masses.dat",
+            "--dt-fs",
+            "1",
+            "--frequency-cm",
+            "1000",
+            "--mode-timeseries",
+            "unused.dat",
+        )
+        self.assertIn("--mode-timeseries requires --position", completed.stderr)
+
     def test_twopt_atomic_fluidicity_and_sum_rule(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -891,6 +999,103 @@ class TrajectoryToolTests(unittest.TestCase):
             self.assertAlmostEqual(values[1][0], 1.5)
             self.assertAlmostEqual(values[1][1], expected_g, places=12)
             self.assertAlmostEqual(values[1][2], 1.0)
+
+    def test_geometry_events_use_hysteresis_and_report_open_events(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "events.xyz"
+            distances = (1.50, 1.71, 1.69, 1.64, 1.68, 1.72, 1.80)
+            source.write_text(
+                "".join(
+                    f"2\nframe {frame}\nA 0 0 0\nB {distance:.8f} 0 0\n"
+                    for frame, distance in enumerate(distances, start=1)
+                ),
+                encoding="utf8",
+            )
+            actions = root / "events.in"
+            actions.write_text("DISTANCE 1 2\n", encoding="utf8")
+            events = root / "events.dat"
+            summary = root / "summary.dat"
+            run(
+                str(TRAJANA),
+                "events",
+                "--input",
+                str(source),
+                "--actions",
+                str(actions),
+                "--dt-fs",
+                "1.0",
+                "--entry",
+                "1.70",
+                "--exit",
+                "1.65",
+                "--output",
+                str(events),
+                "--summary",
+                str(summary),
+            )
+            values = data_lines(events)
+            self.assertEqual(len(values), 2)
+            self.assertEqual([int(value) for value in values[0][:4]], [1, 1, 2, 3])
+            self.assertAlmostEqual(values[0][4], 0.001)
+            self.assertAlmostEqual(values[0][6], 0.002)
+            self.assertAlmostEqual(values[0][7], 1.71)
+            self.assertEqual(int(values[0][-1]), 1)
+            self.assertEqual([int(value) for value in values[1][:4]], [1, 2, 6, 7])
+            self.assertAlmostEqual(values[1][6], 0.002)
+            self.assertAlmostEqual(values[1][7], 1.80)
+            self.assertEqual(int(values[1][-1]), 0)
+
+            summary_line = next(
+                line
+                for line in summary.read_text(encoding="utf8").splitlines()
+                if line and not line.startswith("#")
+            ).split()
+            self.assertEqual(summary_line[1], "distance")
+            self.assertEqual(summary_line[6], "above")
+            self.assertEqual(int(summary_line[9]), 2)
+            self.assertEqual(int(summary_line[10]), 1)
+            self.assertAlmostEqual(float(summary_line[11]), 0.001)
+            self.assertAlmostEqual(float(summary_line[12]), 0.004)
+            self.assertAlmostEqual(float(summary_line[14]), 1.80)
+
+            below_events = root / "below-events.dat"
+            run(
+                str(TRAJANA),
+                "events",
+                "--input",
+                str(source),
+                "--actions",
+                str(actions),
+                "--dt-fs",
+                "1.0",
+                "--direction",
+                "below",
+                "--entry",
+                "1.66",
+                "--exit",
+                "1.70",
+                "--output",
+                str(below_events),
+            )
+            below_values = data_lines(below_events)
+            self.assertEqual(len(below_values), 2)
+            self.assertEqual([int(value) for value in below_values[0][2:4]], [1, 1])
+            self.assertEqual([int(value) for value in below_values[1][2:4]], [4, 5])
+            self.assertTrue(all(int(value[-1]) == 1 for value in below_values))
+
+    def test_geometry_events_reject_invalid_hysteresis(self):
+        completed = run_fails(
+            str(TRAJANA),
+            "events",
+            "--dt-fs",
+            "1",
+            "--entry",
+            "1.70",
+            "--exit",
+            "1.75",
+        )
+        self.assertIn("--exit must be smaller than --entry", completed.stderr)
 
     def test_vacf_uses_all_time_origins(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/trajana/trajana_main.f90
+++ b/tools/trajana/trajana_main.f90
@@ -10,6 +10,7 @@ PROGRAM trajana
                                               fail,&
                                               has_flag
    USE trajana_dsf_analysis,            ONLY: run_dsf
+   USE trajana_event_analysis,          ONLY: run_events
    USE trajana_geometry_analysis,       ONLY: run_geometry
    USE trajana_hbond_analysis,          ONLY: run_hbond
    USE trajana_rdf_analysis,            ONLY: run_rdf
@@ -27,6 +28,8 @@ PROGRAM trajana
       CALL print_help()
    CASE ("geometry")
       CALL run_geometry()
+   CASE ("events")
+      CALL run_events()
    CASE ("rdf")
       CALL run_rdf()
    CASE ("vacf")
@@ -46,6 +49,7 @@ CONTAINS
       WRITE (*, "(A)") ""
       WRITE (*, "(A)") "Analyses:"
       WRITE (*, "(A)") "  geometry  Distances, angles, and torsions from an action file"
+      WRITE (*, "(A)") "  events    Hysteretic events in geometric trajectory observables"
       WRITE (*, "(A)") "  rdf       Radial distribution and running coordination number"
       WRITE (*, "(A)") "  vacf      Velocity autocorrelation and optional spectrum"
       WRITE (*, "(A)") "  hbond     Wernet-type hydrogen-bond network statistics"


### PR DESCRIPTION
## Summary

This change extends the standalone trajectory-analysis tools with two complementary diagnostics:

- `trajana.x events` detects hysteretic threshold-crossing episodes in arbitrary `DISTANCE`,
  `ANGLE`, and `TORSION` actions. It reuses the existing triclinic minimum-image geometry, supports
  both above- and below-threshold events, and writes per-event records plus an optional aggregate
  summary.
- `fresean.x --mode-timeseries` projects synchronized, aligned positions and velocities onto the
  fixed FRESEAN eigenvectors selected at a requested wavenumber. The output contains mass-weighted
  coordinates and velocities, harmonic energy proxies, energy-equivalent quanta, fractions over the
  extracted modes, and an effective phase-correlation time.

The additions replace workflow-specific post-processing scripts with documented, reusable analyses
that operate directly on CP2K trajectory files.

## Numerical conventions

For the event analysis, separate entry and exit thresholds suppress rapid recrossings. Each active
sample contributes one selected-frame time step to the reported residence time. Events still active
at the end of the selected trajectory are retained and marked as open. Event counts and residence
times are descriptive trajectory statistics; they are not interpreted as rates or probabilities.

For a fixed FRESEAN vector `e_k`, the time-series analysis evaluates

```text
q_k(t)    = e_k^T M^(1/2) [R_aligned(t) - R_reference]
qdot_k(t) = e_k^T M^(1/2) V_aligned(t)
E_k(t)    = 1/2 [qdot_k(t)^2 + omega^2 q_k(t)^2].
```

Positions are projected directly rather than reconstructed by velocity integration. The coordinate
mean is removed before evaluating the energy. The output labels the energies as harmonic proxies;
fractions are normalized only over the extracted modes. The reported `1/e` phase-correlation time
is an effective value for the sampled trajectory and is not presented as an intrinsic field-free
IVR lifetime.

## Testing

```console
cd tools/trajana
make check
```

This rebuilds all five executables with
`-O0 -g -std=f2008 -Wall -Wextra -Werror -fcheck=all` and runs 15 tests, including new synthetic
tests for closed and open hysteretic events, reverse threshold direction, invalid hysteresis,
aligned fixed-mode projections, harmonic diagnostics, and required-input validation.

The seven changed files also pass the CP2K precommit service with a clean result.
