### PR TITLE
Fix minimal build without FFTW

### DIFF
--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -800,7 +800,6 @@ CONTAINS
 
 #else
       MARK_USED(plan)
-      MARK_USED(plan_style)
       !MARK_USED does not work with assumed size arguments
       IF (.FALSE.) THEN; DO; IF (ABS(zin(1)) > ABS(zout(1))) EXIT; END DO; END IF
 #endif
@@ -1043,7 +1042,6 @@ CONTAINS
 
 #else
       MARK_USED(plan)
-      MARK_USED(plan_style)
       !MARK_USED does not work with assumed size arguments
       IF (.FALSE.) THEN; DO; IF (ABS(zin(1)) > ABS(zout(1))) EXIT; END DO; END IF
 #endif

--- a/tools/conventions/conventions.supp
+++ b/tools/conventions/conventions.supp
@@ -59,7 +59,7 @@ fftw3_lib.F: Found type fftwf_iodim64 without initializer https://cp2k.org/conv#
 fftw3_lib.F: Found type fftwf_iodim without initializer https://cp2k.org/conv#c016
 fftw3_lib.F: Found type fftw_iodim64 without initializer https://cp2k.org/conv#c016
 fftw3_lib.F: Found type fftw_iodim without initializer https://cp2k.org/conv#c016
-fftw3_lib.F: Same actual argument associated with INTENT(OUT) argument 'in' and INTENT(OUT) argument 'out' at (1)
+fftw3_lib.F: Same actual argument associated with INTENT(OUT) argument 'out' and INTENT(OUT) argument 'in' at (1)
 fparser.F: Found WRITE statement with hardcoded unit in "parseerrmsg" https://cp2k.org/conv#c012
 free_energy_methods.F: Found WRITE statement with hardcoded unit in "ui_check_norm_sc" https://cp2k.org/conv#c012
 free_energy_methods.F: Found WRITE statement with hardcoded unit in "ui_check_norm_sc_low" https://cp2k.org/conv#c012


### PR DESCRIPTION
## Summary

- remove stale `MARK_USED(plan_style)` references left after the FFT plan interface changes in #5868
- update the convention suppression for the current GCC argument ordering of the intentional in-place FFT alias warning
- restore compilation of the no-FFTW minimal build and remove the corresponding conventions failure

## Validation

- `./make_pretty.sh`
- `git diff --check`
- configured a fresh CMake build with GCC/GFortran 16.1 and `CP2K_USE_FFTW3=OFF`
- built `src/CMakeFiles/cp2k.dir/pw/fft/fftw3_lib.F.o` successfully