### PR TITLE
Fix: Mark k-point GEXT_PROJ wavefunctions as orthogonalized

### DIFF
--- a/src/qs_wf_history_methods.F
+++ b/src/qs_wf_history_methods.F
@@ -1137,6 +1137,7 @@ CONTAINS
             nvec = MIN(wf_history%memory_depth, wf_history%snapshot_count)
             CPASSERT(nvec > 0)
             CALL wfi_extrapolate_gext_proj_kp(wf_history, qs_env, nvec, io_unit, print_level)
+            my_orthogonal_wf = .TRUE.
          ELSE
 
             ! figure out the actual number of vectors to use in the extrapolation:
@@ -1211,6 +1212,7 @@ CONTAINS
             nvec = MIN(wf_history%memory_depth, wf_history%snapshot_count)
             CPASSERT(nvec > 0)
             CALL wfi_extrapolate_gext_proj_kp(wf_history, qs_env, nvec, io_unit, print_level)
+            my_orthogonal_wf = .TRUE.
          ELSE
 
             ! figure out the actual number of vectors to use in the extrapolation:


### PR DESCRIPTION
The k-point GEXT extrapolation already reorthogonalizes the extrapolated wavefunctions through `wfi_use_prev_wf_kp()`, but `wfi_extrapolate()` did not mark them as orthogonalized (apparently I forgot to do so). Since OT is now available for k-points, this issue became visible because the extrapolated wavefunctions can reach an OT-specific `reorthogonalize_vectors()` path, which is not for k-points and thus aborts with `Method not implemented for k-points`.

Set `my_orthogonal_wf = .TRUE.` after the k-point `GEXT_PROJ` and `GEXT_PROJ_QTR` extrapolation paths, consistently with the existing k-point PS/ASPC handling. This allows `GEXT_PROJ` extrapolation to be used with k-point OT across subsequent geometry or cell optimization steps.