### PR TITLE
Stabilize Al Mermin LBFGS regression test

### DIFF
--- a/tests/QS/regtest-ot-3-3/Al-kpoint-mermin-lbfgs.inp
+++ b/tests/QS/regtest-ot-3-3/Al-kpoint-mermin-lbfgs.inp
@@ -23,8 +23,8 @@
     &END QS
     &SCF
       ADDED_MOS 16
-      EPS_SCF 1.0E-4
-      MAX_SCF 300
+      EPS_SCF 1.0E-6
+      MAX_SCF 25
       SCF_GUESS ATOMIC
       &OT
         ALGORITHM STRICT
@@ -34,12 +34,16 @@
         PRECONDITIONER FULL_KINETIC
         ROTATION
       &END OT
+      &OUTER_SCF
+        EPS_SCF 1.0E-6
+        MAX_SCF 20
+      &END OUTER_SCF
       &PRINT
         &RESTART OFF
         &END RESTART
       &END PRINT
       &SMEAR
-        ELECTRONIC_TEMPERATURE 3000
+        ELECTRONIC_TEMPERATURE 300
         METHOD FERMI_DIRAC
       &END SMEAR
     &END SCF

--- a/tests/QS/regtest-ot-3-3/TEST_FILES.toml
+++ b/tests/QS/regtest-ot-3-3/TEST_FILES.toml
@@ -3,7 +3,7 @@
 # e.g. 0 means do not compare anything, running is enough
 #      1 compares the last total energy in the file
 #      for details see cp2k/tools/do_regtest
-"Al-kpoint-mermin-lbfgs.inp"            = [{matcher="E_total", tol=1e-8, ref=-8.17199206567539}]
+"Al-kpoint-mermin-lbfgs.inp"            = [{matcher="E_total", tol=5e-6, ref=-8.17199206567539}]
 "Al-kpoint-mermin-lbfgs-occ.inp"        = [{matcher="E_total", tol=1e-9, ref=-2.903015358383124}]
 "Al-kpoint-mermin-broyden-occ.inp"      = [{matcher="E_total", tol=1e-9, ref=-2.903015358436246}]
 "Al-kpoint-mermin-diis-occ.inp"           = [{matcher="E_total", tol=1e-6, ref=-8.15734061513311}]

--- a/tests/QS/regtest-ot-3-3/TEST_FILES.toml
+++ b/tests/QS/regtest-ot-3-3/TEST_FILES.toml
@@ -3,7 +3,7 @@
 # e.g. 0 means do not compare anything, running is enough
 #      1 compares the last total energy in the file
 #      for details see cp2k/tools/do_regtest
-"Al-kpoint-mermin-lbfgs.inp"            = [{matcher="E_total", tol=5e-6, ref=-8.17199206567539}]
+"Al-kpoint-mermin-lbfgs.inp"            = [{matcher="E_total", tol=1e-8, ref=-8.15998175740775}]
 "Al-kpoint-mermin-lbfgs-occ.inp"        = [{matcher="E_total", tol=1e-9, ref=-2.903015358383124}]
 "Al-kpoint-mermin-broyden-occ.inp"      = [{matcher="E_total", tol=1e-9, ref=-2.903015358436246}]
 "Al-kpoint-mermin-diis-occ.inp"           = [{matcher="E_total", tol=1e-6, ref=-8.15734061513311}]


### PR DESCRIPTION
The Al Mermin LBFGS regression test used a single SCF cycle with `EPS_SCF 1.0E-4`. Depending on the build configuration, the optimizer could therefore stop at different iterations while still reporting convergence, leading to a relative spread of about `3.7E-6` in the matched energy.

Following review, this stabilizes the calculation itself instead of relaxing the regression tolerance:

- use an Outer-SCF loop with `EPS_SCF 1.0E-6`;
- limit each inner SCF cycle to 25 steps;
- lower the electronic temperature from 3000 K to 300 K; and
- retain the original `1.0E-8` matcher tolerance with the converged reference energy.

The 300 K calculation still exercises the Mermin path and has a non-zero electronic entropic contribution. It converges in two Outer-SCF cycles and 76 inner steps in total.

Validation:

- 1 MPI rank: `-8.15998175740681` Ha
- 2 MPI ranks: `-8.15998175740832` Ha
- CP2K pre-push checks passed for both modified files
