### PR TITLE
PW/FFT: Translate the FFTW_PLAN_TYPE enum to FFTW planner flags

### DIFF
--- a/src/pw/fft/fftw3_lib.F
+++ b/src/pw/fft/fftw3_lib.F
@@ -225,7 +225,18 @@ CONTAINS
          END IF
       END IF
 
-      fftw_plan_type = plan_style
+      SELECT CASE (plan_style)
+      CASE (1)
+         fftw_plan_type = FFTW_ESTIMATE
+      CASE (2)
+         fftw_plan_type = FFTW_MEASURE
+      CASE (3)
+         fftw_plan_type = FFTW_PATIENT
+      CASE (4)
+         fftw_plan_type = FFTW_EXHAUSTIVE
+      CASE DEFAULT
+         CPABORT("Invalid FFTW_PLAN_TYPE")
+      END SELECT
 #else
       MARK_USED(wisdom_file)
       MARK_USED(plan_style)
@@ -692,7 +703,7 @@ CONTAINS
 !$OMP END PARALLEL
 
       IF ((.NOT. fftw3_is_guru_supported()) .OR. &
-          (.NOT. fftw_plan_type == 1) .OR. &
+          (.NOT. fftw_plan_type == FFTW_ESTIMATE) .OR. &
           (n1 < 256 .AND. n2 < 256 .AND. n3 < 256 .AND. nt == 1)) THEN
          ! If the plan type is MEASURE, PATIENT and EXHAUSTIVE or
          ! the grid size is small (and we are single-threaded) then


### PR DESCRIPTION
Before fc800c616 (#5868) every plan creation routine translated the FFTW_PLAN_TYPE enum to the FFTW planner flags.

The keyword stores the enum 1=ESTIMATE, 2=MEASURE, 3=PATIENT, 4=EXHAUSTIVE.

The FFTW planner flags are bitmasks with MEASURE=0 and ESTIMATE=64.

Since #5868 the enum is stored as is in the module variable fftw_plan_type and passed as the flags argument of dfftw_plan_many_dft.

Every FFTW3 run therefore plans with MEASURE regardless of the FFTW_PLAN_TYPE setting.

The default ESTIMATE is unreachable, and so are PATIENT and EXHAUSTIVE.

MEASURE planning also executes trial transforms on the caller buffers during planning and slows down the startup.

The commit restores the translation in fftw3_do_init and updates the one comparison that still tested the enum.
