### PR TITLE
Fix k-point DIIS group reduction

### DIFF
--- a/src/qs_diis.F
+++ b/src/qs_diis.F
@@ -1109,10 +1109,10 @@ CONTAINS
 !> \param nkp_local ...
 !> \param nmixing ...
 !> \param scf_section ...
-!> \param para_env ...
+!> \param para_env_inter_kp communicator connecting the k-point groups
 ! **************************************************************************************************
    SUBROUTINE qs_diis_b_step_kp(diis_buffer, coeffs, ib, nb, delta, error_max, diis_step, eps_diis, &
-                                nspin, nkp, nkp_local, nmixing, scf_section, para_env)
+                                nspin, nkp, nkp_local, nmixing, scf_section, para_env_inter_kp)
 
       TYPE(qs_diis_buffer_type_kp), POINTER              :: diis_buffer
       COMPLEX(KIND=dp), DIMENSION(:), INTENT(INOUT)      :: coeffs
@@ -1124,7 +1124,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: nspin, nkp, nkp_local
       INTEGER, INTENT(IN), OPTIONAL                      :: nmixing
       TYPE(section_vals_type), POINTER                   :: scf_section
-      TYPE(mp_para_env_type), POINTER                    :: para_env
+      TYPE(mp_para_env_type), POINTER                    :: para_env_inter_kp
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'qs_diis_b_step_kp'
       REAL(KIND=dp), PARAMETER :: eigenvalue_threshold = 1.0E-12_dp
@@ -1185,7 +1185,10 @@ CONTAINS
       CALL cp_fm_release(ierr)
       CALL cp_fm_release(rerr)
       CALL cp_cfm_release(old_errors)
-      CALL para_env%sum(b)
+      ! cp_cfm_trace has already reduced each trace over the ranks of its
+      ! k-point group. Reduce the group contributions only once, over the
+      ! communicator that connects the k-point groups.
+      CALL para_env_inter_kp%sum(b)
 
       error_max = SQRT(REAL(b(ib, ib))**2 + AIMAG(b(ib, ib))**2)
 

--- a/src/qs_scf_diagonalization.F
+++ b/src/qs_scf_diagonalization.F
@@ -685,7 +685,7 @@ CONTAINS
       TYPE(dbcsr_type), POINTER                          :: cmatrix, rmatrix, tmpmat
       TYPE(kpoint_env_type), POINTER                     :: kp
       TYPE(kpoint_operator_context_type)                 :: op_ctx
-      TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_global
+      TYPE(mp_para_env_type), POINTER                    :: para_env
       TYPE(neighbor_list_set_p_type), DIMENSION(:), &
          POINTER                                         :: sab_nl
       TYPE(qs_matrix_pools_type), POINTER                :: mpools
@@ -956,7 +956,6 @@ CONTAINS
 
       ! Finish communication then diagonalise in each group
       IF (do_diis) THEN
-         CALL get_qs_env(qs_env, para_env=para_env_global)
          scf_section => section_vals_get_subs_vals(qs_env%input, "DFT%SCF")
          cdiis_ncall = kpoints%scf_diis_buffer%ncall
          CALL qs_diis_b_info_kp(kpoints%scf_diis_buffer, ib, nb)
@@ -998,7 +997,7 @@ CONTAINS
          CALL qs_diis_b_step_kp(kpoints%scf_diis_buffer, coeffs, ib, nb, scf_env%iter_delta, diis_error, &
                                 cdiis_step, scf_control%eps_diis, nspin, nkp, kplocal, &
                                 MERGE(2, scf_control%nmixing, use_adiis), &
-                                scf_section, para_env_global)
+                                scf_section, kpoints%para_env_inter_kp)
          diis_weight = 1.0_dp
          IF (use_adiis) THEN
             diis_weight = scf_env%scf_subspace_buffer%diis_weight
@@ -1281,11 +1280,10 @@ CONTAINS
          DIMENSION(:)                                    :: workspace
       TYPE(kp_transform_plan_type)                       :: transform_plan
       TYPE(kpoint_env_type), POINTER                     :: kp
-      TYPE(mp_para_env_type), POINTER                    :: para_env_global
       TYPE(section_vals_type), POINTER                   :: scf_section
 
       CALL timeset(routineN, handle)
-      NULLIFY (matrix_struct, mo_struct, mo_coeff, kp, para_env_global, scf_section)
+      NULLIFY (matrix_struct, mo_struct, mo_coeff, kp, scf_section)
 
       kplocal = SIZE(xkp, 2)
       nspin = SIZE(matrix_ks, 1)
@@ -1302,7 +1300,6 @@ CONTAINS
                                     matrix_ks(1, 1)%matrix)
 
       IF (do_diis) THEN
-         CALL get_qs_env(qs_env, para_env=para_env_global)
          scf_section => section_vals_get_subs_vals(qs_env%input, "DFT%SCF")
          cdiis_ncall = kpoints%scf_diis_buffer%ncall
          CALL qs_diis_b_info_kp(kpoints%scf_diis_buffer, ib, nb)
@@ -1324,7 +1321,7 @@ CONTAINS
          CALL qs_diis_b_step_kp(kpoints%scf_diis_buffer, coeffs, ib, nb, scf_env%iter_delta, diis_error, &
                                 cdiis_step, scf_control%eps_diis, nspin, kplocal, kplocal, &
                                 MERGE(2, scf_control%nmixing, use_adiis), &
-                                scf_section, para_env_global)
+                                scf_section, kpoints%para_env_inter_kp)
          diis_weight = 1.0_dp
          IF (use_adiis) THEN
             diis_weight = scf_env%scf_subspace_buffer%diis_weight


### PR DESCRIPTION
`cp_cfm_trace` already sums the contributions from all MPI ranks in a k-point group. The following sum must therefore combine the results from different k-point groups, rather than summing over all MPI ranks again. Using the global communicator counted the same group contribution once on every rank and could make the DIIS error matrix too large.