### PR TITLE
Skip unused spatial derivatives in Skala forward interpolation

### DIFF
--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -1298,7 +1298,7 @@ CONTAINS
                                     grid_atom, harmonics, cross_displacement, cross_cutoff, nspins, &
                                     rho_h, rho_s, drho_h, drho_s, tau_h, tau_s, &
                                     cross_density, cross_grad, cross_kin, cross_density_spatial, &
-                                    cross_grad_spatial, cross_kin_spatial)
+                                    cross_grad_spatial, cross_kin_spatial, calculate_spatial=.FALSE.)
                                  IF (lsd) THEN
                                     IF (use_atom_composite_density) THEN
                                        composite_cross_density(composite_row, 1:2) = &
@@ -3723,10 +3723,11 @@ CONTAINS
 !> \param density_spatial Cartesian derivatives of density
 !> \param gradient_spatial Cartesian derivatives of the density gradient
 !> \param kin_spatial Cartesian derivatives of the kinetic-energy density
+!> \param calculate_spatial evaluate spatial derivatives (default true), otherwise return zeros
 ! **************************************************************************************************
    SUBROUTINE interpolate_gapw_atom_grid_fields( &
       grid_atom, harmonics, displacement, cutoff, nspins, rho_h, rho_s, drho_h, drho_s, &
-      tau_h, tau_s, density, gradient, kin, density_spatial, gradient_spatial, kin_spatial)
+      tau_h, tau_s, density, gradient, kin, density_spatial, gradient_spatial, kin_spatial, calculate_spatial)
       TYPE(grid_atom_type), POINTER                      :: grid_atom
       TYPE(harmonics_atom_type), POINTER                 :: harmonics
       REAL(dp), DIMENSION(3), INTENT(IN)                 :: displacement
@@ -3741,10 +3742,11 @@ CONTAINS
       REAL(dp), DIMENSION(3, 2), INTENT(OUT)             :: density_spatial
       REAL(dp), DIMENSION(3, 3, 2), INTENT(OUT)          :: gradient_spatial
       REAL(dp), DIMENSION(3, 2), INTENT(OUT)             :: kin_spatial
+      LOGICAL, INTENT(IN), OPTIONAL                      :: calculate_spatial
 
       INTEGER                                            :: ia, idir, inode, ir, ispin, jdir, nradial
       INTEGER, DIMENSION(4)                              :: radial_indices
-      LOGICAL                                            :: active
+      LOGICAL                                            :: active, need_spatial
       REAL(dp)                                           :: derivative_weight, weight
       REAL(dp), DIMENSION(grid_atom%ng_sphere)           :: angular_weights
       REAL(dp), DIMENSION(4)                             :: radial_derivative_weights, radial_weights
@@ -3756,9 +3758,17 @@ CONTAINS
       density_spatial = 0.0_dp
       gradient_spatial = 0.0_dp
       kin_spatial = 0.0_dp
-      CALL atom_grid_interpolation_weights( &
-         grid_atom, harmonics, displacement, cutoff, radial_indices, radial_weights, &
-         radial_derivative_weights, nradial, angular_weights, angular_derivative_weights, active)
+      need_spatial = .TRUE.
+      IF (PRESENT(calculate_spatial)) need_spatial = calculate_spatial
+      IF (need_spatial) THEN
+         CALL atom_grid_interpolation_weights( &
+            grid_atom, harmonics, displacement, cutoff, radial_indices, radial_weights, &
+            radial_derivative_weights, nradial, angular_weights, angular_derivative_weights, active)
+      ELSE
+         CALL atom_grid_interpolation_weights( &
+            grid_atom, harmonics, displacement, cutoff, radial_indices, radial_weights, &
+            nradial=nradial, angular_weights=angular_weights, active=active)
+      END IF
       IF (active) THEN
          DO inode = 1, nradial
             ir = radial_indices(inode)
@@ -3773,6 +3783,7 @@ CONTAINS
                      gradient(idir, ispin) = gradient(idir, ispin) + &
                                              weight*(drho_h(idir, ia, ir, ispin) - &
                                                      drho_s(idir, ia, ir, ispin))
+                     IF (.NOT. need_spatial) CYCLE
                      derivative_weight = radial_derivative_weights(inode)* &
                                          displacement(idir)/SQRT(SUM(displacement**2))* &
                                          angular_weights(ia) + radial_weights(inode)* &

--- a/tools/regtesting/check_gapw_atom_adjoint.py
+++ b/tools/regtesting/check_gapw_atom_adjoint.py
@@ -96,6 +96,8 @@ def caller_loop(source, parallel):
     region = source[start:end]
     start = region.rindex("cross_cutoff = gapw_atom_grid_support_radius(")
     region = region[start:]
+    if parallel is None:
+        parallel = "!$OMP PARALLEL" in region
     if parallel:
         start = region.index("!$OMP PARALLEL")
         end = region.index("!$OMP END PARALLEL") + len("!$OMP END PARALLEL")
@@ -112,7 +114,7 @@ def main():
     parser.add_argument(
         "--baseline",
         required=True,
-        help="Unmodified Git revision containing the serial adjoint",
+        help="Unmodified Git revision containing the serial or parallel adjoint",
     )
     parser.add_argument(
         "--check", action="store_true", help="Bounds/FPE checks, no timing"
@@ -132,7 +134,7 @@ def main():
         "interpolate_gapw_atom_grid_fields",
         "add_gapw_atom_grid_interpolation_adjoint",
     ]
-    old_loop, new_loop = caller_loop(baseline, False), caller_loop(patched, True)
+    old_loop, new_loop = caller_loop(baseline, None), caller_loop(patched, True)
     sources = []
     for name, source, loop in [
         ("original", baseline, old_loop),
@@ -232,7 +234,7 @@ def main():
         "generated_sources_sha256": {
             p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in sources
         },
-        "scope": "Extracted production kernels and exact caller loop, real CP2K types/harmonics; no SCF/model test",
+        "scope": "Extracted forward/adjoint kernels and exact caller loop, real CP2K types/harmonics; no SCF/model test",
     }
     (
         work / ("checked-results.json" if args.check else "benchmark-results.json")

--- a/tools/regtesting/gapw_atom_adjoint_fixture.F90
+++ b/tools/regtesting/gapw_atom_adjoint_fixture.F90
@@ -19,7 +19,8 @@ PROGRAM gapw_atom_adjoint_fixture
    USE qs_harmonics_atom,               ONLY: harmonics_atom_type
    USE screened_kernel,                 ONLY: screened_project => project
    USE spherical_harmonics,             ONLY: y_lm
-   USE values_only_kernel,              ONLY: new_weights => atom_grid_interpolation_weights,&
+   USE values_only_kernel,              ONLY: new_fields => interpolate_gapw_atom_grid_fields,&
+                                              new_weights => atom_grid_interpolation_weights,&
                                               value_project => project
 
    IMPLICIT NONE
@@ -61,6 +62,7 @@ PROGRAM gapw_atom_adjoint_fixture
    CALL make_grid(7, 5, 4)
    DO ns = 1, 2
       CALL allocate_potentials()
+      CALL check_forward_fields(.FALSE.)
       CALL check_transpose()
       DO periodic = 0, 2
          CALL make_cell(periodic)
@@ -105,6 +107,7 @@ PROGRAM gapw_atom_adjoint_fixture
    ns = 2
    flags = .TRUE.
    CALL allocate_potentials()
+   CALL check_forward_fields(.TRUE.)
    WRITE (*, '(A,I0,A)') 'BENCHMARK: 150 radial x 770 Lebedev, lmax=6, two spins, ', np, ' rows; best of three seconds'
    WRITE (*, '(A,F8.3,A)') 'Private reduction storage per thread: ', REAL(20*150*770*8, dp)/1024**2, ' MiB'
    DO variant = 1, 4
@@ -127,6 +130,88 @@ PROGRAM gapw_atom_adjoint_fixture
       END DO
    END DO
 CONTAINS
+   SUBROUTINE check_forward_fields(benchmark)
+      LOGICAL, INTENT(IN)                                :: benchmark
+
+      INTEGER                                            :: axis, ia, ir, p, pair, pass, repeats, s, &
+                                                            variant
+      REAL(dp) :: begin, checksum(2), d(2), displacement(3), dm1(2), dn(2), dp1(2), &
+         drho(3, grid%ng_sphere, grid%nr, ns), ds(3, 2), dsn(3, 2), &
+         dsoft(3, grid%ng_sphere, grid%nr, ns), elapsed(2), fd_error, g(3, 2), gm1(3, 2), &
+         gn(3, 2), gp1(3, 2), gs2(3, 3, 2), gsn(3, 3, 2), h, normalization, &
+         rho(grid%ng_sphere, grid%nr, ns), soft(grid%ng_sphere, grid%nr, ns), t(2), &
+         tau(grid%ng_sphere, grid%nr, ns), tm1(2), tn(2), tp1(2), ts2(3, 2), tsn(3, 2), &
+         tsoft(grid%ng_sphere, grid%nr, ns), x(3)
+
+      DO s = 1, ns
+         DO ir = 1, grid%nr
+            DO ia = 1, grid%ng_sphere
+               rho(ia, ir, s) = SIN(REAL(ia + ir + s, dp))
+               soft(ia, ir, s) = COS(REAL(ia - ir + s, dp))
+               drho(:, ia, ir, s) = rho(ia, ir, s)*[0.3_dp, -0.2_dp, 0.7_dp]
+               dsoft(:, ia, ir, s) = soft(ia, ir, s)*[-0.7_dp, 0.4_dp, 0.1_dp]
+            END DO
+         END DO
+      END DO
+      tau = 0.4_dp*rho
+      tsoft = 0.7_dp*soft
+      DO p = 0, 105
+         x = REAL(p, dp)*0.05_dp*[2.0_dp, 3.0_dp, 6.0_dp]/7.0_dp
+         CALL old_fields(grid, harmonics, x, 5.0_dp, ns, rho, soft, drho, dsoft, tau, tsoft, d, g, t, ds, gs2, ts2)
+         CALL new_fields(grid, harmonics, x, 5.0_dp, ns, rho, soft, drho, dsoft, tau, tsoft, dn, gn, tn, dsn, gsn, tsn)
+         IF (ANY(d /= dn) .OR. ANY(g /= gn) .OR. ANY(t /= tn)) ERROR STOP 'Forward values differ'
+         IF (ANY(ds /= dsn) .OR. ANY(gs2 /= gsn) .OR. ANY(ts2 /= tsn)) ERROR STOP 'Forward derivatives differ'
+         CALL new_fields(grid, harmonics, x, 5.0_dp, ns, rho, soft, drho, dsoft, tau, tsoft, &
+                         dn, gn, tn, dsn, gsn, tsn, calculate_spatial=.FALSE.)
+         IF (ANY(d /= dn) .OR. ANY(g /= gn) .OR. ANY(t /= tn)) ERROR STOP 'Value-only forward differs'
+         IF (ANY(dsn /= 0) .OR. ANY(gsn /= 0) .OR. ANY(tsn /= 0)) ERROR STOP 'Unused derivatives not zero'
+      END DO
+      WRITE (*, '(A,I0)') 'PASS: forward rho/gradient/tau and retained force derivatives are bitwise identical; spins=', ns
+      x = [0.9_dp, -0.7_dp, 1.1_dp]
+      CALL new_fields(grid, harmonics, x, 5.0_dp, ns, rho, soft, drho, dsoft, tau, tsoft, d, g, t, ds, gs2, ts2)
+      normalization = MAX(1.0_dp, MAXVAL(ABS(ds)), MAXVAL(ABS(gs2)), MAXVAL(ABS(ts2)))
+      fd_error = 0.0_dp
+      DO axis = 1, 3
+         DO p = 1, 2
+            h = 1.0E-5_dp/REAL(p, dp)
+            displacement = x
+            displacement(axis) = x(axis) + h
+            CALL new_fields(grid, harmonics, displacement, 5.0_dp, ns, rho, soft, drho, dsoft, tau, tsoft, &
+                            dp1, gp1, tp1, dsn, gsn, tsn, calculate_spatial=.FALSE.)
+            displacement(axis) = x(axis) - h
+            CALL new_fields(grid, harmonics, displacement, 5.0_dp, ns, rho, soft, drho, dsoft, tau, tsoft, &
+                            dm1, gm1, tm1, dsn, gsn, tsn, calculate_spatial=.FALSE.)
+            fd_error = MAX(fd_error, MAXVAL(ABS((dp1 - dm1)/(2*h) - ds(axis, :)))/normalization, &
+                           MAXVAL(ABS((gp1 - gm1)/(2*h) - gs2(:, axis, :)))/normalization, &
+                           MAXVAL(ABS((tp1 - tm1)/(2*h) - ts2(axis, :)))/normalization)
+         END DO
+      END DO
+      IF (fd_error > 2.0E-7_dp) ERROR STOP 'Value-only forward spatial finite difference failed'
+      WRITE (*, '(A,ES12.4)') 'PASS: value-only forward spatial finite differences; max relative error=', fd_error
+      IF (.NOT. benchmark) RETURN
+      repeats = 10000
+      DO pair = 1, 5
+         checksum = 0.0_dp
+         DO pass = 1, 2
+            variant = MERGE(pass, 3 - pass, MOD(pair, 2) == 1)
+            begin = omp_get_wtime()
+            DO p = 1, repeats
+               x = [0.9_dp + REAL(MOD(p, 17), dp)*0.013_dp, -0.7_dp, 1.1_dp]
+               IF (variant == 1) THEN
+                  CALL old_fields(grid, harmonics, x, 5.0_dp, ns, rho, soft, drho, dsoft, tau, tsoft, d, g, t, ds, gs2, ts2)
+               ELSE
+                  CALL new_fields(grid, harmonics, x, 5.0_dp, ns, rho, soft, drho, dsoft, tau, tsoft, &
+                                  d, g, t, ds, gs2, ts2, calculate_spatial=.FALSE.)
+               END IF
+               checksum(variant) = checksum(variant) + SUM(d) + SUM(g) + SUM(t)
+            END DO
+            elapsed(variant) = omp_get_wtime() - begin
+         END DO
+         IF (checksum(1) /= checksum(2)) ERROR STOP 'Forward benchmark checksum differs'
+         WRITE (*, '(A,3F12.6)') 'FORWARD seconds full/values-only and speedup: ', elapsed, elapsed(1)/elapsed(2)
+      END DO
+   END SUBROUTINE
+
    SUBROUTINE make_grid(nr, lg, lmax)
       INTEGER, INTENT(IN)                                :: nr, lg, lmax
 


### PR DESCRIPTION
## Summary

Follow-up to #5991. Skip unused spatial interpolation derivatives in the forward
native Skala atom-composite reconstruction. The forward caller needs the density,
its gradient, and kinetic-energy density, but not their spatial derivatives.

- Add an optional `calculate_spatial` argument to the private
  `interpolate_gapw_atom_grid_fields` helper, defaulting to true.
- Select the existing value-only interpolation-weight path only for the forward
  SCF reconstruction. Retain all rho, gradient-rho and tau values.
- Leave the force/stress caller unchanged, including its complete derivative
  evaluation. No scientific input, threshold or grid is changed.
- Extend the extracted-kernel regression fixture to cover this path and accept
  either the older serial or current parallel adjoint as its baseline.

## Validation

The baseline is upstream master `5607b9319f`. The production helper source at
that revision matches the pinned `37aedacbb3` build used for the full-code probes.

- Exact equality of forward rho/gradient/tau and retained spatial derivatives
  for one/two spins and 106 sample points, including origin and support boundary.
- Value-only unused derivative outputs are exactly zero.
- Central finite differences of the retained spatial derivatives pass for rho,
  all gradient components and tau, three axes and two displacement sizes.
  Maximum scaled discrepancy is `2.05e-8` on the 150/770 release fixture.
- Existing adjoint identities, component masks, periodic/triclinic images,
  target ownership, empty-rank and OpenMP checks pass. GNU bounds/FPE checks pass.
- Repository precommit checks pass for all three changed files.

Separate complete CP2K `ENERGY_FORCE` probes were also run on an all-electron
urea molecule with identical input, the same converged WFN, a 200/974 grid and
16 OpenMP threads per probe. Each executable replaced only the complete
`qs_vxc_atom` object in the pinned `37aedacbb3` build. Both converged in one step
at a printed residual of `9e-8`, ended normally and returned exit status zero.
Total energies differ by `5.68e-14` hartree. The nine printed native Skala force
channels for all eight atoms differ by at most `2.36e-9` hartree/bohr.
Total atomic forces were not requested in the output, so this is a check of the
printed native force contributions, not an independent total-force comparison.
The full CP2K regression suite and a separate full-code stress test were not run.

Reproduce with a completed GNU/OpenMP CMake CP2K build:

```sh
python3 tools/regtesting/check_gapw_atom_adjoint.py \
  --build-dir <completed-build> --work-dir <scratch-check> \
  --baseline 5607b9319f --check
python3 tools/regtesting/check_gapw_atom_adjoint.py \
  --build-dir <completed-build> --work-dir <scratch-release> \
  --baseline 5607b9319f --rows 4000
```

## Performance

Five paired, alternating-order measurements of 10000 forward calls on real CP2K
150-radial/770-Lebedev grids, lmax=6 and two spins on an AMD EPYC host:

| Full derivatives (s) | Values only (s) | Speedup |
| ---: | ---: | ---: |
| 1.880 | 0.570 | 3.30 |
| 1.910 | 0.604 | 3.16 |
| 1.902 | 0.619 | 3.07 |
| 1.975 | 0.615 | 3.21 |
| 1.955 | 0.611 | 3.20 |

Median speedup is 3.20x for this forward interpolation routine, not for the full
SCF calculation. The benchmark verifies identical returned-value checksums.

This is specific to native Skala atom-composite reconstruction with one-centre
contributions. It does not change ordinary semilocal GAPW or smooth GPW paths.
Production runs and their pinned binaries were left untouched.
