### PR TITLE
Patch GROMACS to request MPI_THREAD_MULTIPLE for CP2K QM/MM builds

### DIFF
--- a/make_cp2k.sh
+++ b/make_cp2k.sh
@@ -2044,6 +2044,12 @@ if [[ -n "${GROMACS_VERSION}" ]]; then
   cd "${GROMACS_ROOT}" || ${EXIT_CMD} 1
   GROMACS_REVISION="$(git rev-parse --short HEAD)"
 
+  # GROMACS always requests MPI_THREAD_FUNNELED regardless of GMX_MPI/GMX_THREAD_MPI,
+  # but CP2K now requires MPI_THREAD_MULTIPLE when attaching to an already-initialized
+  # MPI environment
+  sed -E -e 's/MPI_Init_thread\(argc, argv, MPI_THREAD_FUNNELED,/MPI_Init_thread(argc, argv, MPI_THREAD_MULTIPLE,/' \
+    -i src/gromacs/utility/init.cpp
+
   # CMake configuration step for GROMACS
   GROMACS_BUILD_PATH="${GROMACS_ROOT}"/build
   mkdir -p "${GROMACS_BUILD_PATH}"


### PR DESCRIPTION
CP2K's MPI wrapper now requires MPI_THREAD_MULTIPLE when attaching to an MPI environment initialized by an embedding application (cp2k/cp2k#5811, #5817), but GROMACS's own gmx::init() always requests MPI_THREAD_FUNNELED which causes an error.

(see also [this GROMACS request](https://gitlab.com/gromacs/gromacs/-/merge_requests/6204))