### PR TITLE
PW/FFT: Fix the plan-6 scratch buffer and assert the plan geometry

### DIFF
--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -3256,7 +3256,7 @@ CONTAINS
                                        fft_scratch_new%fft_scratch%p4buf, fft_scratch_new%fft_scratch%p3buf)
                CALL fft_create_plan_1d(fft_scratch_new%fft_scratch%fft_plan(6), BWFFT, .FALSE., .TRUE., &
                                        n(3), mx1*my1, n(3), mx1*my1, &
-                                       fft_scratch_new%fft_scratch%p3buf, fft_scratch_new%fft_scratch%p1buf)
+                                       fft_scratch_new%fft_scratch%p2buf, fft_scratch_new%fft_scratch%p1buf)
 
             CASE (400) ! serial FFT
                np = 0

--- a/src/pw/fft_tools.F
+++ b/src/pw/fft_tools.F
@@ -3239,21 +3239,31 @@ CONTAINS
                END DO
 
                !set up fft plans
+               ! The scratch buffers must cover the geometry declared in each call
+               ! below, because the FFTW planner may write the buffers during
+               ! planning. The plans pair the buffers such that each of p1-p6 is
+               ! checked once; p7 shares the size of p6.
+               CPASSERT(SIZE(fft_scratch_new%fft_scratch%p1buf) >= mx1*my1*n(3))
                CALL fft_create_plan_1d(fft_scratch_new%fft_scratch%fft_plan(1), FWFFT, .TRUE., .FALSE., &
                                        mx1*my1, n(3), n(3), mx1*my1, &
                                        fft_scratch_new%fft_scratch%p1buf, fft_scratch_new%fft_scratch%p2buf)
+               CPASSERT(SIZE(fft_scratch_new%fft_scratch%p3buf) >= mx2*mz2*n(2))
                CALL fft_create_plan_1d(fft_scratch_new%fft_scratch%fft_plan(2), FWFFT, .TRUE., .FALSE., &
                                        mx2*mz2, n(2), n(2), mx2*mz2, &
                                        fft_scratch_new%fft_scratch%p3buf, fft_scratch_new%fft_scratch%p4buf)
+               CPASSERT(SIZE(fft_scratch_new%fft_scratch%p5buf) >= nyzray*n(1))
                CALL fft_create_plan_1d(fft_scratch_new%fft_scratch%fft_plan(3), FWFFT, .TRUE., .FALSE., &
                                        nyzray, n(1), n(1), nyzray, &
                                        fft_scratch_new%fft_scratch%p5buf, fft_scratch_new%fft_scratch%p6buf)
+               CPASSERT(SIZE(fft_scratch_new%fft_scratch%p6buf) >= n(1)*nyzray)
                CALL fft_create_plan_1d(fft_scratch_new%fft_scratch%fft_plan(4), BWFFT, .FALSE., .TRUE., &
                                        n(1), nyzray, n(1), nyzray, &
                                        fft_scratch_new%fft_scratch%p6buf, fft_scratch_new%fft_scratch%p7buf)
+               CPASSERT(SIZE(fft_scratch_new%fft_scratch%p4buf) >= n(2)*mx2*mz2)
                CALL fft_create_plan_1d(fft_scratch_new%fft_scratch%fft_plan(5), BWFFT, .FALSE., .TRUE., &
                                        n(2), mx2*mz2, n(2), mx2*mz2, &
                                        fft_scratch_new%fft_scratch%p4buf, fft_scratch_new%fft_scratch%p3buf)
+               CPASSERT(SIZE(fft_scratch_new%fft_scratch%p2buf) >= n(3)*mx1*my1)
                CALL fft_create_plan_1d(fft_scratch_new%fft_scratch%fft_plan(6), BWFFT, .FALSE., .TRUE., &
                                        n(3), mx1*my1, n(3), mx1*my1, &
                                        fft_scratch_new%fft_scratch%p2buf, fft_scratch_new%fft_scratch%p1buf)

--- a/tests/QS/regtest-fftw/H2O-fft-plan6.inp
+++ b/tests/QS/regtest-fftw/H2O-fft-plan6.inp
@@ -1,0 +1,53 @@
+! Regression test for the plan-6 scratch buffer of the 2D-distributed FFT path.
+! The cell makes the coarsest multigrid level (2, 24, 25), which drops below the
+! number of ranks and takes a 2D processor layout: there the plan-6 buffers are
+! paired. FFTW_PLAN_TYPE MEASURE lets the planner touch the planning buffers,
+! so a mispaired buffer corrupts the heap from 4 ranks on (1 OpenMP thread).
+! The SCF converges and matches the energy also on 1, 2 and 8 ranks.
+&GLOBAL
+  FFTW_PLAN_TYPE MEASURE
+  PRINT_LEVEL LOW
+  PROJECT H2O-fft-plan6
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD QS
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_SET
+    POTENTIAL_FILE_NAME POTENTIAL
+    &MGRID
+      CUTOFF 200
+      NGRIDS 4
+    &END MGRID
+    &QS
+      EPS_DEFAULT 1.0E-8
+    &END QS
+    &SCF
+      MAX_SCF 20
+      SCF_GUESS ATOMIC
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL Pade
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 1.1 14.5 15.5
+    &END CELL
+    &COORD
+      O    0.000000    0.000000   -0.065587
+      H    0.000000   -0.757136    0.520545
+      H    0.000000    0.757136    0.520545
+    &END COORD
+    &KIND H
+      BASIS_SET DZV-GTH-PADE
+      POTENTIAL GTH-PADE-q1
+    &END KIND
+    &KIND O
+      BASIS_SET DZVP-GTH-PADE
+      POTENTIAL GTH-PADE-q6
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/tests/QS/regtest-fftw/TEST_FILES.toml
+++ b/tests/QS/regtest-fftw/TEST_FILES.toml
@@ -1,2 +1,4 @@
 "H2-big-1.inp"                          = [{matcher="M011", tol=2e-13, ref=-27.808422055041117}]
+# Loose tolerance because FFTW_MEASURE planning varies with the machine load.
+"H2O-fft-plan6.inp"                     = [{matcher="E_total", tol=1e-10, ref=-17.922937036203987}]
 #EOF


### PR DESCRIPTION

The backward z-stage plan of the parallel RS-PW transform is created with a scratch buffer that does not match its declared geometry. The routine signature is

    fft_create_plan_1d(plan, fsign, trans_in, trans_out, ldx_in, ldx_out, n, m, zin, zout)

and the creation call is

    CALL fft_create_plan_1d(fft_scratch%fft_plan(6), BWFFT, .FALSE., .TRUE., &
                            n(3), mx1*my1, n(3), mx1*my1, &
                            fft_scratch%p3buf, fft_scratch%p1buf)

With trans_in = .FALSE. the declared input of this plan is n(3)*mx1*my1 complex values in z layout, that is the shape [n(3), mx1*my1]. The scratch buffers are allocated as p2buf [n(3), mx1*my1] and p3buf [mx2*mz2, n(2)]. The z-layout buffer for this stage is p2buf, and the forward counterpart plan 1 is created with p1buf and p2buf for the same geometry. The call above passes p3buf, which belongs to the y stage and can be smaller than the declared input.

This breaks the convention that the creation-time zin and zout must match the declared n, m and ldx geometry. The FFTW3 backend hands these arrays to fftw_plan_many_dft, so the planner treats them as the memory the declared tensor lives in.

Execution always passes p2buf explicitly, so the computed results were never affected. FFTW_ESTIMATE planning never dereferences the creation-time arrays, so the mismatch stayed harmless. MEASURE class planning zeroes the declared tensor through the creation-time pointer and runs timed trial transforms on it. Current master 2d1258df plans every FFTW3 transform with MEASURE class flags because of the planner flag confusion that is fixed separately. Whenever n(3)*mx1*my1 exceeds the size of p3buf the planning writes past the end of p3buf and corrupts the heap.

A water dimer geometry optimization crashes reliably at 20 MPI ranks within the first SCF on two different machines, as a glibc heap abort or as SIGSEGV. The reproducer input and the crash outputs are attached.

[plan6.tar.gz](https://github.com/user-attachments/files/31868680/plan6.tar.gz)