### PR TITLE
Make k-point OT minimizer restart state reference-safe

### DIFF
--- a/src/kpoint_io.F
+++ b/src/kpoint_io.F
@@ -1247,6 +1247,9 @@ CONTAINS
 
       CALL qs_scf_ot_restart_clear(scf_env)
       scf_env%qs_ot_restart%valid = .TRUE.
+      ! Format version 5 does not serialize matrix_c0/matrix_c0_im or an equivalent
+      ! objective/reference fingerprint. Its chart-dependent minimizer state must not be restored.
+      scf_env%qs_ot_restart%reference_state_compatible = .FALSE.
       scf_env%qs_ot_restart%format_version = version_read
       scf_env%qs_ot_restart%nchannel = nchannel
       ALLOCATE (scf_env%qs_ot_restart%channel(nchannel))

--- a/src/qs_ot_complex_ref_unittest.F
+++ b/src/qs_ot_complex_ref_unittest.F
@@ -75,6 +75,9 @@ PROGRAM qs_ot_complex_ref_unittest
                                               qs_ot_kpoint_preconditioner_solver_supported,&
                                               qs_ot_kpoint_preconditioner_supported,&
                                               qs_ot_type
+   USE qs_scf_types,                    ONLY: qs_scf_env_type,&
+                                              qs_scf_ot_restart_can_restore,&
+                                              qs_scf_ot_restart_clear
    USE reference_manager,               ONLY: remove_all_references
    USE scf_control_types,               ONLY: smear_type
 
@@ -104,6 +107,7 @@ PROGRAM qs_ot_complex_ref_unittest
    nfail = 0
    CALL test_preconditioner_support(nfail)
    CALL test_restart_compatibility(nfail)
+   CALL test_restart_cache_safety(nfail)
    NULLIFY (hc_im_p, hc_re_p, logger, para_env)
    CALL mp_world_init(mp_comm)
    mynode = mp_comm%mepos
@@ -304,6 +308,35 @@ CONTAINS
           smear, .TRUE., .TRUE., 7, 0.02000001_dp, 0.01_dp, 1.0_dp)) nfail = nfail + 1
 
    END SUBROUTINE test_restart_compatibility
+
+! **************************************************************************************************
+!> \brief Check that structurally valid state is unusable without a verified OT reference.
+!> \param nfail accumulated number of failures
+! **************************************************************************************************
+   SUBROUTINE test_restart_cache_safety(nfail)
+      INTEGER, INTENT(INOUT)                             :: nfail
+
+      TYPE(qs_scf_env_type)                              :: scf_env
+
+      scf_env%qs_ot_restart%valid = .TRUE.
+      ALLOCATE (scf_env%qs_ot_restart%channel(1))
+      scf_env%qs_ot_restart%format_version = 5
+      scf_env%qs_ot_restart%reference_state_compatible = .TRUE.
+      IF (qs_scf_ot_restart_can_restore(scf_env)) nfail = nfail + 1
+
+      scf_env%qs_ot_restart%format_version = 6
+      scf_env%qs_ot_restart%reference_state_compatible = .FALSE.
+      IF (qs_scf_ot_restart_can_restore(scf_env)) nfail = nfail + 1
+
+      scf_env%qs_ot_restart%reference_state_compatible = .TRUE.
+      IF (.NOT. qs_scf_ot_restart_can_restore(scf_env)) nfail = nfail + 1
+
+      CALL qs_scf_ot_restart_clear(scf_env)
+      IF (qs_scf_ot_restart_can_restore(scf_env)) nfail = nfail + 1
+      IF (scf_env%qs_ot_restart%reference_state_compatible) nfail = nfail + 1
+      IF (ASSOCIATED(scf_env%qs_ot_restart%channel)) nfail = nfail + 1
+
+   END SUBROUTINE test_restart_cache_safety
 
 ! **************************************************************************************************
 !> \brief Check the noncanonical complex OT energy-weighted density and its gauge covariance.

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -223,7 +223,8 @@ MODULE qs_scf
    USE qs_scf_types,                    ONLY: &
         block_davidson_diag_method_nr, block_krylov_diag_method_nr, filter_matrix_diag_method_nr, &
         general_diag_method_nr, ot_diag_method_nr, ot_method_nr, qs_ot_restart_dense_matrix_type, &
-        qs_scf_env_type, qs_scf_ot_restart_can_restore, smeagol_method_nr, special_diag_method_nr
+        qs_scf_env_type, qs_scf_ot_restart_can_restore, qs_scf_ot_restart_clear, &
+        smeagol_method_nr, special_diag_method_nr
    USE qs_vxc_atom,                     ONLY: gapw_cdft_one_center
    USE qs_wf_history_methods,           ONLY: wfi_purge_history,&
                                               wfi_update
@@ -2353,6 +2354,10 @@ CONTAINS
          CALL dbcsr_release_p(matrix_sk_re)
          CALL dbcsr_release_p(matrix_sk_im)
       END DO
+
+      ! A serialized minimizer state belongs to one OT workspace construction only. In particular,
+      ! it must not be applied again when an outer SCF cycle rebuilds the temporary OT environments.
+      CALL qs_scf_ot_restart_clear(scf_env)
 
       CALL qs_ot_check_channel_context(scf_env%qs_ot_env, dft_control%nspins, &
                                        nkpoint=kpoints%nkp, &

--- a/src/qs_scf.F
+++ b/src/qs_scf.F
@@ -223,7 +223,7 @@ MODULE qs_scf
    USE qs_scf_types,                    ONLY: &
         block_davidson_diag_method_nr, block_krylov_diag_method_nr, filter_matrix_diag_method_nr, &
         general_diag_method_nr, ot_diag_method_nr, ot_method_nr, qs_ot_restart_dense_matrix_type, &
-        qs_scf_env_type, smeagol_method_nr, special_diag_method_nr
+        qs_scf_env_type, qs_scf_ot_restart_can_restore, smeagol_method_nr, special_diag_method_nr
    USE qs_vxc_atom,                     ONLY: gapw_cdft_one_center
    USE qs_wf_history_methods,           ONLY: wfi_purge_history,&
                                               wfi_update
@@ -2134,7 +2134,9 @@ CONTAINS
       INTEGER :: energy_dimension, energy_spin, energy_start, handle, ikpoint, ikpoint_local, &
          ispin, nao, nmo, nocc, ot_channel, restart_compatible_int
       LOGICAL                                            :: restart_channel_restored, &
-                                                            restart_compatible, use_real_wfn
+                                                            restart_compatible, &
+                                                            restart_reference_compatible, &
+                                                            use_real_wfn
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues
       TYPE(cp_fm_struct_type), POINTER                   :: active_mo_struct
       TYPE(cp_fm_type)                                   :: active_mo_coeff, active_mo_coeff_im
@@ -2162,8 +2164,8 @@ CONTAINS
          CPABORT("K-point OT currently requires complex K-point wavefunctions.")
       END IF
 
-      restart_compatible = scf_env%qs_ot_restart%valid .AND. &
-                           ASSOCIATED(scf_env%qs_ot_restart%channel)
+      restart_reference_compatible = scf_env%qs_ot_restart%reference_state_compatible
+      restart_compatible = qs_scf_ot_restart_can_restore(scf_env)
       IF (restart_compatible) THEN
          restart_compatible = SIZE(scf_env%qs_ot_restart%channel) == SIZE(scf_env%qs_ot_env)
       END IF
@@ -2189,7 +2191,11 @@ CONTAINS
       END IF
       restart_compatible_int = MERGE(1, 0, restart_compatible)
       CALL kpoints%para_env%min(restart_compatible_int)
-      IF (scf_env%qs_ot_restart%valid .AND. restart_compatible_int == 0) THEN
+      IF (scf_env%qs_ot_restart%valid .AND. .NOT. restart_reference_compatible) THEN
+         CALL cp_warn(__LOCATION__, &
+                      "K-point OT restart: density restored; minimizer state discarded because "// &
+                      "the payload has no verifiable OT reference state")
+      ELSE IF (scf_env%qs_ot_restart%valid .AND. restart_compatible_int == 0) THEN
          CALL cp_warn(__LOCATION__, &
                       "Ignoring k-point OT restart payload incompatible with current channels or settings")
       END IF
@@ -2413,8 +2419,7 @@ CONTAINS
       TYPE(cp_logger_type), POINTER                      :: logger
 
       restored = .FALSE.
-      IF (.NOT. scf_env%qs_ot_restart%valid) RETURN
-      IF (.NOT. ASSOCIATED(scf_env%qs_ot_restart%channel)) RETURN
+      IF (.NOT. qs_scf_ot_restart_can_restore(scf_env)) RETURN
       IF (ot_channel < 1 .OR. ot_channel > SIZE(scf_env%qs_ot_restart%channel)) RETURN
       IF (.NOT. scf_env%qs_ot_restart%channel(ot_channel)%valid) RETURN
       IF (scf_env%qs_ot_restart%channel(ot_channel)%spin_index /= qs_ot_env%spin_index) RETURN

--- a/src/qs_scf_types.F
+++ b/src/qs_scf_types.F
@@ -53,6 +53,9 @@ MODULE qs_scf_types
    LOGICAL, PRIVATE, PARAMETER :: debug_this_module = .TRUE.
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_scf_types'
+   ! Format version 5 has no serialized OT reference state. A restorable successor must use a
+   ! distinct format version so that legacy chart-dependent coordinates remain permanently gated.
+   INTEGER, PARAMETER, PRIVATE          :: ot_restart_reference_state_min_version = 6
 
    INTEGER, PARAMETER, PUBLIC :: general_diag_method_nr = 1, &
                                  special_diag_method_nr = 2, &
@@ -66,7 +69,7 @@ MODULE qs_scf_types
    PUBLIC :: qs_scf_env_type
    PUBLIC :: qs_ot_restart_dense_matrix_type
    PUBLIC :: scf_env_release, scf_env_create, scf_env_did_change
-   PUBLIC :: qs_scf_ot_restart_clear
+   PUBLIC :: qs_scf_ot_restart_can_restore, qs_scf_ot_restart_clear
    PUBLIC :: krylov_space_type, krylov_space_create, subspace_env_type
    PUBLIC :: diag_subspace_env_create
 
@@ -159,7 +162,7 @@ MODULE qs_scf_types
    END TYPE qs_ot_restart_channel_type
 
    TYPE qs_ot_restart_cache_type
-      LOGICAL :: valid = .FALSE.
+      LOGICAL :: valid = .FALSE., reference_state_compatible = .FALSE.
       INTEGER :: format_version = 0, nchannel = 0
       TYPE(qs_ot_restart_channel_type), DIMENSION(:), POINTER :: channel => NULL()
    END TYPE qs_ot_restart_cache_type
@@ -265,6 +268,7 @@ CONTAINS
       NULLIFY (scf_env%ot_preconditioner)
       NULLIFY (scf_env%qs_ot_env)
       scf_env%qs_ot_restart%valid = .FALSE.
+      scf_env%qs_ot_restart%reference_state_compatible = .FALSE.
       scf_env%qs_ot_restart%format_version = 0
       scf_env%qs_ot_restart%nchannel = 0
       NULLIFY (scf_env%qs_ot_restart%channel)
@@ -473,6 +477,22 @@ CONTAINS
    END SUBROUTINE scf_env_release
 
 ! **************************************************************************************************
+!> \brief report whether cached k-point OT state has a verified coordinate reference
+!> \param scf_env the environment containing the restart cache
+!> \return true only for a structurally valid cache with a compatible reference state
+! **************************************************************************************************
+   PURE FUNCTION qs_scf_ot_restart_can_restore(scf_env) RESULT(can_restore)
+      TYPE(qs_scf_env_type), INTENT(IN)                  :: scf_env
+      LOGICAL                                            :: can_restore
+
+      can_restore = scf_env%qs_ot_restart%valid .AND. &
+                    scf_env%qs_ot_restart%format_version >= ot_restart_reference_state_min_version .AND. &
+                    scf_env%qs_ot_restart%reference_state_compatible .AND. &
+                    ASSOCIATED(scf_env%qs_ot_restart%channel)
+
+   END FUNCTION qs_scf_ot_restart_can_restore
+
+! **************************************************************************************************
 !> \brief clear cached k-point OT restart data
 !> \param scf_env the environment containing the restart cache
 ! **************************************************************************************************
@@ -578,6 +598,7 @@ CONTAINS
          DEALLOCATE (scf_env%qs_ot_restart%channel)
       END IF
       scf_env%qs_ot_restart%valid = .FALSE.
+      scf_env%qs_ot_restart%reference_state_compatible = .FALSE.
       scf_env%qs_ot_restart%format_version = 0
       scf_env%qs_ot_restart%nchannel = 0
       NULLIFY (scf_env%qs_ot_restart%channel)


### PR DESCRIPTION
The k-point restart format v5 (`ot_restart_version = 5`) serializes OT minimizer coordinates and history, including `matrix_x`, previous directions, gradients, DIIS/L-BFGS history, and line-search state. However, it does not serialize `matrix_c0`/`matrix_c0_im` or an equivalent verified reference-state fingerprint.

This makes restoring the minimizer state unsafe. The OT coordinates are defined relative to the reference orbitals, but `allocate_qs_ot_kpoint_state()` currently constructs a new reference from the newly initialized k-point MOs. Restoring the old coordinates and history into this new chart therefore changes their meaning, even when the geometry, smearing settings, channel layout, and OT options still match.

This PR makes the existing behavior conservative:

* `.kp` format v5 remains readable and its density restart is preserved;
* its OT minimizer payload is explicitly treated as non-restorable;
* restoration now requires both:
  * a format version capable of carrying a complete reference state (`>= 6`); and
  * an explicit `reference_state_compatible` result;
* the same guard is checked again immediately before applying cached state;
* the restart cache is cleared after the first OT workspace construction attempt, so it cannot be replayed when an outer SCF cycle rebuilds `qs_ot_env`.

When a v5 payload is encountered, CP2K now reports:

```text
K-point OT restart: density restored; minimizer state discarded because
the payload has no verifiable OT reference state
```

A cache-safety test was added to `qs_ot_complex_ref_unittest` to verify that:

* format v5 cannot restore minimizer state, even if the compatibility flag is set accidentally;
* a newer format still requires explicit reference-state compatibility;
* clearing the cache invalidates the restoration state and releases its channel data.

This PR deliberately does not introduce a new restart format or attempt exact minimizer continuation. A future restorable format must serialize and validate the complete OT reference/objective state before setting `reference_state_compatible`.
