### PR TITLE
Remove duplicate and erroneous periodic RPA density initialization

### DIFF
--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -1059,8 +1059,6 @@ CONTAINS
 
             CALL dbcsr_reserve_all_blocks(mat_dm_global_work(jspin, i_img)%matrix)
 
-            CALL dbcsr_set(mat_dm_global_work(jspin, i_img)%matrix, 0.0_dp)
-
          END DO
 
       END DO

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -1059,7 +1059,7 @@ CONTAINS
 
             CALL dbcsr_reserve_all_blocks(mat_dm_global_work(jspin, i_img)%matrix)
 
-            CALL dbcsr_set(mat_dm_global_work(ispin, i_img)%matrix, 0.0_dp)
+            CALL dbcsr_set(mat_dm_global_work(jspin, i_img)%matrix, 0.0_dp)
 
          END DO
 


### PR DESCRIPTION
Fix the spin index used when initializing temporary density matrices in the periodic imaginary-time RPA path.
In `compute_transl_dm`, `mat_dm_global_work` is initialized by interating over `jspin`, but the matrix passed to `dbcsr_set` was indexed with `ispin`. This is a bug. 