### PR TITLE
Fix standard MO output for MPI-distributed k-points

### DIFF
--- a/src/qs_mo_io.F
+++ b/src/qs_mo_io.F
@@ -1007,6 +1007,7 @@ CONTAINS
 !> \param sim_step ...
 !> \param umo_set ...
 !> \param qs_env ...
+!> \param para_env_inter_kp ...
 !> \date    15.05.2001
 !> \par History:
 !>       - Optionally print Cartesian MOs (20.04.2005, MK)
@@ -1019,9 +1020,10 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE write_mo_set_to_output_unit(mo_set, qs_kind_set, particle_set, &
                                           dft_section, before, kpoint, final_mos, spin, &
-                                          solver_method, rtp, cpart, sim_step, umo_set, qs_env)
+                                          solver_method, rtp, cpart, sim_step, umo_set, qs_env, &
+                                          para_env_inter_kp)
 
-      TYPE(mo_set_type), INTENT(IN)                      :: mo_set
+      TYPE(mo_set_type), INTENT(IN), OPTIONAL            :: mo_set
       TYPE(qs_kind_type), DIMENSION(:), POINTER          :: qs_kind_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(section_vals_type), POINTER                   :: dft_section
@@ -1033,6 +1035,7 @@ CONTAINS
       INTEGER, INTENT(IN), OPTIONAL                      :: cpart, sim_step
       TYPE(mo_set_type), INTENT(IN), OPTIONAL            :: umo_set
       TYPE(qs_environment_type), OPTIONAL, POINTER       :: qs_env
+      TYPE(mp_para_env_type), OPTIONAL, POINTER          :: para_env_inter_kp
 
       CHARACTER(LEN=12)                                  :: symbol
       CHARACTER(LEN=12), DIMENSION(:), POINTER           :: bcgf_symbol
@@ -1050,12 +1053,12 @@ CONTAINS
       CHARACTER(LEN=6), DIMENSION(:), POINTER            :: bsgf_symbol
       INTEGER :: after, first_mo, from, homo, iatom, icgf, ico, icol, ikind, imo, irow, iset, &
          isgf, ishell, iso, iw, jcol, last_mo, left, lmax, lshell, nao, natom, ncgf, ncol, nkind, &
-         nmo, nset, nsgf, numo, right, scf_step, to, width
+         nmo, nmo_local, nset, nsgf, numo, right, scf_step, to, width
       INTEGER, DIMENSION(:), POINTER                     :: mo_index_range, nshell
       INTEGER, DIMENSION(:, :), POINTER                  :: l
       LOGICAL :: ionode, my_final, my_rtp, omit_headers, print_cartesian, print_cartesian_overlap, &
          print_eigvals, print_eigvecs, print_occup, should_output
-      REAL(KIND=dp)                                      :: gap, maxocc
+      REAL(KIND=dp)                                      :: chemical_potential, gap, maxocc
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: mo_eigenvalues, mo_occupation_numbers
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: cmatrix, smatrix
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, occupation_numbers
@@ -1141,39 +1144,79 @@ CONTAINS
       END IF
 
       ! Retrieve MO information
-      CALL get_mo_set(mo_set=mo_set, &
-                      mo_coeff=mo_coeff, &
-                      eigenvalues=eigenvalues, &
-                      occupation_numbers=occupation_numbers, &
-                      homo=homo, &
-                      maxocc=maxocc, &
-                      nao=nao, &
-                      nmo=nmo)
-      IF (PRESENT(umo_set)) THEN
-         CALL get_mo_set(mo_set=umo_set, &
-                         mo_coeff=umo_coeff, &
-                         nmo=numo)
-         nmo = nmo + numo
-      ELSE
+      IF (PRESENT(para_env_inter_kp)) THEN
+         CPASSERT(ASSOCIATED(para_env_inter_kp))
+         CPASSERT(.NOT. PRESENT(umo_set))
+         nmo_local = 0
+         homo = 0
+         maxocc = 0.0_dp
+         chemical_potential = 0.0_dp
+         NULLIFY (eigenvalues, occupation_numbers, mo_coeff)
+         IF (PRESENT(mo_set)) THEN
+            CALL get_mo_set(mo_set=mo_set, eigenvalues=eigenvalues, &
+                            occupation_numbers=occupation_numbers, mo_coeff=mo_coeff, &
+                            homo=homo, maxocc=maxocc, mu=chemical_potential, nmo=nmo_local)
+         END IF
+         nmo = nmo_local
+         CALL para_env_inter_kp%max(nmo)
+         CALL para_env_inter_kp%sum(homo)
+         CALL para_env_inter_kp%sum(maxocc)
+         CALL para_env_inter_kp%sum(chemical_potential)
+         ALLOCATE (mo_eigenvalues(nmo), mo_occupation_numbers(nmo))
+         mo_eigenvalues = 0.0_dp
+         mo_occupation_numbers = 0.0_dp
+         IF (nmo_local > 0 .AND. PRESENT(mo_set)) THEN
+            mo_eigenvalues(1:nmo_local) = eigenvalues(1:nmo_local)
+            mo_occupation_numbers(1:nmo_local) = occupation_numbers(1:nmo_local)
+         END IF
+         CALL para_env_inter_kp%sum(mo_eigenvalues)
+         CALL para_env_inter_kp%sum(mo_occupation_numbers)
+         IF (print_eigvecs) THEN
+            CALL get_qs_kind_set(qs_kind_set, nsgf=nao)
+            ALLOCATE (smatrix(nao, nmo))
+            smatrix = 0.0_dp
+            IF (nmo_local > 0 .AND. PRESENT(mo_set)) THEN
+               CALL cp_fm_get_submatrix(mo_coeff, smatrix(:, 1:nmo_local))
+            END IF
+            CALL para_env_inter_kp%sum(smatrix)
+         END IF
          numo = 0
-      END IF
-      ALLOCATE (mo_eigenvalues(nmo))
-      mo_eigenvalues(:) = 0.0_dp
-      mo_eigenvalues(1:nmo - numo) = eigenvalues(1:nmo - numo)
-      ALLOCATE (mo_occupation_numbers(nmo))
-      mo_occupation_numbers(:) = 0.0_dp
-      mo_occupation_numbers(1:nmo - numo) = occupation_numbers(1:nmo - numo)
-      IF (numo > 0) THEN
-         CALL get_mo_set(mo_set=umo_set, &
-                         eigenvalues=eigenvalues)
-         mo_eigenvalues(nmo - numo + 1:nmo) = eigenvalues(1:numo)
+      ELSE
+         CPASSERT(PRESENT(mo_set))
+         CALL get_mo_set(mo_set=mo_set, &
+                         mo_coeff=mo_coeff, &
+                         eigenvalues=eigenvalues, &
+                         occupation_numbers=occupation_numbers, &
+                         homo=homo, &
+                         maxocc=maxocc, &
+                         nao=nao, &
+                         nmo=nmo, &
+                         mu=chemical_potential)
+         IF (PRESENT(umo_set)) THEN
+            CALL get_mo_set(mo_set=umo_set, &
+                            mo_coeff=umo_coeff, &
+                            nmo=numo)
+            nmo = nmo + numo
+         ELSE
+            numo = 0
+         END IF
+         ALLOCATE (mo_eigenvalues(nmo), mo_occupation_numbers(nmo))
+         mo_eigenvalues(1:nmo - numo) = eigenvalues(1:nmo - numo)
+         mo_occupation_numbers = 0.0_dp
+         mo_occupation_numbers(1:nmo - numo) = occupation_numbers(1:nmo - numo)
+         IF (numo > 0) THEN
+            CALL get_mo_set(mo_set=umo_set, eigenvalues=eigenvalues)
+            mo_eigenvalues(nmo - numo + 1:nmo) = eigenvalues(1:numo)
+         END IF
       END IF
 
       IF (print_eigvecs) THEN
-         ALLOCATE (smatrix(nao, nmo))
-         CALL cp_fm_get_submatrix(mo_coeff, smatrix(1:nao, 1:nmo - numo))
-         IF (numo > 0) THEN
-            CALL cp_fm_get_submatrix(umo_coeff, smatrix(1:nao, nmo - numo + 1:nmo))
+         IF (.NOT. ALLOCATED(smatrix)) THEN
+            ALLOCATE (smatrix(nao, nmo))
+            CALL cp_fm_get_submatrix(mo_coeff, smatrix(1:nao, 1:nmo - numo))
+            IF (numo > 0) THEN
+               CALL cp_fm_get_submatrix(umo_coeff, smatrix(1:nao, nmo - numo + 1:nmo))
+            END IF
          END IF
          IF (.NOT. ionode) THEN
             DEALLOCATE (smatrix)
@@ -1540,7 +1583,7 @@ CONTAINS
             WRITE (UNIT=fmtstr6(12:13), FMT="(I2)") after
             WRITE (UNIT=fmtstr6(25:26), FMT="(I2)") after
             WRITE (UNIT=iw, FMT=fmtstr6) &
-               " MO| E(Fermi):", mo_set%mu, " a.u.", mo_set%mu*evolt, " eV"
+               " MO| E(Fermi):", chemical_potential, " a.u.", chemical_potential*evolt, " eV"
          END IF
          IF ((homo > 0) .AND. .NOT. my_rtp) THEN
             IF ((mo_occupation_numbers(homo) == maxocc) .AND. (last_mo > homo)) THEN

--- a/src/qs_scf_output.F
+++ b/src/qs_scf_output.F
@@ -42,7 +42,8 @@ MODULE qs_scf_output
    USE kahan_sum,                       ONLY: accurate_sum
    USE kinds,                           ONLY: default_string_length,&
                                               dp
-   USE kpoint_types,                    ONLY: kpoint_type
+   USE kpoint_types,                    ONLY: get_kpoint_info,&
+                                              kpoint_type
    USE machine,                         ONLY: m_flush
    USE message_passing,                 ONLY: mp_para_env_type
    USE particle_types,                  ONLY: particle_type
@@ -197,9 +198,10 @@ CONTAINS
       CHARACTER(LEN=5)                                   :: spin
       CHARACTER(LEN=default_string_length), &
          DIMENSION(:), POINTER                           :: tmpstringlist
-      INTEGER                                            :: handle, homo, ikp, ispin, iw, kpoint, &
-                                                            nao, nelectron, nkp, nmo, nspin, numo
-      INTEGER, DIMENSION(2)                              :: nmos_occ
+      INTEGER                                            :: handle, homo, ikp, ikp_local, ispin, iw, &
+                                                            nao, nelectron, nkp, nmo, nmo_occ, &
+                                                            nspin, numo
+      INTEGER, DIMENSION(2)                              :: kp_range, nmos_occ
       INTEGER, DIMENSION(:), POINTER                     :: mo_index_range
       LOGICAL                                            :: do_kpoints, do_printout, print_eigvals, &
                                                             print_eigvecs, print_mo_info, &
@@ -218,7 +220,7 @@ CONTAINS
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
       TYPE(mo_set_type), POINTER                         :: mo_set, umo_set
-      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_inter_kp
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
       TYPE(preconditioner_type), POINTER                 :: local_preconditioner
       TYPE(qs_environment_type), POINTER                 :: cart_overlap_qs_env
@@ -263,39 +265,67 @@ CONTAINS
          RETURN
       END IF
 
-      NULLIFY (fm_struct_tmp)
-      NULLIFY (mo_coeff)
-      NULLIFY (mo_coeff_deriv)
-      NULLIFY (mo_eigenvalues)
-      NULLIFY (mo_set)
-      NULLIFY (umo_coeff)
-      NULLIFY (umo_eigenvalues)
-      NULLIFY (umo_set)
-
       do_printout = .TRUE.
       nspin = dft_control%nspins
       nmos_occ = 0
 
-      ! Check, if we have k points
       IF (do_kpoints) THEN
          CALL get_qs_env(qs_env, kpoints=kpoints)
-         nkp = SIZE(kpoints%kp_env)
+         CALL get_kpoint_info(kpoints, nkp=nkp, kp_range=kp_range, para_env_inter_kp=para_env_inter_kp)
+         CPASSERT(ASSOCIATED(para_env_inter_kp))
+         IF (scf_env%method == ot_method_nr) THEN
+            solver_method = "OT"
+         ELSE
+            solver_method = "TD"
+         END IF
+         DO ikp = 1, nkp
+            DO ispin = 1, nspin
+               ! Optional MO dummies are absent when their pointers are unassociated.
+               NULLIFY (mo_set, cart_overlap_qs_env)
+               nmo_occ = 0
+               IF ((ikp >= kp_range(1)) .AND. (ikp <= kp_range(2))) THEN
+                  ikp_local = ikp - kp_range(1) + 1
+                  mo_set => kpoints%kp_env(ikp_local)%kpoint_env%mos(1, ispin)
+                  IF (print_occup_stats) THEN
+                     nmo_occ = COUNT(mo_set%occupation_numbers > occup_stats_occ_threshold)
+                  END IF
+               END IF
+               IF (print_occup_stats) THEN
+                  CALL para_env_inter_kp%max(nmo_occ)
+                  nmos_occ(ispin) = MAX(nmos_occ(ispin), nmo_occ)
+               END IF
+               IF ((ikp == 1) .AND. (ikp >= kp_range(1)) .AND. &
+                   (ikp <= kp_range(2)) .AND. (ispin == 1)) THEN
+                  cart_overlap_qs_env => qs_env
+               END IF
+               IF (nspin > 1) THEN
+                  SELECT CASE (ispin)
+                  CASE (1)
+                     spin = "ALPHA"
+                  CASE (2)
+                     spin = "BETA"
+                  CASE DEFAULT
+                     CPABORT("Invalid spin")
+                  END SELECT
+                  CALL write_mo_set_to_output_unit(mo_set, qs_kind_set, particle_set, dft_section, 4, ikp, &
+                                                   final_mos=final_mos, spin=TRIM(spin), &
+                                                   solver_method=solver_method, qs_env=cart_overlap_qs_env, &
+                                                   para_env_inter_kp=para_env_inter_kp)
+               ELSE
+                  CALL write_mo_set_to_output_unit(mo_set, qs_kind_set, particle_set, dft_section, 4, ikp, &
+                                                   final_mos=final_mos, solver_method=solver_method, &
+                                                   qs_env=cart_overlap_qs_env, para_env_inter_kp=para_env_inter_kp)
+               END IF
+            END DO
+         END DO
       ELSE
-         CALL get_qs_env(qs_env, matrix_ks=ks, matrix_s=s)
+
+         NULLIFY (fm_struct_tmp, mo_coeff, mo_coeff_deriv, mo_eigenvalues, &
+                  mo_set, umo_coeff, umo_eigenvalues, umo_set)
+
+         CALL get_qs_env(qs_env, matrix_ks=ks, matrix_s=s, mos=mos)
          CPASSERT(ASSOCIATED(ks))
          CPASSERT(ASSOCIATED(s))
-         nkp = 1
-      END IF
-
-      kp_loop: DO ikp = 1, nkp
-
-         IF (do_kpoints) THEN
-            mos => kpoints%kp_env(ikp)%kpoint_env%mos(1, :)
-            kpoint = ikp
-         ELSE
-            CALL get_qs_env(qs_env, matrix_ks=ks, mos=mos)
-            kpoint = 0 ! Gamma point only
-         END IF
          CPASSERT(ASSOCIATED(mos))
 
          ! Prepare MO information for printout
@@ -306,10 +336,7 @@ CONTAINS
 
                solver_method = "OT"
 
-               IF (do_kpoints) THEN
-                  mo_set => mos(ispin)
-                  NULLIFY (umo_set)
-               ELSE IF (final_mos) THEN
+               IF (final_mos) THEN
 
                   matrix_ks => ks(ispin)%matrix
                   matrix_s => s(1)%matrix
@@ -419,9 +446,9 @@ CONTAINS
                             "is achieved when the orbital transformation (OT) method is used"
                   CPWARN(TRIM(message))
                   do_printout = .FALSE.
-                  EXIT kp_loop
+                  EXIT
 
-               END IF ! final MOs / k-point OT
+               END IF ! final MOs / gamma OT
 
             ELSE
 
@@ -433,7 +460,7 @@ CONTAINS
 
             ! Print MO information
             NULLIFY (cart_overlap_qs_env)
-            IF ((ikp == 1) .AND. (ispin == 1)) cart_overlap_qs_env => qs_env
+            IF (ispin == 1) cart_overlap_qs_env => qs_env
             IF (nspin > 1) THEN
                SELECT CASE (ispin)
                CASE (1)
@@ -443,28 +470,17 @@ CONTAINS
                CASE DEFAULT
                   CPABORT("Invalid spin")
                END SELECT
-               IF (ASSOCIATED(umo_set)) THEN
-                  CALL write_mo_set_to_output_unit(mo_set, qs_kind_set, particle_set, dft_section, 4, kpoint, &
-                                                   final_mos=final_mos, spin=TRIM(spin), solver_method=solver_method, &
-                                                   umo_set=umo_set, qs_env=cart_overlap_qs_env)
-               ELSE
-                  CALL write_mo_set_to_output_unit(mo_set, qs_kind_set, particle_set, dft_section, 4, kpoint, &
-                                                   final_mos=final_mos, spin=TRIM(spin), solver_method=solver_method, &
-                                                   qs_env=cart_overlap_qs_env)
-               END IF
+               CALL write_mo_set_to_output_unit(mo_set, qs_kind_set, particle_set, dft_section, 4, 0, &
+                                                final_mos=final_mos, spin=TRIM(spin), solver_method=solver_method, &
+                                                umo_set=umo_set, qs_env=cart_overlap_qs_env)
             ELSE
-               IF (ASSOCIATED(umo_set)) THEN
-                  CALL write_mo_set_to_output_unit(mo_set, qs_kind_set, particle_set, dft_section, 4, kpoint, &
-                                                   final_mos=final_mos, solver_method=solver_method, &
-                                                   umo_set=umo_set, qs_env=cart_overlap_qs_env)
-               ELSE
-                  CALL write_mo_set_to_output_unit(mo_set, qs_kind_set, particle_set, dft_section, 4, kpoint, &
-                                                   final_mos=final_mos, solver_method=solver_method, &
-                                                   qs_env=cart_overlap_qs_env)
-               END IF
+               CALL write_mo_set_to_output_unit(mo_set, qs_kind_set, particle_set, dft_section, 4, 0, &
+                                                final_mos=final_mos, solver_method=solver_method, &
+                                                umo_set=umo_set, qs_env=cart_overlap_qs_env)
             END IF
 
-            nmos_occ(ispin) = MAX(nmos_occ(ispin), COUNT(mo_set%occupation_numbers > occup_stats_occ_threshold))
+            IF (print_occup_stats) nmos_occ(ispin) = MAX(nmos_occ(ispin), &
+                                                         COUNT(mo_set%occupation_numbers > occup_stats_occ_threshold))
 
             ! Deallocate temporary objects needed for OT
             IF (scf_env%method == ot_method_nr) THEN
@@ -478,15 +494,14 @@ CONTAINS
             NULLIFY (mo_set)
 
          END DO ! ispin
-
-      END DO kp_loop
+      END IF
 
       IF (do_printout .AND. print_mo_info .AND. print_occup_stats) THEN
          iw = cp_print_key_unit_nr(logger, dft_section, "PRINT%MO", &
                                    ignore_should_output=print_mo_info, &
                                    extension=".MOLog")
          IF (iw > 0) THEN
-            IF (SIZE(mos) > 1) THEN
+            IF (nspin > 1) THEN
                WRITE (UNIT=iw, FMT="(A,I4)") " MO| Total occupied (ALPHA):", nmos_occ(1)
                WRITE (UNIT=iw, FMT="(A,I4)") " MO| Total occupied (BETA): ", nmos_occ(2)
             ELSE


### PR DESCRIPTION
Fixes #4396 . With PRINT%MO enabled, the old call chain qs_scf_write_mos → write_mo_set_to_output_unit → cp_print_key_unit_nr used the local SIZE(kpoints%kp_env) on each MPI k-point group, while only the global source rank received a writable output unit. As a result, output file contained only the k-points local to the source rank's group. 
`qs_scf_write_mos` now obtains the global k-point count, local k-point range, and inter-k-point communicator through `get_kpoint_info`. All MPI ranks iterate over the complete global k-point and spin ranges. The gathered data are then formatted and written by the global source rank. 
[Ni_prim.zip](https://github.com/user-attachments/files/31875326/Ni_prim.zip)

> for i in Ni_prim_*.out ; do echo $i ; grep "EIGENVALUES AND OCCUPATION NUMBERS FOR K POINT" $i -c ; done
> Ni_prim_psmp_p1t1.out
> 1332
> Ni_prim_psmp_p1t2.out
> 1332
> Ni_prim_psmp_p2t1.out
> 1332
> Ni_prim_psmp_p4t1.out
> 1332
> Ni_prim_psmp_p6t1.out
> 1332