### PR TITLE
Move non-standard CMake build types to presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1007,7 +1007,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
             FORCE)
   # set the possible values of build type for cmake-gui
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
-                                               "Coverage")
+                                               "RelWithDebInfo")
 endif()
 
 # compiler configuration could have impacted package discovery (above)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,6 +32,52 @@
       }
     },
     {
+      "name": "_developer-profile",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "conventions",
+      "inherits": "_developer-profile",
+      "displayName": "GNU conventions check",
+      "description": "Build CP2K with additional GNU Fortran convention diagnostics.",
+      "cacheVariables": {
+        "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O1",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O1",
+        "CMAKE_Fortran_FLAGS_RELWITHDEBINFO": "-O1 -Wno-pedantic -Wall -Wextra -Wsurprising -Warray-temporaries -Wconversion-extra -Wimplicit-interface -Wimplicit-procedure -Wreal-q-constant -Walign-commons -Wfunction-elimination -Wrealloc-lhs -Wcompare-reals -Wzerotrip -fdump-fortran-original"
+      }
+    },
+    {
+      "name": "coverage",
+      "inherits": "_developer-profile",
+      "displayName": "Coverage build",
+      "description": "Build CP2K with GNU coverage instrumentation.",
+      "cacheVariables": {
+        "CMAKE_C_FLAGS_RELWITHDEBINFO": "-coverage -fkeep-static-functions -O1 -D__NO_ABORT",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-coverage -fkeep-static-functions -O1 -D__NO_ABORT",
+        "CMAKE_Fortran_FLAGS_RELWITHDEBINFO": "-coverage -fkeep-static-functions -O1 -D__NO_ABORT",
+        "CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO": "-coverage",
+        "CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO": "-coverage",
+        "CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO": "-coverage"
+      }
+    },
+    {
+      "name": "asan",
+      "inherits": "_developer-profile",
+      "displayName": "AddressSanitizer build",
+      "description": "Build CP2K with AddressSanitizer instrumentation.",
+      "cacheVariables": {
+        "CMAKE_C_FLAGS_RELWITHDEBINFO": "-fsanitize=address -no-pie -O3 -funroll-loops",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-fsanitize=address -no-pie -O3 -funroll-loops",
+        "CMAKE_Fortran_FLAGS_RELWITHDEBINFO": "-fsanitize=address -no-pie -O3 -funroll-loops",
+        "CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO": "-fsanitize=address",
+        "CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO": "-fsanitize=address",
+        "CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO": "-fsanitize=address"
+      }
+    },
+    {
       "name": "none",
       "displayName": "No preset",
       "description": "Use parent environment without any preset.",

--- a/cmake/CompilerConfiguration.cmake
+++ b/cmake/CompilerConfiguration.cmake
@@ -93,28 +93,6 @@ add_link_options(
   "$<$<AND:$<CONFIG:DEBUG>,$<COMPILE_LANG_AND_ID:CXX,GNU>>:-fsanitize=leak>"
   "$<$<AND:$<CONFIG:DEBUG>,$<COMPILE_LANG_AND_ID:C,GNU>>:-fsanitize=leak>")
 
-# Conventions
-add_compile_options(
-  "$<$<CONFIG:CONVENTIONS>:-O1>"
-  "$<$<AND:$<CONFIG:CONVENTIONS>,$<COMPILE_LANG_AND_ID:Fortran,GNU>>:-Wno-pedantic;-Wall;-Wextra;-Wsurprising>"
-  "$<$<AND:$<CONFIG:CONVENTIONS>,$<COMPILE_LANG_AND_ID:Fortran,GNU>>:-Warray-temporaries;-Wconversion-extra;-Wimplicit-interface>"
-  "$<$<AND:$<CONFIG:CONVENTIONS>,$<COMPILE_LANG_AND_ID:Fortran,GNU>>:-Wimplicit-procedure;-Wreal-q-constant;-Walign-commons>"
-  "$<$<AND:$<CONFIG:CONVENTIONS>,$<COMPILE_LANG_AND_ID:Fortran,GNU>>:-Wfunction-elimination;-Wrealloc-lhs;-Wcompare-reals;-Wzerotrip>"
-  # Writes a lot of output. Make sure to use:
-  # -DCMAKE_Fortran_COMPILER_LAUNCHER="redirect_gfortran_output.py"
-  "$<$<AND:$<CONFIG:CONVENTIONS>,$<COMPILE_LANG_AND_ID:Fortran,GNU>>:-fdump-fortran-original>"
-)
-
-# Coverage
-add_compile_options(
-  "$<$<CONFIG:COVERAGE>:-coverage;-fkeep-static-functions;-O1>")
-add_compile_definitions("$<$<CONFIG:COVERAGE>:__NO_ABORT>")
-
-# Address Sanitizer
-add_compile_options(
-  "$<$<CONFIG:ASAN>:-fsanitize=address;-no-pie;-O3;-funroll-loops>")
-add_link_options("$<$<CONFIG:ASAN>:-fsanitize=address>")
-
 # =========================== Intel oneAPI Compilers ===========================
 
 # Baseline
@@ -192,7 +170,6 @@ endif()
 if(CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
   set(CMAKE_Fortran_MODOUT_FLAG "-ef") # override to get lower-case module file
                                        # names
-  set(CMAKE_EXE_LINKER_FLAGS_COVERAGE "-lgcov") # Apple's Clang needs an extra
 endif()
 
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "Cray")

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -773,7 +773,7 @@ if [[ "${TEST_COVERAGE}" == "yes" ]]; then
   CP2K_BUILD_TYPE="RelWithDebInfo"
   CMAKE_PRESET="coverage"
   RUN_TEST="yes"
-  TESTOPTS+=" --ompthreads=1"
+  TESTOPTS+=" --ompthreads=1 --keepalive"
 fi
 
 export BENCHMARK_PROFILE BUILD_DEPS BUILD_DEPS_ONLY BUILD_SHARED_LIBS CHECK_CONVENTIONS CMAKE_FEATURE_FLAGS \

--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -749,7 +749,8 @@ if [[ "${CHECK_CONVENTIONS}" == "yes" ]]; then
     echo ""
     CP2K_VERSION="psmp"
   fi
-  CP2K_BUILD_TYPE="Conventions"
+  CP2K_BUILD_TYPE="RelWithDebInfo"
+  CMAKE_PRESET="conventions"
   Fortran_COMPILER_LAUNCHER="${CP2K_ROOT}/tools/conventions/redirect_gfortran_output.py"
 else
   Fortran_COMPILER_LAUNCHER=""
@@ -769,9 +770,10 @@ if [[ "${TEST_COVERAGE}" == "yes" ]]; then
     echo -e "       Install the missing package and re-run the script\n"
     ${EXIT_CMD} 1
   fi
-  CP2K_BUILD_TYPE="Coverage"
+  CP2K_BUILD_TYPE="RelWithDebInfo"
+  CMAKE_PRESET="coverage"
   RUN_TEST="yes"
-  TESTOPTS+=" --ompthreads=1 --timeout 400"
+  TESTOPTS+=" --ompthreads=1"
 fi
 
 export BENCHMARK_PROFILE BUILD_DEPS BUILD_DEPS_ONLY BUILD_SHARED_LIBS CHECK_CONVENTIONS CMAKE_FEATURE_FLAGS \
@@ -963,7 +965,7 @@ esac
 
 # Check if a valid CMake build type is selected for CP2K
 case "${CP2K_BUILD_TYPE^}" in
-  Conventions | Coverage | Debug | Release | RelWithDebInfo)
+  Debug | Release | RelWithDebInfo)
     true
     ;;
   *)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1847,8 +1847,7 @@ target_link_libraries(
     cp2k_linalg_libs
     # Torch includes some LAPACK routines, but with floating-point exceptions.
     $<$<BOOL:${CP2K_USE_LIBTORCH}>:${TORCH_LIBRARIES}>
-    $<$<BOOL:${CP2K_USE_OPENPMD}>:openPMD::openPMD>
-    $<$<AND:$<CONFIG:COVERAGE>,$<Fortran_COMPILER_ID:GNU>>:gcov>)
+    $<$<BOOL:${CP2K_USE_OPENPMD}>:openPMD::openPMD>)
 
 set(CP2K_BUILD_INFO_FILE "${CMAKE_CURRENT_BINARY_DIR}/cp2k_build_info.h")
 file(
@@ -2152,10 +2151,7 @@ foreach(__app grid_miniapp grid_unittest dbm_miniapp)
            $<$<BOOL:${CP2K_USE_CUDA}>:${CMAKE_CUDA_INCLUDE_DIRECTORIES}>
            $<$<BOOL:${CP2K_USE_HIP}>:${CMAKE_HIP_INCLUDE_DIRECTORIES}>)
 
-  target_link_libraries(
-    ${__app}
-    PUBLIC cp2k_linalg_libs
-           $<$<AND:$<CONFIG:COVERAGE>,$<Fortran_COMPILER_ID:GNU>>:gcov> m)
+  target_link_libraries(${__app} PUBLIC cp2k_linalg_libs m)
 endforeach()
 
 # ##############################################################################

--- a/tools/docker/scripts/cmake_cp2k.sh
+++ b/tools/docker/scripts/cmake_cp2k.sh
@@ -198,9 +198,8 @@ elif [[ "${PROFILE}" == "toolchain_generic" ]] && [[ "${VERSION}" == "psmp" ]]; 
 
 elif [[ "${PROFILE}" == "toolchain_conventions" ]] && [[ "${VERSION}" == "psmp" ]]; then
   cmake \
-    --preset "native-gnu-x86_64" \
+    --preset "conventions" \
     -GNinja \
-    -DCMAKE_BUILD_TYPE="Conventions" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCMAKE_Fortran_COMPILER_LAUNCHER="redirect_gfortran_output.py" \
     -DCP2K_USE_EVERYTHING=ON \
@@ -213,9 +212,8 @@ elif [[ "${PROFILE}" == "toolchain_conventions" ]] && [[ "${VERSION}" == "psmp" 
 
 elif [[ "${PROFILE}" == "toolchain_coverage" ]] && [[ "${VERSION}" == "psmp" ]]; then
   cmake \
-    --preset "native-gnu-x86_64" \
+    --preset "coverage" \
     -GNinja \
-    -DCMAKE_BUILD_TYPE="Coverage" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \
@@ -229,9 +227,8 @@ elif [[ "${PROFILE}" == "toolchain_asan" ]] && [[ "${VERSION}" == "psmp" ]]; the
   # TODO Re-enable GREENX. It currently leads to a heap-buffer-overflow
   # in `greenx_refine_pade()` at greenx_interface.F:80.
   cmake \
-    --preset "native-gnu-x86_64" \
+    --preset "asan" \
     -GNinja \
-    -DCMAKE_BUILD_TYPE="ASAN" \
     -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
     -DCP2K_USE_EVERYTHING=ON \
     -DCP2K_USE_DLAF=OFF \

--- a/tools/docker/scripts/test_coverage.sh
+++ b/tools/docker/scripts/test_coverage.sh
@@ -25,7 +25,7 @@ rm -rf /var/lib/apt/lists/*
 
 echo -e "\n========== Running Regtests =========="
 cd /opt/cp2k || exit 1
-./tests/do_regtest.py --ompthreads=1 ./build/bin/ psmp
+./tests/do_regtest.py --ompthreads=1 --keepalive ./build/bin/ psmp
 
 # gcov gets stuck on some files...
 # Maybe related: https://bugs.launchpad.net/gcc-arm-embedded/+bug/1694644

--- a/tools/precommit/check_file_properties.py
+++ b/tools/precommit/check_file_properties.py
@@ -149,7 +149,11 @@ MIT_PATHS = ("src/grpp/",)
 def get_src_cmakelists_txt() -> str:
     return "\n".join(
         (CP2K_DIR / fn).read_text(encoding="utf8")
-        for fn in ["src/CMakeLists.txt", "cmake/CompilerConfiguration.cmake"]
+        for fn in [
+            "src/CMakeLists.txt",
+            "cmake/CompilerConfiguration.cmake",
+            "CMakePresets.json",
+        ]
     )
 
 
@@ -297,7 +301,7 @@ def check_file(path: pathlib.Path) -> List[str]:
             continue
         if flag not in get_src_cmakelists_txt():
             warnings += [
-                f"{path}: Flag '{flag}' not mentioned in src/CMakeLists.txt nor cmake/CompilerConfiguration.cmake"
+                f"{path}: Flag '{flag}' not mentioned in src/CMakeLists.txt, cmake/CompilerConfiguration.cmake, or CMakePresets.json"
             ]
         if flag not in get_flags_src():
             warnings += [f"{path}: Flag '{flag}' not mentioned in cp2k_flags()"]


### PR DESCRIPTION
Closes #5781.

This is a patch I've prepared long time ago but forgot to push.