### PR TITLE
Unify ao exp ikr operator

### DIFF
--- a/src/almo_scf_optimizer.F
+++ b/src/almo_scf_optimizer.F
@@ -918,7 +918,6 @@ CONTAINS
                ALLOCATE (op_sm_set_qs(reim, idim0)%matrix)
                CALL dbcsr_copy(op_sm_set_qs(reim, idim0)%matrix, qs_matrix_s(1)%matrix, &
                              name="almo_scf_env%op_sm_"//TRIM(ADJUSTL(cp_to_string(reim)))//"-"//TRIM(ADJUSTL(cp_to_string(idim0))))
-               CALL dbcsr_set(op_sm_set_qs(reim, idim0)%matrix, 0.0_dp)
                NULLIFY (op_sm_set_almo(reim, idim0)%matrix)
                ALLOCATE (op_sm_set_almo(reim, idim0)%matrix)
                CALL dbcsr_copy(op_sm_set_almo(reim, idim0)%matrix, almo_scf_env%matrix_s(1), &
@@ -1972,7 +1971,6 @@ CONTAINS
                ALLOCATE (op_sm_set_almo(reim, idim0)%matrix)
                CALL dbcsr_copy(op_sm_set_qs(reim, idim0)%matrix, qs_matrix_s(1)%matrix, &
                              name="almo_scf_env%op_sm_"//TRIM(ADJUSTL(cp_to_string(reim)))//"-"//TRIM(ADJUSTL(cp_to_string(idim0))))
-               CALL dbcsr_set(op_sm_set_qs(reim, idim0)%matrix, 0.0_dp)
                CALL dbcsr_copy(op_sm_set_almo(reim, idim0)%matrix, matrix_s, &
                              name="almo_scf_env%op_sm_"//TRIM(ADJUSTL(cp_to_string(reim)))//"-"//TRIM(ADJUSTL(cp_to_string(idim0))))
                CALL dbcsr_set(op_sm_set_almo(reim, idim0)%matrix, 0.0_dp)

--- a/src/iao_analysis.F
+++ b/src/iao_analysis.F
@@ -1327,7 +1327,6 @@ CONTAINS
             NULLIFY (op_sm_set(j, i)%matrix)
             ALLOCATE (op_sm_set(j, i)%matrix)
             CALL dbcsr_copy(op_sm_set(j, i)%matrix, matrix_s(1)%matrix)
-            CALL dbcsr_set(op_sm_set(j, i)%matrix, 0.0_dp)
          END DO
       END DO
       CALL initialize_weights(cell, weights)

--- a/src/qs_efield_berry.F
+++ b/src/qs_efield_berry.F
@@ -168,8 +168,6 @@ CONTAINS
 
          CALL dbcsr_copy(cosmat(i)%matrix, matrix_s(1)%matrix, 'COS MAT')
          CALL dbcsr_copy(sinmat(i)%matrix, matrix_s(1)%matrix, 'SIN MAT')
-         CALL dbcsr_set(cosmat(i)%matrix, 0.0_dp)
-         CALL dbcsr_set(sinmat(i)%matrix, 0.0_dp)
 
          kvec(:) = twopi*cell%h_inv(i, :)
          CALL build_berry_moment_matrix(qs_env, cosmat(i)%matrix, sinmat(i)%matrix, kvec)

--- a/src/qs_linres_op.F
+++ b/src/qs_linres_op.F
@@ -773,8 +773,6 @@ CONTAINS
 
          DO i = 1, 3
             kvec(:) = twopi*cell%h_inv(i, :)
-            CALL dbcsr_set(cosmat, 0.0_dp)
-            CALL dbcsr_set(sinmat, 0.0_dp)
             CALL build_berry_moment_matrix(qs_env, cosmat, sinmat, kvec)
 
             DO ispin = 1, dft_control%nspins ! spin

--- a/src/qs_loc_utils.F
+++ b/src/qs_loc_utils.F
@@ -12,17 +12,10 @@
 ! **************************************************************************************************
 MODULE qs_loc_utils
 
-   USE ai_moments,                      ONLY: contract_cossin,&
-                                              cossin
-   USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
-                                              gto_basis_set_type
-   USE block_p_types,                   ONLY: block_p_type
-   USE cell_types,                      ONLY: cell_type,&
-                                              pbc
+   USE cell_types,                      ONLY: cell_type
    USE cp_array_utils,                  ONLY: cp_1d_r_p_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_api,                    ONLY: dbcsr_copy,&
-                                              dbcsr_get_block_p,&
                                               dbcsr_p_type,&
                                               dbcsr_set,&
                                               dbcsr_type
@@ -60,14 +53,10 @@ MODULE qs_loc_utils
    USE mathconstants,                   ONLY: twopi
    USE memory_utilities,                ONLY: reallocate
    USE message_passing,                 ONLY: mp_para_env_type
-   USE orbital_pointers,                ONLY: ncoset
    USE parallel_gemm_api,               ONLY: parallel_gemm
    USE particle_types,                  ONLY: particle_type
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
-   USE qs_kind_types,                   ONLY: get_qs_kind,&
-                                              get_qs_kind_set,&
-                                              qs_kind_type
    USE qs_loc_types,                    ONLY: get_qs_loc_env,&
                                               localized_wfn_control_create,&
                                               localized_wfn_control_release,&
@@ -78,12 +67,7 @@ MODULE qs_loc_utils
    USE qs_mo_methods,                   ONLY: make_mo_eig
    USE qs_mo_types,                     ONLY: get_mo_set,&
                                               mo_set_type
-   USE qs_neighbor_list_types,          ONLY: get_iterator_info,&
-                                              neighbor_list_iterate,&
-                                              neighbor_list_iterator_create,&
-                                              neighbor_list_iterator_p_type,&
-                                              neighbor_list_iterator_release,&
-                                              neighbor_list_set_p_type
+   USE qs_operators_ao,                 ONLY: build_exp_ikr_matrix
    USE qs_scf_types,                    ONLY: ot_method_nr
    USE scf_control_types,               ONLY: scf_control_type
 #include "./base/base_uses.f90"
@@ -485,24 +469,21 @@ CONTAINS
    END SUBROUTINE get_berry_operator
 
 ! **************************************************************************************************
-!> \brief Computes the Berry operator for periodic systems
-!>       used to define the spread of the MOS
-!>       Here the matrix elements of the type <mu|cos(kr)|nu> and  <mu|sin(kr)|nu>
-!>       are computed, where mu and nu are the contracted basis functions.
-!>       Namely the Berry operator is exp(ikr)
-!>       k is defined somewhere
-!>       the pair lists are exploited and sparse matrixes are constructed
+!> \brief Computes the reciprocal-space operators used by Berry localization.
+!>       The operators contain the contracted AO matrix elements of
+!>       cos(k*r) and sin(k*r) for reciprocal vectors selected from the cell.
+!>       This routine preserves the historical localization interface and
+!>       delegates the AO assembly to qs_operators_ao::build_exp_ikr_matrix.
 !> \param qs_env the qs_env in which the qs_env lives
-!> \param cell ...
-!> \param op_sm_set ...
-!> \param dim_op ...
+!> \param cell cell used to generate the reciprocal vectors and fold positions
+!> \param op_sm_set cosine and sine operator storage
+!> \param dim_op number of reciprocal vectors, either 3 or 6
 !> \par History
 !>      04.2005 created [MI]
 !>      04.2018 wrapped old code [RZK, ZL]
 !> \author MI
-!> \note
-!>      The intgrals are computed analytically  using the primitives GTO
-!>      The contraction is performed block-wise
+!> \note The supplied cell is also used for coordinate folding and its
+!>       periodicity is temporarily set to three dimensions during assembly.
 ! **************************************************************************************************
    SUBROUTINE compute_berry_operator(qs_env, cell, op_sm_set, dim_op)
       TYPE(qs_environment_type), POINTER                 :: qs_env
@@ -512,60 +493,12 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'compute_berry_operator'
 
-      INTEGER :: handle, i, iatom, icol, ikind, inode, irow, iset, jatom, jkind, jset, last_jatom, &
-         ldab, ldsa, ldsb, ldwork, maxl, ncoa, ncob, nkind, nrow, nseta, nsetb, sgfa, sgfb
-      INTEGER, DIMENSION(3)                              :: perd0
-      INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, lb_max, lb_min, npgfa, &
-                                                            npgfb, nsgfa, nsgfb
-      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb
-      LOGICAL                                            :: found, new_atom_b
-      REAL(KIND=dp)                                      :: dab, kvec(3), rab2, vector_k(3, 6)
-      REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rb
-      REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_a, set_radius_b
-      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: cosab, rpgfa, rpgfb, sinab, sphi_a, &
-                                                            sphi_b, work, zeta, zetb
-      TYPE(block_p_type), DIMENSION(:), POINTER          :: op_cos, op_sin
-      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set_list
-      TYPE(gto_basis_set_type), POINTER                  :: basis_set_a, basis_set_b
-      TYPE(neighbor_list_iterator_p_type), &
-         DIMENSION(:), POINTER                           :: nl_iterator
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_orb
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(qs_kind_type), POINTER                        :: qs_kind
+      INTEGER                                            :: handle
+      REAL(KIND=dp), DIMENSION(3, 6)                     :: vector_k
 
       CALL timeset(routineN, handle)
-      NULLIFY (qs_kind, qs_kind_set)
-      NULLIFY (particle_set)
-      NULLIFY (sab_orb)
-      NULLIFY (cosab, sinab, work)
-      NULLIFY (la_max, la_min, lb_max, lb_min, npgfa, npgfb, nsgfa, nsgfb)
-      NULLIFY (set_radius_a, set_radius_b, rpgfa, rpgfb, sphi_a, sphi_b, zeta, zetb)
-
-      CALL get_qs_env(qs_env=qs_env, qs_kind_set=qs_kind_set, &
-                      particle_set=particle_set, sab_orb=sab_orb)
-
-      nkind = SIZE(qs_kind_set)
-
-      CALL get_qs_kind_set(qs_kind_set=qs_kind_set, &
-                           maxco=ldwork, maxlgto=maxl)
-      ldab = ldwork
-      ALLOCATE (cosab(ldab, ldab))
-      cosab = 0.0_dp
-      ALLOCATE (sinab(ldab, ldab))
-      sinab = 0.0_dp
-      ALLOCATE (work(ldwork, ldwork))
-      work = 0.0_dp
-
-      ALLOCATE (op_cos(dim_op))
-      ALLOCATE (op_sin(dim_op))
-      DO i = 1, dim_op
-         NULLIFY (op_cos(i)%block)
-         NULLIFY (op_sin(i)%block)
-      END DO
-
-      kvec = 0.0_dp
+      CPASSERT(dim_op == 3 .OR. dim_op == 6)
+      CPASSERT(ASSOCIATED(cell))
       vector_k = 0.0_dp
       vector_k(:, 1) = twopi*cell%h_inv(1, :)
       vector_k(:, 2) = twopi*cell%h_inv(2, :)
@@ -574,139 +507,11 @@ CONTAINS
       vector_k(:, 5) = twopi*(cell%h_inv(1, :) + cell%h_inv(3, :))
       vector_k(:, 6) = twopi*(cell%h_inv(2, :) + cell%h_inv(3, :))
 
-      ! This operator can be used only for periodic systems
-      ! If an isolated system is used the periodicity is overimposed
-      perd0(1:3) = cell%perd(1:3)
-      cell%perd(1:3) = 1
-
-      ALLOCATE (basis_set_list(nkind))
-      DO ikind = 1, nkind
-         qs_kind => qs_kind_set(ikind)
-         CALL get_qs_kind(qs_kind=qs_kind, basis_set=basis_set_a)
-         IF (ASSOCIATED(basis_set_a)) THEN
-            basis_set_list(ikind)%gto_basis_set => basis_set_a
-         ELSE
-            NULLIFY (basis_set_list(ikind)%gto_basis_set)
-         END IF
-      END DO
-      CALL neighbor_list_iterator_create(nl_iterator, sab_orb)
-      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
-         CALL get_iterator_info(nl_iterator, ikind=ikind, jkind=jkind, inode=inode, &
-                                iatom=iatom, jatom=jatom, r=rab)
-         basis_set_a => basis_set_list(ikind)%gto_basis_set
-         IF (.NOT. ASSOCIATED(basis_set_a)) CYCLE
-         basis_set_b => basis_set_list(jkind)%gto_basis_set
-         IF (.NOT. ASSOCIATED(basis_set_b)) CYCLE
-         ra = pbc(particle_set(iatom)%r, cell)
-         ! basis ikind
-         first_sgfa => basis_set_a%first_sgf
-         la_max => basis_set_a%lmax
-         la_min => basis_set_a%lmin
-         npgfa => basis_set_a%npgf
-         nseta = basis_set_a%nset
-         nsgfa => basis_set_a%nsgf_set
-         rpgfa => basis_set_a%pgf_radius
-         set_radius_a => basis_set_a%set_radius
-         sphi_a => basis_set_a%sphi
-         zeta => basis_set_a%zet
-         ! basis jkind
-         first_sgfb => basis_set_b%first_sgf
-         lb_max => basis_set_b%lmax
-         lb_min => basis_set_b%lmin
-         npgfb => basis_set_b%npgf
-         nsetb = basis_set_b%nset
-         nsgfb => basis_set_b%nsgf_set
-         rpgfb => basis_set_b%pgf_radius
-         set_radius_b => basis_set_b%set_radius
-         sphi_b => basis_set_b%sphi
-         zetb => basis_set_b%zet
-
-         ldsa = SIZE(sphi_a, 1)
-         ldsb = SIZE(sphi_b, 1)
-         IF (inode == 1) last_jatom = 0
-
-         rb = rab + ra
-
-         IF (jatom /= last_jatom) THEN
-            new_atom_b = .TRUE.
-            last_jatom = jatom
-         ELSE
-            new_atom_b = .FALSE.
-         END IF
-
-         IF (new_atom_b) THEN
-            IF (iatom <= jatom) THEN
-               irow = iatom
-               icol = jatom
-            ELSE
-               irow = jatom
-               icol = iatom
-            END IF
-
-            DO i = 1, dim_op
-               NULLIFY (op_cos(i)%block)
-               CALL dbcsr_get_block_p(matrix=op_sm_set(1, i)%matrix, &
-                                      row=irow, col=icol, block=op_cos(i)%block, found=found)
-               NULLIFY (op_sin(i)%block)
-               CALL dbcsr_get_block_p(matrix=op_sm_set(2, i)%matrix, &
-                                      row=irow, col=icol, block=op_sin(i)%block, found=found)
-            END DO
-         END IF ! new_atom_b
-
-         rab2 = rab(1)*rab(1) + rab(2)*rab(2) + rab(3)*rab(3)
-         dab = SQRT(rab2)
-
-         nrow = 0
-         DO iset = 1, nseta
-
-            ncoa = npgfa(iset)*ncoset(la_max(iset))
-            sgfa = first_sgfa(1, iset)
-
-            DO jset = 1, nsetb
-
-               ncob = npgfb(jset)*ncoset(lb_max(jset))
-               sgfb = first_sgfb(1, jset)
-
-               IF (set_radius_a(iset) + set_radius_b(jset) >= dab) THEN
-
-!           *** Calculate the primitive overlap integrals ***
-                  DO i = 1, dim_op
-                     kvec(1:3) = vector_k(1:3, i)
-                     cosab = 0.0_dp
-                     sinab = 0.0_dp
-                     CALL cossin(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), &
-                                 la_min(iset), lb_max(jset), npgfb(jset), zetb(:, jset), &
-                                 rpgfb(:, jset), lb_min(jset), &
-                                 ra, rb, kvec, cosab, sinab)
-                     CALL contract_cossin(op_cos(i)%block, op_sin(i)%block, &
-                                          iatom, ncoa, nsgfa(iset), sgfa, sphi_a, ldsa, &
-                                          jatom, ncob, nsgfb(jset), sgfb, sphi_b, ldsb, &
-                                          cosab, sinab, ldab, work, ldwork)
-                  END DO
-
-               END IF !  >= dab
-
-            END DO ! jset
-
-            nrow = nrow + ncoa
-
-         END DO ! iset
-
-      END DO
-      CALL neighbor_list_iterator_release(nl_iterator)
-
-      ! Set back the correct periodicity
-      cell%perd(1:3) = perd0(1:3)
-
-      DO i = 1, dim_op
-         NULLIFY (op_cos(i)%block)
-         NULLIFY (op_sin(i)%block)
-      END DO
-      DEALLOCATE (op_cos, op_sin)
-
-      DEALLOCATE (cosab, sinab, work, basis_set_list)
+      CALL build_exp_ikr_matrix(qs_env, op_sm_set, vector_k(:, 1:dim_op), &
+                                force_periodic=.TRUE., cell_external=cell)
 
       CALL timestop(handle)
+
    END SUBROUTINE compute_berry_operator
 
 ! **************************************************************************************************
@@ -1745,4 +1550,3 @@ CONTAINS
    END SUBROUTINE set_loc_wfn_lists
 
 END MODULE qs_loc_utils
-

--- a/src/qs_loc_utils.F
+++ b/src/qs_loc_utils.F
@@ -17,7 +17,6 @@ MODULE qs_loc_utils
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_api,                    ONLY: dbcsr_copy,&
                                               dbcsr_p_type,&
-                                              dbcsr_set,&
                                               dbcsr_type
    USE cp_dbcsr_operations,             ONLY: cp_dbcsr_sm_fm_multiply
    USE cp_files,                        ONLY: close_file,&
@@ -396,7 +395,6 @@ CONTAINS
                   ALLOCATE (qs_loc_env%op_sm_set(j, i)%matrix)
                   CALL dbcsr_copy(qs_loc_env%op_sm_set(j, i)%matrix, matrix_s(1)%matrix, &
                                   name="qs_loc_env%op_sm_"//TRIM(ADJUSTL(cp_to_string(j)))//"-"//TRIM(ADJUSTL(cp_to_string(i))))
-                  CALL dbcsr_set(qs_loc_env%op_sm_set(j, i)%matrix, 0.0_dp)
                END DO
             END DO
 

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -107,7 +107,8 @@ MODULE qs_moments
                                      neighbor_list_iterator_p_type, &
                                      neighbor_list_iterator_release, &
                                      neighbor_list_set_p_type
-   USE qs_operators_ao, ONLY: build_lin_mom_matrix
+   USE qs_operators_ao, ONLY: build_exp_ikr_matrix, &
+                              build_lin_mom_matrix
    USE qs_overlap, ONLY: build_overlap_matrix
    USE qs_rho_types, ONLY: qs_rho_get, &
                            qs_rho_type
@@ -1367,149 +1368,18 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_berry_moment_matrix'
 
-      INTEGER :: handle, iatom, icol, ikind, inode, irow, iset, jatom, jkind, jset, ldab, ldsa, &
-                 ldsb, ldwork, natom, ncoa, ncob, nkind, nseta, nsetb, sgfa, sgfb
-      LOGICAL                                            :: found
-      REAL(dp), DIMENSION(:, :), POINTER                 :: cblock, cosab, sblock, sinab, work
-      REAL(KIND=dp)                                      :: dab
-      REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rb
-      TYPE(cell_type), POINTER                           :: cell
-      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set_list
-      TYPE(gto_basis_set_type), POINTER                  :: basis_set_a, basis_set_b
-      TYPE(neighbor_list_iterator_p_type), &
-         DIMENSION(:), POINTER                           :: nl_iterator
-      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
-         POINTER                                         :: sab_orb
-      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
-      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
-      TYPE(qs_kind_type), POINTER                        :: qs_kind
+      INTEGER                                            :: handle
+      TYPE(dbcsr_p_type), DIMENSION(2, 1)                :: op_sm_set
+      REAL(KIND=dp), DIMENSION(3, 1)                     :: kvec_batch
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (qs_kind_set, particle_set, sab_orb, cell)
-      CALL get_qs_env(qs_env=qs_env, &
-                      qs_kind_set=qs_kind_set, &
-                      particle_set=particle_set, cell=cell, &
-                      sab_orb=sab_orb)
+      op_sm_set(1, 1)%matrix => cosmat
+      op_sm_set(2, 1)%matrix => sinmat
+      kvec_batch(:, 1) = kvec(:)
 
-      IF (PRESENT(sab_orb_external)) sab_orb => sab_orb_external
-
-      CALL dbcsr_set(sinmat, 0.0_dp)
-      CALL dbcsr_set(cosmat, 0.0_dp)
-
-      CALL get_qs_kind_set(qs_kind_set=qs_kind_set, maxco=ldwork, basis_type=basis_type)
-      ldab = ldwork
-      ALLOCATE (cosab(ldab, ldab))
-      ALLOCATE (sinab(ldab, ldab))
-      ALLOCATE (work(ldwork, ldwork))
-
-      nkind = SIZE(qs_kind_set)
-      natom = SIZE(particle_set)
-
-      ALLOCATE (basis_set_list(nkind))
-      DO ikind = 1, nkind
-         qs_kind => qs_kind_set(ikind)
-         CALL get_qs_kind(qs_kind=qs_kind, basis_set=basis_set_a, basis_type=basis_type)
-         IF (ASSOCIATED(basis_set_a)) THEN
-            basis_set_list(ikind)%gto_basis_set => basis_set_a
-         ELSE
-            NULLIFY (basis_set_list(ikind)%gto_basis_set)
-         END IF
-      END DO
-      CALL neighbor_list_iterator_create(nl_iterator, sab_orb)
-      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
-         CALL get_iterator_info(nl_iterator, ikind=ikind, jkind=jkind, inode=inode, &
-                                iatom=iatom, jatom=jatom, r=rab)
-         basis_set_a => basis_set_list(ikind)%gto_basis_set
-         IF (.NOT. ASSOCIATED(basis_set_a)) CYCLE
-         basis_set_b => basis_set_list(jkind)%gto_basis_set
-         IF (.NOT. ASSOCIATED(basis_set_b)) CYCLE
-         ASSOCIATE ( &
-            ! basis ikind
-            first_sgfa => basis_set_a%first_sgf, &
-            la_max => basis_set_a%lmax, &
-            la_min => basis_set_a%lmin, &
-            npgfa => basis_set_a%npgf, &
-            nsgfa => basis_set_a%nsgf_set, &
-            rpgfa => basis_set_a%pgf_radius, &
-            set_radius_a => basis_set_a%set_radius, &
-            sphi_a => basis_set_a%sphi, &
-            zeta => basis_set_a%zet, &
-            ! basis jkind, &
-            first_sgfb => basis_set_b%first_sgf, &
-            lb_max => basis_set_b%lmax, &
-            lb_min => basis_set_b%lmin, &
-            npgfb => basis_set_b%npgf, &
-            nsgfb => basis_set_b%nsgf_set, &
-            rpgfb => basis_set_b%pgf_radius, &
-            set_radius_b => basis_set_b%set_radius, &
-            sphi_b => basis_set_b%sphi, &
-            zetb => basis_set_b%zet)
-
-            nseta = basis_set_a%nset
-            nsetb = basis_set_b%nset
-
-            ldsa = SIZE(sphi_a, 1)
-            ldsb = SIZE(sphi_b, 1)
-
-            IF (iatom <= jatom) THEN
-               irow = iatom
-               icol = jatom
-            ELSE
-               irow = jatom
-               icol = iatom
-            END IF
-
-            NULLIFY (cblock)
-            CALL dbcsr_get_block_p(matrix=cosmat, &
-                                   row=irow, col=icol, BLOCK=cblock, found=found)
-            NULLIFY (sblock)
-            CALL dbcsr_get_block_p(matrix=sinmat, &
-                                   row=irow, col=icol, BLOCK=sblock, found=found)
-            IF (ASSOCIATED(cblock) .AND. .NOT. ASSOCIATED(sblock) .OR. &
-                .NOT. ASSOCIATED(cblock) .AND. ASSOCIATED(sblock)) THEN
-               CPABORT("cblock and sblock should both be present for contract_cossin")
-            END IF
-
-            IF (ASSOCIATED(cblock) .AND. ASSOCIATED(sblock)) THEN
-
-               ra(:) = pbc(particle_set(iatom)%r(:), cell)
-               rb(:) = ra + rab
-               dab = SQRT(rab(1)*rab(1) + rab(2)*rab(2) + rab(3)*rab(3))
-
-               DO iset = 1, nseta
-
-                  ncoa = npgfa(iset)*ncoset(la_max(iset))
-                  sgfa = first_sgfa(1, iset)
-
-                  DO jset = 1, nsetb
-
-                     IF (set_radius_a(iset) + set_radius_b(jset) < dab) CYCLE
-
-                     ncob = npgfb(jset)*ncoset(lb_max(jset))
-                     sgfb = first_sgfb(1, jset)
-
-                     ! Calculate the primitive integrals
-                     CALL cossin(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), la_min(iset), &
-                                 lb_max(jset), npgfb(jset), zetb(:, jset), rpgfb(:, jset), lb_min(jset), &
-                                 ra, rb, kvec, cosab, sinab)
-                     CALL contract_cossin(cblock, sblock, &
-                                          iatom, ncoa, nsgfa(iset), sgfa, sphi_a, ldsa, &
-                                          jatom, ncob, nsgfb(jset), sgfb, sphi_b, ldsb, &
-                                          cosab, sinab, ldab, work, ldwork)
-
-                  END DO
-               END DO
-
-            END IF
-         END ASSOCIATE
-      END DO
-      CALL neighbor_list_iterator_release(nl_iterator)
-
-      DEALLOCATE (cosab)
-      DEALLOCATE (sinab)
-      DEALLOCATE (work)
-      DEALLOCATE (basis_set_list)
+      CALL build_exp_ikr_matrix(qs_env, op_sm_set, kvec_batch, &
+                                sab_orb_external=sab_orb_external, basis_type=basis_type)
 
       CALL timestop(handle)
 

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -1690,8 +1690,6 @@ CONTAINS
       ALLOCATE (cosmat, sinmat)
       CALL dbcsr_copy(cosmat, matrix_s(1)%matrix, 'COS MOM')
       CALL dbcsr_copy(sinmat, matrix_s(1)%matrix, 'SIN MOM')
-      CALL dbcsr_set(cosmat, 0.0_dp)
-      CALL dbcsr_set(sinmat, 0.0_dp)
 
       ALLOCATE (op_fm_set(2, dft_control%nspins))
       ALLOCATE (opvec(dft_control%nspins))

--- a/src/qs_operators_ao.F
+++ b/src/qs_operators_ao.F
@@ -12,7 +12,9 @@
 ! **************************************************************************************************
 MODULE qs_operators_ao
    USE ai_angmom,                       ONLY: angmom
-   USE ai_moments,                      ONLY: diff_momop,&
+   USE ai_moments,                      ONLY: contract_cossin,&
+                                              cossin,&
+                                              diff_momop,&
                                               moment
    USE ai_overlap,                      ONLY: overlap_ab
    USE basis_set_types,                 ONLY: gto_basis_set_p_type,&
@@ -24,6 +26,7 @@ MODULE qs_operators_ao
                                               dbcsr_get_matrix_type,&
                                               dbcsr_has_symmetry,&
                                               dbcsr_p_type,&
+                                              dbcsr_set,&
                                               dbcsr_type_antisymmetric,&
                                               dbcsr_type_no_symmetry
    USE kinds,                           ONLY: default_string_length,&
@@ -51,10 +54,217 @@ MODULE qs_operators_ao
 
 ! *** Public subroutines ***
 
+   PUBLIC :: build_exp_ikr_matrix
    PUBLIC :: rRc_xyz_ao, rRc_xyz_der_ao
    PUBLIC :: build_lin_mom_matrix, build_ang_mom_matrix
 
 CONTAINS
+
+! **************************************************************************************************
+!> \brief Build real and imaginary AO matrices for exp(i*k*r).
+!> \param qs_env ...
+!> \param op_sm_set op_sm_set(1, i) is the cosine matrix and op_sm_set(2, i) is the sine matrix
+!>        for kvec(:, i)
+!> \param kvec Cartesian wave vectors, one column for each output matrix pair
+!> \param sab_orb_external optional neighbor list used instead of the default orbital list
+!> \param basis_type optional basis-set name
+!> \param force_periodic temporarily use all three periodic directions
+!> \param cell_external optional cell used for coordinate folding and periodicity
+!> \author CP2K developers
+!> \note The cosine and sine matrices must be preallocated with matching symmetric
+!>       DBCSR topology. The matrices are overwritten from zero and only canonical
+!>       atom-pair blocks are written.
+! **************************************************************************************************
+   SUBROUTINE build_exp_ikr_matrix(qs_env, op_sm_set, kvec, sab_orb_external, basis_type, force_periodic, cell_external)
+
+      TYPE(qs_environment_type), POINTER                 :: qs_env
+      TYPE(dbcsr_p_type), DIMENSION(:, :)                :: op_sm_set
+      REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: kvec
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         OPTIONAL, POINTER                               :: sab_orb_external
+      CHARACTER(LEN=*), OPTIONAL                         :: basis_type
+      LOGICAL, OPTIONAL                                  :: force_periodic
+      TYPE(cell_type), OPTIONAL, POINTER                 :: cell_external
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'build_exp_ikr_matrix'
+
+      INTEGER :: handle, i, iatom, icol, ikind, inode, irow, iset, jatom, jkind, jset, last_jatom, &
+         ldsa, ldsb, ldwork, ncoa, ncob, nkind, nkvec, nseta, nsetb, reim, sgfa, sgfb
+      INTEGER, DIMENSION(3)                              :: perd0
+      INTEGER, DIMENSION(:), POINTER                     :: la_max, la_min, lb_max, lb_min, npgfa, &
+                                                            npgfb, nsgfa, nsgfb
+      INTEGER, DIMENSION(:, :), POINTER                  :: first_sgfa, first_sgfb
+      LOGICAL                                            :: found, my_force_periodic, new_atom_b
+      REAL(KIND=dp)                                      :: dab
+      REAL(KIND=dp), DIMENSION(3)                        :: ra, rab, rb
+      REAL(KIND=dp), DIMENSION(:), POINTER               :: set_radius_a, set_radius_b
+      REAL(KIND=dp), DIMENSION(:, :), POINTER            :: cosab, rpgfa, rpgfb, sinab, sphi_a, &
+                                                            sphi_b, work, zeta, zetb
+      TYPE(block_p_type), ALLOCATABLE, DIMENSION(:, :)   :: op_cossin
+      TYPE(cell_type), POINTER                           :: cell
+      TYPE(gto_basis_set_p_type), DIMENSION(:), POINTER  :: basis_set_list
+      TYPE(gto_basis_set_type), POINTER                  :: basis_set_a, basis_set_b
+      TYPE(neighbor_list_iterator_p_type), &
+         DIMENSION(:), POINTER                           :: nl_iterator
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_orb
+      TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
+      TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
+      TYPE(qs_kind_type), POINTER                        :: qs_kind
+
+      CALL timeset(routineN, handle)
+
+      CPASSERT(SIZE(kvec, 1) == 3)
+      nkvec = SIZE(kvec, 2)
+      CPASSERT(nkvec > 0)
+      CPASSERT(SIZE(op_sm_set, 1) == 2)
+      CPASSERT(SIZE(op_sm_set, 2) == nkvec)
+      DO i = 1, nkvec
+         DO reim = 1, 2
+            CPASSERT(ASSOCIATED(op_sm_set(reim, i)%matrix))
+            CPASSERT(dbcsr_has_symmetry(op_sm_set(reim, i)%matrix))
+            CALL dbcsr_set(op_sm_set(reim, i)%matrix, 0.0_dp)
+         END DO
+      END DO
+
+      NULLIFY (qs_kind, qs_kind_set, particle_set, sab_orb, cell)
+      CALL get_qs_env(qs_env=qs_env, qs_kind_set=qs_kind_set, &
+                      particle_set=particle_set, cell=cell, sab_orb=sab_orb)
+      CPASSERT(ASSOCIATED(cell))
+      CPASSERT(ASSOCIATED(qs_kind_set))
+      CPASSERT(ASSOCIATED(particle_set))
+      IF (PRESENT(cell_external)) THEN
+         CPASSERT(ASSOCIATED(cell_external))
+         cell => cell_external
+      END IF
+
+      IF (PRESENT(sab_orb_external)) THEN
+         CPASSERT(ASSOCIATED(sab_orb_external))
+         sab_orb => sab_orb_external
+      END IF
+      CPASSERT(ASSOCIATED(sab_orb))
+
+      my_force_periodic = .FALSE.
+      IF (PRESENT(force_periodic)) my_force_periodic = force_periodic
+      IF (my_force_periodic) THEN
+         perd0(:) = cell%perd(:)
+         cell%perd(:) = 1
+      END IF
+
+      nkind = SIZE(qs_kind_set)
+      CALL get_qs_kind_set(qs_kind_set=qs_kind_set, maxco=ldwork, basis_type=basis_type)
+      ALLOCATE (cosab(ldwork, ldwork), sinab(ldwork, ldwork), work(ldwork, ldwork))
+
+      ALLOCATE (op_cossin(2, nkvec))
+
+      ALLOCATE (basis_set_list(nkind))
+      DO ikind = 1, nkind
+         qs_kind => qs_kind_set(ikind)
+         CALL get_qs_kind(qs_kind=qs_kind, basis_set=basis_set_a, basis_type=basis_type)
+         IF (ASSOCIATED(basis_set_a)) THEN
+            basis_set_list(ikind)%gto_basis_set => basis_set_a
+         ELSE
+            NULLIFY (basis_set_list(ikind)%gto_basis_set)
+         END IF
+      END DO
+
+      last_jatom = 0
+      CALL neighbor_list_iterator_create(nl_iterator, sab_orb)
+      DO WHILE (neighbor_list_iterate(nl_iterator) == 0)
+         CALL get_iterator_info(nl_iterator, ikind=ikind, jkind=jkind, inode=inode, &
+                                iatom=iatom, jatom=jatom, r=rab)
+         basis_set_a => basis_set_list(ikind)%gto_basis_set
+         IF (.NOT. ASSOCIATED(basis_set_a)) CYCLE
+         basis_set_b => basis_set_list(jkind)%gto_basis_set
+         IF (.NOT. ASSOCIATED(basis_set_b)) CYCLE
+
+         ra(:) = pbc(particle_set(iatom)%r(:), cell)
+         rb(:) = ra(:) + rab(:)
+
+         first_sgfa => basis_set_a%first_sgf
+         la_max => basis_set_a%lmax
+         la_min => basis_set_a%lmin
+         npgfa => basis_set_a%npgf
+         nsgfa => basis_set_a%nsgf_set
+         rpgfa => basis_set_a%pgf_radius
+         set_radius_a => basis_set_a%set_radius
+         sphi_a => basis_set_a%sphi
+         zeta => basis_set_a%zet
+
+         first_sgfb => basis_set_b%first_sgf
+         lb_max => basis_set_b%lmax
+         lb_min => basis_set_b%lmin
+         npgfb => basis_set_b%npgf
+         nsgfb => basis_set_b%nsgf_set
+         rpgfb => basis_set_b%pgf_radius
+         set_radius_b => basis_set_b%set_radius
+         sphi_b => basis_set_b%sphi
+         zetb => basis_set_b%zet
+
+         nseta = basis_set_a%nset
+         nsetb = basis_set_b%nset
+         ldsa = SIZE(sphi_a, 1)
+         ldsb = SIZE(sphi_b, 1)
+         IF (inode == 1) last_jatom = 0
+
+         IF (jatom /= last_jatom) THEN
+            new_atom_b = .TRUE.
+            last_jatom = jatom
+         ELSE
+            new_atom_b = .FALSE.
+         END IF
+
+         IF (new_atom_b) THEN
+            IF (iatom <= jatom) THEN
+               irow = iatom
+               icol = jatom
+            ELSE
+               irow = jatom
+               icol = iatom
+            END IF
+
+            DO i = 1, nkvec
+               DO reim = 1, 2
+                  NULLIFY (op_cossin(reim, i)%block)
+                  CALL dbcsr_get_block_p(matrix=op_sm_set(reim, i)%matrix, &
+                                         row=irow, col=icol, block=op_cossin(reim, i)%block, found=found)
+               END DO
+               IF (ASSOCIATED(op_cossin(1, i)%block) .NEQV. ASSOCIATED(op_cossin(2, i)%block)) THEN
+                  CPABORT("cosine and sine blocks should have the same topology")
+               END IF
+            END DO
+         END IF
+
+         dab = SQRT(SUM(rab**2))
+         DO iset = 1, nseta
+            ncoa = npgfa(iset)*ncoset(la_max(iset))
+            sgfa = first_sgfa(1, iset)
+            DO jset = 1, nsetb
+               IF (set_radius_a(iset) + set_radius_b(jset) < dab) CYCLE
+               ncob = npgfb(jset)*ncoset(lb_max(jset))
+               sgfb = first_sgfb(1, jset)
+
+               DO i = 1, nkvec
+                  IF (.NOT. ASSOCIATED(op_cossin(1, i)%block)) CYCLE
+                  CALL cossin(la_max(iset), npgfa(iset), zeta(:, iset), rpgfa(:, iset), &
+                              la_min(iset), lb_max(jset), npgfb(jset), zetb(:, jset), &
+                              rpgfb(:, jset), lb_min(jset), ra, rb, kvec(:, i), cosab, sinab)
+                  CALL contract_cossin(op_cossin(1, i)%block, op_cossin(2, i)%block, &
+                                       iatom, ncoa, nsgfa(iset), sgfa, sphi_a, ldsa, &
+                                       jatom, ncob, nsgfb(jset), sgfb, sphi_b, ldsb, &
+                                       cosab, sinab, ldwork, work, ldwork)
+               END DO
+            END DO
+         END DO
+      END DO
+      CALL neighbor_list_iterator_release(nl_iterator)
+
+      DEALLOCATE (op_cossin, cosab, sinab, work, basis_set_list)
+
+      IF (my_force_periodic) cell%perd(:) = perd0(:)
+
+      CALL timestop(handle)
+   END SUBROUTINE build_exp_ikr_matrix
 
 ! **************************************************************************************************
 !> \brief   Calculation of the linear momentum matrix <mu|∂|nu> over

--- a/src/qs_operators_ao.F
+++ b/src/qs_operators_ao.F
@@ -235,7 +235,7 @@ CONTAINS
             END DO
          END IF
 
-         dab = SQRT(SUM(rab**2))
+         dab = NORM2(rab)
          DO iset = 1, nseta
             ncoa = npgfa(iset)*ncoset(la_max(iset))
             sgfa = first_sgfa(1, iset)

--- a/src/qs_tddfpt2_properties.F
+++ b/src/qs_tddfpt2_properties.F
@@ -27,7 +27,7 @@ MODULE qs_tddfpt2_properties
    USE cp_dbcsr_api,                    ONLY: &
         dbcsr_copy, dbcsr_get_block_p, dbcsr_get_info, dbcsr_init_p, dbcsr_iterator_blocks_left, &
         dbcsr_iterator_next_block, dbcsr_iterator_start, dbcsr_iterator_stop, dbcsr_iterator_type, &
-        dbcsr_p_type, dbcsr_set, dbcsr_type
+        dbcsr_p_type, dbcsr_type
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm,&
                                               copy_fm_to_dbcsr,&
                                               cp_dbcsr_sm_fm_multiply,&
@@ -286,9 +286,6 @@ CONTAINS
 
          DO ideriv = 1, nderivs
             kvec(:) = twopi*cell%h_inv(ideriv, :)
-            DO i_cos_sin = 1, 2
-               CALL dbcsr_set(berry_cossin_xyz(i_cos_sin)%matrix, 0.0_dp)
-            END DO
             CALL build_berry_moment_matrix(qs_env, berry_cossin_xyz(1)%matrix, &
                                            berry_cossin_xyz(2)%matrix, kvec)
 

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -2920,8 +2920,6 @@ CONTAINS
                            matrix_type=dbcsr_type_no_symmetry)
          CALL dbcsr_copy(cosmat, matrix_s(1)%matrix)
          CALL dbcsr_copy(sinmat, matrix_s(1)%matrix)
-         CALL dbcsr_set(cosmat, 0.0_dp)
-         CALL dbcsr_set(sinmat, 0.0_dp)
 
          CALL dbcsr_allocate_matrix_set(matrix_berry_re_mo_mo, nkp)
          CALL dbcsr_allocate_matrix_set(matrix_berry_im_mo_mo, nkp)
@@ -3109,8 +3107,6 @@ CONTAINS
                            matrix_type=dbcsr_type_no_symmetry)
          CALL dbcsr_copy(cosmat, matrix_s_aux_aux(1)%matrix)
          CALL dbcsr_copy(sinmat, matrix_s_aux_aux(1)%matrix)
-         CALL dbcsr_set(cosmat, 0.0_dp)
-         CALL dbcsr_set(sinmat, 0.0_dp)
 
          CALL dbcsr_allocate_matrix_set(matrix_berry_re_mo_mo, nkp)
          CALL dbcsr_allocate_matrix_set(matrix_berry_im_mo_mo, nkp)


### PR DESCRIPTION
This PR adds a shared AO matrix builder `qs_operators_ao::build_exp_ikr_matrix` for the Berry exponential operators. It also cleans up the `qs_moments::build_berry_moment_matrix` and `qs_loc_utils::compute_berry_operator` APIs by moving their common AO assembly into the shared builder.