### PR TITLE
Motion/BFGS: Fix two secular equation expressions in rat_fun_opt

### DIFF
--- a/src/motion/bfgs_optimizer.F
+++ b/src/motion/bfgs_optimizer.F
@@ -546,7 +546,7 @@ CONTAINS
             fung = 0.0_dp
             DO indf = 1, ndf
                fun = fun + dg(indf)**2/(ln - eigval(indf))
-               fung = fung - dg(indf)**2/(ln - eigval(indf)**2)
+               fung = fung - dg(indf)**2/((ln - eigval(indf))**2)
             END DO
             fun = fun - ln
             fung = fung - one
@@ -584,7 +584,7 @@ CONTAINS
                   fun2 = 0.0_dp
                   lam2 = lam1 - iter*step
                   DO indf = 1, ndf
-                     fun2 = fun2 + eigval(indf)**2/(lam2 - eigval(indf))
+                     fun2 = fun2 + dg(indf)**2/(lam2 - eigval(indf))
                   END DO
                   fun2 = fun2 - lam2
                   IF (fun2*fun1 < 0.0_dp) THEN


### PR DESCRIPTION
This PR corrects two algebraic issues in `rat_fun_opt` (`src/motion/bfgs_optimizer.F`) when solving the secular equation for Rational Function Optimization (RFO):

The Newton derivative `fung` lacked parentheses around `ln - eigval`.
It computed $\sum_i dg_i^2/(\lambda - eigval_i^2)$ instead of the derivative

$$f'(\lambda) = -\sum_i \frac{dg_i^2}{(\lambda - eigval_i)^2} - 1$$

of the target function

$$f(\lambda) = \sum_i \frac{dg_i^2}{\lambda - eigval_i} - \lambda $$

The fallback bracket function `fun2` used `eigval**2` as the numerator while `fun1` and `fun3` use `dg**2`.
`fun2` therefore evaluated a different function than `fun1` and `fun3`.
A sign change of `fun2*fun1` could bracket an interval that contains no root of the secular equation.

Both corrections make the expressions consistent with the secular equation of Baker, J. Comput. Chem. 7, 385 (1986), eq. (8), first given as eq. (13) of Banerjee, Adams, Simons and Shepard, J. Phys. Chem. 89, 52 (1985).

Verification & Reproducer:
- All existing regtests with USE_RAT_FUN_OPT continue to pass without regression.
- A minimal real reproducer is attached: a DZVP-GTH/PBE water dimer relaxation with a stretched hydrogen bond stalls and does not converge within 100 steps with the current implementation, but converges smoothly in 50 steps with these corrections.
[rat_fun_opt_attachments.tar.gz](https://github.com/user-attachments/files/31916639/rat_fun_opt_attachments.tar.gz)
