### PR TITLE
XC: Avoid ifx ASSOCIATE miscompilation in LibXC workers

### DIFF
--- a/src/xc/xc_libxc.F
+++ b/src/xc/xc_libxc.F
@@ -2094,7 +2094,7 @@ CONTAINS
    INTEGER, INTENT(in)                                :: grad_deriv, npoints
    CHARACTER(LEN=default_string_length), INTENT(IN)   :: func_name
    REAL(KIND=dp), INTENT(in)                          :: sc
-   TYPE(libxc_worker_set_type), INTENT(INOUT)         :: workers
+   TYPE(libxc_worker_set_type), INTENT(INOUT), TARGET :: workers
 
    INTEGER                                            :: bsize, family, i, i0, ib, ii, ithread, &
                                                          nb, nblocks, nthreads
@@ -2134,9 +2134,18 @@ CONTAINS
    ! to the functional object in xc_libxc_wrap_set_thresholds, and LibXC leaves
    ! the outputs of the points it screens at zero, so accumulating them is a
    ! no-op.
-   ASSOCIATE (w => workers%worker(ithread + 1), has_laplace => workers%has_laplace, &
-              no_exc => workers%no_exc, eps_rho => workers%epsilon_rho, &
-              eps_tau => workers%epsilon_tau)
+   BLOCK
+      TYPE(libxc_worker_type), POINTER :: w
+      LOGICAL :: has_laplace, no_exc
+      REAL(KIND=dp) :: eps_rho, eps_tau
+
+      ! Avoid ASSOCIATE aliases across the orphaned OpenMP worksharing loop:
+      ! ifx can lose their bindings even at -O0.
+      w => workers%worker(ithread + 1)
+      has_laplace = workers%has_laplace
+      no_exc = workers%no_exc
+      eps_rho = workers%epsilon_rho
+      eps_tau = workers%epsilon_tau
 !$OMP    DO
       DO ib = 1, nblocks
          i0 = (ib - 1)*bsize
@@ -2380,7 +2389,7 @@ CONTAINS
          END IF
       END DO
 !$OMP    END DO
-   END ASSOCIATE
+   END BLOCK
 
 END SUBROUTINE libxc_spin_unpolarized_calc
 #endif
@@ -2520,7 +2529,7 @@ REAL(KIND=dp), DIMENSION(*), INTENT(INOUT) :: e_ndrhoa_laplace_rhob, e_ndrhob_la
 INTEGER, INTENT(in)                                :: grad_deriv, npoints
 CHARACTER(LEN=default_string_length), INTENT(IN)   :: func_name
 REAL(KIND=dp), INTENT(in)                          :: sc
-TYPE(libxc_worker_set_type), INTENT(INOUT)         :: workers
+TYPE(libxc_worker_set_type), INTENT(INOUT), TARGET :: workers
 
 INTEGER                                            :: bsize, family, i, i0, ib, ii, ithread, &
                                                       nb, nblocks, nthreads
@@ -2555,9 +2564,17 @@ END SELECT
 
 ! As in the spin-unpolarized case the density and kinetic energy density
 ! cutoffs are applied by LibXC itself.
-ASSOCIATE (w => workers%worker(ithread + 1), has_laplace => workers%has_laplace, &
-           no_exc => workers%no_exc, eps_rho => workers%epsilon_rho, &
-           eps_tau => workers%epsilon_tau)
+BLOCK
+   TYPE(libxc_worker_type), POINTER :: w
+   LOGICAL :: has_laplace, no_exc
+   REAL(KIND=dp) :: eps_rho, eps_tau
+
+! Keep the per-thread bindings explicit, as in the spin-unpolarized routine.
+   w => workers%worker(ithread + 1)
+   has_laplace = workers%has_laplace
+   no_exc = workers%no_exc
+   eps_rho = workers%epsilon_rho
+   eps_tau = workers%epsilon_tau
 !$OMP    DO
    DO ib = 1, nblocks
       i0 = (ib - 1)*bsize
@@ -2896,7 +2913,7 @@ ASSOCIATE (w => workers%worker(ithread + 1), has_laplace => workers%has_laplace,
       END IF
    END DO
 !$OMP    END DO
-END ASSOCIATE
+END BLOCK
 
 END SUBROUTINE libxc_spin_polarized_calc
 #endif


### PR DESCRIPTION
## Summary

Work around an ifx 2025.2.1 miscompilation of `ASSOCIATE` bindings around the orphaned OpenMP worksharing loops in the two LibXC evaluators.

- Replace the worker alias with an explicit block-local pointer and copy the four read-only scalar settings into local variables.
- Mark the worker-set dummy arguments `TARGET` for the pointer association.
- Keep the existing block scope, batching, screening, formulas and OpenMP scheduling unchanged. No regtest inputs, references, tolerances, dependencies or compiler optimization levels are changed.

## Diagnosis

Unmodified master `9c4b5efbe0` reproduces the 33 meta-GGA runtime failures reported by the Intel ifx dashboard testers. GDB shows invalid `ASSOCIATE` bindings despite valid worker storage. Reducing the module to `-O0` does not fix it; replacing only the worker alias exposes the same problem with a scalar alias.

A standalone Fortran reproducer, independent of CP2K, LibXC and MKL, also fails with ifx: the original bindings segfault at `-O0` and leave the output zero at `-O3`. Explicit pointer/scalar bindings pass at both optimization levels with 1, 2 and 4 threads. GCC passes both variants. A further 32-line reproducer isolates the logical-component alias alone.

## Validation

Normal Release builds on Terok with ifx 2025.2.1, MKL 2025.2 and LibXC 7.1.2:

| Build | MPI ranks x OpenMP threads | Eleven selected regtest directories |
| --- | --- | --- |
| Original master | 1 x 2 | 33 runtime failures |
| Fixed ssmp | 1 x 1, 1 x 2, 1 x 4 | 104/104 checks pass in each configuration |
| Fixed psmp / Intel MPI | 2 x 1, 2 x 2 | 104/104 checks pass in each configuration |

These directories contain all 33 reported failures, including spin-polarized and unpolarized meta-GGAs, Laplacian-dependent functionals, stress and DCDR. The existing dashboard stack settings were used. This is targeted validation, not a full regression run.

The unchanged input attached to #5948 also passes in both ssmp and psmp. Its XC energy is `-6.95854911100701 Ha`, matching the GCC reference; the SCF total agrees within `2e-14 Ha`, and all twelve printed atomic force components agree.

Native macOS GCC 16/OpenMPI, 2 ranks x 2 threads: 87/91 checks pass in the nine available directories. Four LRI setup aborts are also reproducible with the pre-existing unpatched native binary; enabling Libint does not remove them. They are separate from this fix and are not suppressed.

`make pretty` and `git diff --check` pass.

Addresses #5948. This does not claim to resolve the older memory-growth, Libint or performance problems discussed in #4795.
