### PR TITLE
using system openblas for archtecture detection

### DIFF
--- a/tools/toolchain/scripts/get_openblas_arch.sh
+++ b/tools/toolchain/scripts/get_openblas_arch.sh
@@ -17,7 +17,7 @@ source "${INSTALLDIR}"/toolchain.conf
 source "${INSTALLDIR}"/toolchain.env
 
 find_openblas_dir() {
-  find . -maxdepth 1 -type d -name '*OpenBLAS*' 2>/dev/null | head -1
+  find . -maxdepth 1 -type d -name '*OpenBLAS*' 2> /dev/null | head -1
 }
 
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
@@ -30,9 +30,9 @@ get_system_openblas_arch() {
   local openblas_dir=""
 
   if [ "${with_openblas}" = "__SYSTEM__" ]; then
-    openblas_lib=$(find /usr/lib /usr/local/lib -maxdepth 3 -name "libopenblas*" -type f 2>/dev/null | head -1)
+    openblas_lib=$(find /usr/lib /usr/local/lib -maxdepth 3 -name "libopenblas*" -type f 2> /dev/null | head -1)
   elif [ "${with_openblas}" != "__INSTALL__" ] && [ -d "${with_openblas}" ]; then
-    openblas_lib=$(find "${with_openblas}/lib" -maxdepth 2 -name "libopenblas*" -type f 2>/dev/null | head -1)
+    openblas_lib=$(find "${with_openblas}/lib" -maxdepth 2 -name "libopenblas*" -type f 2> /dev/null | head -1)
   fi
 
   if [ -z "$openblas_lib" ]; then

--- a/tools/toolchain/scripts/get_openblas_arch.sh
+++ b/tools/toolchain/scripts/get_openblas_arch.sh
@@ -17,40 +17,76 @@ source "${INSTALLDIR}"/toolchain.conf
 source "${INSTALLDIR}"/toolchain.env
 
 find_openblas_dir() {
-  local __dir=''
-  for __dir in *OpenBLAS*; do
-    if [ -d "$__dir" ]; then
-      echo "$__dir"
-      return 0
-    fi
-  done
-  echo ''
+  find . -maxdepth 1 -type d -name '*OpenBLAS*' 2>/dev/null | head -1
 }
 
 ! [ -d "${BUILDDIR}" ] && mkdir -p "${BUILDDIR}"
 cd "${BUILDDIR}"
 
 echo "==================== Getting proc arch info using OpenBLAS tools ===================="
-# find existing openblas source dir
-openblas_dir="$(find_openblas_dir)"
-# if cannot find openblas source dir, try download one
-if ! [ "$openblas_dir" ]; then
-  retrieve_package "${openblas_sha256}" "${openblas_pkg}"
-  tar -xzf ${openblas_pkg}
+
+get_system_openblas_arch() {
+  local openblas_lib=""
+  local openblas_dir=""
+
+  if [ "${with_openblas}" = "__SYSTEM__" ]; then
+    openblas_lib=$(find /usr/lib /usr/local/lib -maxdepth 3 -name "libopenblas*" -type f 2>/dev/null | head -1)
+  elif [ "${with_openblas}" != "__INSTALL__" ] && [ -d "${with_openblas}" ]; then
+    openblas_lib=$(find "${with_openblas}/lib" -maxdepth 2 -name "libopenblas*" -type f 2>/dev/null | head -1)
+  fi
+
+  if [ -z "$openblas_lib" ]; then
+    return 1
+  fi
+
+  openblas_dir="$(dirname "$(dirname "$openblas_lib")")"
+
+  local makefile_conf=""
+  for dir in "${openblas_dir}/include" "${openblas_dir}/share/OpenBLAS" "/usr/share/OpenBLAS" "/usr/include"; do
+    if [ -f "${dir}/Makefile.conf" ]; then
+      makefile_conf="${dir}/Makefile.conf"
+      break
+    fi
+  done
+
+  if [ -n "$makefile_conf" ]; then
+    OPENBLAS_LIBCORE="$(sed -n 's/^LIBCORE=//p' "$makefile_conf")"
+    OPENBLAS_ARCH="$(sed -n 's/^ARCH=//p' "$makefile_conf")"
+    return 0
+  fi
+
+  local openblas_so="$(readelf -A "$openblas_lib" 2> /dev/null | grep 'Unknown' | head -1)"
+  case "$openblas_so" in
+    *x86_64*) OPENBLAS_ARCH="x86_64" ;;
+    *aarch64* | *arm64*) OPENBLAS_ARCH="arm64" ;;
+    *ppc64*) OPENBLAS_ARCH="ppc64" ;;
+    *) OPENBLAS_ARCH="$(uname -m)" ;;
+  esac
+  OPENBLAS_LIBCORE=""
+  return 0
+}
+
+if get_system_openblas_arch; then
+  echo "Using system OpenBLAS architecture detection"
+else
   openblas_dir="$(find_openblas_dir)"
+  if [ -z "$openblas_dir" ]; then
+    retrieve_package "${openblas_sha256}" "${openblas_pkg}"
+    tar -xzf "${openblas_pkg}"
+    openblas_dir="$(find_openblas_dir)"
+  fi
+  openblas_conf="${openblas_dir}/Makefile.conf"
+  if ! [ -f "$openblas_conf" ]; then
+    cd "$openblas_dir"
+    make lapack_prebuild
+    cd ..
+  fi
+  OPENBLAS_LIBCORE="$(sed -n 's/^LIBCORE=//p' "$openblas_conf")"
+  OPENBLAS_ARCH="$(sed -n 's/^ARCH=//p' "$openblas_conf")"
 fi
-openblas_conf="${openblas_dir}/Makefile.conf"
-# try find Makefile.config, if not then generate one with make lapack_prebuild
-if ! [ -f "$openblas_conf" ]; then
-  cd "$openblas_dir"
-  make lapack_prebuild
-  cd ..
-fi
-OPENBLAS_LIBCORE="$(grep 'LIBCORE=' $openblas_conf | cut -f2 -d=)"
-OPENBLAS_ARCH="$(grep 'ARCH=' $openblas_conf | cut -f2 -d=)"
+
 echo "OpenBLAS detected LIBCORE = $OPENBLAS_LIBCORE"
 echo "OpenBLAS detected ARCH    = $OPENBLAS_ARCH"
-# output setup file
 cat << EOF > "${BUILDDIR}/openblas_arch"
 export OPENBLAS_LIBCORE="${OPENBLAS_LIBCORE}"
 export OPENBLAS_ARCH="${OPENBLAS_ARCH}"


### PR DESCRIPTION
On certain system the installation by the openblas system detection messes up the paths. 
Using system openblas for detection should avoid this problem. 

