### PR TITLE
Regtesting: Register the cell types unit test

### DIFF
--- a/tests/UNIT_TESTS
+++ b/tests/UNIT_TESTS
@@ -3,6 +3,7 @@
 
 dbt_tas_unittest
 dbt_unittest
+cell_types_unittest
 grid_unittest
 kpoint_lattice_fft_unittest
 kpoint_smearing_unittest


### PR DESCRIPTION
Register `cell_types_unittest` in `tests/UNIT_TESTS`.

The test was added and built by #5646, but was not listed for execution by the standard regression runner. It checks stable periodic wrapping near half-cell boundaries, lattice-translation invariance, and orthorhombic and skew cells.

This adds one registration line only. No test implementation, numerical tolerance or production code changes.

Validation through `tests/do_regtest.py`: GCC 16/OpenMPI (2 ranks x 2 threads), ifx 2025.2.1 ssmp (1 x 1), and ifx/Intel MPI psmp (2 x 2), all passing. Measured test durations: 0.14-0.68 seconds.
