### PR TITLE
Refactor non-local vdW code

### DIFF
--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -610,22 +610,24 @@ CONTAINS
                vdW_xc_energy = vdW_xc_energy + g_multiplier*REAL(uu*CONJG(theta(q2_i)), KIND=dp)
             END IF
             IF (.NOT. energy_only) thetas_g(q2_i)%array(ig) = uu
-
-            IF (use_virial .AND. ig >= grid%first_gne0) THEN
-               DO q1_i = 1, nqs
-                  gm = 0.5_dp*g_multiplier*grid%vol*dkernel_of_dk(q1_i, q2_i)*REAL(theta(q1_i)*CONJG(theta(q2_i)), KIND=dp)
-                  IF (nl_type == vdw_nl_RVV10) THEN
-                     gm = 0.5_dp*gm
-                  END IF
-                  DO l = 1, 3
-                     DO m = 1, l
-                        virial_thread(l, m) = virial_thread(l, m) - gm*(grid%g(l, ig)*grid%g(m, ig))/g
-                     END DO
-                  END DO
-               END DO
-            END IF
-
          END DO
+
+         IF (use_virial .AND. ig >= grid%first_gne0) THEN
+            ! Reduce over all channel pairs before assembling the stress tensor.
+            gm = 0.0_dp
+            DO q2_i = 1, nqs
+               DO q1_i = 1, nqs
+                  gm = gm + dkernel_of_dk(q1_i, q2_i)*REAL(theta(q1_i)*CONJG(theta(q2_i)), KIND=dp)
+               END DO
+            END DO
+            gm = 0.5_dp*g_multiplier*grid%vol*gm
+            IF (nl_type == vdw_nl_RVV10) gm = 0.5_dp*gm
+            DO l = 1, 3
+               DO m = 1, l
+                  virial_thread(l, m) = virial_thread(l, m) - gm*(grid%g(l, ig)*grid%g(m, ig))/g
+               END DO
+            END DO
+         END IF
       END DO
 !$OMP END DO
 
@@ -690,9 +692,10 @@ CONTAINS
       INTEGER                                            :: handle, i_grid, l, m, nl_type, nqs, P_i, &
                                                             q, q_hi, q_low
       LOGICAL                                            :: use_virial
-      REAL(dp)                                           :: a, b, b_value, c, const, d, dP_dq0, dq, &
-                                                            dq_6, e, f, P, prefactor, tmp_1_2, &
-                                                            tmp_1_4, tmp_3_4, y_hi, y_low
+      REAL(dp)                                           :: a, b, b_value, c, const, d, dq, dq_6, e, &
+                                                            f, prefactor, sum_hi, sum_low, &
+                                                            tmp_1_2, tmp_1_4, tmp_3_4, u_dp_dq0, &
+                                                            u_p
       REAL(dp), DIMENSION(3, 3)                          :: virial_thread
       REAL(dp), DIMENSION(:), POINTER                    :: q_mesh
       REAL(dp), DIMENSION(:, :), POINTER                 :: d2y_dx2
@@ -719,26 +722,18 @@ CONTAINS
 !$OMP                 , use_virial, drho, dvol, virial                 &
 !$OMP                 )                                                &
 !$OMP          PRIVATE( q_low, q_hi, q, dq, dq_6, A, b, c, d, e, f      &
-!$OMP                 , y_low, y_hi                                    &
-!$OMP                 , P_i, dP_dq0, P, prefactor, l, m                &
+!$OMP                 , sum_low, sum_hi, u_p, u_dp_dq0                 &
+!$OMP                 , P_i, prefactor, l, m                           &
 !$OMP                 , tmp_1_2, tmp_1_4, tmp_3_4                      &
 !$OMP                 )                                                &
 !$OMP        REDUCTION(+: virial_thread                                &
 !$OMP                 )
 
-      tmp_1_4 = 1.0_dp
-      tmp_3_4 = 0.0_dp
-
 !$OMP DO
       DO i_grid = 1, SIZE(u_vdW, 1)
          potential(i_grid) = 0.0_dp
          h_prefactor(i_grid) = 0.0_dp
-         IF (nl_type == vdw_nl_RVV10) THEN
-            IF (total_rho(i_grid) <= epsr) CYCLE
-            tmp_1_2 = SQRT(total_rho(i_grid))
-            tmp_1_4 = SQRT(tmp_1_2)
-            tmp_3_4 = tmp_1_4*tmp_1_4*tmp_1_4
-         END IF
+         IF (nl_type == vdw_nl_RVV10 .AND. total_rho(i_grid) <= epsr) CYCLE
          q_low = 1
          q_hi = nqs
          ! Figure out which bin our value of q0 is in in the q_mesh
@@ -762,44 +757,44 @@ CONTAINS
          e = (3.0_dp*a**2 - 1.0_dp)*dq_6
          f = (3.0_dp*b**2 - 1.0_dp)*dq_6
 
+         ! Contract the spline second derivatives before assembling the potential.
+         sum_low = 0.0_dp
+         sum_hi = 0.0_dp
          DO P_i = 1, nqs
-            y_low = MERGE(1.0_dp, 0.0_dp, P_i == q_low)
-            y_hi = MERGE(1.0_dp, 0.0_dp, P_i == q_hi)
-            dP_dq0 = (y_hi - y_low)/dq - e*d2y_dx2(P_i, q_low) + f*d2y_dx2(P_i, q_hi)
-            P = a*y_low + b*y_hi + c*d2y_dx2(P_i, q_low) + d*d2y_dx2(P_i, q_hi)
-            !! The first term in equation 13 of SOLER
-            SELECT CASE (nl_type)
-            CASE DEFAULT
-               CPABORT("Unknown vdW-DF functional")
-            CASE (vdw_nl_DRSLL, vdw_nl_LMKLL)
-               potential(i_grid) = potential(i_grid) + u_vdW(i_grid, P_i)*(P + dP_dq0*dq0_drho(i_grid))
-               prefactor = u_vdW(i_grid, P_i)*dP_dq0*dq0_dgradrho(i_grid)
-            CASE (vdw_nl_RVV10)
-               potential(i_grid) = potential(i_grid) &
-                                   + u_vdW(i_grid, P_i)*(const*0.75_dp/tmp_1_4*P &
-                                                         + const*tmp_3_4*dP_dq0*dq0_drho(i_grid))
-               prefactor = u_vdW(i_grid, P_i)*const*tmp_3_4*dP_dq0*dq0_dgradrho(i_grid)
-            END SELECT
-            IF (q0(i_grid) /= q_mesh(nqs)) THEN
-               h_prefactor(i_grid) = h_prefactor(i_grid) + prefactor
-            END IF
+            sum_low = sum_low + u_vdW(i_grid, P_i)*d2y_dx2(P_i, q_low)
+            sum_hi = sum_hi + u_vdW(i_grid, P_i)*d2y_dx2(P_i, q_hi)
+         END DO
+         u_p = a*u_vdW(i_grid, q_low) + b*u_vdW(i_grid, q_hi) + c*sum_low + d*sum_hi
+         u_dp_dq0 = (u_vdW(i_grid, q_hi) - u_vdW(i_grid, q_low))/dq - e*sum_low + f*sum_hi
 
-            IF (use_virial .AND. ABS(prefactor) > 0.0_dp) THEN
-               SELECT CASE (nl_type)
-               CASE DEFAULT
-                  ! do nothing
-               CASE (vdw_nl_RVV10)
-                  prefactor = 0.5_dp*prefactor
-               END SELECT
-               prefactor = prefactor*dvol
-               DO l = 1, 3
-                  DO m = 1, l
-                     virial_thread(l, m) = virial_thread(l, m) - prefactor*drho(i_grid, l)*drho(i_grid, m)
-                  END DO
+         !! The first term in equation 13 of SOLER
+         SELECT CASE (nl_type)
+         CASE DEFAULT
+            CPABORT("Unknown vdW-DF functional")
+         CASE (vdw_nl_DRSLL, vdw_nl_LMKLL)
+            potential(i_grid) = u_p + u_dp_dq0*dq0_drho(i_grid)
+            prefactor = u_dp_dq0*dq0_dgradrho(i_grid)
+         CASE (vdw_nl_RVV10)
+            tmp_1_2 = SQRT(total_rho(i_grid))
+            tmp_1_4 = SQRT(tmp_1_2)
+            tmp_3_4 = tmp_1_4*tmp_1_4*tmp_1_4
+            potential(i_grid) = const*0.75_dp/tmp_1_4*u_p + const*tmp_3_4*u_dp_dq0*dq0_drho(i_grid)
+            prefactor = const*tmp_3_4*u_dp_dq0*dq0_dgradrho(i_grid)
+         END SELECT
+         IF (q0(i_grid) /= q_mesh(nqs)) THEN
+            h_prefactor(i_grid) = prefactor
+         END IF
+
+         ! The saturation guard applies only to h_prefactor, not to the virial.
+         IF (use_virial .AND. ABS(prefactor) > 0.0_dp) THEN
+            IF (nl_type == vdw_nl_RVV10) prefactor = 0.5_dp*prefactor
+            prefactor = prefactor*dvol
+            DO l = 1, 3
+               DO m = 1, l
+                  virial_thread(l, m) = virial_thread(l, m) - prefactor*drho(i_grid, l)*drho(i_grid, m)
                END DO
-            END IF
-
-         END DO ! P_i = 1, nqs
+            END DO
+         END IF
       END DO ! i_grid = 1, SIZE(u_vdW, 1)
 !$OMP END DO
 

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -30,8 +30,7 @@ MODULE qs_dispersion_nonloc
    USE kinds,                           ONLY: default_path_length,&
                                               dp
    USE mathconstants,                   ONLY: pi,&
-                                              rootpi,&
-                                              z_zero
+                                              rootpi
    USE message_passing,                 ONLY: mp_para_env_type
    USE pw_grid_types,                   ONLY: HALFSPACE,&
                                               pw_grid_type
@@ -175,15 +174,16 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'calculate_dispersion_nonloc'
       INTEGER, DIMENSION(3, 3), PARAMETER :: nd = RESHAPE([1, 0, 0, 0, 1, 0, 0, 0, 1], [3, 3])
 
-      INTEGER                                            :: handle, i, i_grid, idir, ispin, nl_type, &
-                                                            np, nspin, p, q, r, s
+      INTEGER                                            :: handle, handle_fft, i, i_grid, idir, &
+                                                            ispin, nl_type, np, nspin, p, q, r, s
+      INTEGER, ALLOCATABLE, DIMENSION(:)                 :: q_low
       INTEGER, DIMENSION(1:3)                            :: hi, lo, n
       LOGICAL                                            :: use_virial
-      REAL(KIND=dp)                                      :: b_value, beta, const, Ec_nl, rho_3_4, &
-                                                            sumnp
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: dq0_dgradrho, dq0_drho, hpot, potential, &
-                                                            q0, rho
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: drho, thetas
+      REAL(KIND=dp)                                      :: b_value, beta, Ec_nl, sumnp
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: dq0_dgradrho, dq0_drho, hpot, q0, rho, &
+                                                            theta_scale
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: drho, spline_coeff, u_contract
+      REAL(KIND=dp), CONTIGUOUS, POINTER                 :: tmp_1d(:), vxc_1d(:)
       TYPE(pw_c1d_gs_type)                               :: div_g, rho_tot_g, tmp_g, vxc_g
       TYPE(pw_c1d_gs_type), ALLOCATABLE, DIMENSION(:)    :: thetas_g
       TYPE(pw_grid_type), POINTER                        :: grid
@@ -213,8 +213,6 @@ CONTAINS
       beta = 0.03125_dp*(3.0_dp/(b_value**2.0_dp))**0.75_dp
       nspin = SIZE(rho_r)
 
-      const = 1.0_dp/(3.0_dp*rootpi*b_value**1.5_dp)/(pi**0.75_dp)
-
       ! temporary arrays for FFT
       CALL pw_pool%create_pw(tmp_g)
       CALL pw_pool%create_pw(tmp_r)
@@ -229,6 +227,7 @@ CONTAINS
       CALL pw_transfer(rho_tot_g, tmp_r)
 
       np = SIZE(tmp_r%array)
+      tmp_1d(1:np) => tmp_r%array
       ALLOCATE (rho(np), drho(np, 3))
       DO i = 1, 3
          lo(i) = LBOUND(tmp_r%array, i)
@@ -294,78 +293,19 @@ CONTAINS
          END SELECT
       END IF
 
-      !! ---------------------------------------------------------------------------------------------
-      !! Here we allocate and calculate the theta functions appearing in equations 8-12 of SOLER.
-      !! They are defined as rho*P_i(q0(rho, gradient_rho)) for vdW and vdW2 or
-      !! constant*rho^(3/4)*P_i(q0(rho, gradient_rho)) for rVV10 where P_i is a polynomial that
-      !! interpolates a Kronecker delta function at the point q_i (taken from the q_mesh) and q0 is
-      !! the saturated version of q.
-      !! q is defined in equations 11 and 12 of DION and the saturation procedure is defined in equation 5
-      !! of soler.  This is the biggest memory consumer in the method since the thetas array is
-      !! (total # of FFT points)*Nqs complex numbers.  In a parallel run, each processor will hold the
-      !! values of all the theta functions on just the points assigned to it.
-      !! --------------------------------------------------------------------------------------------------
-      !! thetas are stored in reciprocal space as  theta_i(k) because this is the way they are used later
-      !! for the convolution (equation 11 of SOLER).
-      !! --------------------------------------------------------------------------------------------------
-      ALLOCATE (thetas(np, dispersion_env%nqs))
-      !! Interpolate the P_i polynomials defined in equation 3 in SOLER for the particular
-      !! q0 values we have.
-      CALL spline_interpolation(dispersion_env%q_mesh, dispersion_env%d2y_dx2, q0, thetas)
-
-      !! Form the thetas where theta is defined as rho*p_i(q0) for vdW and vdW2 or
-      !! constant*rho^(3/4)*p_i(q0) for rVV10
-      !! ------------------------------------------------------------------------------------
-      SELECT CASE (nl_type)
-      CASE DEFAULT
-         CPABORT("Unknown vdW-DF functional")
-      CASE (vdw_nl_DRSLL, vdw_nl_LMKLL)
-!$OMP PARALLEL DO DEFAULT( NONE )                          &
-!$OMP             SHARED( dispersion_env, thetas, rho)
-         DO i = 1, dispersion_env%nqs
-            thetas(:, i) = thetas(:, i)*rho(:)
-         END DO
-!$OMP END PARALLEL DO
-      CASE (vdw_nl_RVV10)
-!$OMP PARALLEL DO DEFAULT( NONE )                                  &
-!$OMP             SHARED( np, rho, dispersion_env, thetas, const ) &
-!$OMP             PRIVATE( i, rho_3_4 )                            &
-!$OMP             SCHEDULE(STATIC)
-         DO i_grid = 1, np
-            IF (rho(i_grid) > epsr) THEN
-               rho_3_4 = rho(i_grid)**(0.75_dp)
-               DO i = 1, dispersion_env%nqs
-                  thetas(i_grid, i) = thetas(i_grid, i)*const*rho_3_4
-               END DO
-            ELSE
-               thetas(i_grid, :) = 0.0_dp
-            END IF
-         END DO
-!$OMP END PARALLEL DO
-      END SELECT
-      !! ------------------------------------------------------------------------------------
-      !! Get thetas in reciprocal space.
-      DO i = 1, 3
-         lo(i) = LBOUND(tmp_r%array, i)
-         hi(i) = UBOUND(tmp_r%array, i)
-         n(i) = hi(i) - lo(i) + 1
-      END DO
+      ! Generate one theta channel directly in the FFT workspace. Only reciprocal-space
+      ! channels must coexist for the convolution; no real-space np-by-nqs array is needed.
+      ALLOCATE (q_low(np), spline_coeff(np, 4), theta_scale(np))
+      CALL prepare_splines(q0, rho, dispersion_env, q_low, spline_coeff, theta_scale)
       ALLOCATE (thetas_g(dispersion_env%nqs))
+      CALL timeset("vdW_theta_forward", handle_fft)
       DO i = 1, dispersion_env%nqs
-!$OMP PARALLEL DO DEFAULT(NONE)                   &
-!$OMP             SHARED(i,n,lo,thetas,tmp_r)     &
-!$OMP             COLLAPSE(3)
-         DO r = 0, n(3) - 1
-            DO q = 0, n(2) - 1
-               DO p = 0, n(1) - 1
-                  tmp_r%array(p + lo(1), q + lo(2), r + lo(3)) = thetas(r*n(2)*n(1) + q*n(1) + p + 1, i)
-               END DO
-            END DO
-         END DO
-!$OMP END PARALLEL DO
+         CALL build_theta(i, q_low, spline_coeff, theta_scale, dispersion_env, tmp_1d)
          CALL pw_pool%create_pw(thetas_g(i))
          CALL pw_transfer(tmp_r, thetas_g(i))
       END DO
+      CALL timestop(handle_fft)
+      DEALLOCATE (spline_coeff, theta_scale)
       grid => thetas_g(1)%pw_grid
       !! ---------------------------------------------------------------------------------------------
       !! Carry out the integration in equation 8 of SOLER.  This also turns the thetas array into the
@@ -398,74 +338,49 @@ CONTAINS
       edispersion = Ec_nl
 
       IF (energy_only) THEN
-         DEALLOCATE (q0)
+         DEALLOCATE (q0, q_low)
       ELSE
-         !! ----------------------------------------------------------------------------
-         !! Inverse Fourier transform the u_i(k) to get the u_i(r) of SOLER equation 11.
-         !!-----------------------------------------------------------------------------
-         DO i = 1, 3
-            lo(i) = LBOUND(tmp_r%array, i)
-            hi(i) = UBOUND(tmp_r%array, i)
-            n(i) = hi(i) - lo(i) + 1
+         ! Accumulate the two spline contractions and their endpoint values as each
+         ! inverse FFT finishes. Keep the original potential-side knot convention.
+         ALLOCATE (u_contract(np, 4), hpot(np))
+!$OMP PARALLEL DO DEFAULT(NONE) SHARED(np, q_low, q0, dispersion_env, u_contract) PRIVATE(s)
+         DO i_grid = 1, np
+            s = q_low(i_grid)
+            IF (s > 0 .AND. s < dispersion_env%nqs - 1) THEN
+               IF (q0(i_grid) == dispersion_env%q_mesh(s + 1)) q_low(i_grid) = s + 1
+            END IF
+            u_contract(i_grid, :) = 0.0_dp
          END DO
+!$OMP END PARALLEL DO
+         CALL timeset("vdW_theta_inverse", handle_fft)
          DO i = 1, dispersion_env%nqs
             CALL pw_transfer(thetas_g(i), tmp_r)
-!$OMP PARALLEL DO DEFAULT(NONE)                        &
-!$OMP             SHARED(i,n,lo,thetas,tmp_r)          &
-!$OMP             COLLAPSE(3)
-            DO r = 0, n(3) - 1
-               DO q = 0, n(2) - 1
-                  DO p = 0, n(1) - 1
-                     thetas(r*n(2)*n(1) + q*n(1) + p + 1, i) = tmp_r%array(p + lo(1), q + lo(2), r + lo(3))
-                  END DO
-               END DO
-            END DO
-!$OMP END PARALLEL DO
+            CALL accumulate_potential(i, q_low, dispersion_env, tmp_1d, u_contract)
          END DO
-         !! -------------------------------------------------------------------------
-         !! Here we allocate the array to hold the potential. This is calculated via
-         !! equation 10 of SOLER, using the u_i(r) calculated from equations 11 and
-         !! 12 of SOLER.  Each processor allocates the array to be the size of the
-         !! full grid  because, as can be seen in SOLER equation 9, processors need
-         !! to access grid points outside their allocated regions.
-         !! -------------------------------------------------------------------------
-         ALLOCATE (potential(np), hpot(np))
+         CALL timestop(handle_fft)
+
+         ! Write the local potential directly into its PW object.
+         CALL pw_pool%create_pw(vxc_r)
+         vxc_1d(1:np) => vxc_r%array
          IF (use_virial) THEN
-            ! calculates gradient contribution to stress
             grid => tmp_g%pw_grid
-            CALL get_potential(q0, dq0_drho, dq0_dgradrho, rho, thetas, potential, hpot, &
+            CALL get_potential(q0, dq0_drho, dq0_dgradrho, rho, q_low, u_contract, vxc_1d, hpot, &
                                dispersion_env, drho, grid%dvol, virial)
          ELSE
-            CALL get_potential(q0, dq0_drho, dq0_dgradrho, rho, thetas, potential, hpot, &
+            CALL get_potential(q0, dq0_drho, dq0_dgradrho, rho, q_low, u_contract, vxc_1d, hpot, &
                                dispersion_env)
          END IF
+         DEALLOCATE (u_contract, q_low, q0, dq0_drho, dq0_dgradrho)
          SELECT CASE (nl_type)
          CASE (vdw_nl_RVV10)
-            potential(:) = (0.5_dp*potential(:) + beta)*dispersion_env%scale_rvv10
-            hpot(:) = 0.5_dp*dispersion_env%scale_rvv10*hpot(:)
-         END SELECT
-         CALL pw_pool%create_pw(vxc_r)
-         DO i = 1, 3
-            lo(i) = LBOUND(vxc_r%array, i)
-            hi(i) = UBOUND(vxc_r%array, i)
-            n(i) = hi(i) - lo(i) + 1
-         END DO
-!$OMP PARALLEL DO DEFAULT(NONE)                         &
-!$OMP             SHARED(i,n,lo,potential,vxc_r)        &
-!$OMP             COLLAPSE(3)
-         DO r = 0, n(3) - 1
-            DO q = 0, n(2) - 1
-               DO p = 0, n(1) - 1
-                  vxc_r%array(p + lo(1), q + lo(2), r + lo(3)) = potential(r*n(2)*n(1) + q*n(1) + p + 1)
-               END DO
+!$OMP PARALLEL DO DEFAULT(NONE) SHARED(np, vxc_1d, hpot, beta, dispersion_env)
+            DO i_grid = 1, np
+               vxc_1d(i_grid) = (0.5_dp*vxc_1d(i_grid) + beta)*dispersion_env%scale_rvv10
+               hpot(i_grid) = 0.5_dp*dispersion_env%scale_rvv10*hpot(i_grid)
             END DO
-         END DO
 !$OMP END PARALLEL DO
-         DO i = 1, 3
-            lo(i) = LBOUND(tmp_r%array, i)
-            hi(i) = UBOUND(tmp_r%array, i)
-            n(i) = hi(i) - lo(i) + 1
-         END DO
+         END SELECT
+         NULLIFY (vxc_1d)
          ! Sum the derivatives before the inverse FFT. Keep the real-space projection
          ! before transferring the potential to a possibly different XC grid.
          CALL pw_pool%create_pw(div_g)
@@ -503,10 +418,9 @@ CONTAINS
          END DO
          CALL xc_pw_pool%give_back_pw(vxc_r)
          CALL xc_pw_pool%give_back_pw(vxc_g)
-         DEALLOCATE (q0, dq0_drho, dq0_dgradrho)
       END IF
 
-      DEALLOCATE (thetas)
+      NULLIFY (tmp_1d)
 
       DO i = 1, dispersion_env%nqs
          CALL pw_pool%give_back_pw(thetas_g(i))
@@ -542,13 +456,13 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'vdW_energy'
 
-      COMPLEX(KIND=dp)                                   :: uu
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: theta
-      INTEGER                                            :: handle, ig, iq, l, m, nl_type, nqs, &
-                                                            q1_i, q2_i
+      INTEGER                                            :: handle, ig, ipair, iq, ir, l, m, &
+                                                            nl_type, nqs, nr_used, q1_i, q2_i
       LOGICAL                                            :: use_virial
       REAL(KIND=dp)                                      :: g, g2, g2_last, g_multiplier, gm
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: theta_im, theta_re, u_im, u_re
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: dkernel_of_dk, kernel_of_k
+      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: kernel_table
       REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_thread
       TYPE(pw_grid_type), POINTER                        :: grid
 
@@ -569,21 +483,41 @@ CONTAINS
 
       nl_type = dispersion_env%nl_type
 
-!$OMP PARALLEL DEFAULT( NONE )                                             &
-!$OMP           SHARED( nqs, energy_only, grid, dispersion_env             &
-!$OMP                 , use_virial, thetas_g, g_multiplier, nl_type        &
-!$OMP                 )                                                    &
-!$OMP          PRIVATE( g2_last, kernel_of_k, dkernel_of_dk, theta         &
-!$OMP                 , g2, g, iq                                          &
-!$OMP                 , q2_i, uu, q1_i, gm, l, m                           &
-!$OMP                 )                                                    &
-!$OMP        REDUCTION( +: vdW_xc_energy, virial_thread                    &
-!$OMP                 )
+      ! Pack the symmetric radial tables once per evaluation. The interpolation then
+      ! reads adjacent channel pairs instead of striding over the radial dimension.
+      ! Copy only the radial prefix needed by the local G points, including its upper endpoint.
+      nr_used = 0
+      IF (grid%ngpts_cut_local > 0) THEN
+         nr_used = MIN(dispersion_env%nr_points, &
+                       INT(SQRT(MAXVAL(grid%gsq(1:grid%ngpts_cut_local)))/dispersion_env%dk) + 1)
+      END IF
+      ALLOCATE (kernel_table(nqs*(nqs + 1)/2, 0:nr_used, 2))
+!$OMP PARALLEL DO DEFAULT(NONE) SHARED(kernel_table, dispersion_env, nqs, nr_used) &
+!$OMP             PRIVATE(q1_i, q2_i, ipair) SCHEDULE(STATIC)
+      DO ir = 0, nr_used
+         ipair = 0
+         DO q1_i = 1, nqs
+            DO q2_i = 1, q1_i
+               ipair = ipair + 1
+               kernel_table(ipair, ir, 1) = dispersion_env%kernel(ir, q1_i, q2_i)
+               kernel_table(ipair, ir, 2) = dispersion_env%d2phi_dk2(ir, q1_i, q2_i)
+            END DO
+         END DO
+      END DO
+!$OMP END PARALLEL DO
+
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP          SHARED(nqs, energy_only, grid, dispersion_env, use_virial, thetas_g, &
+!$OMP                 g_multiplier, nl_type, kernel_table) &
+!$OMP          PRIVATE(g2_last, kernel_of_k, dkernel_of_dk, theta_re, theta_im, &
+!$OMP                  g2, g, iq, q2_i, u_re, u_im, q1_i, gm, l, m) &
+!$OMP          REDUCTION(+:vdW_xc_energy, virial_thread)
 
       g2_last = HUGE(0._dp)
 
-      ALLOCATE (kernel_of_k(nqs, nqs), dkernel_of_dk(nqs, nqs))
-      ALLOCATE (theta(nqs))
+      ALLOCATE (kernel_of_k(nqs, nqs))
+      IF (use_virial) ALLOCATE (dkernel_of_dk(nqs, nqs))
+      ALLOCATE (theta_re(nqs), theta_im(nqs), u_re(nqs), u_im(nqs))
 
 !$OMP DO
       DO ig = 1, grid%ngpts_cut_local
@@ -591,34 +525,48 @@ CONTAINS
          IF (ABS(g2 - g2_last) > 1.e-10) THEN
             g2_last = g2
             g = SQRT(g2)
-            CALL interpolate_kernel(g, kernel_of_k, dispersion_env)
-            IF (use_virial) CALL interpolate_dkernel_dk(g, dkernel_of_dk, dispersion_env)
+            IF (use_virial) THEN
+               CALL interpolate_kernel(g, kernel_of_k, dispersion_env, kernel_table, dkernel_of_dk)
+            ELSE
+               CALL interpolate_kernel(g, kernel_of_k, dispersion_env, kernel_table)
+            END IF
          END IF
-         ! Save every input channel before overwriting any output at this G point.
+         ! Save all inputs before in-place output. Vectorize over output channels;
+         ! the input-channel accumulation order remains unchanged for every output.
          DO iq = 1, nqs
-            theta(iq) = thetas_g(iq)%array(ig)
+            theta_re(iq) = REAL(thetas_g(iq)%array(ig), KIND=dp)
+            theta_im(iq) = AIMAG(thetas_g(iq)%array(ig))
+         END DO
+         u_re(:) = 0.0_dp
+         u_im(:) = 0.0_dp
+         DO q1_i = 1, nqs
+!$OMP SIMD
+            DO q2_i = 1, nqs
+               u_re(q2_i) = u_re(q2_i) + kernel_of_k(q2_i, q1_i)*theta_re(q1_i)
+               u_im(q2_i) = u_im(q2_i) + kernel_of_k(q2_i, q1_i)*theta_im(q1_i)
+            END DO
+!$OMP END SIMD
          END DO
          DO q2_i = 1, nqs
-            uu = z_zero
-            ! The kernel is symmetric; access its contiguous first index.
-            DO q1_i = 1, nqs
-               uu = uu + kernel_of_k(q1_i, q2_i)*theta(q1_i)
-            END DO
             IF (ig < grid%first_gne0) THEN
-               vdW_xc_energy = vdW_xc_energy + REAL(uu*CONJG(theta(q2_i)), KIND=dp)
+               vdW_xc_energy = vdW_xc_energy + (u_re(q2_i)*theta_re(q2_i) + u_im(q2_i)*theta_im(q2_i))
             ELSE
-               vdW_xc_energy = vdW_xc_energy + g_multiplier*REAL(uu*CONJG(theta(q2_i)), KIND=dp)
+               vdW_xc_energy = vdW_xc_energy &
+                               + g_multiplier*(u_re(q2_i)*theta_re(q2_i) + u_im(q2_i)*theta_im(q2_i))
             END IF
-            IF (.NOT. energy_only) thetas_g(q2_i)%array(ig) = uu
+            IF (.NOT. energy_only) thetas_g(q2_i)%array(ig) = CMPLX(u_re(q2_i), u_im(q2_i), KIND=dp)
          END DO
 
          IF (use_virial .AND. ig >= grid%first_gne0) THEN
             ! Reduce over all channel pairs before assembling the stress tensor.
             gm = 0.0_dp
             DO q2_i = 1, nqs
+!$OMP SIMD REDUCTION(+:gm)
                DO q1_i = 1, nqs
-                  gm = gm + dkernel_of_dk(q1_i, q2_i)*REAL(theta(q1_i)*CONJG(theta(q2_i)), KIND=dp)
+                  gm = gm + dkernel_of_dk(q1_i, q2_i) &
+                       *(theta_re(q1_i)*theta_re(q2_i) + theta_im(q1_i)*theta_im(q2_i))
                END DO
+!$OMP END SIMD
             END DO
             gm = 0.5_dp*g_multiplier*grid%vol*gm
             IF (nl_type == vdw_nl_RVV10) gm = 0.5_dp*gm
@@ -631,10 +579,12 @@ CONTAINS
       END DO
 !$OMP END DO
 
-      DEALLOCATE (theta)
-      DEALLOCATE (kernel_of_k, dkernel_of_dk)
+      DEALLOCATE (theta_re, theta_im, u_re, u_im, kernel_of_k)
+      IF (use_virial) DEALLOCATE (dkernel_of_dk)
 
 !$OMP END PARALLEL
+
+      DEALLOCATE (kernel_table)
 
       vdW_xc_energy = vdW_xc_energy*grid%vol*0.5_dp
 
@@ -657,7 +607,7 @@ CONTAINS
 !> \brief This routine finds the non-local correlation contribution to the potential
 !> (i.e. the derivative of the non-local piece of the energy with respect to
 !> density) given in SOLER equation 10.  The u_alpha(k) functions were found
-!> while calculating the energy. They are passed in as the matrix u_vdW.
+!> while calculating the energy. Their spline contractions are accumulated during the inverse FFTs.
 !> Most of the required derivatives were calculated in the "get_q0_on_grid"
 !> routine, but the derivative of the interpolation polynomials, P_alpha(q),
 !> (SOLER equation 3) with respect to q is interpolated here, along with the
@@ -666,7 +616,8 @@ CONTAINS
 !> \param dq0_drho ...
 !> \param dq0_dgradrho ...
 !> \param total_rho ...
-!> \param u_vdW ...
+!> \param q_low_grid Lower spline endpoint at each grid point
+!> \param u_contract Second-derivative contractions and endpoint values
 !> \param potential ...
 !> \param h_prefactor ...
 !> \param dispersion_env ...
@@ -676,11 +627,12 @@ CONTAINS
 !> \par History
 !> OpenMP added: Aug 2016  MTucker
 ! **************************************************************************************************
-   SUBROUTINE get_potential(q0, dq0_drho, dq0_dgradrho, total_rho, u_vdW, potential, h_prefactor, &
+   SUBROUTINE get_potential(q0, dq0_drho, dq0_dgradrho, total_rho, q_low_grid, u_contract, potential, h_prefactor, &
                             dispersion_env, drho, dvol, virial)
 
       REAL(dp), DIMENSION(:), INTENT(in)                 :: q0, dq0_drho, dq0_dgradrho, total_rho
-      REAL(dp), DIMENSION(:, :), INTENT(in)              :: u_vdW
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: q_low_grid
+      REAL(dp), DIMENSION(:, :), INTENT(in)              :: u_contract
       REAL(dp), DIMENSION(:), INTENT(out)                :: potential, h_prefactor
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
       REAL(dp), DIMENSION(:, :), INTENT(in), OPTIONAL    :: drho
@@ -689,16 +641,14 @@ CONTAINS
 
       CHARACTER(len=*), PARAMETER                        :: routineN = 'get_potential'
 
-      INTEGER                                            :: handle, i_grid, l, m, nl_type, nqs, P_i, &
-                                                            q, q_hi, q_low
+      INTEGER                                            :: handle, i_grid, l, m, nl_type, nqs, &
+                                                            q_hi, q_low
       LOGICAL                                            :: use_virial
       REAL(dp)                                           :: a, b, b_value, c, const, d, dq, dq_6, e, &
-                                                            f, prefactor, sum_hi, sum_low, &
-                                                            tmp_1_2, tmp_1_4, tmp_3_4, u_dp_dq0, &
-                                                            u_p
+                                                            f, prefactor, tmp_1_2, tmp_1_4, &
+                                                            tmp_3_4, u_dp_dq0, u_p
       REAL(dp), DIMENSION(3, 3)                          :: virial_thread
       REAL(dp), DIMENSION(:), POINTER                    :: q_mesh
-      REAL(dp), DIMENSION(:, :), POINTER                 :: d2y_dx2
 
       CALL timeset(routineN, handle)
 
@@ -710,42 +660,24 @@ CONTAINS
       b_value = dispersion_env%b_value
       const = 1.0_dp/(3.0_dp*b_value**(3.0_dp/2.0_dp)*pi**(5.0_dp/4.0_dp))
 
-      d2y_dx2 => dispersion_env%d2y_dx2
       q_mesh => dispersion_env%q_mesh
       nqs = dispersion_env%nqs
       nl_type = dispersion_env%nl_type
 
-!$OMP PARALLEL DEFAULT( NONE )                                         &
-!$OMP           SHARED( nqs, u_vdW, q_mesh, q0, d2y_dx2, nl_type       &
-!$OMP                 , potential, h_prefactor                         &
-!$OMP                 , dq0_drho, dq0_dgradrho, total_rho, const       &
-!$OMP                 , use_virial, drho, dvol, virial                 &
-!$OMP                 )                                                &
-!$OMP          PRIVATE( q_low, q_hi, q, dq, dq_6, A, b, c, d, e, f      &
-!$OMP                 , sum_low, sum_hi, u_p, u_dp_dq0                 &
-!$OMP                 , P_i, prefactor, l, m                           &
-!$OMP                 , tmp_1_2, tmp_1_4, tmp_3_4                      &
-!$OMP                 )                                                &
-!$OMP        REDUCTION(+: virial_thread                                &
-!$OMP                 )
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP          SHARED(nqs, u_contract, q_low_grid, q_mesh, q0, nl_type, potential, h_prefactor, &
+!$OMP                 dq0_drho, dq0_dgradrho, total_rho, const, use_virial, drho, dvol, virial) &
+!$OMP          PRIVATE(q_low, q_hi, dq, dq_6, A, b, c, d, e, f, u_p, u_dp_dq0, &
+!$OMP                  prefactor, l, m, tmp_1_2, tmp_1_4, tmp_3_4) &
+!$OMP          REDUCTION(+:virial_thread)
 
 !$OMP DO
-      DO i_grid = 1, SIZE(u_vdW, 1)
+      DO i_grid = 1, SIZE(q0)
          potential(i_grid) = 0.0_dp
          h_prefactor(i_grid) = 0.0_dp
          IF (nl_type == vdw_nl_RVV10 .AND. total_rho(i_grid) <= epsr) CYCLE
-         q_low = 1
-         q_hi = nqs
-         ! Figure out which bin our value of q0 is in in the q_mesh
-         DO WHILE ((q_hi - q_low) > 1)
-            q = INT((q_hi + q_low)/2)
-            IF (q_mesh(q) > q0(i_grid)) THEN
-               q_hi = q
-            ELSE
-               q_low = q
-            END IF
-         END DO
-         IF (q_hi == q_low) CPABORT("get_potential:  qhi == qlow")
+         q_low = q_low_grid(i_grid)
+         q_hi = q_low + 1
 
          dq = q_mesh(q_hi) - q_mesh(q_low)
          dq_6 = dq/6.0_dp
@@ -757,15 +689,10 @@ CONTAINS
          e = (3.0_dp*a**2 - 1.0_dp)*dq_6
          f = (3.0_dp*b**2 - 1.0_dp)*dq_6
 
-         ! Contract the spline second derivatives before assembling the potential.
-         sum_low = 0.0_dp
-         sum_hi = 0.0_dp
-         DO P_i = 1, nqs
-            sum_low = sum_low + u_vdW(i_grid, P_i)*d2y_dx2(P_i, q_low)
-            sum_hi = sum_hi + u_vdW(i_grid, P_i)*d2y_dx2(P_i, q_hi)
-         END DO
-         u_p = a*u_vdW(i_grid, q_low) + b*u_vdW(i_grid, q_hi) + c*sum_low + d*sum_hi
-         u_dp_dq0 = (u_vdW(i_grid, q_hi) - u_vdW(i_grid, q_low))/dq - e*sum_low + f*sum_hi
+         u_p = a*u_contract(i_grid, 3) + b*u_contract(i_grid, 4) &
+               + c*u_contract(i_grid, 1) + d*u_contract(i_grid, 2)
+         u_dp_dq0 = (u_contract(i_grid, 4) - u_contract(i_grid, 3))/dq &
+                    - e*u_contract(i_grid, 1) + f*u_contract(i_grid, 2)
 
          !! The first term in equation 13 of SOLER
          SELECT CASE (nl_type)
@@ -795,7 +722,7 @@ CONTAINS
                END DO
             END DO
          END IF
-      END DO ! i_grid = 1, SIZE(u_vdW, 1)
+      END DO ! i_grid = 1, SIZE(q0)
 !$OMP END DO
 
 !$OMP END PARALLEL
@@ -1218,68 +1145,132 @@ CONTAINS
    END SUBROUTINE get_q0_on_grid_eo_rvv10
 
 ! **************************************************************************************************
-!> \brief This routine is modeled after an algorithm from "Numerical Recipes in C" by Cambridge University
-!> press, page 97.  It was adapted for Fortran, of course and for the problem at hand, in that it finds
-!> the bin a particular x value is in and then loops over all the P_i functions so we only have to find
-!> the bin once.
-!> \param x ...
-!> \param d2y_dx2 ...
-!> \param evaluation_points ...
-!> \param values ...
-!> \par History
-!>     OpenMP added: Aug 2016  MTucker
+!> \brief Prepare the spline intervals, weights and density factors for streamed theta construction.
+!> \param q0 Saturated interpolation points
+!> \param rho Total density
+!> \param dispersion_env Non-local functional parameters
+!> \param q_low Lower spline endpoint; zero denotes an inactive rVV10 point
+!> \param coeff Cubic spline coefficients a, b, c, d
+!> \param theta_scale Density factor multiplying the interpolated spline
 ! **************************************************************************************************
-   SUBROUTINE spline_interpolation(x, d2y_dx2, evaluation_points, values)
-      REAL(dp), INTENT(in)                               :: x(:), d2y_dx2(:, :), evaluation_points(:)
-      REAL(dp), INTENT(out)                              :: values(:, :)
+   SUBROUTINE prepare_splines(q0, rho, dispersion_env, q_low, coeff, theta_scale)
+      REAL(dp), INTENT(IN)                               :: q0(:), rho(:)
+      TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
+      INTEGER, INTENT(OUT)                               :: q_low(:)
+      REAL(dp), INTENT(OUT)                              :: coeff(:, :), theta_scale(:)
 
-      INTEGER                                            :: i_grid, index, lower_bound, &
-                                                            Ngrid_points, Nx, P_i, upper_bound
-      REAL(dp)                                           :: a, b, c, const, d, dx, y_hi, y_low
+      INTEGER                                            :: i, j, lower, nqs, upper
+      LOGICAL                                            :: rvv10
+      REAL(dp)                                           :: a, b, const, dx, dx2_6
+      REAL(dp), POINTER                                  :: q_mesh(:)
 
-      Nx = SIZE(x)
-      Ngrid_points = SIZE(evaluation_points)
-
-!$OMP PARALLEL DEFAULT( NONE )                                         &
-!$OMP           SHARED( x, d2y_dx2, evaluation_points, values          &
-!$OMP                 , Nx, Ngrid_points                               &
-!$OMP                 )                                                &
-!$OMP          PRIVATE( y_low, y_hi, lower_bound, upper_bound, index             &
-!$OMP                 , dx, const, A, b, c, d, P_i                     &
-!$OMP                 )
-
-!$OMP DO
-      DO i_grid = 1, Ngrid_points
-         lower_bound = 1
-         upper_bound = Nx
-         DO WHILE ((upper_bound - lower_bound) > 1)
-            index = (upper_bound + lower_bound)/2
-            IF (evaluation_points(i_grid) > x(index)) THEN
-               lower_bound = index
+      q_mesh => dispersion_env%q_mesh
+      nqs = dispersion_env%nqs
+      CPASSERT(nqs >= 2)
+      rvv10 = dispersion_env%nl_type == vdw_nl_RVV10
+      const = 1.0_dp/(3.0_dp*rootpi*dispersion_env%b_value**1.5_dp)/(pi**0.75_dp)
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP             SHARED(q0, rho, q_mesh, nqs, rvv10, const, q_low, coeff, theta_scale) &
+!$OMP             PRIVATE(j, lower, upper, A, b, dx, dx2_6) SCHEDULE(STATIC)
+      DO i = 1, SIZE(q0)
+         IF (rvv10 .AND. rho(i) <= epsr) THEN
+            q_low(i) = 0
+            coeff(i, :) = 0.0_dp
+            theta_scale(i) = 0.0_dp
+            CYCLE
+         END IF
+         lower = 1
+         upper = nqs
+         DO WHILE (upper - lower > 1)
+            j = (upper + lower)/2
+            IF (q0(i) > q_mesh(j)) THEN
+               lower = j
             ELSE
-               upper_bound = index
+               upper = j
             END IF
          END DO
-
-         dx = x(upper_bound) - x(lower_bound)
-         const = dx*dx/6.0_dp
-
-         a = (x(upper_bound) - evaluation_points(i_grid))/dx
-         b = (evaluation_points(i_grid) - x(lower_bound))/dx
-         c = (a**3 - a)*const
-         d = (b**3 - b)*const
-
-         DO P_i = 1, Nx
-            y_low = MERGE(1.0_dp, 0.0_dp, P_i == lower_bound)
-            y_hi = MERGE(1.0_dp, 0.0_dp, P_i == upper_bound)
-            values(i_grid, P_i) = a*y_low + b*y_hi &
-                                  + (c*d2y_dx2(P_i, lower_bound) + d*d2y_dx2(P_i, upper_bound))
-         END DO
+         q_low(i) = lower
+         dx = q_mesh(upper) - q_mesh(lower)
+         dx2_6 = dx*dx/6.0_dp
+         a = (q_mesh(upper) - q0(i))/dx
+         b = (q0(i) - q_mesh(lower))/dx
+         coeff(i, 1) = a
+         coeff(i, 2) = b
+         coeff(i, 3) = (a**3 - a)*dx2_6
+         coeff(i, 4) = (b**3 - b)*dx2_6
+         IF (rvv10) THEN
+            theta_scale(i) = const*rho(i)**0.75_dp
+         ELSE
+            theta_scale(i) = rho(i)
+         END IF
       END DO
-!$OMP END DO
+!$OMP END PARALLEL DO
+   END SUBROUTINE prepare_splines
 
-!$OMP END PARALLEL
-   END SUBROUTINE spline_interpolation
+! **************************************************************************************************
+!> \brief Generate one real-space theta channel directly in the existing FFT workspace.
+!> \param iq Channel index
+!> \param q_low Lower spline endpoint
+!> \param coeff Spline coefficients
+!> \param theta_scale Density factor
+!> \param dispersion_env Non-local functional parameters
+!> \param theta FFT input, viewed as a contiguous one-dimensional array
+! **************************************************************************************************
+   SUBROUTINE build_theta(iq, q_low, coeff, theta_scale, dispersion_env, theta)
+      INTEGER, INTENT(IN)                                :: iq, q_low(:)
+      REAL(dp), INTENT(IN)                               :: coeff(:, :), theta_scale(:)
+      TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
+      REAL(dp), INTENT(OUT)                              :: theta(:)
+
+      INTEGER                                            :: i, lower
+      REAL(dp)                                           :: p
+      REAL(dp), POINTER                                  :: d2y(:, :)
+
+      d2y => dispersion_env%d2y_dx2
+!$OMP PARALLEL DO SIMD DEFAULT(NONE) &
+!$OMP             SHARED(iq, q_low, coeff, theta_scale, d2y, theta) PRIVATE(lower, p) SCHEDULE(STATIC)
+      DO i = 1, SIZE(theta)
+         lower = q_low(i)
+         theta(i) = 0.0_dp
+         IF (lower == 0) CYCLE
+         p = coeff(i, 1)*MERGE(1.0_dp, 0.0_dp, iq == lower) &
+             + coeff(i, 2)*MERGE(1.0_dp, 0.0_dp, iq == lower + 1) &
+             + (coeff(i, 3)*d2y(iq, lower) + coeff(i, 4)*d2y(iq, lower + 1))
+         theta(i) = p*theta_scale(i)
+      END DO
+!$OMP END PARALLEL DO SIMD
+   END SUBROUTINE build_theta
+
+! **************************************************************************************************
+!> \brief Accumulate one inverse-transformed channel without storing a real-space channel matrix.
+!> \param iq Channel index
+!> \param q_low Lower spline endpoint, using the potential-side knot convention
+!> \param dispersion_env Non-local functional parameters
+!> \param u Inverse FFT output
+!> \param u_contract Sums against the two second-derivative columns, then the two endpoint values
+! **************************************************************************************************
+   SUBROUTINE accumulate_potential(iq, q_low, dispersion_env, u, u_contract)
+      INTEGER, INTENT(IN)                                :: iq, q_low(:)
+      TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
+      REAL(dp), INTENT(IN)                               :: u(:)
+      REAL(dp), INTENT(INOUT)                            :: u_contract(:, :)
+
+      INTEGER                                            :: i, lower
+      REAL(dp), POINTER                                  :: d2y(:, :)
+
+      d2y => dispersion_env%d2y_dx2
+!$OMP PARALLEL DO SIMD DEFAULT(NONE) &
+!$OMP             SHARED(iq, q_low, d2y, u, u_contract) PRIVATE(lower) SCHEDULE(STATIC)
+      DO i = 1, SIZE(u)
+         lower = q_low(i)
+         IF (lower == 0) CYCLE
+         u_contract(i, 1) = u_contract(i, 1) + u(i)*d2y(iq, lower)
+         u_contract(i, 2) = u_contract(i, 2) + u(i)*d2y(iq, lower + 1)
+         IF (iq == lower) u_contract(i, 3) = u(i)
+         IF (iq == lower + 1) u_contract(i, 4) = u(i)
+      END DO
+!$OMP END PARALLEL DO SIMD
+   END SUBROUTINE accumulate_potential
 
 ! **************************************************************************************************
 !> \brief This routine is modeled after an algorithm from "Numerical Recipes in C" by Cambridge
@@ -1341,119 +1332,68 @@ CONTAINS
 
    END SUBROUTINE initialize_spline_interpolation
 
-   ! **************************************************************************************************
-   !! This routine is modeled after an algorithm from "Numerical Recipes in C" by Cambridge
-   !! University Press, page 97.  Adapted for Fortran and the problem at hand.  This function is used to
-   !! find the Phi_alpha_beta needed for equations 8 and 11 of SOLER.
 ! **************************************************************************************************
-!> \brief ...
-!> \param k ...
-!> \param kernel_of_k ...
-!> \param dispersion_env ...
-!> \par History
-!>     Optimised when adding OpenMP to vdw_energy (which calls this routine): Aug 2016 MTucker
+!> \brief Interpolate the symmetric kernel and optionally its radial derivative from packed tables.
+!> \param k Reciprocal-vector length
+!> \param kernel_of_k Interpolated kernel matrix
+!> \param dispersion_env Radial mesh and channel count
+!> \param kernel_table Packed channel pairs, radial points, and value/second derivative
+!> \param dkernel_of_dk Optional derivative matrix for the kernel virial
 ! **************************************************************************************************
-   SUBROUTINE interpolate_kernel(k, kernel_of_k, dispersion_env)
-      REAL(dp), INTENT(in)                               :: k
-      REAL(dp), INTENT(out)                              :: kernel_of_k(:, :)
+   SUBROUTINE interpolate_kernel(k, kernel_of_k, dispersion_env, kernel_table, dkernel_of_dk)
+      REAL(dp), INTENT(IN)                               :: k
+      REAL(dp), INTENT(OUT)                              :: kernel_of_k(:, :)
       TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
+      REAL(dp), INTENT(IN)                               :: kernel_table(:, 0:, :)
+      REAL(dp), INTENT(OUT), OPTIONAL                    :: dkernel_of_dk(:, :)
 
-      INTEGER                                            :: k_i, Nr_points, q1_i, q2_i
-      REAL(dp)                                           :: A, B, C, const, D, dk, r_max
-      REAL(dp), DIMENSION(:, :, :), POINTER              :: d2phi_dk2, kernel
+      INTEGER                                            :: ipair, k_i, q1_i, q2_i
+      LOGICAL                                            :: on_mesh
+      REAL(dp)                                           :: a, b, c, d, da, db, dc, dd, dk, dk_6, &
+                                                            value
 
-      Nr_points = dispersion_env%nr_points
-      r_max = dispersion_env%r_max
       dk = dispersion_env%dk
-      kernel => dispersion_env%kernel
-      d2phi_dk2 => dispersion_env%d2phi_dk2
-
-      !! Check to make sure that the kernel table we have is capable of dealing with this
-      !! value of k.  If k is larger than Nr_points*2*pi/r_max then we can't perform the
-      !! interpolation.  In that case, a kernel file should be generated with a larger number
-      !! of radial points.
-      !! -------------------------------------------------------------------------------------
-      CPASSERT(k < Nr_points*dk)
-      !! -------------------------------------------------------------------------------------
-      kernel_of_k = 0.0_dp
-      !! This integer division figures out which bin k is in since the kernel
-      !! is set on a uniform grid.
+      CPASSERT(k < dispersion_env%nr_points*dk)
       k_i = INT(k/dk)
-
-      !! Test to see if we are trying to interpolate a k that is one of the actual
-      !! function points we have.  The value is just the value of the function in that
-      !! case.
-      !! ----------------------------------------------------------------------------------------
-      IF (MOD(k, dk) == 0) THEN
-         DO q1_i = 1, dispersion_env%Nqs
+      on_mesh = MOD(k, dk) == 0.0_dp
+      a = (dk*(k_i + 1.0_dp) - k)/dk
+      b = (k - dk*k_i)/dk
+      c = (a**3 - a)*(dk*dk/6.0_dp)
+      d = (b**3 - b)*(dk*dk/6.0_dp)
+      DO q1_i = 1, dispersion_env%nqs
+!$OMP SIMD PRIVATE(ipair, value)
+         DO q2_i = 1, q1_i
+            ipair = q1_i*(q1_i - 1)/2 + q2_i
+            IF (on_mesh) THEN
+               value = kernel_table(ipair, k_i, 1)
+            ELSE
+               value = a*kernel_table(ipair, k_i, 1) + b*kernel_table(ipair, k_i + 1, 1) &
+                       + (c*kernel_table(ipair, k_i, 2) + d*kernel_table(ipair, k_i + 1, 2))
+            END IF
+            kernel_of_k(q2_i, q1_i) = value
+            kernel_of_k(q1_i, q2_i) = value
+         END DO
+!$OMP END SIMD
+      END DO
+      IF (PRESENT(dkernel_of_dk)) THEN
+         dk_6 = dk/6.0_dp
+         da = -1.0_dp/dk
+         db = 1.0_dp/dk
+         dc = -(3*a**2 - 1.0_dp)*dk_6
+         dd = (3*b**2 - 1.0_dp)*dk_6
+         DO q1_i = 1, dispersion_env%nqs
+!$OMP SIMD PRIVATE(ipair, value)
             DO q2_i = 1, q1_i
-               kernel_of_k(q1_i, q2_i) = kernel(k_i, q1_i, q2_i)
-               kernel_of_k(q2_i, q1_i) = kernel(k_i, q2_i, q1_i)
+               ipair = q1_i*(q1_i - 1)/2 + q2_i
+               value = da*kernel_table(ipair, k_i, 1) + db*kernel_table(ipair, k_i + 1, 1) &
+                       + dc*kernel_table(ipair, k_i, 2) + dd*kernel_table(ipair, k_i + 1, 2)
+               dkernel_of_dk(q2_i, q1_i) = value
+               dkernel_of_dk(q1_i, q2_i) = value
             END DO
+!$OMP END SIMD
          END DO
-         RETURN
       END IF
-      !! ----------------------------------------------------------------------------------------
-      !! If we are not on a function point then we carry out the interpolation
-      !! ----------------------------------------------------------------------------------------
-      const = dk*dk/6.0_dp
-      A = (dk*(k_i + 1.0_dp) - k)/dk
-      B = (k - dk*k_i)/dk
-      C = (A**3 - A)*const
-      D = (B**3 - B)*const
-      DO q1_i = 1, dispersion_env%Nqs
-         DO q2_i = 1, q1_i
-            kernel_of_k(q1_i, q2_i) = A*kernel(k_i, q1_i, q2_i) + B*kernel(k_i + 1, q1_i, q2_i) &
-                                      + (C*d2phi_dk2(k_i, q1_i, q2_i) + D*d2phi_dk2(k_i + 1, q1_i, q2_i))
-            kernel_of_k(q2_i, q1_i) = kernel_of_k(q1_i, q2_i)
-         END DO
-      END DO
-
    END SUBROUTINE interpolate_kernel
-
-! **************************************************************************************************
-!> \brief ...
-!> \param k ...
-!> \param dkernel_of_dk ...
-!> \param dispersion_env ...
-!> \par History
-!>     Optimised when adding OpenMP to vdw_energy (which calls this routine): Aug 2016 MTucker
-! **************************************************************************************************
-   SUBROUTINE interpolate_dkernel_dk(k, dkernel_of_dk, dispersion_env)
-      REAL(dp), INTENT(in)                               :: k
-      REAL(dp), INTENT(out)                              :: dkernel_of_dk(:, :)
-      TYPE(qs_dispersion_type), POINTER                  :: dispersion_env
-
-      INTEGER                                            :: k_i, Nr_points, q1_i, q2_i
-      REAL(dp)                                           :: A, B, dAdk, dBdk, dCdk, dDdk, dk, dk_6
-      REAL(dp), DIMENSION(:, :, :), POINTER              :: d2phi_dk2, kernel
-
-      Nr_points = dispersion_env%nr_points
-      dk = dispersion_env%dk
-      kernel => dispersion_env%kernel
-      d2phi_dk2 => dispersion_env%d2phi_dk2
-      dk_6 = dk/6.0_dp
-
-      CPASSERT(k < Nr_points*dk)
-
-      dkernel_of_dk = 0.0_dp
-      k_i = INT(k/dk)
-
-      A = (dk*(k_i + 1.0_dp) - k)/dk
-      B = (k - dk*k_i)/dk
-      dAdk = -1.0_dp/dk
-      dBdk = 1.0_dp/dk
-      dCdk = -(3*A**2 - 1.0_dp)*dk_6
-      dDdk = (3*B**2 - 1.0_dp)*dk_6
-      DO q1_i = 1, dispersion_env%Nqs
-         DO q2_i = 1, q1_i
-            dkernel_of_dk(q1_i, q2_i) = dAdk*kernel(k_i, q1_i, q2_i) + dBdk*kernel(k_i + 1, q1_i, q2_i) &
-                                        + dCdk*d2phi_dk2(k_i, q1_i, q2_i) + dDdk*d2phi_dk2(k_i + 1, q1_i, q2_i)
-            dkernel_of_dk(q2_i, q1_i) = dkernel_of_dk(q1_i, q2_i)
-         END DO
-      END DO
-
-   END SUBROUTINE interpolate_dkernel_dk
 
 ! **************************************************************************************************
 

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -179,15 +179,15 @@ CONTAINS
                                                             np, nspin, p, q, r, s
       INTEGER, DIMENSION(1:3)                            :: hi, lo, n
       LOGICAL                                            :: use_virial
-      REAL(KIND=dp)                                      :: b_value, beta, const, Ec_nl, sumnp
+      REAL(KIND=dp)                                      :: b_value, beta, const, Ec_nl, rho_3_4, &
+                                                            sumnp
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: dq0_dgradrho, dq0_drho, hpot, potential, &
                                                             q0, rho
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: drho, thetas
-      TYPE(pw_c1d_gs_type)                               :: tmp_g, vxc_g
+      TYPE(pw_c1d_gs_type)                               :: div_g, rho_tot_g, tmp_g, vxc_g
       TYPE(pw_c1d_gs_type), ALLOCATABLE, DIMENSION(:)    :: thetas_g
       TYPE(pw_grid_type), POINTER                        :: grid
       TYPE(pw_r3d_rs_type)                               :: tmp_r, vxc_r
-      TYPE(pw_r3d_rs_type), ALLOCATABLE, DIMENSION(:, :) :: drho_r
 
       CALL timeset(routineN, handle)
 
@@ -219,80 +219,51 @@ CONTAINS
       CALL pw_pool%create_pw(tmp_g)
       CALL pw_pool%create_pw(tmp_r)
 
-      ! get density derivatives
-      ALLOCATE (drho_r(3, nspin))
-      DO ispin = 1, nspin
-         DO idir = 1, 3
-            CALL pw_pool%create_pw(drho_r(idir, ispin))
-            CALL pw_transfer(rho_g(ispin), tmp_g)
-            CALL pw_derive(tmp_g, nd(:, idir))
-            CALL pw_transfer(tmp_g, drho_r(idir, ispin))
-         END DO
+      ! Sum the spin densities on the vdW grid before transforming or differentiating.
+      CALL pw_pool%create_pw(rho_tot_g)
+      CALL pw_transfer(rho_g(1), rho_tot_g)
+      DO ispin = 2, nspin
+         CALL pw_transfer(rho_g(ispin), tmp_g)
+         CALL pw_axpy(tmp_g, rho_tot_g, 1._dp)
       END DO
+      CALL pw_transfer(rho_tot_g, tmp_r)
 
       np = SIZE(tmp_r%array)
-      ALLOCATE (rho(np), drho(np, 3)) !in the following loops, rho and drho _will_ have the same bounds
+      ALLOCATE (rho(np), drho(np, 3))
       DO i = 1, 3
          lo(i) = LBOUND(tmp_r%array, i)
          hi(i) = UBOUND(tmp_r%array, i)
          n(i) = hi(i) - lo(i) + 1
       END DO
-!$OMP PARALLEL DO DEFAULT(NONE)              &
-!$OMP             SHARED(n,rho)              &
-!$OMP             COLLAPSE(3)
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP             SHARED(n, lo, rho, tmp_r) PRIVATE(s) COLLAPSE(3)
       DO r = 0, n(3) - 1
          DO q = 0, n(2) - 1
             DO p = 0, n(1) - 1
-               rho(r*n(2)*n(1) + q*n(1) + p + 1) = 0.0_dp
+               s = r*n(2)*n(1) + q*n(1) + p + 1
+               rho(s) = tmp_r%array(p + lo(1), q + lo(2), r + lo(3))
             END DO
          END DO
       END DO
 !$OMP END PARALLEL DO
-      DO i = 1, 3
-!$OMP PARALLEL DO DEFAULT(NONE)              &
-!$OMP             SHARED(n,i,drho)           &
-!$OMP             COLLAPSE(3)
-         DO r = 0, n(3) - 1
-            DO q = 0, n(2) - 1
-               DO p = 0, n(1) - 1
-                  drho(r*n(2)*n(1) + q*n(1) + p + 1, i) = 0.0_dp
-               END DO
-            END DO
-         END DO
-!$OMP END PARALLEL DO
-      END DO
-      DO ispin = 1, nspin
-         CALL pw_transfer(rho_g(ispin), tmp_g)
+      DO idir = 1, 3
+         CALL pw_transfer(rho_tot_g, tmp_g)
+         CALL pw_derive(tmp_g, nd(:, idir))
          CALL pw_transfer(tmp_g, tmp_r)
-!$OMP PARALLEL DO DEFAULT(NONE)            &
-!$OMP             SHARED(n,lo,rho,tmp_r)   &
-!$OMP             PRIVATE(s)               &
-!$OMP             COLLAPSE(3)
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP             SHARED(idir, n, lo, drho, tmp_r) PRIVATE(s) COLLAPSE(3)
          DO r = 0, n(3) - 1
             DO q = 0, n(2) - 1
                DO p = 0, n(1) - 1
                   s = r*n(2)*n(1) + q*n(1) + p + 1
-                  rho(s) = rho(s) + tmp_r%array(p + lo(1), q + lo(2), r + lo(3))
+                  drho(s, idir) = tmp_r%array(p + lo(1), q + lo(2), r + lo(3))
                END DO
             END DO
          END DO
 !$OMP END PARALLEL DO
-         DO i = 1, 3
-!$OMP PARALLEL DO DEFAULT(NONE)                      &
-!$OMP             SHARED(ispin,i,n,lo,drho,drho_r)   &
-!$OMP             PRIVATE(s)                         &
-!$OMP             COLLAPSE(3)
-            DO r = 0, n(3) - 1
-               DO q = 0, n(2) - 1
-                  DO p = 0, n(1) - 1
-                     s = r*n(2)*n(1) + q*n(1) + p + 1
-                     drho(s, i) = drho(s, i) + drho_r(i, ispin)%array(p + lo(1), q + lo(2), r + lo(3))
-                  END DO
-               END DO
-            END DO
-!$OMP END PARALLEL DO
-         END DO
       END DO
+      CALL pw_pool%give_back_pw(rho_tot_g)
+
       !! ---------------------------------------------------------------------------------
       !! Find the value of q0 for all assigned grid points.  q is defined in equations
       !! 11 and 12 of DION and q0 is the saturated version of q defined in equation
@@ -358,12 +329,13 @@ CONTAINS
       CASE (vdw_nl_RVV10)
 !$OMP PARALLEL DO DEFAULT( NONE )                                  &
 !$OMP             SHARED( np, rho, dispersion_env, thetas, const ) &
-!$OMP             PRIVATE( i )                                     &
-!$OMP             SCHEDULE(DYNAMIC)    ! use dynamic to allow for possibility of cases having   (rho(i_grid) <= epsr)
+!$OMP             PRIVATE( i, rho_3_4 )                            &
+!$OMP             SCHEDULE(STATIC)
          DO i_grid = 1, np
             IF (rho(i_grid) > epsr) THEN
+               rho_3_4 = rho(i_grid)**(0.75_dp)
                DO i = 1, dispersion_env%nqs
-                  thetas(i_grid, i) = thetas(i_grid, i)*const*rho(i_grid)**(0.75_dp)
+                  thetas(i_grid, i) = thetas(i_grid, i)*const*rho_3_4
                END DO
             ELSE
                thetas(i_grid, :) = 0.0_dp
@@ -494,38 +466,32 @@ CONTAINS
             hi(i) = UBOUND(tmp_r%array, i)
             n(i) = hi(i) - lo(i) + 1
          END DO
+         ! Sum the derivatives before the inverse FFT. Keep the real-space projection
+         ! before transferring the potential to a possibly different XC grid.
+         CALL pw_pool%create_pw(div_g)
          DO idir = 1, 3
-!$OMP PARALLEL DO DEFAULT(NONE)                     &
-!$OMP             SHARED(n,lo,tmp_r)                &
-!$OMP             COLLAPSE(3)
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP             SHARED(n, lo, tmp_r, hpot, drho, idir) PRIVATE(s) COLLAPSE(3)
             DO r = 0, n(3) - 1
                DO q = 0, n(2) - 1
                   DO p = 0, n(1) - 1
-                     tmp_r%array(p + lo(1), q + lo(2), r + lo(3)) = 0.0_dp
+                     s = r*n(2)*n(1) + q*n(1) + p + 1
+                     tmp_r%array(p + lo(1), q + lo(2), r + lo(3)) = hpot(s)*drho(s, idir)
                   END DO
                END DO
             END DO
 !$OMP END PARALLEL DO
-            DO ispin = 1, nspin
-!$OMP PARALLEL DO DEFAULT(NONE)                              &
-!$OMP             SHARED(n,lo,tmp_r,hpot,drho_r,idir,ispin)  &
-!$OMP             COLLAPSE(3)
-               DO r = 0, n(3) - 1
-                  DO q = 0, n(2) - 1
-                     DO p = 0, n(1) - 1
-                        tmp_r%array(p + lo(1), q + lo(2), r + lo(3)) = tmp_r%array(p + lo(1), q + lo(2), r + lo(3)) &
-                                                                       + hpot(r*n(2)*n(1) + q*n(1) + p + 1) &
-                                                                       *drho_r(idir, ispin)%array(p + lo(1), q + lo(2), r + lo(3))
-                     END DO
-                  END DO
-               END DO
-!$OMP END PARALLEL DO
-            END DO
             CALL pw_transfer(tmp_r, tmp_g)
             CALL pw_derive(tmp_g, nd(:, idir))
-            CALL pw_transfer(tmp_g, tmp_r)
-            CALL pw_axpy(tmp_r, vxc_r, -1._dp)
+            IF (idir == 1) THEN
+               CALL pw_transfer(tmp_g, div_g)
+            ELSE
+               CALL pw_axpy(tmp_g, div_g, 1._dp)
+            END IF
          END DO
+         CALL pw_transfer(div_g, tmp_r)
+         CALL pw_pool%give_back_pw(div_g)
+         CALL pw_axpy(tmp_r, vxc_r, -1._dp)
          CALL pw_transfer(vxc_r, tmp_g)
          CALL pw_pool%give_back_pw(vxc_r)
          CALL xc_pw_pool%create_pw(vxc_r)
@@ -545,15 +511,10 @@ CONTAINS
       DO i = 1, dispersion_env%nqs
          CALL pw_pool%give_back_pw(thetas_g(i))
       END DO
-      DO ispin = 1, nspin
-         DO idir = 1, 3
-            CALL pw_pool%give_back_pw(drho_r(idir, ispin))
-         END DO
-      END DO
       CALL pw_pool%give_back_pw(tmp_r)
       CALL pw_pool%give_back_pw(tmp_g)
 
-      DEALLOCATE (rho, drho, drho_r, thetas_g)
+      DEALLOCATE (rho, drho, thetas_g)
 
       CALL timestop(handle)
 
@@ -583,7 +544,6 @@ CONTAINS
 
       COMPLEX(KIND=dp)                                   :: uu
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:)        :: theta
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: u_vdw
       INTEGER                                            :: handle, ig, iq, l, m, nl_type, nqs, &
                                                             q1_i, q2_i
       LOGICAL                                            :: use_virial
@@ -609,15 +569,9 @@ CONTAINS
 
       nl_type = dispersion_env%nl_type
 
-      IF (.NOT. energy_only) THEN
-         ALLOCATE (u_vdW(grid%ngpts_cut_local, nqs))
-         u_vdW(:, :) = z_zero
-      END IF
-
 !$OMP PARALLEL DEFAULT( NONE )                                             &
 !$OMP           SHARED( nqs, energy_only, grid, dispersion_env             &
 !$OMP                 , use_virial, thetas_g, g_multiplier, nl_type        &
-!$OMP                 , u_vdW                                              &
 !$OMP                 )                                                    &
 !$OMP          PRIVATE( g2_last, kernel_of_k, dkernel_of_dk, theta         &
 !$OMP                 , g2, g, iq                                          &
@@ -640,20 +594,22 @@ CONTAINS
             CALL interpolate_kernel(g, kernel_of_k, dispersion_env)
             IF (use_virial) CALL interpolate_dkernel_dk(g, dkernel_of_dk, dispersion_env)
          END IF
+         ! Save every input channel before overwriting any output at this G point.
          DO iq = 1, nqs
             theta(iq) = thetas_g(iq)%array(ig)
          END DO
          DO q2_i = 1, nqs
             uu = z_zero
+            ! The kernel is symmetric; access its contiguous first index.
             DO q1_i = 1, nqs
-               uu = uu + kernel_of_k(q2_i, q1_i)*theta(q1_i)
+               uu = uu + kernel_of_k(q1_i, q2_i)*theta(q1_i)
             END DO
             IF (ig < grid%first_gne0) THEN
                vdW_xc_energy = vdW_xc_energy + REAL(uu*CONJG(theta(q2_i)), KIND=dp)
             ELSE
                vdW_xc_energy = vdW_xc_energy + g_multiplier*REAL(uu*CONJG(theta(q2_i)), KIND=dp)
             END IF
-            IF (.NOT. energy_only) u_vdW(ig, q2_i) = uu
+            IF (.NOT. energy_only) thetas_g(q2_i)%array(ig) = uu
 
             IF (use_virial .AND. ig >= grid%first_gne0) THEN
                DO q1_i = 1, nqs
@@ -676,21 +632,7 @@ CONTAINS
       DEALLOCATE (theta)
       DEALLOCATE (kernel_of_k, dkernel_of_dk)
 
-      IF (.NOT. energy_only) THEN
-!$OMP DO
-         DO ig = 1, grid%ngpts_cut_local
-            DO iq = 1, nqs
-               thetas_g(iq)%array(ig) = u_vdW(ig, iq)
-            END DO
-         END DO
-!$OMP END DO
-      END IF
-
 !$OMP END PARALLEL
-
-      IF (.NOT. energy_only) THEN
-         DEALLOCATE (u_vdW)
-      END IF
 
       vdW_xc_energy = vdW_xc_energy*grid%vol*0.5_dp
 
@@ -750,8 +692,7 @@ CONTAINS
       LOGICAL                                            :: use_virial
       REAL(dp)                                           :: a, b, b_value, c, const, d, dP_dq0, dq, &
                                                             dq_6, e, f, P, prefactor, tmp_1_2, &
-                                                            tmp_1_4, tmp_3_4
-      REAL(dp), ALLOCATABLE, DIMENSION(:)                :: y
+                                                            tmp_1_4, tmp_3_4, y_hi, y_low
       REAL(dp), DIMENSION(3, 3)                          :: virial_thread
       REAL(dp), DIMENSION(:), POINTER                    :: q_mesh
       REAL(dp), DIMENSION(:, :), POINTER                 :: d2y_dx2
@@ -765,8 +706,6 @@ CONTAINS
       virial_thread(:, :) = 0.0_dp ! always initialize to avoid floating point exceptions in OMP REDUCTION
       b_value = dispersion_env%b_value
       const = 1.0_dp/(3.0_dp*b_value**(3.0_dp/2.0_dp)*pi**(5.0_dp/4.0_dp))
-      potential = 0.0_dp
-      h_prefactor = 0.0_dp
 
       d2y_dx2 => dispersion_env%d2y_dx2
       q_mesh => dispersion_env%q_mesh
@@ -779,18 +718,27 @@ CONTAINS
 !$OMP                 , dq0_drho, dq0_dgradrho, total_rho, const       &
 !$OMP                 , use_virial, drho, dvol, virial                 &
 !$OMP                 )                                                &
-!$OMP          PRIVATE( y                                              &
-!$OMP                 , q_low, q_hi, q, dq, dq_6, A, b, c, d, e, f     &
+!$OMP          PRIVATE( q_low, q_hi, q, dq, dq_6, A, b, c, d, e, f      &
+!$OMP                 , y_low, y_hi                                    &
 !$OMP                 , P_i, dP_dq0, P, prefactor, l, m                &
 !$OMP                 , tmp_1_2, tmp_1_4, tmp_3_4                      &
 !$OMP                 )                                                &
 !$OMP        REDUCTION(+: virial_thread                                &
 !$OMP                 )
 
-      ALLOCATE (y(nqs))
+      tmp_1_4 = 1.0_dp
+      tmp_3_4 = 0.0_dp
 
 !$OMP DO
       DO i_grid = 1, SIZE(u_vdW, 1)
+         potential(i_grid) = 0.0_dp
+         h_prefactor(i_grid) = 0.0_dp
+         IF (nl_type == vdw_nl_RVV10) THEN
+            IF (total_rho(i_grid) <= epsr) CYCLE
+            tmp_1_2 = SQRT(total_rho(i_grid))
+            tmp_1_4 = SQRT(tmp_1_2)
+            tmp_3_4 = tmp_1_4*tmp_1_4*tmp_1_4
+         END IF
          q_low = 1
          q_hi = nqs
          ! Figure out which bin our value of q0 is in in the q_mesh
@@ -815,10 +763,10 @@ CONTAINS
          f = (3.0_dp*b**2 - 1.0_dp)*dq_6
 
          DO P_i = 1, nqs
-            y = 0.0_dp
-            y(P_i) = 1.0_dp
-            dP_dq0 = (y(q_hi) - y(q_low))/dq - e*d2y_dx2(P_i, q_low) + f*d2y_dx2(P_i, q_hi)
-            P = a*y(q_low) + b*y(q_hi) + c*d2y_dx2(P_i, q_low) + d*d2y_dx2(P_i, q_hi)
+            y_low = MERGE(1.0_dp, 0.0_dp, P_i == q_low)
+            y_hi = MERGE(1.0_dp, 0.0_dp, P_i == q_hi)
+            dP_dq0 = (y_hi - y_low)/dq - e*d2y_dx2(P_i, q_low) + f*d2y_dx2(P_i, q_hi)
+            P = a*y_low + b*y_hi + c*d2y_dx2(P_i, q_low) + d*d2y_dx2(P_i, q_hi)
             !! The first term in equation 13 of SOLER
             SELECT CASE (nl_type)
             CASE DEFAULT
@@ -827,17 +775,10 @@ CONTAINS
                potential(i_grid) = potential(i_grid) + u_vdW(i_grid, P_i)*(P + dP_dq0*dq0_drho(i_grid))
                prefactor = u_vdW(i_grid, P_i)*dP_dq0*dq0_dgradrho(i_grid)
             CASE (vdw_nl_RVV10)
-               IF (total_rho(i_grid) > epsr) THEN
-                  tmp_1_2 = SQRT(total_rho(i_grid))
-                  tmp_1_4 = SQRT(tmp_1_2) ! == total_rho(i_grid)**(1.0_dp/4.0_dp)
-                  tmp_3_4 = tmp_1_4*tmp_1_4*tmp_1_4 ! == total_rho(i_grid)**(3.0_dp/4.0_dp)
-                  potential(i_grid) = potential(i_grid) &
-                                      + u_vdW(i_grid, P_i)*(const*0.75_dp/tmp_1_4*P &
-                                                            + const*tmp_3_4*dP_dq0*dq0_drho(i_grid))
-                  prefactor = u_vdW(i_grid, P_i)*const*tmp_3_4*dP_dq0*dq0_dgradrho(i_grid)
-               ELSE
-                  prefactor = 0.0_dp
-               END IF
+               potential(i_grid) = potential(i_grid) &
+                                   + u_vdW(i_grid, P_i)*(const*0.75_dp/tmp_1_4*P &
+                                                         + const*tmp_3_4*dP_dq0*dq0_drho(i_grid))
+               prefactor = u_vdW(i_grid, P_i)*const*tmp_3_4*dP_dq0*dq0_dgradrho(i_grid)
             END SELECT
             IF (q0(i_grid) /= q_mesh(nqs)) THEN
                h_prefactor(i_grid) = h_prefactor(i_grid) + prefactor
@@ -862,7 +803,6 @@ CONTAINS
       END DO ! i_grid = 1, SIZE(u_vdW, 1)
 !$OMP END DO
 
-      DEALLOCATE (y)
 !$OMP END PARALLEL
 
       IF (use_virial) THEN
@@ -977,12 +917,14 @@ CONTAINS
          Z_ab = -1.887_dp
       END SELECT
 
-      ! initialize q0-related arrays ...
-      q0(:) = q_cut
-      dq0_drho(:) = 0.0_dp
-      dq0_dgradrho(:) = 0.0_dp
-
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP             SHARED(total_rho, gradient_rho, q0, dq0_drho, dq0_dgradrho, q_cut, q_min, Z_ab) &
+!$OMP             PRIVATE(dq0_dq, exponent, gradient_correction, kF, LDA_1, LDA_2, q, q__q_cut, r_s, sqrt_r_s) &
+!$OMP             SCHEDULE(STATIC)
       DO i_grid = 1, SIZE(total_rho)
+         q0(i_grid) = q_cut
+         dq0_drho(i_grid) = 0.0_dp
+         dq0_dgradrho(i_grid) = 0.0_dp
 
          !! This prevents numerical problems.  If the charge density is negative (an
          !! unphysical situation), we simply treat it as very small.  In that case,
@@ -1043,6 +985,7 @@ CONTAINS
          dq0_dgradrho(i_grid) = total_rho(i_grid)*dq0_dq*2.0_dp*(-Z_ab)/(36.0_dp*kF*total_rho(i_grid)**2)
 
       END DO
+!$OMP END PARALLEL DO
 
    END SUBROUTINE get_q0_on_grid_vdw
 
@@ -1055,7 +998,7 @@ CONTAINS
 !> \param dq0_dgradrho ...
 !> \param dispersion_env ...
 ! **************************************************************************************************
-   PURE SUBROUTINE get_q0_on_grid_rvv10(total_rho, gradient_rho, q0, dq0_drho, dq0_dgradrho, dispersion_env)
+   SUBROUTINE get_q0_on_grid_rvv10(total_rho, gradient_rho, q0, dq0_drho, dq0_dgradrho, dispersion_env)
       !!
       !! more specifically it calculates the following
       !!
@@ -1079,12 +1022,14 @@ CONTAINS
       b_value = dispersion_env%b_value
       C_value = dispersion_env%c_value
 
-      ! initialize q0-related arrays ...
-      q0(:) = q_cut
-      dq0_drho(:) = 0.0_dp
-      dq0_dgradrho(:) = 0.0_dp
-
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP             SHARED(total_rho, gradient_rho, q0, dq0_drho, dq0_dgradrho, q_cut, q_min, b_value, C_value) &
+!$OMP             PRIVATE(dk_dn, dq0_dq, dw0_dn, exponent, gmod2, k, mod_grad, q, q__q_cut, w0, wg2, wp2) &
+!$OMP             SCHEDULE(STATIC)
       DO i_grid = 1, SIZE(total_rho)
+         q0(i_grid) = q_cut
+         dq0_drho(i_grid) = 0.0_dp
+         dq0_dgradrho(i_grid) = 0.0_dp
 
          gmod2 = gradient_rho(i_grid, 1)**2 + gradient_rho(i_grid, 2)**2 + gradient_rho(i_grid, 3)**2
 
@@ -1120,10 +1065,14 @@ CONTAINS
             dk_dn = k/(6.0_dp*total_rho(i_grid))
 
             dq0_drho(i_grid) = dq0_dq*1.0_dp/(k**2.0)*(dw0_dn*k - dk_dn*w0)
-            dq0_dgradrho(i_grid) = dq0_dq*1.0_dp/(2.0_dp*k*w0)*4.0_dp*wg2/gmod2
+            ! wg2 is proportional to |gradient_rho|**4, so this limit is zero.
+            IF (gmod2 > 0.0_dp) THEN
+               dq0_dgradrho(i_grid) = dq0_dq*1.0_dp/(2.0_dp*k*w0)*4.0_dp*wg2/gmod2
+            END IF
          END IF
 
       END DO
+!$OMP END PARALLEL DO
 
    END SUBROUTINE get_q0_on_grid_rvv10
 
@@ -1160,9 +1109,12 @@ CONTAINS
          Z_ab = -1.887_dp
       END SELECT
 
-      ! initialize q0-related arrays ...
-      q0(:) = q_cut
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP             SHARED(total_rho, gradient_rho, q0, q_cut, q_min, Z_ab) &
+!$OMP             PRIVATE(exponent, gradient_correction, kF, LDA_1, LDA_2, q, q__q_cut, r_s, sqrt_r_s) &
+!$OMP             SCHEDULE(STATIC)
       DO i_grid = 1, SIZE(total_rho)
+         q0(i_grid) = q_cut
          !! This prevents numerical problems.  If the charge density is negative (an
          !! unphysical situation), we simply treat it as very small.  In that case,
          !! q0 will be very large and will be saturated.  For a saturated q0 the derivative
@@ -1203,6 +1155,7 @@ CONTAINS
             q0(i_grid) = q_min
          END IF
       END DO
+!$OMP END PARALLEL DO
 
    END SUBROUTINE get_q0_on_grid_eo_vdw
 
@@ -1213,7 +1166,7 @@ CONTAINS
 !> \param q0 ...
 !> \param dispersion_env ...
 ! **************************************************************************************************
-   PURE SUBROUTINE get_q0_on_grid_eo_rvv10(total_rho, gradient_rho, q0, dispersion_env)
+   SUBROUTINE get_q0_on_grid_eo_rvv10(total_rho, gradient_rho, q0, dispersion_env)
 
       REAL(dp), INTENT(IN)                               :: total_rho(:), gradient_rho(:, :)
       REAL(dp), INTENT(OUT)                              :: q0(:)
@@ -1230,10 +1183,12 @@ CONTAINS
       b_value = dispersion_env%b_value
       C_value = dispersion_env%c_value
 
-      ! initialize q0-related arrays ...
-      q0(:) = q_cut
-
+!$OMP PARALLEL DO DEFAULT(NONE) &
+!$OMP             SHARED(total_rho, gradient_rho, q0, q_cut, q_min, b_value, C_value) &
+!$OMP             PRIVATE(exponent, gmod2, k, q, q__q_cut, w0, wg2, wp2) &
+!$OMP             SCHEDULE(STATIC)
       DO i_grid = 1, SIZE(total_rho)
+         q0(i_grid) = q_cut
 
          gmod2 = gradient_rho(i_grid, 1)**2 + gradient_rho(i_grid, 2)**2 + gradient_rho(i_grid, 3)**2
 
@@ -1263,6 +1218,7 @@ CONTAINS
          END IF
 
       END DO
+!$OMP END PARALLEL DO
 
    END SUBROUTINE get_q0_on_grid_eo_rvv10
 
@@ -1284,8 +1240,7 @@ CONTAINS
 
       INTEGER                                            :: i_grid, index, lower_bound, &
                                                             Ngrid_points, Nx, P_i, upper_bound
-      REAL(dp)                                           :: a, b, c, const, d, dx
-      REAL(dp), ALLOCATABLE                              :: y(:)
+      REAL(dp)                                           :: a, b, c, const, d, dx, y_hi, y_low
 
       Nx = SIZE(x)
       Ngrid_points = SIZE(evaluation_points)
@@ -1294,11 +1249,9 @@ CONTAINS
 !$OMP           SHARED( x, d2y_dx2, evaluation_points, values          &
 !$OMP                 , Nx, Ngrid_points                               &
 !$OMP                 )                                                &
-!$OMP          PRIVATE( y, lower_bound, upper_bound, index             &
+!$OMP          PRIVATE( y_low, y_hi, lower_bound, upper_bound, index             &
 !$OMP                 , dx, const, A, b, c, d, P_i                     &
 !$OMP                 )
-
-      ALLOCATE (y(Nx))
 
 !$OMP DO
       DO i_grid = 1, Ngrid_points
@@ -1322,15 +1275,14 @@ CONTAINS
          d = (b**3 - b)*const
 
          DO P_i = 1, Nx
-            y = 0
-            y(P_i) = 1
-            values(i_grid, P_i) = a*y(lower_bound) + b*y(upper_bound) &
+            y_low = MERGE(1.0_dp, 0.0_dp, P_i == lower_bound)
+            y_hi = MERGE(1.0_dp, 0.0_dp, P_i == upper_bound)
+            values(i_grid, P_i) = a*y_low + b*y_hi &
                                   + (c*d2y_dx2(P_i, lower_bound) + d*d2y_dx2(P_i, upper_bound))
          END DO
       END DO
 !$OMP END DO
 
-      DEALLOCATE (y)
 !$OMP END PARALLEL
    END SUBROUTINE spline_interpolation
 

--- a/src/qs_dispersion_nonloc.F
+++ b/src/qs_dispersion_nonloc.F
@@ -70,8 +70,8 @@ CONTAINS
       CHARACTER(len=*), PARAMETER :: routineN = 'qs_dispersion_nonloc_init'
 
       CHARACTER(LEN=default_path_length)                 :: filename
-      INTEGER                                            :: funit, handle, nqs, nr_points, q1_i, &
-                                                            q2_i, vdw_type
+      INTEGER                                            :: funit, handle, ipair, itable, nqs, &
+                                                            nr_points, vdw_type
 
       CALL timeset(routineN, handle)
 
@@ -101,37 +101,23 @@ CONTAINS
          CALL para_env%bcast(nqs)
          CALL para_env%bcast(nr_points)
          CALL para_env%bcast(dispersion_env%r_max)
-         ALLOCATE (dispersion_env%q_mesh(nqs), dispersion_env%kernel(0:nr_points, nqs, nqs), &
-                   dispersion_env%d2phi_dk2(0:nr_points, nqs, nqs))
+         ALLOCATE (dispersion_env%q_mesh(nqs), dispersion_env%kernel_table(nqs*(nqs + 1)/2, 0:nr_points, 2))
          dispersion_env%nqs = nqs
          dispersion_env%nr_points = nr_points
          IF (para_env%is_source()) THEN
             !! Read in the values of the q points used to generate this kernel
             READ (funit, "(1p, 4e23.14)") dispersion_env%q_mesh
-            !! For each pair of q values, read in the function phi_q1_q2(k).
-            !! That is, the fourier transformed kernel function assuming q1 and q2
-            !! for all the values of r used.
-            DO q1_i = 1, nqs
-               DO q2_i = 1, q1_i
-                  READ (funit, "(1p, 4e23.14)") dispersion_env%kernel(0:nr_points, q1_i, q2_i)
-                  dispersion_env%kernel(0:nr_points, q2_i, q1_i) = dispersion_env%kernel(0:nr_points, q1_i, q2_i)
-               END DO
-            END DO
-            !! Again, for each pair of q values (q1 and q2), read in the value
-            !! of the second derivative of the above mentiond Fourier transformed
-            !! kernel function phi_alpha_beta(k).  These are used for spline
-            !! interpolation of the Fourier transformed kernel.
-            DO q1_i = 1, nqs
-               DO q2_i = 1, q1_i
-                  READ (funit, "(1p, 4e23.14)") dispersion_env%d2phi_dk2(0:nr_points, q1_i, q2_i)
-                  dispersion_env%d2phi_dk2(0:nr_points, q2_i, q1_i) = dispersion_env%d2phi_dk2(0:nr_points, q1_i, q2_i)
+            ! The file stores kernel values followed by second derivatives, both in
+            ! lower-triangular pair order. Keep this immutable table in packed form.
+            DO itable = 1, 2
+               DO ipair = 1, nqs*(nqs + 1)/2
+                  READ (funit, "(1p, 4e23.14)") dispersion_env%kernel_table(ipair, 0:nr_points, itable)
                END DO
             END DO
             CALL close_file(unit_number=funit)
          END IF
          CALL para_env%bcast(dispersion_env%q_mesh)
-         CALL para_env%bcast(dispersion_env%kernel)
-         CALL para_env%bcast(dispersion_env%d2phi_dk2)
+         CALL para_env%bcast(dispersion_env%kernel_table)
          ! 2nd derivates for interpolation
          ALLOCATE (dispersion_env%d2y_dx2(nqs, nqs))
          CALL initialize_spline_interpolation(dispersion_env%q_mesh, dispersion_env%d2y_dx2)
@@ -456,13 +442,12 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'vdW_energy'
 
-      INTEGER                                            :: handle, ig, ipair, iq, ir, l, m, &
-                                                            nl_type, nqs, nr_used, q1_i, q2_i
+      INTEGER                                            :: handle, ig, iq, l, m, nl_type, nqs, &
+                                                            q1_i, q2_i
       LOGICAL                                            :: use_virial
       REAL(KIND=dp)                                      :: g, g2, g2_last, g_multiplier, gm
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: theta_im, theta_re, u_im, u_re
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: dkernel_of_dk, kernel_of_k
-      REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: kernel_table
       REAL(KIND=dp), DIMENSION(3, 3)                     :: virial_thread
       TYPE(pw_grid_type), POINTER                        :: grid
 
@@ -483,32 +468,9 @@ CONTAINS
 
       nl_type = dispersion_env%nl_type
 
-      ! Pack the symmetric radial tables once per evaluation. The interpolation then
-      ! reads adjacent channel pairs instead of striding over the radial dimension.
-      ! Copy only the radial prefix needed by the local G points, including its upper endpoint.
-      nr_used = 0
-      IF (grid%ngpts_cut_local > 0) THEN
-         nr_used = MIN(dispersion_env%nr_points, &
-                       INT(SQRT(MAXVAL(grid%gsq(1:grid%ngpts_cut_local)))/dispersion_env%dk) + 1)
-      END IF
-      ALLOCATE (kernel_table(nqs*(nqs + 1)/2, 0:nr_used, 2))
-!$OMP PARALLEL DO DEFAULT(NONE) SHARED(kernel_table, dispersion_env, nqs, nr_used) &
-!$OMP             PRIVATE(q1_i, q2_i, ipair) SCHEDULE(STATIC)
-      DO ir = 0, nr_used
-         ipair = 0
-         DO q1_i = 1, nqs
-            DO q2_i = 1, q1_i
-               ipair = ipair + 1
-               kernel_table(ipair, ir, 1) = dispersion_env%kernel(ir, q1_i, q2_i)
-               kernel_table(ipair, ir, 2) = dispersion_env%d2phi_dk2(ir, q1_i, q2_i)
-            END DO
-         END DO
-      END DO
-!$OMP END PARALLEL DO
-
 !$OMP PARALLEL DEFAULT(NONE) &
 !$OMP          SHARED(nqs, energy_only, grid, dispersion_env, use_virial, thetas_g, &
-!$OMP                 g_multiplier, nl_type, kernel_table) &
+!$OMP                 g_multiplier, nl_type) &
 !$OMP          PRIVATE(g2_last, kernel_of_k, dkernel_of_dk, theta_re, theta_im, &
 !$OMP                  g2, g, iq, q2_i, u_re, u_im, q1_i, gm, l, m) &
 !$OMP          REDUCTION(+:vdW_xc_energy, virial_thread)
@@ -526,9 +488,9 @@ CONTAINS
             g2_last = g2
             g = SQRT(g2)
             IF (use_virial) THEN
-               CALL interpolate_kernel(g, kernel_of_k, dispersion_env, kernel_table, dkernel_of_dk)
+               CALL interpolate_kernel(g, kernel_of_k, dispersion_env, dispersion_env%kernel_table, dkernel_of_dk)
             ELSE
-               CALL interpolate_kernel(g, kernel_of_k, dispersion_env, kernel_table)
+               CALL interpolate_kernel(g, kernel_of_k, dispersion_env, dispersion_env%kernel_table)
             END IF
          END IF
          ! Save all inputs before in-place output. Vectorize over output channels;
@@ -583,8 +545,6 @@ CONTAINS
       IF (use_virial) DEALLOCATE (dkernel_of_dk)
 
 !$OMP END PARALLEL
-
-      DEALLOCATE (kernel_table)
 
       vdW_xc_energy = vdW_xc_energy*grid%vol*0.5_dp
 

--- a/src/qs_dispersion_types.F
+++ b/src/qs_dispersion_types.F
@@ -102,13 +102,9 @@ MODULE qs_dispersion_types
       !! q_cut
       REAL(KIND=dp), DIMENSION(:), POINTER    :: q_mesh => NULL() !! The values of all the q points used
       REAL(KIND=dp), DIMENSION(:, :, :), POINTER &
-         :: kernel => NULL() !! A matrix holding the Fourier transformed kernel function
-      !! for each pair of q values.  The ordering is
-      !! kernel(k_point, q1_value, q2_value)
-      REAL(KIND=dp), DIMENSION(:, :, :), POINTER &
-         :: d2phi_dk2 => NULL() !! A matrix holding the second derivatives of the above
-      !! kernel matrix at each of the q points.  Stored as
-      !! d2phi_dk2(k_point, q1_value, q2_value)
+         :: kernel_table => NULL() !! Fourier transformed kernel and its second radial derivatives
+      !! kernel_table(q1*(q1 - 1)/2 + q2, k_point, itable), with q2 <= q1 and k_point starting at zero.
+      !! itable = 1 for kernel values and 2 for second derivatives.
       REAL(KIND=dp), DIMENSION(:, :), POINTER  :: d2y_dx2 => NULL() !! 2nd derivatives of q_mesh for interpolation
       INTEGER, DIMENSION(:, :), POINTER  :: d3_exclude_pair => NULL()
       INTEGER  :: nd3_exclude_pair = -1
@@ -185,11 +181,8 @@ CONTAINS
          IF (ASSOCIATED(dispersion_env%q_mesh)) THEN
             DEALLOCATE (dispersion_env%q_mesh)
          END IF
-         IF (ASSOCIATED(dispersion_env%kernel)) THEN
-            DEALLOCATE (dispersion_env%kernel)
-         END IF
-         IF (ASSOCIATED(dispersion_env%d2phi_dk2)) THEN
-            DEALLOCATE (dispersion_env%d2phi_dk2)
+         IF (ASSOCIATED(dispersion_env%kernel_table)) THEN
+            DEALLOCATE (dispersion_env%kernel_table)
          END IF
          IF (ASSOCIATED(dispersion_env%d2y_dx2)) THEN
             DEALLOCATE (dispersion_env%d2y_dx2)

--- a/src/qs_dispersion_utils.F
+++ b/src/qs_dispersion_utils.F
@@ -194,8 +194,7 @@ CONTAINS
       NULLIFY (dispersion_env%c6ab, dispersion_env%maxci, dispersion_env%r0ab, dispersion_env%rcov, &
                dispersion_env%r2r4, dispersion_env%cn, dispersion_env%cnkind, dispersion_env%cnlist, &
                dispersion_env%d3_exclude_pair)
-      NULLIFY (dispersion_env%q_mesh, dispersion_env%kernel, dispersion_env%d2phi_dk2, &
-               dispersion_env%d2y_dx2)
+      NULLIFY (dispersion_env%q_mesh, dispersion_env%kernel_table, dispersion_env%d2y_dx2)
       NULLIFY (dispersion_env%sab_vdw, dispersion_env%sab_cn)
       NULLIFY (dispersion_env%dftd_section)
       NULLIFY (vdw_section, xc_fun_section)

--- a/src/qs_environment.F
+++ b/src/qs_environment.F
@@ -1896,7 +1896,7 @@ CONTAINS
          NULLIFY (dispersion_env%c6ab, dispersion_env%maxci, dispersion_env%r0ab, dispersion_env%rcov, &
                   dispersion_env%r2r4, dispersion_env%cn, dispersion_env%cnkind, dispersion_env%cnlist, &
                   dispersion_env%d3_exclude_pair)
-         NULLIFY (dispersion_env%q_mesh, dispersion_env%kernel, dispersion_env%d2phi_dk2, &
+         NULLIFY (dispersion_env%q_mesh, dispersion_env%kernel_table, &
                   dispersion_env%d2y_dx2, dispersion_env%dftd_section)
          NULLIFY (dispersion_env%sab_vdw, dispersion_env%sab_cn)
          IF (dftb_control%dispersion .AND. dftb_control%dispersion_type == dispersion_d3) THEN
@@ -1956,7 +1956,7 @@ CONTAINS
                      dispersion_env%r2r4, dispersion_env%cn, &
                      dispersion_env%cnkind, dispersion_env%cnlist, &
                      dispersion_env%d3_exclude_pair)
-            NULLIFY (dispersion_env%q_mesh, dispersion_env%kernel, dispersion_env%d2phi_dk2, &
+            NULLIFY (dispersion_env%q_mesh, dispersion_env%kernel_table, &
                      dispersion_env%d2y_dx2, dispersion_env%dftd_section)
             NULLIFY (dispersion_env%sab_vdw, dispersion_env%sab_cn)
             dispersion_env%type = xc_vdw_fun_pairpot
@@ -2004,7 +2004,7 @@ CONTAINS
          NULLIFY (dispersion_env%c6ab, dispersion_env%maxci, dispersion_env%r0ab, dispersion_env%rcov, &
                   dispersion_env%r2r4, dispersion_env%cn, dispersion_env%cnkind, dispersion_env%cnlist, &
                   dispersion_env%d3_exclude_pair)
-         NULLIFY (dispersion_env%q_mesh, dispersion_env%kernel, dispersion_env%d2phi_dk2, &
+         NULLIFY (dispersion_env%q_mesh, dispersion_env%kernel_table, &
                   dispersion_env%d2y_dx2, dispersion_env%dftd_section)
          NULLIFY (dispersion_env%sab_vdw, dispersion_env%sab_cn)
          IF (se_control%dispersion) THEN


### PR DESCRIPTION
- Remove large temporary real- and reciprocal-space work arrays and stream the non-local fields through the existing FFT path.
- Reorganize spline, potential, and stress contractions to avoid redundant per-channel work.
- Improve reciprocal-space kernel access and SIMD/vectorization opportunities.
- Parallelize remaining real-space `q0` loops with OpenMP.
- Reduce redundant FFTs in the spin-density and potential-assembly paths.
- Reuse spline metadata and avoid repeated interpolation setup.
- Handle the analytic zero-gradient limit in the rVV10 potential expression.