### PR TITLE
Avoid GCC 15 complex density secant miscompile

### DIFF
--- a/src/qs_ot.F
+++ b/src/qs_ot.F
@@ -33,7 +33,8 @@ MODULE qs_ot
                                               cp_dbcsr_syevd
    USE kinds,                           ONLY: dp
    USE mathlib,                         ONLY: diag_complex,&
-                                              diamat_all
+                                              diamat_all,&
+                                              gemm_square
    USE message_passing,                 ONLY: mp_comm_type
    USE preconditioner,                  ONLY: apply_preconditioner
    USE preconditioner_types,            ONLY: preconditioner_type
@@ -766,9 +767,9 @@ CONTAINS
 
       ALLOCATE (cross_mode(n, n))
       DO mode = 1, nmode
-         cross_mode(:, :) = MATMUL(overlap_start_current, &
-                                   MATMUL(density_modes(:, :, mode), &
-                                          CONJG(TRANSPOSE(overlap_start_current))))
+         ! GCC 15 miscompiles the equivalent complex array expressions with -march=znver3.
+         CALL gemm_square(overlap_start_current, "N", density_modes(:, :, mode), "N", &
+                          overlap_start_current, "C", cross_mode)
          DO i = 1, n
             density_overlap(mode) = density_overlap(mode) + &
                                     occupation_current(i)* &
@@ -776,7 +777,9 @@ CONTAINS
                                     occupation_start(i)*REAL(cross_mode(i, i), KIND=dp)
          END DO
          response_overlap(mode) = &
-            REAL(SUM(CONJG(hamiltonian_step_current)*density_modes(:, :, mode)), KIND=dp)
+            SUM(REAL(hamiltonian_step_current, KIND=dp)* &
+                REAL(density_modes(:, :, mode), KIND=dp) + &
+                AIMAG(hamiltonian_step_current)*AIMAG(density_modes(:, :, mode)))
       END DO
       DEALLOCATE (cross_mode)
 

--- a/src/qs_ot_complex_ref_unittest.F
+++ b/src/qs_ot_complex_ref_unittest.F
@@ -1322,8 +1322,9 @@ CONTAINS
       density_modes(2, 1, 2) = CONJG(density_modes(1, 2, 2))
 
       overlap(:, :) = MATMUL(CONJG(TRANSPOSE(c0)), c1)
-      h0(:, :) = MATMUL(CONJG(TRANSPOSE(c0)), MATMUL(hamiltonian_step, c0))
-      h1(:, :) = MATMUL(CONJG(TRANSPOSE(c1)), MATMUL(hamiltonian_step, c1))
+      ! Keep the reference path independent of optimized complex MATMUL expressions.
+      CALL reference_project_operator(c0, hamiltonian_step, h0)
+      CALL reference_project_operator(c1, hamiltonian_step, h1)
       CALL qs_ot_density_secant_orbital_overlaps( &
          overlap, occupation0, occupation1, h0, h1, density_modes, weight, density_norm, &
          response_work, density_overlap, response_overlap, valid)
@@ -1338,16 +1339,14 @@ CONTAINS
                         SPREAD(CONJG(c0(:, i)), DIM=1, NCOPIES=nao)
       END DO
       DO i = 1, nmode
-         density_modes_ao(:, :, i) = MATMUL(c1, &
-                                            MATMUL(density_modes(:, :, i), &
-                                                   CONJG(TRANSPOSE(c1))))
-         density_overlap_ref(i) = REAL( &
-                                  SUM(CONJG(density_step)*density_modes_ao(:, :, i)), KIND=dp)/weight
+         CALL reference_transform_density_mode(c1, density_modes(:, :, i), density_modes_ao(:, :, i))
+         density_overlap_ref(i) = &
+            reference_frobenius_product_real(density_step, density_modes_ao(:, :, i))/weight
          response_overlap_ref(i) = &
-            REAL(SUM(CONJG(hamiltonian_step)*density_modes_ao(:, :, i)), KIND=dp)
+            reference_frobenius_product_real(hamiltonian_step, density_modes_ao(:, :, i))
       END DO
-      density_norm_ref = REAL(SUM(CONJG(density_step)*density_step), KIND=dp)/weight
-      response_work_ref = REAL(SUM(CONJG(density_step)*hamiltonian_step), KIND=dp)
+      density_norm_ref = reference_frobenius_product_real(density_step, density_step)/weight
+      response_work_ref = reference_frobenius_product_real(density_step, hamiltonian_step)
       error = MAX(ABS(density_norm - density_norm_ref), ABS(response_work - response_work_ref))
       error = MAX(error, MAXVAL(ABS(density_overlap - density_overlap_ref)))
       error = MAX(error, MAXVAL(ABS(response_overlap - response_overlap_ref)))
@@ -1357,6 +1356,75 @@ CONTAINS
          "moving-subspace density secant error:", error
 
    END SUBROUTINE test_density_secant_moving_subspace
+
+! **************************************************************************************************
+!> \brief Reference projection C^H H C using scalar operations.
+!> \param orbitals orbital coefficient matrix C
+!> \param hamiltonian operator matrix H
+!> \param projected projected operator
+! **************************************************************************************************
+   SUBROUTINE reference_project_operator(orbitals, hamiltonian, projected)
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: orbitals, hamiltonian
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: projected
+
+      COMPLEX(KIND=dp)                                   :: value
+      INTEGER                                            :: i, j, mu, nu
+
+      DO j = 1, SIZE(orbitals, 2)
+         DO i = 1, SIZE(orbitals, 2)
+            value = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+            DO nu = 1, SIZE(orbitals, 1)
+               DO mu = 1, SIZE(orbitals, 1)
+                  value = value + CONJG(orbitals(mu, i))*hamiltonian(mu, nu)*orbitals(nu, j)
+               END DO
+            END DO
+            projected(i, j) = value
+         END DO
+      END DO
+
+   END SUBROUTINE reference_project_operator
+
+! **************************************************************************************************
+!> \brief Reference transformation C M C^H using scalar operations.
+!> \param orbitals orbital coefficient matrix C
+!> \param mode density mode M
+!> \param transformed transformed density mode
+! **************************************************************************************************
+   SUBROUTINE reference_transform_density_mode(orbitals, mode, transformed)
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: orbitals, mode
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: transformed
+
+      COMPLEX(KIND=dp)                                   :: value
+      INTEGER                                            :: i, j, m, n
+
+      DO j = 1, SIZE(orbitals, 1)
+         DO i = 1, SIZE(orbitals, 1)
+            value = CMPLX(0.0_dp, 0.0_dp, KIND=dp)
+            DO n = 1, SIZE(orbitals, 2)
+               DO m = 1, SIZE(orbitals, 2)
+                  value = value + orbitals(i, m)*mode(m, n)*CONJG(orbitals(j, n))
+               END DO
+            END DO
+            transformed(i, j) = value
+         END DO
+      END DO
+
+   END SUBROUTINE reference_transform_density_mode
+
+! **************************************************************************************************
+!> \brief Real part of the complex Frobenius inner product.
+!> \param matrix_a first matrix
+!> \param matrix_b second matrix
+!> \return real Frobenius product
+! **************************************************************************************************
+   FUNCTION reference_frobenius_product_real(matrix_a, matrix_b) RESULT(value)
+      COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(IN)      :: matrix_a, matrix_b
+      REAL(KIND=dp)                                      :: value
+
+      value = SUM(REAL(matrix_a, KIND=dp)*REAL(matrix_b, KIND=dp) + &
+                  AIMAG(matrix_a)*AIMAG(matrix_b))
+
+   END FUNCTION reference_frobenius_product_real
 
 ! **************************************************************************************************
 !> \brief fixed-occupation band energy for a dense finite rotation


### PR DESCRIPTION
## Summary

- use the existing BLAS-backed `gemm_square` path for the complex density-mode transformation
- evaluate the real complex Frobenius product through separate real and imaginary components
- keep the unit-test reference independent by using scalar reference contractions

## Motivation

The Current Toolchain psmp and ssmp dashboard builds at 375a5ce fail `qs_ot_complex_ref_unittest` with a moving-subspace density-secant error of `3.575113E-02`. The failure is reproducible with GCC 15.2 on AMD EPYC only when `-O3 -funroll-loops -march=znver3` is enabled. The same reduced program is correct without the architecture optimization, and disabling GCC tree vectorization also restores the result.

The affected expressions are nested complex `MATMUL` operations and complex array reductions. Routing the production contraction through BLAS and keeping the reference implementation scalar avoids the GCC 15 wrong-code path without weakening the test or changing global compiler flags.

## Verification

- GCC 15.2, `-O3 -funroll-loops -march=znver3`: reduced reproducer returns machine-precision agreement after the change
- full CP2K Release build with GCC 16.1
- `qs_ot_complex_ref_unittest.psmp`, 1 MPI rank x 2 OpenMP threads: pass, `4.996004E-16`
- `qs_ot_complex_ref_unittest.psmp`, 2 MPI ranks x 2 OpenMP threads: pass, `4.996004E-16`
- `make_pretty` and precommit checks pass
