### PR TITLE
QS: Shared assembly of complex k-point operators

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -644,6 +644,7 @@ list(
   qs_kernel_types.F
   qs_kind_types.F
   qs_kinetic.F
+  qs_kp_evp_methods.F
   qs_kpoint_state.F
   qs_kpp1_env_methods.F
   qs_kpp1_env_types.F

--- a/src/qs_kp_evp_methods.F
+++ b/src/qs_kp_evp_methods.F
@@ -6,10 +6,11 @@
 !--------------------------------------------------------------------------------------------------!
 
 ! **************************************************************************************************
-!> \brief Shared assembly of complex k-point operators: real-space DBCSR matrices to
-!>        a complex full matrix on the k-point group distribution.
-!>        The work is split so that bulk MPI collectives can be started for all operators
-!>        and finished later, as done by the STANDARD k-point driver.
+!> \brief Assembly of complex k-point operators from real-space DBCSR matrices.
+!>        The output is a complex full matrix on the distribution of the k-point group.
+!>        The module splits this work into a start step and a finish step.
+!>        One process can start the MPI transfers of many operators before it finishes
+!>        any of them. The STANDARD k-point driver uses this order.
 !> \author MI
 ! **************************************************************************************************
 MODULE qs_kp_evp_methods
@@ -50,26 +51,32 @@ MODULE qs_kp_evp_methods
 CONTAINS
 
 ! **************************************************************************************************
-!> \brief Transform one real-space operator to a k point and start its redistribution.
-!>        The real and imaginary parts are densified into fm_re and fm_im, and their
-!>        transfer to the k-point group distribution is started. Both transfers receive
-!>        into private buffers, so any number of starts may target the same fmlocal.
-!>        The results are collected with kp_evp_op_finish_cfm.
+!> \brief Transform one real-space operator to one k point and start the transfer of
+!>        the result to the k-point group.
+!>        The routine densifies the real part into fm_re and the imaginary part into
+!>        fm_im. Densify means: copy the blocks of a DBCSR matrix into a full matrix.
+!>        It then starts the transfer of both parts to the target matrix.
+!>        Each transfer receives its data in a private buffer. For this reason, several
+!>        starts can use the same target matrix.
+!>        Finish a start with kp_evp_op_finish_cfm when its target received data.
+!>        For target fmdummy, clean the start up with cp_fm_cleanup_copy_general and
+!>        do not finish it.
 !> \param rsmat real-space image matrices of the operator
 !> \param ispin spin component of rsmat (1 for spin-free matrices such as S)
 !> \param ik global k-point index
 !> \param xkp coordinates of this k point
 !> \param cell_to_index mapping of cell indices to real-space index
 !> \param sab_nl neighbor lists defining the real-space sparsity
-!> \param grid prepared reciprocal-grid cache, enables the FFT branch with use_grid
+!> \param grid prepared reciprocal-grid cache of the caller. Required when use_grid is set
 !> \param use_grid extract from grid instead of a direct phase sum
 !> \param rmatrix workspace holding the real part of the k-point matrix
 !> \param cmatrix workspace holding the imaginary part of the k-point matrix
 !> \param tmpmat unsymmetric DBCSR workspace
 !> \param fm_re full-matrix workspace of the global communicator holding the real part
 !> \param fm_im full-matrix workspace of the global communicator holding the imaginary part
-!> \param target_fm transfer target on the k-point group (fmlocal, or fmdummy to keep
-!>        collective calls balanced on groups one does not own)
+!> \param target_fm transfer target on the k-point group. Use fmlocal on the group
+!>        that owns this k point. Use fmdummy on the other groups. This keeps the
+!>        collective calls balanced.
 !> \param para_env communicator of source and target distributions
 !> \param info_re transfer state of the real part
 !> \param info_im transfer state of the imaginary part
@@ -118,7 +125,8 @@ CONTAINS
    END SUBROUTINE kp_evp_op_start
 
 ! **************************************************************************************************
-!> \brief Finish one transfer started by kp_evp_op_start and add it to a complex matrix.
+!> \brief Finish one transfer that kp_evp_op_start started and add the received
+!>        matrix to a complex matrix.
 !> \param fmlocal transfer target filled by the finished copy
 !> \param info transfer state of one part
 !> \param cmat complex matrix accumulating the operator
@@ -148,7 +156,7 @@ CONTAINS
 
    END SUBROUTINE kp_evp_op_finish_cfm
 
-!> \brief Split a complex matrix into the real and imaginary MO sets and keep the
+!> rief Split a complex matrix into the real and imaginary MO sets and keep the
 !>        eigenvalues of both spin-imaginary sets in sync.
 !> \param cmat complex MO coefficients
 !> \param mo_re real part MO set

--- a/src/qs_kp_evp_methods.F
+++ b/src/qs_kp_evp_methods.F
@@ -1,0 +1,181 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2026 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+
+! **************************************************************************************************
+!> \brief Shared assembly of complex k-point operators: real-space DBCSR matrices to
+!>        a complex full matrix on the k-point group distribution.
+!>        The work is split so that bulk MPI collectives can be started for all operators
+!>        and finished later, as done by the STANDARD k-point driver.
+!> \author MI
+! **************************************************************************************************
+MODULE qs_kp_evp_methods
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_scale_and_add_fm
+   USE cp_cfm_types,                    ONLY: cp_cfm_to_fm,&
+                                              cp_cfm_type
+   USE cp_dbcsr_api,                    ONLY: dbcsr_desymmetrize,&
+                                              dbcsr_p_type,&
+                                              dbcsr_set,&
+                                              dbcsr_type
+   USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm
+   USE cp_fm_types,                     ONLY: copy_info_type,&
+                                              cp_fm_cleanup_copy_general,&
+                                              cp_fm_finish_copy_general,&
+                                              cp_fm_start_copy_general,&
+                                              cp_fm_type
+   USE kinds,                           ONLY: dp
+   USE kpoint_methods,                  ONLY: rskp_grid_type,&
+                                              rskp_transform,&
+                                              rskp_transform_grid_extract
+   USE mathconstants,                   ONLY: gaussi,&
+                                              z_one,&
+                                              z_zero
+   USE message_passing,                 ONLY: mp_para_env_type
+   USE qs_mo_types,                     ONLY: get_mo_set,&
+                                              mo_set_type
+   USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
+#include "./base/base_uses.f90"
+
+   IMPLICIT NONE
+
+   PRIVATE
+
+   CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_kp_evp_methods'
+
+   PUBLIC :: kp_evp_op_start, kp_evp_op_finish_cfm, kp_evp_cfm_to_mo
+
+CONTAINS
+
+! **************************************************************************************************
+!> \brief Transform one real-space operator to a k point and start its redistribution.
+!>        The real and imaginary parts are densified into fmwork(1:2) and their transfer
+!>        to the k-point group distribution is started. Both transfers receive into
+!>        private buffers, so any number of starts may target the same fmlocal.
+!>        The results are collected with kp_evp_op_finish_cfm.
+!> \param rsmat real-space image matrices of the operator
+!> \param ispin spin component of rsmat (1 for spin-free matrices such as S)
+!> \param ik global k-point index
+!> \param xkp coordinates of this k point
+!> \param cell_to_index mapping of cell indices to real-space index
+!> \param sab_nl neighbor lists defining the real-space sparsity
+!> \param grid prepared reciprocal-grid cache, enables the FFT branch with use_grid
+!> \param use_grid extract from grid instead of a direct phase sum
+!> \param rmatrix workspace holding the real part of the k-point matrix
+!> \param cmatrix workspace holding the imaginary part of the k-point matrix
+!> \param tmpmat unsymmetric DBCSR workspace
+!> \param fmwork full-matrix workspaces on the global communicator, needs slots 1 and 2
+!> \param target_fm transfer target on the k-point group (fmlocal, or fmdummy to keep
+!>        collective calls balanced on groups one does not own)
+!> \param para_env communicator of source and target distributions
+!> \param info_re transfer state of the real part
+!> \param info_im transfer state of the imaginary part
+! **************************************************************************************************
+   SUBROUTINE kp_evp_op_start(rsmat, ispin, ik, xkp, cell_to_index, sab_nl, grid, use_grid, &
+                              rmatrix, cmatrix, tmpmat, fmwork, target_fm, para_env, info_re, info_im)
+
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rsmat
+      INTEGER, INTENT(IN)                                :: ispin, ik
+      REAL(KIND=dp), DIMENSION(3), INTENT(IN)            :: xkp
+      INTEGER, DIMENSION(:, :, :), POINTER               :: cell_to_index
+      TYPE(neighbor_list_set_p_type), DIMENSION(:), &
+         POINTER                                         :: sab_nl
+      TYPE(rskp_grid_type), INTENT(IN), OPTIONAL         :: grid
+      LOGICAL, INTENT(IN)                                :: use_grid
+      TYPE(dbcsr_type)                                   :: rmatrix, cmatrix, tmpmat
+      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fmwork
+      TYPE(cp_fm_type)                                   :: target_fm
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(copy_info_type)                               :: info_re, info_im
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'kp_evp_op_start'
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      IF (use_grid) THEN
+         CPASSERT(PRESENT(grid))
+         CALL rskp_transform_grid_extract(grid, ik, rmatrix, cmatrix)
+      ELSE
+         CALL dbcsr_set(rmatrix, 0.0_dp)
+         CALL dbcsr_set(cmatrix, 0.0_dp)
+         CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=rsmat, ispin=ispin, &
+                             xkp=xkp, cell_to_index=cell_to_index, sab_nl=sab_nl)
+      END IF
+      CALL dbcsr_desymmetrize(rmatrix, tmpmat)
+      CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
+      CALL dbcsr_desymmetrize(cmatrix, tmpmat)
+      CALL copy_dbcsr_to_fm(tmpmat, fmwork(2))
+
+      CALL cp_fm_start_copy_general(fmwork(1), target_fm, para_env, info_re)
+      CALL cp_fm_start_copy_general(fmwork(2), target_fm, para_env, info_im)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE kp_evp_op_start
+
+! **************************************************************************************************
+!> \brief Finish one transfer started by kp_evp_op_start and add it to a complex matrix.
+!> \param fmlocal transfer target filled by the finished copy
+!> \param info transfer state of one part
+!> \param cmat complex matrix accumulating the operator
+!> \param imaginary_part add fmlocal as the imaginary part instead of the real part
+! **************************************************************************************************
+   SUBROUTINE kp_evp_op_finish_cfm(fmlocal, info, cmat, imaginary_part)
+
+      TYPE(cp_fm_type)                                   :: fmlocal
+      TYPE(copy_info_type)                               :: info
+      TYPE(cp_cfm_type)                                  :: cmat
+      LOGICAL, INTENT(IN)                                :: imaginary_part
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'kp_evp_op_finish_cfm'
+
+      INTEGER                                            :: handle
+
+      CALL timeset(routineN, handle)
+
+      CALL cp_fm_finish_copy_general(fmlocal, info)
+      IF (imaginary_part) THEN
+         CALL cp_cfm_scale_and_add_fm(z_one, cmat, gaussi, fmlocal)
+      ELSE
+         CALL cp_cfm_scale_and_add_fm(z_zero, cmat, z_one, fmlocal)
+      END IF
+
+      CALL timestop(handle)
+
+   END SUBROUTINE kp_evp_op_finish_cfm
+
+! **************************************************************************************************
+!> \brief Split a complex matrix into the real and imaginary MO sets and keep the
+!>        eigenvalues of both spin-imaginary sets in sync.
+!> \param cmat complex MO coefficients
+!> \param mo_re real part MO set
+!> \param mo_im imaginary part MO set
+!> \param eigenvalues eigenvalues of mo_re, copied to mo_im
+! **************************************************************************************************
+   SUBROUTINE kp_evp_cfm_to_mo(cmat, mo_re, mo_im, eigenvalues)
+
+      TYPE(cp_cfm_type)                                  :: cmat
+      TYPE(mo_set_type)                                  :: mo_re, mo_im
+      REAL(KIND=dp), DIMENSION(:)                        :: eigenvalues
+
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'kp_evp_cfm_to_mo'
+
+      INTEGER                                            :: handle
+      TYPE(cp_fm_type), POINTER                          :: imos, rmos
+
+      CALL timeset(routineN, handle)
+
+      CALL get_mo_set(mo_re, mo_coeff=rmos)
+      CALL get_mo_set(mo_im, mo_coeff=imos)
+      mo_im%eigenvalues = eigenvalues
+      CALL cp_cfm_to_fm(cmat, rmos, imos)
+
+      CALL timestop(handle)
+
+   END SUBROUTINE kp_evp_cfm_to_mo
+
+END MODULE qs_kp_evp_methods

--- a/src/qs_kp_evp_methods.F
+++ b/src/qs_kp_evp_methods.F
@@ -51,9 +51,9 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief Transform one real-space operator to a k point and start its redistribution.
-!>        The real and imaginary parts are densified into fmwork(1:2) and their transfer
-!>        to the k-point group distribution is started. Both transfers receive into
-!>        private buffers, so any number of starts may target the same fmlocal.
+!>        The real and imaginary parts are densified into fm_re and fm_im, and their
+!>        transfer to the k-point group distribution is started. Both transfers receive
+!>        into private buffers, so any number of starts may target the same fmlocal.
 !>        The results are collected with kp_evp_op_finish_cfm.
 !> \param rsmat real-space image matrices of the operator
 !> \param ispin spin component of rsmat (1 for spin-free matrices such as S)
@@ -66,7 +66,8 @@ CONTAINS
 !> \param rmatrix workspace holding the real part of the k-point matrix
 !> \param cmatrix workspace holding the imaginary part of the k-point matrix
 !> \param tmpmat unsymmetric DBCSR workspace
-!> \param fmwork full-matrix workspaces on the global communicator, needs slots 1 and 2
+!> \param fm_re full-matrix workspace of the global communicator holding the real part
+!> \param fm_im full-matrix workspace of the global communicator holding the imaginary part
 !> \param target_fm transfer target on the k-point group (fmlocal, or fmdummy to keep
 !>        collective calls balanced on groups one does not own)
 !> \param para_env communicator of source and target distributions
@@ -74,7 +75,7 @@ CONTAINS
 !> \param info_im transfer state of the imaginary part
 ! **************************************************************************************************
    SUBROUTINE kp_evp_op_start(rsmat, ispin, ik, xkp, cell_to_index, sab_nl, grid, use_grid, &
-                              rmatrix, cmatrix, tmpmat, fmwork, target_fm, para_env, info_re, info_im)
+                              rmatrix, cmatrix, tmpmat, fm_re, fm_im, target_fm, para_env, info_re, info_im)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rsmat
       INTEGER, INTENT(IN)                                :: ispin, ik
@@ -85,8 +86,7 @@ CONTAINS
       TYPE(rskp_grid_type), INTENT(IN), OPTIONAL         :: grid
       LOGICAL, INTENT(IN)                                :: use_grid
       TYPE(dbcsr_type)                                   :: rmatrix, cmatrix, tmpmat
-      TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fmwork
-      TYPE(cp_fm_type)                                   :: target_fm
+      TYPE(cp_fm_type)                                   :: fm_re, fm_im, target_fm
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(copy_info_type)                               :: info_re, info_im
 
@@ -106,12 +106,12 @@ CONTAINS
                              xkp=xkp, cell_to_index=cell_to_index, sab_nl=sab_nl)
       END IF
       CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-      CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
+      CALL copy_dbcsr_to_fm(tmpmat, fm_re)
       CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-      CALL copy_dbcsr_to_fm(tmpmat, fmwork(2))
+      CALL copy_dbcsr_to_fm(tmpmat, fm_im)
 
-      CALL cp_fm_start_copy_general(fmwork(1), target_fm, para_env, info_re)
-      CALL cp_fm_start_copy_general(fmwork(2), target_fm, para_env, info_im)
+      CALL cp_fm_start_copy_general(fm_re, target_fm, para_env, info_re)
+      CALL cp_fm_start_copy_general(fm_im, target_fm, para_env, info_im)
 
       CALL timestop(handle)
 
@@ -148,7 +148,6 @@ CONTAINS
 
    END SUBROUTINE kp_evp_op_finish_cfm
 
-! **************************************************************************************************
 !> \brief Split a complex matrix into the real and imaginary MO sets and keep the
 !>        eigenvalues of both spin-imaginary sets in sync.
 !> \param cmat complex MO coefficients

--- a/src/qs_kp_evp_methods.F
+++ b/src/qs_kp_evp_methods.F
@@ -23,7 +23,6 @@ MODULE qs_kp_evp_methods
                                               dbcsr_type
    USE cp_dbcsr_operations,             ONLY: copy_dbcsr_to_fm
    USE cp_fm_types,                     ONLY: copy_info_type,&
-                                              cp_fm_cleanup_copy_general,&
                                               cp_fm_finish_copy_general,&
                                               cp_fm_start_copy_general,&
                                               cp_fm_type
@@ -171,8 +170,9 @@ CONTAINS
 
    END SUBROUTINE kp_evp_op_finish_cfm
 
-!> \brief Split a complex matrix into the real and imaginary MO sets and keep the
-!>        eigenvalues of both spin-imaginary sets in sync.
+! **************************************************************************************************
+!> \brief Split a complex matrix into the real and imaginary MO sets and copy
+!>        the eigenvalues to the imaginary set.
 !> \param cmat complex MO coefficients
 !> \param mo_re real part MO set
 !> \param mo_im imaginary part MO set

--- a/src/qs_kp_evp_methods.F
+++ b/src/qs_kp_evp_methods.F
@@ -59,7 +59,8 @@ CONTAINS
 !>        Each transfer receives its data in a private buffer. For this reason, several
 !>        starts can use the same target matrix.
 !>        Finish a start with kp_evp_op_finish_cfm when its target received data.
-!>        For target fmdummy, clean the start up with cp_fm_cleanup_copy_general and
+!>        On the groups that do not own this k point, my_kpgrp routes the transfer
+!>        to fmdummy; clean such a start up with cp_fm_cleanup_copy_general and
 !>        do not finish it.
 !> \param rsmat real-space image matrices of the operator
 !> \param ispin spin component of rsmat (1 for spin-free matrices such as S)
@@ -74,15 +75,17 @@ CONTAINS
 !> \param tmpmat unsymmetric DBCSR workspace
 !> \param fm_re full-matrix workspace of the global communicator holding the real part
 !> \param fm_im full-matrix workspace of the global communicator holding the imaginary part
-!> \param target_fm transfer target on the k-point group. Use fmlocal on the group
-!>        that owns this k point. Use fmdummy on the other groups. This keeps the
-!>        collective calls balanced.
+!> \param fmlocal transfer target on the group that owns this k point
+!> \param fmdummy transfer target on the other groups. This keeps the collective
+!>        calls balanced.
+!> \param my_kpgrp true when the calling group owns this k point
 !> \param para_env communicator that spans the source and the target distributions
 !> \param info_re transfer state of the real part
 !> \param info_im transfer state of the imaginary part
 ! **************************************************************************************************
    SUBROUTINE kp_evp_op_start(rsmat, ispin, ik, xkp, cell_to_index, sab_nl, grid, use_grid, &
-                              rmatrix, cmatrix, tmpmat, fm_re, fm_im, target_fm, para_env, info_re, info_im)
+                              rmatrix, cmatrix, tmpmat, fm_re, fm_im, fmlocal, fmdummy, my_kpgrp, &
+                              para_env, info_re, info_im)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: rsmat
       INTEGER, INTENT(IN)                                :: ispin, ik
@@ -93,7 +96,8 @@ CONTAINS
       TYPE(rskp_grid_type), INTENT(IN), OPTIONAL         :: grid
       LOGICAL, INTENT(IN)                                :: use_grid
       TYPE(dbcsr_type)                                   :: rmatrix, cmatrix, tmpmat
-      TYPE(cp_fm_type)                                   :: fm_re, fm_im, target_fm
+      TYPE(cp_fm_type)                                   :: fm_re, fm_im, fmlocal, fmdummy
+      LOGICAL, INTENT(IN)                                :: my_kpgrp
       TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(copy_info_type)                               :: info_re, info_im
 
@@ -117,8 +121,13 @@ CONTAINS
       CALL dbcsr_desymmetrize(cmatrix, tmpmat)
       CALL copy_dbcsr_to_fm(tmpmat, fm_im)
 
-      CALL cp_fm_start_copy_general(fm_re, target_fm, para_env, info_re)
-      CALL cp_fm_start_copy_general(fm_im, target_fm, para_env, info_im)
+      IF (my_kpgrp) THEN
+         CALL cp_fm_start_copy_general(fm_re, fmlocal, para_env, info_re)
+         CALL cp_fm_start_copy_general(fm_im, fmlocal, para_env, info_im)
+      ELSE
+         CALL cp_fm_start_copy_general(fm_re, fmdummy, para_env, info_re)
+         CALL cp_fm_start_copy_general(fm_im, fmdummy, para_env, info_im)
+      END IF
 
       CALL timestop(handle)
 

--- a/src/qs_kp_evp_methods.F
+++ b/src/qs_kp_evp_methods.F
@@ -69,15 +69,15 @@ CONTAINS
 !> \param sab_nl neighbor lists defining the real-space sparsity
 !> \param grid prepared reciprocal-grid cache of the caller. Required when use_grid is set
 !> \param use_grid extract from grid instead of a direct phase sum
-!> \param rmatrix workspace holding the real part of the k-point matrix
-!> \param cmatrix workspace holding the imaginary part of the k-point matrix
+!> \param rmatrix symmetric DBCSR workspace holding the real part of the k-point matrix
+!> \param cmatrix antisymmetric DBCSR workspace holding the imaginary part of the k-point matrix
 !> \param tmpmat unsymmetric DBCSR workspace
 !> \param fm_re full-matrix workspace of the global communicator holding the real part
 !> \param fm_im full-matrix workspace of the global communicator holding the imaginary part
 !> \param target_fm transfer target on the k-point group. Use fmlocal on the group
 !>        that owns this k point. Use fmdummy on the other groups. This keeps the
 !>        collective calls balanced.
-!> \param para_env communicator of source and target distributions
+!> \param para_env communicator that spans the source and the target distributions
 !> \param info_re transfer state of the real part
 !> \param info_im transfer state of the imaginary part
 ! **************************************************************************************************
@@ -127,6 +127,12 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief Finish one transfer that kp_evp_op_start started and add the received
 !>        matrix to a complex matrix.
+!>        The finish of the real part overwrites cmat.
+!>        The finish of the imaginary part adds to cmat.
+!>        Finish the real part first. A real-part finish after an imaginary-part
+!>        finish erases the imaginary contribution.
+!>        The routine consumes fmlocal before it returns, so the next finish can
+!>        reuse the same matrix.
 !> \param fmlocal transfer target filled by the finished copy
 !> \param info transfer state of one part
 !> \param cmat complex matrix accumulating the operator
@@ -156,7 +162,7 @@ CONTAINS
 
    END SUBROUTINE kp_evp_op_finish_cfm
 
-!> rief Split a complex matrix into the real and imaginary MO sets and keep the
+!> \brief Split a complex matrix into the real and imaginary MO sets and keep the
 !>        eigenvalues of both spin-imaginary sets in sync.
 !> \param cmat complex MO coefficients
 !> \param mo_re real part MO set

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -1052,21 +1052,13 @@ CONTAINS
                ELSE
                   ! complex wavefunctions: assemble KS and S and start their
                   ! transfer to the k-point group
-                  IF (my_kpgrp) THEN
-                     CALL kp_evp_op_start(effective_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                          ks_grid(ispin), use_grid_fft, rmatrix, cmatrix, tmpmat, &
-                                          fmwork(1), fmwork(2), fmlocal, para_env, info(indx, 1), info(indx, 2))
-                     CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, s_grid, &
-                                          use_grid_fft, rmatrix, cmatrix, tmpmat, fmwork(3), fmwork(4), &
-                                          fmlocal, para_env, info(indx, 3), info(indx, 4))
-                  ELSE
-                     CALL kp_evp_op_start(effective_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                          ks_grid(ispin), use_grid_fft, rmatrix, cmatrix, tmpmat, &
-                                          fmwork(1), fmwork(2), fmdummy, para_env, info(indx, 1), info(indx, 2))
-                     CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, s_grid, &
-                                          use_grid_fft, rmatrix, cmatrix, tmpmat, fmwork(3), fmwork(4), &
-                                          fmdummy, para_env, info(indx, 3), info(indx, 4))
-                  END IF
+                  CALL kp_evp_op_start(effective_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                       ks_grid(ispin), use_grid_fft, rmatrix, cmatrix, tmpmat, &
+                                       fmwork(1), fmwork(2), fmlocal, fmdummy, my_kpgrp, para_env, &
+                                       info(indx, 1), info(indx, 2))
+                  CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, s_grid, &
+                                       use_grid_fft, rmatrix, cmatrix, tmpmat, fmwork(3), fmwork(4), &
+                                       fmlocal, fmdummy, my_kpgrp, para_env, info(indx, 3), info(indx, 4))
                END IF
                IF (my_store_ot_kinetic) THEN
                   IF (use_real_wfn) THEN
@@ -1081,19 +1073,11 @@ CONTAINS
                         CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env, info(indx, 3))
                      END IF
                   ELSE
-                     IF (my_kpgrp) THEN
-                        CALL kp_evp_op_start(matrix_t, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                             use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
-                                             tmpmat=tmpmat, fm_re=fmwork(3), fm_im=fmwork(4), &
-                                             target_fm=fmlocal, para_env=para_env, &
-                                             info_re=info(indx, 5), info_im=info(indx, 6))
-                     ELSE
-                        CALL kp_evp_op_start(matrix_t, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                             use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
-                                             tmpmat=tmpmat, fm_re=fmwork(3), fm_im=fmwork(4), &
-                                             target_fm=fmdummy, para_env=para_env, &
-                                             info_re=info(indx, 5), info_im=info(indx, 6))
-                     END IF
+                     CALL kp_evp_op_start(matrix_t, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                          use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
+                                          tmpmat=tmpmat, fm_re=fmwork(3), fm_im=fmwork(4), &
+                                          fmlocal=fmlocal, fmdummy=fmdummy, my_kpgrp=my_kpgrp, &
+                                          para_env=para_env, info_re=info(indx, 5), info_im=info(indx, 6))
                   END IF
                END IF
             END DO
@@ -1183,20 +1167,14 @@ CONTAINS
                      DO igroup = 1, nkp_groups
                         ik = kp_dist(1, igroup) + ikp - 1
                         my_kpgrp = ik >= kp_range(1) .AND. ik <= kp_range(2)
+                        CALL kp_evp_op_start(adiis_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                             use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
+                                             tmpmat=tmpmat, fm_re=fmwork(1), fm_im=fmwork(2), &
+                                             fmlocal=fmlocal, fmdummy=fmdummy, my_kpgrp=my_kpgrp, &
+                                             para_env=para_env, info_re=blend_info(1), info_im=blend_info(2))
                         IF (my_kpgrp) THEN
-                           CALL kp_evp_op_start(adiis_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                                use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
-                                                tmpmat=tmpmat, fm_re=fmwork(1), fm_im=fmwork(2), &
-                                                target_fm=fmlocal, para_env=para_env, &
-                                                info_re=blend_info(1), info_im=blend_info(2))
                            CALL kp_evp_op_finish_cfm(fmlocal, blend_info(1), cwork, .FALSE.)
                            CALL kp_evp_op_finish_cfm(fmlocal, blend_info(2), cwork, .TRUE.)
-                        ELSE
-                           CALL kp_evp_op_start(adiis_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                                use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
-                                                tmpmat=tmpmat, fm_re=fmwork(1), fm_im=fmwork(2), &
-                                                target_fm=fmdummy, para_env=para_env, &
-                                                info_re=blend_info(1), info_im=blend_info(2))
                         END IF
                         CALL cp_fm_cleanup_copy_general(blend_info(1))
                         CALL cp_fm_cleanup_copy_general(blend_info(2))
@@ -1993,25 +1971,16 @@ CONTAINS
                ELSE
                   ! complex wavefunctions: assemble KS and S and start their
                   ! transfer to the k-point group
-                  IF (my_kpgrp) THEN
-                     CALL kp_evp_op_start(matrix_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                          use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
-                                          fm_re=fmwork(1), fm_im=fmwork(2), target_fm=fmlocal, &
-                                          para_env=para_env, info_re=info(indx, 1), info_im=info(indx, 2))
-                     CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                          use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
-                                          fm_re=fmwork(3), fm_im=fmwork(4), target_fm=fmlocal, &
-                                          para_env=para_env, info_re=info(indx, 3), info_im=info(indx, 4))
-                  ELSE
-                     CALL kp_evp_op_start(matrix_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                          use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
-                                          fm_re=fmwork(1), fm_im=fmwork(2), target_fm=fmdummy, &
-                                          para_env=para_env, info_re=info(indx, 1), info_im=info(indx, 2))
-                     CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                          use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
-                                          fm_re=fmwork(3), fm_im=fmwork(4), target_fm=fmdummy, &
-                                          para_env=para_env, info_re=info(indx, 3), info_im=info(indx, 4))
-                  END IF
+                  CALL kp_evp_op_start(matrix_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                       use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
+                                       fm_re=fmwork(1), fm_im=fmwork(2), fmlocal=fmlocal, fmdummy=fmdummy, &
+                                       my_kpgrp=my_kpgrp, para_env=para_env, &
+                                       info_re=info(indx, 1), info_im=info(indx, 2))
+                  CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                       use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
+                                       fm_re=fmwork(3), fm_im=fmwork(4), fmlocal=fmlocal, fmdummy=fmdummy, &
+                                       my_kpgrp=my_kpgrp, para_env=para_env, &
+                                       info_re=info(indx, 3), info_im=info(indx, 4))
                END IF
             END DO
          END DO
@@ -3934,17 +3903,11 @@ CONTAINS
             ELSE
                ! complex wavefunctions: assemble S and start its transfer
                ! to the k-point group
-               IF (my_kpgrp) THEN
-                  CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                       use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
-                                       fm_re=fmwork(1), fm_im=fmwork(2), target_fm=fmlocal, &
-                                       para_env=para_env, info_re=info(indx, 1), info_im=info(indx, 2))
-               ELSE
-                  CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
-                                       use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
-                                       fm_re=fmwork(1), fm_im=fmwork(2), target_fm=fmdummy, &
-                                       para_env=para_env, info_re=info(indx, 1), info_im=info(indx, 2))
-               END IF
+               CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                    use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
+                                    fm_re=fmwork(1), fm_im=fmwork(2), fmlocal=fmlocal, fmdummy=fmdummy, &
+                                    my_kpgrp=my_kpgrp, para_env=para_env, &
+                                    info_re=info(indx, 1), info_im=info(indx, 2))
             END IF
          END DO
       END DO

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -123,6 +123,8 @@ MODULE qs_scf_diagonalization
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_gspace_mixing,                ONLY: gspace_mixing
+   USE qs_kp_evp_methods,               ONLY: kp_evp_op_finish_cfm,&
+                                              kp_evp_op_start
    USE qs_ks_methods,                   ONLY: qs_ks_update_qs_env
    USE qs_ks_types,                     ONLY: qs_ks_did_change,&
                                               qs_ks_env_type
@@ -1038,39 +1040,7 @@ CONTAINS
                   END IF
                   CALL dbcsr_desymmetrize(rmatrix, tmpmat)
                   CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
-               ELSE
-                  ! FT of matrices KS and S, then transfer to FM type
-                  IF (use_grid_fft) THEN
-                     CALL rskp_transform_grid_extract(ks_grid(ispin), ik, rmatrix, cmatrix)
-                  ELSE
-                     CALL dbcsr_set(rmatrix, 0.0_dp)
-                     CALL dbcsr_set(cmatrix, 0.0_dp)
-                     CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=effective_ks, ispin=ispin, &
-                                         xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
-                  END IF
-                  CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
-                  CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(2))
-                  ! s matrix is not spin dependent, double the work
-                  IF (use_grid_fft) THEN
-                     CALL rskp_transform_grid_extract(s_grid, ik, rmatrix, cmatrix)
-                  ELSE
-                     CALL dbcsr_set(rmatrix, 0.0_dp)
-                     CALL dbcsr_set(cmatrix, 0.0_dp)
-                     CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=matrix_s, ispin=1, &
-                                         xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
-                  END IF
-                  CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
-                  CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(4))
-               END IF
-               ! transfer to kpoint group
-               ! redistribution of matrices, new blacs environment
-               ! fmwork -> fmlocal -> rksmat/cksmat
-               ! fmwork -> fmlocal -> rsmat/csmat
-               IF (use_real_wfn) THEN
+                  ! transfer to kpoint group, redistribution with new blacs environment
                   IF (my_kpgrp) THEN
                      CALL cp_fm_start_copy_general(fmwork(1), rksmat, para_env, info(indx, 1))
                      CALL cp_fm_start_copy_general(fmwork(3), rsmat, para_env, info(indx, 2))
@@ -1079,45 +1049,49 @@ CONTAINS
                      CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env, info(indx, 2))
                   END IF
                ELSE
+                  ! complex wavefunctions: assemble KS and S and start their
+                  ! redistribution to the kpoint group
                   IF (my_kpgrp) THEN
-                     CALL cp_fm_start_copy_general(fmwork(1), fmlocal, para_env, info(indx, 1))
-                     CALL cp_fm_start_copy_general(fmwork(2), fmlocal, para_env, info(indx, 2))
-                     CALL cp_fm_start_copy_general(fmwork(3), fmlocal, para_env, info(indx, 3))
-                     CALL cp_fm_start_copy_general(fmwork(4), fmlocal, para_env, info(indx, 4))
+                     CALL kp_evp_op_start(effective_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                          ks_grid(ispin), use_grid_fft, rmatrix, cmatrix, tmpmat, &
+                                          fmwork(1), fmwork(2), fmlocal, para_env, info(indx, 1), info(indx, 2))
+                     CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, s_grid, &
+                                          use_grid_fft, rmatrix, cmatrix, tmpmat, fmwork(3), fmwork(4), &
+                                          fmlocal, para_env, info(indx, 3), info(indx, 4))
                   ELSE
-                     CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env, info(indx, 1))
-                     CALL cp_fm_start_copy_general(fmwork(2), fmdummy, para_env, info(indx, 2))
-                     CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env, info(indx, 3))
-                     CALL cp_fm_start_copy_general(fmwork(4), fmdummy, para_env, info(indx, 4))
+                     CALL kp_evp_op_start(effective_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                          ks_grid(ispin), use_grid_fft, rmatrix, cmatrix, tmpmat, &
+                                          fmwork(1), fmwork(2), fmdummy, para_env, info(indx, 1), info(indx, 2))
+                     CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, s_grid, &
+                                          use_grid_fft, rmatrix, cmatrix, tmpmat, fmwork(3), fmwork(4), &
+                                          fmdummy, para_env, info(indx, 3), info(indx, 4))
                   END IF
                END IF
                IF (my_store_ot_kinetic) THEN
-                  CALL dbcsr_set(rmatrix, 0.0_dp)
                   IF (use_real_wfn) THEN
+                     CALL dbcsr_set(rmatrix, 0.0_dp)
                      CALL rskp_transform(rmatrix=rmatrix, rsmat=matrix_t, ispin=1, &
                                          xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
-                  ELSE
-                     CALL dbcsr_set(cmatrix, 0.0_dp)
-                     CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=matrix_t, ispin=1, &
-                                         xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
-                  END IF
-                  CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
-                  IF (use_real_wfn) THEN
+                     CALL dbcsr_desymmetrize(rmatrix, tmpmat)
+                     CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
                      IF (my_kpgrp) THEN
                         CALL cp_fm_start_copy_general(fmwork(3), rtmat, para_env, info(indx, 3))
                      ELSE
                         CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env, info(indx, 3))
                      END IF
                   ELSE
-                     CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-                     CALL copy_dbcsr_to_fm(tmpmat, fmwork(4))
                      IF (my_kpgrp) THEN
-                        CALL cp_fm_start_copy_general(fmwork(3), fmlocal, para_env, info(indx, 5))
-                        CALL cp_fm_start_copy_general(fmwork(4), fmlocal, para_env, info(indx, 6))
+                        CALL kp_evp_op_start(matrix_t, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                             use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
+                                             tmpmat=tmpmat, fm_re=fmwork(3), fm_im=fmwork(4), &
+                                             target_fm=fmlocal, para_env=para_env, &
+                                             info_re=info(indx, 5), info_im=info(indx, 6))
                      ELSE
-                        CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env, info(indx, 5))
-                        CALL cp_fm_start_copy_general(fmwork(4), fmdummy, para_env, info(indx, 6))
+                        CALL kp_evp_op_start(matrix_t, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                             use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
+                                             tmpmat=tmpmat, fm_re=fmwork(3), fm_im=fmwork(4), &
+                                             target_fm=fmdummy, para_env=para_env, &
+                                             info_re=info(indx, 5), info_im=info(indx, 6))
                      END IF
                   END IF
                END IF
@@ -1149,19 +1123,13 @@ CONTAINS
                         CALL cp_cfm_scale_and_add_fm(z_zero, cksmat, z_one, rksmat)
                         CALL cp_cfm_scale_and_add_fm(z_zero, csmat, z_one, rsmat)
                      ELSE
-                        CALL cp_fm_finish_copy_general(fmlocal, info(indx, 1))
-                        CALL cp_cfm_scale_and_add_fm(z_zero, cksmat, z_one, fmlocal)
-                        CALL cp_fm_finish_copy_general(fmlocal, info(indx, 2))
-                        CALL cp_cfm_scale_and_add_fm(z_one, cksmat, gaussi, fmlocal)
-                        CALL cp_fm_finish_copy_general(fmlocal, info(indx, 3))
-                        CALL cp_cfm_scale_and_add_fm(z_zero, csmat, z_one, fmlocal)
-                        CALL cp_fm_finish_copy_general(fmlocal, info(indx, 4))
-                        CALL cp_cfm_scale_and_add_fm(z_one, csmat, gaussi, fmlocal)
+                        CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 1), cksmat, .FALSE.)
+                        CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 2), cksmat, .TRUE.)
+                        CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 3), csmat, .FALSE.)
+                        CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 4), csmat, .TRUE.)
                         IF (my_store_ot_kinetic) THEN
-                           CALL cp_fm_finish_copy_general(fmlocal, info(indx, 5))
-                           CALL cp_cfm_scale_and_add_fm(z_zero, ctmat, z_one, fmlocal)
-                           CALL cp_fm_finish_copy_general(fmlocal, info(indx, 6))
-                           CALL cp_cfm_scale_and_add_fm(z_one, ctmat, gaussi, fmlocal)
+                           CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 5), ctmat, .FALSE.)
+                           CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 6), ctmat, .TRUE.)
                         END IF
                      END IF
                   END IF
@@ -1214,25 +1182,20 @@ CONTAINS
                      DO igroup = 1, nkp_groups
                         ik = kp_dist(1, igroup) + ikp - 1
                         my_kpgrp = ik >= kp_range(1) .AND. ik <= kp_range(2)
-                        CALL dbcsr_set(rmatrix, 0.0_dp)
-                        CALL dbcsr_set(cmatrix, 0.0_dp)
-                        CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, &
-                                            rsmat=adiis_ks, ispin=ispin, &
-                                            xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
-                        CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                        CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
-                        CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-                        CALL copy_dbcsr_to_fm(tmpmat, fmwork(2))
                         IF (my_kpgrp) THEN
-                           CALL cp_fm_start_copy_general(fmwork(1), fmlocal, para_env, blend_info(1))
-                           CALL cp_fm_start_copy_general(fmwork(2), fmlocal, para_env, blend_info(2))
-                           CALL cp_fm_finish_copy_general(fmlocal, blend_info(1))
-                           CALL cp_cfm_scale_and_add_fm(z_zero, cwork, z_one, fmlocal)
-                           CALL cp_fm_finish_copy_general(fmlocal, blend_info(2))
-                           CALL cp_cfm_scale_and_add_fm(z_one, cwork, gaussi, fmlocal)
+                           CALL kp_evp_op_start(adiis_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                                use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
+                                                tmpmat=tmpmat, fm_re=fmwork(1), fm_im=fmwork(2), &
+                                                target_fm=fmlocal, para_env=para_env, &
+                                                info_re=blend_info(1), info_im=blend_info(2))
+                           CALL kp_evp_op_finish_cfm(fmlocal, blend_info(1), cwork, .FALSE.)
+                           CALL kp_evp_op_finish_cfm(fmlocal, blend_info(2), cwork, .TRUE.)
                         ELSE
-                           CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env, blend_info(1))
-                           CALL cp_fm_start_copy_general(fmwork(2), fmdummy, para_env, blend_info(2))
+                           CALL kp_evp_op_start(adiis_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                                use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, &
+                                                tmpmat=tmpmat, fm_re=fmwork(1), fm_im=fmwork(2), &
+                                                target_fm=fmdummy, para_env=para_env, &
+                                                info_re=blend_info(1), info_im=blend_info(2))
                         END IF
                         CALL cp_fm_cleanup_copy_general(blend_info(1))
                         CALL cp_fm_cleanup_copy_general(blend_info(2))
@@ -1298,19 +1261,13 @@ CONTAINS
                            CALL cp_fm_finish_copy_general(rtmat, info(indx, 3))
                         END IF
                      ELSE
-                        CALL cp_fm_finish_copy_general(fmlocal, info(indx, 1))
-                        CALL cp_cfm_scale_and_add_fm(z_zero, cksmat, z_one, fmlocal)
-                        CALL cp_fm_finish_copy_general(fmlocal, info(indx, 2))
-                        CALL cp_cfm_scale_and_add_fm(z_one, cksmat, gaussi, fmlocal)
-                        CALL cp_fm_finish_copy_general(fmlocal, info(indx, 3))
-                        CALL cp_cfm_scale_and_add_fm(z_zero, csmat, z_one, fmlocal)
-                        CALL cp_fm_finish_copy_general(fmlocal, info(indx, 4))
-                        CALL cp_cfm_scale_and_add_fm(z_one, csmat, gaussi, fmlocal)
+                        CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 1), cksmat, .FALSE.)
+                        CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 2), cksmat, .TRUE.)
+                        CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 3), csmat, .FALSE.)
+                        CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 4), csmat, .TRUE.)
                         IF (my_store_ot_kinetic) THEN
-                           CALL cp_fm_finish_copy_general(fmlocal, info(indx, 5))
-                           CALL cp_cfm_scale_and_add_fm(z_zero, ctmat, z_one, fmlocal)
-                           CALL cp_fm_finish_copy_general(fmlocal, info(indx, 6))
-                           CALL cp_cfm_scale_and_add_fm(z_one, ctmat, gaussi, fmlocal)
+                           CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 5), ctmat, .FALSE.)
+                           CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 6), ctmat, .TRUE.)
                         END IF
                      END IF
                   END IF
@@ -2030,31 +1987,7 @@ CONTAINS
                                       xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
                   CALL dbcsr_desymmetrize(rmatrix, tmpmat)
                   CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
-               ELSE
-                  ! FT of matrices KS and S, then transfer to FM type
-                  CALL dbcsr_set(rmatrix, 0.0_dp)
-                  CALL dbcsr_set(cmatrix, 0.0_dp)
-                  CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=matrix_ks, ispin=ispin, &
-                                      xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
-                  CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
-                  CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(2))
-                  ! s matrix is not spin dependent, double the work
-                  CALL dbcsr_set(rmatrix, 0.0_dp)
-                  CALL dbcsr_set(cmatrix, 0.0_dp)
-                  CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=matrix_s, ispin=1, &
-                                      xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
-                  CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
-                  CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-                  CALL copy_dbcsr_to_fm(tmpmat, fmwork(4))
-               END IF
-               ! transfer to kpoint group
-               ! redistribution of matrices, new blacs environment
-               ! fmwork -> fmlocal -> rksmat/cksmat
-               ! fmwork -> fmlocal -> rsmat/csmat
-               IF (use_real_wfn) THEN
+                  ! transfer to kpoint group, redistribution with new blacs environment
                   IF (my_kpgrp) THEN
                      CALL cp_fm_start_copy_general(fmwork(1), rksmat, para_env, info(indx, 1))
                      CALL cp_fm_start_copy_general(fmwork(3), rsmat, para_env, info(indx, 2))
@@ -2063,16 +1996,26 @@ CONTAINS
                      CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env, info(indx, 2))
                   END IF
                ELSE
+                  ! complex wavefunctions: assemble KS and S and start their
+                  ! redistribution to the kpoint group
                   IF (my_kpgrp) THEN
-                     CALL cp_fm_start_copy_general(fmwork(1), fmlocal, para_env, info(indx, 1))
-                     CALL cp_fm_start_copy_general(fmwork(2), fmlocal, para_env, info(indx, 2))
-                     CALL cp_fm_start_copy_general(fmwork(3), fmlocal, para_env, info(indx, 3))
-                     CALL cp_fm_start_copy_general(fmwork(4), fmlocal, para_env, info(indx, 4))
+                     CALL kp_evp_op_start(matrix_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                          use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
+                                          fm_re=fmwork(1), fm_im=fmwork(2), target_fm=fmlocal, &
+                                          para_env=para_env, info_re=info(indx, 1), info_im=info(indx, 2))
+                     CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                          use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
+                                          fm_re=fmwork(3), fm_im=fmwork(4), target_fm=fmlocal, &
+                                          para_env=para_env, info_re=info(indx, 3), info_im=info(indx, 4))
                   ELSE
-                     CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env, info(indx, 1))
-                     CALL cp_fm_start_copy_general(fmwork(2), fmdummy, para_env, info(indx, 2))
-                     CALL cp_fm_start_copy_general(fmwork(3), fmdummy, para_env, info(indx, 3))
-                     CALL cp_fm_start_copy_general(fmwork(4), fmdummy, para_env, info(indx, 4))
+                     CALL kp_evp_op_start(matrix_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                          use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
+                                          fm_re=fmwork(1), fm_im=fmwork(2), target_fm=fmdummy, &
+                                          para_env=para_env, info_re=info(indx, 1), info_im=info(indx, 2))
+                     CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                          use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
+                                          fm_re=fmwork(3), fm_im=fmwork(4), target_fm=fmdummy, &
+                                          para_env=para_env, info_re=info(indx, 3), info_im=info(indx, 4))
                   END IF
                END IF
             END DO
@@ -2093,14 +2036,10 @@ CONTAINS
                      CALL cp_fm_finish_copy_general(rksmat, info(indx, 1))
                      CALL cp_fm_finish_copy_general(rsmat, info(indx, 2))
                   ELSE
-                     CALL cp_fm_finish_copy_general(fmlocal, info(indx, 1))
-                     CALL cp_cfm_scale_and_add_fm(z_zero, cksmat, z_one, fmlocal)
-                     CALL cp_fm_finish_copy_general(fmlocal, info(indx, 2))
-                     CALL cp_cfm_scale_and_add_fm(z_one, cksmat, gaussi, fmlocal)
-                     CALL cp_fm_finish_copy_general(fmlocal, info(indx, 3))
-                     CALL cp_cfm_scale_and_add_fm(z_zero, csmat, z_one, fmlocal)
-                     CALL cp_fm_finish_copy_general(fmlocal, info(indx, 4))
-                     CALL cp_cfm_scale_and_add_fm(z_one, csmat, gaussi, fmlocal)
+                     CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 1), cksmat, .FALSE.)
+                     CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 2), cksmat, .TRUE.)
+                     CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 3), csmat, .FALSE.)
+                     CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 4), csmat, .TRUE.)
                   END IF
                END IF
             END DO
@@ -3994,32 +3933,25 @@ CONTAINS
                                    xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
                CALL dbcsr_desymmetrize(rmatrix, tmpmat)
                CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
-            ELSE
-               CALL dbcsr_set(rmatrix, 0.0_dp)
-               CALL dbcsr_set(cmatrix, 0.0_dp)
-               CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=matrix_s, ispin=1, &
-                                   xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
-               CALL dbcsr_desymmetrize(rmatrix, tmpmat)
-               CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
-               CALL dbcsr_desymmetrize(cmatrix, tmpmat)
-               CALL copy_dbcsr_to_fm(tmpmat, fmwork(2))
-            END IF
-            ! transfer to kpoint group
-            ! redistribution of matrices, new blacs environment
-            ! fmwork -> fmlocal -> rsmat/csmat
-            IF (use_real_wfn) THEN
+               ! transfer to kpoint group, redistribution with new blacs environment
                IF (my_kpgrp) THEN
                   CALL cp_fm_start_copy_general(fmwork(1), rsmat, para_env, info(indx, 1))
                ELSE
                   CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env, info(indx, 1))
                END IF
             ELSE
+               ! complex wavefunctions: assemble S and start its redistribution
+               ! to the kpoint group
                IF (my_kpgrp) THEN
-                  CALL cp_fm_start_copy_general(fmwork(1), fmlocal, para_env, info(indx, 1))
-                  CALL cp_fm_start_copy_general(fmwork(2), fmlocal, para_env, info(indx, 2))
+                  CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                       use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
+                                       fm_re=fmwork(1), fm_im=fmwork(2), target_fm=fmlocal, &
+                                       para_env=para_env, info_re=info(indx, 1), info_im=info(indx, 2))
                ELSE
-                  CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env, info(indx, 1))
-                  CALL cp_fm_start_copy_general(fmwork(2), fmdummy, para_env, info(indx, 2))
+                  CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
+                                       use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
+                                       fm_re=fmwork(1), fm_im=fmwork(2), target_fm=fmdummy, &
+                                       para_env=para_env, info_re=info(indx, 1), info_im=info(indx, 2))
                END IF
             END IF
          END DO
@@ -4037,10 +3969,8 @@ CONTAINS
                IF (use_real_wfn) THEN
                   CALL cp_fm_finish_copy_general(rsmat, info(indx, 1))
                ELSE
-                  CALL cp_fm_finish_copy_general(fmlocal, info(indx, 1))
-                  CALL cp_cfm_scale_and_add_fm(z_zero, csmat, z_one, fmlocal)
-                  CALL cp_fm_finish_copy_general(fmlocal, info(indx, 2))
-                  CALL cp_cfm_scale_and_add_fm(z_one, csmat, gaussi, fmlocal)
+                  CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 1), csmat, .FALSE.)
+                  CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 2), csmat, .TRUE.)
                END IF
             END IF
          END DO

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -1041,7 +1041,7 @@ CONTAINS
                   END IF
                   CALL dbcsr_desymmetrize(rmatrix, tmpmat)
                   CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
-                  ! transfer to kpoint group, redistribution with new blacs environment
+                  ! transfer to the kpoint group with a new blacs environment
                   IF (my_kpgrp) THEN
                      CALL cp_fm_start_copy_general(fmwork(1), rksmat, para_env, info(indx, 1))
                      CALL cp_fm_start_copy_general(fmwork(3), rsmat, para_env, info(indx, 2))
@@ -1051,7 +1051,7 @@ CONTAINS
                   END IF
                ELSE
                   ! complex wavefunctions: assemble KS and S and start their
-                  ! redistribution to the kpoint group
+                  ! transfer to the k-point group
                   IF (my_kpgrp) THEN
                      CALL kp_evp_op_start(effective_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
                                           ks_grid(ispin), use_grid_fft, rmatrix, cmatrix, tmpmat, &
@@ -1235,7 +1235,7 @@ CONTAINS
                   ELSE
                      CALL cp_cfm_geeig(cksmat, csmat, cmos, eigenvalues, cwork)
                   END IF
-                  ! split real and imaginary part of mos and sync the eigenvalues
+                  ! split the real and imaginary parts of the mos and copy the eigenvalues to the imaginary set
                   CALL kp_evp_cfm_to_mo(cmos, kp%mos(1, ispin), kp%mos(2, ispin), eigenvalues)
                END IF
             END DO
@@ -1309,7 +1309,7 @@ CONTAINS
                      ELSE
                         CALL cp_cfm_geeig(cksmat, csmat, cmos, eigenvalues, cwork)
                      END IF
-                     ! split real and imaginary part of mos and sync the eigenvalues
+                     ! split the real and imaginary parts of the mos and copy the eigenvalues to the imaginary set
                      CALL kp_evp_cfm_to_mo(cmos, kp%mos(1, ispin), kp%mos(2, ispin), eigenvalues)
                   END IF
                END IF
@@ -1982,7 +1982,7 @@ CONTAINS
                                       xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
                   CALL dbcsr_desymmetrize(rmatrix, tmpmat)
                   CALL copy_dbcsr_to_fm(tmpmat, fmwork(3))
-                  ! transfer to kpoint group, redistribution with new blacs environment
+                  ! transfer to the kpoint group with a new blacs environment
                   IF (my_kpgrp) THEN
                      CALL cp_fm_start_copy_general(fmwork(1), rksmat, para_env, info(indx, 1))
                      CALL cp_fm_start_copy_general(fmwork(3), rsmat, para_env, info(indx, 2))
@@ -1992,7 +1992,7 @@ CONTAINS
                   END IF
                ELSE
                   ! complex wavefunctions: assemble KS and S and start their
-                  ! redistribution to the kpoint group
+                  ! transfer to the k-point group
                   IF (my_kpgrp) THEN
                      CALL kp_evp_op_start(matrix_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
                                           use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &
@@ -2048,7 +2048,7 @@ CONTAINS
             ELSE
                CALL get_mo_set(kp%mos(1, ispin), eigenvalues=eigenvalues)
                CALL cp_cfm_geeig(cksmat, csmat, cmos, eigenvalues, cwork)
-               ! split real and imaginary part of mos and sync the eigenvalues
+               ! split the real and imaginary parts of the mos and copy the eigenvalues to the imaginary set
                CALL kp_evp_cfm_to_mo(cmos, kp%mos(1, ispin), kp%mos(2, ispin), eigenvalues)
             END IF
          END DO
@@ -3925,15 +3925,15 @@ CONTAINS
                                    xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
                CALL dbcsr_desymmetrize(rmatrix, tmpmat)
                CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
-               ! transfer to kpoint group, redistribution with new blacs environment
+               ! transfer to the kpoint group with a new blacs environment
                IF (my_kpgrp) THEN
                   CALL cp_fm_start_copy_general(fmwork(1), rsmat, para_env, info(indx, 1))
                ELSE
                   CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env, info(indx, 1))
                END IF
             ELSE
-               ! complex wavefunctions: assemble S and start its redistribution
-               ! to the kpoint group
+               ! complex wavefunctions: assemble S and start its transfer
+               ! to the k-point group
                IF (my_kpgrp) THEN
                   CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
                                        use_grid=.FALSE., rmatrix=rmatrix, cmatrix=cmatrix, tmpmat=tmpmat, &

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -123,7 +123,8 @@ MODULE qs_scf_diagonalization
    USE qs_environment_types,            ONLY: get_qs_env,&
                                               qs_environment_type
    USE qs_gspace_mixing,                ONLY: gspace_mixing
-   USE qs_kp_evp_methods,               ONLY: kp_evp_op_finish_cfm,&
+   USE qs_kp_evp_methods,               ONLY: kp_evp_cfm_to_mo,&
+                                              kp_evp_op_finish_cfm,&
                                               kp_evp_op_start
    USE qs_ks_methods,                   ONLY: qs_ks_update_qs_env
    USE qs_ks_types,                     ONLY: qs_ks_did_change,&
@@ -810,7 +811,7 @@ CONTAINS
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct, mo_struct
       TYPE(cp_fm_type)                                   :: fmdummy, fmlocal, rksmat, rsmat, rtmat
       TYPE(cp_fm_type), DIMENSION(:), POINTER            :: fmwork
-      TYPE(cp_fm_type), POINTER                          :: imos, mo_coeff, rmos
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: adiis_ks, effective_ks
       TYPE(dbcsr_type), POINTER                          :: cmatrix, rmatrix, tmpmat
       TYPE(kpoint_env_type), POINTER                     :: kp
@@ -1227,18 +1228,15 @@ CONTAINS
                      CALL cp_fm_geeig(rksmat, rsmat, mo_coeff, eigenvalues, fmlocal)
                   END IF
                ELSE
-                  CALL get_mo_set(kp%mos(1, ispin), mo_coeff=rmos, eigenvalues=eigenvalues)
-                  CALL get_mo_set(kp%mos(2, ispin), mo_coeff=imos)
+                  CALL get_mo_set(kp%mos(1, ispin), eigenvalues=eigenvalues)
                   IF (scf_env%cholesky_method == cholesky_off) THEN
                      CALL cp_cfm_geeig_canon(cksmat, csmat, cmos, eigenvalues, cwork, &
                                              scf_control%eps_eigval)
                   ELSE
                      CALL cp_cfm_geeig(cksmat, csmat, cmos, eigenvalues, cwork)
                   END IF
-                  ! copy eigenvalues to imag set (keep them in sync)
-                  kp%mos(2, ispin)%eigenvalues = eigenvalues
-                  ! split real and imaginary part of mos
-                  CALL cp_cfm_to_fm(cmos, rmos, imos)
+                  ! split real and imaginary part of mos and sync the eigenvalues
+                  CALL kp_evp_cfm_to_mo(cmos, kp%mos(1, ispin), kp%mos(2, ispin), eigenvalues)
                END IF
             END DO
          END DO
@@ -1294,8 +1292,7 @@ CONTAINS
                      END IF
                   END IF
                ELSE
-                  CALL get_mo_set(kp%mos(1, ispin), mo_coeff=rmos, eigenvalues=eigenvalues)
-                  CALL get_mo_set(kp%mos(2, ispin), mo_coeff=imos)
+                  CALL get_mo_set(kp%mos(1, ispin), eigenvalues=eigenvalues)
                   IF (my_store_ot_matrices) THEN
                      CALL cp_cfm_to_fm(cksmat, kp%ot_hmat(1, ispin), kp%ot_hmat(2, ispin))
                      IF (ispin == 1) THEN
@@ -1312,10 +1309,8 @@ CONTAINS
                      ELSE
                         CALL cp_cfm_geeig(cksmat, csmat, cmos, eigenvalues, cwork)
                      END IF
-                     ! copy eigenvalues to imag set (keep them in sync)
-                     kp%mos(2, ispin)%eigenvalues = eigenvalues
-                     ! split real and imaginary part of mos
-                     CALL cp_cfm_to_fm(cmos, rmos, imos)
+                     ! split real and imaginary part of mos and sync the eigenvalues
+                     CALL kp_evp_cfm_to_mo(cmos, kp%mos(1, ispin), kp%mos(2, ispin), eigenvalues)
                   END IF
                END IF
             END DO
@@ -1913,7 +1908,7 @@ CONTAINS
       TYPE(cp_fm_pool_p_type), DIMENSION(:), POINTER     :: ao_ao_fm_pools
       TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct, mo_struct
       TYPE(cp_fm_type)                                   :: fmdummy, fmlocal, rksmat, rsmat
-      TYPE(cp_fm_type), POINTER                          :: imos, mo_coeff, rmos
+      TYPE(cp_fm_type), POINTER                          :: mo_coeff
       TYPE(dbcsr_type), POINTER                          :: cmatrix, rmatrix, tempmat, tmpmat
       TYPE(kpoint_env_type), POINTER                     :: kp
       TYPE(mp_para_env_type), POINTER                    :: para_env
@@ -2051,13 +2046,10 @@ CONTAINS
                CALL get_mo_set(kp%mos(1, ispin), mo_coeff=mo_coeff, eigenvalues=eigenvalues)
                CALL cp_fm_geeig(rksmat, rsmat, mo_coeff, eigenvalues, fmlocal)
             ELSE
-               CALL get_mo_set(kp%mos(1, ispin), mo_coeff=rmos, eigenvalues=eigenvalues)
-               CALL get_mo_set(kp%mos(2, ispin), mo_coeff=imos)
+               CALL get_mo_set(kp%mos(1, ispin), eigenvalues=eigenvalues)
                CALL cp_cfm_geeig(cksmat, csmat, cmos, eigenvalues, cwork)
-               ! copy eigenvalues to imag set (keep them in sync)
-               kp%mos(2, ispin)%eigenvalues = eigenvalues
-               ! split real and imaginary part of mos
-               CALL cp_cfm_to_fm(cmos, rmos, imos)
+               ! split real and imaginary part of mos and sync the eigenvalues
+               CALL kp_evp_cfm_to_mo(cmos, kp%mos(1, ispin), kp%mos(2, ispin), eigenvalues)
             END IF
          END DO
       END DO


### PR DESCRIPTION
The complex k-point operator assembly (phase transform, densification, and the pool-to-group redistribution of `cp_fm_start_copy_general`) existed as inline copies in the STANDARD diagonalization driver and its helper routines.
This PR consolidates it into a dedicated module, `qs_kp_evp_methods`, mirroring the Davidson fix from #5945: the Davidson driver and its preconditioner already assemble through `distribute_kpoint_operator_channel`, and this PR gives the remaining inline call sites the same treatment through a two-phase interface.
The Mermin exact-Hxc distribution (`qs_scf_loop_utils.F`) already goes through the #5945 helper and stays untouched.

This is the refactoring discussed in [#5934 (comment)](https://github.com/cp2k/cp2k/pull/5934#issuecomment-5494360763): with STANDARD and Davidson as two concrete users, the shared complex k-point plumbing is worth a small common layer, while solver-specific parts (such as the Davidson preconditioner scheduling) stay in the solvers.

`kp_evp_op_start` fuses the previously separated transform, densification, and MPI transfer into a single atomic call per operator, eliminating the multi-stage manual staging into `fmwork(1:4)`.
And this allows multiple non-blocking transfers to proceed concurrently, while `kp_evp_op_finish_cfm` collects each completed transfer into the target complex matrix.
The STANDARD assembly loop, the ADIIS blend, `diag_kp_basic`, and `diag_kp_smat` preserve this communication overlap, effectively hiding redistribution latency behind the transformation of subsequent operators.
`kp_evp_cfm_to_mo` splits one complex matrix into the real and imaginary MO sets and keeps their eigenvalues in sync, replacing the three inline writebacks.

The operator assembly, DIIS finish, and MO writeback in `do_general_diag_kp` (`src/qs_scf_diagonalization.F`), before this PR and with this PR:

```fortran
! ==============================================================================
! 1. Operator assembly & non-blocking dispatch (KS and S matrices)
! ==============================================================================
! Before this PR: manual transforms and densifications into fmwork(1:4),
! followed dozens of lines later by split MPI dispatch branches
IF (use_grid_fft) THEN
   CALL rskp_transform_grid_extract(ks_grid(ispin), ik, rmatrix, cmatrix)
ELSE
   CALL dbcsr_set(rmatrix, 0.0_dp); CALL dbcsr_set(cmatrix, 0.0_dp)
   CALL rskp_transform(rmatrix=rmatrix, cmatrix=cmatrix, rsmat=effective_ks, ispin=ispin, &
                       xkp=xkp(1:3, ik), cell_to_index=cell_to_index, sab_nl=sab_nl)
END IF
CALL dbcsr_desymmetrize(rmatrix, tmpmat); CALL copy_dbcsr_to_fm(tmpmat, fmwork(1))
CALL dbcsr_desymmetrize(cmatrix, tmpmat); CALL copy_dbcsr_to_fm(tmpmat, fmwork(2))
! ... identical transform and densification boilerplate repeated for matrix_s into fmwork(3:4) ...
! ... and dozens of lines later, manual collective routing:
IF (my_kpgrp) THEN
   CALL cp_fm_start_copy_general(fmwork(1), fmlocal, para_env, info(indx, 1))
   CALL cp_fm_start_copy_general(fmwork(2), fmlocal, para_env, info(indx, 2))
   CALL cp_fm_start_copy_general(fmwork(3), fmlocal, para_env, info(indx, 3))
   CALL cp_fm_start_copy_general(fmwork(4), fmlocal, para_env, info(indx, 4))
ELSE
   CALL cp_fm_start_copy_general(fmwork(1), fmdummy, para_env, info(indx, 1))
   ... (repeated for all 4 slots) ...
END IF

! This PR: fused atomic launch per operator with encapsulated receiver routing
CALL kp_evp_op_start(effective_ks, ispin, ik, xkp(1:3, ik), cell_to_index, sab_nl, &
                     ks_grid(ispin), use_grid_fft, rmatrix, cmatrix, tmpmat, &
                     fmwork(1), fmwork(2), fmlocal, fmdummy, my_kpgrp, para_env, &
                     info(indx, 1), info(indx, 2))
CALL kp_evp_op_start(matrix_s, 1, ik, xkp(1:3, ik), cell_to_index, sab_nl, s_grid, &
                     use_grid_fft, rmatrix, cmatrix, tmpmat, &
                     fmwork(3), fmwork(4), fmlocal, fmdummy, my_kpgrp, para_env, &
                     info(indx, 3), info(indx, 4))

! ==============================================================================
! 2. DIIS finish & accumulation
! ==============================================================================
! Before this PR
CALL cp_fm_finish_copy_general(fmlocal, info(indx, 1))
CALL cp_cfm_scale_and_add_fm(z_zero, cksmat, z_one, fmlocal)
CALL cp_fm_finish_copy_general(fmlocal, info(indx, 2))
CALL cp_cfm_scale_and_add_fm(z_one, cksmat, gaussi, fmlocal)
CALL cp_fm_finish_copy_general(fmlocal, info(indx, 3))
CALL cp_cfm_scale_and_add_fm(z_zero, csmat, z_one, fmlocal)
CALL cp_fm_finish_copy_general(fmlocal, info(indx, 4))
CALL cp_cfm_scale_and_add_fm(z_one, csmat, gaussi, fmlocal)
IF (my_store_ot_kinetic) THEN
   CALL cp_fm_finish_copy_general(fmlocal, info(indx, 5))
   CALL cp_cfm_scale_and_add_fm(z_zero, ctmat, z_one, fmlocal)
   CALL cp_fm_finish_copy_general(fmlocal, info(indx, 6))
   CALL cp_cfm_scale_and_add_fm(z_one, ctmat, gaussi, fmlocal)
END IF

! This PR
CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 1), cksmat, .FALSE.)
CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 2), cksmat, .TRUE.)
CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 3), csmat, .FALSE.)
CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 4), csmat, .TRUE.)
IF (my_store_ot_kinetic) THEN
   CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 5), ctmat, .FALSE.)
   CALL kp_evp_op_finish_cfm(fmlocal, info(indx, 6), ctmat, .TRUE.)
END IF

! ==============================================================================
! 3. MO writeback & eigenvalue synchronization
! ==============================================================================
! Before this PR
kp%mos(2, ispin)%eigenvalues = eigenvalues
CALL cp_cfm_to_fm(cmos, rmos, imos)

! This PR
CALL kp_evp_cfm_to_mo(cmos, kp%mos(1, ispin), kp%mos(2, ispin), eigenvalues)
```

### Tests

- **Regression suites**: `kp-2` and `kp-3` regressions pass completely (90/90), including the multi-group test cases from #5945.

### What moved

- New module `src/qs_kp_evp_methods.F`: `kp_evp_op_start`, `kp_evp_op_finish_cfm`, `kp_evp_cfm_to_mo`, with the calling contracts documented (finish order, receiver selection, workspace lifetimes).
- `do_general_diag_kp`: complex KS and S assembly, replacing the split transform-and-transfer staging with atomic `kp_evp_op_start` launches, along with the T-matrix slots, the ADIIS blend, and both DIIS and non-DIIS finish loops.
- `diag_kp_basic` and `diag_kp_smat`: complex assembly and the MO writeback.
- The OT complex writeback.

### Scope boundaries & unchanged paths

- Real-wavefunction paths stay in the drivers, as does the fused transform of the OMP executor.
- The Davidson path is untouched: it assembles through the channel routine of #5945.
- The Mermin exact-Hxc distribution and the OT operator builder keep their own paths.

### Inherited workspace conventions

The workspace slot numbering is inherited from the inline code unchanged.
In the complex path, `info(indx, 1:6)` holds one transfer state per operator part (KS 1/2, S 3/4, and the optional T matrix 5/6, hence `ninfo = 4` or `6`), while `fmwork(1:4)` is consumed by the start itself and is therefore reused across operators.
This PR strictly relocates statements to guarantee bitwise equivalence, so the numbering stays exactly as it was; naming these slots belongs to the planned common layer, where they become explicit members of the service context.

### Follow-up

A follow-up will unify the two assembly primitives (the channel routine of #5945 and `kp_evp_op_start`) behind one service context (`kp_operator_ctx`), continuing the discussion in [#5934 (comment)](https://github.com/cp2k/cp2k/pull/5934#issuecomment-5494360763).
Rather than an abstract redesign, this service is targeted to absorb and simplify concrete call sites across the repository:

- **Davidson solver and preconditioner (`src/qs_scf_diagonalization.F`)**: Replaces the channel helper of #5945 and folds the manual `copy_fm_to_dbcsr_bc` round-trip into a native block-cyclic DBCSR output mode.
- **STANDARD assembly driver (`src/qs_scf_diagonalization.F`)**: Replaces the manual slot indexing (`info(indx, 1:6)`, `fmwork(1:4)`) and grid setup boilerplate with service-managed buffer slots, while strictly preserving communication overlap.
- **Mermin exact-Hxc response (`src/qs_scf_loop_utils.F`)**: Absorbs the standalone operator distribution pipeline (`qs_scf_kp_exact_hxc_projected`) into the same service.
- **Wavefunction history extrapolation (`src/qs_wf_history_methods.F`)**: Replaces three separate copies of the S(k) assembly pipeline (`wfs_update`, `wfi_use_prev_wf_kp`, and `wfi_extrapolate_gext_proj_kp`) with a shared S(k) cache that skips redundant phase transforms across SCF iterations when geometry is static.

In total, this will consolidate seven distinct transform-and-redistribution copies across the codebase into a single entry point.
The unified service layer itself stays out of this PR; the detailed design will be proposed separately once this lands.

cc @Growl1234 