### PR TITLE
Fix one-step parallel FFT plan dimensions

### DIFF
--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -3068,7 +3068,7 @@ CONTAINS
 
                !set up fft plans
                CALL fft_create_plan_1d(fft_scratch_new%fft_scratch%fft_plan(1), FWFFT, .TRUE., .FALSE., &
-                                       mx1*my1, n(3), n(1), my3*mz3, &
+                                       mx1*my1, n(3), n(3), mx1*my1, &
                                        fft_scratch_new%fft_scratch%a1buf, fft_scratch_new%fft_scratch%a3buf)
                CALL fft_create_plan_1d(fft_scratch_new%fft_scratch%fft_plan(2), FWFFT, .TRUE., .FALSE., &
                                        mx1*mz1, n(2), n(2), mx1*mz1, &


### PR DESCRIPTION
The generalized 1D FFT interface introduced in #5868 accidentally initializes the first one-step (`tf_type=101`) FFT plan with the dimensions of the later x transform.

For a 12 x 15 x 20 grid distributed over two ranks this requests 3600 complex values from a buffer containing 1800. The transform therefore produces wrong values and corrupts the heap, which later aborts while releasing the FFT scratch pool. This is the common failure visible in the Current psmp, ARM64, and coverage dashboard reports.

Restore the original z-transform length and batch count, `n(3)` and `mx1*my1`.

Validation:
- `test_pw.inp`, 2 MPI ranks x 1 OpenMP thread
- `test_pw.inp`, 2 MPI ranks x 2 OpenMP threads (dashboard configuration)
- `test_pw.inp`, 2 MPI ranks x 4 OpenMP threads

All parallel FFT checks now agree to about 1e-16 and the runs release the scratch pool cleanly. `make_pretty.sh src/pw/fft_tools.F` passes.