### PR TITLE
Resolve current coding convention failures

### DIFF
--- a/src/fm/cp_fm_basic_linalg.F
+++ b/src/fm/cp_fm_basic_linalg.F
@@ -450,7 +450,7 @@ CONTAINS
 !> \brief computes matrix_c = beta * matrix_c + alpha * ( matrix_a  ** transa ) * ( matrix_b ** transb )
 !> \param transa : 'N' -> normal   'T' -> transpose
 !>      alpha,beta :: can be 0.0_dp and 1.0_dp
-!> \param transb ...
+!> \param transb same operation choices as transa
 !> \param m ...
 !> \param n ...
 !> \param k ...
@@ -1792,7 +1792,7 @@ CONTAINS
 !> \brief Convenience function. Computes the matrix multiplications needed
 !>        for the multiplication of complex matrices.
 !>        C = beta * C + alpha * ( A  ** transa ) * ( B ** transb )
-!> \param transa : 'N' -> normal   'T' -> transpose
+!> \param transa : 'N' -> normal   'T' -> transpose   'C' -> conjugate transpose
 !>      alpha,beta :: can be 0.0_dp and 1.0_dp
 !> \param transb ...
 !> \param m ...
@@ -1830,32 +1830,48 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER :: routineN = 'cp_complex_fm_gemm'
 
+      CHARACTER(LEN=1)                                   :: transa_real, transb_real
       INTEGER                                            :: handle
+      REAL(KIND=dp)                                      :: sign_a, sign_b
 
       CALL timeset(routineN, handle)
 
-      CALL cp_fm_gemm(transa, transb, m, n, k, alpha, A_re, B_re, beta, C_re, &
+      transa_real = transa
+      transb_real = transb
+      sign_a = 1.0_dp
+      sign_b = 1.0_dp
+      IF (transa == "C") THEN
+         transa_real = "T"
+         sign_a = -1.0_dp
+      END IF
+      IF (transb == "C") THEN
+         transb_real = "T"
+         sign_b = -1.0_dp
+      END IF
+
+      CALL cp_fm_gemm(transa_real, transb_real, m, n, k, alpha, A_re, B_re, beta, C_re, &
                       a_first_col=a_first_col, &
                       a_first_row=a_first_row, &
                       b_first_col=b_first_col, &
                       b_first_row=b_first_row, &
                       c_first_col=c_first_col, &
                       c_first_row=c_first_row)
-      CALL cp_fm_gemm(transa, transb, m, n, k, -alpha, A_im, B_im, 1.0_dp, C_re, &
+      CALL cp_fm_gemm(transa_real, transb_real, m, n, k, -sign_a*sign_b*alpha, &
+                      A_im, B_im, 1.0_dp, C_re, &
                       a_first_col=a_first_col, &
                       a_first_row=a_first_row, &
                       b_first_col=b_first_col, &
                       b_first_row=b_first_row, &
                       c_first_col=c_first_col, &
                       c_first_row=c_first_row)
-      CALL cp_fm_gemm(transa, transb, m, n, k, alpha, A_re, B_im, beta, C_im, &
+      CALL cp_fm_gemm(transa_real, transb_real, m, n, k, sign_b*alpha, A_re, B_im, beta, C_im, &
                       a_first_col=a_first_col, &
                       a_first_row=a_first_row, &
                       b_first_col=b_first_col, &
                       b_first_row=b_first_row, &
                       c_first_col=c_first_col, &
                       c_first_row=c_first_row)
-      CALL cp_fm_gemm(transa, transb, m, n, k, alpha, A_im, B_re, 1.0_dp, C_im, &
+      CALL cp_fm_gemm(transa_real, transb_real, m, n, k, sign_a*alpha, A_im, B_re, 1.0_dp, C_im, &
                       a_first_col=a_first_col, &
                       a_first_row=a_first_row, &
                       b_first_col=b_first_col, &

--- a/src/qs_external_density.F
+++ b/src/qs_external_density.F
@@ -13,6 +13,7 @@ MODULE qs_external_density
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_files,                        ONLY: close_file,&
                                               open_file
+   USE cp_log_handling,                 ONLY: cp_logger_get_default_io_unit
    USE gaussian_gridlevels,             ONLY: gridlevel_info_type
    USE input_section_types,             ONLY: section_vals_get_subs_vals,&
                                               section_vals_type,&
@@ -101,7 +102,7 @@ CONTAINS
       CHARACTER(len=*), PARAMETER                        :: routineN = 'read_cube_density'
 
       INTEGER                                            :: extunit, handle, i, igrid_level, j, k, &
-                                                            nat, ndum
+                                                            nat, ndum, output_unit
       INTEGER, DIMENSION(3)                              :: lbounds, lbounds_local, npoints, &
                                                             ubounds, ubounds_local
       LOGICAL                                            :: grid_mismatch
@@ -119,6 +120,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
       NULLIFY (pw_env, rho_r, rho_g, tot_rho_r, rs_descs)
+      output_unit = cp_logger_get_default_io_unit()
 
       IF (total_density_sign /= -1 .AND. total_density_sign /= 1) THEN
          CPABORT("total_density_sign has to be -1 or 1")
@@ -147,7 +149,8 @@ CONTAINS
                  my_rank => rho_r(1)%pw_grid%para%group%mepos)
          grid_mismatch = .FALSE.
          IF (my_rank == 0) THEN
-            WRITE (*, FMT="(/,T3,A,A)") TRIM(source_label)//"| Reading electron density: ", TRIM(filename)
+            WRITE (output_unit, FMT="(/,T3,A,A)") &
+               TRIM(source_label)//"| Reading electron density: ", TRIM(filename)
             CALL open_file(file_name=filename, file_status="OLD", file_form="FORMATTED", &
                            file_action="READ", unit_number=extunit)
 
@@ -156,12 +159,12 @@ CONTAINS
             READ (extunit, *) nat, cube_origin
             IF (MAXVAL(ABS(cube_origin)) > 1.0E-4_dp) THEN
                grid_mismatch = .TRUE.
-               WRITE (*, FMT="(T3,A,3ES16.8)") TRIM(source_label)// &
+               WRITE (output_unit, FMT="(T3,A,3ES16.8)") TRIM(source_label)// &
                   "| Cube origin is not the CP2K grid origin: ", cube_origin
             END IF
             IF (nat < 0) THEN
                grid_mismatch = .TRUE.
-               WRITE (*, FMT="(T3,A)") TRIM(source_label)// &
+               WRITE (output_unit, FMT="(T3,A)") TRIM(source_label)// &
                   "| Multi-orbital cube files are not supported"
             END IF
             DO i = 1, 3
@@ -169,12 +172,12 @@ CONTAINS
                IF (ndum /= npoints(i) .OR. &
                    MAXVAL(ABS(voxel - rs_descs(igrid_level)%rs_desc%dh(:, i))) > 1.0E-4_dp) THEN
                   grid_mismatch = .TRUE.
-                  WRITE (*, FMT="(T3,A,I0)") TRIM(source_label)// &
+                  WRITE (output_unit, FMT="(T3,A,I0)") TRIM(source_label)// &
                      "| Cube grid does not coincide with CP2K grid along axis ", i
-                  WRITE (*, FMT="(T3,A,I0,A,I0)") TRIM(source_label)//"| Grid points: ", &
+                  WRITE (output_unit, FMT="(T3,A,I0,A,I0)") TRIM(source_label)//"| Grid points: ", &
                      ndum, " instead of ", npoints(i)
-                  WRITE (*, FMT="(T3,A,3ES16.8)") TRIM(source_label)//"| Cube vector: ", voxel
-                  WRITE (*, FMT="(T3,A,3ES16.8)") TRIM(source_label)//"| CP2K vector: ", &
+                  WRITE (output_unit, FMT="(T3,A,3ES16.8)") TRIM(source_label)//"| Cube vector: ", voxel
+                  WRITE (output_unit, FMT="(T3,A,3ES16.8)") TRIM(source_label)//"| CP2K vector: ", &
                      rs_descs(igrid_level)%rs_desc%dh(:, i)
                END IF
             END DO
@@ -206,7 +209,7 @@ CONTAINS
          CALL density_rs2pw(pw_env, rs_rho, rho=rho_r(1), rho_gspace=rho_g(1))
          tot_rho_r(1) = pw_integrate_function(rho_r(1), isign=total_density_sign)
          IF (my_rank == 0) THEN
-            WRITE (*, FMT="(T3,A,T61,F20.10)") TRIM(source_label)// &
+            WRITE (output_unit, FMT="(T3,A,T61,F20.10)") TRIM(source_label)// &
                "| Integrated electron density:", REAL(total_density_sign, dp)*tot_rho_r(1)
          END IF
          CALL gid%sync()

--- a/src/qs_ot_complex_ref_unittest.F
+++ b/src/qs_ot_complex_ref_unittest.F
@@ -23,6 +23,7 @@ PROGRAM qs_ot_complex_ref_unittest
         dbcsr_create, dbcsr_distribution_new, dbcsr_distribution_release, dbcsr_distribution_type, &
         dbcsr_finalize, dbcsr_finalize_lib, dbcsr_get_block_p, dbcsr_init_lib, dbcsr_put_block, &
         dbcsr_release, dbcsr_reserve_blocks, dbcsr_type, dbcsr_type_no_symmetry
+   USE cp_fm_basic_linalg,              ONLY: cp_complex_fm_gemm
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
@@ -105,7 +106,7 @@ PROGRAM qs_ot_complex_ref_unittest
    mynode = mp_comm%mepos
    io_unit = -1
    IF (mynode == 0) io_unit = default_output_unit
-   CALL test_antihermitian_spectral_norm(mynode, nfail)
+   CALL test_antihermitian_spectral_norm(io_unit, nfail)
    CALL test_fixed_n_mermin_energy(mynode, nfail)
    CALL test_fixed_n_projector_frechet(mynode, nfail)
    CALL test_finite_rotation_response(mynode, nfail)
@@ -128,8 +129,9 @@ PROGRAM qs_ot_complex_ref_unittest
    CALL test_complex_rotation_frechet(para_env, nfail)
    CALL test_sparse_frechet_patterns(para_env, nfail)
    CALL test_complex_ref_rotation(para_env, nfail)
+   CALL test_split_complex_fm_gemm(para_env, io_unit, nfail)
    CALL test_complex_preconditioner_gauge(para_env, nfail)
-   CALL test_kpoint_ot_energy_weighted_density(para_env, nfail)
+   CALL test_kpoint_ot_energy_weighted_density(para_env, io_unit, nfail)
 
    x(:, 1) = [CMPLX(1.10_dp, 0.10_dp, KIND=dp), CMPLX(0.20_dp, -0.30_dp, KIND=dp), &
               CMPLX(-0.10_dp, 0.20_dp, KIND=dp)]
@@ -263,12 +265,96 @@ PROGRAM qs_ot_complex_ref_unittest
 CONTAINS
 
 ! **************************************************************************************************
-!> \brief Check the noncanonical complex OT energy-weighted density and its gauge covariance.
+!> \brief Check split-complex full-matrix multiplication including adjoints.
 !> \param para_env parallel environment
+!> \param io_unit output unit
 !> \param nfail accumulated number of failures
 ! **************************************************************************************************
-   SUBROUTINE test_kpoint_ot_energy_weighted_density(para_env, nfail)
+   SUBROUTINE test_split_complex_fm_gemm(para_env, io_unit, nfail)
       TYPE(mp_para_env_type), POINTER                    :: para_env
+      INTEGER, INTENT(IN)                                :: io_unit
+      INTEGER, INTENT(INOUT)                             :: nfail
+
+      INTEGER, PARAMETER                                 :: ndim = 3
+
+      COMPLEX(KIND=dp), DIMENSION(ndim, ndim)            :: a, actual, b, expected
+      INTEGER                                            :: i, j
+      REAL(KIND=dp)                                      :: error_cn, error_nc, error_nn
+      REAL(KIND=dp), DIMENSION(ndim, ndim)               :: actual_im, actual_re
+      TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
+      TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
+      TYPE(cp_fm_type)                                   :: a_im, a_re, b_im, b_re, c_im, c_re
+
+      NULLIFY (blacs_env, matrix_struct)
+      DO j = 1, ndim
+         DO i = 1, ndim
+            a(i, j) = CMPLX(0.13_dp*i - 0.07_dp*j, 0.05_dp*i*j - 0.11_dp*j, KIND=dp)
+            b(i, j) = CMPLX(-0.09_dp*i + 0.17_dp*j, 0.08_dp*i*j + 0.04_dp*i, KIND=dp)
+         END DO
+      END DO
+
+      CALL cp_blacs_env_create(blacs_env=blacs_env, para_env=para_env)
+      CALL cp_fm_struct_create(matrix_struct, nrow_global=ndim, ncol_global=ndim, &
+                               context=blacs_env, para_env=para_env)
+      CALL cp_fm_create(a_re, matrix_struct)
+      CALL cp_fm_create(a_im, matrix_struct)
+      CALL cp_fm_create(b_re, matrix_struct)
+      CALL cp_fm_create(b_im, matrix_struct)
+      CALL cp_fm_create(c_re, matrix_struct)
+      CALL cp_fm_create(c_im, matrix_struct)
+      CALL cp_fm_set_submatrix(a_re, REAL(a, KIND=dp))
+      CALL cp_fm_set_submatrix(a_im, AIMAG(a))
+      CALL cp_fm_set_submatrix(b_re, REAL(b, KIND=dp))
+      CALL cp_fm_set_submatrix(b_im, AIMAG(b))
+
+      CALL cp_complex_fm_gemm('N', 'N', ndim, ndim, ndim, 1.0_dp, &
+                              a_re, a_im, b_re, b_im, 0.0_dp, c_re, c_im)
+      CALL cp_fm_get_submatrix(c_re, actual_re)
+      CALL cp_fm_get_submatrix(c_im, actual_im)
+      actual = CMPLX(actual_re, actual_im, KIND=dp)
+      expected = MATMUL(a, b)
+      error_nn = MAXVAL(ABS(actual - expected))
+
+      CALL cp_complex_fm_gemm('C', 'N', ndim, ndim, ndim, 1.0_dp, &
+                              a_re, a_im, b_re, b_im, 0.0_dp, c_re, c_im)
+      CALL cp_fm_get_submatrix(c_re, actual_re)
+      CALL cp_fm_get_submatrix(c_im, actual_im)
+      actual = CMPLX(actual_re, actual_im, KIND=dp)
+      expected = MATMUL(CONJG(TRANSPOSE(a)), b)
+      error_cn = MAXVAL(ABS(actual - expected))
+
+      CALL cp_complex_fm_gemm('N', 'C', ndim, ndim, ndim, 1.0_dp, &
+                              a_re, a_im, b_re, b_im, 0.0_dp, c_re, c_im)
+      CALL cp_fm_get_submatrix(c_re, actual_re)
+      CALL cp_fm_get_submatrix(c_im, actual_im)
+      actual = CMPLX(actual_re, actual_im, KIND=dp)
+      expected = MATMUL(a, CONJG(TRANSPOSE(b)))
+      error_nc = MAXVAL(ABS(actual - expected))
+
+      IF (MAX(error_nn, error_cn, error_nc) > 1.0E-12_dp) nfail = nfail + 1
+      IF (io_unit >= 0) WRITE (io_unit, '(A,3(1X,ES13.6))') &
+         'split-complex GEMM N/N, C/N, N/C errors:', error_nn, error_cn, error_nc
+
+      CALL cp_fm_release(c_im)
+      CALL cp_fm_release(c_re)
+      CALL cp_fm_release(b_im)
+      CALL cp_fm_release(b_re)
+      CALL cp_fm_release(a_im)
+      CALL cp_fm_release(a_re)
+      CALL cp_fm_struct_release(matrix_struct)
+      CALL cp_blacs_env_release(blacs_env)
+
+   END SUBROUTINE test_split_complex_fm_gemm
+
+! **************************************************************************************************
+!> \brief Check the noncanonical complex OT energy-weighted density and its gauge covariance.
+!> \param para_env parallel environment
+!> \param io_unit output unit
+!> \param nfail accumulated number of failures
+! **************************************************************************************************
+   SUBROUTINE test_kpoint_ot_energy_weighted_density(para_env, io_unit, nfail)
+      TYPE(mp_para_env_type), POINTER                    :: para_env
+      INTEGER, INTENT(IN)                                :: io_unit
       INTEGER, INTENT(INOUT)                             :: nfail
 
       INTEGER, PARAMETER                                 :: nao = 4, nmo = 3
@@ -370,8 +456,8 @@ CONTAINS
 
       IF (error > 5.0E-12_dp .OR. hermitian_error > 5.0E-12_dp .OR. &
           gauge_error > 5.0E-12_dp) nfail = nfail + 1
-      IF (para_env%is_source()) THEN
-         WRITE (*, '(A,3(1X,ES13.6))') 'complex OT W error/hermitian/gauge', &
+      IF (io_unit >= 0) THEN
+         WRITE (io_unit, '(A,3(1X,ES13.6))') 'complex OT W error/hermitian/gauge', &
             error, hermitian_error, gauge_error
       END IF
 
@@ -388,11 +474,11 @@ CONTAINS
    END SUBROUTINE test_kpoint_ot_energy_weighted_density
 ! **************************************************************************************************
 !> \brief Check the complex rotation norm against an analytic pair and a unitary gauge change.
-!> \param mynode MPI rank
+!> \param io_unit output unit
 !> \param nfail accumulated failures
 ! **************************************************************************************************
-   SUBROUTINE test_antihermitian_spectral_norm(mynode, nfail)
-      INTEGER, INTENT(IN)                                :: mynode
+   SUBROUTINE test_antihermitian_spectral_norm(io_unit, nfail)
+      INTEGER, INTENT(IN)                                :: io_unit
       INTEGER, INTENT(INOUT)                             :: nfail
 
       COMPLEX(KIND=dp), DIMENSION(3)                     :: phase
@@ -413,7 +499,7 @@ CONTAINS
       norm = qs_ot_antihermitian_spectral_norm(generator)
       transformed_norm = qs_ot_antihermitian_spectral_norm(transformed)
       error = MAX(ABS(norm - 0.5_dp), ABS(transformed_norm - norm))
-      IF (mynode == 0) WRITE (default_output_unit, '(A,ES14.6)') &
+      IF (io_unit >= 0) WRITE (io_unit, '(A,ES14.6)') &
          "complex rotation spectral-norm error: ", error
       IF (error > 1.0E-13_dp) nfail = nfail + 1
 

--- a/src/qs_scf_loop_utils.F
+++ b/src/qs_scf_loop_utils.F
@@ -27,8 +27,8 @@ MODULE qs_scf_loop_utils
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
    USE cp_external_control,             ONLY: external_control
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
-                                              cp_fm_gemm,&
+   USE cp_fm_basic_linalg,              ONLY: cp_complex_fm_gemm,&
+                                              cp_fm_column_scale,&
                                               cp_fm_scale_and_add
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
@@ -1449,10 +1449,7 @@ CONTAINS
       CALL cp_fm_get_info(b_re, nrow_global=k_b, ncol_global=n)
       CALL cp_fm_get_info(c_re, nrow_global=m_c, ncol_global=n_c)
       CPASSERT(k_b == k .AND. m_c == m .AND. n_c == n)
-      CALL cp_fm_gemm('N', 'N', m, n, k, alpha, a_re, b_re, beta, c_re)
-      CALL cp_fm_gemm('N', 'N', m, n, k, -alpha, a_im, b_im, 1.0_dp, c_re)
-      CALL cp_fm_gemm('N', 'N', m, n, k, alpha, a_re, b_im, beta, c_im)
-      CALL cp_fm_gemm('N', 'N', m, n, k, alpha, a_im, b_re, 1.0_dp, c_im)
+      CALL cp_complex_fm_gemm('N', 'N', m, n, k, alpha, a_re, a_im, b_re, b_im, beta, c_re, c_im)
 
    END SUBROUTINE multiply_complex_fm_nn
 
@@ -1477,10 +1474,7 @@ CONTAINS
       CALL cp_fm_get_info(b_re, nrow_global=k_b, ncol_global=n)
       CALL cp_fm_get_info(c_re, nrow_global=m_c, ncol_global=n_c)
       CPASSERT(k_b == k .AND. m_c == m .AND. n_c == n)
-      CALL cp_fm_gemm('T', 'N', m, n, k, alpha, a_re, b_re, beta, c_re)
-      CALL cp_fm_gemm('T', 'N', m, n, k, alpha, a_im, b_im, 1.0_dp, c_re)
-      CALL cp_fm_gemm('T', 'N', m, n, k, alpha, a_re, b_im, beta, c_im)
-      CALL cp_fm_gemm('T', 'N', m, n, k, -alpha, a_im, b_re, 1.0_dp, c_im)
+      CALL cp_complex_fm_gemm('C', 'N', m, n, k, alpha, a_re, a_im, b_re, b_im, beta, c_re, c_im)
 
    END SUBROUTINE multiply_complex_fm_adjoint
 
@@ -1505,10 +1499,7 @@ CONTAINS
       CALL cp_fm_get_info(b_re, nrow_global=n, ncol_global=k_b)
       CALL cp_fm_get_info(c_re, nrow_global=m_c, ncol_global=n_c)
       CPASSERT(k_b == k .AND. m_c == m .AND. n_c == n)
-      CALL cp_fm_gemm('N', 'T', m, n, k, alpha, a_re, b_re, beta, c_re)
-      CALL cp_fm_gemm('N', 'T', m, n, k, alpha, a_im, b_im, 1.0_dp, c_re)
-      CALL cp_fm_gemm('N', 'T', m, n, k, -alpha, a_re, b_im, beta, c_im)
-      CALL cp_fm_gemm('N', 'T', m, n, k, alpha, a_im, b_re, 1.0_dp, c_im)
+      CALL cp_complex_fm_gemm('N', 'C', m, n, k, alpha, a_re, a_im, b_re, b_im, beta, c_re, c_im)
 
    END SUBROUTINE multiply_complex_fm_right_adjoint
 


### PR DESCRIPTION
## Summary

- route cube-density and complex-OT diagnostics through explicit logger/output units
- extend `cp_complex_fm_gemm` with conjugate-transpose operands
- replace three local split-complex GEMM implementations with the central helper
- add deterministic N/N, C/N, and N/C test coverage

This addresses the six remaining unsuppressed issues on the current Coding conventions and Spack conventions dashboards. The separate FFTW warning is handled in #5953.

## Validation

- `./make_pretty.sh`: 9311 files checked, 0 failures
- `git diff --check`
- GCC/GFortran 16.1 Debug MPI build of all affected objects and `qs_ot_complex_ref_unittest.pdbg`
- split-complex GEMM errors: `6.94e-17`, `5.55e-17`, `5.55e-17` (threshold `1e-12`)
- targeted GCC AST/warning convention analysis: 0 unsuppressed issues

The new numerical test runs successfully. The complete local unit executable later reaches an existing current-master debug assertion in `test_complex_preconditioner_gauge` on this macOS setup.