### PR TITLE
LS_SCF: Guard dense submatrix linear algebra on macOS

### DIFF
--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -100,6 +100,10 @@ CONTAINS
 
 !$    flags = TRIM(flags)//" omp"
 
+#if defined(__MACOSX)
+      flags = TRIM(flags)//" macos"
+#endif
+
       ! TODO: remove __INTEL_LLVM_COMPILER conditions (regtests)
 #if defined(__INTEL_LLVM_COMPILER)
       flags = TRIM(flags)//" ifx"

--- a/src/iterate_matrix.F
+++ b/src/iterate_matrix.F
@@ -1209,34 +1209,44 @@ CONTAINS
       INTEGER                                            :: info, liwork, lwork
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iwork
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: work
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: tmp
 
-      ALLOCATE (eigvecs(N, N), tmp(N, N))
+      ALLOCATE (eigvecs(N, N))
       ALLOCATE (eigvals(N))
 
       ! symmetrize sm
       eigvecs(:, :) = 0.5*(sm + TRANSPOSE(sm))
 
-      ! probe optimal sizes for WORK and IWORK
+      ! Probe optimal sizes for WORK and IWORK. On macOS, BLAS/LAPACK libraries
+      ! using a different OpenMP runtime can fail when entered concurrently.
       LWORK = -1
       LIWORK = -1
       ALLOCATE (WORK(1))
       ALLOCATE (IWORK(1))
+#if defined(__MACOSX)
+      !$OMP CRITICAL (submatrix_dense_linalg)
+#endif
       CALL dsyevd('V', 'U', N, eigvecs, N, eigvals, WORK, LWORK, IWORK, LIWORK, INFO)
+#if defined(__MACOSX)
+      !$OMP END CRITICAL (submatrix_dense_linalg)
+#endif
       LWORK = INT(WORK(1))
       LIWORK = INT(IWORK(1))
       DEALLOCATE (IWORK)
       DEALLOCATE (WORK)
 
-      ! calculate eigenvalues and eigenvectors
+      ! Calculate eigenvalues and eigenvectors.
       ALLOCATE (WORK(LWORK))
       ALLOCATE (IWORK(LIWORK))
+#if defined(__MACOSX)
+      !$OMP CRITICAL (submatrix_dense_linalg)
+#endif
       CALL dsyevd('V', 'U', N, eigvecs, N, eigvals, WORK, LWORK, IWORK, LIWORK, INFO)
+#if defined(__MACOSX)
+      !$OMP END CRITICAL (submatrix_dense_linalg)
+#endif
       DEALLOCATE (IWORK)
       DEALLOCATE (WORK)
       IF (INFO /= 0) CPABORT("dsyevd did not succeed")
-
-      DEALLOCATE (tmp)
    END SUBROUTINE eigdecomp
 
 ! **************************************************************************************************
@@ -1273,8 +1283,14 @@ CONTAINS
 
       ! Create matrix with eigenvalues in {-1,0,1} and eigenvectors of sm:
       ! sm_sign = eigvecs * sm_sign * eigvecs.T
+#if defined(__MACOSX)
+      !$OMP CRITICAL (submatrix_dense_linalg)
+#endif
       CALL dgemm('N', 'N', N, N, N, 1.0_dp, eigvecs, N, sm_sign, N, 0.0_dp, tmp, N)
       CALL dgemm('N', 'T', N, N, N, 1.0_dp, tmp, N, eigvecs, N, 0.0_dp, sm_sign, N)
+#if defined(__MACOSX)
+      !$OMP END CRITICAL (submatrix_dense_linalg)
+#endif
    END SUBROUTINE sign_from_eigdecomp
 
 ! **************************************************************************************************
@@ -1578,7 +1594,7 @@ CONTAINS
       IF ((variant == ls_scf_submatrix_sign_direct_muadj_lowmem) .AND. (mu /= new_mu)) THEN
          !$OMP PARALLEL DEFAULT(OMP_DEFAULT_NONE_WITH_OOP) &
          !$OMP          PRIVATE(sm, sm_sign, sm_size, sm_firstcol, sm_lastcol, j) &
-         !$OMP          SHARED(dissection, myrank, my_sms, unit_nr, eigbufs, mu, new_mu)
+         !$OMP          SHARED(dissection, myrank, my_sms, unit_nr, mu, new_mu)
          !$OMP DO SCHEDULE(GUIDED)
          DO i = 1, SIZE(my_sms)
             WRITE (unit_nr, '(T3,A,1X,I4,1X,A,1X,I6)') "Rank", myrank, "reprocessing submatrix", my_sms(i)


### PR DESCRIPTION
The direct LS_SCF submatrix sign paths call DSYEVD and DGEMM concurrently from an OpenMP region. On macOS builds where CP2K and Homebrew BLAS use different OpenMP runtimes, this produces either DSYEVD failures or NaN trace estimates during internal chemical-potential adjustment.

This change serializes only those dense BLAS/LAPACK calls on macOS. Linux and other HPC platforms retain the existing submatrix-level parallelism. It also removes an unused N-by-N allocation and a deallocated buffer from an OpenMP SHARED clause.

Validation:
- Existing H2O DIRECT_MUADJ_LOWMEM regression with OMP_NUM_THREADS=4: -17.031737706156235 Ha, matching the reference.
- B144 CUBE Harris test with OMP_NUM_THREADS=4: internal mu converges to 0.29 with zero trace error and no NaN.
- DIRECT_MUADJ and DIRECT_MUADJ_LOWMEM agree to about 1e-13 Ha for the B144 test.
- CP2K precommit checks pass.