### PR TITLE
Compute momentum matrix option in qs_moment_kpoints_deep

### DIFF
--- a/src/floquet_main.F
+++ b/src/floquet_main.F
@@ -28,8 +28,8 @@ MODULE floquet_main
                                               floquet_env_type
    USE floquet_utils,                   ONLY: &
         build_floquet_matrix, calculate_floquet_observables, check_floquet_convergence, &
-        compute_e_k_de_dk_dipole, distribute_floquet_kp_data, floquet_sector_weights, &
-        make_floquet_subgroups, write_floquet_header, write_floquet_results
+        compute_e_k_de_dk_offdiagonal_momentum, distribute_floquet_kp_data, &
+        floquet_sector_weights, make_floquet_subgroups, write_floquet_header, write_floquet_results
    USE kinds,                           ONLY: dp
    USE mathconstants,                   ONLY: z_zero
    USE message_passing,                 ONLY: mp_para_env_release,&
@@ -61,7 +61,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'floquet'
 
       COMPLEX(KIND=dp), ALLOCATABLE, &
-         DIMENSION(:, :, :, :, :)                        :: dipole
+         DIMENSION(:, :, :, :, :)                        :: offdiagonal_momentum
       INTEGER                                            :: handle, ikp, ispin, my_group, &
                                                             n_est_done, n_source_done, ngroups
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: group_distribution
@@ -99,7 +99,7 @@ CONTAINS
       !   k-derivatives    ∇_k ε_nk = C_n(k)^† ∇_k H(k) C_n(k) - ε_nk C_n(k)^† ∇_k S(k) C_n(k)
       !   dipoles          d_nm(k) = <ψ_nk| r |ψ_mk>
       ! Results are distributed across ranks (k-point ikp stored on rank MOD(ikp-1,num_pe)).
-      CALL compute_e_k_de_dk_dipole(qs_env, bs_env, e_k, de_dk, dipole)
+      CALL compute_e_k_de_dk_offdiagonal_momentum(qs_env, bs_env, e_k, de_dk, offdiagonal_momentum)
 
       ! Split the global communicator into Floquet subgroups (Hamiltonian distributed within each
       ! subgroup, k-points distributed across subgroups) and create the subgroup BLACS context.
@@ -124,7 +124,7 @@ CONTAINS
             ! Broadcast this k-point/spin's ε_nk, ∇_k ε_nk and d_nm(k) to every rank of the
             ! owning subgroup (its owner rank holds them from the distributed precompute above).
             CALL distribute_floquet_kp_data(para_env, para_env_sub, ispin, ikp, e_k, de_dk, &
-                                            dipole, floquet_env)
+                                            offdiagonal_momentum, floquet_env)
 
             ! Assemble H_F(k) in Sambe space (blocks m,m' = -M..M, each nao×nao)
             !  diagonal      (H_F)^{m,m}_{nn'}   = (ε_nk + m ħΩ) δ_{nn'}
@@ -180,7 +180,7 @@ CONTAINS
       ! respective files
       CALL write_floquet_results(bs_env, floquet_env)
 
-      DEALLOCATE (e_k, de_dk, dipole)
+      DEALLOCATE (e_k, de_dk, offdiagonal_momentum)
       DEALLOCATE (group_distribution)
       CALL floquet_env_release(floquet_env)
       CALL cp_cfm_release(floquet_matrix)

--- a/src/floquet_main.F
+++ b/src/floquet_main.F
@@ -95,9 +95,10 @@ CONTAINS
       CALL floquet_env_create(floquet_env, bs_env)
 
       ! Equilibrium band data at every band-structure k-point k from H(k)C(k) = S(k)C(k)ε(k):
-      !   band energies    ε_nk
-      !   k-derivatives    ∇_k ε_nk = C_n(k)^† ∇_k H(k) C_n(k) - ε_nk C_n(k)^† ∇_k S(k) C_n(k)
-      !   dipoles          d_nm(k) = <ψ_nk| r |ψ_mk>
+      !   band energies:   ε_nk
+      !   k-derivatives:   ∇_k ε_nk = C_n(k)^† ∇_k H(k) C_n(k) - ε_nk C_n(k)^† ∇_k S(k) C_n(k)
+      !   off-diagonal momentum matrix elements (n ≠ m):
+      !                    p_nm(k) = - (m/ħ) (ε_nk - ε_mk) <u_nk| ∇_k |u_mk>
       ! Results are distributed across ranks (k-point ikp stored on rank MOD(ikp-1,num_pe)).
       CALL compute_e_k_de_dk_offdiagonal_momentum(qs_env, bs_env, e_k, de_dk, offdiagonal_momentum)
 

--- a/src/floquet_types.F
+++ b/src/floquet_types.F
@@ -45,7 +45,7 @@ MODULE floquet_types
 !> \param m0_weights central-sector weight of each m=0 band (nao)
 !> \param e_k_kp_spin band energies for the current (k-point,spin) (nao)
 !> \param de_dk_kp_spin band-energy k-derivatives for the current (k-point,spin) (3, nao)
-!> \param dipole_kp_spin dipole matrix elements for the current (k-point,spin) (3, nao, nao)
+!> \param momentum_kp_spin momentum matrix elements for the current (k-point,spin) (3, nao, nao)
 !> \param all_quasi_energies quasi-energies for every (band, spin, bs k-point) (nao, n_spin, nkp_only_bs)
 !> \param all_a_k spectral function for every (energy, spin, bs k-point) (n_E, n_spin, nkp_only_bs)
 !> \param all_m0_energies m=0 band energies for every (band, spin, bs k-point) (nao, n_spin, nkp_only_bs)
@@ -62,7 +62,7 @@ MODULE floquet_types
                                                           quasi_energies, m0_energies, &
                                                           m0_weights, e_k_kp_spin
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)      :: de_dk_kp_spin
-      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :) :: dipole_kp_spin
+      COMPLEX(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :) :: momentum_kp_spin
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)   :: all_quasi_energies, all_a_k, &
                                                           all_m0_energies, all_m0_weights
    END TYPE floquet_env_type
@@ -103,7 +103,7 @@ CONTAINS
       ALLOCATE (floquet_env%quasi_energies(nao), floquet_env%m0_energies(nao), &
                 floquet_env%m0_weights(nao))
       ALLOCATE (floquet_env%e_k_kp_spin(nao), floquet_env%de_dk_kp_spin(3, nao), &
-                floquet_env%dipole_kp_spin(3, nao, nao))
+                floquet_env%momentum_kp_spin(3, nao, nao))
 
       ! per-(spin,k-point) accumulation arrays, filled once by the owning subgroup source and
       ! summed across the global communicator after the k-point loop
@@ -138,7 +138,7 @@ CONTAINS
       IF (ALLOCATED(floquet_env%m0_weights)) DEALLOCATE (floquet_env%m0_weights)
       IF (ALLOCATED(floquet_env%e_k_kp_spin)) DEALLOCATE (floquet_env%e_k_kp_spin)
       IF (ALLOCATED(floquet_env%de_dk_kp_spin)) DEALLOCATE (floquet_env%de_dk_kp_spin)
-      IF (ALLOCATED(floquet_env%dipole_kp_spin)) DEALLOCATE (floquet_env%dipole_kp_spin)
+      IF (ALLOCATED(floquet_env%momentum_kp_spin)) DEALLOCATE (floquet_env%momentum_kp_spin)
       IF (ALLOCATED(floquet_env%all_quasi_energies)) DEALLOCATE (floquet_env%all_quasi_energies)
       IF (ALLOCATED(floquet_env%all_a_k)) DEALLOCATE (floquet_env%all_a_k)
       IF (ALLOCATED(floquet_env%all_m0_energies)) DEALLOCATE (floquet_env%all_m0_energies)

--- a/src/floquet_utils.F
+++ b/src/floquet_utils.F
@@ -69,7 +69,7 @@ MODULE floquet_utils
 
    ! Public subroutines
    PUBLIC :: build_floquet_matrix, &
-             compute_e_k_de_dk_dipole, &
+             compute_e_k_de_dk_offdiagonal_momentum, &
              make_floquet_subgroups, &
              distribute_floquet_kp_data, &
              floquet_sector_weights, &
@@ -230,13 +230,13 @@ CONTAINS
 !> \brief Momentum matrix elements p_nm(k) for one k-point and one spin.
 !> \param e_k_kp_spin ...
 !> \param de_dk_kp_spin ...
-!> \param dipole_kp_spin ...
+!> \param momentum_kp_spin ...
 !> \param momentum ...
 ! **************************************************************************************************
-   SUBROUTINE build_momentum_matrix(e_k_kp_spin, de_dk_kp_spin, dipole_kp_spin, momentum)
+   SUBROUTINE build_momentum_matrix(e_k_kp_spin, de_dk_kp_spin, momentum_kp_spin, momentum)
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: e_k_kp_spin
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: de_dk_kp_spin
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(IN)   :: dipole_kp_spin
+      COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(IN)   :: momentum_kp_spin
       COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(OUT)  :: momentum
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_momentum_matrix'
@@ -253,7 +253,7 @@ CONTAINS
 
 !$OMP PARALLEL DEFAULT(NONE) &
 !$OMP PRIVATE(i_dir, i, j) &
-!$OMP SHARED(nao, momentum, dipole_kp_spin, e_k_kp_spin, de_dk_kp_spin)
+!$OMP SHARED(nao, momentum, momentum_kp_spin, e_k_kp_spin, de_dk_kp_spin)
 !$OMP DO COLLAPSE(3)
       DO i_dir = 1, 3
          DO i = 1, nao
@@ -261,8 +261,7 @@ CONTAINS
                IF (j == i) THEN
                   momentum(i_dir, i, j) = de_dk_kp_spin(i_dir, i)
                ELSE
-                  momentum(i_dir, i, j) = gaussi*(e_k_kp_spin(i) - e_k_kp_spin(j))* &
-                                          dipole_kp_spin(i_dir, i, j)
+                  momentum(i_dir, i, j) = momentum_kp_spin(i_dir, i, j)
                END IF
             END DO
          END DO
@@ -278,14 +277,14 @@ CONTAINS
 !> \param bs_env ...
 !> \param e_k_kp_spin ...
 !> \param de_dk_kp_spin ...
-!> \param dipole_kp_spin ...
+!> \param momentum_kp_spin ...
 !> \param off_diag_m ...
 ! **************************************************************************************************
-   SUBROUTINE build_off_diagonal_matrix(bs_env, e_k_kp_spin, de_dk_kp_spin, dipole_kp_spin, off_diag_m)
+   SUBROUTINE build_off_diagonal_matrix(bs_env, e_k_kp_spin, de_dk_kp_spin, momentum_kp_spin, off_diag_m)
       TYPE(post_scf_bandstructure_type), POINTER         :: bs_env
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: e_k_kp_spin
       REAL(KIND=dp), DIMENSION(:, :), INTENT(IN)         :: de_dk_kp_spin
-      COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(IN)   :: dipole_kp_spin
+      COMPLEX(KIND=dp), DIMENSION(:, :, :), INTENT(IN)   :: momentum_kp_spin
       COMPLEX(KIND=dp), DIMENSION(:, :), INTENT(OUT)     :: off_diag_m
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'build_off_diagonal_matrix'
@@ -313,7 +312,7 @@ CONTAINS
       omega = bs_env%floquet_omega
 
       ALLOCATE (momentum(3, nao, nao), source=z_zero)
-      CALL build_momentum_matrix(e_k_kp_spin, de_dk_kp_spin, dipole_kp_spin, momentum)
+      CALL build_momentum_matrix(e_k_kp_spin, de_dk_kp_spin, momentum_kp_spin, momentum)
 
       ! E_factor(α) = (i E(α) exp(i·φ(α)))/(2ω), where α = x,y,z
       DO i_dir = 1, 3
@@ -398,7 +397,7 @@ CONTAINS
       ALLOCATE (conj_off_diag_m(nao, nao), source=z_zero)
 
       CALL build_off_diagonal_matrix(bs_env, floquet_env%e_k_kp_spin, floquet_env%de_dk_kp_spin, &
-                                     floquet_env%dipole_kp_spin, off_diag_m)
+                                     floquet_env%momentum_kp_spin, off_diag_m)
       conj_off_diag_m(:, :) = CONJG(TRANSPOSE(off_diag_m(:, :)))
 
       floquet_matrix%local_data(:, :) = z_zero
@@ -425,17 +424,17 @@ CONTAINS
 !> \param ikp the DOS k-point index
 !> \param e_k band energies for all DOS k-points, distributed
 !> \param de_dk band-energy k-derivatives, distributed
-!> \param dipole dipole matrix elements, distributed
+!> \param offdiagonal_momentum offdiagonal momentum matrix elements, distributed
 !> \param floquet_env ...
 ! **************************************************************************************************
-   SUBROUTINE distribute_floquet_kp_data(para_env, para_env_sub, ispin, ikp, e_k, de_dk, dipole, &
+   SUBROUTINE distribute_floquet_kp_data(para_env, para_env_sub, ispin, ikp, e_k, de_dk, offdiagonal_momentum, &
                                          floquet_env)
       TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_sub
       INTEGER, INTENT(IN)                                :: ispin, ikp
       REAL(KIND=dp), DIMENSION(:, :, :), INTENT(IN)      :: e_k
       REAL(KIND=dp), DIMENSION(:, :, :, :), INTENT(IN)   :: de_dk
       COMPLEX(KIND=dp), DIMENSION(:, :, :, :, :), &
-         INTENT(IN)                                      :: dipole
+         INTENT(IN)                                      :: offdiagonal_momentum
       TYPE(floquet_env_type), INTENT(INOUT)              :: floquet_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'distribute_floquet_kp_data'
@@ -457,11 +456,11 @@ CONTAINS
          loc_idx = CEILING(REAL(ikp)/para_env%num_pe)
          floquet_env%e_k_kp_spin(:) = e_k(ispin, loc_idx, :)
          floquet_env%de_dk_kp_spin(:, :) = de_dk(ispin, loc_idx, :, :)
-         floquet_env%dipole_kp_spin(:, :, :) = dipole(ispin, loc_idx, :, :, :)
+         floquet_env%momentum_kp_spin(:, :, :) = offdiagonal_momentum(ispin, loc_idx, :, :, :)
       END IF
       CALL para_env_sub%bcast(floquet_env%e_k_kp_spin, local_src)
       CALL para_env_sub%bcast(floquet_env%de_dk_kp_spin, local_src)
-      CALL para_env_sub%bcast(floquet_env%dipole_kp_spin, local_src)
+      CALL para_env_sub%bcast(floquet_env%momentum_kp_spin, local_src)
 
       CALL timestop(handle)
 
@@ -474,9 +473,9 @@ CONTAINS
 !> \param bs_env ...
 !> \param e_k ...
 !> \param de_dk ...
-!> \param dipole ...
+!> \param offdiagonal_momentum ...
 ! **************************************************************************************************
-   SUBROUTINE compute_e_k_de_dk_dipole(qs_env, bs_env, e_k, de_dk, dipole)
+   SUBROUTINE compute_e_k_de_dk_offdiagonal_momentum(qs_env, bs_env, e_k, de_dk, offdiagonal_momentum)
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(post_scf_bandstructure_type), POINTER         :: bs_env
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :), &
@@ -484,9 +483,9 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, &
          DIMENSION(:, :, :, :), INTENT(OUT)              :: de_dk
       COMPLEX(KIND=dp), ALLOCATABLE, &
-         DIMENSION(:, :, :, :, :), INTENT(OUT)           :: dipole
+         DIMENSION(:, :, :, :, :), INTENT(OUT)           :: offdiagonal_momentum
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_e_k_de_dk_dipole'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_e_k_de_dk_offdiagonal_momentum'
 
       INTEGER                                            :: handle, ikp, nkp_only_bs, nkp_start
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :)        :: xkp_all
@@ -508,12 +507,12 @@ CONTAINS
       ! One k-point per rank, round-robin by global rank
       ! So the results for ikp are stored in mepos==MOD(ikp-1,num_pe)
       CALL calculate_epsilon_derivative(qs_env, xkp_all, e_k=e_k, de_dk=de_dk, do_parallel=.TRUE.)
-      CALL qs_moment_kpoints_deep(qs_env, xkp_all, dipole, do_parallel=.TRUE.)
+      CALL qs_moment_kpoints_deep(qs_env, xkp_all, offdiagonal_momentum, do_parallel=.TRUE., compute_momentum=.TRUE.)
 
       DEALLOCATE (xkp_all)
 
       CALL timestop(handle)
-   END SUBROUTINE compute_e_k_de_dk_dipole
+   END SUBROUTINE compute_e_k_de_dk_offdiagonal_momentum
 
 ! **************************************************************************************************
 !> \brief Finds the number of MPI ranks that share a physical node, determined by splitting the

--- a/src/qs_moments.F
+++ b/src/qs_moments.F
@@ -2964,12 +2964,14 @@ CONTAINS
 !> \param berry_c berry curvature calculated using Ω^γ_n = Σ_m 2*Im[d^α_nm (d^β_mn)*]
 !> \param do_parallel option to distribute the result in dipole across
 !>        different MPI ranks
+!> \param compute_momentum option to calculate the momentum matrix elements
+!>        instead of the dipole matrix elements
 !> \author Shridhar Shanbhag
 ! **************************************************************************************************
-   SUBROUTINE qs_moment_kpoints_deep(qs_env, xkp, dipole, rcc, berry_c, do_parallel)
+   SUBROUTINE qs_moment_kpoints_deep(qs_env, xkp, dipole, rcc, berry_c, do_parallel, compute_momentum)
       TYPE(qs_environment_type), POINTER                 :: qs_env
-      LOGICAL, OPTIONAL                                  :: do_parallel
-      LOGICAL                                            :: my_do_parallel, calc_bc
+      LOGICAL, OPTIONAL                                  :: do_parallel, compute_momentum
+      LOGICAL                                            :: my_do_parallel, my_compute_momentum, calc_bc
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'qs_moment_kpoints_deep'
       COMPLEX(KIND=dp)                                   :: phase, tmp_max
       COMPLEX(KIND=dp), DIMENSION(:, :), ALLOCATABLE     :: C_k, H_k, S_k, D_k, CDC, C_dH_C, &
@@ -3006,8 +3008,10 @@ CONTAINS
       CALL timeset(routineN, handle)
       calc_bc = PRESENT(berry_c)
       my_do_parallel = .FALSE.
+      my_compute_momentum = .FALSE.
       my_rcc = 0.0_dp
       IF (PRESENT(do_parallel)) my_do_parallel = do_parallel
+      IF (PRESENT(compute_momentum)) my_compute_momentum = compute_momentum
       IF (PRESENT(rcc)) my_rcc = rcc
 
       CALL get_qs_env(qs_env, &
@@ -3063,7 +3067,7 @@ CONTAINS
 !$OMP PARALLEL DEFAULT(NONE) PRIVATE(ikp, S_k, H_k, eigenvals, C_k, ispin, n, m, &
 !$OMP i_dir, dS_dk_i, dH_dk_i, D_k, dip, bc, C_dS_C, C_dH_C, CDC, tmp_max, phase) &
 !$OMP SHARED(num_pe, mepos, dipole, berry_c, nao, nspin, periodic, &
-!$OMP nkp, xkp, S_rs, H_rs, D_rs, index_to_cell_all, hmat, calc_bc)
+!$OMP nkp, xkp, S_rs, H_rs, D_rs, index_to_cell_all, hmat, my_compute_momentum, calc_bc)
       ALLOCATE (dS_dk_i(nao, nao), C_dS_C(nao, nao), dH_dk_i(nao, nao), C_dH_C(nao, nao), source=z_zero)
       ALLOCATE (CDC(nao, nao), dip(3, nao, nao), S_k(nao, nao), H_k(nao, nao), source=z_zero)
       ALLOCATE (C_k(nao, nao), D_k(nao, nao), source=z_zero)
@@ -3121,6 +3125,11 @@ CONTAINS
                      dip(i_dir, n, m) = -gaussi*C_dH_C(n, m)/(eigenvals(n) - eigenvals(m)) &
                                         + gaussi*eigenvals(n)*C_dS_C(n, m)/(eigenvals(n) - eigenvals(m)) &
                                         + CDC(n, m)
+                     ! dip now contains momentum matrix elements instead
+                     IF (my_compute_momentum) THEN
+                        dip(i_dir, n, m) = C_dH_C(n, m) - eigenvals(n)*C_dS_C(n, m) &
+                                           + gaussi*CDC(n, m)*(eigenvals(n) - eigenvals(m))
+                     END IF
                   END DO
                END DO
             END DO
@@ -3138,7 +3147,7 @@ CONTAINS
                   END DO
                END DO
             END IF
-            ! Store the dipoles and berry curvature for each MPI rank
+            ! Store the dipoles (or momentum if compute_momentum == .TRUE.) and berry curvature for each MPI rank
             dipole(ispin, CEILING(REAL(ikp)/num_pe), :, :, :) = dip(:, :, :)
             IF (calc_bc) berry_c(ispin, CEILING(REAL(ikp)/num_pe), :, :) = bc(:, :)
          END DO


### PR DESCRIPTION
Changed qs_moment_kpoints_deep to include a flag that allows to calculate off diagonal momentum matrix elements directly instead of the dipole matrix elements. Updated Floquet files to use this feature.