### PR TITLE
Revert "LS_SCF: Guard dense submatrix linear algebra on macOS"

### DIFF
--- a/src/cp2k_info.F
+++ b/src/cp2k_info.F
@@ -100,10 +100,6 @@ CONTAINS
 
 !$    flags = TRIM(flags)//" omp"
 
-#if defined(__MACOSX)
-      flags = TRIM(flags)//" macos"
-#endif
-
       ! TODO: remove __INTEL_LLVM_COMPILER conditions (regtests)
 #if defined(__INTEL_LLVM_COMPILER)
       flags = TRIM(flags)//" ifx"

--- a/src/iterate_matrix.F
+++ b/src/iterate_matrix.F
@@ -1209,44 +1209,34 @@ CONTAINS
       INTEGER                                            :: info, liwork, lwork
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: iwork
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: work
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: tmp
 
-      ALLOCATE (eigvecs(N, N))
+      ALLOCATE (eigvecs(N, N), tmp(N, N))
       ALLOCATE (eigvals(N))
 
       ! symmetrize sm
       eigvecs(:, :) = 0.5*(sm + TRANSPOSE(sm))
 
-      ! Probe optimal sizes for WORK and IWORK. On macOS, BLAS/LAPACK libraries
-      ! using a different OpenMP runtime can fail when entered concurrently.
+      ! probe optimal sizes for WORK and IWORK
       LWORK = -1
       LIWORK = -1
       ALLOCATE (WORK(1))
       ALLOCATE (IWORK(1))
-#if defined(__MACOSX)
-      !$OMP CRITICAL (submatrix_dense_linalg)
-#endif
       CALL dsyevd('V', 'U', N, eigvecs, N, eigvals, WORK, LWORK, IWORK, LIWORK, INFO)
-#if defined(__MACOSX)
-      !$OMP END CRITICAL (submatrix_dense_linalg)
-#endif
       LWORK = INT(WORK(1))
       LIWORK = INT(IWORK(1))
       DEALLOCATE (IWORK)
       DEALLOCATE (WORK)
 
-      ! Calculate eigenvalues and eigenvectors.
+      ! calculate eigenvalues and eigenvectors
       ALLOCATE (WORK(LWORK))
       ALLOCATE (IWORK(LIWORK))
-#if defined(__MACOSX)
-      !$OMP CRITICAL (submatrix_dense_linalg)
-#endif
       CALL dsyevd('V', 'U', N, eigvecs, N, eigvals, WORK, LWORK, IWORK, LIWORK, INFO)
-#if defined(__MACOSX)
-      !$OMP END CRITICAL (submatrix_dense_linalg)
-#endif
       DEALLOCATE (IWORK)
       DEALLOCATE (WORK)
       IF (INFO /= 0) CPABORT("dsyevd did not succeed")
+
+      DEALLOCATE (tmp)
    END SUBROUTINE eigdecomp
 
 ! **************************************************************************************************
@@ -1283,14 +1273,8 @@ CONTAINS
 
       ! Create matrix with eigenvalues in {-1,0,1} and eigenvectors of sm:
       ! sm_sign = eigvecs * sm_sign * eigvecs.T
-#if defined(__MACOSX)
-      !$OMP CRITICAL (submatrix_dense_linalg)
-#endif
       CALL dgemm('N', 'N', N, N, N, 1.0_dp, eigvecs, N, sm_sign, N, 0.0_dp, tmp, N)
       CALL dgemm('N', 'T', N, N, N, 1.0_dp, tmp, N, eigvecs, N, 0.0_dp, sm_sign, N)
-#if defined(__MACOSX)
-      !$OMP END CRITICAL (submatrix_dense_linalg)
-#endif
    END SUBROUTINE sign_from_eigdecomp
 
 ! **************************************************************************************************
@@ -1594,7 +1578,7 @@ CONTAINS
       IF ((variant == ls_scf_submatrix_sign_direct_muadj_lowmem) .AND. (mu /= new_mu)) THEN
          !$OMP PARALLEL DEFAULT(OMP_DEFAULT_NONE_WITH_OOP) &
          !$OMP          PRIVATE(sm, sm_sign, sm_size, sm_firstcol, sm_lastcol, j) &
-         !$OMP          SHARED(dissection, myrank, my_sms, unit_nr, mu, new_mu)
+         !$OMP          SHARED(dissection, myrank, my_sms, unit_nr, eigbufs, mu, new_mu)
          !$OMP DO SCHEDULE(GUIDED)
          DO i = 1, SIZE(my_sms)
             WRITE (unit_nr, '(T3,A,1X,I4,1X,A,1X,I6)') "Rank", myrank, "reprocessing submatrix", my_sms(i)


### PR DESCRIPTION
# Revert "LS_SCF: Guard dense submatrix linear algebra on macOS"

## Summary

This PR reverts #5922 in full.

#5922 added macOS-specific OpenMP critical sections around selected dense
BLAS/LAPACK calls in the LS_SCF submatrix-sign path. The observed failure came
from a local toolchain mixing Homebrew components built against different
OpenMP runtimes and was not reproduced with the container used by the Apple M1
test.

Serializing two call sites cannot make mixed OpenMP runtimes safe and may hide
related failures elsewhere. CP2K should instead use an internally consistent,
supported toolchain. A general code change should only follow from a reproducer
with such a configuration.

The revert also removes the temporary `macos` build flag introduced by #5922
and restores the original LS_SCF OpenMP data-sharing clause and dense-linear-
algebra implementation.

## Validation

- `src/cp2k_info.F` and `src/iterate_matrix.F` are byte-identical to their
  versions immediately before #5922.
- No-cache precommit passes for both changed files.
- `git diff --check` passes.
- GCC 16 MPI/OpenMP Release build passes.
