### PR TITLE
Fix AO propagator dimensions for reduced MOs

### DIFF
--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -5445,7 +5445,7 @@ CONTAINS
 
       COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :)     :: delta_corr_omega
       INTEGER :: gw_lev_end, gw_lev_start, handle, handle3, i, iblk_mo, iquad, jquad, mo_end, &
-         mo_start, n_level_gw, n_level_gw_ref, nblk_mo, unit_nr_prv
+         mo_start, n_level_gw, n_level_gw_ref, nao, nblk_mo, unit_nr_prv
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: batch_range_mo, dist1, dist2, mo_bsizes, &
                                                             mo_offsets, sizes_AO, sizes_RI
       INTEGER, DIMENSION(2)                              :: mo_bounds, pdims_2d
@@ -5464,6 +5464,8 @@ CONTAINS
                                                             t_SinvVSinv, t_W
 
       CALL timeset(routineN, handle)
+
+      CALL cp_fm_get_info(fm_mo_coeff_occ, nrow_global=nao)
 
       CALL decompress_tensor(t_3c_overl_int_ao_mo, t_3c_O_mo_ind, t_3c_O_mo_compressed, &
                              mp2_env%ri_rpa_im_time%eps_compress)
@@ -5641,7 +5643,7 @@ CONTAINS
          CALL timeset(routineN//"_RI_HFX_operation_1", handle3)
 
          ! get density matrix
-         CALL parallel_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
+         CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
                             matrix_a=fm_mo_coeff_occ, matrix_b=fm_mo_coeff_occ, beta=0.0_dp, &
                             matrix_c=fm_scaled_dm_occ_tau)
 
@@ -6825,8 +6827,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function_time'
 
-      INTEGER                                            :: handle, i_global, iiB, jjB, ncol_local, &
-                                                            nrow_local
+      INTEGER                                            :: handle, i_global, iiB, jjB, nao, &
+                                                            ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: stabilize_exp
 
@@ -6836,6 +6838,7 @@ CONTAINS
 
       ! get info of fm_mo_coeff_occ
       CALL cp_fm_get_info(matrix=fm_mo_coeff_occ, &
+                          nrow_global=nao, &
                           nrow_local=nrow_local, &
                           ncol_local=ncol_local, &
                           row_indices=row_indices, &
@@ -6879,11 +6882,11 @@ CONTAINS
 
       CALL para_env%sync()
 
-      CALL parallel_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
+      CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
                          matrix_a=fm_mo_coeff_occ_scaled, matrix_b=fm_mo_coeff_occ_scaled, beta=0.0_dp, &
                          matrix_c=fm_scaled_dm_occ_tau)
 
-      CALL parallel_gemm(transa="N", transb="T", m=nmo, n=nmo, k=nmo, alpha=1.0_dp, &
+      CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
                          matrix_a=fm_mo_coeff_virt_scaled, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
                          matrix_c=fm_scaled_dm_virt_tau)
 

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -687,9 +687,8 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_mat_dm_global'
       REAL(KIND=dp), PARAMETER                           :: stabilize_exp = 70.0_dp
 
-      INTEGER                                            :: handle, i_global, iiB, iquad, jjB, &
-                                                            ncol_local, nrow_local, size_dm_occ, &
-                                                            size_dm_virt
+      INTEGER                                            :: handle, i_global, iiB, iquad, jjB, nao, &
+                                                            ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: tau
 
@@ -734,6 +733,7 @@ CONTAINS
 
          ! get info of fm_mo_coeff_occ
          CALL cp_fm_get_info(matrix=fm_mo_coeff_occ, &
+                             nrow_global=nao, &
                              nrow_local=nrow_local, &
                              ncol_local=ncol_local, &
                              row_indices=row_indices, &
@@ -784,14 +784,11 @@ CONTAINS
 
          CALL para_env%sync()
 
-         size_dm_occ = nmo
-         size_dm_virt = nmo
-
-         CALL parallel_gemm(transa="N", transb="T", m=size_dm_occ, n=size_dm_occ, k=nmo, alpha=1.0_dp, &
+         CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
                             matrix_a=fm_mo_coeff_occ_scaled, matrix_b=fm_mo_coeff_occ_scaled, beta=0.0_dp, &
                             matrix_c=fm_scaled_dm_occ_tau)
 
-         CALL parallel_gemm(transa="N", transb="T", m=size_dm_virt, n=size_dm_virt, k=nmo, alpha=1.0_dp, &
+         CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
                             matrix_a=fm_mo_coeff_virt_scaled, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
                             matrix_c=fm_scaled_dm_virt_tau)
 

--- a/src/rpa_util.F
+++ b/src/rpa_util.F
@@ -194,7 +194,7 @@ CONTAINS
 
       INTEGER                                            :: cell_grid_dm(3), first_ikp_local, &
                                                             handle, i_dim, i_kp, ispin, jquad, &
-                                                            nspins_P_omega, periodic(3)
+                                                            nao, nspins_P_omega, periodic(3)
       INTEGER, DIMENSION(:), POINTER                     :: row_blk_size
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: wkp_V
       TYPE(cell_type), POINTER                           :: cell
@@ -204,11 +204,19 @@ CONTAINS
 
       ALLOCATE (fm_mo_coeff_occ(nspins), fm_mo_coeff_virt(nspins))
 
-      CALL cp_fm_create(fm_scaled_dm_occ_tau, mo_coeff(1)%matrix_struct)
+      CALL cp_fm_get_info(mo_coeff(1), nrow_global=nao)
+      NULLIFY (fm_struct)
+      CALL cp_fm_struct_create(fm_struct, template_fmstruct=mo_coeff(1)%matrix_struct, &
+                               nrow_global=nao, ncol_global=nao)
+
+      ! The propagator is an AO matrix, even when the MO coefficient matrix is
+      ! rectangular because linearly dependent overlap states were removed.
+      CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_struct)
       CALL cp_fm_set_all(fm_scaled_dm_occ_tau, 0.0_dp)
 
-      CALL cp_fm_create(fm_scaled_dm_virt_tau, mo_coeff(1)%matrix_struct)
+      CALL cp_fm_create(fm_scaled_dm_virt_tau, fm_struct)
       CALL cp_fm_set_all(fm_scaled_dm_virt_tau, 0.0_dp)
+      CALL cp_fm_struct_release(fm_struct)
 
       DO ispin = 1, SIZE(mo_coeff)
          CALL create_occ_virt_mo_coeffs(fm_mo_coeff_occ(ispin), fm_mo_coeff_virt(ispin), mo_coeff(ispin), &
@@ -403,9 +411,11 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'create_occ_virt_mo_coeffs'
 
-      INTEGER                                            :: handle, icol_global, irow_global
+      INTEGER                                            :: handle, icol_global, irow_global, nao
 
       CALL timeset(routineN, handle)
+
+      CALL cp_fm_get_info(mo_coeff, nrow_global=nao)
 
       CALL cp_fm_create(fm_mo_coeff_occ, mo_coeff%matrix_struct)
       CALL cp_fm_set_all(fm_mo_coeff_occ, 0.0_dp)
@@ -413,7 +423,7 @@ CONTAINS
 
       ! set all virtual MO coeffs to zero
       DO icol_global = homo + 1, nmo
-         DO irow_global = 1, nmo
+         DO irow_global = 1, nao
             CALL cp_fm_set_element(fm_mo_coeff_occ, irow_global, icol_global, 0.0_dp)
          END DO
       END DO
@@ -424,7 +434,7 @@ CONTAINS
 
       ! set all occupied MO coeffs to zero
       DO icol_global = 1, homo
-         DO irow_global = 1, nmo
+         DO irow_global = 1, nao
             CALL cp_fm_set_element(fm_mo_coeff_virt, irow_global, icol_global, 0.0_dp)
          END DO
       END DO

--- a/tests/QS/regtest-gw-cubic/TEST_FILES.toml
+++ b/tests/QS/regtest-gw-cubic/TEST_FILES.toml
@@ -7,7 +7,7 @@
 "scGW0_and_evGW_H2O_PBE0_trunc_minimax.inp" = [{matcher="M011", tol=1e-08, ref=-17.108489005370274}]
 "scGW0_H2O_PBE0_trunc_minimax_RI_HFX.inp" = [{matcher="M011", tol=1e-08, ref=-13.191093644224157}]
 "G0W0_H2O_PBE_periodic.inp"             = [{matcher="E_G0W0_gap", tol=3e-04, ref=16.556}]
-"G0W0_H2O_PBE_cholesky_off.inp"         = [{matcher="E_G0W0_gap", tol=1e-04, ref=18.969}]
+"G0W0_H2O_PBE_cholesky_off.inp"         = [{matcher="E_G0W0_gap", tol=1e-04, ref=21.3771}]
 "G0W0_OH_PBE.inp"                       = [{matcher="E_G0W0_gap_beta", tol=1e-04, ref=11.794}]
 "G0W0_OH_PBE_svd.inp"                   = [{matcher="E_G0W0_gap_beta", tol=1e-04, ref=11.794}]
 "G0W0_OH_PBE_ADMM.inp"                  = [{matcher="E_G0W0_gap_beta", tol=1e-04, ref=11.488}]


### PR DESCRIPTION
When linearly dependent overlap states are removed with SVD/CHOLESKY OFF, the MO coefficient matrix has dimensions `nao × nmo` where nmo can be smaller than nao. The imaginary-time occupied and virtual propagators have dimensions `nao × nao`. The previous implementation used m=nmo, n=nmo, and k=nmo for these products. This was only valid under the historical assumption nmo == nao. In the current implemention, it could silently truncate the AO propagator.  This PR fixes this bug. 