### PR TITLE
SKALA: Accelerate GAPW atom-grid adjoint backprojection

### DIFF
--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -311,8 +311,10 @@ CONTAINS
                                                             smooth_kin_adjoint_storage
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :) :: composite_cross_grad, composite_grad, &
          composite_grad_grad, composite_int_h, composite_int_s, composite_partition_datom, &
-         composite_partition_dstrain, composite_smooth_gradient_cache
+         composite_partition_dstrain, composite_smooth_gradient_cache, vtau_h_local, vtau_s_local, &
+         vxc_h_local, vxc_s_local
       REAL(dp), ALLOCATABLE, DIMENSION(:, :, :), TARGET  :: smooth_grad_adjoint_storage
+      REAL(dp), ALLOCATABLE, DIMENSION(:, :, :, :)       :: vxg_h_local, vxg_s_local
       REAL(dp), DIMENSION(1, 1, 1)                       :: tau_d
       REAL(dp), DIMENSION(1, 1, 1, 1)                    :: rho_d
       REAL(dp), DIMENSION(2) :: composite_smooth_density_adjoint_value, &
@@ -2224,76 +2226,111 @@ CONTAINS
                                                   cross_cutoff*SQRT(SUM(cell%h_inv(idir, :)**2))) + 1
                            END IF
                         END DO
-                        DO composite_local_atom = 1, composite_local_natom
-                           target_atom = composite_local_atoms(composite_local_atom)
-                           DO composite_row = composite_atom_start(target_atom), &
-                              composite_atom_end(target_atom)
-                              cross_density_adjoint = 0.0_dp
-                              cross_grad_adjoint = 0.0_dp
-                              cross_kin_adjoint = 0.0_dp
-                              IF (lsd) THEN
-                                 IF (use_atom_composite_density) THEN
-                                    cross_density_adjoint(1:2) = &
-                                       composite_density_grad(composite_row, 1:2)
-                                 END IF
-                                 IF (use_atom_composite_gradient) THEN
-                                    cross_grad_adjoint(:, 1:2) = &
-                                       composite_grad_grad(composite_row, :, 1:2)
-                                 END IF
-                                 IF (use_atom_composite_tau) THEN
-                                    cross_kin_adjoint(1:2) = &
-                                       composite_kin_grad(composite_row, 1:2)
-                                 END IF
-                              ELSE
-                                 IF (use_atom_composite_density) THEN
-                                    cross_density_adjoint(1) = 0.5_dp* &
-                                                               SUM(composite_density_grad(composite_row, :))
-                                 END IF
-                                 IF (use_atom_composite_gradient) THEN
-                                    DO idir = 1, 3
-                                       cross_grad_adjoint(idir, 1) = 0.5_dp* &
-                                                                     SUM(composite_grad_grad(composite_row, idir, :))
-                                    END DO
-                                 END IF
-                                 IF (use_atom_composite_tau) THEN
-                                    cross_kin_adjoint(1) = 0.5_dp* &
-                                                           SUM(composite_kin_grad(composite_row, :))
-                                 END IF
+                        ! Each thread accumulates its own one-center potentials; combine them
+                        ! before the existing MPI reduction over target-atom owners.
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP PRIVATE(base_shift, composite_row, cross_density_adjoint, cross_displacement, &
+!$OMP         cross_grad_adjoint, cross_kin_adjoint, fractional, idir, image_i1, &
+!$OMP         image_i2, image_i3, image_shift, image_translation, jdir, target_atom, &
+!$OMP         vxc_h_local, vxc_s_local, vxg_h_local, vxg_s_local, vtau_h_local, vtau_s_local) &
+!$OMP SHARED(cell, composite_density_grad, composite_grad_grad, composite_grid_atom, &
+!$OMP        composite_grid_coords, composite_kin_grad, composite_nflat, cross_cutoff, &
+!$OMP        grid_atom, harmonics, iatom, image_shell, lsd, nspins, particle_set, &
+!$OMP        use_atom_composite_density, use_atom_composite_gradient, use_atom_composite_tau, &
+!$OMP        vxc_h, vxc_s, vxg_h, vxg_s, vtau_h, vtau_s)
+                        ALLOCATE (vxc_h_local, MOLD=vxc_h)
+                        ALLOCATE (vxc_s_local, MOLD=vxc_s)
+                        ALLOCATE (vxg_h_local, MOLD=vxg_h)
+                        ALLOCATE (vxg_s_local, MOLD=vxg_s)
+                        ALLOCATE (vtau_h_local, MOLD=vtau_h)
+                        ALLOCATE (vtau_s_local, MOLD=vtau_s)
+                        vxc_h_local = 0.0_dp
+                        vxc_s_local = 0.0_dp
+                        vxg_h_local = 0.0_dp
+                        vxg_s_local = 0.0_dp
+                        vtau_h_local = 0.0_dp
+                        vtau_s_local = 0.0_dp
+!$OMP DO SCHEDULE(STATIC)
+                        DO composite_row = 1, composite_nflat
+                           target_atom = composite_grid_atom(composite_row)
+                           cross_density_adjoint = 0.0_dp
+                           cross_grad_adjoint = 0.0_dp
+                           cross_kin_adjoint = 0.0_dp
+                           IF (lsd) THEN
+                              IF (use_atom_composite_density) THEN
+                                 cross_density_adjoint(1:2) = &
+                                    composite_density_grad(composite_row, 1:2)
                               END IF
-                              fractional = 0.0_dp
-                              DO idir = 1, 3
-                                 DO jdir = 1, 3
-                                    fractional(idir) = fractional(idir) + cell%h_inv(idir, jdir)* &
-                                                       (composite_grid_coords(jdir, composite_row) - &
-                                                        particle_set(iatom)%r(jdir))
+                              IF (use_atom_composite_gradient) THEN
+                                 cross_grad_adjoint(:, 1:2) = &
+                                    composite_grad_grad(composite_row, :, 1:2)
+                              END IF
+                              IF (use_atom_composite_tau) THEN
+                                 cross_kin_adjoint(1:2) = &
+                                    composite_kin_grad(composite_row, 1:2)
+                              END IF
+                           ELSE
+                              IF (use_atom_composite_density) THEN
+                                 cross_density_adjoint(1) = 0.5_dp* &
+                                                            SUM(composite_density_grad(composite_row, :))
+                              END IF
+                              IF (use_atom_composite_gradient) THEN
+                                 DO idir = 1, 3
+                                    cross_grad_adjoint(idir, 1) = 0.5_dp* &
+                                                                  SUM(composite_grad_grad(composite_row, idir, :))
                                  END DO
+                              END IF
+                              IF (use_atom_composite_tau) THEN
+                                 cross_kin_adjoint(1) = 0.5_dp* &
+                                                        SUM(composite_kin_grad(composite_row, :))
+                              END IF
+                           END IF
+                           fractional = 0.0_dp
+                           DO idir = 1, 3
+                              DO jdir = 1, 3
+                                 fractional(idir) = fractional(idir) + cell%h_inv(idir, jdir)* &
+                                                    (composite_grid_coords(jdir, composite_row) - &
+                                                     particle_set(iatom)%r(jdir))
                               END DO
-                              DO idir = 1, 3
-                                 base_shift(idir) = cell%perd(idir)*NINT(fractional(idir))
-                              END DO
-                              DO image_i3 = base_shift(3) - image_shell(3), &
-                                 base_shift(3) + image_shell(3)
-                                 DO image_i2 = base_shift(2) - image_shell(2), &
-                                    base_shift(2) + image_shell(2)
-                                    DO image_i1 = base_shift(1) - image_shell(1), &
-                                       base_shift(1) + image_shell(1)
-                                       image_shift = [image_i1, image_i2, image_i3]
-                                       IF (target_atom == iatom .AND. ALL(image_shift == 0)) CYCLE
-                                       image_translation = MATMUL( &
-                                                           cell%hmat, REAL(image_shift, dp))
-                                       cross_displacement = &
-                                          composite_grid_coords(:, composite_row) - &
-                                          particle_set(iatom)%r - image_translation
-                                       CALL add_gapw_atom_grid_interpolation_adjoint( &
-                                          grid_atom, harmonics, cross_displacement, cross_cutoff, &
-                                          nspins, cross_density_adjoint, cross_grad_adjoint, &
-                                          cross_kin_adjoint, vxc_h, vxc_s, vxg_h, vxg_s, &
-                                          vtau_h, vtau_s)
-                                    END DO
+                           END DO
+                           DO idir = 1, 3
+                              base_shift(idir) = cell%perd(idir)*NINT(fractional(idir))
+                           END DO
+                           DO image_i3 = base_shift(3) - image_shell(3), &
+                              base_shift(3) + image_shell(3)
+                              DO image_i2 = base_shift(2) - image_shell(2), &
+                                 base_shift(2) + image_shell(2)
+                                 DO image_i1 = base_shift(1) - image_shell(1), &
+                                    base_shift(1) + image_shell(1)
+                                    image_shift = [image_i1, image_i2, image_i3]
+                                    IF (target_atom == iatom .AND. ALL(image_shift == 0)) CYCLE
+                                    image_translation = MATMUL( &
+                                                        cell%hmat, REAL(image_shift, dp))
+                                    cross_displacement = &
+                                       composite_grid_coords(:, composite_row) - &
+                                       particle_set(iatom)%r - image_translation
+                                    ! Reject inactive images before allocating interpolation scratch.
+                                    IF (SQRT(SUM(cross_displacement**2)) > cross_cutoff) CYCLE
+                                    CALL add_gapw_atom_grid_interpolation_adjoint( &
+                                       grid_atom, harmonics, cross_displacement, cross_cutoff, &
+                                       nspins, cross_density_adjoint, cross_grad_adjoint, &
+                                       cross_kin_adjoint, vxc_h_local, vxc_s_local, vxg_h_local, vxg_s_local, &
+                                       vtau_h_local, vtau_s_local)
                                  END DO
                               END DO
                            END DO
                         END DO
+!$OMP END DO
+!$OMP CRITICAL(skala_atom_composite_adjoint_reduction)
+                        vxc_h = vxc_h + vxc_h_local
+                        vxc_s = vxc_s + vxc_s_local
+                        vxg_h = vxg_h + vxg_h_local
+                        vxg_s = vxg_s + vxg_s_local
+                        vtau_h = vtau_h + vtau_h_local
+                        vtau_s = vtau_s + vtau_s_local
+!$OMP END CRITICAL(skala_atom_composite_adjoint_reduction)
+                        DEALLOCATE (vxc_h_local, vxc_s_local, vxg_h_local, vxg_s_local, vtau_h_local, vtau_s_local)
+!$OMP END PARALLEL
                      END IF
 
                      ! Model rows are distributed by target atom, while CP2K stores each
@@ -3491,10 +3528,10 @@ CONTAINS
 !> \param cutoff compact support radius
 !> \param radial_indices active radial nodes
 !> \param radial_weights interpolation weights on the active radial nodes
-!> \param radial_derivative_weights radial derivatives of the interpolation weights
+!> \param radial_derivative_weights optional radial derivatives of the interpolation weights
 !> \param nradial number of active radial nodes
 !> \param angular_weights angular interpolation weights
-!> \param angular_derivative_weights Cartesian derivatives of the angular weights
+!> \param angular_derivative_weights optional Cartesian derivatives of the angular weights
 !> \param active whether the point lies inside the compact support
 ! **************************************************************************************************
    SUBROUTINE atom_grid_interpolation_weights( &
@@ -3505,10 +3542,11 @@ CONTAINS
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: displacement
       REAL(dp), INTENT(IN)                               :: cutoff
       INTEGER, DIMENSION(4), INTENT(OUT)                 :: radial_indices
-      REAL(dp), DIMENSION(4), INTENT(OUT)                :: radial_weights, radial_derivative_weights
+      REAL(dp), DIMENSION(4), INTENT(OUT)                :: radial_weights
+      REAL(dp), DIMENSION(4), INTENT(OUT), OPTIONAL      :: radial_derivative_weights
       INTEGER, INTENT(OUT)                               :: nradial
       REAL(dp), DIMENSION(:), INTENT(OUT)                :: angular_weights
-      REAL(dp), DIMENSION(:, :), INTENT(OUT)             :: angular_derivative_weights
+      REAL(dp), DIMENSION(:, :), INTENT(OUT), OPTIONAL   :: angular_derivative_weights
       LOGICAL, INTENT(OUT)                               :: active
 
       INTEGER                                            :: ia, ic, inode, iso, l, left, left_pos, &
@@ -3528,14 +3566,16 @@ CONTAINS
       CPASSERT(ASSOCIATED(grid_atom))
       CPASSERT(ASSOCIATED(harmonics))
       CPASSERT(SIZE(angular_weights) == grid_atom%ng_sphere)
-      CPASSERT(SIZE(angular_derivative_weights, 1) == 3)
-      CPASSERT(SIZE(angular_derivative_weights, 2) == grid_atom%ng_sphere)
+      IF (PRESENT(angular_derivative_weights)) THEN
+         CPASSERT(SIZE(angular_derivative_weights, 1) == 3)
+         CPASSERT(SIZE(angular_derivative_weights, 2) == grid_atom%ng_sphere)
+      END IF
 
       radial_indices = 0
       radial_weights = 0.0_dp
-      radial_derivative_weights = 0.0_dp
+      IF (PRESENT(radial_derivative_weights)) radial_derivative_weights = 0.0_dp
       angular_weights = 0.0_dp
-      angular_derivative_weights = 0.0_dp
+      IF (PRESENT(angular_derivative_weights)) angular_derivative_weights = 0.0_dp
       nradial = 0
       active = .FALSE.
       n = grid_atom%nr
@@ -3579,12 +3619,6 @@ CONTAINS
       h01 = 10.0_dp*t**3 - 15.0_dp*t**4 + 6.0_dp*t**5
       h11 = -4.0_dp*t**3 + 7.0_dp*t**4 - 3.0_dp*t**5
       h21 = 0.5_dp*(t**3 - 2.0_dp*t**4 + t**5)
-      dh00 = -30.0_dp*t**2 + 60.0_dp*t**3 - 30.0_dp*t**4
-      dh10 = 1.0_dp - 18.0_dp*t**2 + 32.0_dp*t**3 - 15.0_dp*t**4
-      dh20 = 0.5_dp*(2.0_dp*t - 9.0_dp*t**2 + 12.0_dp*t**3 - 5.0_dp*t**4)
-      dh01 = 30.0_dp*t**2 - 60.0_dp*t**3 + 30.0_dp*t**4
-      dh11 = -12.0_dp*t**2 + 28.0_dp*t**3 - 15.0_dp*t**4
-      dh21 = 0.5_dp*(3.0_dp*t**2 - 8.0_dp*t**3 + 5.0_dp*t**4)
 
       CALL radial_node_derivative_coefficients( &
          grid_atom, descending, left, logical_start, slope_left, curvature_left)
@@ -3597,22 +3631,30 @@ CONTAINS
                                               h11*slope_right(1:nradial)) + &
                                   h_interval**2*(h20*curvature_left(1:nradial) + &
                                                  h21*curvature_right(1:nradial))
-      radial_derivative_weights(left_pos) = &
-         radial_derivative_weights(left_pos) + dh00/h_interval
-      radial_derivative_weights(right_pos) = &
-         radial_derivative_weights(right_pos) + dh01/h_interval
-      radial_derivative_weights(1:nradial) = radial_derivative_weights(1:nradial) + &
-                                             dh10*slope_left(1:nradial) + &
-                                             dh11*slope_right(1:nradial) + &
-                                             h_interval*(dh20*curvature_left(1:nradial) + &
-                                                         dh21*curvature_right(1:nradial))
+      IF (PRESENT(radial_derivative_weights)) THEN
+         dh00 = -30.0_dp*t**2 + 60.0_dp*t**3 - 30.0_dp*t**4
+         dh10 = 1.0_dp - 18.0_dp*t**2 + 32.0_dp*t**3 - 15.0_dp*t**4
+         dh20 = 0.5_dp*(2.0_dp*t - 9.0_dp*t**2 + 12.0_dp*t**3 - 5.0_dp*t**4)
+         dh01 = 30.0_dp*t**2 - 60.0_dp*t**3 + 30.0_dp*t**4
+         dh11 = -12.0_dp*t**2 + 28.0_dp*t**3 - 15.0_dp*t**4
+         dh21 = 0.5_dp*(3.0_dp*t**2 - 8.0_dp*t**3 + 5.0_dp*t**4)
+         radial_derivative_weights(left_pos) = &
+            radial_derivative_weights(left_pos) + dh00/h_interval
+         radial_derivative_weights(right_pos) = &
+            radial_derivative_weights(right_pos) + dh01/h_interval
+         radial_derivative_weights(1:nradial) = radial_derivative_weights(1:nradial) + &
+                                                dh10*slope_left(1:nradial) + &
+                                                dh11*slope_right(1:nradial) + &
+                                                h_interval*(dh20*curvature_left(1:nradial) + &
+                                                            dh21*curvature_right(1:nradial))
+      END IF
 
       angular_values = 0.0_dp
-      angular_value_derivatives = 0.0_dp
+      IF (PRESENT(angular_derivative_weights)) angular_value_derivatives = 0.0_dp
       DO iso = 1, harmonics%max_s_harm
          l = indso(1, iso)
          CALL y_lm(direction, angular_values(iso), l, indso(2, iso))
-         IF (l == 0) CYCLE
+         IF (l == 0 .OR. .NOT. PRESENT(angular_derivative_weights)) CYCLE
          shell_index = iso - nsoset(l - 1)
          DO ic = 1, nco(l)
             lx = indco(1, ic + ncoset(l - 1))
@@ -3649,11 +3691,13 @@ CONTAINS
          angular_weights(ia) = grid_atom%wa(ia)* &
                                DOT_PRODUCT(harmonics%slm(ia, 1:harmonics%max_s_harm), &
                                            angular_values)
-         DO inode = 1, 3
-            angular_derivative_weights(inode, ia) = grid_atom%wa(ia)* &
-                                                    DOT_PRODUCT(harmonics%slm(ia, 1:harmonics%max_s_harm), &
-                                                                angular_value_derivatives(inode, :))
-         END DO
+         IF (PRESENT(angular_derivative_weights)) THEN
+            DO inode = 1, 3
+               angular_derivative_weights(inode, ia) = grid_atom%wa(ia)* &
+                                                       DOT_PRODUCT(harmonics%slm(ia, 1:harmonics%max_s_harm), &
+                                                                   angular_value_derivatives(inode, :))
+            END DO
+         END IF
       END DO
       active = .TRUE.
 
@@ -3785,13 +3829,12 @@ CONTAINS
       INTEGER, DIMENSION(4)                              :: radial_indices
       LOGICAL                                            :: active
       REAL(dp)                                           :: value
+      REAL(dp), DIMENSION(4)                             :: radial_weights
       REAL(dp), DIMENSION(grid_atom%ng_sphere)           :: angular_weights
-      REAL(dp), DIMENSION(4)                             :: radial_derivative_weights, radial_weights
-      REAL(dp), DIMENSION(3, grid_atom%ng_sphere)        :: angular_derivative_weights
 
       CALL atom_grid_interpolation_weights( &
          grid_atom, harmonics, displacement, cutoff, radial_indices, radial_weights, &
-         radial_derivative_weights, nradial, angular_weights, angular_derivative_weights, active)
+         nradial=nradial, angular_weights=angular_weights, active=active)
       IF (active) THEN
          DO inode = 1, nradial
             ir = radial_indices(inode)

--- a/tools/regtesting/GAPW_ADJOINT_PERFORMANCE.md
+++ b/tools/regtesting/GAPW_ADJOINT_PERFORMANCE.md
@@ -1,0 +1,63 @@
+# GAPW atom-grid adjoint check
+
+`check_gapw_atom_adjoint.py` compares the native Skala GAPW atom-grid backprojection with an
+unmodified source revision. It extracts the private interpolation routines and the actual caller
+loop directly from both sources, then links them with CP2K's real grid types, Lebedev data, orbital
+tables and spherical harmonics. No Torch model or SCF calculation is required.
+
+## Running
+
+Use a completed GNU Fortran/OpenMP Ninja CMake build of the patched CP2K library. The script obtains
+its compiler and resolved link dependencies from that build. The
+`orbital_transformation_matrices_unittest` target must exist, but need not be built. The baseline
+must contain the original serial caller; specify it explicitly, including after committing the
+patch.
+
+```sh
+python3 tools/regtesting/check_gapw_atom_adjoint.py \
+  --build-dir build --work-dir build/adjoint-check \
+  --baseline bcbbd8ccf92872e534cf4bab913a86eb32d676bb --check
+python3 tools/regtesting/check_gapw_atom_adjoint.py \
+  --build-dir build --work-dir build/adjoint-check \
+  --baseline bcbbd8ccf92872e534cf4bab913a86eb32d676bb --rows 120000
+```
+
+The first command enables bounds and floating-point exception checks. The second uses release
+optimization and reports the best of three wall times. All generated sources, executables and JSON
+results stay in the supplied work directory. The JSON records source hashes, compiler flags, output
+and peak-memory statistics.
+
+## Coverage
+
+- Full, value-only, radial-only and angular-only interpolation outputs against the unmodified
+  implementation.
+- Ascending/descending nonuniform radial grids with 2, 3, 7 and 150 nodes, including radial nodes,
+  zero displacement and points outside support.
+- Hard-minus-soft forward/adjoint dot-product identity for one and two spins.
+- All density/gradient/tau activation masks, repeated target points, nonperiodic,
+  orthorhombic-periodic and triclinic-periodic images.
+- Nonzero initial potentials, empty local row sets, and sums over separate target-atom ownership
+  partitions.
+- 1, 2, 4, 8 and 16 OpenMP threads, plus a larger 150 x 770 radial/Lebedev fixture.
+
+The ownership test simulates MPI partitions and their sum; it is not a multi-rank MPI run. It tests
+the interpolation transpose, not model inference or an end-to-end SCF/force/virial calculation. The
+source-extraction checks deliberately fail if the expected caller structure is no longer present.
+
+## Interpreting timings
+
+`original` uses the old serial caller and derivative-producing weights. `values_only` changes only
+the unused derivative work. `screened` uses the new caller, early support rejection and local
+buffers, with OpenMP directives omitted. `parallel` uses the complete patched caller. Compare its
+one-thread time with its multi-thread times to isolate parallel scaling. Compare all variants with
+`original` to measure the combined kernel improvement.
+
+Each thread's six heap-allocated potential buffers occupy 17.624 MiB for the 150 x 770, two-spin
+fixture (282 MiB for 16 threads). The protected merge precedes the existing MPI sums. It changes
+floating-point summation order, not the interpolation mapping. No support radius, cutoff, spin
+factor or hard/soft sign is changed. Spatial derivatives needed for forces and virial remain
+available.
+
+Kernel timings are not a whole-SCF speedup prediction. Use an otherwise idle machine, document
+compiler/hardware and any oversubscription, and validate a complete production runtime separately
+before deploying it.

--- a/tools/regtesting/check_gapw_atom_adjoint.py
+++ b/tools/regtesting/check_gapw_atom_adjoint.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Compare the GAPW interpolation/adjoint kernels with an unmodified Git revision.
+
+Uses a completed GNU/OpenMP CMake CP2K build (no Torch model or SCF calculation).
+Extracts the actual private routines and caller loops, not rewritten numerical
+surrogates. Generated sources, executable and JSON results stay in --work-dir.
+The shared CP2K library supplies the real grids, harmonics and orbital tables.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import sys
+
+USES = """
+ USE kinds, ONLY: dp
+ USE qs_grid_atom, ONLY: grid_atom_type
+ USE qs_harmonics_atom, ONLY: harmonics_atom_type
+ USE orbital_pointers, ONLY: indco, indso, nco, ncoset, nsoset
+ USE orbital_transformation_matrices, ONLY: orbtramat
+ USE spherical_harmonics, ONLY: y_lm
+ USE cell_types, ONLY: cell_type
+ USE particle_types, ONLY: particle_type
+ IMPLICIT NONE
+ CONTAINS
+"""
+
+WRAPPER = """
+ SUBROUTINE project(cell, particle_set, grid_atom, harmonics, nspins, flags, &
+   composite_grid_coords, composite_grid_atom, composite_local_atoms, &
+   composite_atom_start, composite_atom_end, composite_density_grad, &
+   composite_grad_grad, composite_kin_grad, cross_cutoff, &
+   vxc_h, vxc_s, vxg_h, vxg_s, vtau_h, vtau_s)
+ TYPE(cell_type), POINTER :: cell
+ TYPE(particle_type), DIMENSION(:), POINTER :: particle_set
+ TYPE(grid_atom_type), POINTER :: grid_atom
+ TYPE(harmonics_atom_type), POINTER :: harmonics
+ INTEGER, INTENT(IN) :: nspins
+ LOGICAL, INTENT(IN) :: flags(3)
+ REAL(dp), INTENT(IN) :: composite_grid_coords(:, :), composite_density_grad(:, :)
+ REAL(dp), INTENT(IN) :: composite_grad_grad(:, :, :), composite_kin_grad(:, :)
+ INTEGER, INTENT(IN) :: composite_grid_atom(:), composite_local_atoms(:)
+ INTEGER, INTENT(IN) :: composite_atom_start(:), composite_atom_end(:)
+ REAL(dp), INTENT(IN) :: cross_cutoff
+ REAL(dp), POINTER :: vxc_h(:, :, :), vxc_s(:, :, :), vtau_h(:, :, :), vtau_s(:, :, :)
+ REAL(dp), POINTER :: vxg_h(:, :, :, :), vxg_s(:, :, :, :)
+ REAL(dp), ALLOCATABLE :: vxc_h_local(:, :, :), vxc_s_local(:, :, :), vtau_h_local(:, :, :), vtau_s_local(:, :, :)
+ REAL(dp), ALLOCATABLE :: vxg_h_local(:, :, :, :), vxg_s_local(:, :, :, :)
+ INTEGER :: base_shift(3), composite_row, idir, image_i1, image_i2, image_i3
+ INTEGER :: image_shift(3), image_shell(3), jdir, target_atom, iatom
+ INTEGER :: composite_local_atom, composite_local_natom, composite_nflat
+ REAL(dp) :: cross_density_adjoint(2), cross_grad_adjoint(3, 2), cross_kin_adjoint(2)
+ REAL(dp) :: cross_displacement(3), fractional(3), image_translation(3)
+ LOGICAL :: lsd, use_atom_composite_density, use_atom_composite_gradient, use_atom_composite_tau
+ iatom = 1
+ composite_nflat = SIZE(composite_grid_atom)
+ composite_local_natom = SIZE(composite_local_atoms)
+ lsd = nspins == 2
+ use_atom_composite_density = flags(1)
+ use_atom_composite_gradient = flags(2)
+ use_atom_composite_tau = flags(3)
+ image_shell = 0
+ DO idir = 1, 3
+   IF (cell%perd(idir) == 1) image_shell(idir) = &
+     CEILING(cross_cutoff*SQRT(SUM(cell%h_inv(idir, :)**2))) + 1
+ END DO
+{loop}
+ END SUBROUTINE project
+"""
+
+
+def routine(source, name):
+    matches = re.findall(
+        rf"^   SUBROUTINE {name}\b.*?^   END SUBROUTINE {name}\b",
+        source,
+        re.M | re.S,
+    )
+    if len(matches) != 1:
+        raise ValueError(f"Expected one definition of {name}, got {len(matches)}")
+    return matches[0]
+
+
+def caller_loop(source, parallel):
+    start = source.index(
+        "cross_cutoff = gapw_atom_grid_support_radius(",
+        source.index("SUBROUTINE calculate_vxc_atom("),
+    )
+    # The first occurrence is in the forward path; the adjoint is the last one
+    # before the target-owner MPI reduction.
+    end = source.index("! Model rows are distributed by target atom")
+    region = source[start:end]
+    start = region.rindex("cross_cutoff = gapw_atom_grid_support_radius(")
+    region = region[start:]
+    if parallel:
+        start = region.index("!$OMP PARALLEL")
+        end = region.index("!$OMP END PARALLEL") + len("!$OMP END PARALLEL")
+    else:
+        start = region.index("DO composite_local_atom = 1, composite_local_natom")
+        end = region.rindex("END IF")
+    return region[start:end].strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--work-dir", type=Path, required=True)
+    parser.add_argument(
+        "--baseline",
+        required=True,
+        help="Unmodified Git revision containing the serial adjoint",
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="Bounds/FPE checks, no timing"
+    )
+    parser.add_argument("--rows", type=int, default=4000)
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[2]
+    build, work = args.build_dir.resolve(), args.work_dir.resolve()
+    work.mkdir(parents=True, exist_ok=True)
+    baseline = subprocess.check_output(
+        ["git", "show", f"{args.baseline}:src/qs_vxc_atom.F"], cwd=root, text=True
+    )
+    patched = (root / "src/qs_vxc_atom.F").read_text()
+    helpers = [
+        "radial_node_derivative_coefficients",
+        "atom_grid_interpolation_weights",
+        "interpolate_gapw_atom_grid_fields",
+        "add_gapw_atom_grid_interpolation_adjoint",
+    ]
+    old_loop, new_loop = caller_loop(baseline, False), caller_loop(patched, True)
+    sources = []
+    for name, source, loop in [
+        ("original", baseline, old_loop),
+        ("values_only", patched, old_loop),
+        ("screened", patched, re.sub(r"^!\$OMP.*\n?", "", new_loop, flags=re.M)),
+        ("parallel", patched, new_loop),
+    ]:
+        path = work / f"{name}.F90"
+        content = (
+            "#define CPASSERT(cond) IF (.NOT. (cond)) ERROR STOP 'CPASSERT'\n"
+            f"MODULE {name}_kernel\n"
+            + USES
+            + "\n".join(routine(source, n) for n in helpers)
+            + WRAPPER.format(loop=loop)
+            + f"\nEND MODULE {name}_kernel\n"
+        )
+        path.write_text(content)
+        sources.append(path)
+    # Reuse the build's resolved compiler and link dependencies without guessing
+    # site-specific library paths. Invoke argv directly, never through a shell.
+    commands = subprocess.check_output(
+        [
+            "ninja",
+            "-C",
+            str(build),
+            "-t",
+            "commands",
+            "orbital_transformation_matrices_unittest",
+        ],
+        text=True,
+    )
+    link = shlex.split(commands.strip().splitlines()[-1])
+    if link[:2] != [":", "&&"] or link[-2:] != ["&&", ":"]:
+        raise ValueError("Unsupported CMake link command layout")
+    link = link[2:-2]
+    objects = [x for x in link if x.endswith(".F.o")]
+    if len(objects) != 1:
+        raise ValueError("Expected one unit-test driver object")
+    compiler = link[0]
+    executable = work / ("adjoint_checked" if args.check else "adjoint_release")
+    flags = [
+        "-cpp",
+        "-fopenmp",
+        "-ffree-line-length-none",
+        "-I",
+        str(build / "src/mod_files"),
+    ]
+    flags += (
+        ["-O1", "-g", "-fcheck=all", "-ffpe-trap=invalid,zero,overflow"]
+        if args.check
+        else ["-O3", "-funroll-loops"]
+    )
+    sources.append(Path(__file__).with_name("gapw_atom_adjoint_fixture.F90"))
+    compiled = []
+    for source in sources:
+        target = work / (source.stem + ".o")
+        subprocess.run(
+            [compiler, *flags, "-c", str(source), "-o", str(target)],
+            cwd=work,
+            check=True,
+        )
+        compiled.append(str(target))
+    pos = link.index(objects[0])
+    link[pos : pos + 1] = compiled
+    link[link.index("-o") + 1] = str(executable)
+    subprocess.run(link, cwd=build, check=True)
+    env = dict(os.environ, OPENBLAS_NUM_THREADS="1", OMP_DYNAMIC="FALSE")
+    run_command = [
+        str(executable),
+        "check" if args.check else "benchmark",
+        str(args.rows),
+    ]
+    if Path("/usr/bin/time").exists():
+        run_command = [
+            "/usr/bin/time",
+            "-l" if sys.platform == "darwin" else "-v",
+            *run_command,
+        ]
+    completed = subprocess.run(
+        run_command, cwd=work, env=env, text=True, capture_output=True
+    )
+    print(completed.stdout, end="")
+    print(completed.stderr, end="")
+    report = {
+        "baseline_revision": subprocess.check_output(
+            ["git", "rev-parse", args.baseline], cwd=root, text=True
+        ).strip(),
+        "baseline_sha256": hashlib.sha256(baseline.encode()).hexdigest(),
+        "patched_sha256": hashlib.sha256(patched.encode()).hexdigest(),
+        "compiler": subprocess.check_output(
+            [compiler, "--version"], text=True
+        ).splitlines()[0],
+        "flags": flags,
+        "exit_code": completed.returncode,
+        "output": completed.stdout,
+        "stderr": completed.stderr,
+        "generated_sources_sha256": {
+            p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in sources
+        },
+        "scope": "Extracted production kernels and exact caller loop, real CP2K types/harmonics; no SCF/model test",
+    }
+    (
+        work / ("checked-results.json" if args.check else "benchmark-results.json")
+    ).write_text(json.dumps(report, indent=2) + "\n")
+    completed.check_returncode()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/regtesting/gapw_atom_adjoint_fixture.F90
+++ b/tools/regtesting/gapw_atom_adjoint_fixture.F90
@@ -1,0 +1,332 @@
+! SPDX-License-Identifier: GPL-2.0-or-later
+! Synthetic fields on nonuniform radial grids and real CP2K Lebedev grids.
+PROGRAM gapw_atom_adjoint_fixture
+   USE cell_types,                      ONLY: cell_type
+   USE kinds,                           ONLY: dp
+   USE lebedev,                         ONLY: init_lebedev_grids,&
+                                              lebedev_grid
+   USE omp_lib,                         ONLY: omp_get_wtime,&
+                                              omp_set_num_threads
+   USE orbital_pointers,                ONLY: indso,&
+                                              init_orbital_pointers
+   USE orbital_transformation_matrices, ONLY: init_spherical_harmonics
+   USE original_kernel,                 ONLY: old_fields => interpolate_gapw_atom_grid_fields,&
+                                              old_project => project,&
+                                              old_weights => atom_grid_interpolation_weights
+   USE parallel_kernel,                 ONLY: parallel_project => project
+   USE particle_types,                  ONLY: particle_type
+   USE qs_grid_atom,                    ONLY: grid_atom_type
+   USE qs_harmonics_atom,               ONLY: harmonics_atom_type
+   USE screened_kernel,                 ONLY: screened_project => project
+   USE spherical_harmonics,             ONLY: y_lm
+   USE values_only_kernel,              ONLY: new_weights => atom_grid_interpolation_weights,&
+                                              value_project => project
+
+   IMPLICIT NONE
+   TYPE(grid_atom_type), POINTER :: grid
+   TYPE(harmonics_atom_type), POINTER :: harmonics
+   TYPE(cell_type), POINTER :: cell
+   TYPE(particle_type), POINTER :: particles(:)
+   REAL(dp), POINTER :: vh(:, :, :), vs(:, :, :), th(:, :, :), ts(:, :, :)
+   REAL(dp), POINTER :: gh(:, :, :, :), gs(:, :, :, :)
+   REAL(dp), ALLOCATABLE :: coords(:, :), density(:, :), gradient(:, :, :), kin(:, :)
+   INTEGER, ALLOCATABLE :: atoms(:), local_atoms(:), first(:), last(:)
+   REAL(dp), ALLOCATABLE :: reference(:), actual(:)
+   LOGICAL :: flags(3)
+   INTEGER :: ns, i, n, order, periodic, mask, threads, variant, rep, np
+   INTEGER, PARAMETER :: counts(4) = [2, 3, 7, 150], thread_counts(5) = [1, 2, 4, 8, 16]
+   REAL(dp) :: t0, elapsed, best, error, max_error
+   CHARACTER(32) :: mode, arg
+   CHARACTER(12), PARAMETER :: names(4) = [CHARACTER(12) :: 'original', 'values_only', 'screened', 'parallel']
+
+   CALL get_command_argument(1, mode)
+   CALL get_command_argument(2, arg)
+   READ (arg, *) np
+   CALL init_orbital_pointers(6)
+   i = -1
+   CALL init_spherical_harmonics(6, i)
+   CALL init_lebedev_grids()
+   ALLOCATE (grid, harmonics, cell, particles(3))
+   max_error = 0.0_dp
+   DO n = 1, SIZE(counts)
+      CALL make_grid(counts(n), 5, 4)
+      DO order = 1, 2
+         CALL check_weights()
+         grid%rad = grid%rad(grid%nr:1:-1)
+      END DO
+      CALL free_grid()
+   END DO
+   WRITE (*, '(A)') 'PASS: value weights and full/optional derivatives agree exactly with baseline'
+
+   CALL make_grid(7, 5, 4)
+   DO ns = 1, 2
+      CALL allocate_potentials()
+      CALL check_transpose()
+      DO periodic = 0, 2
+         CALL make_cell(periodic)
+         CALL make_points(37)
+         DO mask = 0, 7
+            flags = [BTEST(mask, 0), BTEST(mask, 1), BTEST(mask, 2)]
+            CALL reset_potentials()
+            CALL project_variant(1)
+            reference = pack_potentials()
+            DO threads = 1, SIZE(thread_counts)
+               CALL omp_set_num_threads(thread_counts(threads))
+               DO variant = 2, 4
+                  CALL reset_potentials()
+                  CALL project_variant(variant)
+                  actual = pack_potentials()
+                  error = MAXVAL(ABS(actual - reference))/MAX(1.0_dp, MAXVAL(ABS(reference)))
+                  max_error = MAX(max_error, error)
+                  IF (error > 2.0E-13_dp) ERROR STOP 'Parallel adjoint differs from original'
+               END DO
+            END DO
+         END DO
+         CALL check_target_partitions()
+         CALL free_points()
+      END DO
+      CALL make_points(0)
+      flags = .TRUE.
+      CALL reset_potentials()
+      reference = pack_potentials()
+      CALL project_variant(4)
+      actual = pack_potentials()
+      IF (ANY(actual /= reference)) ERROR STOP 'Empty-rank potentials changed'
+      CALL free_points()
+      CALL free_potentials()
+   END DO
+   CALL free_grid()
+   WRITE (*, '(A,ES12.4)') 'PASS: transpose, spin/masks, periodic/triclinic images, empty rank; max relative error=', max_error
+   IF (TRIM(mode) == 'check') STOP
+
+   CALL make_grid(150, 13, 6)
+   CALL make_cell(2)
+   CALL make_points(np)
+   ns = 2
+   flags = .TRUE.
+   CALL allocate_potentials()
+   WRITE (*, '(A,I0,A)') 'BENCHMARK: 150 radial x 770 Lebedev, lmax=6, two spins, ', np, ' rows; best of three seconds'
+   WRITE (*, '(A,F8.3,A)') 'Private reduction storage per thread: ', REAL(20*150*770*8, dp)/1024**2, ' MiB'
+   DO variant = 1, 4
+      DO threads = 1, SIZE(thread_counts)
+         IF (variant /= 4 .AND. threads /= 1) CYCLE
+         CALL omp_set_num_threads(thread_counts(threads))
+         best = HUGE(1.0_dp)
+         DO rep = 1, 3
+            CALL reset_potentials()
+            t0 = omp_get_wtime()
+            CALL project_variant(variant)
+            elapsed = omp_get_wtime() - t0
+            best = MIN(best, elapsed)
+         END DO
+         actual = pack_potentials()
+         IF (variant == 1) reference = actual
+         error = MAXVAL(ABS(actual - reference))/MAX(1.0_dp, MAXVAL(ABS(reference)))
+         IF (error > 2.0E-12_dp) ERROR STOP 'Benchmark equivalence failed'
+         WRITE (*, '(A,1X,I2,1X,F12.6,1X,ES12.4)') names(variant), thread_counts(threads), best, error
+      END DO
+   END DO
+CONTAINS
+   SUBROUTINE make_grid(nr, lg, lmax)
+      INTEGER, INTENT(IN)                                :: nr, lg, lmax
+
+      INTEGER                                            :: ia, ir, iso
+
+      grid%nr = nr
+      grid%ng_sphere = lebedev_grid(lg)%n
+      harmonics%max_s_harm = (lmax + 1)**2
+      ALLOCATE (grid%rad(nr), grid%wa(grid%ng_sphere))
+      ALLOCATE (harmonics%slm(grid%ng_sphere, harmonics%max_s_harm))
+      DO ir = 1, nr
+         grid%rad(ir) = 0.05_dp + 4.95_dp*(REAL(ir - 1, dp)/REAL(nr - 1, dp))**2
+      END DO
+      grid%wa = 4.0_dp*ACOS(-1.0_dp)*lebedev_grid(lg)%w
+      DO iso = 1, harmonics%max_s_harm
+         DO ia = 1, grid%ng_sphere
+            CALL y_lm(lebedev_grid(lg)%r(:, ia), harmonics%slm(ia, iso), indso(1, iso), indso(2, iso))
+         END DO
+      END DO
+   END SUBROUTINE
+
+   SUBROUTINE free_grid()
+      DEALLOCATE (grid%rad, grid%wa, harmonics%slm)
+   END SUBROUTINE
+
+   SUBROUTINE check_weights()
+      INTEGER                                            :: ii(4), jj(4), ni, nj, p
+      LOGICAL                                            :: active_i, active_j
+      REAL(dp) :: ai(grid%ng_sphere), aj(grid%ng_sphere), di(4), dj(4), gi(3, grid%ng_sphere), &
+         gj(3, grid%ng_sphere), r, wi(4), wj(4), x(3)
+
+      DO p = 0, 100 + grid%nr
+         r = REAL(p, dp)*0.052_dp
+         IF (p > 100) r = grid%rad(p - 100)
+         x = r*[2.0_dp, 3.0_dp, 6.0_dp]/7.0_dp
+         CALL old_weights(grid, harmonics, x, 5.0_dp, ii, wi, di, ni, ai, gi, active_i)
+         CALL new_weights(grid, harmonics, x, 5.0_dp, jj, wj, dj, nj, aj, gj, active_j)
+         IF (active_i .NEQV. active_j) ERROR STOP 'Support changed'
+         IF (ni /= nj .OR. ANY(ii /= jj)) ERROR STOP 'Radial indices changed'
+         IF (ANY(wi /= wj) .OR. ANY(ai /= aj)) ERROR STOP 'Value weights changed'
+         IF (ANY(di /= dj) .OR. ANY(gi /= gj)) ERROR STOP 'Spatial derivatives changed'
+         CALL new_weights(grid, harmonics, x, 5.0_dp, jj, wj, nradial=nj, angular_weights=aj, active=active_j)
+         IF (ANY(wi /= wj) .OR. ANY(ai /= aj)) ERROR STOP 'Value-only weights changed'
+         CALL new_weights(grid, harmonics, x, 5.0_dp, jj, wj, dj, nj, aj, active=active_j)
+         IF (ANY(di /= dj)) ERROR STOP 'Radial-only derivatives changed'
+         CALL new_weights(grid, harmonics, x, 5.0_dp, jj, wj, nradial=nj, angular_weights=aj, &
+                          angular_derivative_weights=gj, active=active_j)
+         IF (ANY(gi /= gj)) ERROR STOP 'Angular-only derivatives changed'
+      END DO
+   END SUBROUTINE
+
+   SUBROUTINE make_cell(periodic)
+      INTEGER, INTENT(IN)                                :: periodic
+
+      cell%hmat = 0.0_dp
+      cell%h_inv = 0.0_dp
+      DO i = 1, 3
+         cell%hmat(i, i) = 8.0_dp
+         cell%h_inv(i, i) = 0.125_dp
+      END DO
+      cell%perd = MERGE(1, 0, periodic > 0)
+      IF (periodic == 2) THEN
+         cell%hmat(1, 2) = 1.6_dp
+         cell%h_inv(1, 2) = -0.025_dp
+      END IF
+      particles(1)%r = [0.1_dp, 0.2_dp, 0.3_dp]
+   END SUBROUTINE
+
+   SUBROUTINE make_points(np)
+      INTEGER, INTENT(IN)                                :: np
+
+      INTEGER                                            :: a, p
+      REAL(dp)                                           :: q
+
+      ALLOCATE (coords(3, np), density(np, 2), gradient(np, 3, 2), kin(np, 2))
+      ALLOCATE (atoms(np), local_atoms(3), first(3), last(3))
+      local_atoms = [1, 2, 3]
+      DO a = 1, 3
+         first(a) = (a - 1)*np/3 + 1
+         last(a) = a*np/3
+         atoms(first(a):last(a)) = a
+      END DO
+      DO p = 1, np
+         q = REAL((p + 1)/2, dp)
+         coords(:, p) = particles(1)%r + 3.1_dp*[SIN(q), COS(0.7_dp*q), SIN(1.3_dp*q)]
+         IF (MOD(p, 11) == 0) coords(:, p) = coords(:, p) + cell%hmat(:, 1)
+         density(p, :) = [SIN(q), COS(q)]
+         kin(p, :) = [COS(0.2_dp*q), SIN(0.3_dp*q)]
+         DO a = 1, 3
+            gradient(p, a, :) = [SIN(q + a), COS(q - a)]
+         END DO
+      END DO
+   END SUBROUTINE
+
+   SUBROUTINE free_points()
+      DEALLOCATE (coords, density, gradient, kin, atoms, local_atoms, first, last)
+   END SUBROUTINE
+
+   SUBROUTINE check_target_partitions()
+      ! Mimic target-atom MPI ownership and its subsequent sum without changing
+      ! the actual caller loop: each partition owns one contiguous atom block.
+      INTEGER                                            :: a, hi, lo, rank_first(3), rank_last(3)
+      REAL(dp), ALLOCATABLE                              :: contribution(:), initial(:), total(:)
+
+      CALL reset_potentials()
+      initial = pack_potentials()
+      total = initial
+      DO a = 1, 3
+         lo = first(a)
+         hi = last(a)
+         rank_first = 1
+         rank_last = 0
+         rank_last(a) = hi - lo + 1
+         vh = 0; vs = 0; gh = 0; gs = 0; th = 0; ts = 0
+         CALL parallel_project(cell, particles, grid, harmonics, ns, flags, &
+                               coords(:, lo:hi), atoms(lo:hi), local_atoms(a:a), rank_first, rank_last, &
+                               density(lo:hi, :), gradient(lo:hi, :, :), kin(lo:hi, :), 5.0_dp, vh, vs, gh, gs, th, ts)
+         contribution = pack_potentials()
+         total = total + contribution
+      END DO
+      IF (MAXVAL(ABS(total - reference)) > 2.0E-13_dp*MAX(1.0_dp, MAXVAL(ABS(reference)))) &
+         ERROR STOP 'Target ownership partition sum differs from original'
+   END SUBROUTINE
+
+   SUBROUTINE allocate_potentials()
+      INTEGER                                            :: na, nr
+
+      na = grid%ng_sphere
+      nr = grid%nr
+      ALLOCATE (vh(na, nr, ns), vs(na, nr, ns), th(na, nr, ns), ts(na, nr, ns), gh(3, na, nr, ns), gs(3, na, nr, ns))
+   END SUBROUTINE
+
+   SUBROUTINE free_potentials()
+      DEALLOCATE (vh, vs, th, ts, gh, gs)
+   END SUBROUTINE
+
+   SUBROUTINE reset_potentials()
+      vh = 0.031_dp
+      vs = -0.072_dp
+      th = 0.11_dp
+      ts = -0.03_dp
+      gh = 0.07_dp
+      gs = -0.012_dp
+   END SUBROUTINE
+
+   FUNCTION pack_potentials() RESULT(p)
+      REAL(dp), ALLOCATABLE                              :: p(:)
+
+      p = [RESHAPE(vh, [SIZE(vh)]), RESHAPE(vs, [SIZE(vs)]), RESHAPE(th, [SIZE(th)]), &
+           RESHAPE(ts, [SIZE(ts)]), RESHAPE(gh, [SIZE(gh)]), RESHAPE(gs, [SIZE(gs)])]
+   END FUNCTION
+
+   SUBROUTINE project_variant(which)
+      INTEGER, INTENT(IN)                                :: which
+
+      SELECT CASE (which)
+      CASE (1)
+         CALL old_project(cell, particles, grid, harmonics, ns, flags, coords, atoms, local_atoms, first, last, &
+                          density, gradient, kin, 5.0_dp, vh, vs, gh, gs, th, ts)
+      CASE (2)
+         CALL value_project(cell, particles, grid, harmonics, ns, flags, coords, atoms, local_atoms, first, last, &
+                            density, gradient, kin, 5.0_dp, vh, vs, gh, gs, th, ts)
+      CASE (3)
+         CALL screened_project(cell, particles, grid, harmonics, ns, flags, coords, atoms, local_atoms, first, last, &
+                               density, gradient, kin, 5.0_dp, vh, vs, gh, gs, th, ts)
+      CASE (4)
+         CALL parallel_project(cell, particles, grid, harmonics, ns, flags, coords, atoms, local_atoms, first, last, &
+                               density, gradient, kin, 5.0_dp, vh, vs, gh, gs, th, ts)
+      END SELECT
+   END SUBROUTINE
+
+   SUBROUTINE check_transpose()
+      USE parallel_kernel, ONLY: add_gapw_atom_grid_interpolation_adjoint
+      INTEGER                                            :: ia, ir, s
+      REAL(dp) :: d(2), da(2), drho(3, grid%ng_sphere, grid%nr, ns), ds(3, 2), &
+         dsoft(3, grid%ng_sphere, grid%nr, ns), g(3, 2), ga(3, 2), gs2(3, 3, 2), lhs, &
+         rho(grid%ng_sphere, grid%nr, ns), rhs, soft(grid%ng_sphere, grid%nr, ns), t(2), ta(2), &
+         tau(grid%ng_sphere, grid%nr, ns), tsoft(grid%ng_sphere, grid%nr, ns), tss(3, 2), x(3)
+
+      DO s = 1, ns
+         DO ir = 1, grid%nr
+            DO ia = 1, grid%ng_sphere
+               rho(ia, ir, s) = SIN(REAL(ia + ir + s, dp))
+               soft(ia, ir, s) = COS(REAL(ia - ir + s, dp))
+               drho(:, ia, ir, s) = rho(ia, ir, s)*[0.3_dp, -0.2_dp, 0.7_dp]
+               dsoft(:, ia, ir, s) = soft(ia, ir, s)*[-0.7_dp, 0.4_dp, 0.1_dp]
+            END DO
+         END DO
+      END DO
+      tau = 0.4_dp*rho
+      tsoft = 0.7_dp*soft
+      da = [0.3_dp, -0.2_dp]
+      ga = RESHAPE([0.1_dp, 0.7_dp, -0.3_dp, 0.8_dp, -0.2_dp, 0.3_dp], [3, 2])
+      ta = [0.9_dp, -0.6_dp]
+      x = [0.9_dp, -0.7_dp, 1.1_dp]
+      CALL old_fields(grid, harmonics, x, 5.0_dp, ns, rho, soft, drho, dsoft, tau, tsoft, d, g, t, ds, gs2, tss)
+      vh = 0; vs = 0; gh = 0; gs = 0; th = 0; ts = 0
+      CALL add_gapw_atom_grid_interpolation_adjoint(grid, harmonics, x, 5.0_dp, ns, da, ga, ta, vh, vs, gh, gs, th, ts)
+      lhs = SUM(d*da) + SUM(g*ga) + SUM(t*ta)
+      rhs = SUM(vh*rho) - SUM(vs*soft) + SUM(gh*drho) - SUM(gs*dsoft) + SUM(th*tau) - SUM(ts*tsoft)
+      IF (ABS(lhs - rhs) > 2.0E-13_dp*MAX(1.0_dp, ABS(lhs))) ERROR STOP 'Adjoint dot-product identity failed'
+   END SUBROUTINE
+END PROGRAM


### PR DESCRIPTION

The native Skala GAPW atom-composite adjoint currently traverses its local target
rows serially. Each interpolation call also computes spatial derivatives of the
interpolation weights, although this adjoint consumes only the value weights.

This patch:

- Makes the radial and angular derivative outputs optional, retaining them for
  callers that require spatial derivatives, including force and virial paths.
- Uses the value-only weights in the interpolation adjoint. Density, density
  gradient and kinetic-energy-density adjoints are all retained.
- Rejects periodic images outside the existing compact support before allocating
  interpolation scratch, using the same support predicate as the callee.
- Distributes local target rows over OpenMP threads. Six private, heap-allocated
  potential buffers are merged under a critical section before the unchanged MPI
  sums. Existing direct contributions are retained exactly once.
- Adds a reproducible comparison and timing fixture that extracts the actual
  private routines and caller loops from the baseline and patched sources and
  links them against CP2K's grid and spherical-harmonic implementation.

No input keywords, grids, cutoffs, support radii, SCF settings, spin factors or
hard/soft signs are changed. The parallel reduction changes floating-point
summation order, not the mathematical interpolation mapping.

### Validation

The full patched CP2K shared library compiled and linked from the current upstream
base with GNU 16.1.0, MPI and OpenMP enabled, and LibTorch disabled. The extracted
production kernels were then checked with bounds checking and floating-point
exception traps, and separately with release optimization.

- Value weights and full/optional spatial derivatives agree exactly with baseline.
- Ascending and descending nonuniform radial grids, 2/3/7/150 radial nodes, nodes,
  zero displacement and points outside support are covered.
- Hard-minus-soft transpose identity, one/two spins, all density/gradient/tau
  activation masks, overlapping target points and nonzero initial potentials pass.
- Nonperiodic, orthorhombic-periodic and triclinic-periodic image tests pass.
- Empty local row sets and simulated target-atom ownership partitions pass.
- 1/2/4/8/16 OpenMP threads pass. The maximum normalized difference was
  `6.25e-16` in the checked suite and `1.44e-14` in the larger release fixture.
- Fortran formatting, Fortitude 0.9.0, Black 26.3.1, Python compilation, CP2K file
  properties and `git diff --check` pass.

The normalized difference is `max(abs(actual-reference))/max(1,max(abs(reference)))`.
The MPI ownership test simulates partitions and their sum; it is not a multi-rank
MPI execution. This does not replace an end-to-end Skala model/SCF/force/virial test
or the upstream regression suite, neither of which was run for this preparation.

### Kernel timings

Apple M4 Max, 14 physical/logical cores, GNU Fortran 16.1.0, `-O3 -funroll-loops`,
120000 target rows, 150 radial x 770 Lebedev points, lmax=6, two spins, best of three
wall times. No build was running during this measurement. The 16-thread case
oversubscribes the 14 available cores.

| Variant | Threads | Seconds |
| --- | ---: | ---: |
| Original serial caller | 1 | 8.974904 |
| Value-only weights, original caller | 1 | 4.033019 |
| New screened caller, OpenMP disabled | 1 | 1.719834 |
| Complete patch | 1 | 1.727794 |
| Complete patch | 2 | 1.237191 |
| Complete patch | 4 | 0.633221 |
| Complete patch | 8 | 0.328449 |
| Complete patch | 16 | 0.245376 |

The combined kernel improvement is 36.6x at 16 threads; parallel scaling alone is
7.04x relative to the patched one-thread result. These are fixture-specific kernel
timings, not a whole-SCF speedup claim. Each thread uses 17.624 MiB of private
potential buffers for this grid (282 MiB at 16 threads). Measured process maximum
RSS was 545.8 MiB, with no swaps.

Reproduction commands and test scope are documented in
`tools/regtesting/GAPW_ADJOINT_PERFORMANCE.md`. Generated sources, binaries and
result JSONs are not included in the patch.

