### PR TITLE
OT: Add finite complex Mermin response kernels

### DIFF
--- a/src/qs_ot.F
+++ b/src/qs_ot.F
@@ -58,6 +58,7 @@ MODULE qs_ot
    PUBLIC  :: qs_ot_fixed_n_energy_hessian
    PUBLIC  :: qs_ot_fixed_n_projector_frechet
    PUBLIC  :: qs_ot_fixed_n_response_mu_shift
+   PUBLIC  :: qs_ot_finite_rotation_response
    PUBLIC  :: qs_ot_generate_rotation
    PUBLIC  :: qs_ot_generate_rotation_complex
    PUBLIC  :: qs_ot_rot_mat_derivative
@@ -256,6 +257,262 @@ CONTAINS
       DEALLOCATE (eigenvectors, kernel, work, eigenvalues, weighted_occupation)
 
    END SUBROUTINE qs_ot_fixed_n_projector_frechet
+
+! **************************************************************************************************
+!> \brief finite complex REF rotation Hessian and Rayleigh-energy response
+!>
+!>        The current projected Hamiltonian is pulled back through the finite rotation and then
+!>        differentiated in the independent real-antisymmetric and imaginary-symmetric pair
+!>        coordinates. This keeps the response consistent with the exponential chart used by REF
+!>        OT instead of replacing it by an infinitesimal commutator away from the chart origin.
+!> \param chc current projected Hermitian Hamiltonian U^H H_ref U
+!> \param rotation_generator current anti-Hermitian REF generator
+!> \param occupation fixed occupations attached to the rotated columns
+!> \param kpoint_weight irreducible-k-point weight
+!> \param rotation_gradient gradient in interleaved real/imaginary pair coordinates
+!> \param rotation_hessian derivative of rotation_gradient in the same coordinates
+!> \param rayleigh_response derivative of diag(U^H H_ref U) with respect to the pair coordinates
+!> \param difference_step optional central finite-difference step for the Hessian action
+! **************************************************************************************************
+   SUBROUTINE qs_ot_finite_rotation_response( &
+      chc, rotation_generator, occupation, kpoint_weight, rotation_gradient, &
+      rotation_hessian, rayleigh_response, difference_step)
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: chc, rotation_generator
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: occupation
+      REAL(KIND=dp), INTENT(IN)                          :: kpoint_weight
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: rotation_gradient
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: rotation_hessian, rayleigh_response
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: difference_step
+
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: base_hamiltonian, generator_minus, &
+                                                            generator_plus, rotation
+      INTEGER                                            :: i, j, n, nrotation, r, s
+      REAL(KIND=dp)                                      :: step
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: occupation_scale, rayleigh, &
+                                                            rayleigh_minus, rayleigh_plus
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: gradient_imag, gradient_minus_imag, &
+         gradient_minus_real, gradient_plus_imag, gradient_plus_real, gradient_real
+
+      n = SIZE(chc, 1)
+      nrotation = n*(n - 1)
+      CPASSERT(n > 0)
+      CPASSERT(ALL(SHAPE(chc) == [n, n]))
+      CPASSERT(ALL(SHAPE(rotation_generator) == [n, n]))
+      CPASSERT(SIZE(occupation) == n)
+      CPASSERT(SIZE(rotation_gradient) == nrotation)
+      CPASSERT(ALL(SHAPE(rotation_hessian) == [nrotation, nrotation]))
+      CPASSERT(ALL(SHAPE(rayleigh_response) == [n, nrotation]))
+      CPASSERT(kpoint_weight > 0.0_dp)
+
+      step = 1.0E-4_dp
+      IF (PRESENT(difference_step)) step = difference_step
+      CPASSERT(step > SQRT(EPSILON(step)))
+
+      ALLOCATE (base_hamiltonian(n, n), generator_minus(n, n), generator_plus(n, n), &
+                rotation(n, n), occupation_scale(n), rayleigh(n), rayleigh_minus(n), &
+                rayleigh_plus(n), gradient_imag(n, n), gradient_minus_imag(n, n), &
+                gradient_minus_real(n, n), gradient_plus_imag(n, n), &
+                gradient_plus_real(n, n), gradient_real(n, n))
+
+      CALL qs_ot_dense_rotation_state(rotation_generator, rotation)
+      base_hamiltonian(:, :) = MATMUL(rotation, MATMUL(chc, CONJG(TRANSPOSE(rotation))))
+      occupation_scale(:) = 2.0_dp*kpoint_weight*occupation(:)
+      CALL qs_ot_dense_rotation_gradient(rotation_generator, base_hamiltonian, occupation_scale, &
+                                         gradient_real, gradient_imag, rayleigh)
+
+      r = 0
+      DO i = 1, n - 1
+         DO j = i + 1, n
+            r = r + 1
+            rotation_gradient(r) = gradient_real(i, j)
+            r = r + 1
+            rotation_gradient(r) = gradient_imag(i, j)
+         END DO
+      END DO
+      CPASSERT(r == nrotation)
+
+      s = 0
+      DO i = 1, n - 1
+         DO j = i + 1, n
+            generator_plus(:, :) = rotation_generator(:, :)
+            generator_minus(:, :) = rotation_generator(:, :)
+            generator_plus(i, j) = generator_plus(i, j) + step
+            generator_plus(j, i) = generator_plus(j, i) - step
+            generator_minus(i, j) = generator_minus(i, j) - step
+            generator_minus(j, i) = generator_minus(j, i) + step
+            s = s + 1
+            CALL qs_ot_dense_rotation_gradient(generator_plus, base_hamiltonian, occupation_scale, &
+                                               gradient_plus_real, gradient_plus_imag, rayleigh_plus)
+            CALL qs_ot_dense_rotation_gradient(generator_minus, base_hamiltonian, occupation_scale, &
+                                               gradient_minus_real, gradient_minus_imag, rayleigh_minus)
+            CALL qs_ot_pack_rotation_response( &
+               gradient_plus_real, gradient_plus_imag, gradient_minus_real, gradient_minus_imag, &
+               rayleigh_plus, rayleigh_minus, step, rotation_hessian(:, s), &
+               rayleigh_response(:, s))
+
+            generator_plus(:, :) = rotation_generator(:, :)
+            generator_minus(:, :) = rotation_generator(:, :)
+            generator_plus(i, j) = generator_plus(i, j) + CMPLX(0.0_dp, step, KIND=dp)
+            generator_plus(j, i) = generator_plus(j, i) + CMPLX(0.0_dp, step, KIND=dp)
+            generator_minus(i, j) = generator_minus(i, j) - CMPLX(0.0_dp, step, KIND=dp)
+            generator_minus(j, i) = generator_minus(j, i) - CMPLX(0.0_dp, step, KIND=dp)
+            s = s + 1
+            CALL qs_ot_dense_rotation_gradient(generator_plus, base_hamiltonian, occupation_scale, &
+                                               gradient_plus_real, gradient_plus_imag, rayleigh_plus)
+            CALL qs_ot_dense_rotation_gradient(generator_minus, base_hamiltonian, occupation_scale, &
+                                               gradient_minus_real, gradient_minus_imag, rayleigh_minus)
+            CALL qs_ot_pack_rotation_response( &
+               gradient_plus_real, gradient_plus_imag, gradient_minus_real, gradient_minus_imag, &
+               rayleigh_plus, rayleigh_minus, step, rotation_hessian(:, s), &
+               rayleigh_response(:, s))
+         END DO
+      END DO
+      CPASSERT(s == nrotation)
+      rotation_hessian(:, :) = 0.5_dp*(rotation_hessian + TRANSPOSE(rotation_hessian))
+
+      DEALLOCATE (base_hamiltonian, generator_minus, generator_plus, rotation, occupation_scale, &
+                  rayleigh, rayleigh_minus, rayleigh_plus, gradient_imag, gradient_minus_imag, &
+                  gradient_minus_real, gradient_plus_imag, gradient_plus_real, gradient_real)
+
+   END SUBROUTINE qs_ot_finite_rotation_response
+
+! **************************************************************************************************
+!> \brief pack one finite complex rotation response column
+!> \param gradient_plus_real real gradient at the positive endpoint
+!> \param gradient_plus_imag imaginary gradient at the positive endpoint
+!> \param gradient_minus_real real gradient at the negative endpoint
+!> \param gradient_minus_imag imaginary gradient at the negative endpoint
+!> \param rayleigh_plus Rayleigh energies at the positive endpoint
+!> \param rayleigh_minus Rayleigh energies at the negative endpoint
+!> \param step central finite-difference step
+!> \param hessian_column packed rotation-Hessian column
+!> \param rayleigh_column packed Rayleigh-response column
+! **************************************************************************************************
+   SUBROUTINE qs_ot_pack_rotation_response( &
+      gradient_plus_real, gradient_plus_imag, gradient_minus_real, gradient_minus_imag, &
+      rayleigh_plus, rayleigh_minus, step, hessian_column, rayleigh_column)
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: gradient_plus_real, gradient_plus_imag, &
+                                                            gradient_minus_real, &
+                                                            gradient_minus_imag
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: rayleigh_plus, rayleigh_minus
+      REAL(KIND=dp), INTENT(IN)                          :: step
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: hessian_column, rayleigh_column
+
+      INTEGER                                            :: i, j, n, r
+
+      n = SIZE(gradient_plus_real, 1)
+      CPASSERT(ALL(SHAPE(gradient_plus_real) == [n, n]))
+      CPASSERT(ALL(SHAPE(gradient_plus_imag) == [n, n]))
+      CPASSERT(ALL(SHAPE(gradient_minus_real) == [n, n]))
+      CPASSERT(ALL(SHAPE(gradient_minus_imag) == [n, n]))
+      CPASSERT(SIZE(hessian_column) == n*(n - 1))
+      CPASSERT(SIZE(rayleigh_column) == n)
+
+      r = 0
+      DO i = 1, n - 1
+         DO j = i + 1, n
+            r = r + 1
+            hessian_column(r) = &
+               (gradient_plus_real(i, j) - gradient_minus_real(i, j))/(2.0_dp*step)
+            r = r + 1
+            hessian_column(r) = &
+               (gradient_plus_imag(i, j) - gradient_minus_imag(i, j))/(2.0_dp*step)
+         END DO
+      END DO
+      rayleigh_column(:) = (rayleigh_plus(:) - rayleigh_minus(:))/(2.0_dp*step)
+
+   END SUBROUTINE qs_ot_pack_rotation_response
+
+! **************************************************************************************************
+!> \brief dense complex rotation and projected-Hamiltonian diagonal
+!> \param rotation_generator anti-Hermitian REF generator
+!> \param base_hamiltonian fixed Hamiltonian in the unrotated REF basis
+!> \param occupation_scale twice the weighted occupations
+!> \param gradient_real real-antisymmetric gradient component
+!> \param gradient_imag imaginary-symmetric gradient component
+!> \param rayleigh diagonal of the rotated Hamiltonian
+! **************************************************************************************************
+   SUBROUTINE qs_ot_dense_rotation_gradient( &
+      rotation_generator, base_hamiltonian, occupation_scale, gradient_real, gradient_imag, rayleigh)
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: rotation_generator, base_hamiltonian
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: occupation_scale
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: gradient_real, gradient_imag
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: rayleigh
+
+      COMPLEX(KIND=dp)                                   :: kernel
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: covector, eigenvectors, frechet, inner, &
+                                                            outer, rotation, work
+      INTEGER                                            :: i, j, n
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eigenvalues
+
+      n = SIZE(rotation_generator, 1)
+      ALLOCATE (covector(n, n), eigenvectors(n, n), frechet(n, n), inner(n, n), &
+                outer(n, n), rotation(n, n), work(n, n), eigenvalues(n))
+      CALL qs_ot_dense_rotation_state(rotation_generator, rotation, &
+                                      eigenvectors=eigenvectors, eigenvalues=eigenvalues)
+
+      work(:, :) = MATMUL(base_hamiltonian, rotation)
+      covector(:, :) = work(:, :)
+      DO j = 1, n
+         covector(:, j) = occupation_scale(j)*covector(:, j)
+      END DO
+
+      work(:, :) = MATMUL(CONJG(TRANSPOSE(rotation)), &
+                          MATMUL(base_hamiltonian, rotation))
+      DO i = 1, n
+         rayleigh(i) = REAL(work(i, i), KIND=dp)
+      END DO
+
+      inner(:, :) = MATMUL(CONJG(TRANSPOSE(eigenvectors)), &
+                           MATMUL(covector, eigenvectors))
+      DO j = 1, n
+         DO i = 1, n
+            kernel = CONJG(qs_ot_complex_exp_frechet_kernel(eigenvalues(i), eigenvalues(j)))
+            outer(i, j) = inner(i, j)*kernel
+         END DO
+      END DO
+      frechet(:, :) = MATMUL(eigenvectors, &
+                             MATMUL(outer, CONJG(TRANSPOSE(eigenvectors))))
+      gradient_real(:, :) = REAL(frechet, KIND=dp) - TRANSPOSE(REAL(frechet, KIND=dp))
+      gradient_imag(:, :) = AIMAG(frechet) + TRANSPOSE(AIMAG(frechet))
+
+      DEALLOCATE (covector, eigenvectors, frechet, inner, outer, rotation, work, eigenvalues)
+
+   END SUBROUTINE qs_ot_dense_rotation_gradient
+
+! **************************************************************************************************
+!> \brief dense exponential of an anti-Hermitian REF generator
+!> \param rotation_generator anti-Hermitian generator
+!> \param rotation exp(rotation_generator)
+!> \param eigenvectors optional eigenvectors of i*rotation_generator
+!> \param eigenvalues optional eigenvalues of i*rotation_generator
+! **************************************************************************************************
+   SUBROUTINE qs_ot_dense_rotation_state(rotation_generator, rotation, eigenvectors, eigenvalues)
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: rotation_generator
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: rotation
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT), &
+         OPTIONAL                                        :: eigenvectors
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT), OPTIONAL :: eigenvalues
+
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: vectors, weighted_vectors
+      INTEGER                                            :: j, n
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: values
+
+      n = SIZE(rotation_generator, 1)
+      ALLOCATE (vectors(n, n), weighted_vectors(n, n), values(n))
+      CALL diag_complex(CMPLX(0.0_dp, 1.0_dp, KIND=dp)*rotation_generator, &
+                        vectors, values)
+      weighted_vectors(:, :) = vectors(:, :)
+      DO j = 1, n
+         weighted_vectors(:, j) = EXP(CMPLX(0.0_dp, -values(j), KIND=dp))* &
+                                  weighted_vectors(:, j)
+      END DO
+      rotation(:, :) = MATMUL(weighted_vectors, CONJG(TRANSPOSE(vectors)))
+      IF (PRESENT(eigenvectors)) eigenvectors(:, :) = vectors(:, :)
+      IF (PRESENT(eigenvalues)) eigenvalues(:) = values(:)
+      DEALLOCATE (vectors, weighted_vectors, values)
+
+   END SUBROUTINE qs_ot_dense_rotation_state
 
 ! **************************************************************************************************
 !> \brief Frechet divided-difference kernel for exp(-i*evals)

--- a/src/qs_ot.F
+++ b/src/qs_ot.F
@@ -56,6 +56,7 @@ MODULE qs_ot
    PUBLIC  :: qs_ot_complex_exp_frechet_kernel
    PUBLIC  :: qs_ot_fixed_n_energy_gradient
    PUBLIC  :: qs_ot_fixed_n_energy_hessian
+   PUBLIC  :: qs_ot_fixed_n_schur_block
    PUBLIC  :: qs_ot_fixed_n_projector_frechet
    PUBLIC  :: qs_ot_fixed_n_response_mu_shift
    PUBLIC  :: qs_ot_finite_rotation_response
@@ -165,6 +166,62 @@ CONTAINS
       hessian(:, :) = 0.5_dp*(hessian + TRANSPOSE(hessian))
 
    END SUBROUTINE qs_ot_fixed_n_energy_hessian
+
+! **************************************************************************************************
+!> \brief local block of the fixed-N rotation/energy Schur complement
+!>
+!>        For C = D - chi chi^T / sum(chi), elimination of the auxiliary-energy block gives
+!>
+!>          S = A - R^T C R
+!>            = (A - R^T D R) + v v^T / sum(chi),  v = R^T chi.
+!>
+!>        This routine builds the channel-local terms. The final rank-one term is deliberately left
+!>        separate so spin/k-point channels can be coupled without assembling a global dense
+!>        rotation Hessian.
+!> \param rotation_hessian fixed-occupation rotation Hessian A
+!> \param rayleigh_response derivative R of the Rayleigh energies with respect to rotations
+!> \param response_weight local positive occupation susceptibilities chi
+!> \param rotation_gradient physical rotation gradient
+!> \param energy_gradient physical auxiliary-energy gradient
+!> \param schur_block local block A - R^T D R
+!> \param coupling_vector local part of v = R^T chi
+!> \param schur_rhs local right-hand side g_x + R^T g_e
+! **************************************************************************************************
+   SUBROUTINE qs_ot_fixed_n_schur_block( &
+      rotation_hessian, rayleigh_response, response_weight, rotation_gradient, energy_gradient, &
+      schur_block, coupling_vector, schur_rhs)
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: rotation_hessian, rayleigh_response
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: response_weight, rotation_gradient, &
+                                                            energy_gradient
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: schur_block
+      REAL(KIND=dp), DIMENSION(:), INTENT(OUT)           :: coupling_vector, schur_rhs
+
+      INTEGER                                            :: i, nenergy, nrotation
+      REAL(KIND=dp)                                      :: weight
+
+      nenergy = SIZE(response_weight)
+      nrotation = SIZE(rotation_gradient)
+      CPASSERT(ALL(SHAPE(rotation_hessian) == [nrotation, nrotation]))
+      CPASSERT(ALL(SHAPE(rayleigh_response) == [nenergy, nrotation]))
+      CPASSERT(SIZE(energy_gradient) == nenergy)
+      CPASSERT(ALL(SHAPE(schur_block) == [nrotation, nrotation]))
+      CPASSERT(SIZE(coupling_vector) == nrotation)
+      CPASSERT(SIZE(schur_rhs) == nrotation)
+
+      schur_block(:, :) = rotation_hessian(:, :)
+      DO i = 1, nenergy
+         weight = MAX(0.0_dp, response_weight(i))
+         schur_block(:, :) = schur_block(:, :) - weight* &
+                             SPREAD(rayleigh_response(i, :), DIM=2, NCOPIES=nrotation)* &
+                             SPREAD(rayleigh_response(i, :), DIM=1, NCOPIES=nrotation)
+      END DO
+      schur_block(:, :) = 0.5_dp*(schur_block + TRANSPOSE(schur_block))
+      coupling_vector(:) = MATMUL(TRANSPOSE(rayleigh_response), &
+                                  MAX(0.0_dp, response_weight))
+      schur_rhs(:) = rotation_gradient + &
+                     MATMUL(TRANSPOSE(rayleigh_response), energy_gradient)
+
+   END SUBROUTINE qs_ot_fixed_n_schur_block
 
 ! **************************************************************************************************
 !> \brief fixed-N Frechet derivative of a smooth occupation projector

--- a/src/qs_ot.F
+++ b/src/qs_ot.F
@@ -32,7 +32,8 @@ MODULE qs_ot
    USE cp_dbcsr_diag,                   ONLY: cp_dbcsr_heevd,&
                                               cp_dbcsr_syevd
    USE kinds,                           ONLY: dp
-   USE mathlib,                         ONLY: diag_complex
+   USE mathlib,                         ONLY: diag_complex,&
+                                              diamat_all
    USE message_passing,                 ONLY: mp_comm_type
    USE preconditioner,                  ONLY: apply_preconditioner
    USE preconditioner_types,            ONLY: preconditioner_type
@@ -60,6 +61,7 @@ MODULE qs_ot
    PUBLIC  :: qs_ot_fixed_n_projector_frechet
    PUBLIC  :: qs_ot_fixed_n_response_mu_shift
    PUBLIC  :: qs_ot_finite_rotation_response
+   PUBLIC  :: qs_ot_symmetric_abs_solve
    PUBLIC  :: qs_ot_generate_rotation
    PUBLIC  :: qs_ot_generate_rotation_complex
    PUBLIC  :: qs_ot_rot_mat_derivative
@@ -222,6 +224,57 @@ CONTAINS
                      MATMUL(TRANSPOSE(rayleigh_response), energy_gradient)
 
    END SUBROUTINE qs_ot_fixed_n_schur_block
+
+! **************************************************************************************************
+!> \brief apply a positive spectral inverse of a real symmetric response matrix
+!>
+!>        The magnitude of every resolved eigenmode is retained, including modes with negative
+!>        physical curvature. Replacing lambda by abs(lambda) gives a descent metric without the
+!>        loss of response information caused by discarding the negative subspace.
+!> \param matrix real symmetric response matrix
+!> \param rhs one or more right-hand sides
+!> \param solution spectral-absolute inverse applied to rhs
+!> \param valid whether finite input and output were obtained
+!> \param relative_floor optional relative eigenvalue floor
+! **************************************************************************************************
+   SUBROUTINE qs_ot_symmetric_abs_solve(matrix, rhs, solution, valid, relative_floor)
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)          :: matrix, rhs
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)         :: solution
+      LOGICAL, INTENT(OUT)                                :: valid
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                 :: relative_floor
+
+      INTEGER                                             :: i, n
+      REAL(KIND=dp)                                       :: eigenvalue_floor, relative_floor_eff, scale
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)            :: eigenvalues
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)         :: eigenvectors, work
+
+      n = SIZE(matrix, 1)
+      CPASSERT(ALL(SHAPE(matrix) == [n, n]))
+      CPASSERT(SIZE(rhs, 1) == n)
+      CPASSERT(ALL(SHAPE(solution) == SHAPE(rhs)))
+      valid = ALL(matrix == matrix) .AND. ALL(rhs == rhs)
+      IF (.NOT. valid) THEN
+         solution(:, :) = 0.0_dp
+         RETURN
+      END IF
+
+      relative_floor_eff = SQRT(EPSILON(1.0_dp))
+      IF (PRESENT(relative_floor)) relative_floor_eff = MAX(relative_floor, relative_floor_eff)
+      ALLOCATE (eigenvalues(n), eigenvectors(n, n), work(n, SIZE(rhs, 2)))
+      eigenvectors(:, :) = 0.5_dp*(matrix + TRANSPOSE(matrix))
+      CALL diamat_all(eigenvectors, eigenvalues)
+      scale = MAX(1.0_dp, MAXVAL(ABS(eigenvalues)))
+      eigenvalue_floor = relative_floor_eff*scale
+      work(:, :) = MATMUL(TRANSPOSE(eigenvectors), rhs)
+      DO i = 1, n
+         work(i, :) = work(i, :)/MAX(ABS(eigenvalues(i)), eigenvalue_floor)
+      END DO
+      solution(:, :) = MATMUL(eigenvectors, work)
+      valid = ALL(solution == solution)
+      IF (.NOT. valid) solution(:, :) = 0.0_dp
+      DEALLOCATE (eigenvalues, eigenvectors, work)
+
+   END SUBROUTINE qs_ot_symmetric_abs_solve
 
 ! **************************************************************************************************
 !> \brief fixed-N Frechet derivative of a smooth occupation projector

--- a/src/qs_ot.F
+++ b/src/qs_ot.F
@@ -230,7 +230,8 @@ CONTAINS
 !>
 !>        The magnitude of every resolved eigenmode is retained, including modes with negative
 !>        physical curvature. Replacing lambda by abs(lambda) gives a descent metric without the
-!>        loss of response information caused by discarding the negative subspace.
+!>        loss of response information caused by discarding the negative subspace. Unresolved
+!>        null modes are projected out instead of being amplified by an artificial eigenvalue floor.
 !> \param matrix real symmetric response matrix
 !> \param rhs one or more right-hand sides
 !> \param solution spectral-absolute inverse applied to rhs
@@ -238,15 +239,16 @@ CONTAINS
 !> \param relative_floor optional relative eigenvalue floor
 ! **************************************************************************************************
    SUBROUTINE qs_ot_symmetric_abs_solve(matrix, rhs, solution, valid, relative_floor)
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)          :: matrix, rhs
-      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)         :: solution
-      LOGICAL, INTENT(OUT)                                :: valid
-      REAL(KIND=dp), INTENT(IN), OPTIONAL                 :: relative_floor
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: matrix, rhs
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(OUT)        :: solution
+      LOGICAL, INTENT(OUT)                               :: valid
+      REAL(KIND=dp), INTENT(IN), OPTIONAL                :: relative_floor
 
-      INTEGER                                             :: i, n
-      REAL(KIND=dp)                                       :: eigenvalue_floor, relative_floor_eff, scale
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)            :: eigenvalues
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)         :: eigenvectors, work
+      INTEGER                                            :: i, n, nresolved
+      REAL(KIND=dp)                                      :: eigenvalue_floor, relative_floor_eff, &
+                                                            scale
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: eigenvalues
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: eigenvectors, work
 
       n = SIZE(matrix, 1)
       CPASSERT(ALL(SHAPE(matrix) == [n, n]))
@@ -266,11 +268,17 @@ CONTAINS
       scale = MAX(1.0_dp, MAXVAL(ABS(eigenvalues)))
       eigenvalue_floor = relative_floor_eff*scale
       work(:, :) = MATMUL(TRANSPOSE(eigenvectors), rhs)
+      nresolved = 0
       DO i = 1, n
-         work(i, :) = work(i, :)/MAX(ABS(eigenvalues(i)), eigenvalue_floor)
+         IF (ABS(eigenvalues(i)) > eigenvalue_floor) THEN
+            work(i, :) = work(i, :)/ABS(eigenvalues(i))
+            nresolved = nresolved + 1
+         ELSE
+            work(i, :) = 0.0_dp
+         END IF
       END DO
       solution(:, :) = MATMUL(eigenvectors, work)
-      valid = ALL(solution == solution)
+      valid = nresolved > 0 .AND. ALL(solution == solution)
       IF (.NOT. valid) solution(:, :) = 0.0_dp
       DEALLOCATE (eigenvalues, eigenvectors, work)
 

--- a/src/qs_ot_complex_ref_unittest.F
+++ b/src/qs_ot_complex_ref_unittest.F
@@ -57,7 +57,8 @@ PROGRAM qs_ot_complex_ref_unittest
         qs_ot_finite_rotation_response, qs_ot_fixed_n_energy_gradient, &
         qs_ot_fixed_n_energy_hessian, qs_ot_fixed_n_projector_frechet, qs_ot_fixed_n_schur_block, &
         qs_ot_generate_rotation, qs_ot_get_derivative_complex, qs_ot_get_derivative_ref_complex, &
-        qs_ot_get_orbitals_ref_complex, qs_ot_get_p_complex, qs_ot_rot_mat_derivative
+        qs_ot_get_orbitals_ref_complex, qs_ot_get_p_complex, qs_ot_rot_mat_derivative, &
+        qs_ot_symmetric_abs_solve
    USE qs_ot_types,                     ONLY: qs_ot_kpoint_preconditioner_scale,&
                                               qs_ot_kpoint_preconditioner_solver_supported,&
                                               qs_ot_kpoint_preconditioner_supported,&
@@ -98,6 +99,7 @@ PROGRAM qs_ot_complex_ref_unittest
    CALL test_fixed_n_projector_frechet(mynode, nfail)
    CALL test_finite_rotation_response(mynode, nfail)
    CALL test_fixed_n_rotation_schur(mynode, nfail)
+   CALL test_symmetric_abs_solve(mynode, nfail)
    ALLOCATE (para_env)
    CALL para_env%from_dup(mp_comm)
    CALL cp_logger_create(logger, para_env=para_env, default_global_unit_nr=io_unit, &
@@ -584,6 +586,41 @@ CONTAINS
       END IF
 
    END SUBROUTINE test_fixed_n_rotation_schur
+
+! **************************************************************************************************
+!> \brief Check that positive and negative response modes retain their spectral magnitude.
+!> \param mynode MPI rank
+!> \param nfail accumulated number of failures
+! **************************************************************************************************
+   SUBROUTINE test_symmetric_abs_solve(mynode, nfail)
+      INTEGER, INTENT(IN)                                :: mynode
+      INTEGER, INTENT(INOUT)                             :: nfail
+
+      LOGICAL                                            :: valid
+      REAL(KIND=dp)                                      :: error
+      REAL(KIND=dp), DIMENSION(3)                        :: eigenvalues
+      REAL(KIND=dp), DIMENSION(3, 2)                     :: expected, rhs, solution
+      REAL(KIND=dp), DIMENSION(3, 3)                     :: absolute_matrix, matrix, vectors
+
+      vectors(:, 1) = [0.8_dp, 0.6_dp, 0.0_dp]
+      vectors(:, 2) = [-0.6_dp, 0.8_dp, 0.0_dp]
+      vectors(:, 3) = [0.0_dp, 0.0_dp, 1.0_dp]
+      eigenvalues(:) = [-0.4_dp, 1.7_dp, 0.25_dp]
+      matrix(:, :) = MATMUL(vectors, MATMUL( &
+         RESHAPE([eigenvalues(1), 0.0_dp, 0.0_dp, 0.0_dp, eigenvalues(2), 0.0_dp, &
+                  0.0_dp, 0.0_dp, eigenvalues(3)], [3, 3]), TRANSPOSE(vectors)))
+      absolute_matrix(:, :) = MATMUL(vectors, MATMUL( &
+         RESHAPE([ABS(eigenvalues(1)), 0.0_dp, 0.0_dp, 0.0_dp, ABS(eigenvalues(2)), 0.0_dp, &
+                  0.0_dp, 0.0_dp, ABS(eigenvalues(3))], [3, 3]), TRANSPOSE(vectors)))
+      rhs(:, 1) = [0.3_dp, -0.5_dp, 0.7_dp]
+      rhs(:, 2) = [-0.2_dp, 0.4_dp, 0.1_dp]
+      CALL qs_ot_symmetric_abs_solve(matrix, rhs, solution, valid)
+      expected(:, :) = MATMUL(absolute_matrix, solution)
+      error = MAXVAL(ABS(expected - rhs))
+      IF (.NOT. valid .OR. error > 2.0E-13_dp) nfail = nfail + 1
+      IF (mynode == 0) WRITE (io_unit, '(A,1X,ES13.6)') "symmetric absolute solve error:", error
+
+   END SUBROUTINE test_symmetric_abs_solve
 
 ! **************************************************************************************************
 !> \brief fixed-occupation band energy for a dense finite rotation

--- a/src/qs_ot_complex_ref_unittest.F
+++ b/src/qs_ot_complex_ref_unittest.F
@@ -55,8 +55,8 @@ PROGRAM qs_ot_complex_ref_unittest
    USE qs_ot,                           ONLY: &
         qs_ot_apply_complex_frechet_dbcsr, qs_ot_complex_exp_frechet_kernel, &
         qs_ot_finite_rotation_response, qs_ot_fixed_n_energy_gradient, &
-        qs_ot_fixed_n_energy_hessian, qs_ot_fixed_n_projector_frechet, qs_ot_generate_rotation, &
-        qs_ot_get_derivative_complex, qs_ot_get_derivative_ref_complex, &
+        qs_ot_fixed_n_energy_hessian, qs_ot_fixed_n_projector_frechet, qs_ot_fixed_n_schur_block, &
+        qs_ot_generate_rotation, qs_ot_get_derivative_complex, qs_ot_get_derivative_ref_complex, &
         qs_ot_get_orbitals_ref_complex, qs_ot_get_p_complex, qs_ot_rot_mat_derivative
    USE qs_ot_types,                     ONLY: qs_ot_kpoint_preconditioner_scale,&
                                               qs_ot_kpoint_preconditioner_solver_supported,&
@@ -97,6 +97,7 @@ PROGRAM qs_ot_complex_ref_unittest
    CALL test_fixed_n_mermin_energy(mynode, nfail)
    CALL test_fixed_n_projector_frechet(mynode, nfail)
    CALL test_finite_rotation_response(mynode, nfail)
+   CALL test_fixed_n_rotation_schur(mynode, nfail)
    ALLOCATE (para_env)
    CALL para_env%from_dup(mp_comm)
    CALL cp_logger_create(logger, para_env=para_env, default_global_unit_nr=io_unit, &
@@ -468,6 +469,121 @@ CONTAINS
       END IF
 
    END SUBROUTINE test_finite_rotation_response
+
+! **************************************************************************************************
+!> \brief Check the coupled fixed-N rotation/energy Hessian and its Schur decomposition.
+!> \param mynode MPI rank
+!> \param nfail accumulated number of failures
+! **************************************************************************************************
+   SUBROUTINE test_fixed_n_rotation_schur(mynode, nfail)
+      INTEGER, INTENT(IN)                                :: mynode
+      INTEGER, INTENT(INOUT)                             :: nfail
+
+      INTEGER, PARAMETER                                 :: nbands = 3, nrotation = 6
+      REAL(KIND=dp), PARAMETER                           :: fd_step = 1.0E-4_dp, &
+                                                            kpoint_weight = 0.625_dp, &
+                                                            maxocc = 2.0_dp, temperature = 0.08_dp
+
+      COMPLEX(KIND=dp), DIMENSION(nbands, nbands)        :: base_hamiltonian, chc, &
+                                                            direction_generator, generator, &
+                                                            rotation, rotation_minus, rotation_plus
+      INTEGER                                            :: i
+      REAL(KIND=dp)                                      :: curvature, curvature_error, &
+                                                            energy_minus, energy_plus, &
+                                                            energy_zero, mu, response_sum, &
+                                                            schur_error
+      REAL(KIND=dp), DIMENSION(nbands) :: energy_coordinate, energy_direction, energy_gradient, &
+         energy_minus_coordinate, energy_plus_coordinate, occupation, rayleigh, rayleigh_minus, &
+         rayleigh_plus, response, weights
+      REAL(KIND=dp), DIMENSION(nbands, nbands)           :: energy_hessian
+      REAL(KIND=dp), DIMENSION(nbands, nrotation)        :: rayleigh_response
+      REAL(KIND=dp), DIMENSION(nrotation)                :: coupling, rotation_direction, &
+                                                            rotation_gradient, schur_rhs
+      REAL(KIND=dp), DIMENSION(nrotation, nrotation)     :: rotation_hessian, schur, schur_block
+
+      base_hamiltonian(:, :) = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+      base_hamiltonian(1, 1) = CMPLX(-0.31_dp, 0.0_dp, KIND=dp)
+      base_hamiltonian(2, 2) = CMPLX(0.07_dp, 0.0_dp, KIND=dp)
+      base_hamiltonian(3, 3) = CMPLX(0.42_dp, 0.0_dp, KIND=dp)
+      base_hamiltonian(1, 2) = CMPLX(0.09_dp, -0.06_dp, KIND=dp)
+      base_hamiltonian(1, 3) = CMPLX(-0.04_dp, 0.08_dp, KIND=dp)
+      base_hamiltonian(2, 3) = CMPLX(0.11_dp, 0.05_dp, KIND=dp)
+      DO i = 1, nbands
+         base_hamiltonian(i, 1:i - 1) = CONJG(base_hamiltonian(1:i - 1, i))
+      END DO
+
+      generator(:, :) = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+      generator(1, 2) = CMPLX(0.17_dp, -0.08_dp, KIND=dp)
+      generator(1, 3) = CMPLX(-0.09_dp, 0.04_dp, KIND=dp)
+      generator(2, 3) = CMPLX(0.12_dp, 0.07_dp, KIND=dp)
+      DO i = 1, nbands
+         generator(i, 1:i - 1) = -CONJG(generator(1:i - 1, i))
+      END DO
+      rotation_direction(:) = [0.14_dp, -0.07_dp, -0.11_dp, 0.09_dp, 0.05_dp, 0.13_dp]
+      energy_direction(:) = [0.08_dp, -0.11_dp, 0.03_dp]
+      direction_generator(:, :) = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+      direction_generator(1, 2) = CMPLX(rotation_direction(1), rotation_direction(2), KIND=dp)
+      direction_generator(2, 1) = -CONJG(direction_generator(1, 2))
+      direction_generator(1, 3) = CMPLX(rotation_direction(3), rotation_direction(4), KIND=dp)
+      direction_generator(3, 1) = -CONJG(direction_generator(1, 3))
+      direction_generator(2, 3) = CMPLX(rotation_direction(5), rotation_direction(6), KIND=dp)
+      direction_generator(3, 2) = -CONJG(direction_generator(2, 3))
+
+      rotation(:, :) = dense_antihermitian_exp(generator)
+      chc(:, :) = MATMUL(CONJG(TRANSPOSE(rotation)), MATMUL(base_hamiltonian, rotation))
+      DO i = 1, nbands
+         rayleigh(i) = REAL(chc(i, i), KIND=dp)
+      END DO
+      energy_coordinate(:) = rayleigh(:)
+      weights(:) = kpoint_weight
+      CALL fixed_n_fermi_occupations(energy_coordinate, weights, 1.7_dp, temperature, &
+                                     maxocc, occupation, mu)
+      response(:) = weights*occupation*(maxocc - occupation)/(maxocc*temperature)
+      response_sum = SUM(response)
+      CALL qs_ot_finite_rotation_response(chc, generator, occupation, kpoint_weight, &
+                                          rotation_gradient, rotation_hessian, rayleigh_response)
+      CALL qs_ot_fixed_n_energy_gradient(rayleigh, energy_coordinate, response, response_sum, &
+                                         0.0_dp, energy_gradient)
+      CALL qs_ot_fixed_n_energy_hessian(response, response_sum, energy_hessian)
+      CALL qs_ot_fixed_n_schur_block( &
+         rotation_hessian, rayleigh_response, response, rotation_gradient, energy_gradient, &
+         schur_block, coupling, schur_rhs)
+      schur(:, :) = schur_block + SPREAD(coupling, DIM=2, NCOPIES=nrotation)* &
+                    SPREAD(coupling, DIM=1, NCOPIES=nrotation)/response_sum
+      schur_error = MAXVAL(ABS(schur - rotation_hessian + &
+                               MATMUL(TRANSPOSE(rayleigh_response), &
+                                      MATMUL(energy_hessian, rayleigh_response))))
+
+      rotation_plus(:, :) = dense_antihermitian_exp(generator + fd_step*direction_generator)
+      rotation_minus(:, :) = dense_antihermitian_exp(generator - fd_step*direction_generator)
+      DO i = 1, nbands
+         rayleigh_plus(i) = REAL(DOT_PRODUCT(rotation_plus(:, i), &
+                                             MATMUL(base_hamiltonian, rotation_plus(:, i))), KIND=dp)
+         rayleigh_minus(i) = REAL(DOT_PRODUCT(rotation_minus(:, i), &
+                                              MATMUL(base_hamiltonian, rotation_minus(:, i))), KIND=dp)
+      END DO
+      energy_plus_coordinate(:) = energy_coordinate + fd_step*energy_direction
+      energy_minus_coordinate(:) = energy_coordinate - fd_step*energy_direction
+      energy_zero = fixed_n_mermin_value(rayleigh, energy_coordinate, weights, 1.7_dp, &
+                                         temperature, maxocc)
+      energy_plus = fixed_n_mermin_value(rayleigh_plus, energy_plus_coordinate, weights, 1.7_dp, &
+                                         temperature, maxocc)
+      energy_minus = fixed_n_mermin_value(rayleigh_minus, energy_minus_coordinate, weights, 1.7_dp, &
+                                          temperature, maxocc)
+      curvature = DOT_PRODUCT(rotation_direction, MATMUL(rotation_hessian, rotation_direction)) - &
+                  2.0_dp*DOT_PRODUCT(energy_direction, &
+                                     MATMUL(energy_hessian, &
+                                            MATMUL(rayleigh_response, rotation_direction))) + &
+                  DOT_PRODUCT(energy_direction, MATMUL(energy_hessian, energy_direction))
+      curvature_error = ABS((energy_plus - 2.0_dp*energy_zero + energy_minus)/fd_step**2 - curvature)
+
+      IF (schur_error > 2.0E-11_dp .OR. curvature_error > 3.0E-6_dp) nfail = nfail + 1
+      IF (mynode == 0) THEN
+         WRITE (io_unit, '(A,2(1X,ES13.6))') "fixed-N rotation Schur errors:", &
+            schur_error, curvature_error
+      END IF
+
+   END SUBROUTINE test_fixed_n_rotation_schur
 
 ! **************************************************************************************************
 !> \brief fixed-occupation band energy for a dense finite rotation

--- a/src/qs_ot_complex_ref_unittest.F
+++ b/src/qs_ot_complex_ref_unittest.F
@@ -607,17 +607,34 @@ CONTAINS
       vectors(:, 3) = [0.0_dp, 0.0_dp, 1.0_dp]
       eigenvalues(:) = [-0.4_dp, 1.7_dp, 0.25_dp]
       matrix(:, :) = MATMUL(vectors, MATMUL( &
-         RESHAPE([eigenvalues(1), 0.0_dp, 0.0_dp, 0.0_dp, eigenvalues(2), 0.0_dp, &
-                  0.0_dp, 0.0_dp, eigenvalues(3)], [3, 3]), TRANSPOSE(vectors)))
+                            RESHAPE([eigenvalues(1), 0.0_dp, 0.0_dp, 0.0_dp, eigenvalues(2), 0.0_dp, &
+                                     0.0_dp, 0.0_dp, eigenvalues(3)], [3, 3]), TRANSPOSE(vectors)))
       absolute_matrix(:, :) = MATMUL(vectors, MATMUL( &
-         RESHAPE([ABS(eigenvalues(1)), 0.0_dp, 0.0_dp, 0.0_dp, ABS(eigenvalues(2)), 0.0_dp, &
-                  0.0_dp, 0.0_dp, ABS(eigenvalues(3))], [3, 3]), TRANSPOSE(vectors)))
+                                     RESHAPE([ABS(eigenvalues(1)), 0.0_dp, 0.0_dp, 0.0_dp, ABS(eigenvalues(2)), 0.0_dp, &
+                                              0.0_dp, 0.0_dp, ABS(eigenvalues(3))], [3, 3]), TRANSPOSE(vectors)))
       rhs(:, 1) = [0.3_dp, -0.5_dp, 0.7_dp]
       rhs(:, 2) = [-0.2_dp, 0.4_dp, 0.1_dp]
       CALL qs_ot_symmetric_abs_solve(matrix, rhs, solution, valid)
       expected(:, :) = MATMUL(absolute_matrix, solution)
       error = MAXVAL(ABS(expected - rhs))
       IF (.NOT. valid .OR. error > 2.0E-13_dp) nfail = nfail + 1
+
+      eigenvalues(:) = [-0.4_dp, 1.7_dp, 1.0E-12_dp]
+      matrix(:, :) = MATMUL(vectors, MATMUL( &
+                            RESHAPE([eigenvalues(1), 0.0_dp, 0.0_dp, 0.0_dp, eigenvalues(2), 0.0_dp, &
+                                     0.0_dp, 0.0_dp, eigenvalues(3)], [3, 3]), TRANSPOSE(vectors)))
+      rhs(:, 1) = [0.3_dp, -0.5_dp, 0.7_dp]
+      rhs(:, 2) = [-0.2_dp, 0.4_dp, 0.1_dp]
+      CALL qs_ot_symmetric_abs_solve(matrix, rhs, solution, valid)
+      expected(:, :) = rhs(:, :)
+      expected(3, :) = 0.0_dp
+      absolute_matrix(:, :) = MATMUL(vectors(:, 1:2), MATMUL( &
+                                     RESHAPE([ABS(eigenvalues(1)), 0.0_dp, 0.0_dp, ABS(eigenvalues(2))], [2, 2]), &
+                                     TRANSPOSE(vectors(:, 1:2))))
+      error = MAX(error, MAXVAL(ABS(MATMUL(absolute_matrix, solution) - expected)))
+      IF (.NOT. valid .OR. error > 2.0E-13_dp .OR. MAXVAL(ABS(solution(3, :))) > 2.0E-13_dp) THEN
+         nfail = nfail + 1
+      END IF
       IF (mynode == 0) WRITE (io_unit, '(A,1X,ES13.6)') "symmetric absolute solve error:", error
 
    END SUBROUTINE test_symmetric_abs_solve

--- a/src/qs_ot_complex_ref_unittest.F
+++ b/src/qs_ot_complex_ref_unittest.F
@@ -54,10 +54,10 @@ PROGRAM qs_ot_complex_ref_unittest
                                               preconditioner_type
    USE qs_ot,                           ONLY: &
         qs_ot_apply_complex_frechet_dbcsr, qs_ot_complex_exp_frechet_kernel, &
-        qs_ot_fixed_n_energy_gradient, qs_ot_fixed_n_energy_hessian, &
-        qs_ot_fixed_n_projector_frechet, qs_ot_generate_rotation, qs_ot_get_derivative_complex, &
-        qs_ot_get_derivative_ref_complex, qs_ot_get_orbitals_ref_complex, qs_ot_get_p_complex, &
-        qs_ot_rot_mat_derivative
+        qs_ot_finite_rotation_response, qs_ot_fixed_n_energy_gradient, &
+        qs_ot_fixed_n_energy_hessian, qs_ot_fixed_n_projector_frechet, qs_ot_generate_rotation, &
+        qs_ot_get_derivative_complex, qs_ot_get_derivative_ref_complex, &
+        qs_ot_get_orbitals_ref_complex, qs_ot_get_p_complex, qs_ot_rot_mat_derivative
    USE qs_ot_types,                     ONLY: qs_ot_kpoint_preconditioner_scale,&
                                               qs_ot_kpoint_preconditioner_solver_supported,&
                                               qs_ot_kpoint_preconditioner_supported,&
@@ -96,6 +96,7 @@ PROGRAM qs_ot_complex_ref_unittest
    IF (mynode == 0) io_unit = default_output_unit
    CALL test_fixed_n_mermin_energy(mynode, nfail)
    CALL test_fixed_n_projector_frechet(mynode, nfail)
+   CALL test_finite_rotation_response(mynode, nfail)
    ALLOCATE (para_env)
    CALL para_env%from_dup(mp_comm)
    CALL cp_logger_create(logger, para_env=para_env, default_global_unit_nr=io_unit, &
@@ -378,6 +379,120 @@ CONTAINS
          "fixed-N complex occupation-projector error:", error
 
    END SUBROUTINE test_fixed_n_projector_frechet
+
+! **************************************************************************************************
+!> \brief Check the finite complex REF rotation Hessian against the scalar band energy.
+!> \param mynode MPI rank
+!> \param nfail accumulated number of failures
+! **************************************************************************************************
+   SUBROUTINE test_finite_rotation_response(mynode, nfail)
+      INTEGER, INTENT(IN)                                :: mynode
+      INTEGER, INTENT(INOUT)                             :: nfail
+
+      INTEGER, PARAMETER                                 :: nbands = 3, nrotation = 6
+      REAL(KIND=dp), PARAMETER                           :: fd_step = 2.0E-4_dp, &
+                                                            kpoint_weight = 0.625_dp
+
+      COMPLEX(KIND=dp), DIMENSION(nbands, nbands)        :: base_hamiltonian, chc, &
+                                                            direction_generator, generator, &
+                                                            rotation, rotation_minus, rotation_plus
+      INTEGER                                            :: i
+      REAL(KIND=dp)                                      :: energy, energy_minus, energy_plus, &
+                                                            gradient_error, hessian_error, &
+                                                            rayleigh_error, symmetry_error
+      REAL(KIND=dp), DIMENSION(nbands)                   :: occupation, rayleigh_minus, rayleigh_plus
+      REAL(KIND=dp), DIMENSION(nbands, nrotation)        :: rayleigh_response
+      REAL(KIND=dp), DIMENSION(nrotation)                :: direction, gradient
+      REAL(KIND=dp), DIMENSION(nrotation, nrotation)     :: hessian
+
+      base_hamiltonian(:, :) = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+      base_hamiltonian(1, 1) = CMPLX(-0.31_dp, 0.0_dp, KIND=dp)
+      base_hamiltonian(2, 2) = CMPLX(0.07_dp, 0.0_dp, KIND=dp)
+      base_hamiltonian(3, 3) = CMPLX(0.42_dp, 0.0_dp, KIND=dp)
+      base_hamiltonian(1, 2) = CMPLX(0.09_dp, -0.06_dp, KIND=dp)
+      base_hamiltonian(1, 3) = CMPLX(-0.04_dp, 0.08_dp, KIND=dp)
+      base_hamiltonian(2, 3) = CMPLX(0.11_dp, 0.05_dp, KIND=dp)
+      DO i = 1, nbands
+         base_hamiltonian(i, 1:i - 1) = CONJG(base_hamiltonian(1:i - 1, i))
+      END DO
+
+      generator(:, :) = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+      generator(1, 2) = CMPLX(0.17_dp, -0.08_dp, KIND=dp)
+      generator(1, 3) = CMPLX(-0.09_dp, 0.04_dp, KIND=dp)
+      generator(2, 3) = CMPLX(0.12_dp, 0.07_dp, KIND=dp)
+      DO i = 1, nbands
+         generator(i, 1:i - 1) = -CONJG(generator(1:i - 1, i))
+      END DO
+
+      direction(:) = [0.14_dp, -0.07_dp, -0.11_dp, 0.09_dp, 0.05_dp, 0.13_dp]
+      direction_generator(:, :) = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+      direction_generator(1, 2) = CMPLX(direction(1), direction(2), KIND=dp)
+      direction_generator(2, 1) = -CONJG(direction_generator(1, 2))
+      direction_generator(1, 3) = CMPLX(direction(3), direction(4), KIND=dp)
+      direction_generator(3, 1) = -CONJG(direction_generator(1, 3))
+      direction_generator(2, 3) = CMPLX(direction(5), direction(6), KIND=dp)
+      direction_generator(3, 2) = -CONJG(direction_generator(2, 3))
+      occupation(:) = [1.73_dp, 0.88_dp, 0.19_dp]
+
+      rotation(:, :) = dense_antihermitian_exp(generator)
+      chc(:, :) = MATMUL(CONJG(TRANSPOSE(rotation)), &
+                         MATMUL(base_hamiltonian, rotation))
+      CALL qs_ot_finite_rotation_response(chc, generator, occupation, kpoint_weight, &
+                                          gradient, hessian, rayleigh_response)
+
+      rotation_plus(:, :) = dense_antihermitian_exp(generator + fd_step*direction_generator)
+      rotation_minus(:, :) = dense_antihermitian_exp(generator - fd_step*direction_generator)
+      energy = finite_rotation_energy(rotation, base_hamiltonian, occupation, kpoint_weight)
+      energy_plus = finite_rotation_energy(rotation_plus, base_hamiltonian, occupation, kpoint_weight)
+      energy_minus = finite_rotation_energy(rotation_minus, base_hamiltonian, occupation, kpoint_weight)
+      gradient_error = ABS((energy_plus - energy_minus)/(2.0_dp*fd_step) - &
+                           DOT_PRODUCT(gradient, direction))
+      hessian_error = ABS((energy_plus - 2.0_dp*energy + energy_minus)/fd_step**2 - &
+                          DOT_PRODUCT(direction, MATMUL(hessian, direction)))
+      symmetry_error = MAXVAL(ABS(hessian - TRANSPOSE(hessian)))
+
+      DO i = 1, nbands
+         rayleigh_plus(i) = REAL(DOT_PRODUCT(rotation_plus(:, i), &
+                                             MATMUL(base_hamiltonian, rotation_plus(:, i))), KIND=dp)
+         rayleigh_minus(i) = REAL(DOT_PRODUCT(rotation_minus(:, i), &
+                                              MATMUL(base_hamiltonian, rotation_minus(:, i))), KIND=dp)
+      END DO
+      rayleigh_error = MAXVAL(ABS((rayleigh_plus - rayleigh_minus)/(2.0_dp*fd_step) - &
+                                  MATMUL(rayleigh_response, direction)))
+
+      IF (gradient_error > 5.0E-8_dp .OR. hessian_error > 2.0E-6_dp .OR. &
+          rayleigh_error > 2.0E-7_dp .OR. symmetry_error > 1.0E-12_dp) nfail = nfail + 1
+      IF (mynode == 0) THEN
+         WRITE (io_unit, '(A,4(1X,ES13.6))') "finite complex rotation response errors:", &
+            gradient_error, hessian_error, rayleigh_error, symmetry_error
+      END IF
+
+   END SUBROUTINE test_finite_rotation_response
+
+! **************************************************************************************************
+!> \brief fixed-occupation band energy for a dense finite rotation
+!> \param rotation unitary REF rotation
+!> \param hamiltonian fixed Hermitian Hamiltonian in the REF basis
+!> \param occupation band occupations
+!> \param kpoint_weight irreducible-k-point weight
+!> \return weighted band energy
+! **************************************************************************************************
+   FUNCTION finite_rotation_energy(rotation, hamiltonian, occupation, kpoint_weight) RESULT(energy)
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: rotation, hamiltonian
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: occupation
+      REAL(KIND=dp), INTENT(IN)                          :: kpoint_weight
+      REAL(KIND=dp)                                      :: energy
+
+      INTEGER                                            :: i
+
+      energy = 0.0_dp
+      DO i = 1, SIZE(occupation)
+         energy = energy + kpoint_weight*occupation(i)* &
+                  REAL(DOT_PRODUCT(rotation(:, i), &
+                                   MATMUL(hamiltonian, rotation(:, i))), KIND=dp)
+      END DO
+
+   END FUNCTION finite_rotation_energy
 
 ! **************************************************************************************************
 !> \brief Solve fixed-N Fermi occupations by bisection.

--- a/src/qs_scf_loop_utils.F
+++ b/src/qs_scf_loop_utils.F
@@ -604,7 +604,7 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation_numbers, wkp
       TYPE(cp_fm_struct_type), POINTER                   :: active_mo_struct, chc_struct
       TYPE(cp_fm_type)                                   :: active_mo_coeff, active_mo_coeff_im, &
-                                                            chc_re, hc_im, hc_re
+                                                            chc_im, chc_re, hc_im, hc_re
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fmwork
       TYPE(cp_fm_type), POINTER                          :: mo_coeff, mo_coeff_im
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_hc, matrix_hc_im, &
@@ -758,16 +758,24 @@ CONTAINS
                CALL cp_fm_struct_create(chc_struct, template_fmstruct=active_mo_struct, &
                                         nrow_global=homo, ncol_global=homo)
                CALL cp_fm_create(chc_re, chc_struct)
+               CALL cp_fm_create(chc_im, chc_struct)
                CALL cp_fm_gemm("T", "N", homo, homo, nao, 1.0_dp, &
                                active_mo_coeff, hc_re, 0.0_dp, chc_re)
                CALL cp_fm_gemm("T", "N", homo, homo, nao, 1.0_dp, &
                                active_mo_coeff_im, hc_im, 1.0_dp, chc_re)
+               CALL cp_fm_gemm("T", "N", homo, homo, nao, 1.0_dp, &
+                               active_mo_coeff, hc_im, 0.0_dp, chc_im)
+               CALL cp_fm_gemm("T", "N", homo, homo, nao, -1.0_dp, &
+                               active_mo_coeff_im, hc_re, 1.0_dp, chc_im)
                CALL copy_fm_to_dbcsr(chc_re, local_ot_env(local_channel)%rot_mat_chc)
+               CPASSERT(ASSOCIATED(local_ot_env(local_channel)%rot_mat_chc_im))
+               CALL copy_fm_to_dbcsr(chc_im, local_ot_env(local_channel)%rot_mat_chc_im)
                CALL dbcsr_get_diag(local_ot_env(local_channel)%rot_mat_chc, &
                                    local_ot_env(local_channel)%ener_rayleigh)
                CPASSERT(ASSOCIATED(local_ot_env(local_channel)%para_env))
                CALL local_ot_env(local_channel)%para_env%sum( &
                   local_ot_env(local_channel)%ener_rayleigh)
+               CALL cp_fm_release(chc_im)
                CALL cp_fm_release(chc_re)
                CALL cp_fm_struct_release(chc_struct)
             END IF


### PR DESCRIPTION
# OT: Add finite complex Mermin response kernels

## Summary

This PR adds the mathematical response kernels needed for a coupled finite-temperature OT update with complex K points. It does not enable a new minimizer direction or change the existing candidate-selection policy.

The implementation:

- retains the full complex projected Hamiltonian $C^\dagger H C$ for every local spin/K-point OT channel;
- evaluates finite complex REF-rotation gradients, Hessians, and Rayleigh-energy response in the current exponential chart;
- builds the channel-local fixed-$N$ rotation/auxiliary-energy Schur block;
- provides a sign-aware spectral response solve that preserves resolved positive and negative curvature modes while projecting out unresolved null modes;
- extends the complex OT unit test with finite-difference, symmetry, gauge, and null-space regressions.

## Mathematical model

For the anti-Hermitian complex rotation generator $A$, the finite REF rotation is

```math
U(A) = \exp(A),
\qquad
\widetilde H(A) = U(A)^\dagger H_{\mathrm{ref}} U(A).
```

The response is evaluated in independent real-antisymmetric and imaginary-symmetric pair coordinates. Central finite differences of the finite-chart gradient provide the symmetric rotation Hessian and the response of the Rayleigh energies at the current, generally nonzero generator.

For fixed-$N$ Fermi-Dirac occupations, define the nonnegative susceptibility vector $\chi$, its diagonal matrix $D=\mathrm{diag}(\chi)$, and

```math
C_N = D - \frac{\chi\chi^{\mathsf T}}{\sum_i \chi_i}.
```

The constant auxiliary-energy shift is therefore an exact null mode. Eliminating the auxiliary-energy block gives

```math
S
= K_{\mathrm{rot}} - R^{\mathsf T} C_N R
= \left(K_{\mathrm{rot}} - R^{\mathsf T} D R\right)
  + \frac{v v^{\mathsf T}}{\sum_i \chi_i},
\qquad
v = R^{\mathsf T}\chi.
```

The implementation returns the channel-local dense term and $v$ separately, so the fixed-$N$ rank-one coupling can later be assembled across distributed spin/K-point channels without constructing a global dense rotation Hessian.

An indefinite but resolved response matrix $B=Q\Lambda Q^{\mathsf T}$ is converted into a descent metric through its spectral absolute pseudoinverse,

```math
|B|^{+} = Q\,\mathrm{diag}(d_i)\,Q^{\mathsf T},
\qquad
d_i =
\begin{cases}
|\lambda_i|^{-1}, & |\lambda_i| > \tau,\\
0, & |\lambda_i| \le \tau.
\end{cases}
```

This retains physical negative-curvature information without amplifying gauge or numerically unresolved modes.

## Scope

This PR is a response-kernel foundation. Existing OT algorithms, minimizers, preconditioners, line searches, and defaults are unchanged. In particular, it does not activate the experimental coupled response candidate.

The imaginary projected Hamiltonian is written into an already allocated per-channel matrix, so this change adds no production allocation.

## Testing

- GCC 16 MPI/OpenMP Release build, including `cp2k.psmp`
- `qs_ot_complex_ref_unittest.psmp` with MPI 1, 2, and 4
- finite complex rotation gradient/Hessian finite differences
- fixed-\(N\) projector and Schur-response finite differences
- resolved positive/negative spectral response and explicit near-null projection
- no-cache precommit: 3/3 files
- `QS/regtest-ot-2`, MPI 2/OpenMP 2: 48/48 correct
