### PR TITLE
Stabilize sparse RI-RS grid optimization regtest

### DIFF
--- a/tests/QS/regtest-gw-realspace/TEST_FILES.toml
+++ b/tests/QS/regtest-gw-realspace/TEST_FILES.toml
@@ -36,9 +36,7 @@
 
 "rirs-grid-optimization-percentage-10-H2O.inp" = [{matcher="RIRS_Grid", tol=1e-12, ref=62},
                                                   {matcher="RIRS_Grid_Optimization_Error", tol=1e-1, ref=1.6e-4},
-                                                  {matcher="E_RIRS_HOMO", tol=8e-4, ref=-6.218},
-                                                  {matcher="E_RIRS_LUMO", tol=8e-4, ref=17.598},
-                                                  {matcher="E_G0W0_direct_gap", tol=1e-3, ref=23.816}]
+                                                  {matcher="E_RIRS_HOMO", tol=8e-4, ref=-6.218}]
 
 "rirs-grid-optimization-percentage-H2O.inp" = [{matcher="RIRS_Grid", tol=1e-12, ref=121},
                                                {matcher="RIRS_Grid_Optimization_Error", tol=1e-1, ref=4.9e-11},


### PR DESCRIPTION
The 10% RI-RS grid is deliberately strongly undersampled (62 points instead of 608). Its optimizer objective has multiple numerically equivalent solutions: different compiler/BLAS configurations reach the same normalized 3C error while producing noticeably different virtual energies.

A direct A/B test of cccc8452 and b6ef100 found identical results within each build:

- macOS/GFortran 16: LUMO 17.605 eV, direct gap 23.824 eV
- Linux/GCC 16/OpenMPI: LUMO 17.598 eV, direct gap 23.816 eV
- Linux/GCC 15/Zen2/OpenBLAS/LibXS: LUMO 17.645 eV, direct gap 23.863 eV

The dashboard's GCC 15 Spack build likewise reached the expected 62 points and normalized 3C error of 1.6e-4, but obtained 17.682 and 23.896 eV. This shows that b6ef100 is not the source of the numerical change; it only removed the executable-stack trampoline.

This PR therefore keeps the checks that exercise the 10% grid feature itself:

- selected grid size
- optimized normalized 3C error
- end-to-end occupied HOMO result

It removes only the LUMO and derived gap checks from this deliberately underdetermined case. The neighboring 20% grid test continues to check both LUMO and direct gap with the original tight tolerances.

Verification:

- make_pretty.sh on the changed TEST_FILES.toml
- GCC 15 Spack-like output passes all three retained matchers
- A/B runs of the parent and b6ef100 with GCC 15 and GCC 16
