### PR TITLE
Cache native-grid interpolation stencils across SCF iterations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -775,6 +775,7 @@ list(
   qs_fgxc_atom.F
   qs_vxc_atom_utils.F
   qs_vxc_atom.F
+  qs_native_grid_cache.F
   qs_vxc.F
   qs_wannier90.F
   qs_wf_history_methods.F

--- a/src/qs_environment_types.F
+++ b/src/qs_environment_types.F
@@ -124,6 +124,8 @@ MODULE qs_environment_types
                                               qs_matrix_pools_type
    USE qs_mo_types,                     ONLY: deallocate_mo_set,&
                                               mo_set_type
+   USE qs_native_grid_cache,            ONLY: native_grid_cache_type,&
+                                              release_native_grid_cache
    USE qs_neighbor_list_types,          ONLY: neighbor_list_set_p_type
    USE qs_oce_types,                    ONLY: deallocate_oce_set,&
                                               oce_matrix_type
@@ -330,6 +332,7 @@ MODULE qs_environment_types
       ! tblite
       TYPE(tblite_type), POINTER                            :: tb_tblite => Null()
       TYPE(cp_gauxc_cache_type), POINTER                    :: gauxc_cache => NULL()
+      TYPE(native_grid_cache_type)                         :: native_grid_cache
    END TYPE qs_environment_type
 
 CONTAINS
@@ -1709,6 +1712,8 @@ CONTAINS
          DEALLOCATE (qs_env%gauxc_cache)
       END IF
 
+      CALL release_native_grid_cache(qs_env%native_grid_cache)
+
    END SUBROUTINE qs_env_release
 
 ! **************************************************************************************************
@@ -1939,6 +1944,8 @@ CONTAINS
          CALL gauxc_cache_release(qs_env%gauxc_cache)
          DEALLOCATE (qs_env%gauxc_cache)
       END IF
+
+      CALL release_native_grid_cache(qs_env%native_grid_cache)
 
    END SUBROUTINE qs_env_part_release
 

--- a/src/qs_native_grid_cache.F
+++ b/src/qs_native_grid_cache.F
@@ -1,0 +1,151 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2026 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+!> \brief Bounded geometry-only cache for native atom-grid interpolation.
+MODULE qs_native_grid_cache
+   USE cell_types,                      ONLY: cell_type
+   USE kinds,                           ONLY: dp,&
+                                              int_8
+   USE pw_grid_types,                   ONLY: pw_grid_type
+
+   IMPLICIT NONE
+   PRIVATE
+
+   INTEGER, PARAMETER :: native_grid_interp_offset_min = -5, native_grid_interp_offset_max = 6
+   INTEGER, PARAMETER :: native_grid_interp_npts = native_grid_interp_offset_max - native_grid_interp_offset_min + 1
+   INTEGER(KIND=int_8), PARAMETER :: cache_budget = 128_int_8*1024*1024
+
+   TYPE native_grid_interpolation_stencil_type
+      INTEGER :: relative_index(native_grid_interp_npts, 3) = 0
+      REAL(dp) :: weight(native_grid_interp_npts, 3) = 0.0_dp
+      LOGICAL :: valid(native_grid_interp_npts, 3) = .FALSE.
+      LOGICAL :: active = .FALSE.
+   END TYPE native_grid_interpolation_stencil_type
+
+   TYPE stencil_entry_type
+      TYPE(native_grid_interpolation_stencil_type) :: stencil
+      REAL(dp) :: point(3) = 0.0_dp
+      LOGICAL :: ready = .FALSE.
+   END TYPE stencil_entry_type
+
+   TYPE native_grid_cache_type
+      PRIVATE
+      TYPE(stencil_entry_type), ALLOCATABLE :: entries(:)
+      REAL(dp) :: dh_inv(3, 3) = 0.0_dp, hmat(3, 3) = 0.0_dp
+      INTEGER :: npts(3) = 0, periodic(3) = 0, nrows = -1
+      LOGICAL :: wrap = .FALSE., prepared = .FALSE.
+   END TYPE native_grid_cache_type
+
+   PUBLIC :: native_grid_cache_type, native_grid_interpolation_stencil_type
+   PUBLIC :: native_grid_interp_offset_min, native_grid_interp_offset_max, native_grid_interp_npts
+   PUBLIC :: prepare_native_grid_cache, release_native_grid_cache, fetch_native_grid_stencil, store_native_grid_stencil
+CONTAINS
+! **************************************************************************************************
+!> \brief Prepare outside parallel regions. Cache a bounded prefix and compute the rest normally.
+!> \param cache per-QS-environment cache
+!> \param grid current auxiliary grid
+!> \param cell current cell and periodicity
+!> \param nrows local atom-grid row count
+!> \param wrap wrap the auxiliary cell in nonperiodic directions
+!> \param max_bytes optional memory budget for testing, in bytes
+! **************************************************************************************************
+   SUBROUTINE prepare_native_grid_cache(cache, grid, cell, nrows, wrap, max_bytes)
+      TYPE(native_grid_cache_type), INTENT(INOUT)        :: cache
+      TYPE(pw_grid_type), INTENT(IN)                     :: grid
+      TYPE(cell_type), INTENT(IN)                        :: cell
+      INTEGER, INTENT(IN)                                :: nrows
+      LOGICAL, INTENT(IN)                                :: wrap
+      INTEGER(KIND=int_8), INTENT(IN), OPTIONAL          :: max_bytes
+
+      INTEGER                                            :: count, ierr
+      INTEGER(KIND=int_8)                                :: budget, bytes_per_entry
+      LOGICAL                                            :: unchanged
+      TYPE(stencil_entry_type)                           :: entry
+
+      budget = cache_budget
+      IF (PRESENT(max_bytes)) budget = MAX(0_int_8, max_bytes)
+      bytes_per_entry = INT((STORAGE_SIZE(ENTRY) + 7)/8, int_8)
+      count = INT(MIN(INT(MAX(0, nrows), int_8), budget/bytes_per_entry))
+      unchanged = .FALSE.
+      IF (ALLOCATED(cache%entries)) THEN
+         unchanged = SIZE(cache%entries) == count
+         IF (.NOT. unchanged) CALL release_native_grid_cache(cache)
+      END IF
+      IF (.NOT. ALLOCATED(cache%entries)) THEN
+         ALLOCATE (cache%entries(count), STAT=ierr)
+         IF (ierr /= 0) RETURN
+      END IF
+      unchanged = unchanged .AND. cache%prepared .AND. cache%nrows == nrows
+      unchanged = unchanged .AND. ALL(cache%dh_inv == grid%dh_inv) .AND. ALL(cache%npts == grid%npts)
+      unchanged = unchanged .AND. ALL(cache%hmat == cell%hmat) .AND. ALL(cache%periodic == cell%perd)
+      unchanged = unchanged .AND. (cache%wrap .EQV. wrap)
+      IF (.NOT. unchanged) cache%entries%ready = .FALSE.
+      cache%dh_inv = grid%dh_inv
+      cache%npts = grid%npts
+      cache%hmat = cell%hmat
+      cache%periodic = cell%perd
+      cache%nrows = nrows
+      cache%wrap = wrap
+      cache%prepared = .TRUE.
+   END SUBROUTINE prepare_native_grid_cache
+
+! **************************************************************************************************
+!> \brief Release geometry storage, including when the QS environment is only partly released.
+!> \param cache ...
+! **************************************************************************************************
+   SUBROUTINE release_native_grid_cache(cache)
+      TYPE(native_grid_cache_type), INTENT(INOUT)        :: cache
+
+      IF (ALLOCATED(cache%entries)) DEALLOCATE (cache%entries)
+      cache%prepared = .FALSE.
+   END SUBROUTINE release_native_grid_cache
+
+! **************************************************************************************************
+!> \brief Read a stencil only on an exact coordinate match. Safe for concurrent readers.
+!> \param cache ...
+!> \param row local grid row
+!> \param point current Cartesian coordinates, including atom motion and quadrature changes
+!> \param stencil cached interpolation stencil on a hit
+!> \return whether the cached stencil matches
+! **************************************************************************************************
+   FUNCTION fetch_native_grid_stencil(cache, row, point, stencil) RESULT(hit)
+      TYPE(native_grid_cache_type), INTENT(IN)           :: cache
+      INTEGER, INTENT(IN)                                :: row
+      REAL(dp), INTENT(IN)                               :: point(3)
+      TYPE(native_grid_interpolation_stencil_type), &
+         INTENT(OUT)                                     :: stencil
+      LOGICAL                                            :: hit
+
+      hit = .FALSE.
+      IF (.NOT. cache%prepared .OR. .NOT. ALLOCATED(cache%entries)) RETURN
+      IF (row < 1 .OR. row > SIZE(cache%entries)) RETURN
+      IF (.NOT. cache%entries(row)%ready) RETURN
+      IF (ANY(cache%entries(row)%point /= point)) RETURN
+      stencil = cache%entries(row)%stencil
+      hit = .TRUE.
+   END FUNCTION fetch_native_grid_stencil
+
+! **************************************************************************************************
+!> \brief Store from the unique forward owner of a row, never from concurrent adjoint readers.
+!> \param cache ...
+!> \param row local grid row
+!> \param point current Cartesian coordinates
+!> \param stencil complete value stencil, not an indices-only stencil
+! **************************************************************************************************
+   SUBROUTINE store_native_grid_stencil(cache, row, point, stencil)
+      TYPE(native_grid_cache_type), INTENT(INOUT)        :: cache
+      INTEGER, INTENT(IN)                                :: row
+      REAL(dp), INTENT(IN)                               :: point(3)
+      TYPE(native_grid_interpolation_stencil_type), &
+         INTENT(IN)                                      :: stencil
+
+      IF (.NOT. cache%prepared .OR. .NOT. ALLOCATED(cache%entries)) RETURN
+      IF (row < 1 .OR. row > SIZE(cache%entries)) RETURN
+      cache%entries(row)%stencil = stencil
+      cache%entries(row)%point = point
+      cache%entries(row)%ready = .TRUE.
+   END SUBROUTINE store_native_grid_stencil
+END MODULE qs_native_grid_cache

--- a/src/qs_vxc_atom.F
+++ b/src/qs_vxc_atom.F
@@ -66,6 +66,13 @@ MODULE qs_vxc_atom
                                               has_nlcc,&
                                               qs_kind_type
    USE qs_linres_types,                 ONLY: nablavks_atom_type
+   USE qs_native_grid_cache,            ONLY: fetch_native_grid_stencil,&
+                                              native_grid_interp_npts,&
+                                              native_grid_interp_offset_max,&
+                                              native_grid_interp_offset_min,&
+                                              native_grid_interpolation_stencil_type,&
+                                              prepare_native_grid_cache,&
+                                              store_native_grid_stencil
    USE qs_rho_atom_methods,             ONLY: replicate_rho_atom_radial
    USE qs_rho_atom_types,               ONLY: get_rho_atom,&
                                               rho_atom_coeff,&
@@ -119,25 +126,12 @@ MODULE qs_vxc_atom
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'qs_vxc_atom'
 
-   ! The wider stencil suppresses mixed-kind eggbox forces while preserving an exact transpose.
-   INTEGER, PARAMETER, PRIVATE :: native_grid_interp_offset_min = -5, &
-                                  native_grid_interp_offset_max = 6, &
-                                  native_grid_interp_npts = &
-                                  native_grid_interp_offset_max - &
-                                  native_grid_interp_offset_min + 1
    ! A wrapped stencil can touch both end tiles and one adjacent interior tile when the final
    ! tile is shorter than the stencil. Three tiles per direction are therefore sufficient.
    INTEGER, PARAMETER, PRIVATE :: native_grid_adjoint_tile_edge = 64, &
                                   native_grid_adjoint_max_tiles_per_direction = 3, &
                                   native_grid_adjoint_max_bins_per_row = &
                                   native_grid_adjoint_max_tiles_per_direction**3
-
-   TYPE native_grid_interpolation_stencil_type
-      INTEGER, DIMENSION(native_grid_interp_npts, 3)     :: relative_index = 0
-      REAL(KIND=dp), DIMENSION(native_grid_interp_npts, 3) :: weight = 0.0_dp
-      LOGICAL, DIMENSION(native_grid_interp_npts, 3)     :: valid = .FALSE.
-      LOGICAL                                            :: active = .FALSE.
-   END TYPE native_grid_interpolation_stencil_type
 
    PUBLIC :: calculate_vxc_atom, &
              calculate_vxc_atom_epr, &
@@ -668,6 +662,8 @@ CONTAINS
             CPASSERT(ASSOCIATED(smooth_rho_r))
             CPASSERT(ASSOCIATED(smooth_rho_g))
             CPASSERT(ASSOCIATED(smooth_tau_r))
+            CALL prepare_native_grid_cache(qs_env%native_grid_cache, smooth_rho_r(1)%pw_grid, &
+                                           cell, composite_nflat, image_partition_atom_composite)
             CALL pw_env_get(pw_env, auxbas_pw_pool=auxbas_pw_pool)
             CALL section_vals_val_get(my_xc_section, "XC_GRID%XC_DERIV", &
                                       i_val=xc_deriv_method_id)
@@ -895,7 +891,7 @@ CONTAINS
 !$OMP        composite_smooth_rhob, composite_smooth_tau, composite_smooth_tau_a, &
 !$OMP        composite_smooth_tau_b, drho_h, drho_s, grid_atom, iatom, &
 !$OMP        image_partition_atom_composite, lsd, my_kind_set, na, nlcc, nr, one_center_kind, &
-!$OMP        particle_set, rho_h, rho_s, smooth_rho_r, tau_h, tau_s, &
+!$OMP        particle_set, qs_env, rho_h, rho_s, smooth_rho_r, tau_h, tau_s, &
 !$OMP        use_atom_composite_density, use_atom_composite_gradient, use_atom_composite_tau)
                   DO ir = 1, nr
                      DO ia = 1, na
@@ -932,9 +928,14 @@ CONTAINS
                         composite_grid_weights(composite_row) = &
                            composite_base_grid_weights(composite_row)* &
                            partition_weight
-                        CALL create_native_grid_interpolation_stencil( &
-                           interpolation_stencil, smooth_rho_r(1)%pw_grid, cell, composite_point, &
-                           image_partition_atom_composite)
+                        IF (.NOT. fetch_native_grid_stencil(qs_env%native_grid_cache, composite_row, &
+                                                            composite_point, interpolation_stencil)) THEN
+                           CALL create_native_grid_interpolation_stencil( &
+                              interpolation_stencil, smooth_rho_r(1)%pw_grid, cell, composite_point, &
+                              image_partition_atom_composite)
+                           CALL store_native_grid_stencil(qs_env%native_grid_cache, composite_row, &
+                                                          composite_point, interpolation_stencil)
+                        END IF
                         IF (lsd) THEN
                            CALL interpolate_native_grid_fields( &
                               composite_smooth_rhoa, composite_smooth_drhoa(1)%array, &
@@ -1985,7 +1986,7 @@ CONTAINS
 !$OMP        adjoint_tile_count, cell, composite_density_grad, composite_grad_grad, &
 !$OMP        composite_grid_coords, composite_kin_grad, image_partition_atom_composite, lsd, &
 !$OMP        smooth_density_adjoint_storage, smooth_grad_adjoint_storage, &
-!$OMP        smooth_kin_adjoint_storage, smooth_rho_r)
+!$OMP        smooth_kin_adjoint_storage, smooth_rho_r, qs_env)
             DO adjoint_bin = 1, adjoint_nbins
                CALL native_grid_adjoint_tile_bounds( &
                   smooth_rho_r(1)%pw_grid, adjoint_bin, adjoint_tile_count, &
@@ -1993,9 +1994,12 @@ CONTAINS
                DO adjoint_entry = adjoint_bin_offsets(adjoint_bin), &
                   adjoint_bin_offsets(adjoint_bin + 1) - 1
                   composite_row = adjoint_bin_rows(adjoint_entry)
-                  CALL create_native_grid_interpolation_stencil( &
-                     interpolation_stencil, smooth_rho_r(1)%pw_grid, cell, &
-                     composite_grid_coords(:, composite_row), image_partition_atom_composite)
+                  IF (.NOT. fetch_native_grid_stencil(qs_env%native_grid_cache, composite_row, &
+                                                      composite_grid_coords(:, composite_row), interpolation_stencil)) THEN
+                     CALL create_native_grid_interpolation_stencil( &
+                        interpolation_stencil, smooth_rho_r(1)%pw_grid, cell, &
+                        composite_grid_coords(:, composite_row), image_partition_atom_composite)
+                  END IF
                   IF (lsd) THEN
                      composite_smooth_density_adjoint_value = &
                         composite_density_grad(composite_row, :)

--- a/tools/regtesting/check_native_grid_cache.py
+++ b/tools/regtesting/check_native_grid_cache.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Check the geometry cache with actual CP2K types and interpolation routines.
+
+Requires a completed GNU/OpenMP CMake build. No SCF calculation or Torch model
+is used. All generated files and the machine-readable report stay in work-dir.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=Path, required=True)
+    parser.add_argument("--work-dir", type=Path, required=True)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[2]
+    build, work = args.build_dir.resolve(), args.work_dir.resolve()
+    work.mkdir(parents=True, exist_ok=True)
+    production = (root / "src/qs_vxc_atom.F").read_text()
+    routines = []
+    for name in (
+        "create_native_grid_interpolation_stencil",
+        "native_grid_lagrange_weights",
+    ):
+        matches = re.findall(
+            rf"^   SUBROUTINE {name}\b.*?^   END SUBROUTINE {name}\b",
+            production,
+            re.M | re.S,
+        )
+        if len(matches) != 1:
+            raise ValueError(f"Expected one production routine: {name}")
+        routines.append(matches[0])
+    kernel = work / "stencil_kernel.F90"
+    kernel.write_text(
+        "#define CPASSERT(cond) IF (.NOT. (cond)) ERROR STOP 'CPASSERT'\n"
+        "MODULE stencil_kernel\n USE kinds, ONLY: dp\n USE cell_types, ONLY: cell_type\n"
+        " USE pw_grid_types, ONLY: pw_grid_type\n USE qs_native_grid_cache\n"
+        " IMPLICIT NONE\n CONTAINS\n" + "\n".join(routines) + "\nEND MODULE\n"
+    )
+    sources = [
+        root / "src/qs_native_grid_cache.F",
+        kernel,
+        Path(__file__).with_name("native_grid_cache_fixture.F90"),
+    ]
+    commands = subprocess.check_output(
+        [
+            "ninja",
+            "-C",
+            str(build),
+            "-t",
+            "commands",
+            "orbital_transformation_matrices_unittest",
+        ],
+        text=True,
+    )
+    link = shlex.split(commands.strip().splitlines()[-1])
+    if link[:2] != [":", "&&"] or link[-2:] != ["&&", ":"]:
+        raise ValueError("Unsupported CMake link layout")
+    link = link[2:-2]
+    objects = [x for x in link if x.endswith(".F.o")]
+    if len(objects) != 1:
+        raise ValueError("Expected one driver object")
+    flags = [
+        "-cpp",
+        "-fopenmp",
+        "-ffree-form",
+        "-ffree-line-length-none",
+        "-I",
+        str(work),
+        "-I",
+        str(build / "src/mod_files"),
+        "-J",
+        str(work),
+    ]
+    flags += (
+        ["-O1", "-g", "-fcheck=all", "-ffpe-trap=invalid,zero,overflow"]
+        if args.check
+        else ["-O3"]
+    )
+    compiled = []
+    for source in sources:
+        target = work / (source.stem + ".o")
+        subprocess.run(
+            [link[0], *flags, "-c", str(source), "-o", str(target)],
+            cwd=work,
+            check=True,
+        )
+        compiled.append(str(target))
+    executable = work / "cache_test"
+    pos = link.index(objects[0])
+    link[pos : pos + 1] = compiled
+    link[link.index("-o") + 1] = str(executable)
+    subprocess.run(link, cwd=build, check=True)
+    result = subprocess.run(
+        [str(executable)],
+        cwd=work,
+        text=True,
+        capture_output=True,
+        env=dict(os.environ, OMP_DYNAMIC="FALSE", OPENBLAS_NUM_THREADS="1"),
+    )
+    print(result.stdout, end="")
+    print(result.stderr, end="")
+    (work / "results.json").write_text(
+        json.dumps(
+            {
+                "exit_code": result.returncode,
+                "output": result.stdout,
+                "stderr": result.stderr,
+                "flags": flags,
+                "sources": {
+                    str(p): hashlib.sha256(p.read_bytes()).hexdigest() for p in sources
+                },
+                "scope": "Geometry-cache unit tests and extracted unchanged production stencil factory; no SCF/model timing",
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    result.check_returncode()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/regtesting/native_grid_cache_fixture.F90
+++ b/tools/regtesting/native_grid_cache_fixture.F90
@@ -1,0 +1,134 @@
+! SPDX-License-Identifier: GPL-2.0-or-later
+PROGRAM native_grid_cache_fixture
+   USE cell_types, ONLY: cell_type
+   USE kinds, ONLY: dp, int_8
+   USE omp_lib, ONLY: omp_get_wtime, omp_set_num_threads
+   USE pw_grid_types, ONLY: pw_grid_type
+   USE qs_native_grid_cache
+   USE stencil_kernel, ONLY: create_native_grid_interpolation_stencil
+   IMPLICIT NONE
+   TYPE(native_grid_cache_type) :: cache, other
+   TYPE(native_grid_interpolation_stencil_type) :: expected, actual
+   TYPE(pw_grid_type), POINTER :: grid
+   TYPE(cell_type), POINTER :: cell
+   INTEGER, PARAMETER :: nrows = 257
+   REAL(dp) :: points(3, nrows), t0, elapsed, checksum
+   INTEGER :: i, d, m, w, scenario, pass, rep, misses
+   LOGICAL :: hit, wrap
+
+   ALLOCATE (grid, cell)
+   CALL omp_set_num_threads(4)
+   DO m = 0, 7
+      DO w = 0, 1
+         wrap = w == 1
+         grid%dh_inv = 0.0_dp
+         cell%hmat = 0.0_dp
+         DO d = 1, 3
+            grid%dh_inv(d, d) = 2.0_dp
+            cell%hmat(d, d) = 8.0_dp
+            cell%perd(d) = MERGE(1, 0, BTEST(m, d - 1))
+         END DO
+         grid%npts = 16
+         DO i = 1, nrows
+            points(:, i) = [SIN(REAL(i, dp)), COS(0.7_dp*i), SIN(1.3_dp*i)]*10.0_dp
+         END DO
+         DO scenario = 0, 8
+            SELECT CASE (scenario)
+            CASE (1)
+               points(1, :) = points(1, :) + 1.0E-6_dp
+            CASE (2)
+               points = points(:, nrows:1:-1)
+            CASE (3)
+               grid%dh_inv(1, 2) = 0.21_dp
+            CASE (4)
+               grid%npts(2) = 17
+            CASE (5)
+               cell%hmat(1, 2) = 0.03_dp
+            CASE (6)
+               cell%perd(1) = 1 - cell%perd(1)
+            CASE (7)
+               wrap = .NOT. wrap
+            CASE (8)
+               CALL release_native_grid_cache(cache)
+            END SELECT
+            CALL prepare_native_grid_cache(cache, grid, cell, nrows, wrap)
+            DO pass = 1, 2
+               misses = 0
+!$OMP PARALLEL DO DEFAULT(NONE) SHARED(cache, grid, cell, points, wrap) &
+!$OMP PRIVATE(i, expected, actual, hit) REDUCTION(+:misses)
+               DO i = 1, nrows
+                  CALL create_native_grid_interpolation_stencil(expected, grid, cell, points(:, i), wrap)
+                  hit = fetch_native_grid_stencil(cache, i, points(:, i), actual)
+                  IF (.NOT. hit) THEN
+                     misses = misses + 1
+                     actual = expected
+                     CALL store_native_grid_stencil(cache, i, points(:, i), actual)
+                  END IF
+                  CALL compare(expected, actual)
+               END DO
+!$OMP END PARALLEL DO
+               IF (pass == 2 .AND. misses /= 0) ERROR STOP 'Unchanged geometry missed'
+               IF (pass == 1 .AND. scenario > 0) THEN
+                  ! Reversing an odd-sized row set leaves the middle point unchanged.
+                  IF (misses /= nrows - MERGE(1, 0, scenario == 2)) ERROR STOP 'Changed geometry reused'
+               END IF
+            END DO
+            ! Repeated readers of the same rows must never write the cache.
+!$OMP PARALLEL DO DEFAULT(NONE) SHARED(cache, grid, cell, points, wrap) PRIVATE(i, expected, actual, hit)
+            DO i = 1, 3*nrows
+               CALL create_native_grid_interpolation_stencil(expected, grid, cell, points(:, MOD(i, nrows) + 1), wrap)
+               hit = fetch_native_grid_stencil(cache, MOD(i, nrows) + 1, points(:, MOD(i, nrows) + 1), actual)
+               IF (.NOT. hit) ERROR STOP 'Concurrent read missed'
+               CALL compare(expected, actual)
+            END DO
+!$OMP END PARALLEL DO
+         END DO
+         CALL release_native_grid_cache(cache)
+      END DO
+   END DO
+   CALL prepare_native_grid_cache(cache, grid, cell, nrows, wrap, max_bytes=1024_int_8)
+   CALL create_native_grid_interpolation_stencil(expected, grid, cell, points(:, 1), wrap)
+   CALL store_native_grid_stencil(cache, 1, points(:, 1), expected)
+   IF (.NOT. fetch_native_grid_stencil(cache, 1, points(:, 1), actual)) ERROR STOP 'Small cache did not store'
+   IF (fetch_native_grid_stencil(cache, nrows, points(:, 1), actual)) ERROR STOP 'Memory cap ignored'
+   IF (fetch_native_grid_stencil(cache, 0, points(:, 1), actual)) ERROR STOP 'Invalid row hit'
+   IF (fetch_native_grid_stencil(other, 1, points(:, 1), actual)) ERROR STOP 'Environment alias'
+   CALL prepare_native_grid_cache(cache, grid, cell, 0, wrap)
+   IF (fetch_native_grid_stencil(cache, 1, points(:, 1), actual)) ERROR STOP 'Empty rank hit'
+   CALL prepare_native_grid_cache(cache, grid, cell, nrows, wrap, max_bytes=0_int_8)
+   CALL store_native_grid_stencil(cache, 1, points(:, 1), expected)
+   IF (fetch_native_grid_stencil(cache, 1, points(:, 1), actual)) ERROR STOP 'Disabled cache hit'
+   CALL release_native_grid_cache(cache)
+   CALL release_native_grid_cache(cache)
+   WRITE (*, '(A)') 'PASS: exact stencils, motion, reordered grids, cell/grid/periodicity/wrap changes, OpenMP, memory cap, empty rank'
+   CALL prepare_native_grid_cache(cache, grid, cell, nrows, wrap)
+   DO i = 1, nrows
+      CALL create_native_grid_interpolation_stencil(expected, grid, cell, points(:, i), wrap)
+      CALL store_native_grid_stencil(cache, i, points(:, i), expected)
+   END DO
+   DO pass = 1, 2
+      checksum = 0.0_dp
+      t0 = omp_get_wtime()
+      DO rep = 1, 1000
+         DO i = 1, nrows
+            IF (pass == 1) THEN
+               CALL create_native_grid_interpolation_stencil(actual, grid, cell, points(:, i), wrap)
+            ELSE
+               hit = fetch_native_grid_stencil(cache, i, points(:, i), actual)
+               IF (.NOT. hit) ERROR STOP 'Benchmark cache miss'
+            END IF
+            checksum = checksum + SUM(actual%weight)
+         END DO
+      END DO
+      elapsed = omp_get_wtime() - t0
+      WRITE (*, '(A,I0,A,F12.6,A,ES20.12)') 'Stencil benchmark variant=', pass, ' seconds=', elapsed, ' checksum=', checksum
+   END DO
+CONTAINS
+   SUBROUTINE compare(a, b)
+      TYPE(native_grid_interpolation_stencil_type), INTENT(IN) :: a, b
+      IF (a%active .NEQV. b%active) ERROR STOP 'Active differs'
+      IF (ANY(a%valid .NEQV. b%valid)) ERROR STOP 'Valid differs'
+      IF (ANY(a%weight /= b%weight)) ERROR STOP 'Weights differ'
+      IF (ANY(a%relative_index /= b%relative_index)) ERROR STOP 'Indices differ'
+   END SUBROUTINE compare
+END PROGRAM native_grid_cache_fixture


### PR DESCRIPTION
## Summary

Reuse geometry-dependent native-grid interpolation stencils across SCF iterations, with bounded storage owned by each QS environment. This is independent of #6006 and applies directly to master.

- Keep the existing 12-point-per-direction interpolation factory and its mathematical mapping unchanged.
- Cache complete value stencils for at most a 128 MiB prefix of local atom-grid rows per environment/rank. Other rows and allocation failures use the existing uncached path.
- Invalidate on auxiliary-grid metric/dimension, cell, periodicity, wrapping-mode or row-count changes. Require an exact Cartesian coordinate match for each row, covering atom motion, changed quadrature points and reordered rows.
- Populate only from unique forward row owners. Adjoint tile loops only read the cache because multiple tiles can visit the same row.
- Release storage on both full and partial QS-environment release.
- Do not cache density-dependent support radii, field values, forces or spatial derivatives.

This affects native atom-composite interpolation and its transpose, not every GAPW calculation. No model or numerical cutoff is changed.

## Validation

The new standalone checker compiles the cache and extracts the unchanged production stencil factory against real CP2K types. GNU bounds/FPE and release builds pass tests for exact indices/weights/validity, fixed geometry, moved and reordered points, changed cells/grids/periodicity/wrapping, separate environments, release/reinitialization, empty ranks, disabled/bounded caches, parallel unique writers and repeated concurrent readers.

```sh
python tools/regtesting/check_native_grid_cache.py \
  --build-dir /path/to/completed-gnu-cmake-build \
  --work-dir /path/to/cache-check --check
```

In a release microbenchmark of 257000 stencil operations, construction took 0.059158 s and cached lookup/copy 0.013758 s on the test host, about 4.3x faster for this operation only. This is not a whole-SCF speedup claim.

Independent full CP2K baseline and patched executables were compared for four small native-Skala cases: periodic mixed AE/GTH H2, a sheared cell, a displaced atom, and all-electron H2. Each ran three fixed SCF iterations and evaluated total forces and analytical stress. These are equivalence tests, not converged physical benchmarks or finite-difference validation.

- Maximum absolute total-energy difference: `8.89e-16 Ha`.
- Printed total forces: identical.
- Maximum analytical-stress difference: `3.01e-14 GPa`.
- All executions ended normally with exit status zero.

All source files pass the repository pre-commit checks. Ongoing scientific production used separate unchanged binaries and inputs.
