### PR TITLE
QS: Fix finite rotations in REF OT

### DIFF
--- a/src/qs_ot.F
+++ b/src/qs_ot.F
@@ -15,11 +15,12 @@
 MODULE qs_ot
    USE arnoldi_api,                     ONLY: arnoldi_extremal
    USE cp_dbcsr_api,                    ONLY: &
-        dbcsr_add, dbcsr_copy, dbcsr_distribution_type, dbcsr_filter, dbcsr_get_block_p, &
-        dbcsr_get_info, dbcsr_get_occupation, dbcsr_init_p, dbcsr_iterator_blocks_left, &
-        dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, &
-        dbcsr_multiply, dbcsr_release, dbcsr_release_p, dbcsr_scale, dbcsr_set, dbcsr_transposed, &
-        dbcsr_type
+        dbcsr_add, dbcsr_copy, dbcsr_create, dbcsr_distribution_type, dbcsr_filter, &
+        dbcsr_finalize, dbcsr_get_block_p, dbcsr_get_info, dbcsr_get_occupation, dbcsr_init_p, &
+        dbcsr_iterator_blocks_left, dbcsr_iterator_next_block, dbcsr_iterator_start, &
+        dbcsr_iterator_stop, dbcsr_iterator_type, dbcsr_multiply, dbcsr_release, dbcsr_release_p, &
+        dbcsr_reserve_blocks, dbcsr_scale, dbcsr_set, dbcsr_transposed, dbcsr_type, &
+        dbcsr_type_no_symmetry
    USE cp_dbcsr_cholesky,               ONLY: cp_dbcsr_cholesky_decompose,&
                                               cp_dbcsr_cholesky_invert,&
                                               cp_dbcsr_cholesky_restore
@@ -1133,15 +1134,18 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'qs_ot_rot_mat_derivative'
 
-      INTEGER                                  :: handle, i, j, k
+      INTEGER                                  :: col, handle, i, iblock, j, k, max_blocks, nblocks, row
+      INTEGER, ALLOCATABLE, DIMENSION(:)       :: cols, rows
+      INTEGER, DIMENSION(:), POINTER           :: col_blk_offset, col_blk_size, row_blk_offset, row_blk_size
       REAL(KIND=dp)                            :: e1, e2
       TYPE(dbcsr_type)                         :: outer_deriv_re, outer_deriv_im, mat_buf, &
                                                   inner_deriv_re, inner_deriv_im
+      TYPE(dbcsr_distribution_type)            :: dist
       TYPE(dbcsr_iterator_type)                :: iter
-      INTEGER, DIMENSION(:), POINTER           :: row_blk_offset, col_blk_offset
       REAL(dp), DIMENSION(:, :), POINTER       :: block_in_re, block_in_im, block_out_re, block_out_im
-      INTEGER                                  :: row, col
-      LOGICAL                                  :: found
+      LOGICAL                                  :: duplicate, found_in_im, found_in_re, found_out_im, &
+                                                  found_out_re
+      REAL(KIND=dp)                            :: im_part, re_part
       COMPLEX(dp)                              :: cval_in, cval_out
       CALL timeset(routineN, handle)
 
@@ -1163,24 +1167,87 @@ CONTAINS
          CALL dbcsr_multiply('T', 'N', +1.0_dp, qs_ot_env%rot_mat_evec_re, mat_buf, 1.0_dp, inner_deriv_re)
          CALL dbcsr_multiply('T', 'N', -1.0_dp, qs_ot_env%rot_mat_evec_im, mat_buf, 1.0_dp, inner_deriv_im)
 
-         ! outer_deriv_ij = cint(eval_i, eval_j) * inner_deriv_ij
-         CALL dbcsr_copy(outer_deriv_re, qs_ot_env%rot_mat_dedu, "outer_deriv_re") ! TODO just create
-         CALL dbcsr_copy(outer_deriv_im, qs_ot_env%rot_mat_dedu, "outer_deriv_im") ! TODO just create
-
-         CALL dbcsr_get_info(qs_ot_env%rot_mat_dedu, row_blk_offset=row_blk_offset, col_blk_offset=col_blk_offset)
-         CALL dbcsr_iterator_start(iter, qs_ot_env%rot_mat_dedu)
+         ! Real and imaginary products can have different sparse block patterns.
+         ! Form their union explicitly and treat a missing partner block as zero.
+         max_blocks = 0
+         CALL dbcsr_iterator_start(iter, inner_deriv_re)
          DO WHILE (dbcsr_iterator_blocks_left(iter))
             CALL dbcsr_iterator_next_block(iter, row, col)
-            CALL dbcsr_get_block_p(inner_deriv_re, row, col, block_in_re, found)
-            CALL dbcsr_get_block_p(inner_deriv_im, row, col, block_in_im, found)
-            CALL dbcsr_get_block_p(outer_deriv_re, row, col, block_out_re, found)
-            CALL dbcsr_get_block_p(outer_deriv_im, row, col, block_out_im, found)
+            max_blocks = max_blocks + 1
+         END DO
+         CALL dbcsr_iterator_stop(iter)
+         CALL dbcsr_iterator_start(iter, inner_deriv_im)
+         DO WHILE (dbcsr_iterator_blocks_left(iter))
+            CALL dbcsr_iterator_next_block(iter, row, col)
+            max_blocks = max_blocks + 1
+         END DO
+         CALL dbcsr_iterator_stop(iter)
 
-            DO i = 1, SIZE(block_in_re, 1)
-            DO j = 1, SIZE(block_in_re, 2)
+         ALLOCATE (rows(MAX(max_blocks, 1)), cols(MAX(max_blocks, 1)))
+         nblocks = 0
+         CALL dbcsr_iterator_start(iter, inner_deriv_re)
+         DO WHILE (dbcsr_iterator_blocks_left(iter))
+            CALL dbcsr_iterator_next_block(iter, row, col)
+            duplicate = .FALSE.
+            DO iblock = 1, nblocks
+               duplicate = duplicate .OR. (rows(iblock) == row .AND. cols(iblock) == col)
+            END DO
+            IF (.NOT. duplicate) THEN
+               nblocks = nblocks + 1
+               rows(nblocks) = row
+               cols(nblocks) = col
+            END IF
+         END DO
+         CALL dbcsr_iterator_stop(iter)
+         CALL dbcsr_iterator_start(iter, inner_deriv_im)
+         DO WHILE (dbcsr_iterator_blocks_left(iter))
+            CALL dbcsr_iterator_next_block(iter, row, col)
+            duplicate = .FALSE.
+            DO iblock = 1, nblocks
+               duplicate = duplicate .OR. (rows(iblock) == row .AND. cols(iblock) == col)
+            END DO
+            IF (.NOT. duplicate) THEN
+               nblocks = nblocks + 1
+               rows(nblocks) = row
+               cols(nblocks) = col
+            END IF
+         END DO
+         CALL dbcsr_iterator_stop(iter)
+
+         CALL dbcsr_get_info(inner_deriv_re, distribution=dist, row_blk_size=row_blk_size, &
+                             col_blk_size=col_blk_size)
+         CALL dbcsr_create(outer_deriv_re, "outer_deriv_re", dist, dbcsr_type_no_symmetry, &
+                           row_blk_size, col_blk_size)
+         CALL dbcsr_create(outer_deriv_im, "outer_deriv_im", dist, dbcsr_type_no_symmetry, &
+                           row_blk_size, col_blk_size)
+         IF (nblocks > 0) THEN
+            CALL dbcsr_reserve_blocks(outer_deriv_re, rows=rows(1:nblocks), cols=cols(1:nblocks))
+            CALL dbcsr_reserve_blocks(outer_deriv_im, rows=rows(1:nblocks), cols=cols(1:nblocks))
+         END IF
+         CALL dbcsr_finalize(outer_deriv_re)
+         CALL dbcsr_finalize(outer_deriv_im)
+         CALL dbcsr_set(outer_deriv_re, 0.0_dp)
+         CALL dbcsr_set(outer_deriv_im, 0.0_dp)
+
+         CALL dbcsr_get_info(outer_deriv_re, row_blk_offset=row_blk_offset, col_blk_offset=col_blk_offset)
+         CALL dbcsr_iterator_start(iter, outer_deriv_re)
+         DO WHILE (dbcsr_iterator_blocks_left(iter))
+            CALL dbcsr_iterator_next_block(iter, row, col)
+            CALL dbcsr_get_block_p(inner_deriv_re, row, col, block_in_re, found_in_re)
+            CALL dbcsr_get_block_p(inner_deriv_im, row, col, block_in_im, found_in_im)
+            CALL dbcsr_get_block_p(outer_deriv_re, row, col, block_out_re, found_out_re)
+            CALL dbcsr_get_block_p(outer_deriv_im, row, col, block_out_im, found_out_im)
+            CPASSERT(found_out_re .AND. found_out_im)
+
+            DO i = 1, SIZE(block_out_re, 1)
+            DO j = 1, SIZE(block_out_re, 2)
                e1 = qs_ot_env%rot_mat_evals(row_blk_offset(row) + i - 1)
                e2 = qs_ot_env%rot_mat_evals(col_blk_offset(col) + j - 1)
-               cval_in = CMPLX(block_in_re(i, j), block_in_im(i, j), dp)
+               re_part = 0.0_dp
+               im_part = 0.0_dp
+               IF (found_in_re) re_part = block_in_re(i, j)
+               IF (found_in_im) im_part = block_in_im(i, j)
+               cval_in = CMPLX(re_part, im_part, dp)
                cval_out = cval_in*cint(e1, e2)
                block_out_re(i, j) = REAL(cval_out)
                block_out_im(i, j) = AIMAG(cval_out)
@@ -1188,6 +1255,7 @@ CONTAINS
             END DO
          END DO
          CALL dbcsr_iterator_stop(iter)
+         DEALLOCATE (rows, cols)
          CALL dbcsr_release(inner_deriv_re)
          CALL dbcsr_release(inner_deriv_im)
 

--- a/src/qs_ot.F
+++ b/src/qs_ot.F
@@ -47,6 +47,8 @@ MODULE qs_ot
    PUBLIC  :: qs_ot_get_orbitals_ref_complex
    PUBLIC  :: qs_ot_get_derivative_ref
    PUBLIC  :: qs_ot_get_derivative_ref_complex
+   PUBLIC  :: qs_ot_generate_rotation
+   PUBLIC  :: qs_ot_rot_mat_derivative
    PUBLIC  :: qs_ot_new_preconditioner
    PRIVATE :: qs_ot_p2m_diag
    PRIVATE :: qs_ot_sinc
@@ -603,6 +605,13 @@ CONTAINS
          END IF
          CALL dbcsr_copy(C_OLD, C_NEW)
       END IF
+
+      IF (qs_ot_env%settings%do_rotation) THEN
+         CALL qs_ot_generate_rotation(qs_ot_env)
+         CALL dbcsr_multiply('N', 'N', 1.0_dp, C_NEW, qs_ot_env%rot_mat_u, &
+                             0.0_dp, C_TMP)
+         CALL dbcsr_copy(C_NEW, C_TMP)
+      END IF
       !
       CALL timestop(handle)
    END SUBROUTINE qs_ot_get_orbitals_ref
@@ -845,7 +854,7 @@ CONTAINS
 
       INTEGER                                            :: handle, k, n
       REAL(dp)                                           :: occ_in, occ_out
-      TYPE(dbcsr_type), POINTER                          :: C, CHC, G, G_dp, HC, SC
+      TYPE(dbcsr_type), POINTER                          :: C, CHC, G, HC, HC_work, SC
 
       CALL timeset(routineN, handle)
 
@@ -856,10 +865,20 @@ CONTAINS
       HC => matrix_hc ! NBsf*NOcc
       G => matrix_gx ! NBsf*NOcc
       CHC => qs_ot_env%buf1_k_k_sym ! buffer
-      G_dp => qs_ot_env%buf1_n_k_dp ! buffer dp
+
+      IF (qs_ot_env%settings%do_rotation) THEN
+         ! The physical orbitals are C_current=Q*U. Pull dE/dC_current
+         ! back to the unrotated REF basis before projecting it.
+         CALL qs_ot_rot_mat_derivative(qs_ot_env)
+         HC_work => qs_ot_env%buf1_n_k
+         CALL dbcsr_multiply('N', 'T', 1.0_dp, HC, qs_ot_env%rot_mat_u, &
+                             0.0_dp, HC_work)
+      ELSE
+         HC_work => HC
+      END IF
 
       ! C'*(H*C)
-      CALL dbcsr_multiply('T', 'N', 1.0_dp, C, HC, 0.0_dp, CHC)
+      CALL dbcsr_multiply('T', 'N', 1.0_dp, C, HC_work, 0.0_dp, CHC)
       IF (qs_ot_env%settings%eps_irac_filter_matrix > 0.0_dp) THEN
          occ_in = dbcsr_get_occupation(chc)
          CALL dbcsr_filter(chc, qs_ot_env%settings%eps_irac_filter_matrix)
@@ -873,7 +892,7 @@ CONTAINS
          occ_out = dbcsr_get_occupation(g)
       END IF
       ! G = 2*(1-S*C*C')*H*C
-      CALL dbcsr_add(G, HC, alpha_scalar=-1.0_dp, beta_scalar=1.0_dp)
+      CALL dbcsr_add(G, HC_work, alpha_scalar=-1.0_dp, beta_scalar=1.0_dp)
       !
       CALL timestop(handle)
    END SUBROUTINE qs_ot_get_derivative_ref
@@ -1124,8 +1143,6 @@ CONTAINS
       INTEGER                                  :: row, col
       LOGICAL                                  :: found
       COMPLEX(dp)                              :: cval_in, cval_out
-      TYPE(dbcsr_distribution_type)            :: dist
-
       CALL timeset(routineN, handle)
 
       CALL dbcsr_get_info(qs_ot_env%rot_mat_u, nfullrows_total=k)
@@ -1183,15 +1200,12 @@ CONTAINS
          CALL dbcsr_multiply('N', 'N', +1.0_dp, qs_ot_env%rot_mat_evec_im, outer_deriv_re, 1.0_dp, mat_buf)
          CALL dbcsr_multiply('N', 'T', +1.0_dp, mat_buf, qs_ot_env%rot_mat_evec_im, 1.0_dp, qs_ot_env%matrix_buf1)
 
-         ! Account for anti-symmetry of rot_mat_x.
-         CALL dbcsr_get_info(qs_ot_env%matrix_buf3, distribution=dist)
-         CALL dbcsr_transposed(qs_ot_env%matrix_buf2, qs_ot_env%matrix_buf1, &
-                               shallow_data_copy=.FALSE., use_distribution=dist, &
-                               transpose_distribution=.FALSE.)
-
-         ! rot_mat_gx = matrix_buf1^T - matrix_buf1
-         CALL dbcsr_add(qs_ot_env%matrix_buf1, qs_ot_env%matrix_buf2, alpha_scalar=-1.0_dp, beta_scalar=+1.0_dp)
-         CALL dbcsr_copy(qs_ot_env%rot_mat_gx, qs_ot_env%matrix_buf1)
+         ! Account for anti-symmetry of rot_mat_x without relying on
+         ! STRICT-only matrix buffers. REF uses the same finite chart.
+         CALL qs_ot_square_transpose(qs_ot_env%matrix_buf1, mat_buf, qs_ot_env%rot_mat_u)
+         CALL dbcsr_copy(qs_ot_env%rot_mat_gx, mat_buf)
+         CALL dbcsr_add(qs_ot_env%rot_mat_gx, qs_ot_env%matrix_buf1, &
+                        alpha_scalar=1.0_dp, beta_scalar=-1.0_dp)
 
          CALL dbcsr_release(mat_buf)
          CALL dbcsr_release(outer_deriv_re)
@@ -1228,6 +1242,26 @@ CONTAINS
          END IF
       END FUNCTION cint
    END SUBROUTINE qs_ot_rot_mat_derivative
+
+! **************************************************************************************************
+!> \brief Transpose a square DBCSR matrix while retaining its target distribution.
+!> \param matrix source matrix
+!> \param transposed transposed matrix
+!> \param identity_template square matrix template
+! **************************************************************************************************
+   SUBROUTINE qs_ot_square_transpose(matrix, transposed, identity_template)
+      TYPE(dbcsr_type)                                   :: matrix, transposed, identity_template
+
+      TYPE(dbcsr_type)                                   :: identity
+
+      CALL dbcsr_copy(transposed, matrix, name='square_transposed')
+      CALL dbcsr_copy(identity, identity_template, name='transpose_identity')
+      CALL dbcsr_set(identity, 0.0_dp)
+      CALL dbcsr_add_on_diag(identity, 1.0_dp)
+      CALL dbcsr_multiply('T', 'N', 1.0_dp, matrix, identity, 0.0_dp, transposed)
+      CALL dbcsr_release(identity)
+
+   END SUBROUTINE qs_ot_square_transpose
 
 ! **************************************************************************************************
 !> \brief decide strategy

--- a/src/qs_ot_complex_ref_unittest.F
+++ b/src/qs_ot_complex_ref_unittest.F
@@ -50,7 +50,9 @@ PROGRAM qs_ot_complex_ref_unittest
    USE preconditioner_types,            ONLY: destroy_preconditioner,&
                                               init_preconditioner,&
                                               preconditioner_type
-   USE qs_ot,                           ONLY: qs_ot_get_derivative_ref_complex
+   USE qs_ot,                           ONLY: qs_ot_generate_rotation,&
+                                              qs_ot_get_derivative_ref_complex,&
+                                              qs_ot_rot_mat_derivative
    USE qs_ot_types,                     ONLY: qs_ot_kpoint_preconditioner_scale,&
                                               qs_ot_kpoint_preconditioner_solver_supported,&
                                               qs_ot_kpoint_preconditioner_supported,&
@@ -94,6 +96,7 @@ PROGRAM qs_ot_complex_ref_unittest
    CALL cp_add_default_logger(logger)
    CALL add_all_references()
    CALL dbcsr_init_lib(mp_comm%get_handle(), io_unit)
+   CALL test_real_rotation_frechet(para_env, nfail)
    CALL test_complex_preconditioner_gauge(para_env, nfail)
 
    x(:, 1) = [CMPLX(1.10_dp, 0.10_dp, KIND=dp), CMPLX(0.20_dp, -0.30_dp, KIND=dp), &
@@ -225,6 +228,111 @@ PROGRAM qs_ot_complex_ref_unittest
    IF (nfail > 0) ERROR STOP "qs_ot_complex_ref_unittest failed"
 
 CONTAINS
+
+! **************************************************************************************************
+!> \brief Check the real finite rotation pullback used by Gamma-point REF OT.
+!> \param para_env parallel environment
+!> \param nfail accumulated number of failures
+! **************************************************************************************************
+   SUBROUTINE test_real_rotation_frechet(para_env, nfail)
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      INTEGER, INTENT(INOUT)                             :: nfail
+
+      INTEGER, PARAMETER                                 :: m = 3
+
+      INTEGER                                            :: i
+      INTEGER, DIMENSION(:), POINTER                     :: col_dist, col_size, row_dist, row_size
+      INTEGER, DIMENSION(:, :), POINTER                  :: pgrid
+      LOGICAL                                            :: found
+      REAL(KIND=dp)                                      :: error, fd_slope, hstep, predicted
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: block
+      REAL(KIND=dp), DIMENSION(m), TARGET                :: rotation_evals
+      REAL(KIND=dp), DIMENSION(m, m)                     :: dedu, direction, generator, gradient, &
+                                                            rotation_minus, rotation_plus
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(dbcsr_distribution_type)                      :: dist
+      TYPE(dbcsr_type), DIMENSION(7), TARGET             :: matrices
+      TYPE(mp_para_env_type), POINTER                    :: local_para_env
+      TYPE(qs_ot_type)                                   :: rotation_env
+
+      NULLIFY (blacs_env, local_para_env)
+      generator(:, :) = 0.0_dp
+      generator(1, 2) = 0.23_dp
+      generator(2, 1) = -generator(1, 2)
+      generator(1, 3) = -0.11_dp
+      generator(3, 1) = -generator(1, 3)
+      generator(2, 3) = 0.17_dp
+      generator(3, 2) = -generator(2, 3)
+
+      direction(:, :) = 0.0_dp
+      direction(1, 2) = -0.09_dp
+      direction(2, 1) = -direction(1, 2)
+      direction(1, 3) = 0.14_dp
+      direction(3, 1) = -direction(1, 3)
+      direction(2, 3) = 0.06_dp
+      direction(3, 2) = -direction(2, 3)
+
+      dedu = RESHAPE([0.31_dp, -0.27_dp, 0.08_dp, &
+                      0.19_dp, 0.42_dp, -0.16_dp, &
+                      -0.07_dp, 0.21_dp, 0.35_dp], [m, m])
+
+      ALLOCATE (local_para_env)
+      CALL local_para_env%from_dup(mp_comm_self)
+      CALL cp_blacs_env_create(blacs_env=blacs_env, para_env=local_para_env)
+      ALLOCATE (pgrid(0:0, 0:0), row_dist(1), col_dist(1), row_size(1), col_size(1))
+      pgrid(:, :) = 0
+      row_dist(:) = 0
+      col_dist(:) = 0
+      row_size(:) = m
+      col_size(:) = m
+      CALL dbcsr_distribution_new(dist, group=mp_comm_self%get_handle(), pgrid=pgrid, &
+                                  row_dist=row_dist, col_dist=col_dist)
+      DO i = 1, SIZE(matrices)
+         CALL create_one_block(matrices(i), 'real_rotation', dist, row_size, col_size)
+      END DO
+      CALL dbcsr_put_block(matrices(2), 1, 1, generator)
+      CALL dbcsr_put_block(matrices(3), 1, 1, dedu)
+
+      rotation_env%para_env => local_para_env
+      rotation_env%blacs_env => blacs_env
+      rotation_env%rot_mat_u => matrices(1)
+      rotation_env%rot_mat_x => matrices(2)
+      rotation_env%rot_mat_dedu => matrices(3)
+      rotation_env%rot_mat_gx => matrices(4)
+      rotation_env%rot_mat_evec_re => matrices(5)
+      rotation_env%rot_mat_evec_im => matrices(6)
+      rotation_env%matrix_buf1 => matrices(7)
+      rotation_env%rot_mat_evals => rotation_evals
+
+      CALL qs_ot_generate_rotation(rotation_env)
+      CALL qs_ot_rot_mat_derivative(rotation_env)
+      gradient(:, :) = 0.0_dp
+      CALL dbcsr_get_block_p(matrices(4), 1, 1, block, found)
+      IF (found) gradient = block
+
+      hstep = 1.0E-6_dp
+      rotation_plus = REAL(dense_antihermitian_exp( &
+                           CMPLX(generator + hstep*direction, 0.0_dp, KIND=dp)), KIND=dp)
+      rotation_minus = REAL(dense_antihermitian_exp( &
+                            CMPLX(generator - hstep*direction, 0.0_dp, KIND=dp)), KIND=dp)
+      fd_slope = SUM(dedu*(rotation_plus - rotation_minus))/(2.0_dp*hstep)
+      predicted = 0.5_dp*SUM(gradient*direction)
+      error = ABS(predicted - fd_slope)
+      IF (error > 5.0E-8_dp) nfail = nfail + 1
+      IF (para_env%is_source()) THEN
+         WRITE (*, '(A,3(1X,ES13.6))') 'real finite rotation slope fd/predicted/error', &
+            fd_slope, predicted, error
+      END IF
+
+      DO i = 1, SIZE(matrices)
+         CALL dbcsr_release(matrices(i))
+      END DO
+      CALL dbcsr_distribution_release(dist)
+      DEALLOCATE (pgrid, row_dist, col_dist, row_size, col_size)
+      CALL cp_blacs_env_release(blacs_env)
+      CALL mp_para_env_release(local_para_env)
+
+   END SUBROUTINE test_real_rotation_frechet
 
 ! **************************************************************************************************
 !> \brief Check gauge invariance, Hermiticity, and positivity of the complex inverse operator.
@@ -440,6 +548,32 @@ CONTAINS
       CALL dbcsr_put_block(matrix_im, 1, 1, AIMAG(matrix))
 
    END SUBROUTINE put_complex_pair
+
+! **************************************************************************************************
+!> \brief Dense reference exponential for an anti-Hermitian matrix.
+!> \param generator anti-Hermitian generator
+!> \return its unitary exponential
+! **************************************************************************************************
+   FUNCTION dense_antihermitian_exp(generator) RESULT(rotation)
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: generator
+      COMPLEX(KIND=dp), DIMENSION(SIZE(generator, 1), &
+         SIZE(generator, 2))                             :: rotation
+
+      COMPLEX(KIND=dp), DIMENSION(SIZE(generator, 1), &
+         SIZE(generator, 2))                             :: hermitian, vectors
+      INTEGER                                            :: i
+      REAL(KIND=dp), DIMENSION(SIZE(generator, 1))       :: eigenvalues
+
+      hermitian = CMPLX(0.0_dp, 1.0_dp, KIND=dp)*generator
+      CALL diag_complex(hermitian, vectors, eigenvalues)
+      rotation(:, :) = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+      DO i = 1, SIZE(eigenvalues)
+         rotation = rotation + EXP(CMPLX(0.0_dp, -eigenvalues(i), KIND=dp))* &
+                    MATMUL(RESHAPE(vectors(:, i), [SIZE(generator, 1), 1]), &
+                           RESHAPE(CONJG(vectors(:, i)), [1, SIZE(generator, 1)]))
+      END DO
+
+   END FUNCTION dense_antihermitian_exp
 
 ! **************************************************************************************************
 !> \brief Hermitian inverse for an independent dense reference.

--- a/src/qs_ot_scf.F
+++ b/src/qs_ot_scf.F
@@ -16,7 +16,8 @@ MODULE qs_ot_scf
    USE cp_dbcsr_api,                    ONLY: &
         dbcsr_copy, dbcsr_get_info, dbcsr_init_p, dbcsr_multiply, dbcsr_p_type, dbcsr_release, &
         dbcsr_set, dbcsr_type, dbcsr_type_no_symmetry
-   USE cp_dbcsr_contrib,                ONLY: dbcsr_dot,&
+   USE cp_dbcsr_contrib,                ONLY: dbcsr_add_on_diag,&
+                                              dbcsr_dot,&
                                               dbcsr_get_diag,&
                                               dbcsr_scale_by_vector,&
                                               dbcsr_set_diag
@@ -419,6 +420,8 @@ CONTAINS
 
          IF (qs_ot_env(ispin)%settings%do_rotation) THEN
             CALL dbcsr_set(qs_ot_env(ispin)%rot_mat_x, 0.0_dp)
+            CALL dbcsr_set(qs_ot_env(ispin)%rot_mat_u, 0.0_dp)
+            CALL dbcsr_add_on_diag(qs_ot_env(ispin)%rot_mat_u, 1.0_dp)
          END IF
 
          IF (qs_ot_env(ispin)%settings%do_ener) THEN

--- a/tests/QS/regtest-ot-refine/TEST_FILES.toml
+++ b/tests/QS/regtest-ot-refine/TEST_FILES.toml
@@ -12,5 +12,5 @@
 "o2_ot_refine_diis_1.inp"               = [{matcher="E_total", tol=8e-14, ref=-31.68975974949591}]
 "o2_ot_refine_diis_2.inp"               = [{matcher="E_total", tol=5e-14, ref=-31.26277230138910}]
 "ethylene_l1_loc.inp"                   = [{matcher="M013", tol=1.0E-14, ref=0.4063601640E+02}]
-"o2_ot_refine_roks.inp"                 = [{matcher="E_total", tol=1e-13, ref=-31.33473048057817}]
+"o2_ot_refine_roks.inp"                 = [{matcher="E_total", tol=1e-13, ref=-31.34843768570860}]
 #EOF


### PR DESCRIPTION
## Summary

Complete the finite orbital-rotation path for the REF representation used by
`ALGORITHM IRAC`.

For a REF coordinate $X$ and an antisymmetric rotation generator $A$, the
physical orbitals are

$$
C(X,A) = Q(X)\,U(A), \qquad U(A) = \exp(A), \qquad A^\mathrm{T}=-A.
$$

Previously, REF OT accepted `ROTATION`, but it did not consistently implement
this product map:

- $U$ was not initialized before the first REF gradient evaluation.
- REF returned $Q(X)$ instead of the physical orbitals $Q(X)U(A)$.
- The orbital gradient was projected without the pullback
  $G_Q = G_C U^\mathrm{T}$.
- The finite exponential adjoint used work matrices allocated only for the
  STRICT representation.

As a result, REF rotations could be ineffective or use undefined state,
particularly for non-equivalent orbitals.

## Implementation

- Initialize the product chart with $A=0$ and $U=I$.
- Apply the finite rotation to the orbitals returned by REF.
- Pull the physical orbital gradient back into the unrotated REF basis.
- Evaluate the existing finite rotation Frechet adjoint without relying on
  STRICT-only work matrices.
- Add a real DBCSR finite-difference regression for the rotation derivative.

The existing `o2_ot_refine_roks.inp` test now exercises the rotation that was
previously ineffective. Its four-step reference energy changes intentionally
from `-31.33473048057817` to `-31.34843768570860` Ha.

This PR does not add smearing or fractional occupations. It fixes the finite
REF product chart needed by orbital-dependent and future Mermin OT paths.

## Validation

- GNU 16 MPI/OpenMP/tblite Release build
- `qs_ot_complex_ref_unittest.psmp`, MPI-1 and MPI-2
  - real finite-rotation slope error: `2.48E-10`
  - existing complex REF pullback error: `2.67E-10`
- `QS/regtest-ot-refine`, MPI-2: `10/10`
- `o2_ot_refine_roks.inp`, serial/MPI-2 agreement: `4E-15` Ha
- no-cache precommit: `4/4`
