### PR TITLE
Screen unsupported periodic images in native atom-grid reconstruction

### DIFF
--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -255,13 +255,14 @@ CONTAINS
 
       INTEGER :: adjoint_bin, adjoint_entry, adjoint_nbins, adjoint_nchannels, &
          adjoint_tile_count(3), adjoint_tile_lower(3), adjoint_tile_upper(3), &
-         atom_composite_components, base_shift(3), bo(2), composite_descriptor_target_image, &
+         atom_composite_components, bo(2), composite_descriptor_target_image, &
          composite_image_periodicity(3), composite_local_atom, composite_local_natom, &
          composite_nflat, composite_partition_target_image, composite_pw_nflat, composite_row, &
          gapw_density_partition, gapw_representation, handle, ia, iat, iatom, icomponent, idir, &
-         ikind, image_i1, image_i2, image_i3, image_shell(3), image_shift(3), ir, ispin, iw, jdir, &
-         myfun, na, natom, nr, nspins
-      INTEGER :: num_pe, source_atom, target_atom, xc_deriv_method_id, xc_rho_smooth_id, zatom
+         ikind, image_i1, image_i2, image_i3, image_lower(3), image_shell(3), image_shift(3), &
+         image_upper(3), ir, ispin, iw, jdir, myfun, na
+      INTEGER :: natom, nr, nspins, num_pe, source_atom, target_atom, xc_deriv_method_id, &
+         xc_rho_smooth_id, zatom
       INTEGER(KIND=int_8), ALLOCATABLE, DIMENSION(:)     :: composite_atomic_grid_sizes, &
                                                             composite_local_grid_sizes
       INTEGER, ALLOCATABLE, DIMENSION(:) :: adjoint_bin_offsets, adjoint_bin_rows, &
@@ -1258,7 +1259,7 @@ CONTAINS
                      END DO
 
 !$OMP PARALLEL DO DEFAULT(NONE) SCHEDULE(STATIC) &
-!$OMP PRIVATE(base_shift, composite_row, cross_density, cross_density_spatial, &
+!$OMP PRIVATE(image_lower, image_upper, composite_row, cross_density, cross_density_spatial, &
 !$OMP         cross_displacement, cross_grad, cross_grad_spatial, cross_kin, &
 !$OMP         cross_kin_spatial, fractional, idir, image_i1, image_i2, image_i3, jdir, &
 !$OMP         image_shift, image_translation, target_atom) &
@@ -1277,15 +1278,11 @@ CONTAINS
                                                   particle_set(source_atom)%r(jdir))
                            END DO
                         END DO
-                        DO idir = 1, 3
-                           base_shift(idir) = cell%perd(idir)*NINT(fractional(idir))
-                        END DO
-                        DO image_i3 = base_shift(3) - image_shell(3), &
-                           base_shift(3) + image_shell(3)
-                           DO image_i2 = base_shift(2) - image_shell(2), &
-                              base_shift(2) + image_shell(2)
-                              DO image_i1 = base_shift(1) - image_shell(1), &
-                                 base_shift(1) + image_shell(1)
+                        CALL atom_grid_image_bounds(cell, fractional, cross_cutoff, image_shell, &
+                                                    image_lower, image_upper)
+                        DO image_i3 = image_lower(3), image_upper(3)
+                           DO image_i2 = image_lower(2), image_upper(2)
+                              DO image_i1 = image_lower(1), image_upper(1)
                                  image_shift = [image_i1, image_i2, image_i3]
                                  IF (target_atom == source_atom .AND. &
                                      ALL(image_shift == 0)) CYCLE
@@ -1294,6 +1291,7 @@ CONTAINS
                                  cross_displacement = composite_grid_coords(:, composite_row) - &
                                                       particle_set(source_atom)%r - &
                                                       image_translation
+                                 IF (SQRT(SUM(cross_displacement**2)) > cross_cutoff) CYCLE
                                  CALL interpolate_gapw_atom_grid_fields( &
                                     grid_atom, harmonics, cross_displacement, cross_cutoff, nspins, &
                                     rho_h, rho_s, drho_h, drho_s, tau_h, tau_s, &
@@ -1701,7 +1699,7 @@ CONTAINS
                         END DO
 
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP PRIVATE(base_shift, composite_cross_force_local, composite_cross_image_virial_local, &
+!$OMP PRIVATE(image_lower, image_upper, composite_cross_force_local, composite_cross_image_virial_local, &
 !$OMP         composite_row, cross_density, cross_density_adjoint, cross_density_spatial, &
 !$OMP         cross_displacement, cross_grad, cross_grad_adjoint, cross_grad_spatial, &
 !$OMP         cross_kin, cross_kin_adjoint, cross_kin_spatial, cross_spatial_derivative, &
@@ -1763,15 +1761,11 @@ CONTAINS
                                                      particle_set(source_atom)%r(jdir))
                               END DO
                            END DO
-                           DO idir = 1, 3
-                              base_shift(idir) = cell%perd(idir)*NINT(fractional(idir))
-                           END DO
-                           DO image_i3 = base_shift(3) - image_shell(3), &
-                              base_shift(3) + image_shell(3)
-                              DO image_i2 = base_shift(2) - image_shell(2), &
-                                 base_shift(2) + image_shell(2)
-                                 DO image_i1 = base_shift(1) - image_shell(1), &
-                                    base_shift(1) + image_shell(1)
+                           CALL atom_grid_image_bounds(cell, fractional, cross_cutoff, image_shell, &
+                                                       image_lower, image_upper)
+                           DO image_i3 = image_lower(3), image_upper(3)
+                              DO image_i2 = image_lower(2), image_upper(2)
+                                 DO image_i1 = image_lower(1), image_upper(1)
                                     image_shift = [image_i1, image_i2, image_i3]
                                     IF (target_atom == source_atom .AND. &
                                         ALL(image_shift == 0)) CYCLE
@@ -1780,6 +1774,7 @@ CONTAINS
                                     cross_displacement = &
                                        composite_grid_coords(:, composite_row) - &
                                        particle_set(source_atom)%r - image_translation
+                                    IF (SQRT(SUM(cross_displacement**2)) > cross_cutoff) CYCLE
                                     CALL interpolate_gapw_atom_grid_fields( &
                                        grid_atom, harmonics, cross_displacement, cross_cutoff, &
                                        nspins, rho_h, rho_s, drho_h, drho_s, tau_h, tau_s, &
@@ -2229,7 +2224,7 @@ CONTAINS
                         ! Each thread accumulates its own one-center potentials; combine them
                         ! before the existing MPI reduction over target-atom owners.
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP PRIVATE(base_shift, composite_row, cross_density_adjoint, cross_displacement, &
+!$OMP PRIVATE(image_lower, image_upper, composite_row, cross_density_adjoint, cross_displacement, &
 !$OMP         cross_grad_adjoint, cross_kin_adjoint, fractional, idir, image_i1, &
 !$OMP         image_i2, image_i3, image_shift, image_translation, jdir, target_atom, &
 !$OMP         vxc_h_local, vxc_s_local, vxg_h_local, vxg_s_local, vtau_h_local, vtau_s_local) &
@@ -2293,15 +2288,11 @@ CONTAINS
                                                      particle_set(iatom)%r(jdir))
                               END DO
                            END DO
-                           DO idir = 1, 3
-                              base_shift(idir) = cell%perd(idir)*NINT(fractional(idir))
-                           END DO
-                           DO image_i3 = base_shift(3) - image_shell(3), &
-                              base_shift(3) + image_shell(3)
-                              DO image_i2 = base_shift(2) - image_shell(2), &
-                                 base_shift(2) + image_shell(2)
-                                 DO image_i1 = base_shift(1) - image_shell(1), &
-                                    base_shift(1) + image_shell(1)
+                           CALL atom_grid_image_bounds(cell, fractional, cross_cutoff, image_shell, &
+                                                       image_lower, image_upper)
+                           DO image_i3 = image_lower(3), image_upper(3)
+                              DO image_i2 = image_lower(2), image_upper(2)
+                                 DO image_i1 = image_lower(1), image_upper(1)
                                     image_shift = [image_i1, image_i2, image_i3]
                                     IF (target_atom == iatom .AND. ALL(image_shift == 0)) CYCLE
                                     image_translation = MATMUL( &
@@ -3464,6 +3455,40 @@ CONTAINS
       END DO
 
    END SUBROUTINE native_grid_lagrange_weights
+
+! **************************************************************************************************
+!> \brief Conservatively bound periodic images that can intersect a Cartesian support sphere.
+!> \param cell current cell and periodicity
+!> \param fractional target-minus-source displacement in lattice coordinates
+!> \param cutoff current, density-dependent Cartesian support radius
+!> \param image_shell original enclosing image shell
+!> \param lower inclusive lower image indices
+!> \param upper inclusive upper image indices (may be smaller than lower)
+! **************************************************************************************************
+   SUBROUTINE atom_grid_image_bounds(cell, fractional, cutoff, image_shell, lower, upper)
+      TYPE(cell_type), INTENT(IN), POINTER               :: cell
+      REAL(dp), INTENT(IN)                               :: fractional(3), cutoff
+      INTEGER, INTENT(IN)                                :: image_shell(3)
+      INTEGER, INTENT(OUT)                               :: lower(3), upper(3)
+
+      INTEGER                                            :: center, idir
+      REAL(dp)                                           :: condition_bound, padding, radius
+
+      ! |(H^-1 d)_i| <= cutoff ||(H^-1)_i|| also holds for triclinic cells.
+      ! Inflate the bounds for cancellation in fractional coordinates and the inverse cell.
+      condition_bound = MAX(1.0_dp, SUM(ABS(cell%hmat))*SUM(ABS(cell%h_inv)))
+      lower = 0
+      upper = 0
+      DO idir = 1, 3
+         IF (cell%perd(idir) == 0) CYCLE
+         center = NINT(fractional(idir))
+         radius = cutoff*SQRT(SUM(cell%h_inv(idir, :)**2))
+         padding = 128.0_dp*EPSILON(1.0_dp)*condition_bound* &
+                   MAX(1.0_dp, MAXVAL(ABS(fractional)), radius)
+         lower(idir) = MAX(center - image_shell(idir), CEILING(fractional(idir) - radius - padding))
+         upper(idir) = MIN(center + image_shell(idir), FLOOR(fractional(idir) + radius + padding))
+      END DO
+   END SUBROUTINE atom_grid_image_bounds
 
 ! **************************************************************************************************
 !> \brief Express one radial node's first and second derivatives as linear combinations of the

--- a/tools/regtesting/check_gapw_atom_adjoint.py
+++ b/tools/regtesting/check_gapw_atom_adjoint.py
@@ -52,6 +52,7 @@ WRAPPER = """
  REAL(dp), ALLOCATABLE :: vxc_h_local(:, :, :), vxc_s_local(:, :, :), vtau_h_local(:, :, :), vtau_s_local(:, :, :)
  REAL(dp), ALLOCATABLE :: vxg_h_local(:, :, :, :), vxg_s_local(:, :, :, :)
  INTEGER :: base_shift(3), composite_row, idir, image_i1, image_i2, image_i3
+ INTEGER :: image_lower(3), image_upper(3)
  INTEGER :: image_shift(3), image_shell(3), jdir, target_atom, iatom
  INTEGER :: composite_local_atom, composite_local_natom, composite_nflat
  REAL(dp) :: cross_density_adjoint(2), cross_grad_adjoint(3, 2), cross_kin_adjoint(2)
@@ -148,6 +149,8 @@ def main():
             f"MODULE {name}_kernel\n"
             + USES
             + "\n".join(routine(source, n) for n in helpers)
+            + "\n"
+            + routine(patched, "atom_grid_image_bounds")
             + WRAPPER.format(loop=loop)
             + f"\nEND MODULE {name}_kernel\n"
         )

--- a/tools/regtesting/gapw_atom_adjoint_fixture.F90
+++ b/tools/regtesting/gapw_atom_adjoint_fixture.F90
@@ -19,7 +19,8 @@ PROGRAM gapw_atom_adjoint_fixture
    USE qs_harmonics_atom,               ONLY: harmonics_atom_type
    USE screened_kernel,                 ONLY: screened_project => project
    USE spherical_harmonics,             ONLY: y_lm
-   USE values_only_kernel,              ONLY: new_fields => interpolate_gapw_atom_grid_fields,&
+   USE values_only_kernel,              ONLY: image_bounds => atom_grid_image_bounds,&
+                                              new_fields => interpolate_gapw_atom_grid_fields,&
                                               new_weights => atom_grid_interpolation_weights,&
                                               value_project => project
 
@@ -48,6 +49,7 @@ PROGRAM gapw_atom_adjoint_fixture
    CALL init_spherical_harmonics(6, i)
    CALL init_lebedev_grids()
    ALLOCATE (grid, harmonics, cell, particles(3))
+   CALL check_image_bounds()
    max_error = 0.0_dp
    DO n = 1, SIZE(counts)
       CALL make_grid(counts(n), 5, 4)
@@ -211,6 +213,72 @@ CONTAINS
          WRITE (*, '(A,3F12.6)') 'FORWARD seconds full/values-only and speedup: ', elapsed, elapsed(1)/elapsed(2)
       END DO
    END SUBROUTINE
+
+   SUBROUTINE check_image_bounds()
+      USE ieee_arithmetic, ONLY: ieee_next_after
+      INTEGER                                            :: c, center(3), hi(3), i1, i2, i3, idir, &
+                                                            k, lo(3), m, p, shell(3), shift(3)
+      INTEGER(KIND=8)                                    :: kept, new_count, old_count
+      REAL(dp)                                           :: displacement(3), distance, frac(3), &
+                                                            point(3), radius
+
+      old_count = 0; new_count = 0; kept = 0
+      DO c = 1, 3
+         CALL make_cell(2)
+         IF (c == 1) THEN
+            cell%hmat(1, 2) = 0.0_dp
+            cell%h_inv(1, 2) = 0.0_dp
+         ELSE IF (c == 3) THEN
+            cell%hmat(1, 2) = 32.0_dp
+            cell%h_inv(1, 2) = -0.5_dp
+         END IF
+         DO m = 0, 7
+            DO idir = 1, 3
+               cell%perd(idir) = MERGE(1, 0, BTEST(m, idir - 1))
+            END DO
+            DO p = 0, 35
+               point = MATMUL(cell%hmat, [SIN(REAL(p, dp)), COS(0.7_dp*p), SIN(1.3_dp*p)])
+               IF (p > 20) point = point + MATMUL(cell%hmat, cell%perd*[100.0_dp, -51.0_dp, 77.0_dp])
+               IF (p > 30) point = point + MATMUL(cell%hmat, cell%perd*[0.0_dp, 1.0E8_dp, 0.0_dp])
+               frac = MATMUL(cell%h_inv, point)
+               DO k = 0, 6
+                  SELECT CASE (k)
+                  CASE (0:3)
+                     radius = REAL(k, dp)*1.7_dp
+                  CASE (4:6)
+                     ! Place an image exactly at, just within and just outside the support.
+                     shift = cell%perd*NINT(frac)
+                     radius = SQRT(SUM((point - MATMUL(cell%hmat, REAL(shift, dp)))**2))
+                     IF (k == 5) radius = ieee_next_after(radius, HUGE(radius))
+                     IF (k == 6) radius = ieee_next_after(radius, 0.0_dp)
+                  END SELECT
+                  DO idir = 1, 3
+                     center(idir) = cell%perd(idir)*NINT(frac(idir))
+                     shell(idir) = cell%perd(idir)*(CEILING(radius*SQRT(SUM(cell%h_inv(idir, :)**2))) + 1)
+                  END DO
+                  CALL image_bounds(cell, frac, radius, shell, lo, hi)
+                  old_count = old_count + PRODUCT(INT(2*shell + 1, 8))
+                  new_count = new_count + PRODUCT(INT(MAX(0, hi - lo + 1), 8))
+                  IF (ANY(lo < center - shell) .OR. ANY(hi > center + shell)) ERROR STOP 'Bounds expanded'
+                  DO i3 = center(3) - shell(3), center(3) + shell(3)
+                     DO i2 = center(2) - shell(2), center(2) + shell(2)
+                        DO i1 = center(1) - shell(1), center(1) + shell(1)
+                           shift = [i1, i2, i3]
+                           displacement = point - MATMUL(cell%hmat, REAL(shift, dp))
+                           distance = SQRT(SUM(displacement**2))
+                           IF (distance > radius) CYCLE
+                           kept = kept + 1
+                           IF (ANY(shift < lo) .OR. ANY(shift > hi)) ERROR STOP 'Image within support omitted'
+                        END DO
+                     END DO
+                  END DO
+               END DO
+            END DO
+         END DO
+      END DO
+      WRITE (*, '(A,3(1X,I0))') 'PASS: image bounds, all periodicity masks, skew, translation, changing cutoff; old/new/kept:', &
+         old_count, new_count, kept
+   END SUBROUTINE check_image_bounds
 
    SUBROUTINE make_grid(nr, lg, lmax)
       INTEGER, INTENT(IN)                                :: nr, lg, lmax


### PR DESCRIPTION
## Summary

Reduce unnecessary periodic-image traversal in native atom-composite reconstruction and its force/stress and adjoint paths. This is independent of #6006 and applies directly to master.

- Bound candidate images using `|(H^-1 d)_i| <= R ||(H^-1)_i||`, with conservative floating-point padding and intersection with the original image shell.
- Apply the existing Cartesian support-sphere test before allocating/interpolating cross-atom contributions.
- Retain the existing density-dependent support radius, recomputed on every call. Retained images keep their original order. No model, grid, threshold or physical cutoff changes.
- Use the same bounds for forward reconstruction, force/stress derivatives and the adjoint.

The affected code is the native atom-composite reconstruction path, not every GAPW calculation.

## Validation

The standalone adjoint checker extracts the actual production interpolation routines and loop bodies. It covers one/two spin channels, all eight periodicity masks, empty local ownership, orthogonal/triclinic/skewed cells, changing radii, large translations and support-boundary rounding. GNU bounds/FPE checks and OpenMP 1/2/4/8/16-thread comparisons pass. Maximum relative adjoint discrepancy is about `5.2e-16`.

The image-bound fixture reduces 240944 candidate images to 37464 while retaining all 6924 images inside the existing support sphere. This is an image-enumeration result, not a whole-SCF speedup. The interpolation-dominated standalone adjoint timing was essentially unchanged.

Independent full CP2K baseline and patched executables were compared for four small native-Skala cases: periodic mixed AE/GTH H2, a sheared cell, a displaced atom, and all-electron H2. Each ran three fixed SCF iterations and evaluated total forces and analytical stress. These are equivalence tests, not converged physical benchmarks or finite-difference validation.

- Maximum absolute total-energy difference: `1.11e-15 Ha`.
- Printed total forces: identical.
- Maximum analytical-stress difference: `1.01e-13 GPa`.
- All executions ended normally with exit status zero.

All source files pass the repository pre-commit checks. Ongoing scientific production used separate unchanged binaries and inputs.

Run the standalone checker using `tools/regtesting/check_gapw_atom_adjoint.py` with a completed GNU/OpenMP CMake build. It records its source hashes, checks and timings in its work directory.
