### PR TITLE
Stabilize K290 atom matching at symmetry tolerance boundaries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1563,6 +1563,7 @@ set(CP2K_PROGS_F
     common/parallel_rng_types_unittest.F
     kpoint_lattice_fft_unittest.F
     kpoint_smearing_unittest.F
+    kpsym_unittest.F
     qs_ot_minimizer_unittest.F
     optbas_frontier_orbitals_utils_unittest.F
     rirs_grid_utils_unittest.F
@@ -1978,6 +1979,7 @@ list(
   "parallel_rng_types_unittest"
   "kpoint_lattice_fft_unittest"
   "kpoint_smearing_unittest"
+  "kpsym_unittest"
   "qs_ot_minimizer_unittest"
   "optbas_frontier_orbitals_utils_unittest"
   "rirs_grid_utils_unittest"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2012,6 +2012,7 @@ add_executable(memory_utilities_unittest common/memory_utilities_unittest.F)
 add_executable(parallel_rng_types_unittest common/parallel_rng_types_unittest.F)
 add_executable(kpoint_lattice_fft_unittest kpoint_lattice_fft_unittest.F)
 add_executable(kpoint_smearing_unittest kpoint_smearing_unittest.F)
+add_executable(kpsym_unittest kpsym_unittest.F)
 add_executable(qs_ot_minimizer_unittest qs_ot_minimizer_unittest.F)
 add_executable(optbas_frontier_orbitals_utils_unittest
                optbas_frontier_orbitals_utils_unittest.F)

--- a/src/input_cp2k_kpoints.F
+++ b/src/input_cp2k_kpoints.F
@@ -223,6 +223,9 @@ CONTAINS
 
       CALL keyword_create(keyword, __LOCATION__, name="EPS_SYMMETRY", variants=["EPS_GEO"], &
                           description="Accuracy in k-point symmetry determination."//newline// &
+                          "K290 applies this value in lattice and fractional-coordinate checks. "// &
+                          "SPGLIB uses a Cartesian distance tolerance in bohr. The same numerical "// &
+                          "value is therefore not an equivalent geometric tolerance for both backends."//newline// &
                           "EPS_GEO is accepted as an alias.", &
                           usage="EPS_SYMMETRY <real>", &
                           default_r_val=1.0e-6_dp)

--- a/src/kpsym.F
+++ b/src/kpsym.F
@@ -1751,7 +1751,13 @@ CONTAINS
       REAL(dp)                                           :: delta
 
       INTEGER                                            :: ia, ib, il
-      REAL(dp)                                           :: vt(3), xb(3)
+      REAL(dp)                                           :: tol, vt(3), xb(3)
+
+      ! Fractional residuals at the tolerance boundary accumulate Cartesian
+      ! rotation and lattice-conversion roundoff. Account for that roundoff so
+      ! equivalent operations are not accepted or rejected by a few ulps.
+      tol = delta + 32.0_dp*EPSILON(1.0_dp)*MAX(1.0_dp, &
+                                                MAXVAL(SUM(ABS(ai), DIM=2))*MAX(MAXVAL(ABS(rx)), MAXVAL(ABS(x))))
 
       DO ia = 1, nat
          isc(ia) = 0
@@ -1765,9 +1771,7 @@ CONTAINS
                xb(3) = rx(3, ia) - x(3, ib)
                CALL rlv3(ai, xb, vt, il, delta)
                ! VT STANDS FOR V-TEST
-               oksym = (ABS((vr(1) - vt(1)) - NINT(vr(1) - vt(1))) < delta) .AND. &
-                       (ABS((vr(2) - vt(2)) - NINT(vr(2) - vt(2))) < delta) .AND. &
-                       (ABS((vr(3) - vt(3)) - NINT(vr(3) - vt(3))) < delta)
+               oksym = ALL(ABS((vr - vt) - ANINT(vr - vt)) <= tol)
                IF (oksym) THEN
                   IF (nodupli) isc(ib) = 1
                   f0(n, ia) = ib

--- a/src/kpsym_unittest.F
+++ b/src/kpsym_unittest.F
@@ -1,0 +1,140 @@
+!--------------------------------------------------------------------------------------------------!
+!   CP2K: A general program to perform molecular dynamics simulations                              !
+!   Copyright 2000-2026 CP2K developers group <https://cp2k.org>                                   !
+!                                                                                                  !
+!   SPDX-License-Identifier: GPL-2.0-or-later                                                      !
+!--------------------------------------------------------------------------------------------------!
+PROGRAM kpsym_unittest
+   USE cryssym,                         ONLY: crys_sym_gen,&
+                                              csym_type,&
+                                              kpoint_gen,&
+                                              release_csym_type
+   USE kinds,                           ONLY: dp
+   USE libcp2k,                         ONLY: cp2k_finalize,&
+                                              cp2k_init
+   USE physcon,                         ONLY: bohr
+
+   IMPLICIT NONE
+   REAL(dp), PARAMETER :: ice_ix(3, 36) = RESHAPE([ &
+                                                  -0.006830_dp, 0.340009_dp, 0.190161_dp, &
+                                                  0.113981_dp, 0.164412_dp, 0.283330_dp, &
+                                                  0.309270_dp, 0.370346_dp, 0.106284_dp, &
+                                                  0.159991_dp, 0.493170_dp, 0.440161_dp, &
+                                                  0.335588_dp, 0.613981_dp, 0.533330_dp, &
+                                                  0.129654_dp, 0.809270_dp, 0.356284_dp, &
+                                                  0.840009_dp, 0.506830_dp, -0.059839_dp, &
+                                                  0.664412_dp, 0.386019_dp, 0.033330_dp, &
+                                                  0.870346_dp, 0.190730_dp, 0.856284_dp, &
+                                                  0.506830_dp, 0.840009_dp, 1.059839_dp, &
+                                                  0.386019_dp, 0.664412_dp, 0.966670_dp, &
+                                                  0.190730_dp, 0.870346_dp, 0.143716_dp, &
+                                                  0.493170_dp, 0.159991_dp, 0.559839_dp, &
+                                                  0.613981_dp, 0.335588_dp, 0.466670_dp, &
+                                                  0.809270_dp, 0.129654_dp, 0.643716_dp, &
+                                                  0.370346_dp, 0.309270_dp, -0.106284_dp, &
+                                                  0.659991_dp, 1.006830_dp, 0.309839_dp, &
+                                                  0.835588_dp, 0.886019_dp, 0.216670_dp, &
+                                                  0.629654_dp, 0.690730_dp, 0.393716_dp, &
+                                                  1.006830_dp, 0.659991_dp, 0.690161_dp, &
+                                                  0.886019_dp, 0.835588_dp, 0.783330_dp, &
+                                                  0.690730_dp, 0.629654_dp, 0.606284_dp, &
+                                                  0.340009_dp, -0.006830_dp, 0.809839_dp, &
+                                                  0.164412_dp, 0.113981_dp, 0.716670_dp, &
+                                                  0.114088_dp, 0.310030_dp, 0.267366_dp, &
+                                                  0.189970_dp, 0.614088_dp, 0.517366_dp, &
+                                                  0.810030_dp, 0.385912_dp, 0.017365_dp, &
+                                                  0.385912_dp, 0.810030_dp, 0.982634_dp, &
+                                                  0.614088_dp, 0.189970_dp, 0.482634_dp, &
+                                                  0.689970_dp, 0.885912_dp, 0.232634_dp, &
+                                                  0.885912_dp, 0.689970_dp, 0.767366_dp, &
+                                                  0.310030_dp, 0.114088_dp, 0.732634_dp, &
+                                                  0.404256_dp, 0.404256_dp, 0.000000_dp, &
+                                                  0.095744_dp, 0.904256_dp, 0.250000_dp, &
+                                                  0.904256_dp, 0.095744_dp, 0.750000_dp, &
+                                                  0.595744_dp, 0.595744_dp, 0.500000_dp], [3, 36])
+   REAL(dp) :: cell(3, 3), coords(3, 36), shifted(3, 36)
+   INTEGER :: i
+   INTEGER :: types(36)
+
+   CALL cp2k_init()
+   cell = 0.0_dp
+   cell(1, 1) = 6.784903_dp*bohr
+   cell(2, 2) = 6.784903_dp*bohr
+   cell(3, 3) = 6.807916_dp*bohr
+   types(:24) = 1
+   types(25:) = 2
+   coords = ice_ix
+
+   ! Rounded coordinates put seven operations within a few ulps of the boundary.
+   CALL check_mesh(coords, cell, 1.0e-6_dp, 6, .FALSE., .TRUE.)
+   CALL check_mesh(coords, cell, 1.0e-7_dp, 14, .FALSE., .TRUE.)
+   shifted = coords + SPREAD([0.137_dp, -0.231_dp, 0.319_dp], 2, 36)
+   CALL check_mesh(shifted, cell, 1.0e-6_dp, 6, .FALSE., .TRUE.)
+   CALL check_mesh(coords, 1.3_dp*cell, 1.0e-6_dp, 6, .FALSE., .TRUE.)
+   DO i = 1, 24
+      shifted(:, i) = coords(:, 25 - i)
+   END DO
+   DO i = 25, 36
+      shifted(:, i) = coords(:, 61 - i)
+   END DO
+   CALL check_mesh(shifted, cell, 1.0e-6_dp, 6, .FALSE., .TRUE.)
+
+   ! Genuine tolerance-induced nonclosure must still trigger the orbit guard.
+   coords = ice_ix
+   coords(3, 27) = coords(3, 27) + 1.0e-6_dp
+   coords(3, 33) = coords(3, 33) + 0.75e-6_dp
+   coords(3, 36) = coords(3, 36) - 0.75e-6_dp
+   CALL check_mesh(coords, cell, 1.0e-6_dp, 14, .TRUE., .FALSE.)
+   CALL cp2k_finalize()
+   PRINT *, "K290 tolerance-boundary and orbit-guard tests passed"
+
+CONTAINS
+
+! **************************************************************************************************
+!> \brief Check mesh reduction and atomic operation consistency without an SCF calculation.
+!> \param x fractional atomic coordinates
+!> \param h cell matrix in bohr
+!> \param delta K290 symmetry tolerance
+!> \param expected expected irreducible k-point count
+!> \param fallback expected inversion fallback
+!> \param closed whether to check closure of the retained atomic operations
+! **************************************************************************************************
+   SUBROUTINE check_mesh(x, h, delta, expected, fallback, closed)
+      REAL(dp), INTENT(IN)                               :: x(:, :), h(3, 3), delta
+      INTEGER, INTENT(IN)                                :: expected
+      LOGICAL, INTENT(IN)                                :: fallback, closed
+
+      INTEGER                                            :: a, i, j, k
+      LOGICAL                                            :: found
+      REAL(dp)                                           :: product(3, 3)
+      TYPE(csym_type)                                    :: csym
+
+      CALL crys_sym_gen(csym, x, types, h, delta=delta, use_spglib=.FALSE.)
+      CALL kpoint_gen(csym, [3, 3, 3], symm=.TRUE., shift=[0.0_dp, 0.0_dp, 0.0_dp])
+      IF (csym%nkpoint /= expected) ERROR STOP "Incorrect irreducible mesh size"
+      IF (csym%inversion_only .NEQV. fallback) ERROR STOP "Incorrect orbit-guard decision"
+      IF (ABS(SUM(csym%wkpoint) - 27.0_dp) > 1.0e-12_dp) ERROR STOP "Incorrect weight sum"
+      IF (ANY(csym%kplink <= 0)) ERROR STOP "Incomplete mesh mapping"
+      DO k = 1, SIZE(csym%rt, 3)
+         DO a = 1, SIZE(types)
+            IF (COUNT(csym%f0(:, k) == a) /= 1) ERROR STOP "Nonbijective atom mapping"
+         END DO
+         IF (ANY(types(csym%f0(:, k)) /= types)) ERROR STOP "Atom types not preserved"
+      END DO
+      IF (closed) THEN
+         DO i = 1, csym%nrtot
+            DO j = 1, csym%nrtot
+               product = MATMUL(csym%rt(:, :, i), csym%rt(:, :, j))
+               found = .FALSE.
+               DO k = 1, csym%nrtot
+                  IF (MAXVAL(ABS(product - csym%rt(:, :, k))) > 1.0e-12_dp) CYCLE
+                  IF (ANY(csym%f0(csym%f0(:, j), i) /= csym%f0(:, k))) CYCLE
+                  found = .TRUE.
+               END DO
+               IF (.NOT. found) ERROR STOP "Operation group not closed"
+            END DO
+         END DO
+      END IF
+      CALL release_csym_type(csym)
+   END SUBROUTINE check_mesh
+END PROGRAM kpsym_unittest

--- a/tests/UNIT_TESTS
+++ b/tests/UNIT_TESTS
@@ -7,6 +7,7 @@ cell_types_unittest
 grid_unittest
 kpoint_lattice_fft_unittest
 kpoint_smearing_unittest
+kpsym_unittest
 qs_ot_minimizer_unittest
 low_rank_preconditioner_unittest
 ot_covariant_preconditioner_unittest

--- a/tests/xTB/regtest-3-spglib/TEST_FILES.toml
+++ b/tests/xTB/regtest-3-spglib/TEST_FILES.toml
@@ -14,5 +14,5 @@
 "ice_viii_gfn2_kp_spglib_nonsymmorphic.inp" = [{matcher="E_total", tol=1.0E-10, ref=-40.71301330821884},
                                                  {matcher="N_special_kpoints", tol=0.0, ref=6}]
 "ice_ix_gfn2_kp_k290_nonsymmorphic.inp" = [{matcher="E_total", tol=1.0E-10, ref=-61.10270533472814},
-                                            {matcher="N_special_kpoints", tol=0.0, ref=14}]
+                                            {matcher="N_special_kpoints", tol=0.0, ref=6}]
 #EOF


### PR DESCRIPTION
## Summary

Stabilize K290 atom matching when a fractional displacement is at the requested symmetry tolerance. Keep the existing overlapping-orbit fallback unchanged.

The existing rounded ice IX regression input puts seven operations within floating-point roundoff of a fractional residual of `1e-6`. The strict componentwise `< delta` comparison could accept only three operations, depending on Cartesian/lattice conversion roundoff. That incomplete operation set triggered the overlapping-orbit guard and reduced a 3x3x3 mesh to 14 rather than 6 points. Using an alternative Angstrom-to-bohr conversion constant changed which boundary operations were retained, although the fractional geometry was identical.

The atom comparison now includes a roundoff allowance scaled by the inverse lattice and coordinate magnitude. It is about `1e-14` in fractional coordinates for this example, not a relaxation of the user tolerance to a different physical scale. Truly non-closed tolerance-selected sets still trigger the existing guard.

## Changes

- Add a scale-aware roundoff allowance and an inclusive periodic fractional-coordinate comparison in `checkrlv3`.
- Add a geometry-only unit test covering the actual ice IX fixture, a stricter tolerance, a shifted origin, cell scaling, atom reordering, atom bijections, rotation/permutation closure, mesh weights, and a genuinely non-closed case that must retain the inversion fallback.
- Change the existing GFN2 ice IX k-point-count expectation from 14 to 6. Its energy reference and tolerance remain unchanged.
- Document that K290 and SPGLIB do not interpret the numerical symmetry tolerance identically.

## Validation

- Bounds-checked GNU build of the current K290 source and new unit test, linked against an existing CPU CP2K build: all checks pass. No SPGLIB dependency is needed by the unit test.
- Geometry sweep at seven tolerances with K290 alone, K290 with SPGLIB available, and the full SPGLIB backend. At `1e-6`, the candidate retains eight K290 operations and six k-points; at `1e-7`, it correctly retains only identity plus time reversal (14 points).
- Four isolated, converged GFN2 ice IX calculations using an existing TBLITE-enabled build and a separate replacement K290 object:

| Configuration | k-points | Energy / Ha |
| --- | ---: | ---: |
| Original K290 | 14 | -61.102705334606554 |
| K290 with this fix | 6 | -61.102705336224737 |
| Unreduced mesh | 27 | -61.102705334606568 |
| SPGLIB, Cartesian tolerance 1e-4 bohr | 6 | -61.102705336224716 |

The fixed K290 result differs from SPGLIB by `2.1e-14 Ha`, and from the unreduced result by `1.62e-9 Ha`. Both official matchers for the updated existing regression pass, including its unchanged energy reference. All four executions converged and ended normally with exit zero.

Fortran formatting, file-property checks, and `git diff --check` pass. These are targeted tests with isolated objects/executables, not a claim that the entire CP2K regression suite has been run.
