### PR TITLE
ALMO: Guard activation access after SCF cleanup

### DIFF
--- a/src/almo_scf.F
+++ b/src/almo_scf.F
@@ -263,8 +263,10 @@ CONTAINS
          almo_scf_env%ndomains = almo_scf_env%natoms
       END IF
 
-      IF (ALLOCATED(almo_scf_env%activate) .AND. almo_scf_env%activate(1) > 1) THEN
-         DEALLOCATE (almo_scf_env%activate)
+      IF (ALLOCATED(almo_scf_env%activate)) THEN
+         IF (almo_scf_env%activate(1) > 1) THEN
+            DEALLOCATE (almo_scf_env%activate)
+         END IF
       END IF
 
       IF (.NOT. ALLOCATED(almo_scf_env%activate)) THEN


### PR DESCRIPTION
# ALMO: Guard activation access after SCF cleanup

`almo_scf_clean_up` deallocates `almo_scf_env%activate` after each SCF calculation. The next call to `almo_scf_init` combines `ALLOCATED(activate)` and an access to `activate(1)` in a single `.AND.` expression. Fortran does not guarantee short-circuit evaluation, so this can access an unallocated array on the first MD step.

Use nested `IF` statements to ensure that the element is inspected only while the array is allocated. The existing activation/reset logic is otherwise unchanged.

Fixes #5944.

This fixes the reported ALMO activation-array access on the first MD step. The additional MP2/MPI crashes and wrong-result reports discussed in the issue's attached test report need separate investigation and are not addressed by this change.

Validation:

- Reproduced a SIGSEGV at the original guard in the full `almo-md-full-scf.inp` test with GNU Fortran 15.2 and the ALMO module compiled at `-O0`. The same test passes with the fix at `-O0`.
- All 14 existing tests in `QS/regtest-almo-md`, `QS/regtest-almo-strong`, and `QS/regtest-almo-trustr` pass with the fixed ALMO module at `-O3` (Linux x86-64, GNU Fortran 15.2, ssmp, two OpenMP threads).
- A small activation-lifecycle reproducer fails with the original guard under Flang 23.1.0 at both `-O0` and `-O2`, and passes with the fix at both optimization levels (Linux x86-64).
- CP2K Fortran formatting and `git diff --check` pass.

The CP2K integration checks used an isolated rebuild of the ALMO module linked against an existing build. The unpatched ALMO source and all three test manifests match the current master checkout. A complete Flang/AArch64 build matching the reporter's environment has not been tested.

No reference energies, tolerances, or test inputs were changed. No additional regression tests are needed: the existing MD tests already exercise the allocation lifecycle.
