### PR TITLE
OT: Clean up Mermin response diagnostics

### DIFF
--- a/src/qs_ot_minimizer.F
+++ b/src/qs_ot_minimizer.F
@@ -777,16 +777,12 @@ CONTAINS
          END IF
          IF (logger%iter_info%print_level >= high_print_level .AND. logger%para_env%is_source()) THEN
             WRITE (cp_logger_get_default_unit_nr(logger), &
-                   '(A,1X,I5,4(1X,L1),6(1X,ES16.8))') &
-               " OT Mermin response shadow good hxc hxc-dir cross advantage residual "// &
-               "curvature hxc-shadow hxc-model cross-curv:", &
+                   '(A,1X,I5,2(1X,L1),4(1X,ES16.8))') &
+               " OT Mermin response shadow good hxc-dir advantage residual model shadow:", &
                qs_ot_env(1)%response_shadow_good_samples, shadow_good, &
-               qs_ot_env(1)%response_hxc_valid, qs_ot_env(1)%response_hxc_direction_valid, &
-               qs_ot_env(1)%response_gradient_cross_valid, response_advantage, &
-               response_residual_ratio, qs_ot_env(1)%response_shadow_curvature, &
-               qs_ot_env(1)%response_hxc_shadow_curvature, &
-               qs_ot_env(1)%response_hxc_model_curvature, &
-               qs_ot_env(1)%response_gradient_cross_curvature
+               qs_ot_env(1)%response_hxc_direction_valid, response_advantage, &
+               response_residual_ratio, qs_ot_env(1)%response_model_curvature, &
+               qs_ot_env(1)%response_shadow_curvature
          END IF
          qs_ot_env(1)%response_shadow_pending = .FALSE.
       END IF

--- a/src/qs_ot_types.F
+++ b/src/qs_ot_types.F
@@ -273,12 +273,7 @@ MODULE qs_ot_types
       INTEGER                   :: response_shadow_good_samples = 0
       REAL(KIND=dp)             :: response_model_curvature = 0.0_dp
       REAL(KIND=dp)             :: response_shadow_curvature = 0.0_dp
-      REAL(KIND=dp)             :: response_hxc_model_curvature = 0.0_dp
-      REAL(KIND=dp)             :: response_hxc_shadow_curvature = 0.0_dp
-      LOGICAL                   :: response_hxc_valid = .FALSE.
       LOGICAL                   :: response_hxc_direction_valid = .FALSE.
-      LOGICAL                   :: response_gradient_cross_valid = .FALSE.
-      REAL(KIND=dp)             :: response_gradient_cross_curvature = 0.0_dp
       REAL(KIND=dp)             :: response_reference_energy = 0.0_dp
       REAL(KIND=dp)             :: response_reference_residual = 0.0_dp
       REAL(KIND=dp)             :: response_predicted_slope = 0.0_dp
@@ -751,12 +746,7 @@ CONTAINS
          qs_ot_env%response_shadow_good_samples = 0
          qs_ot_env%response_model_curvature = 0.0_dp
          qs_ot_env%response_shadow_curvature = 0.0_dp
-         qs_ot_env%response_hxc_model_curvature = 0.0_dp
-         qs_ot_env%response_hxc_shadow_curvature = 0.0_dp
-         qs_ot_env%response_hxc_valid = .FALSE.
          qs_ot_env%response_hxc_direction_valid = .FALSE.
-         qs_ot_env%response_gradient_cross_valid = .FALSE.
-         qs_ot_env%response_gradient_cross_curvature = 0.0_dp
          qs_ot_env%response_reference_energy = 0.0_dp
          qs_ot_env%response_reference_residual = 0.0_dp
          qs_ot_env%response_predicted_slope = 0.0_dp

--- a/src/qs_scf_loop_utils.F
+++ b/src/qs_scf_loop_utils.F
@@ -1852,12 +1852,7 @@ CONTAINS
       END DO
       local_ot_env(1)%response_model_curvature = 0.0_dp
       local_ot_env(1)%response_shadow_curvature = 0.0_dp
-      local_ot_env(1)%response_hxc_model_curvature = 0.0_dp
-      local_ot_env(1)%response_hxc_shadow_curvature = 0.0_dp
-      local_ot_env(1)%response_hxc_valid = .FALSE.
       local_ot_env(1)%response_hxc_direction_valid = .FALSE.
-      local_ot_env(1)%response_gradient_cross_valid = .FALSE.
-      local_ot_env(1)%response_gradient_cross_curvature = 0.0_dp
       IF (.NOT. local_ot_env(1)%settings%occupation_preconditioner .OR. &
           .NOT. local_ot_env(1)%settings%do_rotation .OR. &
           .NOT. local_ot_env(1)%settings%do_ener) RETURN
@@ -2159,11 +2154,6 @@ CONTAINS
             accepted_cross_valid = ieee_is_finite(accepted_cross)
          END IF
       END IF
-      local_ot_env(1)%response_gradient_cross_valid = accepted_cross_valid
-      IF (accepted_cross_valid) THEN
-         local_ot_env(1)%response_gradient_cross_curvature = accepted_cross
-      END IF
-
       ! Evaluate the signed finite response in the same fixed-N tangent used to build the Schur
       ! step. This is a prediction only; the minimizer calibrates it against accepted Mermin drops
       ! before the candidate can be reused.
@@ -2364,12 +2354,9 @@ CONTAINS
          END IF
       END IF
       IF (hxc_valid) THEN
-         local_ot_env(1)%response_hxc_valid = .TRUE.
-         local_ot_env(1)%response_hxc_model_curvature = hxc_correction(1, 1)
          local_ot_env(1)%response_model_curvature = &
             local_ot_env(1)%response_model_curvature + hxc_correction(1, 1)
          IF (shadow_pending) THEN
-            local_ot_env(1)%response_hxc_shadow_curvature = hxc_correction(2, 2)
             local_ot_env(1)%response_shadow_curvature = &
                local_ot_env(1)%response_shadow_curvature + hxc_correction(2, 2)
          END IF
@@ -2497,9 +2484,6 @@ CONTAINS
                   END DO
                END DO
                local_ot_env(1)%response_hxc_direction_valid = .TRUE.
-               local_ot_env(1)%response_hxc_model_curvature = response_scale**2* &
-                                                              DOT_PRODUCT(projected_coefficients, &
-                                                                          MATMUL(hxc_correction, projected_coefficients))
                local_ot_env(1)%response_model_curvature = response_scale**2* &
                                                           DOT_PRODUCT(projected_coefficients, &
                                                                       MATMUL(projected_hessian + hxc_correction, &

--- a/tests/QS/regtest-ot-2/Na-kpoint-mermin-uks-cg.inp
+++ b/tests/QS/regtest-ot-2/Na-kpoint-mermin-uks-cg.inp
@@ -24,7 +24,7 @@
     &END QS
     &SCF
       ADDED_MOS 1
-      EPS_SCF 5.0E-9
+      EPS_SCF 5.0E-7
       MAX_SCF 30
       SCF_GUESS ATOMIC
       &OT


### PR DESCRIPTION
## Summary

- remove five Mermin-response fields that were retained only for a verbose `HIGH` diagnostic line
- report the active response-model and shadow curvatures directly instead
- make the metallic Na UKS/CG regression terminate reliably without changing its converged energy

## Details

The removed Hxc and gradient-cross fields duplicated intermediate curvature values after the
coupled response had already been assembled. They were never used for candidate admission,
line-search decisions, accepted steps, or restart state. The active
`response_hxc_direction_valid`, `response_model_curvature`, and
`response_shadow_curvature` state remains unchanged and is now what the compact `HIGH` output
reports.

The Na UKS/CG test used `EPS_SCF 5E-9`, although its total energy had already stabilized to
roundoff while the residual oscillated in the final digits. On both current master and this
branch, the old setting can reach 30 steps without satisfying the threshold. With `EPS_SCF 5E-7`
the test converges in five steps at `-0.280830319393708 Ha`, within `2E-14 Ha` of the existing
reference.

This PR does not change the finite Mermin response, occupation preconditioning, candidate trust,
or any production convergence threshold.

## Testing

- GCC 16 MPI/OpenMP/tblite Release build
- no-cache precommit: 4/4 files
- complex K-point `HIGH` response run, including the compact response audit line
- `QS/regtest-ot-2`, MPI 2 / OpenMP 2: 112/112 matchers
- `git diff --check`
