### PR TITLE
Use a common representation for RPA imaginary-time propagators

### DIFF
--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -1179,8 +1179,7 @@ CONTAINS
 !> \param ic_corr_list ...
 !> \param weights_cos_tf_t_to_w ...
 !> \param weights_sin_tf_t_to_w ...
-!> \param cfm_mo_coeff_occ ...
-!> \param cfm_mo_coeff_virt ...
+!> \param cfm_mo_coeff ...
 !> \param mo_coeff ...
 !> \param fm_mat_W ...
 !> \param para_env ...
@@ -1217,8 +1216,8 @@ CONTAINS
                                   fermi_level_offset, delta_corr, Eigenval, &
                                   Eigenval_last, Eigenval_scf, iter_sc_GW0, exit_ev_gw, tau_tj, tj, &
                                   vec_omega_fit_gw, vec_Sigma_x_gw, ic_corr_list, &
-                                  weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, cfm_mo_coeff_occ, &
-                                  cfm_mo_coeff_virt, mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_MinvVMinv, &
+                                  weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, cfm_mo_coeff, mo_coeff, fm_mat_W, &
+                                  para_env, para_env_RPA, mat_dm, mat_MinvVMinv, &
                                   t_3c_O, t_3c_M, t_3c_overl_int_ao_mo, &
                                   t_3c_O_compressed, t_3c_O_mo_compressed, &
                                   t_3c_O_ind, t_3c_O_mo_ind, &
@@ -1255,7 +1254,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(IN)                                      :: weights_cos_tf_t_to_w, &
                                                             weights_sin_tf_t_to_w
-      TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff
       TYPE(cp_fm_type), INTENT(IN)                       :: mo_coeff
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: fm_mat_W
@@ -1309,8 +1308,7 @@ CONTAINS
 
             DO ispin = 1, nspins
                CALL compute_self_energy_cubic_gw(num_integ_points, nmo, tau_tj, tj, &
-                                                 matrix_s, cfm_mo_coeff_occ(ispin), &
-                                                 cfm_mo_coeff_virt(ispin), Eigenval(:, 1, ispin), eps_filter, &
+                                                 matrix_s, cfm_mo_coeff(ispin), Eigenval(:, 1, ispin), eps_filter, &
                                                  e_fermi(ispin), fm_mat_W, &
                                                  gw_corr_lev_tot, gw_corr_lev_occ(ispin), gw_corr_lev_virt(ispin), homo(ispin), &
                                                  count_ev_sc_GW, count_sc_GW0, &
@@ -5332,8 +5330,7 @@ CONTAINS
 !> \param tau_tj ...
 !> \param tj ...
 !> \param matrix_s ...
-!> \param cfm_mo_coeff_occ ...
-!> \param cfm_mo_coeff_virt ...
+!> \param cfm_mo_coeff ...
 !> \param Eigenval ...
 !> \param eps_filter ...
 !> \param e_fermi ...
@@ -5374,7 +5371,7 @@ CONTAINS
 !> \param ispin ...
 ! **************************************************************************************************
    SUBROUTINE compute_self_energy_cubic_gw(num_integ_points, nmo, tau_tj, tj, &
-                                           matrix_s, cfm_mo_coeff_occ, cfm_mo_coeff_virt, Eigenval, eps_filter, &
+                                           matrix_s, cfm_mo_coeff, Eigenval, eps_filter, &
                                            e_fermi, fm_mat_W, &
                                            gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, &
                                            count_ev_sc_GW, count_sc_GW0, &
@@ -5390,7 +5387,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: tau_tj, tj
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: matrix_s
-      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       REAL(KIND=dp), INTENT(INOUT)                       :: e_fermi
@@ -5453,7 +5450,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL cp_cfm_get_info(cfm_mo_coeff_occ, nrow_global=nao)
+      CALL cp_cfm_get_info(cfm_mo_coeff, nrow_global=nao)
 
       CALL decompress_tensor(t_3c_overl_int_ao_mo, t_3c_O_mo_ind, t_3c_O_mo_compressed, &
                              mp2_env%ri_rpa_im_time%eps_compress)
@@ -5527,7 +5524,7 @@ CONTAINS
 
       DO jquad = 1, num_integ_points
 
-         CALL compute_gamma_propagator(greens_fct, 1, cfm_mo_coeff_occ, cfm_mo_coeff_virt, Eigenval, nmo, &
+         CALL compute_gamma_propagator(greens_fct, 1, cfm_mo_coeff, homo, Eigenval, nmo, &
                                        eps_filter, e_fermi, tau_tj(jquad), para_env)
 
          CALL dbcsr_set(mat_W, 0.0_dp)
@@ -5624,11 +5621,11 @@ CONTAINS
 
          CALL timeset(routineN//"_RI_HFX_operation_1", handle3)
 
-         CALL cp_cfm_create(cfm_scaled_dm_occ_tau, cfm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
+         CALL cp_cfm_create(cfm_scaled_dm_occ_tau, cfm_mo_coeff%matrix_struct, nrow=nao, ncol=nao)
 
          ! get density matrix
-         CALL parallel_gemm(transa="N", transb="C", m=nao, n=nao, k=nmo, alpha=(1.0_dp, 0.0_dp), &
-                            matrix_a=cfm_mo_coeff_occ, matrix_b=cfm_mo_coeff_occ, beta=(0.0_dp, 0.0_dp), &
+         CALL parallel_gemm(transa="N", transb="C", m=nao, n=nao, k=homo, alpha=(1.0_dp, 0.0_dp), &
+                            matrix_a=cfm_mo_coeff, matrix_b=cfm_mo_coeff, beta=(0.0_dp, 0.0_dp), &
                             matrix_c=cfm_scaled_dm_occ_tau)
 
          CALL cp_fm_create(fm_scaled_dm_occ_tau, cfm_scaled_dm_occ_tau%matrix_struct)

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -140,7 +140,10 @@ MODULE rpa_gw
    USE rpa_gw_kpoints_util,             ONLY: get_mat_cell_T_from_mat_gamma,&
                                               mat_kp_from_mat_gamma,&
                                               real_space_to_kpoint_transform_rpa
-   USE rpa_im_time,                     ONLY: compute_periodic_dm
+   USE rpa_im_time,                     ONLY: compute_periodic_dm,&
+                                              create_propagator_matrix_set,&
+                                              propagator_sector_occupied,&
+                                              propagator_sector_virtual
    USE scf_control_types,               ONLY: scf_control_type
    USE util,                            ONLY: sort
    USE virial_types,                    ONLY: virial_type
@@ -5449,6 +5452,7 @@ CONTAINS
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: batch_range_mo, dist1, dist2, mo_bsizes, &
                                                             mo_offsets, sizes_AO, sizes_RI
       INTEGER, DIMENSION(2)                              :: mo_bounds, pdims_2d
+      INTEGER, DIMENSION(3, 1)                           :: index_to_cell_zero
       LOGICAL                                            :: memory_info
       REAL(KIND=dp)                                      :: ext_scaling, omega, omega_i, omega_sign, &
                                                             sign_occ_virt, t_i_Clenshaw, tau, &
@@ -5456,7 +5460,8 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: vec_Sigma_c_gw_cos_omega, &
          vec_Sigma_c_gw_cos_tau, vec_Sigma_c_gw_neg_tau, vec_Sigma_c_gw_pos_tau, &
          vec_Sigma_c_gw_sin_omega, vec_Sigma_c_gw_sin_tau
-      TYPE(dbcsr_type), TARGET                           :: mat_greens_fct_occ, mat_greens_fct_virt
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: greens_fct
+      TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
       TYPE(dbt_pgrid_type)                               :: pgrid_2d
       TYPE(dbt_type)                                     :: t_3c_ctr_AO, t_3c_ctr_RI, t_AO_tmp, &
                                                             t_dm, t_greens_fct_occ, &
@@ -5502,15 +5507,13 @@ CONTAINS
       ALLOCATE (delta_corr_omega(1 + homo - gw_corr_lev_occ:homo + gw_corr_lev_virt, num_integ_points))
       delta_corr_omega(:, :) = z_zero
 
-      CALL dbcsr_create(matrix=mat_greens_fct_occ, &
-                        template=matrix_s(1)%matrix, &
-                        matrix_type=dbcsr_type_no_symmetry)
-
-      CALL dbcsr_create(matrix=mat_greens_fct_virt, &
-                        template=matrix_s(1)%matrix, &
-                        matrix_type=dbcsr_type_no_symmetry)
-
       e_fermi = 0.5_dp*(Eigenval(homo) + Eigenval(homo + 1))
+
+      index_to_cell_zero = 0
+      NULLIFY (greens_fct)
+      CALL create_propagator_matrix_set(greens_fct, 1, matrix_s(1)%matrix, index_to_cell_zero)
+      mat_greens_fct_occ => greens_fct(propagator_sector_occupied, 1, 1)%matrix
+      mat_greens_fct_virt => greens_fct(propagator_sector_virtual, 1, 1)%matrix
 
       nblk_mo = dbt_nblks_total(t_3c_overl_int_gw_AO, 3)
       ALLOCATE (mo_offsets(nblk_mo))
@@ -5541,7 +5544,7 @@ CONTAINS
 
       DO jquad = 1, num_integ_points
 
-         CALL compute_Greens_function_time(mat_greens_fct_occ, mat_greens_fct_virt, &
+         CALL compute_Greens_function_time(greens_fct, &
                                            fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                            fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, &
@@ -5635,8 +5638,7 @@ CONTAINS
       vec_Sigma_c_gw(:, 1:num_fit_points, 1) = vec_Sigma_c_gw_cos_omega(:, 1:num_fit_points) + &
                                                gaussi*vec_Sigma_c_gw_sin_omega(:, 1:num_fit_points)
 
-      CALL dbcsr_release(mat_greens_fct_occ)
-      CALL dbcsr_release(mat_greens_fct_virt)
+      CALL dbcsr_deallocate_matrix_set(greens_fct)
 
       IF (do_ri_Sigma_x .AND. count_ev_sc_GW == 1 .AND. count_sc_GW0 == 1) THEN
 
@@ -5883,8 +5885,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :, :) :: vec_Sigma_c_gw_cos_omega, &
          vec_Sigma_c_gw_cos_tau, vec_Sigma_c_gw_neg_tau, vec_Sigma_c_gw_pos_tau, &
          vec_Sigma_c_gw_sin_omega, vec_Sigma_c_gw_sin_tau
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_p_greens_fct_occ, &
-                                                            mat_p_greens_fct_virt
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: propagator
       TYPE(dbcsr_type), TARGET :: mat_greens_fct_occ, mat_greens_fct_virt, mat_mo_coeff, &
          mat_self_energy_ao_ao_neg_tau, mat_self_energy_ao_ao_pos_tau
       TYPE(dbt_pgrid_type)                               :: pgrid_2d
@@ -5893,6 +5894,8 @@ CONTAINS
                                                             t_greens_fct_virt, t_RI_tmp, t_W
 
       CALL timeset(routineN, handle)
+
+      NULLIFY (propagator)
 
       memory_info = mp2_env%ri_rpa_im_time%memory_info
       IF (memory_info) THEN
@@ -6022,21 +6025,21 @@ CONTAINS
 
          DO ispin = 1, nspins
 
-            CALL compute_periodic_dm(mat_p_greens_fct_occ, qs_env, &
+            CALL compute_periodic_dm(propagator, qs_env, &
                                      ispin, num_points, jquad, e_fermi(ispin), tau, &
-                                     remove_occ=.FALSE., remove_virt=.TRUE., &
-                                     alloc_dm=(jquad == 1 .AND. ispin == 1))
+                                     sector=propagator_sector_occupied)
 
-            CALL compute_periodic_dm(mat_p_greens_fct_virt, qs_env, &
+            CALL compute_periodic_dm(propagator, qs_env, &
                                      ispin, num_points, jquad, e_fermi(ispin), tau, &
-                                     remove_occ=.TRUE., remove_virt=.FALSE., &
-                                     alloc_dm=(jquad == 1 .AND. ispin == 1))
+                                     sector=propagator_sector_virtual)
 
             CALL dbcsr_set(mat_greens_fct_occ, 0.0_dp)
-            CALL dbcsr_copy(mat_greens_fct_occ, mat_p_greens_fct_occ(jquad, 1)%matrix)
+            CALL dbcsr_copy(mat_greens_fct_occ, &
+                            propagator(propagator_sector_occupied, jquad, 1)%matrix)
 
             CALL dbcsr_set(mat_greens_fct_virt, 0.0_dp)
-            CALL dbcsr_copy(mat_greens_fct_virt, mat_p_greens_fct_virt(jquad, 1)%matrix)
+            CALL dbcsr_copy(mat_greens_fct_virt, &
+                            propagator(propagator_sector_virtual, jquad, 1)%matrix)
 
             CALL dbt_copy_matrix_to_tensor(mat_greens_fct_occ, t_AO_tmp)
             CALL dbt_copy(t_AO_tmp, t_greens_fct_occ)
@@ -6185,8 +6188,7 @@ CONTAINS
       CALL dbcsr_release(mat_self_energy_ao_ao_pos_tau)
       CALL dbcsr_release(mat_mo_coeff)
 
-      CALL dbcsr_deallocate_matrix_set(mat_p_greens_fct_occ)
-      CALL dbcsr_deallocate_matrix_set(mat_p_greens_fct_virt)
+      CALL dbcsr_deallocate_matrix_set(propagator)
 
       CALL dbt_destroy(t_W)
       CALL dbt_destroy(t_RI_tmp)
@@ -6797,8 +6799,7 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param mat_greens_fct_occ ...
-!> \param mat_greens_fct_virt ...
+!> \param greens_fct ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
 !> \param fm_mo_coeff_occ_scaled ...
@@ -6812,12 +6813,13 @@ CONTAINS
 !> \param tau ...
 !> \param para_env ...
 ! **************************************************************************************************
-   SUBROUTINE compute_Greens_function_time(mat_greens_fct_occ, mat_greens_fct_virt, fm_mo_coeff_occ, fm_mo_coeff_virt, &
+   SUBROUTINE compute_Greens_function_time(greens_fct, fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                            fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
                                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, nmo, &
                                            eps_filter, e_fermi, tau, para_env)
 
-      TYPE(dbcsr_type), INTENT(INOUT)                    :: mat_greens_fct_occ, mat_greens_fct_virt
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
+         INTENT(INOUT), POINTER                          :: greens_fct
       TYPE(cp_fm_type), INTENT(IN) :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
          fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
@@ -6831,6 +6833,10 @@ CONTAINS
                                                             ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: stabilize_exp
+      TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
+
+      mat_greens_fct_occ => greens_fct(propagator_sector_occupied, 1, 1)%matrix
+      mat_greens_fct_virt => greens_fct(propagator_sector_virtual, 1, 1)%matrix
 
       CALL timeset(routineN, handle)
 

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -282,8 +282,6 @@ CONTAINS
       DO jquad = 1, num_integ_points
 
          CALL cp_fm_create(fm_mat_W(jquad), fm_mat_Q%matrix_struct, set_zero=.TRUE.)
-         CALL cp_fm_to_fm(fm_mat_Q, fm_mat_W(jquad))
-         CALL cp_fm_set_all(fm_mat_W(jquad), 0.0_dp)
 
       END DO
 
@@ -1180,12 +1178,8 @@ CONTAINS
 !> \param ic_corr_list ...
 !> \param weights_cos_tf_t_to_w ...
 !> \param weights_sin_tf_t_to_w ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
 !> \param mo_coeff ...
 !> \param fm_mat_W ...
 !> \param para_env ...
@@ -1222,10 +1216,8 @@ CONTAINS
                                   fermi_level_offset, delta_corr, Eigenval, &
                                   Eigenval_last, Eigenval_scf, iter_sc_GW0, exit_ev_gw, tau_tj, tj, &
                                   vec_omega_fit_gw, vec_Sigma_x_gw, ic_corr_list, &
-                                  weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
-                                  fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_mo_coeff_occ, &
-                                  fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-                                  mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_MinvVMinv, &
+                                  weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, fm_mo_coeff_occ, &
+                                  fm_mo_coeff_virt, mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_MinvVMinv, &
                                   t_3c_O, t_3c_M, t_3c_overl_int_ao_mo, &
                                   t_3c_O_compressed, t_3c_O_mo_compressed, &
                                   t_3c_O_ind, t_3c_O_mo_ind, &
@@ -1262,11 +1254,8 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(IN)                                      :: weights_cos_tf_t_to_w, &
                                                             weights_sin_tf_t_to_w
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_mo_coeff_occ_scaled, &
-                                                            fm_mo_coeff_virt_scaled
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_mo_coeff_occ, fm_mo_coeff_virt
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_scaled_dm_occ_tau, &
-                                                            fm_scaled_dm_virt_tau, mo_coeff
+      TYPE(cp_fm_type), INTENT(IN)                       :: mo_coeff
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: fm_mat_W
       TYPE(mp_para_env_type), POINTER                    :: para_env, para_env_RPA
@@ -1320,9 +1309,7 @@ CONTAINS
             DO ispin = 1, nspins
                CALL compute_self_energy_cubic_gw(num_integ_points, nmo, tau_tj, tj, &
                                                  matrix_s, fm_mo_coeff_occ(ispin), &
-                                                 fm_mo_coeff_virt(ispin), fm_mo_coeff_occ_scaled, &
-                                                 fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                                 fm_scaled_dm_virt_tau, Eigenval(:, 1, ispin), eps_filter, &
+                                                 fm_mo_coeff_virt(ispin), Eigenval(:, 1, ispin), eps_filter, &
                                                  e_fermi(ispin), fm_mat_W, &
                                                  gw_corr_lev_tot, gw_corr_lev_occ(ispin), gw_corr_lev_virt(ispin), homo(ispin), &
                                                  count_ev_sc_GW, count_sc_GW0, &
@@ -5346,10 +5333,6 @@ CONTAINS
 !> \param matrix_s ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
 !> \param Eigenval ...
 !> \param eps_filter ...
 !> \param e_fermi ...
@@ -5390,9 +5373,7 @@ CONTAINS
 !> \param ispin ...
 ! **************************************************************************************************
    SUBROUTINE compute_self_energy_cubic_gw(num_integ_points, nmo, tau_tj, tj, &
-                                           matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                           fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-                                           fm_scaled_dm_virt_tau, Eigenval, eps_filter, &
+                                           matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, eps_filter, &
                                            e_fermi, fm_mat_W, &
                                            gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, &
                                            count_ev_sc_GW, count_sc_GW0, &
@@ -5408,8 +5389,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: tau_tj, tj
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: matrix_s
-      TYPE(cp_fm_type), INTENT(IN) :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-         fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
+      TYPE(cp_fm_type), INTENT(IN) :: fm_mo_coeff_occ, fm_mo_coeff_virt
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       REAL(KIND=dp), INTENT(INOUT)                       :: e_fermi
@@ -5463,6 +5443,7 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: greens_fct
       TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
       TYPE(dbt_pgrid_type)                               :: pgrid_2d
+      TYPE(cp_fm_type)                                   :: fm_scaled_dm_occ_tau
       TYPE(dbt_type)                                     :: t_3c_ctr_AO, t_3c_ctr_RI, t_AO_tmp, &
                                                             t_dm, t_greens_fct_occ, &
                                                             t_greens_fct_virt, t_RI_tmp, &
@@ -5544,10 +5525,7 @@ CONTAINS
 
       DO jquad = 1, num_integ_points
 
-         CALL compute_Greens_function_time(greens_fct, &
-                                           fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                           fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                           fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, &
+         CALL compute_Greens_function_time(greens_fct, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, &
                                            nmo, eps_filter, e_fermi, tau_tj(jquad), para_env)
 
          CALL dbcsr_set(mat_W, 0.0_dp)
@@ -5644,6 +5622,8 @@ CONTAINS
 
          CALL timeset(routineN//"_RI_HFX_operation_1", handle3)
 
+         CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
+
          ! get density matrix
          CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
                             matrix_a=fm_mo_coeff_occ, matrix_b=fm_mo_coeff_occ, beta=0.0_dp, &
@@ -5656,6 +5636,8 @@ CONTAINS
          CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
                                mat_dm%matrix, &
                                keep_sparsity=.FALSE.)
+
+         CALL cp_fm_release(fm_scaled_dm_occ_tau)
 
          CALL timestop(handle3)
 
@@ -6458,8 +6440,6 @@ CONTAINS
 
       CALL cp_fm_create(fm_mat_re, cfm_mat%matrix_struct)
       CALL cp_fm_create(fm_mat_im, cfm_mat%matrix_struct)
-      CALL cp_fm_set_all(fm_mat_re, 0.0_dp)
-      CALL cp_fm_set_all(fm_mat_im, 0.0_dp)
 
       CALL copy_dbcsr_to_fm(dbcsr_re, fm_mat_re)
       CALL copy_dbcsr_to_fm(dbcsr_im, fm_mat_im)
@@ -6802,10 +6782,6 @@ CONTAINS
 !> \param greens_fct ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
 !> \param Eigenval ...
 !> \param nmo ...
 !> \param eps_filter ...
@@ -6813,15 +6789,12 @@ CONTAINS
 !> \param tau ...
 !> \param para_env ...
 ! **************************************************************************************************
-   SUBROUTINE compute_Greens_function_time(greens_fct, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                           fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                           fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, Eigenval, nmo, &
+   SUBROUTINE compute_Greens_function_time(greens_fct, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, nmo, &
                                            eps_filter, e_fermi, tau, para_env)
 
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
          INTENT(INOUT), POINTER                          :: greens_fct
-      TYPE(cp_fm_type), INTENT(IN) :: fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-         fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
+      TYPE(cp_fm_type), INTENT(IN) :: fm_mo_coeff_occ, fm_mo_coeff_virt
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
       INTEGER, INTENT(IN)                                :: nmo
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, tau
@@ -6834,6 +6807,8 @@ CONTAINS
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: stabilize_exp
       TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
+      TYPE(cp_fm_type)                                   :: fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
 
       mat_greens_fct_occ => greens_fct(propagator_sector_occupied, 1, 1)%matrix
       mat_greens_fct_virt => greens_fct(propagator_sector_virtual, 1, 1)%matrix
@@ -6849,6 +6824,11 @@ CONTAINS
                           ncol_local=ncol_local, &
                           row_indices=row_indices, &
                           col_indices=col_indices)
+
+      CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
+      CALL cp_fm_create(fm_scaled_dm_virt_tau, fm_mo_coeff_virt%matrix_struct, nrow=nao, ncol=nao)
+      CALL cp_fm_create(fm_mo_coeff_occ_scaled, fm_mo_coeff_occ%matrix_struct)
+      CALL cp_fm_create(fm_mo_coeff_virt_scaled, fm_mo_coeff_virt%matrix_struct)
 
       ! Multiply the occupied and the virtual MO coefficients with the factor exp((-e_i-e_F)*tau/2).
       ! Then, we simply get the sum over all occ states and virt. states by a simple matrix-matrix
@@ -6911,6 +6891,11 @@ CONTAINS
                             keep_sparsity=.FALSE.)
 
       CALL dbcsr_filter(mat_greens_fct_virt, eps_filter)
+
+      CALL cp_fm_release(fm_scaled_dm_occ_tau)
+      CALL cp_fm_release(fm_scaled_dm_virt_tau)
+      CALL cp_fm_release(fm_mo_coeff_occ_scaled)
+      CALL cp_fm_release(fm_mo_coeff_virt_scaled)
 
       CALL timestop(handle)
 

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -140,8 +140,8 @@ MODULE rpa_gw
    USE rpa_gw_kpoints_util,             ONLY: get_mat_cell_T_from_mat_gamma,&
                                               mat_kp_from_mat_gamma,&
                                               real_space_to_kpoint_transform_rpa
-   USE rpa_im_time,                     ONLY: compute_periodic_dm,&
-                                              compute_gamma_propagator,&
+   USE rpa_im_time,                     ONLY: compute_gamma_propagator,&
+                                              compute_periodic_dm,&
                                               create_propagator_matrix_set,&
                                               propagator_sector_occupied,&
                                               propagator_sector_virtual
@@ -1179,8 +1179,8 @@ CONTAINS
 !> \param ic_corr_list ...
 !> \param weights_cos_tf_t_to_w ...
 !> \param weights_sin_tf_t_to_w ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
+!> \param cfm_mo_coeff_occ ...
+!> \param cfm_mo_coeff_virt ...
 !> \param mo_coeff ...
 !> \param fm_mat_W ...
 !> \param para_env ...
@@ -1217,8 +1217,8 @@ CONTAINS
                                   fermi_level_offset, delta_corr, Eigenval, &
                                   Eigenval_last, Eigenval_scf, iter_sc_GW0, exit_ev_gw, tau_tj, tj, &
                                   vec_omega_fit_gw, vec_Sigma_x_gw, ic_corr_list, &
-                                  weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, fm_mo_coeff_occ, &
-                                  fm_mo_coeff_virt, mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_MinvVMinv, &
+                                  weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, cfm_mo_coeff_occ, &
+                                  cfm_mo_coeff_virt, mo_coeff, fm_mat_W, para_env, para_env_RPA, mat_dm, mat_MinvVMinv, &
                                   t_3c_O, t_3c_M, t_3c_overl_int_ao_mo, &
                                   t_3c_O_compressed, t_3c_O_mo_compressed, &
                                   t_3c_O_ind, t_3c_O_mo_ind, &
@@ -1255,7 +1255,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :), &
          INTENT(IN)                                      :: weights_cos_tf_t_to_w, &
                                                             weights_sin_tf_t_to_w
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
       TYPE(cp_fm_type), INTENT(IN)                       :: mo_coeff
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: fm_mat_W
@@ -1309,8 +1309,8 @@ CONTAINS
 
             DO ispin = 1, nspins
                CALL compute_self_energy_cubic_gw(num_integ_points, nmo, tau_tj, tj, &
-                                                 matrix_s, fm_mo_coeff_occ(ispin), &
-                                                 fm_mo_coeff_virt(ispin), Eigenval(:, 1, ispin), eps_filter, &
+                                                 matrix_s, cfm_mo_coeff_occ(ispin), &
+                                                 cfm_mo_coeff_virt(ispin), Eigenval(:, 1, ispin), eps_filter, &
                                                  e_fermi(ispin), fm_mat_W, &
                                                  gw_corr_lev_tot, gw_corr_lev_occ(ispin), gw_corr_lev_virt(ispin), homo(ispin), &
                                                  count_ev_sc_GW, count_sc_GW0, &
@@ -5332,8 +5332,8 @@ CONTAINS
 !> \param tau_tj ...
 !> \param tj ...
 !> \param matrix_s ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
+!> \param cfm_mo_coeff_occ ...
+!> \param cfm_mo_coeff_virt ...
 !> \param Eigenval ...
 !> \param eps_filter ...
 !> \param e_fermi ...
@@ -5374,7 +5374,7 @@ CONTAINS
 !> \param ispin ...
 ! **************************************************************************************************
    SUBROUTINE compute_self_energy_cubic_gw(num_integ_points, nmo, tau_tj, tj, &
-                                           matrix_s, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, eps_filter, &
+                                           matrix_s, cfm_mo_coeff_occ, cfm_mo_coeff_virt, Eigenval, eps_filter, &
                                            e_fermi, fm_mat_W, &
                                            gw_corr_lev_tot, gw_corr_lev_occ, gw_corr_lev_virt, homo, &
                                            count_ev_sc_GW, count_sc_GW0, &
@@ -5390,7 +5390,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:), &
          INTENT(IN)                                      :: tau_tj, tj
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: matrix_s
-      TYPE(cp_fm_type), INTENT(IN) :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter
       REAL(KIND=dp), INTENT(INOUT)                       :: e_fermi
@@ -5441,10 +5441,11 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :) :: vec_Sigma_c_gw_cos_omega, &
          vec_Sigma_c_gw_cos_tau, vec_Sigma_c_gw_neg_tau, vec_Sigma_c_gw_pos_tau, &
          vec_Sigma_c_gw_sin_omega, vec_Sigma_c_gw_sin_tau
+      TYPE(cp_cfm_type)                                  :: cfm_scaled_dm_occ_tau
+      TYPE(cp_fm_type)                                   :: fm_scaled_dm_occ_tau
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: greens_fct
       TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
       TYPE(dbt_pgrid_type)                               :: pgrid_2d
-      TYPE(cp_fm_type)                                   :: fm_scaled_dm_occ_tau
       TYPE(dbt_type)                                     :: t_3c_ctr_AO, t_3c_ctr_RI, t_AO_tmp, &
                                                             t_dm, t_greens_fct_occ, &
                                                             t_greens_fct_virt, t_RI_tmp, &
@@ -5452,7 +5453,7 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      CALL cp_fm_get_info(fm_mo_coeff_occ, nrow_global=nao)
+      CALL cp_cfm_get_info(cfm_mo_coeff_occ, nrow_global=nao)
 
       CALL decompress_tensor(t_3c_overl_int_ao_mo, t_3c_O_mo_ind, t_3c_O_mo_compressed, &
                              mp2_env%ri_rpa_im_time%eps_compress)
@@ -5526,7 +5527,7 @@ CONTAINS
 
       DO jquad = 1, num_integ_points
 
-         CALL compute_gamma_propagator(greens_fct, 1, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, nmo, &
+         CALL compute_gamma_propagator(greens_fct, 1, cfm_mo_coeff_occ, cfm_mo_coeff_virt, Eigenval, nmo, &
                                        eps_filter, e_fermi, tau_tj(jquad), para_env)
 
          CALL dbcsr_set(mat_W, 0.0_dp)
@@ -5623,12 +5624,15 @@ CONTAINS
 
          CALL timeset(routineN//"_RI_HFX_operation_1", handle3)
 
-         CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
+         CALL cp_cfm_create(cfm_scaled_dm_occ_tau, cfm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
 
          ! get density matrix
-         CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
-                            matrix_a=fm_mo_coeff_occ, matrix_b=fm_mo_coeff_occ, beta=0.0_dp, &
-                            matrix_c=fm_scaled_dm_occ_tau)
+         CALL parallel_gemm(transa="N", transb="C", m=nao, n=nao, k=nmo, alpha=(1.0_dp, 0.0_dp), &
+                            matrix_a=cfm_mo_coeff_occ, matrix_b=cfm_mo_coeff_occ, beta=(0.0_dp, 0.0_dp), &
+                            matrix_c=cfm_scaled_dm_occ_tau)
+
+         CALL cp_fm_create(fm_scaled_dm_occ_tau, cfm_scaled_dm_occ_tau%matrix_struct)
+         CALL cp_cfm_to_fm(cfm_scaled_dm_occ_tau, fm_scaled_dm_occ_tau)
 
          CALL timestop(handle3)
 
@@ -5639,6 +5643,7 @@ CONTAINS
                                keep_sparsity=.FALSE.)
 
          CALL cp_fm_release(fm_scaled_dm_occ_tau)
+         CALL cp_cfm_release(cfm_scaled_dm_occ_tau)
 
          CALL timestop(handle3)
 

--- a/src/rpa_gw.F
+++ b/src/rpa_gw.F
@@ -141,6 +141,7 @@ MODULE rpa_gw
                                               mat_kp_from_mat_gamma,&
                                               real_space_to_kpoint_transform_rpa
    USE rpa_im_time,                     ONLY: compute_periodic_dm,&
+                                              compute_gamma_propagator,&
                                               create_propagator_matrix_set,&
                                               propagator_sector_occupied,&
                                               propagator_sector_virtual
@@ -5525,8 +5526,8 @@ CONTAINS
 
       DO jquad = 1, num_integ_points
 
-         CALL compute_Greens_function_time(greens_fct, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, &
-                                           nmo, eps_filter, e_fermi, tau_tj(jquad), para_env)
+         CALL compute_gamma_propagator(greens_fct, 1, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, nmo, &
+                                       eps_filter, e_fermi, tau_tj(jquad), para_env)
 
          CALL dbcsr_set(mat_W, 0.0_dp)
          CALL copy_fm_to_dbcsr(fm_mat_W(jquad), mat_W, keep_sparsity=.FALSE.)
@@ -6776,129 +6777,5 @@ CONTAINS
 
       CALL timestop(handle)
    END SUBROUTINE trace_sigma_gw
-
-! **************************************************************************************************
-!> \brief ...
-!> \param greens_fct ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
-!> \param Eigenval ...
-!> \param nmo ...
-!> \param eps_filter ...
-!> \param e_fermi ...
-!> \param tau ...
-!> \param para_env ...
-! **************************************************************************************************
-   SUBROUTINE compute_Greens_function_time(greens_fct, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, nmo, &
-                                           eps_filter, e_fermi, tau, para_env)
-
-      TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
-         INTENT(INOUT), POINTER                          :: greens_fct
-      TYPE(cp_fm_type), INTENT(IN) :: fm_mo_coeff_occ, fm_mo_coeff_virt
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
-      INTEGER, INTENT(IN)                                :: nmo
-      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, tau
-      TYPE(mp_para_env_type), INTENT(IN)                 :: para_env
-
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_Greens_function_time'
-
-      INTEGER                                            :: handle, i_global, iiB, jjB, nao, &
-                                                            ncol_local, nrow_local
-      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
-      REAL(KIND=dp)                                      :: stabilize_exp
-      TYPE(dbcsr_type), POINTER                          :: mat_greens_fct_occ, mat_greens_fct_virt
-      TYPE(cp_fm_type)                                   :: fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
-
-      mat_greens_fct_occ => greens_fct(propagator_sector_occupied, 1, 1)%matrix
-      mat_greens_fct_virt => greens_fct(propagator_sector_virtual, 1, 1)%matrix
-
-      CALL timeset(routineN, handle)
-
-      CALL para_env%sync()
-
-      ! get info of fm_mo_coeff_occ
-      CALL cp_fm_get_info(matrix=fm_mo_coeff_occ, &
-                          nrow_global=nao, &
-                          nrow_local=nrow_local, &
-                          ncol_local=ncol_local, &
-                          row_indices=row_indices, &
-                          col_indices=col_indices)
-
-      CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
-      CALL cp_fm_create(fm_scaled_dm_virt_tau, fm_mo_coeff_virt%matrix_struct, nrow=nao, ncol=nao)
-      CALL cp_fm_create(fm_mo_coeff_occ_scaled, fm_mo_coeff_occ%matrix_struct)
-      CALL cp_fm_create(fm_mo_coeff_virt_scaled, fm_mo_coeff_virt%matrix_struct)
-
-      ! Multiply the occupied and the virtual MO coefficients with the factor exp((-e_i-e_F)*tau/2).
-      ! Then, we simply get the sum over all occ states and virt. states by a simple matrix-matrix
-      ! multiplication.
-
-      stabilize_exp = 70.0_dp
-
-      ! first, the occ
-      DO jjB = 1, nrow_local
-         DO iiB = 1, ncol_local
-            i_global = col_indices(iiB)
-
-            IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
-               fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = &
-                  fm_mo_coeff_occ%local_data(jjB, iiB)*EXP(tau*0.5_dp*(Eigenval(i_global) - e_fermi))
-            ELSE
-               fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = 0.0_dp
-            END IF
-
-         END DO
-      END DO
-
-      ! the same for virt
-      DO jjB = 1, nrow_local
-         DO iiB = 1, ncol_local
-            i_global = col_indices(iiB)
-
-            IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
-               fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = &
-                  fm_mo_coeff_virt%local_data(jjB, iiB)*EXP(-tau*0.5_dp*(Eigenval(i_global) - e_fermi))
-            ELSE
-               fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = 0.0_dp
-            END IF
-
-         END DO
-      END DO
-
-      CALL para_env%sync()
-
-      CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
-                         matrix_a=fm_mo_coeff_occ_scaled, matrix_b=fm_mo_coeff_occ_scaled, beta=0.0_dp, &
-                         matrix_c=fm_scaled_dm_occ_tau)
-
-      CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
-                         matrix_a=fm_mo_coeff_virt_scaled, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
-                         matrix_c=fm_scaled_dm_virt_tau)
-
-      CALL dbcsr_set(mat_greens_fct_occ, 0.0_dp)
-
-      CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
-                            mat_greens_fct_occ, &
-                            keep_sparsity=.FALSE.)
-
-      CALL dbcsr_filter(mat_greens_fct_occ, eps_filter)
-
-      CALL dbcsr_set(mat_greens_fct_virt, 0.0_dp)
-
-      CALL copy_fm_to_dbcsr(fm_scaled_dm_virt_tau, &
-                            mat_greens_fct_virt, &
-                            keep_sparsity=.FALSE.)
-
-      CALL dbcsr_filter(mat_greens_fct_virt, eps_filter)
-
-      CALL cp_fm_release(fm_scaled_dm_occ_tau)
-      CALL cp_fm_release(fm_scaled_dm_virt_tau)
-      CALL cp_fm_release(fm_mo_coeff_occ_scaled)
-      CALL cp_fm_release(fm_mo_coeff_virt_scaled)
-
-      CALL timestop(handle)
-
-   END SUBROUTINE compute_Greens_function_time
 
 END MODULE rpa_gw

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -1180,11 +1180,11 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_matrix_from_kp_to_mic'
 
-      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), POINTER :: cfm_data
-      INTEGER                                            :: handle, iatom, iatom_old, ik, ik_global, ik_old, &
-                                                            irow, jatom, jatom_old, jcol, &
-                                                            nao, ncol_local, nrow_local, &
-                                                            num_cells
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), &
+         POINTER                                         :: cfm_data
+      INTEGER                                            :: handle, iatom, iatom_old, ik, ik_global, &
+                                                            ik_old, irow, jatom, jatom_old, jcol, &
+                                                            nao, ncol_local, nrow_local, num_cells
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_from_ao_index
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell
@@ -1292,7 +1292,8 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_matrix_from_kp_to_transl'
 
-      INTEGER                                            :: handle, icell, ik, ik_global, xcell, ycell, zcell
+      INTEGER                                            :: handle, icell, ik, ik_global, xcell, &
+                                                            ycell, zcell
       REAL(KIND=dp)                                      :: arg, coskl, sinkl
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -1000,23 +1000,20 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'compute_transl_dm'
 
-      INTEGER                                            :: handle, i_dim, i_img, jspin, nao, nspin
+      INTEGER                                            :: handle, i_dim, i_img, nao
       INTEGER, DIMENSION(3)                              :: cell_grid_dm
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_cfm_type)                                  :: cfm_density
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work, matrix_s_kp
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_dm_global_work
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp
       TYPE(kpoint_type), POINTER                         :: kpoints
-      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
 
       CALL timeset(routineN, handle)
 
       CALL get_qs_env(qs_env, &
                       matrix_s_kp=matrix_s_kp, &
-                      mos=mos, &
                       kpoints=kpoints, &
                       cell=cell)
-
-      nspin = SIZE(mos)
 
       ! we always use an odd number of image cells
       ! CAUTION: also at another point, cell_grid_dm is defined, these definitions have to be identical
@@ -1027,21 +1024,18 @@ CONTAINS
       num_cells_dm = cell_grid_dm(1)*cell_grid_dm(2)*cell_grid_dm(3)
 
       NULLIFY (mat_dm_global_work)
-      CALL dbcsr_allocate_matrix_set(mat_dm_global_work, nspin, num_cells_dm)
+      ! Only the requested spin is built.
+      CALL dbcsr_allocate_matrix_set(mat_dm_global_work, num_cells_dm)
 
-      DO jspin = 1, nspin
+      DO i_img = 1, num_cells_dm
 
-         DO i_img = 1, num_cells_dm
+         ALLOCATE (mat_dm_global_work(i_img)%matrix)
+         CALL dbcsr_create(matrix=mat_dm_global_work(i_img)%matrix, &
+                           template=matrix_s_kp(1, 1)%matrix, &
+                           !                           matrix_type=dbcsr_type_symmetric)
+                           matrix_type=dbcsr_type_no_symmetry)
 
-            ALLOCATE (mat_dm_global_work(jspin, i_img)%matrix)
-            CALL dbcsr_create(matrix=mat_dm_global_work(jspin, i_img)%matrix, &
-                              template=matrix_s_kp(1, 1)%matrix, &
-                              !                              matrix_type=dbcsr_type_symmetric)
-                              matrix_type=dbcsr_type_no_symmetry)
-
-            CALL dbcsr_reserve_all_blocks(mat_dm_global_work(jspin, i_img)%matrix)
-
-         END DO
+         CALL dbcsr_reserve_all_blocks(mat_dm_global_work(i_img)%matrix)
 
       END DO
 
@@ -1056,7 +1050,7 @@ CONTAINS
       ! density matrices in real space, the cell vectors T for transforming are taken from kpoints%index_to_cell
       ! (custom made for RPA) and not from sab_nl (which is symmetric and from SCF)
       CALL density_matrix_from_kp_to_transl(kpoints, cfm_density, mat_dm_global_work, kpoints%index_to_cell, &
-                                            tau, e_fermi, sector)
+                                            ispin, tau, e_fermi, sector)
 
       CALL cp_cfm_release(cfm_density)
 
@@ -1072,10 +1066,10 @@ CONTAINS
       DO i_img = 1, num_cells_dm
 
          ! filter to get rid of the blocks full with zeros on the lower half, otherwise blocks doubled
-         CALL dbcsr_filter(mat_dm_global_work(ispin, i_img)%matrix, eps_filter)
+         CALL dbcsr_filter(mat_dm_global_work(i_img)%matrix, eps_filter)
 
          CALL dbcsr_copy(propagator(sector, jquad, i_img)%matrix, &
-                         mat_dm_global_work(ispin, i_img)%matrix)
+                         mat_dm_global_work(i_img)%matrix)
 
       END DO
 
@@ -1107,30 +1101,28 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_periodic_dm'
 
-      INTEGER                                            :: handle, jspin, nao, nspin, num_cells_dm
+      INTEGER                                            :: handle, nao, num_cells_dm
       INTEGER, DIMENSION(3, 1)                           :: index_to_cell_zero
       TYPE(cp_cfm_type)                                  :: cfm_density
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work, matrix_s_kp
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_dm_global_work
+      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: matrix_s_kp
       TYPE(kpoint_type), POINTER                         :: kpoints_G
-      TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
 
       CALL timeset(routineN, handle)
 
-      NULLIFY (matrix_s_kp, mos)
+      NULLIFY (matrix_s_kp)
 
       CALL get_qs_env(qs_env, &
-                      matrix_s_kp=matrix_s_kp, &
-                      mos=mos)
+                      matrix_s_kp=matrix_s_kp)
 
       kpoints_G => qs_env%mp2_env%ri_rpa_im_time%kpoints_G
-
-      nspin = SIZE(mos)
 
       num_cells_dm = 1
       index_to_cell_zero = 0
 
       NULLIFY (mat_dm_global_work)
-      CALL dbcsr_allocate_matrix_set(mat_dm_global_work, nspin, num_cells_dm)
+      ! Only the requested spin is built.
+      CALL dbcsr_allocate_matrix_set(mat_dm_global_work, num_cells_dm)
 
       ! The first request owns allocation of the complete time-indexed propagator set.
       IF (.NOT. ASSOCIATED(propagator)) THEN
@@ -1138,30 +1130,26 @@ CONTAINS
                                            index_to_cell_zero)
       END IF
 
-      DO jspin = 1, nspin
+      ALLOCATE (mat_dm_global_work(1)%matrix)
+      CALL dbcsr_create(matrix=mat_dm_global_work(1)%matrix, &
+                        template=matrix_s_kp(1, 1)%matrix, &
+                        matrix_type=dbcsr_type_no_symmetry)
 
-         ALLOCATE (mat_dm_global_work(jspin, 1)%matrix)
-         CALL dbcsr_create(matrix=mat_dm_global_work(jspin, 1)%matrix, &
-                           template=matrix_s_kp(1, 1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
+      CALL dbcsr_reserve_all_blocks(mat_dm_global_work(1)%matrix)
 
-         CALL dbcsr_reserve_all_blocks(mat_dm_global_work(jspin, 1)%matrix)
-
-         CALL dbcsr_set(mat_dm_global_work(jspin, 1)%matrix, 0.0_dp)
-
-      END DO
+      CALL dbcsr_set(mat_dm_global_work(1)%matrix, 0.0_dp)
 
       ! Reusable complex AO scratch for the k-point density source.
       CALL get_mo_set(kpoints_G%kp_env(1)%kpoint_env%mos(1, 1), nao=nao)
       CALL cp_cfm_create(cfm_density, kpoints_G%kp_env(1)%kpoint_env%mos(1, 1)%mo_coeff%matrix_struct, &
                          nrow=nao, ncol=nao)
 
-      CALL density_matrix_from_kp_to_mic(kpoints_G, cfm_density, mat_dm_global_work, qs_env, tau, e_fermi, sector)
+      CALL density_matrix_from_kp_to_mic(kpoints_G, cfm_density, mat_dm_global_work, qs_env, ispin, tau, e_fermi, sector)
 
       CALL cp_cfm_release(cfm_density)
 
       CALL dbcsr_copy(propagator(sector, jquad, 1)%matrix, &
-                      mat_dm_global_work(ispin, 1)%matrix)
+                      mat_dm_global_work(1)%matrix)
 
       CALL dbcsr_deallocate_matrix_set(mat_dm_global_work)
 
@@ -1175,16 +1163,18 @@ CONTAINS
 !> \param density complex AO density scratch matrix
 !> \param mat_dm_global_work ...
 !> \param qs_env ...
+!> \param ispin ...
 !> \param tau ...
 !> \param e_fermi ...
 !> \param sector ...
 ! **************************************************************************************************
-   SUBROUTINE density_matrix_from_kp_to_mic(kpoints_G, density, mat_dm_global_work, qs_env, tau, e_fermi, sector)
+   SUBROUTINE density_matrix_from_kp_to_mic(kpoints_G, density, mat_dm_global_work, qs_env, ispin, tau, e_fermi, sector)
 
       TYPE(kpoint_type), POINTER                         :: kpoints_G
       TYPE(cp_cfm_type), INTENT(INOUT)                   :: density
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work
+      TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_dm_global_work
       TYPE(qs_environment_type), POINTER                 :: qs_env
+      INTEGER, INTENT(IN)                                :: ispin
       REAL(KIND=dp), INTENT(IN)                          :: tau, e_fermi
       INTEGER, INTENT(IN)                                :: sector
 
@@ -1192,8 +1182,8 @@ CONTAINS
 
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), POINTER :: cfm_data
       INTEGER                                            :: handle, iatom, iatom_old, ik, ik_global, ik_old, &
-                                                            irow, ispin, jatom, jatom_old, jcol, &
-                                                            nao, ncol_local, nrow_local, nspin, &
+                                                            irow, jatom, jatom_old, jcol, &
+                                                            nao, ncol_local, nrow_local, &
                                                             num_cells
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_from_ao_index
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
@@ -1215,8 +1205,6 @@ CONTAINS
       index_to_cell => kpoints_G%index_to_cell
       num_cells = SIZE(index_to_cell, 2)
 
-      nspin = SIZE(mat_dm_global_work, 1)
-
       CALL cp_cfm_get_info(density, nrow_global=nao, nrow_local=nrow_local, ncol_local=ncol_local, &
                            row_indices=row_indices, col_indices=col_indices)
       CALL cp_fm_create(fm_mat_work, density%matrix_struct, set_zero=.TRUE.)
@@ -1233,48 +1221,45 @@ CONTAINS
       jatom_old = 0
       ik_old = 0
 
-      DO ispin = 1, nspin
+      CALL dbcsr_set(mat_dm_global_work(1)%matrix, 0.0_dp)
 
-         CALL dbcsr_set(mat_dm_global_work(ispin, 1)%matrix, 0.0_dp)
+      DO ik = 1, SIZE(kpoints_G%kp_env)
 
-         DO ik = 1, SIZE(kpoints_G%kp_env)
+         kp => kpoints_G%kp_env(ik)%kpoint_env
+         ik_global = kp%nkpoint
+         CALL build_kpoint_density_matrix_rpa(kpoints_G, ik, ispin, tau, e_fermi, sector, density)
+         CALL cp_cfm_get_info(density, local_data=cfm_data)
 
-            kp => kpoints_G%kp_env(ik)%kpoint_env
-            ik_global = kp%nkpoint
-            CALL build_kpoint_density_matrix_rpa(kpoints_G, ik, ispin, tau, e_fermi, sector, density)
-            CALL cp_cfm_get_info(density, local_data=cfm_data)
+         DO irow = 1, nrow_local
+            DO jcol = 1, ncol_local
 
-            DO irow = 1, nrow_local
-               DO jcol = 1, ncol_local
+               iatom = atom_from_ao_index(row_indices(irow))
+               jatom = atom_from_ao_index(col_indices(jcol))
 
-                  iatom = atom_from_ao_index(row_indices(irow))
-                  jatom = atom_from_ao_index(col_indices(jcol))
+               IF (ik_global /= ik_old .OR. iatom /= iatom_old .OR. jatom /= jatom_old) THEN
 
-                  IF (ik_global /= ik_old .OR. iatom /= iatom_old .OR. jatom /= jatom_old) THEN
+                  CALL compute_weight_re_im(weight_re, weight_im, &
+                                            num_cells, iatom, jatom, xkp(1:3, ik_global), wkp(ik_global), &
+                                            cell, index_to_cell, hmat, particle_set)
 
-                     CALL compute_weight_re_im(weight_re, weight_im, &
-                                               num_cells, iatom, jatom, xkp(1:3, ik_global), wkp(ik_global), &
-                                               cell, index_to_cell, hmat, particle_set)
+                  iatom_old = iatom
+                  jatom_old = jatom
+                  ik_old = ik_global
 
-                     iatom_old = iatom
-                     jatom_old = jatom
-                     ik_old = ik_global
+               END IF
 
-                  END IF
+               contribution = REAL(CMPLX(weight_re, -weight_im, KIND=dp)*cfm_data(irow, jcol), KIND=dp)
 
-                  contribution = REAL(CMPLX(weight_re, -weight_im, KIND=dp)*cfm_data(irow, jcol), KIND=dp)
+               fm_mat_work%local_data(irow, jcol) = fm_mat_work%local_data(irow, jcol) + contribution
 
-                  fm_mat_work%local_data(irow, jcol) = fm_mat_work%local_data(irow, jcol) + contribution
-
-               END DO
             END DO
+         END DO
 
-         END DO ! ik
+      END DO ! ik
 
-         CALL copy_fm_to_dbcsr(fm_mat_work, mat_dm_global_work(ispin, 1)%matrix, keep_sparsity=.FALSE.)
-         CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+      CALL copy_fm_to_dbcsr(fm_mat_work, mat_dm_global_work(1)%matrix, keep_sparsity=.FALSE.)
 
-      END DO
+      CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
 
       CALL cp_fm_release(fm_mat_work)
       DEALLOCATE (atom_from_ao_index)
@@ -1289,24 +1274,25 @@ CONTAINS
 !> \param density complex AO density scratch matrix
 !> \param mat_dm_global_work ...
 !> \param index_to_cell ...
+!> \param ispin ...
 !> \param tau ...
 !> \param e_fermi ...
 !> \param sector ...
 ! **************************************************************************************************
    SUBROUTINE density_matrix_from_kp_to_transl(kpoints, density, mat_dm_global_work, index_to_cell, &
-                                               tau, e_fermi, sector)
+                                               ispin, tau, e_fermi, sector)
 
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(cp_cfm_type), INTENT(INOUT)                   :: density
-      TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(IN)    :: mat_dm_global_work
+      TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: mat_dm_global_work
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: index_to_cell
+      INTEGER, INTENT(IN)                                :: ispin
       REAL(KIND=dp), INTENT(IN)                          :: tau, e_fermi
       INTEGER, INTENT(IN)                                :: sector
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_matrix_from_kp_to_transl'
 
-      INTEGER                                            :: handle, icell, ik, ik_global, ispin, &
-                                                            nspin, xcell, ycell, zcell
+      INTEGER                                            :: handle, icell, ik, ik_global, xcell, ycell, zcell
       REAL(KIND=dp)                                      :: arg, coskl, sinkl
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
@@ -1321,13 +1307,13 @@ CONTAINS
       NULLIFY (mat_work_re)
       CALL dbcsr_init_p(mat_work_re)
       CALL dbcsr_create(matrix=mat_work_re, &
-                        template=mat_dm_global_work(1, 1)%matrix, &
+                        template=mat_dm_global_work(1)%matrix, &
                         matrix_type=dbcsr_type_no_symmetry)
 
       NULLIFY (mat_work_im)
       CALL dbcsr_init_p(mat_work_im)
       CALL dbcsr_create(matrix=mat_work_im, &
-                        template=mat_dm_global_work(1, 1)%matrix, &
+                        template=mat_dm_global_work(1)%matrix, &
                         matrix_type=dbcsr_type_no_symmetry)
 
       CALL cp_fm_create(fm_mat_re, density%matrix_struct)
@@ -1335,50 +1321,41 @@ CONTAINS
 
       CALL get_kpoint_info(kpoints, xkp=xkp, wkp=wkp)
 
-      nspin = SIZE(mat_dm_global_work, 1)
+      CPASSERT(SIZE(mat_dm_global_work) == SIZE(index_to_cell, 2))
 
-      CPASSERT(SIZE(mat_dm_global_work, 2) == SIZE(index_to_cell, 2))
+      DO icell = 1, SIZE(mat_dm_global_work)
 
-      DO ispin = 1, nspin
-
-         DO icell = 1, SIZE(mat_dm_global_work, 2)
-
-            CALL dbcsr_set(mat_dm_global_work(ispin, icell)%matrix, 0.0_dp)
-
-         END DO
+         CALL dbcsr_set(mat_dm_global_work(icell)%matrix, 0.0_dp)
 
       END DO
 
-      DO ispin = 1, nspin
+      DO ik = 1, SIZE(kpoints%kp_env)
 
-         DO ik = 1, SIZE(kpoints%kp_env)
+         kp => kpoints%kp_env(ik)%kpoint_env
+         ik_global = kp%nkpoint
+         CALL build_kpoint_density_matrix_rpa(kpoints, ik, ispin, tau, e_fermi, sector, density)
+         CALL cp_cfm_to_fm(density, fm_mat_re, fm_mat_im)
 
-            kp => kpoints%kp_env(ik)%kpoint_env
-            ik_global = kp%nkpoint
-            CALL build_kpoint_density_matrix_rpa(kpoints, ik, ispin, tau, e_fermi, sector, density)
-            CALL cp_cfm_to_fm(density, fm_mat_re, fm_mat_im)
+         CALL copy_fm_to_dbcsr(fm_mat_re, mat_work_re, keep_sparsity=.FALSE.)
+         CALL copy_fm_to_dbcsr(fm_mat_im, mat_work_im, keep_sparsity=.FALSE.)
 
-            CALL copy_fm_to_dbcsr(fm_mat_re, mat_work_re, keep_sparsity=.FALSE.)
-            CALL copy_fm_to_dbcsr(fm_mat_im, mat_work_im, keep_sparsity=.FALSE.)
+         DO icell = 1, SIZE(mat_dm_global_work)
 
-            DO icell = 1, SIZE(mat_dm_global_work, 2)
+            xcell = index_to_cell(1, icell)
+            ycell = index_to_cell(2, icell)
+            zcell = index_to_cell(3, icell)
 
-               xcell = index_to_cell(1, icell)
-               ycell = index_to_cell(2, icell)
-               zcell = index_to_cell(3, icell)
+            arg = REAL(xcell, dp)*xkp(1, ik_global) + REAL(ycell, dp)*xkp(2, ik_global) + &
+                  REAL(zcell, dp)*xkp(3, ik_global)
+            coskl = wkp(ik_global)*COS(twopi*arg)
+            sinkl = wkp(ik_global)*SIN(twopi*arg)
 
-               arg = REAL(xcell, dp)*xkp(1, ik_global) + REAL(ycell, dp)*xkp(2, ik_global) + &
-                     REAL(zcell, dp)*xkp(3, ik_global)
-               coskl = wkp(ik_global)*COS(twopi*arg)
-               sinkl = wkp(ik_global)*SIN(twopi*arg)
-
-               CALL dbcsr_add(mat_dm_global_work(ispin, icell)%matrix, mat_work_re, 1.0_dp, coskl)
-               ! The real-space convention is Re(exp(i k R) G(k)).
-               CALL dbcsr_add(mat_dm_global_work(ispin, icell)%matrix, mat_work_im, 1.0_dp, -sinkl)
-
-            END DO
+            CALL dbcsr_add(mat_dm_global_work(icell)%matrix, mat_work_re, 1.0_dp, coskl)
+            ! The real-space convention is Re(exp(i k R) G(k)).
+            CALL dbcsr_add(mat_dm_global_work(icell)%matrix, mat_work_im, 1.0_dp, -sinkl)
 
          END DO
+
       END DO
 
       CALL dbcsr_release_p(mat_work_re)

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -119,12 +119,8 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param mat_P_omega ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
 !> \param mat_P_global ...
 !> \param matrix_s ...
 !> \param ispin ...
@@ -159,9 +155,7 @@ CONTAINS
 !> \param dbcsr_time ...
 !> \param dbcsr_nflop ...
 ! **************************************************************************************************
-   SUBROUTINE compute_mat_P_omega(mat_P_omega, fm_scaled_dm_occ_tau, &
-                                  fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                  fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+   SUBROUTINE compute_mat_P_omega(mat_P_omega, fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                   mat_P_global, &
                                   matrix_s, &
                                   ispin, &
@@ -178,8 +172,7 @@ CONTAINS
                                   has_mat_P_blocks, do_ri_sos_laplace_mp2, &
                                   dbcsr_time, dbcsr_nflop)
       TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(IN)    :: mat_P_omega
-      TYPE(cp_fm_type), INTENT(IN) :: fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-         fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled
+      TYPE(cp_fm_type), INTENT(IN) :: fm_mo_coeff_occ, fm_mo_coeff_virt
       TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_P_global
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       INTEGER, INTENT(IN)                                :: ispin
@@ -281,9 +274,7 @@ CONTAINS
          CALL para_env%sync()
          t1 = m_walltime()
 
-         CALL compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, nmo, &
-                                    fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                    fm_mo_coeff_virt_scaled, propagator, &
+         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, fm_mo_coeff_occ, fm_mo_coeff_virt, propagator, &
                                     matrix_s, ispin, &
                                     Eigenval, e_fermi, eps_filter, memory_info, unit_nr, &
                                     jquad, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, qs_env, &
@@ -672,15 +663,11 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
 !> \param tau_tj ...
 !> \param num_integ_points ...
 !> \param nmo ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
 !> \param propagator ...
 !> \param matrix_s ...
 !> \param ispin ...
@@ -697,21 +684,15 @@ CONTAINS
 !> \param index_to_cell_dm ...
 !> \param para_env ...
 ! **************************************************************************************************
-   SUBROUTINE compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, nmo, &
-                                    fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                    fm_mo_coeff_virt_scaled, propagator, &
+   SUBROUTINE compute_mat_dm_global(tau_tj, num_integ_points, nmo, fm_mo_coeff_occ, fm_mo_coeff_virt, propagator, &
                                     matrix_s, ispin, &
                                     Eigenval, e_fermi, eps_filter, memory_info, unit_nr, &
                                     jquad, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, qs_env, &
                                     num_cells_dm, index_to_cell_dm, para_env)
 
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_scaled_dm_occ_tau, &
-                                                            fm_scaled_dm_virt_tau
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tau_tj
       INTEGER, INTENT(IN)                                :: num_integ_points, nmo
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                                            fm_mo_coeff_occ_scaled, &
-                                                            fm_mo_coeff_virt_scaled
+      TYPE(cp_fm_type), INTENT(IN)                       :: fm_mo_coeff_occ, fm_mo_coeff_virt
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
          INTENT(INOUT), POINTER                          :: propagator
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: matrix_s
@@ -735,6 +716,8 @@ CONTAINS
       INTEGER, DIMENSION(3, 1)                           :: index_to_cell_zero
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: tau
+      TYPE(cp_fm_type)                                   :: fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
 
       index_to_cell_zero = 0
 
@@ -782,6 +765,11 @@ CONTAINS
                              ncol_local=ncol_local, &
                              row_indices=row_indices, &
                              col_indices=col_indices)
+
+         CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
+         CALL cp_fm_create(fm_scaled_dm_virt_tau, fm_mo_coeff_virt%matrix_struct, nrow=nao, ncol=nao)
+         CALL cp_fm_create(fm_mo_coeff_occ_scaled, fm_mo_coeff_occ%matrix_struct)
+         CALL cp_fm_create(fm_mo_coeff_virt_scaled, fm_mo_coeff_virt%matrix_struct)
 
          ! Multiply the occupied and the virtual MO coefficients with the factor exp((-e_i-e_F)*tau/2).
          ! Then, we simply get the sum over all occ states and virt. states by a simple matrix-matrix
@@ -863,6 +851,11 @@ CONTAINS
             CALL dbcsr_filter(propagator(propagator_sector_occupied, jquad - 1, 1)%matrix, 0.0_dp)
             CALL dbcsr_filter(propagator(propagator_sector_virtual, jquad - 1, 1)%matrix, 0.0_dp)
          END IF
+
+         CALL cp_fm_release(fm_scaled_dm_occ_tau)
+         CALL cp_fm_release(fm_scaled_dm_virt_tau)
+         CALL cp_fm_release(fm_mo_coeff_occ_scaled)
+         CALL cp_fm_release(fm_mo_coeff_virt_scaled)
 
       END IF ! do kpoints
 
@@ -1218,8 +1211,7 @@ CONTAINS
 
       NULLIFY (xkp, wkp)
 
-      CALL cp_fm_create(fm_mat_work, kpoints_G%kp_env(1)%kpoint_env%wmat(1, 1)%matrix_struct)
-      CALL cp_fm_set_all(fm_mat_work, 0.0_dp)
+      CALL cp_fm_create(fm_mat_work, kpoints_G%kp_env(1)%kpoint_env%wmat(1, 1)%matrix_struct, set_zero=.TRUE.)
 
       CALL get_kpoint_info(kpoints_G, nkp=nkp, xkp=xkp, wkp=wkp)
       index_to_cell => kpoints_G%index_to_cell

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -123,8 +123,8 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param mat_P_omega ...
-!> \param cfm_mo_coeff_occ ...
-!> \param cfm_mo_coeff_virt ...
+!> \param cfm_mo_coeff ...
+!> \param homo ...
 !> \param mat_P_global ...
 !> \param matrix_s ...
 !> \param ispin ...
@@ -159,7 +159,7 @@ CONTAINS
 !> \param dbcsr_time ...
 !> \param dbcsr_nflop ...
 ! **************************************************************************************************
-   SUBROUTINE compute_mat_P_omega(mat_P_omega, cfm_mo_coeff_occ, cfm_mo_coeff_virt, &
+   SUBROUTINE compute_mat_P_omega(mat_P_omega, cfm_mo_coeff, homo, &
                                   mat_P_global, &
                                   matrix_s, &
                                   ispin, &
@@ -176,7 +176,8 @@ CONTAINS
                                   has_mat_P_blocks, do_ri_sos_laplace_mp2, &
                                   dbcsr_time, dbcsr_nflop)
       TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(IN)    :: mat_P_omega
-      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff
+      INTEGER, INTENT(IN)                                :: homo
       TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_P_global
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       INTEGER, INTENT(IN)                                :: ispin
@@ -278,7 +279,7 @@ CONTAINS
          CALL para_env%sync()
          t1 = m_walltime()
 
-         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff_occ, cfm_mo_coeff_virt, propagator, &
+         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff, homo, propagator, &
                                     matrix_s, ispin, &
                                     Eigenval, e_fermi, eps_filter, memory_info, unit_nr, &
                                     jquad, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, qs_env, &
@@ -670,8 +671,8 @@ CONTAINS
 !> \param tau_tj ...
 !> \param num_integ_points ...
 !> \param nmo ...
-!> \param cfm_mo_coeff_occ ...
-!> \param cfm_mo_coeff_virt ...
+!> \param cfm_mo_coeff ...
+!> \param homo ...
 !> \param propagator ...
 !> \param matrix_s ...
 !> \param ispin ...
@@ -688,7 +689,7 @@ CONTAINS
 !> \param index_to_cell_dm ...
 !> \param para_env ...
 ! **************************************************************************************************
-   SUBROUTINE compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff_occ, cfm_mo_coeff_virt, propagator, &
+   SUBROUTINE compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff, homo, propagator, &
                                     matrix_s, ispin, &
                                     Eigenval, e_fermi, eps_filter, memory_info, unit_nr, &
                                     jquad, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, qs_env, &
@@ -696,7 +697,8 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tau_tj
       INTEGER, INTENT(IN)                                :: num_integ_points, nmo
-      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff
+      INTEGER, INTENT(IN)                                :: homo
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
          INTENT(INOUT), POINTER                          :: propagator
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: matrix_s
@@ -760,7 +762,7 @@ CONTAINS
                                               index_to_cell_zero)
          END IF
 
-         CALL compute_gamma_propagator(propagator, jquad, cfm_mo_coeff_occ, cfm_mo_coeff_virt, Eigenval, nmo, &
+         CALL compute_gamma_propagator(propagator, jquad, cfm_mo_coeff, homo, Eigenval, nmo, &
                                        eps_filter, e_fermi, tau, para_env)
 
          ! release memory
@@ -781,8 +783,8 @@ CONTAINS
 !> \brief Builds the Gamma-point occupied and virtual propagators.
 !> \param propagator sector/time/cell propagator matrix set
 !> \param jquad time-point index
-!> \param cfm_mo_coeff_occ occupied-orbital coefficients
-!> \param cfm_mo_coeff_virt virtual-orbital coefficients
+!> \param cfm_mo_coeff complete MO coefficient matrix
+!> \param homo number of occupied orbitals
 !> \param Eigenval orbital energies
 !> \param nmo number of orbitals
 !> \param eps_filter DBCSR filtering threshold
@@ -790,12 +792,13 @@ CONTAINS
 !> \param tau imaginary time
 !> \param para_env parallel environment
 ! **************************************************************************************************
-   SUBROUTINE compute_gamma_propagator(propagator, jquad, cfm_mo_coeff_occ, cfm_mo_coeff_virt, Eigenval, nmo, &
+   SUBROUTINE compute_gamma_propagator(propagator, jquad, cfm_mo_coeff, homo, Eigenval, nmo, &
                                        eps_filter, e_fermi, tau, para_env)
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
          INTENT(INOUT), POINTER                          :: propagator
       INTEGER, INTENT(IN)                                :: jquad
-      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff
+      INTEGER, INTENT(IN)                                :: homo
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
       INTEGER, INTENT(IN)                                :: nmo
       REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, tau
@@ -821,42 +824,36 @@ CONTAINS
       mat_occ => propagator(propagator_sector_occupied, jquad, 1)%matrix
       mat_virt => propagator(propagator_sector_virtual, jquad, 1)%matrix
 
-      CALL cp_cfm_get_info(matrix=cfm_mo_coeff_occ, &
+      CALL cp_cfm_get_info(matrix=cfm_mo_coeff, &
                            nrow_global=nao, &
                            nrow_local=nrow_local, &
                            ncol_local=ncol_local, &
                            row_indices=row_indices, &
                            col_indices=col_indices)
 
-      CALL cp_cfm_create(cfm_scaled_dm_occ_tau, cfm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
-      CALL cp_cfm_create(cfm_scaled_dm_virt_tau, cfm_mo_coeff_virt%matrix_struct, nrow=nao, ncol=nao)
-      CALL cp_cfm_create(cfm_mo_coeff_occ_scaled, cfm_mo_coeff_occ%matrix_struct)
-      CALL cp_cfm_create(cfm_mo_coeff_virt_scaled, cfm_mo_coeff_virt%matrix_struct)
+      CALL cp_cfm_create(cfm_scaled_dm_occ_tau, cfm_mo_coeff%matrix_struct, nrow=nao, ncol=nao)
+      CALL cp_cfm_create(cfm_scaled_dm_virt_tau, cfm_mo_coeff%matrix_struct, nrow=nao, ncol=nao)
+      CALL cp_cfm_create(cfm_mo_coeff_occ_scaled, cfm_mo_coeff%matrix_struct)
+      CALL cp_cfm_create(cfm_mo_coeff_virt_scaled, cfm_mo_coeff%matrix_struct)
 
       DO jjB = 1, nrow_local
          DO iiB = 1, ncol_local
             i_global = col_indices(iiB)
-            IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
+            IF (i_global <= homo .AND. ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
                cfm_mo_coeff_occ_scaled%local_data(jjB, iiB) = &
-                  cfm_mo_coeff_occ%local_data(jjB, iiB)*EXP(tau*0.5_dp*(Eigenval(i_global) - e_fermi))
+                  cfm_mo_coeff%local_data(jjB, iiB)*EXP(tau*0.5_dp*(Eigenval(i_global) - e_fermi))
             ELSE
                cfm_mo_coeff_occ_scaled%local_data(jjB, iiB) = (0.0_dp, 0.0_dp)
             END IF
          END DO
       END DO
 
-      CALL cp_cfm_get_info(matrix=cfm_mo_coeff_virt, &
-                           nrow_local=nrow_local, &
-                           ncol_local=ncol_local, &
-                           row_indices=row_indices, &
-                           col_indices=col_indices)
-
       DO jjB = 1, nrow_local
          DO iiB = 1, ncol_local
             i_global = col_indices(iiB)
-            IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
+            IF (i_global > homo .AND. ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
                cfm_mo_coeff_virt_scaled%local_data(jjB, iiB) = &
-                  cfm_mo_coeff_virt%local_data(jjB, iiB)*EXP(-tau*0.5_dp*(Eigenval(i_global) - e_fermi))
+                  cfm_mo_coeff%local_data(jjB, iiB)*EXP(-tau*0.5_dp*(Eigenval(i_global) - e_fermi))
             ELSE
                cfm_mo_coeff_virt_scaled%local_data(jjB, iiB) = (0.0_dp, 0.0_dp)
             END IF

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -13,6 +13,11 @@
 MODULE rpa_im_time
    USE cell_types,                      ONLY: cell_type,&
                                               get_cell
+   USE cp_cfm_types,                    ONLY: cp_cfm_create,&
+                                              cp_cfm_get_info,&
+                                              cp_cfm_release,&
+                                              cp_cfm_to_fm,&
+                                              cp_cfm_type
    USE cp_dbcsr_api,                    ONLY: &
         dbcsr_add, dbcsr_clear, dbcsr_copy, dbcsr_create, dbcsr_distribution_get, &
         dbcsr_distribution_type, dbcsr_filter, dbcsr_get_info, dbcsr_init_p, dbcsr_p_type, &
@@ -119,8 +124,8 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param mat_P_omega ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
+!> \param cfm_mo_coeff_occ ...
+!> \param cfm_mo_coeff_virt ...
 !> \param mat_P_global ...
 !> \param matrix_s ...
 !> \param ispin ...
@@ -155,7 +160,7 @@ CONTAINS
 !> \param dbcsr_time ...
 !> \param dbcsr_nflop ...
 ! **************************************************************************************************
-   SUBROUTINE compute_mat_P_omega(mat_P_omega, fm_mo_coeff_occ, fm_mo_coeff_virt, &
+   SUBROUTINE compute_mat_P_omega(mat_P_omega, cfm_mo_coeff_occ, cfm_mo_coeff_virt, &
                                   mat_P_global, &
                                   matrix_s, &
                                   ispin, &
@@ -172,7 +177,7 @@ CONTAINS
                                   has_mat_P_blocks, do_ri_sos_laplace_mp2, &
                                   dbcsr_time, dbcsr_nflop)
       TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(IN)    :: mat_P_omega
-      TYPE(cp_fm_type), INTENT(IN) :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
       TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_P_global
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_s
       INTEGER, INTENT(IN)                                :: ispin
@@ -274,7 +279,7 @@ CONTAINS
          CALL para_env%sync()
          t1 = m_walltime()
 
-         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, fm_mo_coeff_occ, fm_mo_coeff_virt, propagator, &
+         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff_occ, cfm_mo_coeff_virt, propagator, &
                                     matrix_s, ispin, &
                                     Eigenval, e_fermi, eps_filter, memory_info, unit_nr, &
                                     jquad, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, qs_env, &
@@ -666,8 +671,8 @@ CONTAINS
 !> \param tau_tj ...
 !> \param num_integ_points ...
 !> \param nmo ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
+!> \param cfm_mo_coeff_occ ...
+!> \param cfm_mo_coeff_virt ...
 !> \param propagator ...
 !> \param matrix_s ...
 !> \param ispin ...
@@ -684,7 +689,7 @@ CONTAINS
 !> \param index_to_cell_dm ...
 !> \param para_env ...
 ! **************************************************************************************************
-   SUBROUTINE compute_mat_dm_global(tau_tj, num_integ_points, nmo, fm_mo_coeff_occ, fm_mo_coeff_virt, propagator, &
+   SUBROUTINE compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff_occ, cfm_mo_coeff_virt, propagator, &
                                     matrix_s, ispin, &
                                     Eigenval, e_fermi, eps_filter, memory_info, unit_nr, &
                                     jquad, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, qs_env, &
@@ -692,7 +697,7 @@ CONTAINS
 
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: tau_tj
       INTEGER, INTENT(IN)                                :: num_integ_points, nmo
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
       TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
          INTENT(INOUT), POINTER                          :: propagator
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: matrix_s
@@ -756,7 +761,7 @@ CONTAINS
                                               index_to_cell_zero)
          END IF
 
-         CALL compute_gamma_propagator(propagator, jquad, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, nmo, &
+         CALL compute_gamma_propagator(propagator, jquad, cfm_mo_coeff_occ, cfm_mo_coeff_virt, Eigenval, nmo, &
                                        eps_filter, e_fermi, tau, para_env)
 
          ! release memory
@@ -777,8 +782,8 @@ CONTAINS
 !> \brief Builds the Gamma-point occupied and virtual propagators.
 !> \param propagator sector/time/cell propagator matrix set
 !> \param jquad time-point index
-!> \param fm_mo_coeff_occ occupied-orbital coefficients
-!> \param fm_mo_coeff_virt virtual-orbital coefficients
+!> \param cfm_mo_coeff_occ occupied-orbital coefficients
+!> \param cfm_mo_coeff_virt virtual-orbital coefficients
 !> \param Eigenval orbital energies
 !> \param nmo number of orbitals
 !> \param eps_filter DBCSR filtering threshold
@@ -786,14 +791,16 @@ CONTAINS
 !> \param tau imaginary time
 !> \param para_env parallel environment
 ! **************************************************************************************************
-   SUBROUTINE compute_gamma_propagator(propagator, jquad, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, nmo, &
-                                        eps_filter, e_fermi, tau, para_env)
-      TYPE(dbcsr_p_type), DIMENSION(:, :, :), INTENT(INOUT), POINTER :: propagator
-      INTEGER, INTENT(IN)                                :: jquad, nmo
-      TYPE(cp_fm_type), INTENT(IN)                        :: fm_mo_coeff_occ, fm_mo_coeff_virt
-      REAL(KIND=dp), DIMENSION(:), INTENT(IN)             :: Eigenval
-      REAL(KIND=dp), INTENT(IN)                           :: eps_filter, e_fermi, tau
-      TYPE(mp_para_env_type), INTENT(IN)                  :: para_env
+   SUBROUTINE compute_gamma_propagator(propagator, jquad, cfm_mo_coeff_occ, cfm_mo_coeff_virt, Eigenval, nmo, &
+                                       eps_filter, e_fermi, tau, para_env)
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
+         INTENT(INOUT), POINTER                          :: propagator
+      INTEGER, INTENT(IN)                                :: jquad
+      TYPE(cp_cfm_type), INTENT(IN)                      :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
+      INTEGER, INTENT(IN)                                :: nmo
+      REAL(KIND=dp), INTENT(IN)                          :: eps_filter, e_fermi, tau
+      TYPE(mp_para_env_type), INTENT(IN)                 :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_gamma_propagator'
       REAL(KIND=dp), PARAMETER                           :: stabilize_exp = 70.0_dp
@@ -801,9 +808,13 @@ CONTAINS
       INTEGER                                            :: handle, i_global, iiB, jjB, nao, &
                                                             ncol_local, nrow_local
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
+      TYPE(cp_cfm_type)                                  :: cfm_mo_coeff_occ_scaled, &
+                                                            cfm_mo_coeff_virt_scaled, &
+                                                            cfm_scaled_dm_occ_tau, &
+                                                            cfm_scaled_dm_virt_tau
+      TYPE(cp_fm_type)                                   :: fm_scaled_dm_occ_tau, &
+                                                            fm_scaled_dm_virt_tau
       TYPE(dbcsr_type), POINTER                          :: mat_occ, mat_virt
-      TYPE(cp_fm_type)                                   :: fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
 
       CALL timeset(routineN, handle)
       CALL para_env%sync()
@@ -811,56 +822,61 @@ CONTAINS
       mat_occ => propagator(propagator_sector_occupied, jquad, 1)%matrix
       mat_virt => propagator(propagator_sector_virtual, jquad, 1)%matrix
 
-      CALL cp_fm_get_info(matrix=fm_mo_coeff_occ, &
-                          nrow_global=nao, &
-                          nrow_local=nrow_local, &
-                          ncol_local=ncol_local, &
-                          row_indices=row_indices, &
-                          col_indices=col_indices)
+      CALL cp_cfm_get_info(matrix=cfm_mo_coeff_occ, &
+                           nrow_global=nao, &
+                           nrow_local=nrow_local, &
+                           ncol_local=ncol_local, &
+                           row_indices=row_indices, &
+                           col_indices=col_indices)
 
-      CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
-      CALL cp_fm_create(fm_scaled_dm_virt_tau, fm_mo_coeff_virt%matrix_struct, nrow=nao, ncol=nao)
-      CALL cp_fm_create(fm_mo_coeff_occ_scaled, fm_mo_coeff_occ%matrix_struct)
-      CALL cp_fm_create(fm_mo_coeff_virt_scaled, fm_mo_coeff_virt%matrix_struct)
+      CALL cp_cfm_create(cfm_scaled_dm_occ_tau, cfm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
+      CALL cp_cfm_create(cfm_scaled_dm_virt_tau, cfm_mo_coeff_virt%matrix_struct, nrow=nao, ncol=nao)
+      CALL cp_cfm_create(cfm_mo_coeff_occ_scaled, cfm_mo_coeff_occ%matrix_struct)
+      CALL cp_cfm_create(cfm_mo_coeff_virt_scaled, cfm_mo_coeff_virt%matrix_struct)
 
       DO jjB = 1, nrow_local
          DO iiB = 1, ncol_local
             i_global = col_indices(iiB)
             IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
-               fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = &
-                  fm_mo_coeff_occ%local_data(jjB, iiB)*EXP(tau*0.5_dp*(Eigenval(i_global) - e_fermi))
+               cfm_mo_coeff_occ_scaled%local_data(jjB, iiB) = &
+                  cfm_mo_coeff_occ%local_data(jjB, iiB)*EXP(tau*0.5_dp*(Eigenval(i_global) - e_fermi))
             ELSE
-               fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = 0.0_dp
+               cfm_mo_coeff_occ_scaled%local_data(jjB, iiB) = (0.0_dp, 0.0_dp)
             END IF
          END DO
       END DO
 
-      CALL cp_fm_get_info(matrix=fm_mo_coeff_virt, &
-                          nrow_local=nrow_local, &
-                          ncol_local=ncol_local, &
-                          row_indices=row_indices, &
-                          col_indices=col_indices)
+      CALL cp_cfm_get_info(matrix=cfm_mo_coeff_virt, &
+                           nrow_local=nrow_local, &
+                           ncol_local=ncol_local, &
+                           row_indices=row_indices, &
+                           col_indices=col_indices)
 
       DO jjB = 1, nrow_local
          DO iiB = 1, ncol_local
             i_global = col_indices(iiB)
             IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
-               fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = &
-                  fm_mo_coeff_virt%local_data(jjB, iiB)*EXP(-tau*0.5_dp*(Eigenval(i_global) - e_fermi))
+               cfm_mo_coeff_virt_scaled%local_data(jjB, iiB) = &
+                  cfm_mo_coeff_virt%local_data(jjB, iiB)*EXP(-tau*0.5_dp*(Eigenval(i_global) - e_fermi))
             ELSE
-               fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = 0.0_dp
+               cfm_mo_coeff_virt_scaled%local_data(jjB, iiB) = (0.0_dp, 0.0_dp)
             END IF
          END DO
       END DO
 
       CALL para_env%sync()
 
-      CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
-                         matrix_a=fm_mo_coeff_occ_scaled, matrix_b=fm_mo_coeff_occ_scaled, beta=0.0_dp, &
-                         matrix_c=fm_scaled_dm_occ_tau)
-      CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
-                         matrix_a=fm_mo_coeff_virt_scaled, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
-                         matrix_c=fm_scaled_dm_virt_tau)
+      CALL parallel_gemm(transa="N", transb="C", m=nao, n=nao, k=nmo, alpha=(1.0_dp, 0.0_dp), &
+                         matrix_a=cfm_mo_coeff_occ_scaled, matrix_b=cfm_mo_coeff_occ_scaled, beta=(0.0_dp, 0.0_dp), &
+                         matrix_c=cfm_scaled_dm_occ_tau)
+      CALL parallel_gemm(transa="N", transb="C", m=nao, n=nao, k=nmo, alpha=(1.0_dp, 0.0_dp), &
+                         matrix_a=cfm_mo_coeff_virt_scaled, matrix_b=cfm_mo_coeff_virt_scaled, beta=(0.0_dp, 0.0_dp), &
+                         matrix_c=cfm_scaled_dm_virt_tau)
+
+      CALL cp_fm_create(fm_scaled_dm_occ_tau, cfm_scaled_dm_occ_tau%matrix_struct)
+      CALL cp_fm_create(fm_scaled_dm_virt_tau, cfm_scaled_dm_virt_tau%matrix_struct)
+      CALL cp_cfm_to_fm(cfm_scaled_dm_occ_tau, fm_scaled_dm_occ_tau)
+      CALL cp_cfm_to_fm(cfm_scaled_dm_virt_tau, fm_scaled_dm_virt_tau)
 
       CALL dbcsr_set(mat_occ, 0.0_dp)
       CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, mat_occ, keep_sparsity=.FALSE.)
@@ -871,8 +887,10 @@ CONTAINS
 
       CALL cp_fm_release(fm_scaled_dm_occ_tau)
       CALL cp_fm_release(fm_scaled_dm_virt_tau)
-      CALL cp_fm_release(fm_mo_coeff_occ_scaled)
-      CALL cp_fm_release(fm_mo_coeff_virt_scaled)
+      CALL cp_cfm_release(cfm_scaled_dm_occ_tau)
+      CALL cp_cfm_release(cfm_scaled_dm_virt_tau)
+      CALL cp_cfm_release(cfm_mo_coeff_occ_scaled)
+      CALL cp_cfm_release(cfm_mo_coeff_virt_scaled)
       CALL timestop(handle)
 
    END SUBROUTINE compute_gamma_propagator

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -76,6 +76,7 @@ MODULE rpa_im_time
              zero_mat_P_omega, &
              compute_periodic_dm, &
              compute_mat_dm_global, &
+             compute_gamma_propagator, &
              create_propagator_matrix_set
 
 CONTAINS
@@ -97,7 +98,6 @@ CONTAINS
 
       CPASSERT(ntime > 0)
       CPASSERT(SIZE(index_to_cell, 1) == 3)
-
       ncell = SIZE(index_to_cell, 2)
       CPASSERT(ncell > 0)
 
@@ -709,15 +709,10 @@ CONTAINS
       TYPE(mp_para_env_type), INTENT(IN)                 :: para_env
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_mat_dm_global'
-      REAL(KIND=dp), PARAMETER                           :: stabilize_exp = 70.0_dp
 
-      INTEGER                                            :: handle, i_global, iiB, jjB, nao, &
-                                                            ncol_local, nrow_local
+      INTEGER                                            :: handle
       INTEGER, DIMENSION(3, 1)                           :: index_to_cell_zero
-      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: tau
-      TYPE(cp_fm_type)                                   :: fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
-                                                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
 
       index_to_cell_zero = 0
 
@@ -756,93 +751,13 @@ CONTAINS
 
          num_cells_dm = 1
 
-         CALL para_env%sync()
-
-         ! get info of fm_mo_coeff_occ
-         CALL cp_fm_get_info(matrix=fm_mo_coeff_occ, &
-                             nrow_global=nao, &
-                             nrow_local=nrow_local, &
-                             ncol_local=ncol_local, &
-                             row_indices=row_indices, &
-                             col_indices=col_indices)
-
-         CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
-         CALL cp_fm_create(fm_scaled_dm_virt_tau, fm_mo_coeff_virt%matrix_struct, nrow=nao, ncol=nao)
-         CALL cp_fm_create(fm_mo_coeff_occ_scaled, fm_mo_coeff_occ%matrix_struct)
-         CALL cp_fm_create(fm_mo_coeff_virt_scaled, fm_mo_coeff_virt%matrix_struct)
-
-         ! Multiply the occupied and the virtual MO coefficients with the factor exp((-e_i-e_F)*tau/2).
-         ! Then, we simply get the sum over all occ states and virt. states by a simple matrix-matrix
-         ! multiplication.
-
-         ! first, the occ
-         DO jjB = 1, nrow_local
-            DO iiB = 1, ncol_local
-               i_global = col_indices(iiB)
-
-               ! hard coded: exponential function gets NaN if argument is negative with large absolute value
-               ! use 69, since e^(-69) = 10^(-30) which should be sufficiently small that it does not matter
-               IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
-                  fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = &
-                     fm_mo_coeff_occ%local_data(jjB, iiB)*EXP(tau*0.5_dp*(Eigenval(i_global) - e_fermi))
-               ELSE
-                  fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = 0.0_dp
-               END IF
-
-            END DO
-         END DO
-
-         ! get info of fm_mo_coeff_virt
-         CALL cp_fm_get_info(matrix=fm_mo_coeff_virt, &
-                             nrow_local=nrow_local, &
-                             ncol_local=ncol_local, &
-                             row_indices=row_indices, &
-                             col_indices=col_indices)
-
-         ! the same for virt
-         DO jjB = 1, nrow_local
-            DO iiB = 1, ncol_local
-               i_global = col_indices(iiB)
-
-               IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
-                  fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = &
-                     fm_mo_coeff_virt%local_data(jjB, iiB)*EXP(-tau*0.5_dp*(Eigenval(i_global) - e_fermi))
-               ELSE
-                  fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = 0.0_dp
-               END IF
-
-            END DO
-         END DO
-
-         CALL para_env%sync()
-
-         CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
-                            matrix_a=fm_mo_coeff_occ_scaled, matrix_b=fm_mo_coeff_occ_scaled, beta=0.0_dp, &
-                            matrix_c=fm_scaled_dm_occ_tau)
-
-         CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
-                            matrix_a=fm_mo_coeff_virt_scaled, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
-                            matrix_c=fm_scaled_dm_virt_tau)
-
          IF (jquad == 1) THEN
-
-            ! transfer fm density matrices to dbcsr matrix
             CALL create_propagator_matrix_set(propagator, num_integ_points, matrix_s(1)%matrix, &
                                               index_to_cell_zero)
-
          END IF
 
-         CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
-                               propagator(propagator_sector_occupied, jquad, 1)%matrix, &
-                               keep_sparsity=.FALSE.)
-
-         CALL dbcsr_filter(propagator(propagator_sector_occupied, jquad, 1)%matrix, eps_filter)
-
-         CALL copy_fm_to_dbcsr(fm_scaled_dm_virt_tau, &
-                               propagator(propagator_sector_virtual, jquad, 1)%matrix, &
-                               keep_sparsity=.FALSE.)
-
-         CALL dbcsr_filter(propagator(propagator_sector_virtual, jquad, 1)%matrix, eps_filter)
+         CALL compute_gamma_propagator(propagator, jquad, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, nmo, &
+                                       eps_filter, e_fermi, tau, para_env)
 
          ! release memory
          IF (jquad > 1) THEN
@@ -852,16 +767,115 @@ CONTAINS
             CALL dbcsr_filter(propagator(propagator_sector_virtual, jquad - 1, 1)%matrix, 0.0_dp)
          END IF
 
-         CALL cp_fm_release(fm_scaled_dm_occ_tau)
-         CALL cp_fm_release(fm_scaled_dm_virt_tau)
-         CALL cp_fm_release(fm_mo_coeff_occ_scaled)
-         CALL cp_fm_release(fm_mo_coeff_virt_scaled)
-
       END IF ! do kpoints
 
       CALL timestop(handle)
 
    END SUBROUTINE compute_mat_dm_global
+
+! **************************************************************************************************
+!> \brief Builds the Gamma-point occupied and virtual propagators.
+!> \param propagator sector/time/cell propagator matrix set
+!> \param jquad time-point index
+!> \param fm_mo_coeff_occ occupied-orbital coefficients
+!> \param fm_mo_coeff_virt virtual-orbital coefficients
+!> \param Eigenval orbital energies
+!> \param nmo number of orbitals
+!> \param eps_filter DBCSR filtering threshold
+!> \param e_fermi Fermi energy
+!> \param tau imaginary time
+!> \param para_env parallel environment
+! **************************************************************************************************
+   SUBROUTINE compute_gamma_propagator(propagator, jquad, fm_mo_coeff_occ, fm_mo_coeff_virt, Eigenval, nmo, &
+                                        eps_filter, e_fermi, tau, para_env)
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), INTENT(INOUT), POINTER :: propagator
+      INTEGER, INTENT(IN)                                :: jquad, nmo
+      TYPE(cp_fm_type), INTENT(IN)                        :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      REAL(KIND=dp), DIMENSION(:), INTENT(IN)             :: Eigenval
+      REAL(KIND=dp), INTENT(IN)                           :: eps_filter, e_fermi, tau
+      TYPE(mp_para_env_type), INTENT(IN)                  :: para_env
+
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_gamma_propagator'
+      REAL(KIND=dp), PARAMETER                           :: stabilize_exp = 70.0_dp
+
+      INTEGER                                            :: handle, i_global, iiB, jjB, nao, &
+                                                            ncol_local, nrow_local
+      INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
+      TYPE(dbcsr_type), POINTER                          :: mat_occ, mat_virt
+      TYPE(cp_fm_type)                                   :: fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau
+
+      CALL timeset(routineN, handle)
+      CALL para_env%sync()
+
+      mat_occ => propagator(propagator_sector_occupied, jquad, 1)%matrix
+      mat_virt => propagator(propagator_sector_virtual, jquad, 1)%matrix
+
+      CALL cp_fm_get_info(matrix=fm_mo_coeff_occ, &
+                          nrow_global=nao, &
+                          nrow_local=nrow_local, &
+                          ncol_local=ncol_local, &
+                          row_indices=row_indices, &
+                          col_indices=col_indices)
+
+      CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_mo_coeff_occ%matrix_struct, nrow=nao, ncol=nao)
+      CALL cp_fm_create(fm_scaled_dm_virt_tau, fm_mo_coeff_virt%matrix_struct, nrow=nao, ncol=nao)
+      CALL cp_fm_create(fm_mo_coeff_occ_scaled, fm_mo_coeff_occ%matrix_struct)
+      CALL cp_fm_create(fm_mo_coeff_virt_scaled, fm_mo_coeff_virt%matrix_struct)
+
+      DO jjB = 1, nrow_local
+         DO iiB = 1, ncol_local
+            i_global = col_indices(iiB)
+            IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
+               fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = &
+                  fm_mo_coeff_occ%local_data(jjB, iiB)*EXP(tau*0.5_dp*(Eigenval(i_global) - e_fermi))
+            ELSE
+               fm_mo_coeff_occ_scaled%local_data(jjB, iiB) = 0.0_dp
+            END IF
+         END DO
+      END DO
+
+      CALL cp_fm_get_info(matrix=fm_mo_coeff_virt, &
+                          nrow_local=nrow_local, &
+                          ncol_local=ncol_local, &
+                          row_indices=row_indices, &
+                          col_indices=col_indices)
+
+      DO jjB = 1, nrow_local
+         DO iiB = 1, ncol_local
+            i_global = col_indices(iiB)
+            IF (ABS(tau*0.5_dp*(Eigenval(i_global) - e_fermi)) < stabilize_exp) THEN
+               fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = &
+                  fm_mo_coeff_virt%local_data(jjB, iiB)*EXP(-tau*0.5_dp*(Eigenval(i_global) - e_fermi))
+            ELSE
+               fm_mo_coeff_virt_scaled%local_data(jjB, iiB) = 0.0_dp
+            END IF
+         END DO
+      END DO
+
+      CALL para_env%sync()
+
+      CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
+                         matrix_a=fm_mo_coeff_occ_scaled, matrix_b=fm_mo_coeff_occ_scaled, beta=0.0_dp, &
+                         matrix_c=fm_scaled_dm_occ_tau)
+      CALL parallel_gemm(transa="N", transb="T", m=nao, n=nao, k=nmo, alpha=1.0_dp, &
+                         matrix_a=fm_mo_coeff_virt_scaled, matrix_b=fm_mo_coeff_virt_scaled, beta=0.0_dp, &
+                         matrix_c=fm_scaled_dm_virt_tau)
+
+      CALL dbcsr_set(mat_occ, 0.0_dp)
+      CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, mat_occ, keep_sparsity=.FALSE.)
+      CALL dbcsr_filter(mat_occ, eps_filter)
+      CALL dbcsr_set(mat_virt, 0.0_dp)
+      CALL copy_fm_to_dbcsr(fm_scaled_dm_virt_tau, mat_virt, keep_sparsity=.FALSE.)
+      CALL dbcsr_filter(mat_virt, eps_filter)
+
+      CALL cp_fm_release(fm_scaled_dm_occ_tau)
+      CALL cp_fm_release(fm_scaled_dm_virt_tau)
+      CALL cp_fm_release(fm_mo_coeff_occ_scaled)
+      CALL cp_fm_release(fm_mo_coeff_virt_scaled)
+      CALL timestop(handle)
+
+   END SUBROUTINE compute_gamma_propagator
 
 ! **************************************************************************************************
 !> \brief Calculate kpoint density matrices (rho(k), owned by kpoint groups)

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -66,14 +66,55 @@ MODULE rpa_im_time
 
    CHARACTER(len=*), PARAMETER, PRIVATE :: moduleN = 'rpa_im_time'
 
+   INTEGER, PARAMETER, PUBLIC :: propagator_sector_occupied = 1
+   INTEGER, PARAMETER, PUBLIC :: propagator_sector_virtual = 2
+   INTEGER, PARAMETER, PUBLIC :: propagator_number_of_sectors = 2
+
    PUBLIC :: compute_mat_P_omega, &
              compute_transl_dm, &
              init_cell_index_rpa, &
              zero_mat_P_omega, &
              compute_periodic_dm, &
-             compute_mat_dm_global
+             compute_mat_dm_global, &
+             create_propagator_matrix_set
 
 CONTAINS
+
+! **************************************************************************************************
+!> \brief Creates the sector-, time-, and cell-resolved propagator matrix set.
+!> \param propagator propagator matrix set to create
+!> \param ntime number of time or frequency points
+!> \param matrix_template DBCSR matrix template for every matrix
+!> \param index_to_cell cell coordinates for the third matrix-set index
+! **************************************************************************************************
+   SUBROUTINE create_propagator_matrix_set(propagator, ntime, matrix_template, index_to_cell)
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: propagator
+      INTEGER, INTENT(IN)                                :: ntime
+      TYPE(dbcsr_type), INTENT(IN)                       :: matrix_template
+      INTEGER, DIMENSION(:, :), INTENT(IN)               :: index_to_cell
+
+      INTEGER                                            :: icell, isector, jtime, ncell
+
+      CPASSERT(ntime > 0)
+      CPASSERT(SIZE(index_to_cell, 1) == 3)
+
+      ncell = SIZE(index_to_cell, 2)
+      CPASSERT(ncell > 0)
+
+      CALL dbcsr_allocate_matrix_set(propagator, propagator_number_of_sectors, ntime, ncell)
+
+      DO icell = 1, ncell
+         DO jtime = 1, ntime
+            DO isector = 1, propagator_number_of_sectors
+               ALLOCATE (propagator(isector, jtime, icell)%matrix)
+               CALL dbcsr_create(matrix=propagator(isector, jtime, icell)%matrix, &
+                                 template=matrix_template, &
+                                 matrix_type=dbcsr_type_no_symmetry)
+            END DO
+         END DO
+      END DO
+
+   END SUBROUTINE create_propagator_matrix_set
 
 ! **************************************************************************************************
 !> \brief ...
@@ -195,7 +236,7 @@ CONTAINS
       REAL(KIND=dp)                                      :: omega, omega_old, t1, t2, tau, weight, &
                                                             weight_old
       TYPE(dbcsr_distribution_type)                      :: dist_P
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_global, mat_dm_virt_global
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: propagator
       TYPE(dbt_pgrid_type)                               :: pgrid_2d
       TYPE(dbt_type)                                     :: t_3c_M_occ, t_3c_M_occ_tmp, t_3c_M_virt, &
                                                             t_3c_M_virt_tmp, t_dm, t_dm_tmp, t_P, &
@@ -205,6 +246,8 @@ CONTAINS
       TYPE(mp_comm_type)                                 :: comm_2d
 
       CALL timeset(routineN, handle)
+
+      NULLIFY (propagator)
 
       memory_info = mp2_env%ri_rpa_im_time%memory_info
       IF (memory_info) THEN
@@ -240,7 +283,7 @@ CONTAINS
 
          CALL compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, nmo, &
                                     fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                    fm_mo_coeff_virt_scaled, mat_dm_occ_global, mat_dm_virt_global, &
+                                    fm_mo_coeff_virt_scaled, propagator, &
                                     matrix_s, ispin, &
                                     Eigenval, e_fermi, eps_filter, memory_info, unit_nr, &
                                     jquad, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, qs_env, &
@@ -268,16 +311,16 @@ CONTAINS
 
          DO i_cell = 1, num_cells_dm
             CALL dbt_create(t_dm, t_dm_virt(i_cell), name="D virt (AO | AO)")
-            CALL dbt_create(mat_dm_virt_global(jquad, i_cell)%matrix, t_dm_tmp)
-            CALL dbt_copy_matrix_to_tensor(mat_dm_virt_global(jquad, i_cell)%matrix, t_dm_tmp)
+            CALL dbt_create(propagator(propagator_sector_virtual, jquad, i_cell)%matrix, t_dm_tmp)
+            CALL dbt_copy_matrix_to_tensor(propagator(propagator_sector_virtual, jquad, i_cell)%matrix, t_dm_tmp)
             CALL dbt_copy(t_dm_tmp, t_dm_virt(i_cell), move_data=.TRUE.)
-            CALL dbcsr_clear(mat_dm_virt_global(jquad, i_cell)%matrix)
+            CALL dbcsr_clear(propagator(propagator_sector_virtual, jquad, i_cell)%matrix)
 
             CALL dbt_create(t_dm, t_dm_occ(i_cell), name="D occ (AO | AO)")
-            CALL dbt_copy_matrix_to_tensor(mat_dm_occ_global(jquad, i_cell)%matrix, t_dm_tmp)
+            CALL dbt_copy_matrix_to_tensor(propagator(propagator_sector_occupied, jquad, i_cell)%matrix, t_dm_tmp)
             CALL dbt_copy(t_dm_tmp, t_dm_occ(i_cell), move_data=.TRUE.)
             CALL dbt_destroy(t_dm_tmp)
-            CALL dbcsr_clear(mat_dm_occ_global(jquad, i_cell)%matrix)
+            CALL dbcsr_clear(propagator(propagator_sector_occupied, jquad, i_cell)%matrix)
          END DO
 
          CALL get_tensor_occupancy(t_dm_occ(1), nze_dm_occ, occ_dm_occ)
@@ -602,7 +645,7 @@ CONTAINS
          END DO
       END DO
 
-      CALL clean_up(mat_dm_occ_global, mat_dm_virt_global)
+      CALL dbcsr_deallocate_matrix_set(propagator)
 
       CALL timestop(handle)
 
@@ -638,8 +681,7 @@ CONTAINS
 !> \param fm_mo_coeff_virt ...
 !> \param fm_mo_coeff_occ_scaled ...
 !> \param fm_mo_coeff_virt_scaled ...
-!> \param mat_dm_occ_global ...
-!> \param mat_dm_virt_global ...
+!> \param propagator ...
 !> \param matrix_s ...
 !> \param ispin ...
 !> \param Eigenval ...
@@ -657,7 +699,7 @@ CONTAINS
 ! **************************************************************************************************
    SUBROUTINE compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, nmo, &
                                     fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                    fm_mo_coeff_virt_scaled, mat_dm_occ_global, mat_dm_virt_global, &
+                                    fm_mo_coeff_virt_scaled, propagator, &
                                     matrix_s, ispin, &
                                     Eigenval, e_fermi, eps_filter, memory_info, unit_nr, &
                                     jquad, do_kpoints_cubic_RPA, do_kpoints_from_Gamma, qs_env, &
@@ -670,7 +712,8 @@ CONTAINS
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_mo_coeff_occ, fm_mo_coeff_virt, &
                                                             fm_mo_coeff_occ_scaled, &
                                                             fm_mo_coeff_virt_scaled
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_global, mat_dm_virt_global
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
+         INTENT(INOUT), POINTER                          :: propagator
       TYPE(dbcsr_p_type), DIMENSION(:), INTENT(IN)       :: matrix_s
       INTEGER, INTENT(IN)                                :: ispin
       REAL(KIND=dp), DIMENSION(:), INTENT(IN)            :: Eigenval
@@ -687,10 +730,13 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_mat_dm_global'
       REAL(KIND=dp), PARAMETER                           :: stabilize_exp = 70.0_dp
 
-      INTEGER                                            :: handle, i_global, iiB, iquad, jjB, nao, &
+      INTEGER                                            :: handle, i_global, iiB, jjB, nao, &
                                                             ncol_local, nrow_local
+      INTEGER, DIMENSION(3, 1)                           :: index_to_cell_zero
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
       REAL(KIND=dp)                                      :: tau
+
+      index_to_cell_zero = 0
 
       CALL timeset(routineN, handle)
 
@@ -701,27 +747,25 @@ CONTAINS
 
       IF (do_kpoints_cubic_RPA) THEN
 
-         CALL compute_transl_dm(mat_dm_occ_global, qs_env, &
+         CALL compute_transl_dm(propagator, qs_env, &
                                 ispin, num_integ_points, jquad, e_fermi, tau, &
                                 eps_filter, num_cells_dm, index_to_cell_dm, &
-                                remove_occ=.FALSE., remove_virt=.TRUE., first_jquad=1)
+                                sector=propagator_sector_occupied)
 
-         CALL compute_transl_dm(mat_dm_virt_global, qs_env, &
+         CALL compute_transl_dm(propagator, qs_env, &
                                 ispin, num_integ_points, jquad, e_fermi, tau, &
                                 eps_filter, num_cells_dm, index_to_cell_dm, &
-                                remove_occ=.TRUE., remove_virt=.FALSE., first_jquad=1)
+                                sector=propagator_sector_virtual)
 
       ELSE IF (do_kpoints_from_Gamma) THEN
 
-         CALL compute_periodic_dm(mat_dm_occ_global, qs_env, &
+         CALL compute_periodic_dm(propagator, qs_env, &
                                   ispin, num_integ_points, jquad, e_fermi, tau, &
-                                  remove_occ=.FALSE., remove_virt=.TRUE., &
-                                  alloc_dm=(jquad == 1))
+                                  sector=propagator_sector_occupied)
 
-         CALL compute_periodic_dm(mat_dm_virt_global, qs_env, &
+         CALL compute_periodic_dm(propagator, qs_env, &
                                   ispin, num_integ_points, jquad, e_fermi, tau, &
-                                  remove_occ=.TRUE., remove_virt=.FALSE., &
-                                  alloc_dm=(jquad == 1))
+                                  sector=propagator_sector_virtual)
 
          num_cells_dm = 1
 
@@ -795,49 +839,29 @@ CONTAINS
          IF (jquad == 1) THEN
 
             ! transfer fm density matrices to dbcsr matrix
-            NULLIFY (mat_dm_occ_global)
-            CALL dbcsr_allocate_matrix_set(mat_dm_occ_global, num_integ_points, 1)
-
-            DO iquad = 1, num_integ_points
-
-               ALLOCATE (mat_dm_occ_global(iquad, 1)%matrix)
-               CALL dbcsr_create(matrix=mat_dm_occ_global(iquad, 1)%matrix, &
-                                 template=matrix_s(1)%matrix, &
-                                 matrix_type=dbcsr_type_no_symmetry)
-
-            END DO
+            CALL create_propagator_matrix_set(propagator, num_integ_points, matrix_s(1)%matrix, &
+                                              index_to_cell_zero)
 
          END IF
 
          CALL copy_fm_to_dbcsr(fm_scaled_dm_occ_tau, &
-                               mat_dm_occ_global(jquad, 1)%matrix, &
+                               propagator(propagator_sector_occupied, jquad, 1)%matrix, &
                                keep_sparsity=.FALSE.)
 
-         CALL dbcsr_filter(mat_dm_occ_global(jquad, 1)%matrix, eps_filter)
+         CALL dbcsr_filter(propagator(propagator_sector_occupied, jquad, 1)%matrix, eps_filter)
 
-         IF (jquad == 1) THEN
-
-            NULLIFY (mat_dm_virt_global)
-            CALL dbcsr_allocate_matrix_set(mat_dm_virt_global, num_integ_points, 1)
-
-         END IF
-
-         ALLOCATE (mat_dm_virt_global(jquad, 1)%matrix)
-         CALL dbcsr_create(matrix=mat_dm_virt_global(jquad, 1)%matrix, &
-                           template=matrix_s(1)%matrix, &
-                           matrix_type=dbcsr_type_no_symmetry)
          CALL copy_fm_to_dbcsr(fm_scaled_dm_virt_tau, &
-                               mat_dm_virt_global(jquad, 1)%matrix, &
+                               propagator(propagator_sector_virtual, jquad, 1)%matrix, &
                                keep_sparsity=.FALSE.)
 
-         CALL dbcsr_filter(mat_dm_virt_global(jquad, 1)%matrix, eps_filter)
+         CALL dbcsr_filter(propagator(propagator_sector_virtual, jquad, 1)%matrix, eps_filter)
 
          ! release memory
          IF (jquad > 1) THEN
-            CALL dbcsr_set(mat_dm_occ_global(jquad - 1, 1)%matrix, 0.0_dp)
-            CALL dbcsr_set(mat_dm_virt_global(jquad - 1, 1)%matrix, 0.0_dp)
-            CALL dbcsr_filter(mat_dm_occ_global(jquad - 1, 1)%matrix, 0.0_dp)
-            CALL dbcsr_filter(mat_dm_virt_global(jquad - 1, 1)%matrix, 0.0_dp)
+            CALL dbcsr_set(propagator(propagator_sector_occupied, jquad - 1, 1)%matrix, 0.0_dp)
+            CALL dbcsr_set(propagator(propagator_sector_virtual, jquad - 1, 1)%matrix, 0.0_dp)
+            CALL dbcsr_filter(propagator(propagator_sector_occupied, jquad - 1, 1)%matrix, 0.0_dp)
+            CALL dbcsr_filter(propagator(propagator_sector_virtual, jquad - 1, 1)%matrix, 0.0_dp)
          END IF
 
       END IF ! do kpoints
@@ -847,31 +871,17 @@ CONTAINS
    END SUBROUTINE compute_mat_dm_global
 
 ! **************************************************************************************************
-!> \brief ...
-!> \param mat_dm_occ_global ...
-!> \param mat_dm_virt_global ...
-! **************************************************************************************************
-   SUBROUTINE clean_up(mat_dm_occ_global, mat_dm_virt_global)
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ_global, mat_dm_virt_global
-
-      CALL dbcsr_deallocate_matrix_set(mat_dm_occ_global)
-      CALL dbcsr_deallocate_matrix_set(mat_dm_virt_global)
-
-   END SUBROUTINE clean_up
-
-! **************************************************************************************************
 !> \brief Calculate kpoint density matrices (rho(k), owned by kpoint groups)
 !> \param kpoint    kpoint environment
 !> \param tau ...
 !> \param e_fermi ...
-!> \param remove_occ ...
-!> \param remove_virt ...
+!> \param sector ...
 ! **************************************************************************************************
-   SUBROUTINE kpoint_density_matrices_rpa(kpoint, tau, e_fermi, remove_occ, remove_virt)
+   SUBROUTINE kpoint_density_matrices_rpa(kpoint, tau, e_fermi, sector)
 
       TYPE(kpoint_type), POINTER                         :: kpoint
       REAL(KIND=dp), INTENT(IN)                          :: tau, e_fermi
-      LOGICAL, INTENT(IN)                                :: remove_occ, remove_virt
+      INTEGER, INTENT(IN)                                :: sector
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_density_matrices_rpa'
       REAL(KIND=dp), PARAMETER                           :: stabilize_exp = 70.0_dp
@@ -887,6 +897,8 @@ CONTAINS
       TYPE(mo_set_type), POINTER                         :: mo_set
 
       CALL timeset(routineN, handle)
+
+      CPASSERT(sector == propagator_sector_occupied .OR. sector == propagator_sector_virtual)
 
       ! only imaginary wavefunctions supported in kpoint cubic scaling RPA
       CPASSERT(kpoint%use_real_wfn .EQV. .FALSE.)
@@ -918,10 +930,9 @@ CONTAINS
             CALL get_mo_set(mo_set, occupation_numbers=occupation)
             CALL cp_fm_to_fm(mo_set%mo_coeff, fwork)
 
-            IF (remove_virt) THEN
+            IF (sector == propagator_sector_occupied) THEN
                CALL cp_fm_column_scale(fwork, occupation)
-            END IF
-            IF (remove_occ) THEN
+            ELSE
                CALL cp_fm_column_scale(fwork, 2.0_dp/REAL(nspin, KIND=dp) - occupation)
             END IF
 
@@ -951,10 +962,9 @@ CONTAINS
 
             CALL cp_fm_to_fm(mo_set%mo_coeff, fwork)
 
-            IF (remove_virt) THEN
+            IF (sector == propagator_sector_occupied) THEN
                CALL cp_fm_column_scale(fwork, occupation)
-            END IF
-            IF (remove_occ) THEN
+            ELSE
                CALL cp_fm_column_scale(fwork, 2.0_dp/REAL(nspin, KIND=dp) - occupation)
             END IF
 
@@ -988,7 +998,7 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param mat_dm_global ...
+!> \param propagator ...
 !> \param qs_env ...
 !> \param ispin ...
 !> \param num_integ_points ...
@@ -998,25 +1008,23 @@ CONTAINS
 !> \param eps_filter ...
 !> \param num_cells_dm ...
 !> \param index_to_cell_dm ...
-!> \param remove_occ ...
-!> \param remove_virt ...
-!> \param first_jquad ...
+!> \param sector ...
 ! **************************************************************************************************
-   SUBROUTINE compute_transl_dm(mat_dm_global, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
-                                eps_filter, num_cells_dm, index_to_cell_dm, remove_occ, remove_virt, &
-                                first_jquad)
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global
+   SUBROUTINE compute_transl_dm(propagator, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
+                                eps_filter, num_cells_dm, index_to_cell_dm, &
+                                sector)
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
+         INTENT(INOUT), POINTER                          :: propagator
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: ispin, num_integ_points, jquad
       REAL(KIND=dp), INTENT(IN)                          :: e_fermi, tau, eps_filter
       INTEGER, INTENT(OUT)                               :: num_cells_dm
       INTEGER, DIMENSION(:, :), POINTER                  :: index_to_cell_dm
-      LOGICAL, INTENT(IN)                                :: remove_occ, remove_virt
-      INTEGER, INTENT(IN)                                :: first_jquad
+      INTEGER, INTENT(IN)                                :: sector
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'compute_transl_dm'
 
-      INTEGER                                            :: handle, i_dim, i_img, iquad, jspin, nspin
+      INTEGER                                            :: handle, i_dim, i_img, jspin, nspin
       INTEGER, DIMENSION(3)                              :: cell_grid_dm
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work, matrix_s_kp
@@ -1061,8 +1069,7 @@ CONTAINS
       END DO
 
       ! density matrices in k-space weighted with EXP(-|e_i-e_F|*t) for occupied orbitals
-      CALL kpoint_density_matrices_rpa(kpoints, tau, e_fermi, &
-                                       remove_occ=remove_occ, remove_virt=remove_virt)
+      CALL kpoint_density_matrices_rpa(kpoints, tau, e_fermi, sector)
 
       ! overwrite the cell indices in kpoints
       CALL init_cell_index_rpa(cell_grid_dm, kpoints%cell_to_index, kpoints%index_to_cell, cell)
@@ -1074,23 +1081,10 @@ CONTAINS
       ! we need the index to cell for the density matrices later
       index_to_cell_dm => kpoints%index_to_cell
 
-      ! normally, jquad = 1 to allocate the matrix set, but for GW jquad = 0 is the exchange self-energy
-      IF (jquad == first_jquad) THEN
-
-         NULLIFY (mat_dm_global)
-         ALLOCATE (mat_dm_global(first_jquad:num_integ_points, num_cells_dm))
-
-         DO iquad = first_jquad, num_integ_points
-            DO i_img = 1, num_cells_dm
-               NULLIFY (mat_dm_global(iquad, i_img)%matrix)
-               ALLOCATE (mat_dm_global(iquad, i_img)%matrix)
-               CALL dbcsr_create(matrix=mat_dm_global(iquad, i_img)%matrix, &
-                                 template=matrix_s_kp(1, 1)%matrix, &
-                                 matrix_type=dbcsr_type_no_symmetry)
-
-            END DO
-         END DO
-
+      ! The first request owns allocation of the complete time-indexed propagator set.
+      IF (.NOT. ASSOCIATED(propagator)) THEN
+         CALL create_propagator_matrix_set(propagator, num_integ_points, matrix_s_kp(1, 1)%matrix, &
+                                           kpoints%index_to_cell)
       END IF
 
       DO i_img = 1, num_cells_dm
@@ -1098,7 +1092,7 @@ CONTAINS
          ! filter to get rid of the blocks full with zeros on the lower half, otherwise blocks doubled
          CALL dbcsr_filter(mat_dm_global_work(ispin, i_img)%matrix, eps_filter)
 
-         CALL dbcsr_copy(mat_dm_global(jquad, i_img)%matrix, &
+         CALL dbcsr_copy(propagator(sector, jquad, i_img)%matrix, &
                          mat_dm_global_work(ispin, i_img)%matrix)
 
       END DO
@@ -1111,28 +1105,28 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param mat_dm_global ...
+!> \param propagator ...
 !> \param qs_env ...
 !> \param ispin ...
 !> \param num_integ_points ...
 !> \param jquad ...
 !> \param e_fermi ...
 !> \param tau ...
-!> \param remove_occ ...
-!> \param remove_virt ...
-!> \param alloc_dm ...
+!> \param sector ...
 ! **************************************************************************************************
-   SUBROUTINE compute_periodic_dm(mat_dm_global, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
-                                  remove_occ, remove_virt, alloc_dm)
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global
+   SUBROUTINE compute_periodic_dm(propagator, qs_env, ispin, num_integ_points, jquad, e_fermi, tau, &
+                                  sector)
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), &
+         INTENT(INOUT), POINTER                          :: propagator
       TYPE(qs_environment_type), POINTER                 :: qs_env
       INTEGER, INTENT(IN)                                :: ispin, num_integ_points, jquad
       REAL(KIND=dp), INTENT(IN)                          :: e_fermi, tau
-      LOGICAL, INTENT(IN)                                :: remove_occ, remove_virt, alloc_dm
+      INTEGER, INTENT(IN)                                :: sector
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_periodic_dm'
 
-      INTEGER                                            :: handle, iquad, jspin, nspin, num_cells_dm
+      INTEGER                                            :: handle, jspin, nspin, num_cells_dm
+      INTEGER, DIMENSION(3, 1)                           :: index_to_cell_zero
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work, matrix_s_kp
       TYPE(kpoint_type), POINTER                         :: kpoints_G
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
@@ -1150,25 +1144,15 @@ CONTAINS
       nspin = SIZE(mos)
 
       num_cells_dm = 1
+      index_to_cell_zero = 0
 
       NULLIFY (mat_dm_global_work)
       CALL dbcsr_allocate_matrix_set(mat_dm_global_work, nspin, num_cells_dm)
 
-      ! if necessaray, allocate mat_dm_global
-      IF (alloc_dm) THEN
-
-         NULLIFY (mat_dm_global)
-         ALLOCATE (mat_dm_global(1:num_integ_points, num_cells_dm))
-
-         DO iquad = 1, num_integ_points
-            NULLIFY (mat_dm_global(iquad, 1)%matrix)
-            ALLOCATE (mat_dm_global(iquad, 1)%matrix)
-            CALL dbcsr_create(matrix=mat_dm_global(iquad, 1)%matrix, &
-                              template=matrix_s_kp(1, 1)%matrix, &
-                              matrix_type=dbcsr_type_no_symmetry)
-
-         END DO
-
+      ! The first request owns allocation of the complete time-indexed propagator set.
+      IF (.NOT. ASSOCIATED(propagator)) THEN
+         CALL create_propagator_matrix_set(propagator, num_integ_points, matrix_s_kp(1, 1)%matrix, &
+                                           index_to_cell_zero)
       END IF
 
       DO jspin = 1, nspin
@@ -1185,12 +1169,11 @@ CONTAINS
       END DO
 
       ! density matrices in k-space weighted with EXP(-|e_i-e_F|*t) for occupied orbitals
-      CALL kpoint_density_matrices_rpa(kpoints_G, tau, e_fermi, &
-                                       remove_occ=remove_occ, remove_virt=remove_virt)
+      CALL kpoint_density_matrices_rpa(kpoints_G, tau, e_fermi, sector)
 
       CALL density_matrix_from_kp_to_mic(kpoints_G, mat_dm_global_work, qs_env)
 
-      CALL dbcsr_copy(mat_dm_global(jquad, 1)%matrix, &
+      CALL dbcsr_copy(propagator(sector, jquad, 1)%matrix, &
                       mat_dm_global_work(ispin, 1)%matrix)
 
       CALL dbcsr_deallocate_matrix_set(mat_dm_global_work)

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -1194,7 +1194,7 @@ CONTAINS
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_matrix_from_kp_to_mic'
 
       COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), POINTER :: cfm_data
-      INTEGER                                            :: handle, iatom, iatom_old, ik, ik_global, &
+      INTEGER                                            :: handle, iatom, iatom_old, ik, ik_global, ik_old, &
                                                             irow, ispin, jatom, jatom_old, jcol, &
                                                             nao, ncol_local, nrow_local, nspin, &
                                                             num_cells
@@ -1234,6 +1234,7 @@ CONTAINS
 
       iatom_old = 0
       jatom_old = 0
+      ik_old = 0
 
       DO ispin = 1, nspin
 
@@ -1252,7 +1253,7 @@ CONTAINS
                   iatom = atom_from_ao_index(row_indices(irow))
                   jatom = atom_from_ao_index(col_indices(jcol))
 
-                  IF (iatom /= iatom_old .OR. jatom /= jatom_old) THEN
+                  IF (ik_global /= ik_old .OR. iatom /= iatom_old .OR. jatom /= jatom_old) THEN
 
                      CALL compute_weight_re_im(weight_re, weight_im, &
                                                num_cells, iatom, jatom, xkp(1:3, ik_global), wkp(ik_global), &
@@ -1260,6 +1261,7 @@ CONTAINS
 
                      iatom_old = iatom
                      jatom_old = jatom
+                     ik_old = ik_global
 
                   END IF
 

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -30,9 +30,7 @@ MODULE rpa_im_time
    USE cp_dbcsr_operations,             ONLY: copy_fm_to_dbcsr,&
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_scale
    USE cp_fm_types,                     ONLY: cp_fm_create,&
-                                              cp_fm_get_info,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
                                               cp_fm_type
@@ -897,109 +895,85 @@ CONTAINS
    END SUBROUTINE compute_gamma_propagator
 
 ! **************************************************************************************************
-!> \brief Calculate kpoint density matrices (rho(k), owned by kpoint groups)
+!> \brief Calculate one kpoint density matrix in the complex AO representation.
 !> \param kpoint    kpoint environment
+!> \param ikpgr     local kpoint index
+!> \param ispin     spin index
 !> \param tau ...
 !> \param e_fermi ...
 !> \param sector ...
+!> \param density complex AO density matrix
 ! **************************************************************************************************
-   SUBROUTINE kpoint_density_matrices_rpa(kpoint, tau, e_fermi, sector)
+   SUBROUTINE build_kpoint_density_matrix_rpa(kpoint, ikpgr, ispin, tau, e_fermi, sector, density)
 
       TYPE(kpoint_type), POINTER                         :: kpoint
+      INTEGER, INTENT(IN)                                :: ikpgr, ispin
       REAL(KIND=dp), INTENT(IN)                          :: tau, e_fermi
       INTEGER, INTENT(IN)                                :: sector
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: density
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'kpoint_density_matrices_rpa'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'build_kpoint_density_matrix_rpa'
       REAL(KIND=dp), PARAMETER                           :: stabilize_exp = 70.0_dp
 
-      INTEGER                                            :: handle, i_mo, ikpgr, ispin, kplocal, &
-                                                            nao, nmo, nspin
-      INTEGER, DIMENSION(2)                              :: kp_range
+      INTEGER                                            :: handle, i_mo, nao, nmo, nspin
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, exp_scaling, occupation
-      TYPE(cp_cfm_type)                                  :: cfm_density, cfm_mo_coeff, cfm_work
-      TYPE(cp_fm_type), POINTER                          :: cpmat, rpmat
+      TYPE(cp_cfm_type)                                  :: cfm_mo_coeff, cfm_work
       TYPE(kpoint_env_type), POINTER                     :: kp
       TYPE(mo_set_type), POINTER                         :: mo_set, mo_set_im
 
       CALL timeset(routineN, handle)
 
       CPASSERT(sector == propagator_sector_occupied .OR. sector == propagator_sector_virtual)
-
-      ! only imaginary wavefunctions supported in kpoint cubic scaling RPA
       CPASSERT(kpoint%use_real_wfn .EQV. .FALSE.)
 
-      ! work matrix
-      mo_set => kpoint%kp_env(1)%kpoint_env%mos(1, 1)
-      CALL get_mo_set(mo_set, nao=nao, nmo=nmo)
+      kp => kpoint%kp_env(ikpgr)%kpoint_env
+      nspin = SIZE(kp%mos, 2)
+      CPASSERT(ispin >= 1 .AND. ispin <= nspin)
+      mo_set => kp%mos(1, ispin)
+      mo_set_im => kp%mos(2, ispin)
+      CALL get_mo_set(mo_set, nao=nao, nmo=nmo, eigenvalues=eigenvalues, occupation_numbers=occupation)
 
       ! if this CPASSERT is triggered, please add all virtual MOs to SCF section,
       ! e.g. ADDED_MOS 1000000
       CPASSERT(nao == nmo)
 
       ALLOCATE (exp_scaling(nmo))
+      CALL cp_cfm_create(cfm_mo_coeff, mo_set%mo_coeff%matrix_struct)
+      CALL cp_cfm_create(cfm_work, mo_set%mo_coeff%matrix_struct)
+      CALL cp_fm_to_cfm(msourcer=mo_set%mo_coeff, msourcei=mo_set_im%mo_coeff, &
+                        mtarget=cfm_mo_coeff)
+      CALL cp_cfm_to_cfm(cfm_mo_coeff, cfm_work)
 
-      CALL get_kpoint_info(kpoint, kp_range=kp_range)
-      kplocal = kp_range(2) - kp_range(1) + 1
+      IF (sector == propagator_sector_occupied) THEN
+         CALL cp_cfm_column_scale(cfm_work, CMPLX(occupation, 0.0_dp, KIND=dp))
+      ELSE
+         CALL cp_cfm_column_scale(cfm_work, &
+                                  CMPLX(2.0_dp/REAL(nspin, KIND=dp) - occupation, 0.0_dp, KIND=dp))
+      END IF
 
-      DO ikpgr = 1, kplocal
-         kp => kpoint%kp_env(ikpgr)%kpoint_env
-         nspin = SIZE(kp%mos, 2)
-         DO ispin = 1, nspin
-            mo_set => kp%mos(1, ispin)
-            mo_set_im => kp%mos(2, ispin)
-            CALL get_mo_set(mo_set, eigenvalues=eigenvalues)
-            rpmat => kp%wmat(1, ispin)
-            cpmat => kp%wmat(2, ispin)
-            CALL get_mo_set(mo_set, occupation_numbers=occupation)
-            CALL cp_cfm_create(cfm_mo_coeff, mo_set%mo_coeff%matrix_struct)
-            CALL cp_cfm_create(cfm_work, mo_set%mo_coeff%matrix_struct)
-            CALL cp_cfm_create(cfm_density, rpmat%matrix_struct)
-            CALL cp_fm_to_cfm(msourcer=mo_set%mo_coeff, msourcei=mo_set_im%mo_coeff, &
-                              mtarget=cfm_mo_coeff)
-            CALL cp_cfm_to_cfm(cfm_mo_coeff, cfm_work)
+      IF (nspin == 1) THEN
+         CALL cp_cfm_scale(0.5_dp, cfm_work)
+      END IF
 
-            IF (sector == propagator_sector_occupied) THEN
-               CALL cp_cfm_column_scale(cfm_work, CMPLX(occupation, 0.0_dp, KIND=dp))
-            ELSE
-               CALL cp_cfm_column_scale(cfm_work, &
-                                        CMPLX(2.0_dp/REAL(nspin, KIND=dp) - occupation, 0.0_dp, KIND=dp))
-            END IF
-
-            ! proper spin
-            IF (nspin == 1) THEN
-               CALL cp_cfm_scale(0.5_dp, cfm_work)
-            END IF
-
-            DO i_mo = 1, nmo
-
-               IF (ABS(tau*0.5_dp*(eigenvalues(i_mo) - e_fermi)) < stabilize_exp) THEN
-                  exp_scaling(i_mo) = EXP(-ABS(tau*(eigenvalues(i_mo) - e_fermi)))
-               ELSE
-                  exp_scaling(i_mo) = 0.0_dp
-               END IF
-            END DO
-
-            CALL cp_cfm_column_scale(cfm_work, CMPLX(exp_scaling, 0.0_dp, KIND=dp))
-
-            CALL parallel_gemm("N", "C", nao, nao, nmo, (1.0_dp, 0.0_dp), cfm_mo_coeff, cfm_work, &
-                               (0.0_dp, 0.0_dp), cfm_density)
-            CALL cp_cfm_to_fm(cfm_density, rpmat, cpmat)
-            ! The historical wmat convention stores minus the imaginary part.
-            CALL cp_fm_scale(-1.0_dp, cpmat)
-
-            CALL cp_cfm_release(cfm_density)
-            CALL cp_cfm_release(cfm_work)
-            CALL cp_cfm_release(cfm_mo_coeff)
-
-         END DO
-
+      DO i_mo = 1, nmo
+         IF (ABS(tau*0.5_dp*(eigenvalues(i_mo) - e_fermi)) < stabilize_exp) THEN
+            exp_scaling(i_mo) = EXP(-ABS(tau*(eigenvalues(i_mo) - e_fermi)))
+         ELSE
+            exp_scaling(i_mo) = 0.0_dp
+         END IF
       END DO
 
+      CALL cp_cfm_column_scale(cfm_work, CMPLX(exp_scaling, 0.0_dp, KIND=dp))
+      CALL parallel_gemm("N", "C", nao, nao, nmo, (1.0_dp, 0.0_dp), cfm_mo_coeff, cfm_work, &
+                         (0.0_dp, 0.0_dp), density)
+
+      CALL cp_cfm_release(cfm_work)
+      CALL cp_cfm_release(cfm_mo_coeff)
       DEALLOCATE (exp_scaling)
 
       CALL timestop(handle)
 
-   END SUBROUTINE kpoint_density_matrices_rpa
+   END SUBROUTINE build_kpoint_density_matrix_rpa
 
 ! **************************************************************************************************
 !> \brief ...
@@ -1029,9 +1003,10 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'compute_transl_dm'
 
-      INTEGER                                            :: handle, i_dim, i_img, jspin, nspin
+      INTEGER                                            :: handle, i_dim, i_img, jspin, nao, nspin
       INTEGER, DIMENSION(3)                              :: cell_grid_dm
       TYPE(cell_type), POINTER                           :: cell
+      TYPE(cp_cfm_type)                                  :: cfm_density
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work, matrix_s_kp
       TYPE(kpoint_type), POINTER                         :: kpoints
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
@@ -1073,15 +1048,20 @@ CONTAINS
 
       END DO
 
-      ! density matrices in k-space weighted with EXP(-|e_i-e_F|*t) for occupied orbitals
-      CALL kpoint_density_matrices_rpa(kpoints, tau, e_fermi, sector)
+      ! Reusable complex AO scratch for the k-point density source.
+      CALL get_mo_set(kpoints%kp_env(1)%kpoint_env%mos(1, 1), nao=nao)
+      CALL cp_cfm_create(cfm_density, kpoints%kp_env(1)%kpoint_env%mos(1, 1)%mo_coeff%matrix_struct, &
+                         nrow=nao, ncol=nao)
 
       ! overwrite the cell indices in kpoints
       CALL init_cell_index_rpa(cell_grid_dm, kpoints%cell_to_index, kpoints%index_to_cell, cell)
 
       ! density matrices in real space, the cell vectors T for transforming are taken from kpoints%index_to_cell
       ! (custom made for RPA) and not from sab_nl (which is symmetric and from SCF)
-      CALL density_matrix_from_kp_to_transl(kpoints, mat_dm_global_work, kpoints%index_to_cell)
+      CALL density_matrix_from_kp_to_transl(kpoints, cfm_density, mat_dm_global_work, kpoints%index_to_cell, &
+                                            tau, e_fermi, sector)
+
+      CALL cp_cfm_release(cfm_density)
 
       ! we need the index to cell for the density matrices later
       index_to_cell_dm => kpoints%index_to_cell
@@ -1130,8 +1110,9 @@ CONTAINS
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'compute_periodic_dm'
 
-      INTEGER                                            :: handle, jspin, nspin, num_cells_dm
+      INTEGER                                            :: handle, jspin, nao, nspin, num_cells_dm
       INTEGER, DIMENSION(3, 1)                           :: index_to_cell_zero
+      TYPE(cp_cfm_type)                                  :: cfm_density
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work, matrix_s_kp
       TYPE(kpoint_type), POINTER                         :: kpoints_G
       TYPE(mo_set_type), DIMENSION(:), POINTER           :: mos
@@ -1173,10 +1154,14 @@ CONTAINS
 
       END DO
 
-      ! density matrices in k-space weighted with EXP(-|e_i-e_F|*t) for occupied orbitals
-      CALL kpoint_density_matrices_rpa(kpoints_G, tau, e_fermi, sector)
+      ! Reusable complex AO scratch for the k-point density source.
+      CALL get_mo_set(kpoints_G%kp_env(1)%kpoint_env%mos(1, 1), nao=nao)
+      CALL cp_cfm_create(cfm_density, kpoints_G%kp_env(1)%kpoint_env%mos(1, 1)%mo_coeff%matrix_struct, &
+                         nrow=nao, ncol=nao)
 
-      CALL density_matrix_from_kp_to_mic(kpoints_G, mat_dm_global_work, qs_env)
+      CALL density_matrix_from_kp_to_mic(kpoints_G, cfm_density, mat_dm_global_work, qs_env, tau, e_fermi, sector)
+
+      CALL cp_cfm_release(cfm_density)
 
       CALL dbcsr_copy(propagator(sector, jquad, 1)%matrix, &
                       mat_dm_global_work(ispin, 1)%matrix)
@@ -1190,20 +1175,28 @@ CONTAINS
    ! **************************************************************************************************
 !> \brief ...
 !> \param kpoints_G ...
+!> \param density complex AO density scratch matrix
 !> \param mat_dm_global_work ...
 !> \param qs_env ...
+!> \param tau ...
+!> \param e_fermi ...
+!> \param sector ...
 ! **************************************************************************************************
-   SUBROUTINE density_matrix_from_kp_to_mic(kpoints_G, mat_dm_global_work, qs_env)
+   SUBROUTINE density_matrix_from_kp_to_mic(kpoints_G, density, mat_dm_global_work, qs_env, tau, e_fermi, sector)
 
       TYPE(kpoint_type), POINTER                         :: kpoints_G
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: density
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_global_work
       TYPE(qs_environment_type), POINTER                 :: qs_env
+      REAL(KIND=dp), INTENT(IN)                          :: tau, e_fermi
+      INTEGER, INTENT(IN)                                :: sector
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_matrix_from_kp_to_mic'
 
-      INTEGER                                            :: handle, iatom, iatom_old, ik, irow, &
-                                                            ispin, jatom, jatom_old, jcol, nao, &
-                                                            ncol_local, nkp, nrow_local, nspin, &
+      COMPLEX(KIND=dp), CONTIGUOUS, DIMENSION(:, :), POINTER :: cfm_data
+      INTEGER                                            :: handle, iatom, iatom_old, ik, ik_global, &
+                                                            irow, ispin, jatom, jatom_old, jcol, &
+                                                            nao, ncol_local, nrow_local, nspin, &
                                                             num_cells
       INTEGER, ALLOCATABLE, DIMENSION(:)                 :: atom_from_ao_index
       INTEGER, DIMENSION(:), POINTER                     :: col_indices, row_indices
@@ -1214,35 +1207,26 @@ CONTAINS
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_fm_type)                                   :: fm_mat_work
-      TYPE(cp_fm_type), POINTER                          :: cpmat, rpmat
       TYPE(kpoint_env_type), POINTER                     :: kp
-      TYPE(mo_set_type), POINTER                         :: mo_set
       TYPE(particle_type), DIMENSION(:), POINTER         :: particle_set
 
       CALL timeset(routineN, handle)
 
       NULLIFY (xkp, wkp)
 
-      CALL cp_fm_create(fm_mat_work, kpoints_G%kp_env(1)%kpoint_env%wmat(1, 1)%matrix_struct, set_zero=.TRUE.)
-
-      CALL get_kpoint_info(kpoints_G, nkp=nkp, xkp=xkp, wkp=wkp)
+      CALL get_kpoint_info(kpoints_G, xkp=xkp, wkp=wkp)
       index_to_cell => kpoints_G%index_to_cell
       num_cells = SIZE(index_to_cell, 2)
 
       nspin = SIZE(mat_dm_global_work, 1)
 
-      mo_set => kpoints_G%kp_env(1)%kpoint_env%mos(1, 1)
-      CALL get_mo_set(mo_set, nao=nao)
+      CALL cp_cfm_get_info(density, nrow_global=nao, nrow_local=nrow_local, ncol_local=ncol_local, &
+                           row_indices=row_indices, col_indices=col_indices)
+      CALL cp_fm_create(fm_mat_work, density%matrix_struct, set_zero=.TRUE.)
 
       ALLOCATE (atom_from_ao_index(nao))
 
       CALL get_atom_index_from_basis_function_index(qs_env, atom_from_ao_index, nao, "ORB")
-
-      CALL cp_fm_get_info(matrix=kpoints_G%kp_env(1)%kpoint_env%wmat(1, 1), &
-                          nrow_local=nrow_local, &
-                          ncol_local=ncol_local, &
-                          row_indices=row_indices, &
-                          col_indices=col_indices)
 
       NULLIFY (cell, particle_set)
       CALL get_qs_env(qs_env, cell=cell, particle_set=particle_set)
@@ -1255,11 +1239,12 @@ CONTAINS
 
          CALL dbcsr_set(mat_dm_global_work(ispin, 1)%matrix, 0.0_dp)
 
-         DO ik = 1, nkp
+         DO ik = 1, SIZE(kpoints_G%kp_env)
 
             kp => kpoints_G%kp_env(ik)%kpoint_env
-            rpmat => kp%wmat(1, ispin)
-            cpmat => kp%wmat(2, ispin)
+            ik_global = kp%nkpoint
+            CALL build_kpoint_density_matrix_rpa(kpoints_G, ik, ispin, tau, e_fermi, sector, density)
+            CALL cp_cfm_get_info(density, local_data=cfm_data)
 
             DO irow = 1, nrow_local
                DO jcol = 1, ncol_local
@@ -1270,7 +1255,7 @@ CONTAINS
                   IF (iatom /= iatom_old .OR. jatom /= jatom_old) THEN
 
                      CALL compute_weight_re_im(weight_re, weight_im, &
-                                               num_cells, iatom, jatom, xkp(1:3, ik), wkp(ik), &
+                                               num_cells, iatom, jatom, xkp(1:3, ik_global), wkp(ik_global), &
                                                cell, index_to_cell, hmat, particle_set)
 
                      iatom_old = iatom
@@ -1278,9 +1263,7 @@ CONTAINS
 
                   END IF
 
-                  ! minus sign because of i^2 = -1
-                  contribution = weight_re*rpmat%local_data(irow, jcol) - &
-                                 weight_im*cpmat%local_data(irow, jcol)
+                  contribution = REAL(CMPLX(weight_re, -weight_im, KIND=dp)*cfm_data(irow, jcol), KIND=dp)
 
                   fm_mat_work%local_data(irow, jcol) = fm_mat_work%local_data(irow, jcol) + contribution
 
@@ -1304,23 +1287,31 @@ CONTAINS
 ! **************************************************************************************************
 !> \brief ...
 !> \param kpoints ...
+!> \param density complex AO density scratch matrix
 !> \param mat_dm_global_work ...
 !> \param index_to_cell ...
+!> \param tau ...
+!> \param e_fermi ...
+!> \param sector ...
 ! **************************************************************************************************
-   SUBROUTINE density_matrix_from_kp_to_transl(kpoints, mat_dm_global_work, index_to_cell)
+   SUBROUTINE density_matrix_from_kp_to_transl(kpoints, density, mat_dm_global_work, index_to_cell, &
+                                               tau, e_fermi, sector)
 
       TYPE(kpoint_type), POINTER                         :: kpoints
+      TYPE(cp_cfm_type), INTENT(INOUT)                   :: density
       TYPE(dbcsr_p_type), DIMENSION(:, :), INTENT(IN)    :: mat_dm_global_work
       INTEGER, DIMENSION(:, :), INTENT(IN)               :: index_to_cell
+      REAL(KIND=dp), INTENT(IN)                          :: tau, e_fermi
+      INTEGER, INTENT(IN)                                :: sector
 
       CHARACTER(LEN=*), PARAMETER :: routineN = 'density_matrix_from_kp_to_transl'
 
-      INTEGER                                            :: handle, icell, ik, ispin, nkp, nspin, &
-                                                            xcell, ycell, zcell
+      INTEGER                                            :: handle, icell, ik, ik_global, ispin, &
+                                                            nspin, xcell, ycell, zcell
       REAL(KIND=dp)                                      :: arg, coskl, sinkl
       REAL(KIND=dp), DIMENSION(:), POINTER               :: wkp
       REAL(KIND=dp), DIMENSION(:, :), POINTER            :: xkp
-      TYPE(cp_fm_type), POINTER                          :: cpmat, rpmat
+      TYPE(cp_fm_type)                                   :: fm_mat_im, fm_mat_re
       TYPE(dbcsr_type), POINTER                          :: mat_work_im, mat_work_re
       TYPE(kpoint_env_type), POINTER                     :: kp
 
@@ -1340,7 +1331,10 @@ CONTAINS
                         template=mat_dm_global_work(1, 1)%matrix, &
                         matrix_type=dbcsr_type_no_symmetry)
 
-      CALL get_kpoint_info(kpoints, nkp=nkp, xkp=xkp, wkp=wkp)
+      CALL cp_fm_create(fm_mat_re, density%matrix_struct)
+      CALL cp_fm_create(fm_mat_im, density%matrix_struct)
+
+      CALL get_kpoint_info(kpoints, xkp=xkp, wkp=wkp)
 
       nspin = SIZE(mat_dm_global_work, 1)
 
@@ -1358,14 +1352,15 @@ CONTAINS
 
       DO ispin = 1, nspin
 
-         DO ik = 1, nkp
+         DO ik = 1, SIZE(kpoints%kp_env)
 
             kp => kpoints%kp_env(ik)%kpoint_env
-            rpmat => kp%wmat(1, ispin)
-            cpmat => kp%wmat(2, ispin)
+            ik_global = kp%nkpoint
+            CALL build_kpoint_density_matrix_rpa(kpoints, ik, ispin, tau, e_fermi, sector, density)
+            CALL cp_cfm_to_fm(density, fm_mat_re, fm_mat_im)
 
-            CALL copy_fm_to_dbcsr(rpmat, mat_work_re, keep_sparsity=.FALSE.)
-            CALL copy_fm_to_dbcsr(cpmat, mat_work_im, keep_sparsity=.FALSE.)
+            CALL copy_fm_to_dbcsr(fm_mat_re, mat_work_re, keep_sparsity=.FALSE.)
+            CALL copy_fm_to_dbcsr(fm_mat_im, mat_work_im, keep_sparsity=.FALSE.)
 
             DO icell = 1, SIZE(mat_dm_global_work, 2)
 
@@ -1373,12 +1368,14 @@ CONTAINS
                ycell = index_to_cell(2, icell)
                zcell = index_to_cell(3, icell)
 
-               arg = REAL(xcell, dp)*xkp(1, ik) + REAL(ycell, dp)*xkp(2, ik) + REAL(zcell, dp)*xkp(3, ik)
-               coskl = wkp(ik)*COS(twopi*arg)
-               sinkl = wkp(ik)*SIN(twopi*arg)
+               arg = REAL(xcell, dp)*xkp(1, ik_global) + REAL(ycell, dp)*xkp(2, ik_global) + &
+                     REAL(zcell, dp)*xkp(3, ik_global)
+               coskl = wkp(ik_global)*COS(twopi*arg)
+               sinkl = wkp(ik_global)*SIN(twopi*arg)
 
                CALL dbcsr_add(mat_dm_global_work(ispin, icell)%matrix, mat_work_re, 1.0_dp, coskl)
-               CALL dbcsr_add(mat_dm_global_work(ispin, icell)%matrix, mat_work_im, 1.0_dp, sinkl)
+               ! The real-space convention is Re(exp(i k R) G(k)).
+               CALL dbcsr_add(mat_dm_global_work(ispin, icell)%matrix, mat_work_im, 1.0_dp, -sinkl)
 
             END DO
 
@@ -1387,6 +1384,8 @@ CONTAINS
 
       CALL dbcsr_release_p(mat_work_re)
       CALL dbcsr_release_p(mat_work_im)
+      CALL cp_fm_release(fm_mat_re)
+      CALL cp_fm_release(fm_mat_im)
 
       CALL timestop(handle)
 

--- a/src/rpa_im_time.F
+++ b/src/rpa_im_time.F
@@ -13,11 +13,15 @@
 MODULE rpa_im_time
    USE cell_types,                      ONLY: cell_type,&
                                               get_cell
+   USE cp_cfm_basic_linalg,             ONLY: cp_cfm_column_scale,&
+                                              cp_cfm_scale
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_get_info,&
                                               cp_cfm_release,&
+                                              cp_cfm_to_cfm,&
                                               cp_cfm_to_fm,&
-                                              cp_cfm_type
+                                              cp_cfm_type,&
+                                              cp_fm_to_cfm
    USE cp_dbcsr_api,                    ONLY: &
         dbcsr_add, dbcsr_clear, dbcsr_copy, dbcsr_create, dbcsr_distribution_get, &
         dbcsr_distribution_type, dbcsr_filter, dbcsr_get_info, dbcsr_init_p, dbcsr_p_type, &
@@ -26,14 +30,11 @@ MODULE rpa_im_time
    USE cp_dbcsr_operations,             ONLY: copy_fm_to_dbcsr,&
                                               dbcsr_allocate_matrix_set,&
                                               dbcsr_deallocate_matrix_set
-   USE cp_fm_basic_linalg,              ONLY: cp_fm_column_scale,&
-                                              cp_fm_scale
-   USE cp_fm_struct,                    ONLY: cp_fm_struct_type
+   USE cp_fm_basic_linalg,              ONLY: cp_fm_scale
    USE cp_fm_types,                     ONLY: cp_fm_create,&
                                               cp_fm_get_info,&
                                               cp_fm_release,&
                                               cp_fm_set_all,&
-                                              cp_fm_to_fm,&
                                               cp_fm_type
    USE dbt_api,                         ONLY: &
         dbt_batched_contract_finalize, dbt_batched_contract_init, dbt_contract, dbt_copy, &
@@ -915,11 +916,10 @@ CONTAINS
                                                             nao, nmo, nspin
       INTEGER, DIMENSION(2)                              :: kp_range
       REAL(KIND=dp), DIMENSION(:), POINTER               :: eigenvalues, exp_scaling, occupation
-      TYPE(cp_fm_struct_type), POINTER                   :: matrix_struct
-      TYPE(cp_fm_type)                                   :: fwork
+      TYPE(cp_cfm_type)                                  :: cfm_density, cfm_mo_coeff, cfm_work
       TYPE(cp_fm_type), POINTER                          :: cpmat, rpmat
       TYPE(kpoint_env_type), POINTER                     :: kp
-      TYPE(mo_set_type), POINTER                         :: mo_set
+      TYPE(mo_set_type), POINTER                         :: mo_set, mo_set_im
 
       CALL timeset(routineN, handle)
 
@@ -938,9 +938,6 @@ CONTAINS
 
       ALLOCATE (exp_scaling(nmo))
 
-      CALL cp_fm_get_info(mo_set%mo_coeff, matrix_struct=matrix_struct)
-      CALL cp_fm_create(fwork, matrix_struct)
-
       CALL get_kpoint_info(kpoint, kp_range=kp_range)
       kplocal = kp_range(2) - kp_range(1) + 1
 
@@ -949,21 +946,28 @@ CONTAINS
          nspin = SIZE(kp%mos, 2)
          DO ispin = 1, nspin
             mo_set => kp%mos(1, ispin)
+            mo_set_im => kp%mos(2, ispin)
             CALL get_mo_set(mo_set, eigenvalues=eigenvalues)
             rpmat => kp%wmat(1, ispin)
             cpmat => kp%wmat(2, ispin)
             CALL get_mo_set(mo_set, occupation_numbers=occupation)
-            CALL cp_fm_to_fm(mo_set%mo_coeff, fwork)
+            CALL cp_cfm_create(cfm_mo_coeff, mo_set%mo_coeff%matrix_struct)
+            CALL cp_cfm_create(cfm_work, mo_set%mo_coeff%matrix_struct)
+            CALL cp_cfm_create(cfm_density, rpmat%matrix_struct)
+            CALL cp_fm_to_cfm(msourcer=mo_set%mo_coeff, msourcei=mo_set_im%mo_coeff, &
+                              mtarget=cfm_mo_coeff)
+            CALL cp_cfm_to_cfm(cfm_mo_coeff, cfm_work)
 
             IF (sector == propagator_sector_occupied) THEN
-               CALL cp_fm_column_scale(fwork, occupation)
+               CALL cp_cfm_column_scale(cfm_work, CMPLX(occupation, 0.0_dp, KIND=dp))
             ELSE
-               CALL cp_fm_column_scale(fwork, 2.0_dp/REAL(nspin, KIND=dp) - occupation)
+               CALL cp_cfm_column_scale(cfm_work, &
+                                        CMPLX(2.0_dp/REAL(nspin, KIND=dp) - occupation, 0.0_dp, KIND=dp))
             END IF
 
             ! proper spin
             IF (nspin == 1) THEN
-               CALL cp_fm_scale(0.5_dp, fwork)
+               CALL cp_cfm_scale(0.5_dp, cfm_work)
             END IF
 
             DO i_mo = 1, nmo
@@ -975,46 +979,22 @@ CONTAINS
                END IF
             END DO
 
-            CALL cp_fm_column_scale(fwork, exp_scaling)
+            CALL cp_cfm_column_scale(cfm_work, CMPLX(exp_scaling, 0.0_dp, KIND=dp))
 
-            ! Re(c)*Re(c)
-            CALL parallel_gemm("N", "T", nao, nao, nmo, 1.0_dp, mo_set%mo_coeff, fwork, 0.0_dp, rpmat)
-            mo_set => kp%mos(2, ispin)
-            ! Im(c)*Re(c)
-            CALL parallel_gemm("N", "T", nao, nao, nmo, -1.0_dp, mo_set%mo_coeff, fwork, 0.0_dp, cpmat)
-            ! Re(c)*Im(c)
-            CALL parallel_gemm("N", "T", nao, nao, nmo, 1.0_dp, fwork, mo_set%mo_coeff, 1.0_dp, cpmat)
+            CALL parallel_gemm("N", "C", nao, nao, nmo, (1.0_dp, 0.0_dp), cfm_mo_coeff, cfm_work, &
+                               (0.0_dp, 0.0_dp), cfm_density)
+            CALL cp_cfm_to_fm(cfm_density, rpmat, cpmat)
+            ! The historical wmat convention stores minus the imaginary part.
+            CALL cp_fm_scale(-1.0_dp, cpmat)
 
-            CALL cp_fm_to_fm(mo_set%mo_coeff, fwork)
-
-            IF (sector == propagator_sector_occupied) THEN
-               CALL cp_fm_column_scale(fwork, occupation)
-            ELSE
-               CALL cp_fm_column_scale(fwork, 2.0_dp/REAL(nspin, KIND=dp) - occupation)
-            END IF
-
-            ! proper spin
-            IF (nspin == 1) THEN
-               CALL cp_fm_scale(0.5_dp, fwork)
-            END IF
-
-            DO i_mo = 1, nmo
-               IF (ABS(tau*0.5_dp*(eigenvalues(i_mo) - e_fermi)) < stabilize_exp) THEN
-                  exp_scaling(i_mo) = EXP(-ABS(tau*(eigenvalues(i_mo) - e_fermi)))
-               ELSE
-                  exp_scaling(i_mo) = 0.0_dp
-               END IF
-            END DO
-
-            CALL cp_fm_column_scale(fwork, exp_scaling)
-            ! Im(c)*Im(c)
-            CALL parallel_gemm("N", "T", nao, nao, nmo, 1.0_dp, mo_set%mo_coeff, fwork, 1.0_dp, rpmat)
+            CALL cp_cfm_release(cfm_density)
+            CALL cp_cfm_release(cfm_work)
+            CALL cp_cfm_release(cfm_mo_coeff)
 
          END DO
 
       END DO
 
-      CALL cp_fm_release(fwork)
       DEALLOCATE (exp_scaling)
 
       CALL timestop(handle)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -637,8 +637,8 @@ CONTAINS
 !> \param t_3c_O ...
 !> \param t_3c_O_compressed ...
 !> \param t_3c_O_ind ...
-!> \param cfm_mo_coeff_occ ...
-!> \param cfm_mo_coeff_virt ...
+!> \param cfm_mo_coeff ...
+!> \param homo ...
 !> \param starts_array_mc ...
 !> \param ends_array_mc ...
 !> \param starts_array_mc_block ...
@@ -660,7 +660,7 @@ CONTAINS
 !> \note In open-shell, we need to take Q from one spin, and everything from the other
 ! **************************************************************************************************
    SUBROUTINE calc_laplace_loop_forces(force_data, mat_P_omega, t_3c_M, t_3c_O, t_3c_O_compressed, &
-                                       t_3c_O_ind, cfm_mo_coeff_occ, cfm_mo_coeff_virt, starts_array_mc, ends_array_mc, &
+                                       t_3c_O_ind, cfm_mo_coeff, homo, starts_array_mc, ends_array_mc, &
                                        starts_array_mc_block, ends_array_mc_block, num_integ_points, &
                                        nmo, Eigenval, tau_tj, tau_wj, cut_memory, Pspin, Qspin, &
                                        open_shell, unit_nr, dbcsr_time, dbcsr_nflop, mp2_env, qs_env)
@@ -670,7 +670,8 @@ CONTAINS
       TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_M, t_3c_O
       TYPE(hfx_compression_type), DIMENSION(:)           :: t_3c_O_compressed
       TYPE(block_ind_type), DIMENSION(:), INTENT(INOUT)  :: t_3c_O_ind
-      TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
       INTEGER, DIMENSION(:), INTENT(IN)                  :: starts_array_mc, ends_array_mc, &
                                                             starts_array_mc_block, &
                                                             ends_array_mc_block
@@ -928,8 +929,7 @@ CONTAINS
          CALL get_tensor_occupancy(t_KQKT, nze_KQK, occ_KQK)
 
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
-         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff_occ(Pspin), &
-                                    cfm_mo_coeff_virt(Pspin), propagator, &
+         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff(Pspin), homo(Pspin), propagator, &
                                     matrix_s, Pspin, Eigenval(:, Pspin), 0.0_dp, eps_filter, &
                                     mp2_env%ri_rpa_im_time%memory_info, unit_nr, &
                                     jquad, .FALSE., .FALSE., qs_env, dummy_int, dummy_ptr, para_env)
@@ -1175,8 +1175,8 @@ CONTAINS
 !> \param t_3c_O ...
 !> \param t_3c_O_compressed ...
 !> \param t_3c_O_ind ...
-!> \param cfm_mo_coeff_occ ...
-!> \param cfm_mo_coeff_virt ...
+!> \param cfm_mo_coeff ...
+!> \param homo ...
 !> \param starts_array_mc ...
 !> \param ends_array_mc ...
 !> \param starts_array_mc_block ...
@@ -1200,7 +1200,7 @@ CONTAINS
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE calc_rpa_loop_forces(force_data, mat_P_omega, t_3c_M, t_3c_O, t_3c_O_compressed, &
-                                   t_3c_O_ind, cfm_mo_coeff_occ, cfm_mo_coeff_virt, starts_array_mc, ends_array_mc, &
+                                   t_3c_O_ind, cfm_mo_coeff, homo, starts_array_mc, ends_array_mc, &
                                    starts_array_mc_block, ends_array_mc_block, num_integ_points, &
                                    nmo, Eigenval, e_fermi, weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, &
                                    tj, wj, tau_tj, cut_memory, ispin, open_shell, unit_nr, dbcsr_time, &
@@ -1211,7 +1211,8 @@ CONTAINS
       TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_M, t_3c_O
       TYPE(hfx_compression_type), DIMENSION(:)           :: t_3c_O_compressed
       TYPE(block_ind_type), DIMENSION(:), INTENT(INOUT)  :: t_3c_O_ind
-      TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
       INTEGER, DIMENSION(:), INTENT(IN)                  :: starts_array_mc, ends_array_mc, &
                                                             starts_array_mc_block, &
                                                             ends_array_mc_block
@@ -1529,8 +1530,7 @@ CONTAINS
          CALL get_tensor_occupancy(t_KBKT, nze_KBK, occ_KBK)
 
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
-         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff_occ(ispin), &
-                                    cfm_mo_coeff_virt(ispin), propagator, &
+         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff(ispin), homo(ispin), propagator, &
                                     matrix_s, ispin, Eigenval(:, ispin), e_fermi, eps_filter, &
                                     mp2_env%ri_rpa_im_time%memory_info, unit_nr, &
                                     jquad, .FALSE., .FALSE., qs_env, dummy_int, dummy_ptr, para_env)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -23,6 +23,7 @@ MODULE rpa_im_time_force_methods
    USE cell_types,                      ONLY: cell_type,&
                                               pbc
    USE cp_blacs_env,                    ONLY: cp_blacs_env_type
+   USE cp_cfm_types,                    ONLY: cp_cfm_type
    USE cp_control_types,                ONLY: dft_control_type
    USE cp_dbcsr_api,                    ONLY: &
         dbcsr_add, dbcsr_clear, dbcsr_complete_redistribute, dbcsr_copy, dbcsr_create, &
@@ -636,8 +637,8 @@ CONTAINS
 !> \param t_3c_O ...
 !> \param t_3c_O_compressed ...
 !> \param t_3c_O_ind ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
+!> \param cfm_mo_coeff_occ ...
+!> \param cfm_mo_coeff_virt ...
 !> \param starts_array_mc ...
 !> \param ends_array_mc ...
 !> \param starts_array_mc_block ...
@@ -659,7 +660,7 @@ CONTAINS
 !> \note In open-shell, we need to take Q from one spin, and everything from the other
 ! **************************************************************************************************
    SUBROUTINE calc_laplace_loop_forces(force_data, mat_P_omega, t_3c_M, t_3c_O, t_3c_O_compressed, &
-                                       t_3c_O_ind, fm_mo_coeff_occ, fm_mo_coeff_virt, starts_array_mc, ends_array_mc, &
+                                       t_3c_O_ind, cfm_mo_coeff_occ, cfm_mo_coeff_virt, starts_array_mc, ends_array_mc, &
                                        starts_array_mc_block, ends_array_mc_block, num_integ_points, &
                                        nmo, Eigenval, tau_tj, tau_wj, cut_memory, Pspin, Qspin, &
                                        open_shell, unit_nr, dbcsr_time, dbcsr_nflop, mp2_env, qs_env)
@@ -669,7 +670,7 @@ CONTAINS
       TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_M, t_3c_O
       TYPE(hfx_compression_type), DIMENSION(:)           :: t_3c_O_compressed
       TYPE(block_ind_type), DIMENSION(:), INTENT(INOUT)  :: t_3c_O_ind
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
       INTEGER, DIMENSION(:), INTENT(IN)                  :: starts_array_mc, ends_array_mc, &
                                                             starts_array_mc_block, &
                                                             ends_array_mc_block
@@ -927,8 +928,8 @@ CONTAINS
          CALL get_tensor_occupancy(t_KQKT, nze_KQK, occ_KQK)
 
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
-         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, fm_mo_coeff_occ(Pspin), &
-                                    fm_mo_coeff_virt(Pspin), propagator, &
+         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff_occ(Pspin), &
+                                    cfm_mo_coeff_virt(Pspin), propagator, &
                                     matrix_s, Pspin, Eigenval(:, Pspin), 0.0_dp, eps_filter, &
                                     mp2_env%ri_rpa_im_time%memory_info, unit_nr, &
                                     jquad, .FALSE., .FALSE., qs_env, dummy_int, dummy_ptr, para_env)
@@ -1174,8 +1175,8 @@ CONTAINS
 !> \param t_3c_O ...
 !> \param t_3c_O_compressed ...
 !> \param t_3c_O_ind ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
+!> \param cfm_mo_coeff_occ ...
+!> \param cfm_mo_coeff_virt ...
 !> \param starts_array_mc ...
 !> \param ends_array_mc ...
 !> \param starts_array_mc_block ...
@@ -1199,7 +1200,7 @@ CONTAINS
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE calc_rpa_loop_forces(force_data, mat_P_omega, t_3c_M, t_3c_O, t_3c_O_compressed, &
-                                   t_3c_O_ind, fm_mo_coeff_occ, fm_mo_coeff_virt, starts_array_mc, ends_array_mc, &
+                                   t_3c_O_ind, cfm_mo_coeff_occ, cfm_mo_coeff_virt, starts_array_mc, ends_array_mc, &
                                    starts_array_mc_block, ends_array_mc_block, num_integ_points, &
                                    nmo, Eigenval, e_fermi, weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, &
                                    tj, wj, tau_tj, cut_memory, ispin, open_shell, unit_nr, dbcsr_time, &
@@ -1210,7 +1211,7 @@ CONTAINS
       TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_M, t_3c_O
       TYPE(hfx_compression_type), DIMENSION(:)           :: t_3c_O_compressed
       TYPE(block_ind_type), DIMENSION(:), INTENT(INOUT)  :: t_3c_O_ind
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
       INTEGER, DIMENSION(:), INTENT(IN)                  :: starts_array_mc, ends_array_mc, &
                                                             starts_array_mc_block, &
                                                             ends_array_mc_block
@@ -1528,8 +1529,8 @@ CONTAINS
          CALL get_tensor_occupancy(t_KBKT, nze_KBK, occ_KBK)
 
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
-         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, fm_mo_coeff_occ(ispin), &
-                                    fm_mo_coeff_virt(ispin), propagator, &
+         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, cfm_mo_coeff_occ(ispin), &
+                                    cfm_mo_coeff_virt(ispin), propagator, &
                                     matrix_s, ispin, Eigenval(:, ispin), e_fermi, eps_filter, &
                                     mp2_env%ri_rpa_im_time%memory_info, unit_nr, &
                                     jquad, .FALSE., .FALSE., qs_env, dummy_int, dummy_ptr, para_env)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -160,7 +160,9 @@ MODULE rpa_im_time_force_methods
    USE realspace_grid_types,            ONLY: map_gaussian_here,&
                                               realspace_grid_type
    USE response_solver,                 ONLY: response_equation_new
-   USE rpa_im_time,                     ONLY: compute_mat_dm_global
+   USE rpa_im_time,                     ONLY: compute_mat_dm_global,&
+                                              propagator_sector_occupied,&
+                                              propagator_sector_virtual
    USE rpa_im_time_force_types,         ONLY: im_time_force_type
    USE rs_pw_interface,                 ONLY: potential_pw2rs
    USE task_list_types,                 ONLY: task_list_type
@@ -715,7 +717,7 @@ CONTAINS
       TYPE(atomic_kind_type), DIMENSION(:), POINTER      :: atomic_kind_set
       TYPE(cell_type), POINTER                           :: cell
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: matrix_ks, matrix_s
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ, mat_dm_virt
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: propagator
       TYPE(dbcsr_type)                                   :: dbcsr_work1, dbcsr_work2, dbcsr_work3, &
                                                             exp_occ, exp_virt, R_occ, R_virt, &
                                                             virial_ovlp, Y_1, Y_2
@@ -735,11 +737,13 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: qs_section
       TYPE(virial_type), POINTER                         :: virial
 
-      NULLIFY (matrix_s, dummy_ptr, atomic_kind_set, force, matrix_s, matrix_ks, mat_dm_occ, mat_dm_virt)
+      NULLIFY (matrix_s, dummy_ptr, atomic_kind_set, force, matrix_s, matrix_ks)
       NULLIFY (dft_control, virial, particle_set, cell, para_env, orb_basis, ri_basis, qs_section)
       NULLIFY (qs_kind_set)
 
       CALL timeset(routineN, handle)
+
+      NULLIFY (propagator)
 
       CALL get_qs_env(qs_env, matrix_s=matrix_s, natom=natom, atomic_kind_set=atomic_kind_set, &
                       force=force, matrix_ks=matrix_ks, dft_control=dft_control, virial=virial, &
@@ -935,19 +939,19 @@ CONTAINS
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
          CALL compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, &
                                     nmo, fm_mo_coeff_occ(Pspin), fm_mo_coeff_virt(Pspin), &
-                                    fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, mat_dm_occ, mat_dm_virt, &
+                                    fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, propagator, &
                                     matrix_s, Pspin, Eigenval(:, Pspin), 0.0_dp, eps_filter, &
                                     mp2_env%ri_rpa_im_time%memory_info, unit_nr, &
                                     jquad, .FALSE., .FALSE., qs_env, dummy_int, dummy_ptr, para_env)
 
-         CALL dbt_create(mat_dm_occ(jquad, 1)%matrix, t_2c_tmp)
-         CALL dbt_copy_matrix_to_tensor(mat_dm_occ(jquad, 1)%matrix, t_2c_tmp)
+         CALL dbt_create(propagator(propagator_sector_occupied, jquad, 1)%matrix, t_2c_tmp)
+         CALL dbt_copy_matrix_to_tensor(propagator(propagator_sector_occupied, jquad, 1)%matrix, t_2c_tmp)
          CALL dbt_copy(t_2c_tmp, t_dm_occ, move_data=.TRUE.)
          CALL dbt_filter(t_dm_occ, eps_filter)
          CALL dbt_destroy(t_2c_tmp)
 
-         CALL dbt_create(mat_dm_virt(jquad, 1)%matrix, t_2c_tmp)
-         CALL dbt_copy_matrix_to_tensor(mat_dm_virt(jquad, 1)%matrix, t_2c_tmp)
+         CALL dbt_create(propagator(propagator_sector_virtual, jquad, 1)%matrix, t_2c_tmp)
+         CALL dbt_copy_matrix_to_tensor(propagator(propagator_sector_virtual, jquad, 1)%matrix, t_2c_tmp)
          CALL dbt_copy(t_2c_tmp, t_dm_virt, move_data=.TRUE.)
          CALL dbt_filter(t_dm_virt, eps_filter)
          CALL dbt_destroy(t_2c_tmp)
@@ -1166,8 +1170,7 @@ CONTAINS
       CALL dbt_destroy(t_2c_RI)
       CALL dbt_destroy(t_2c_RI_2)
       CALL dbt_destroy(t_2c_AO)
-      CALL dbcsr_deallocate_matrix_set(mat_dm_occ)
-      CALL dbcsr_deallocate_matrix_set(mat_dm_virt)
+      CALL dbcsr_deallocate_matrix_set(propagator)
 
       CALL timestop(handle)
 
@@ -1269,7 +1272,7 @@ CONTAINS
       TYPE(cell_type), POINTER                           :: cell
       TYPE(cp_blacs_env_type), POINTER                   :: blacs_env
       TYPE(dbcsr_p_type), DIMENSION(:), POINTER          :: mat_P_tau, matrix_ks, matrix_s
-      TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_dm_occ, mat_dm_virt
+      TYPE(dbcsr_p_type), DIMENSION(:, :, :), POINTER    :: propagator
       TYPE(dbcsr_type)                                   :: dbcsr_work1, dbcsr_work2, dbcsr_work3, &
                                                             dbcsr_work_symm, exp_occ, exp_virt, &
                                                             R_occ, R_virt, virial_ovlp, Y_1, Y_2
@@ -1289,11 +1292,13 @@ CONTAINS
       TYPE(section_vals_type), POINTER                   :: qs_section
       TYPE(virial_type), POINTER                         :: virial
 
-      NULLIFY (matrix_s, dummy_ptr, atomic_kind_set, force, matrix_s, matrix_ks, mat_dm_occ, mat_dm_virt)
+      NULLIFY (matrix_s, dummy_ptr, atomic_kind_set, force, matrix_s, matrix_ks)
       NULLIFY (dft_control, virial, particle_set, cell, blacs_env, para_env, orb_basis, ri_basis)
       NULLIFY (qs_kind_set)
 
       CALL timeset(routineN, handle)
+
+      NULLIFY (propagator)
 
       CALL get_qs_env(qs_env, matrix_s=matrix_s, natom=natom, atomic_kind_set=atomic_kind_set, &
                       force=force, matrix_ks=matrix_ks, dft_control=dft_control, virial=virial, &
@@ -1546,19 +1551,19 @@ CONTAINS
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
          CALL compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, &
                                     nmo, fm_mo_coeff_occ(ispin), fm_mo_coeff_virt(ispin), &
-                                    fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, mat_dm_occ, mat_dm_virt, &
+                                    fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, propagator, &
                                     matrix_s, ispin, Eigenval(:, ispin), e_fermi, eps_filter, &
                                     mp2_env%ri_rpa_im_time%memory_info, unit_nr, &
                                     jquad, .FALSE., .FALSE., qs_env, dummy_int, dummy_ptr, para_env)
 
-         CALL dbt_create(mat_dm_occ(jquad, 1)%matrix, t_2c_tmp)
-         CALL dbt_copy_matrix_to_tensor(mat_dm_occ(jquad, 1)%matrix, t_2c_tmp)
+         CALL dbt_create(propagator(propagator_sector_occupied, jquad, 1)%matrix, t_2c_tmp)
+         CALL dbt_copy_matrix_to_tensor(propagator(propagator_sector_occupied, jquad, 1)%matrix, t_2c_tmp)
          CALL dbt_copy(t_2c_tmp, t_dm_occ, move_data=.TRUE.)
          CALL dbt_filter(t_dm_occ, eps_filter)
          CALL dbt_destroy(t_2c_tmp)
 
-         CALL dbt_create(mat_dm_virt(jquad, 1)%matrix, t_2c_tmp)
-         CALL dbt_copy_matrix_to_tensor(mat_dm_virt(jquad, 1)%matrix, t_2c_tmp)
+         CALL dbt_create(propagator(propagator_sector_virtual, jquad, 1)%matrix, t_2c_tmp)
+         CALL dbt_copy_matrix_to_tensor(propagator(propagator_sector_virtual, jquad, 1)%matrix, t_2c_tmp)
          CALL dbt_copy(t_2c_tmp, t_dm_virt, move_data=.TRUE.)
          CALL dbt_filter(t_dm_virt, eps_filter)
          CALL dbt_destroy(t_2c_tmp)
@@ -1784,8 +1789,7 @@ CONTAINS
       CALL dbt_destroy(t_2c_RI)
       CALL dbt_destroy(t_2c_RI_2)
       CALL dbt_destroy(t_2c_AO)
-      CALL dbcsr_deallocate_matrix_set(mat_dm_occ)
-      CALL dbcsr_deallocate_matrix_set(mat_dm_virt)
+      CALL dbcsr_deallocate_matrix_set(propagator)
       CALL dbcsr_deallocate_matrix_set(mat_P_tau)
 
       CALL timestop(handle)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -636,12 +636,8 @@ CONTAINS
 !> \param t_3c_O ...
 !> \param t_3c_O_compressed ...
 !> \param t_3c_O_ind ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
 !> \param starts_array_mc ...
 !> \param ends_array_mc ...
 !> \param starts_array_mc_block ...
@@ -663,9 +659,7 @@ CONTAINS
 !> \note In open-shell, we need to take Q from one spin, and everything from the other
 ! **************************************************************************************************
    SUBROUTINE calc_laplace_loop_forces(force_data, mat_P_omega, t_3c_M, t_3c_O, t_3c_O_compressed, &
-                                       t_3c_O_ind, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-                                       fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                       fm_mo_coeff_virt_scaled, starts_array_mc, ends_array_mc, &
+                                       t_3c_O_ind, fm_mo_coeff_occ, fm_mo_coeff_virt, starts_array_mc, ends_array_mc, &
                                        starts_array_mc_block, ends_array_mc_block, num_integ_points, &
                                        nmo, Eigenval, tau_tj, tau_wj, cut_memory, Pspin, Qspin, &
                                        open_shell, unit_nr, dbcsr_time, dbcsr_nflop, mp2_env, qs_env)
@@ -675,11 +669,7 @@ CONTAINS
       TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_M, t_3c_O
       TYPE(hfx_compression_type), DIMENSION(:)           :: t_3c_O_compressed
       TYPE(block_ind_type), DIMENSION(:), INTENT(INOUT)  :: t_3c_O_ind
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_scaled_dm_occ_tau, &
-                                                            fm_scaled_dm_virt_tau
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_mo_coeff_occ, fm_mo_coeff_virt
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_mo_coeff_occ_scaled, &
-                                                            fm_mo_coeff_virt_scaled
       INTEGER, DIMENSION(:), INTENT(IN)                  :: starts_array_mc, ends_array_mc, &
                                                             starts_array_mc_block, &
                                                             ends_array_mc_block
@@ -937,9 +927,8 @@ CONTAINS
          CALL get_tensor_occupancy(t_KQKT, nze_KQK, occ_KQK)
 
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
-         CALL compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, &
-                                    nmo, fm_mo_coeff_occ(Pspin), fm_mo_coeff_virt(Pspin), &
-                                    fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, propagator, &
+         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, fm_mo_coeff_occ(Pspin), &
+                                    fm_mo_coeff_virt(Pspin), propagator, &
                                     matrix_s, Pspin, Eigenval(:, Pspin), 0.0_dp, eps_filter, &
                                     mp2_env%ri_rpa_im_time%memory_info, unit_nr, &
                                     jquad, .FALSE., .FALSE., qs_env, dummy_int, dummy_ptr, para_env)
@@ -1185,12 +1174,8 @@ CONTAINS
 !> \param t_3c_O ...
 !> \param t_3c_O_compressed ...
 !> \param t_3c_O_ind ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
 !> \param starts_array_mc ...
 !> \param ends_array_mc ...
 !> \param starts_array_mc_block ...
@@ -1214,9 +1199,7 @@ CONTAINS
 !> \param qs_env ...
 ! **************************************************************************************************
    SUBROUTINE calc_rpa_loop_forces(force_data, mat_P_omega, t_3c_M, t_3c_O, t_3c_O_compressed, &
-                                   t_3c_O_ind, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-                                   fm_mo_coeff_occ, fm_mo_coeff_virt, fm_mo_coeff_occ_scaled, &
-                                   fm_mo_coeff_virt_scaled, starts_array_mc, ends_array_mc, &
+                                   t_3c_O_ind, fm_mo_coeff_occ, fm_mo_coeff_virt, starts_array_mc, ends_array_mc, &
                                    starts_array_mc_block, ends_array_mc_block, num_integ_points, &
                                    nmo, Eigenval, e_fermi, weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, &
                                    tj, wj, tau_tj, cut_memory, ispin, open_shell, unit_nr, dbcsr_time, &
@@ -1227,11 +1210,7 @@ CONTAINS
       TYPE(dbt_type), INTENT(INOUT)                      :: t_3c_M, t_3c_O
       TYPE(hfx_compression_type), DIMENSION(:)           :: t_3c_O_compressed
       TYPE(block_ind_type), DIMENSION(:), INTENT(INOUT)  :: t_3c_O_ind
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_scaled_dm_occ_tau, &
-                                                            fm_scaled_dm_virt_tau
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: fm_mo_coeff_occ, fm_mo_coeff_virt
-      TYPE(cp_fm_type), INTENT(IN)                       :: fm_mo_coeff_occ_scaled, &
-                                                            fm_mo_coeff_virt_scaled
       INTEGER, DIMENSION(:), INTENT(IN)                  :: starts_array_mc, ends_array_mc, &
                                                             starts_array_mc_block, &
                                                             ends_array_mc_block
@@ -1549,9 +1528,8 @@ CONTAINS
          CALL get_tensor_occupancy(t_KBKT, nze_KBK, occ_KBK)
 
          !Calculate the pseudo-density matrix in tensor form. There are a few useless arguments for SOS-MP2
-         CALL compute_mat_dm_global(fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, tau_tj, num_integ_points, &
-                                    nmo, fm_mo_coeff_occ(ispin), fm_mo_coeff_virt(ispin), &
-                                    fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, propagator, &
+         CALL compute_mat_dm_global(tau_tj, num_integ_points, nmo, fm_mo_coeff_occ(ispin), &
+                                    fm_mo_coeff_virt(ispin), propagator, &
                                     matrix_s, ispin, Eigenval(:, ispin), e_fermi, eps_filter, &
                                     mp2_env%ri_rpa_im_time%memory_info, unit_nr, &
                                     jquad, .FALSE., .FALSE., qs_env, dummy_int, dummy_ptr, para_env)

--- a/src/rpa_im_time_force_methods.F
+++ b/src/rpa_im_time_force_methods.F
@@ -671,8 +671,7 @@ CONTAINS
       TYPE(hfx_compression_type), DIMENSION(:)           :: t_3c_O_compressed
       TYPE(block_ind_type), DIMENSION(:), INTENT(INOUT)  :: t_3c_O_ind
       TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: starts_array_mc, ends_array_mc, &
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo, starts_array_mc, ends_array_mc, &
                                                             starts_array_mc_block, &
                                                             ends_array_mc_block
       INTEGER, INTENT(IN)                                :: num_integ_points, nmo
@@ -1212,8 +1211,7 @@ CONTAINS
       TYPE(hfx_compression_type), DIMENSION(:)           :: t_3c_O_compressed
       TYPE(block_ind_type), DIMENSION(:), INTENT(INOUT)  :: t_3c_O_ind
       TYPE(cp_cfm_type), DIMENSION(:), INTENT(IN)        :: cfm_mo_coeff
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: starts_array_mc, ends_array_mc, &
+      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo, starts_array_mc, ends_array_mc, &
                                                             starts_array_mc_block, &
                                                             ends_array_mc_block
       INTEGER, INTENT(IN)                                :: num_integ_points, nmo

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -634,7 +634,7 @@ CONTAINS
       END IF
 
       ! Now start the RPA calculation
-      ! cfm_mo_coeff_occ, cfm_mo_coeff_virt will be deallocated here
+      ! cfm_mo_coeff will be deallocated here
       CALL rpa_num_int(qs_env, Erpa, mp2_env, para_env, para_env_RPA, para_env_sub, unit_nr, &
                        homo, virtual, dimen_RI, dimen_RI_red, dimen_ia, dimen_nm_gw, &
                        Eigenval_kp, num_integ_points, num_integ_group, color_rpa_group, &
@@ -1153,7 +1153,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: Eigenval_last, Eigenval_scf, &
                                                             vec_Sigma_x_gw
       TYPE(cp_cfm_type)                                  :: cfm_mat_Q
-      TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:)       :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:)       :: cfm_mo_coeff
       TYPE(cp_fm_type)                                   :: fm_mat_Q_static_bse_gemm, &
                                                             fm_mat_RI_global_work, fm_mat_work
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_mat_S_gw_work, fm_mat_S_ia_bse, &
@@ -1235,7 +1235,7 @@ CONTAINS
          min_bsize = mp2_env%ri_rpa_im_time%min_bsize
 
          CALL alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, &
-                            num_integ_points, nspins, fm_mat_Q(1), cfm_mo_coeff_occ, cfm_mo_coeff_virt, &
+                            num_integ_points, nspins, fm_mat_Q(1), cfm_mo_coeff, &
                             fm_matrix_Minv_L_kpoints, fm_matrix_L_kpoints, mat_P_global, &
                             t_3c_O, matrix_s, kpoints, eps_filter_im_time, &
                             cut_memory, nkp, num_cells_dm, num_3c_repl, &
@@ -1248,8 +1248,7 @@ CONTAINS
                             has_mat_P_blocks, wkp_W, &
                             cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
                             fm_mat_RI_global_work, fm_mat_work, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, &
-                            mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, mat_work, mo_coeff, &
-                            homo, nmo)
+                            mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, mat_work, mo_coeff)
 
          IF (calc_forces) CALL init_im_time_forces(force_data, fm_matrix_PQ, t_3c_M, unit_nr, mp2_env, qs_env)
 
@@ -1395,7 +1394,7 @@ CONTAINS
             CALL zero_mat_P_omega(mat_P_omega(:, :, 1))
 
             ! compute the matrix Q(it) and Fourier transform it directly to mat_P_omega(iw)
-            CALL compute_mat_P_omega(mat_P_omega(:, :, 1), cfm_mo_coeff_occ(1), cfm_mo_coeff_virt(1), &
+            CALL compute_mat_P_omega(mat_P_omega(:, :, 1), cfm_mo_coeff(1), homo(1), &
                                      mat_P_global, matrix_s, 1, &
                                      t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                                      starts_array_mc, ends_array_mc, &
@@ -1409,10 +1408,10 @@ CONTAINS
                                      has_mat_P_blocks, do_ri_sos_laplace_mp2, &
                                      dbcsr_time, dbcsr_nflop)
 
-            ! the same for open shell, use cfm_mo_coeff_occ_beta and cfm_mo_coeff_virt_beta
+            ! the same for open shell, use the beta-spin MO coefficients
             IF (my_open_shell) THEN
                CALL zero_mat_P_omega(mat_P_omega(:, :, 2))
-               CALL compute_mat_P_omega(mat_P_omega(:, :, 2), cfm_mo_coeff_occ(2), cfm_mo_coeff_virt(2), &
+               CALL compute_mat_P_omega(mat_P_omega(:, :, 2), cfm_mo_coeff(2), homo(2), &
                                         mat_P_global, matrix_s, 2, &
                                         t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                                         starts_array_mc, ends_array_mc, &
@@ -1638,8 +1637,7 @@ CONTAINS
                Pspin = 1
                Qspin = 2
                CALL calc_laplace_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff_occ, &
-                                             cfm_mo_coeff_virt, &
+                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff, homo, &
                                              starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                              ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                              tau_tj, tau_wj, cut_memory, Pspin, Qspin, my_open_shell, &
@@ -1647,8 +1645,7 @@ CONTAINS
                Pspin = 2
                Qspin = 1
                CALL calc_laplace_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff_occ, &
-                                             cfm_mo_coeff_virt, &
+                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff, homo, &
                                              starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                              ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                              tau_tj, tau_wj, cut_memory, Pspin, Qspin, my_open_shell, &
@@ -1658,8 +1655,7 @@ CONTAINS
                Pspin = 1
                Qspin = 1
                CALL calc_laplace_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff_occ, &
-                                             cfm_mo_coeff_virt, &
+                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff, homo, &
                                              starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                              ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                              tau_tj, tau_wj, cut_memory, Pspin, Qspin, my_open_shell, &
@@ -1671,8 +1667,7 @@ CONTAINS
          IF (calc_forces .AND. do_im_time .AND. .NOT. do_ri_sos_laplace_mp2) THEN
             DO ispin = 1, nspins
                CALL calc_rpa_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                         t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff_occ, &
-                                         cfm_mo_coeff_virt, &
+                                         t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff, homo, &
                                          starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                          ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                          e_fermi(ispin), weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, tj, &
@@ -1713,7 +1708,7 @@ CONTAINS
                                      Eigenval_last, Eigenval_scf, iter_sc_GW0, exit_ev_gw, tau_tj, tj, &
                                      vec_omega_fit_gw, vec_Sigma_x_gw, mp2_env%ri_g0w0%ic_corr_list, &
                                      weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
-                                     cfm_mo_coeff_occ, cfm_mo_coeff_virt, mo_coeff(1), fm_mat_W, para_env, &
+                                     cfm_mo_coeff, mo_coeff(1), fm_mat_W, para_env, &
                                      para_env_RPA, mat_dm, mat_MinvVMinv, &
                                      t_3c_O, t_3c_M, t_3c_overl_int_ao_mo, t_3c_O_compressed, t_3c_O_mo_compressed, &
                                      t_3c_O_ind, t_3c_O_mo_ind, &
@@ -1803,7 +1798,7 @@ CONTAINS
 
       IF (do_im_time) THEN
 
-         CALL dealloc_im_time(cfm_mo_coeff_occ, cfm_mo_coeff_virt, index_to_cell_3c, &
+         CALL dealloc_im_time(cfm_mo_coeff, index_to_cell_3c, &
                               cell_to_index_3c, do_ic_model, &
                               do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_ri_Sigma_x, &
                               has_mat_P_blocks, &

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -1153,9 +1153,7 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: Eigenval_last, Eigenval_scf, &
                                                             vec_Sigma_x_gw
       TYPE(cp_cfm_type)                                  :: cfm_mat_Q
-      TYPE(cp_fm_type) :: fm_mat_Q_static_bse_gemm, fm_mat_RI_global_work, fm_mat_work, &
-         fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_scaled_dm_occ_tau, &
-         fm_scaled_dm_virt_tau
+      TYPE(cp_fm_type) :: fm_mat_Q_static_bse_gemm, fm_mat_RI_global_work, fm_mat_work
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_mat_S_gw_work, fm_mat_S_ia_bse, &
                                                             fm_mat_W, fm_mo_coeff_occ, &
                                                             fm_mo_coeff_virt
@@ -1248,10 +1246,9 @@ CONTAINS
                             do_kpoints_from_Gamma, do_ri_Sigma_x, my_open_shell, &
                             has_mat_P_blocks, wkp_W, &
                             cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
-                            fm_mat_RI_global_work, fm_mat_work, fm_mo_coeff_occ_scaled, &
-                            fm_mo_coeff_virt_scaled, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, &
+                            fm_mat_RI_global_work, fm_mat_work, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, &
                             mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, mat_work, mo_coeff, &
-                            fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, homo, nmo)
+                            homo, nmo)
 
          IF (calc_forces) CALL init_im_time_forces(force_data, fm_matrix_PQ, t_3c_M, unit_nr, mp2_env, qs_env)
 
@@ -1340,9 +1337,7 @@ CONTAINS
 
          IF (do_bse) THEN
 
-            CALL cp_fm_create(fm_mat_Q_static_bse_gemm, fm_mat_Q_gemm(1)%matrix_struct)
-            CALL cp_fm_to_fm(fm_mat_Q_gemm(1), fm_mat_Q_static_bse_gemm)
-            CALL cp_fm_set_all(fm_mat_Q_static_bse_gemm, 0.0_dp)
+            CALL cp_fm_create(fm_mat_Q_static_bse_gemm, fm_mat_Q_gemm(1)%matrix_struct, set_zero=.TRUE.)
 
          END IF
 
@@ -1399,9 +1394,7 @@ CONTAINS
             CALL zero_mat_P_omega(mat_P_omega(:, :, 1))
 
             ! compute the matrix Q(it) and Fourier transform it directly to mat_P_omega(iw)
-            CALL compute_mat_P_omega(mat_P_omega(:, :, 1), fm_scaled_dm_occ_tau, &
-                                     fm_scaled_dm_virt_tau, fm_mo_coeff_occ(1), fm_mo_coeff_virt(1), &
-                                     fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+            CALL compute_mat_P_omega(mat_P_omega(:, :, 1), fm_mo_coeff_occ(1), fm_mo_coeff_virt(1), &
                                      mat_P_global, matrix_s, 1, &
                                      t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                                      starts_array_mc, ends_array_mc, &
@@ -1418,10 +1411,7 @@ CONTAINS
             ! the same for open shell, use fm_mo_coeff_occ_beta and fm_mo_coeff_virt_beta
             IF (my_open_shell) THEN
                CALL zero_mat_P_omega(mat_P_omega(:, :, 2))
-               CALL compute_mat_P_omega(mat_P_omega(:, :, 2), fm_scaled_dm_occ_tau, &
-                                        fm_scaled_dm_virt_tau, fm_mo_coeff_occ(2), &
-                                        fm_mo_coeff_virt(2), &
-                                        fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+               CALL compute_mat_P_omega(mat_P_omega(:, :, 2), fm_mo_coeff_occ(2), fm_mo_coeff_virt(2), &
                                         mat_P_global, matrix_s, 2, &
                                         t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                                         starts_array_mc, ends_array_mc, &
@@ -1647,9 +1637,8 @@ CONTAINS
                Pspin = 1
                Qspin = 2
                CALL calc_laplace_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_scaled_dm_occ_tau, &
-                                             fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                             fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_mo_coeff_occ, &
+                                             fm_mo_coeff_virt, &
                                              starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                              ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                              tau_tj, tau_wj, cut_memory, Pspin, Qspin, my_open_shell, &
@@ -1657,9 +1646,8 @@ CONTAINS
                Pspin = 2
                Qspin = 1
                CALL calc_laplace_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_scaled_dm_occ_tau, &
-                                             fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                             fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_mo_coeff_occ, &
+                                             fm_mo_coeff_virt, &
                                              starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                              ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                              tau_tj, tau_wj, cut_memory, Pspin, Qspin, my_open_shell, &
@@ -1669,9 +1657,8 @@ CONTAINS
                Pspin = 1
                Qspin = 1
                CALL calc_laplace_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_scaled_dm_occ_tau, &
-                                             fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                             fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_mo_coeff_occ, &
+                                             fm_mo_coeff_virt, &
                                              starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                              ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                              tau_tj, tau_wj, cut_memory, Pspin, Qspin, my_open_shell, &
@@ -1683,9 +1670,8 @@ CONTAINS
          IF (calc_forces .AND. do_im_time .AND. .NOT. do_ri_sos_laplace_mp2) THEN
             DO ispin = 1, nspins
                CALL calc_rpa_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                         t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_scaled_dm_occ_tau, &
-                                         fm_scaled_dm_virt_tau, fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                                         fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, &
+                                         t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_mo_coeff_occ, &
+                                         fm_mo_coeff_virt, &
                                          starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                          ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                          e_fermi(ispin), weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, tj, &
@@ -1726,9 +1712,8 @@ CONTAINS
                                      Eigenval_last, Eigenval_scf, iter_sc_GW0, exit_ev_gw, tau_tj, tj, &
                                      vec_omega_fit_gw, vec_Sigma_x_gw, mp2_env%ri_g0w0%ic_corr_list, &
                                      weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
-                                     fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, fm_mo_coeff_occ, &
-                                     fm_mo_coeff_virt, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, &
-                                     mo_coeff(1), fm_mat_W, para_env, para_env_RPA, mat_dm, mat_MinvVMinv, &
+                                     fm_mo_coeff_occ, fm_mo_coeff_virt, mo_coeff(1), fm_mat_W, para_env, &
+                                     para_env_RPA, mat_dm, mat_MinvVMinv, &
                                      t_3c_O, t_3c_M, t_3c_overl_int_ao_mo, t_3c_O_compressed, t_3c_O_mo_compressed, &
                                      t_3c_O_ind, t_3c_O_mo_ind, &
                                      t_3c_overl_int_gw_RI, t_3c_overl_int_gw_AO, &
@@ -1817,14 +1802,13 @@ CONTAINS
 
       IF (do_im_time) THEN
 
-         CALL dealloc_im_time(fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                              fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, index_to_cell_3c, &
+         CALL dealloc_im_time(fm_mo_coeff_occ, fm_mo_coeff_virt, index_to_cell_3c, &
                               cell_to_index_3c, do_ic_model, &
                               do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_ri_Sigma_x, &
                               has_mat_P_blocks, &
                               wkp_W, cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
                               fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, fm_mat_RI_global_work, fm_mat_work, &
-                              fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, mat_dm, mat_L, &
+                              mat_dm, mat_L, &
                               mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, &
                               t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, mat_work, qs_env)
 

--- a/src/rpa_main.F
+++ b/src/rpa_main.F
@@ -634,7 +634,7 @@ CONTAINS
       END IF
 
       ! Now start the RPA calculation
-      ! fm_mo_coeff_occ, fm_mo_coeff_virt will be deallocated here
+      ! cfm_mo_coeff_occ, cfm_mo_coeff_virt will be deallocated here
       CALL rpa_num_int(qs_env, Erpa, mp2_env, para_env, para_env_RPA, para_env_sub, unit_nr, &
                        homo, virtual, dimen_RI, dimen_RI_red, dimen_ia, dimen_nm_gw, &
                        Eigenval_kp, num_integ_points, num_integ_group, color_rpa_group, &
@@ -1153,10 +1153,11 @@ CONTAINS
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:, :, :)     :: Eigenval_last, Eigenval_scf, &
                                                             vec_Sigma_x_gw
       TYPE(cp_cfm_type)                                  :: cfm_mat_Q
-      TYPE(cp_fm_type) :: fm_mat_Q_static_bse_gemm, fm_mat_RI_global_work, fm_mat_work
+      TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:)       :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_fm_type)                                   :: fm_mat_Q_static_bse_gemm, &
+                                                            fm_mat_RI_global_work, fm_mat_work
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_mat_S_gw_work, fm_mat_S_ia_bse, &
-                                                            fm_mat_W, fm_mo_coeff_occ, &
-                                                            fm_mo_coeff_virt
+                                                            fm_mat_W
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_L_kpoints, fm_mat_Minv_L_kpoints
       TYPE(dbcsr_p_type)                                 :: mat_dm, mat_L, mat_M_P_munu_occ, &
                                                             mat_M_P_munu_virt, mat_MinvVMinv
@@ -1234,7 +1235,7 @@ CONTAINS
          min_bsize = mp2_env%ri_rpa_im_time%min_bsize
 
          CALL alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, &
-                            num_integ_points, nspins, fm_mat_Q(1), fm_mo_coeff_occ, fm_mo_coeff_virt, &
+                            num_integ_points, nspins, fm_mat_Q(1), cfm_mo_coeff_occ, cfm_mo_coeff_virt, &
                             fm_matrix_Minv_L_kpoints, fm_matrix_L_kpoints, mat_P_global, &
                             t_3c_O, matrix_s, kpoints, eps_filter_im_time, &
                             cut_memory, nkp, num_cells_dm, num_3c_repl, &
@@ -1394,7 +1395,7 @@ CONTAINS
             CALL zero_mat_P_omega(mat_P_omega(:, :, 1))
 
             ! compute the matrix Q(it) and Fourier transform it directly to mat_P_omega(iw)
-            CALL compute_mat_P_omega(mat_P_omega(:, :, 1), fm_mo_coeff_occ(1), fm_mo_coeff_virt(1), &
+            CALL compute_mat_P_omega(mat_P_omega(:, :, 1), cfm_mo_coeff_occ(1), cfm_mo_coeff_virt(1), &
                                      mat_P_global, matrix_s, 1, &
                                      t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                                      starts_array_mc, ends_array_mc, &
@@ -1408,10 +1409,10 @@ CONTAINS
                                      has_mat_P_blocks, do_ri_sos_laplace_mp2, &
                                      dbcsr_time, dbcsr_nflop)
 
-            ! the same for open shell, use fm_mo_coeff_occ_beta and fm_mo_coeff_virt_beta
+            ! the same for open shell, use cfm_mo_coeff_occ_beta and cfm_mo_coeff_virt_beta
             IF (my_open_shell) THEN
                CALL zero_mat_P_omega(mat_P_omega(:, :, 2))
-               CALL compute_mat_P_omega(mat_P_omega(:, :, 2), fm_mo_coeff_occ(2), fm_mo_coeff_virt(2), &
+               CALL compute_mat_P_omega(mat_P_omega(:, :, 2), cfm_mo_coeff_occ(2), cfm_mo_coeff_virt(2), &
                                         mat_P_global, matrix_s, 2, &
                                         t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                                         starts_array_mc, ends_array_mc, &
@@ -1637,8 +1638,8 @@ CONTAINS
                Pspin = 1
                Qspin = 2
                CALL calc_laplace_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_mo_coeff_occ, &
-                                             fm_mo_coeff_virt, &
+                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff_occ, &
+                                             cfm_mo_coeff_virt, &
                                              starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                              ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                              tau_tj, tau_wj, cut_memory, Pspin, Qspin, my_open_shell, &
@@ -1646,8 +1647,8 @@ CONTAINS
                Pspin = 2
                Qspin = 1
                CALL calc_laplace_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_mo_coeff_occ, &
-                                             fm_mo_coeff_virt, &
+                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff_occ, &
+                                             cfm_mo_coeff_virt, &
                                              starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                              ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                              tau_tj, tau_wj, cut_memory, Pspin, Qspin, my_open_shell, &
@@ -1657,8 +1658,8 @@ CONTAINS
                Pspin = 1
                Qspin = 1
                CALL calc_laplace_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_mo_coeff_occ, &
-                                             fm_mo_coeff_virt, &
+                                             t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff_occ, &
+                                             cfm_mo_coeff_virt, &
                                              starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                              ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                              tau_tj, tau_wj, cut_memory, Pspin, Qspin, my_open_shell, &
@@ -1670,8 +1671,8 @@ CONTAINS
          IF (calc_forces .AND. do_im_time .AND. .NOT. do_ri_sos_laplace_mp2) THEN
             DO ispin = 1, nspins
                CALL calc_rpa_loop_forces(force_data, mat_P_omega(:, 1, :), t_3c_M, t_3c_O(1, 1), &
-                                         t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), fm_mo_coeff_occ, &
-                                         fm_mo_coeff_virt, &
+                                         t_3c_O_compressed(1, 1, :), t_3c_O_ind(1, 1, :), cfm_mo_coeff_occ, &
+                                         cfm_mo_coeff_virt, &
                                          starts_array_mc, ends_array_mc, starts_array_mc_block, &
                                          ends_array_mc_block, num_integ_points, nmo, Eigenval(:, 1, :), &
                                          e_fermi(ispin), weights_cos_tf_t_to_w, weights_cos_tf_w_to_t, tj, &
@@ -1712,7 +1713,7 @@ CONTAINS
                                      Eigenval_last, Eigenval_scf, iter_sc_GW0, exit_ev_gw, tau_tj, tj, &
                                      vec_omega_fit_gw, vec_Sigma_x_gw, mp2_env%ri_g0w0%ic_corr_list, &
                                      weights_cos_tf_t_to_w, weights_sin_tf_t_to_w, &
-                                     fm_mo_coeff_occ, fm_mo_coeff_virt, mo_coeff(1), fm_mat_W, para_env, &
+                                     cfm_mo_coeff_occ, cfm_mo_coeff_virt, mo_coeff(1), fm_mat_W, para_env, &
                                      para_env_RPA, mat_dm, mat_MinvVMinv, &
                                      t_3c_O, t_3c_M, t_3c_overl_int_ao_mo, t_3c_O_compressed, t_3c_O_mo_compressed, &
                                      t_3c_O_ind, t_3c_O_mo_ind, &
@@ -1802,7 +1803,7 @@ CONTAINS
 
       IF (do_im_time) THEN
 
-         CALL dealloc_im_time(fm_mo_coeff_occ, fm_mo_coeff_virt, index_to_cell_3c, &
+         CALL dealloc_im_time(cfm_mo_coeff_occ, cfm_mo_coeff_virt, index_to_cell_3c, &
                               cell_to_index_3c, do_ic_model, &
                               do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_ri_Sigma_x, &
                               has_mat_P_blocks, &

--- a/src/rpa_util.F
+++ b/src/rpa_util.F
@@ -111,8 +111,6 @@ CONTAINS
 !> \param fm_mat_L_kpoints ...
 !> \param fm_mat_RI_global_work ...
 !> \param fm_mat_work ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
 !> \param mat_dm ...
 !> \param mat_L ...
 !> \param mat_M_P_munu_occ ...
@@ -122,8 +120,6 @@ CONTAINS
 !> \param mat_P_omega_kp ...
 !> \param mat_work ...
 !> \param mo_coeff ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
 !> \param homo ...
 !> \param nmo ...
 ! **************************************************************************************************
@@ -140,10 +136,9 @@ CONTAINS
                             do_kpoints_from_Gamma, do_ri_Sigma_x, my_open_shell, &
                             has_mat_P_blocks, wkp_W, &
                             cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
-                            fm_mat_RI_global_work, fm_mat_work, fm_mo_coeff_occ_scaled, &
-                            fm_mo_coeff_virt_scaled, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, &
+                            fm_mat_RI_global_work, fm_mat_work, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, &
                             mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, &
-                            mat_work, mo_coeff, fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, homo, nmo)
+                            mat_work, mo_coeff, homo, nmo)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(mp_para_env_type), POINTER                    :: para_env
@@ -175,9 +170,7 @@ CONTAINS
          INTENT(OUT)                                     :: wkp_W
       TYPE(cp_cfm_type), INTENT(OUT)                     :: cfm_mat_Q
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_Minv_L_kpoints, fm_mat_L_kpoints
-      TYPE(cp_fm_type), INTENT(OUT)                      :: fm_mat_RI_global_work, fm_mat_work, &
-                                                            fm_mo_coeff_occ_scaled, &
-                                                            fm_mo_coeff_virt_scaled
+      TYPE(cp_fm_type), INTENT(OUT)                      :: fm_mat_RI_global_work, fm_mat_work
       TYPE(dbcsr_p_type), INTENT(OUT)                    :: mat_dm, mat_L, mat_M_P_munu_occ, &
                                                             mat_M_P_munu_virt, mat_MinvVMinv
       TYPE(dbcsr_p_type), ALLOCATABLE, &
@@ -185,8 +178,6 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega_kp
       TYPE(dbcsr_type), POINTER                          :: mat_work
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mo_coeff
-      TYPE(cp_fm_type), INTENT(OUT)                      :: fm_scaled_dm_occ_tau, &
-                                                            fm_scaled_dm_virt_tau
       INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
       INTEGER, INTENT(IN)                                :: nmo
 
@@ -194,29 +185,15 @@ CONTAINS
 
       INTEGER                                            :: cell_grid_dm(3), first_ikp_local, &
                                                             handle, i_dim, i_kp, ispin, jquad, &
-                                                            nao, nspins_P_omega, periodic(3)
+                                                            nspins_P_omega, periodic(3)
       INTEGER, DIMENSION(:), POINTER                     :: row_blk_size
       REAL(KIND=dp), ALLOCATABLE, DIMENSION(:)           :: wkp_V
       TYPE(cell_type), POINTER                           :: cell
-      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct, fm_struct_sub_kp
+      TYPE(cp_fm_struct_type), POINTER                   :: fm_struct_sub_kp
 
       CALL timeset(routineN, handle)
 
       ALLOCATE (fm_mo_coeff_occ(nspins), fm_mo_coeff_virt(nspins))
-
-      CALL cp_fm_get_info(mo_coeff(1), nrow_global=nao)
-      NULLIFY (fm_struct)
-      CALL cp_fm_struct_create(fm_struct, template_fmstruct=mo_coeff(1)%matrix_struct, &
-                               nrow_global=nao, ncol_global=nao)
-
-      ! The propagator is an AO matrix, even when the MO coefficient matrix is
-      ! rectangular because linearly dependent overlap states were removed.
-      CALL cp_fm_create(fm_scaled_dm_occ_tau, fm_struct)
-      CALL cp_fm_set_all(fm_scaled_dm_occ_tau, 0.0_dp)
-
-      CALL cp_fm_create(fm_scaled_dm_virt_tau, fm_struct)
-      CALL cp_fm_set_all(fm_scaled_dm_virt_tau, 0.0_dp)
-      CALL cp_fm_struct_release(fm_struct)
 
       DO ispin = 1, SIZE(mo_coeff)
          CALL create_occ_virt_mo_coeffs(fm_mo_coeff_occ(ispin), fm_mo_coeff_virt(ispin), mo_coeff(ispin), &
@@ -304,18 +281,8 @@ CONTAINS
          CALL alloc_mat_P_omega(mat_P_omega_kp, 2, size_P, mat_P_global%matrix)
       END IF
 
-      CALL cp_fm_create(fm_mo_coeff_occ_scaled, fm_mo_coeff_occ(1)%matrix_struct)
-      CALL cp_fm_to_fm(fm_mo_coeff_occ(1), fm_mo_coeff_occ_scaled)
-      CALL cp_fm_set_all(matrix=fm_mo_coeff_occ_scaled, alpha=0.0_dp)
-
-      CALL cp_fm_create(fm_mo_coeff_virt_scaled, fm_mo_coeff_virt(1)%matrix_struct)
-      CALL cp_fm_to_fm(fm_mo_coeff_virt(1), fm_mo_coeff_virt_scaled)
-      CALL cp_fm_set_all(matrix=fm_mo_coeff_virt_scaled, alpha=0.0_dp)
-
       IF (do_kpoints_cubic_RPA .OR. do_kpoints_from_Gamma) THEN
-         CALL cp_fm_create(fm_mat_RI_global_work, fm_matrix_Minv_L_kpoints(1, 1)%matrix_struct)
-         CALL cp_fm_to_fm(fm_matrix_Minv_L_kpoints(1, 1), fm_mat_RI_global_work)
-         CALL cp_fm_set_all(fm_mat_RI_global_work, 0.0_dp)
+         CALL cp_fm_create(fm_mat_RI_global_work, fm_matrix_Minv_L_kpoints(1, 1)%matrix_struct, set_zero=.TRUE.)
       END IF
 
       ALLOCATE (has_mat_P_blocks(num_cells_dm/2 + 1, cut_memory, cut_memory, num_3c_repl, num_3c_repl))
@@ -338,19 +305,11 @@ CONTAINS
 
       ! Create Scalapack working matrix for the contraction with the metric
       IF (dimen_RI == dimen_RI_red) THEN
-         CALL cp_fm_create(fm_mat_work, fm_mat_Q%matrix_struct)
-         CALL cp_fm_to_fm(fm_mat_Q, fm_mat_work)
-         CALL cp_fm_set_all(matrix=fm_mat_work, alpha=0.0_dp)
+         CALL cp_fm_create(fm_mat_work, fm_mat_Q%matrix_struct, set_zero=.TRUE.)
 
       ELSE
-         NULLIFY (fm_struct)
-         CALL cp_fm_struct_create(fm_struct, template_fmstruct=fm_mat_Q%matrix_struct, &
-                                  ncol_global=dimen_RI_red, nrow_global=dimen_RI)
-
-         CALL cp_fm_create(fm_mat_work, fm_struct)
-         CALL cp_fm_set_all(matrix=fm_mat_work, alpha=0.0_dp)
-
-         CALL cp_fm_struct_release(fm_struct)
+         CALL cp_fm_create(fm_mat_work, fm_mat_Q%matrix_struct, nrow=dimen_RI, ncol=dimen_RI_red, &
+                           set_zero=.TRUE.)
 
       END IF
 
@@ -418,7 +377,6 @@ CONTAINS
       CALL cp_fm_get_info(mo_coeff, nrow_global=nao)
 
       CALL cp_fm_create(fm_mo_coeff_occ, mo_coeff%matrix_struct)
-      CALL cp_fm_set_all(fm_mo_coeff_occ, 0.0_dp)
       CALL cp_fm_to_fm(mo_coeff, fm_mo_coeff_occ)
 
       ! set all virtual MO coeffs to zero
@@ -429,7 +387,6 @@ CONTAINS
       END DO
 
       CALL cp_fm_create(fm_mo_coeff_virt, mo_coeff%matrix_struct)
-      CALL cp_fm_set_all(fm_mo_coeff_virt, 0.0_dp)
       CALL cp_fm_to_fm(mo_coeff, fm_mo_coeff_virt)
 
       ! set all occupied MO coeffs to zero
@@ -1080,8 +1037,6 @@ CONTAINS
 !> \brief ...
 !> \param fm_mo_coeff_occ ...
 !> \param fm_mo_coeff_virt ...
-!> \param fm_scaled_dm_occ_tau ...
-!> \param fm_scaled_dm_virt_tau ...
 !> \param index_to_cell_3c ...
 !> \param cell_to_index_3c ...
 !> \param do_ic_model ...
@@ -1097,8 +1052,6 @@ CONTAINS
 !> \param fm_matrix_Minv_Vtrunc_Minv ...
 !> \param fm_mat_RI_global_work ...
 !> \param fm_mat_work ...
-!> \param fm_mo_coeff_occ_scaled ...
-!> \param fm_mo_coeff_virt_scaled ...
 !> \param mat_dm ...
 !> \param mat_L ...
 !> \param mat_MinvVMinv ...
@@ -1111,22 +1064,18 @@ CONTAINS
 !> \param mat_work ...
 !> \param qs_env ...
 ! **************************************************************************************************
-   SUBROUTINE dealloc_im_time(fm_mo_coeff_occ, fm_mo_coeff_virt, &
-                              fm_scaled_dm_occ_tau, fm_scaled_dm_virt_tau, index_to_cell_3c, &
+   SUBROUTINE dealloc_im_time(fm_mo_coeff_occ, fm_mo_coeff_virt, index_to_cell_3c, &
                               cell_to_index_3c, do_ic_model, &
                               do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_ri_Sigma_x, &
                               has_mat_P_blocks, &
                               wkp_W, cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
                               fm_matrix_Minv, fm_matrix_Minv_Vtrunc_Minv, &
-                              fm_mat_RI_global_work, fm_mat_work, &
-                              fm_mo_coeff_occ_scaled, fm_mo_coeff_virt_scaled, mat_dm, mat_L, &
+                              fm_mat_RI_global_work, fm_mat_work, mat_dm, mat_L, &
                               mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, &
                               t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                               mat_work, qs_env)
 
       TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: fm_mo_coeff_occ, fm_mo_coeff_virt
-      TYPE(cp_fm_type), INTENT(INOUT)                    :: fm_scaled_dm_occ_tau, &
-                                                            fm_scaled_dm_virt_tau
       INTEGER, ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: index_to_cell_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
@@ -1141,9 +1090,7 @@ CONTAINS
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
                                                             fm_matrix_Minv, &
                                                             fm_matrix_Minv_Vtrunc_Minv
-      TYPE(cp_fm_type), INTENT(INOUT)                    :: fm_mat_RI_global_work, fm_mat_work, &
-                                                            fm_mo_coeff_occ_scaled, &
-                                                            fm_mo_coeff_virt_scaled
+      TYPE(cp_fm_type), INTENT(INOUT)                    :: fm_mat_RI_global_work, fm_mat_work
       TYPE(dbcsr_p_type), INTENT(INOUT)                  :: mat_dm, mat_L, mat_MinvVMinv
       TYPE(dbcsr_p_type), ALLOCATABLE, &
          DIMENSION(:, :, :), INTENT(INOUT)               :: mat_P_omega
@@ -1168,15 +1115,10 @@ CONTAINS
       nspins = SIZE(fm_mo_coeff_occ)
       my_open_shell = (nspins == 2)
 
-      CALL cp_fm_release(fm_scaled_dm_occ_tau)
-      CALL cp_fm_release(fm_scaled_dm_virt_tau)
       DO ispin = 1, SIZE(fm_mo_coeff_occ)
          CALL cp_fm_release(fm_mo_coeff_occ(ispin))
          CALL cp_fm_release(fm_mo_coeff_virt(ispin))
       END DO
-      CALL cp_fm_release(fm_mo_coeff_occ_scaled)
-      CALL cp_fm_release(fm_mo_coeff_virt_scaled)
-
       CALL cp_fm_release(fm_mat_Minv_L_kpoints)
       CALL cp_fm_release(fm_mat_L_kpoints)
 

--- a/src/rpa_util.F
+++ b/src/rpa_util.F
@@ -20,7 +20,6 @@ MODULE rpa_util
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_release,&
                                               cp_cfm_set_all,&
-                                              cp_cfm_set_element,&
                                               cp_cfm_type,&
                                               cp_fm_to_cfm
    USE cp_dbcsr_api,                    ONLY: &
@@ -88,8 +87,7 @@ CONTAINS
 !> \param num_integ_points ...
 !> \param nspins ...
 !> \param fm_mat_Q ...
-!> \param cfm_mo_coeff_occ ...
-!> \param cfm_mo_coeff_virt ...
+!> \param cfm_mo_coeff ...
 !> \param fm_matrix_Minv_L_kpoints ...
 !> \param fm_matrix_L_kpoints ...
 !> \param mat_P_global ...
@@ -127,11 +125,9 @@ CONTAINS
 !> \param mat_P_omega_kp ...
 !> \param mat_work ...
 !> \param mo_coeff ...
-!> \param homo ...
-!> \param nmo ...
 ! **************************************************************************************************
    SUBROUTINE alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, num_integ_points, nspins, &
-                            fm_mat_Q, cfm_mo_coeff_occ, cfm_mo_coeff_virt, &
+                            fm_mat_Q, cfm_mo_coeff, &
                             fm_matrix_Minv_L_kpoints, fm_matrix_L_kpoints, mat_P_global, &
                             t_3c_O, matrix_s, kpoints, eps_filter_im_time, &
                             cut_memory, nkp, num_cells_dm, num_3c_repl, &
@@ -145,14 +141,14 @@ CONTAINS
                             cfm_mat_Q, fm_mat_Minv_L_kpoints, fm_mat_L_kpoints, &
                             fm_mat_RI_global_work, fm_mat_work, mat_dm, mat_L, mat_M_P_munu_occ, mat_M_P_munu_virt, &
                             mat_MinvVMinv, mat_P_omega, mat_P_omega_kp, &
-                            mat_work, mo_coeff, homo, nmo)
+                            mat_work, mo_coeff)
 
       TYPE(qs_environment_type), POINTER                 :: qs_env
       TYPE(mp_para_env_type), POINTER                    :: para_env
       INTEGER, INTENT(IN)                                :: dimen_RI, dimen_RI_red, &
                                                             num_integ_points, nspins
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_mat_Q
-      TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:)       :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:)       :: cfm_mo_coeff
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_Minv_L_kpoints, &
                                                             fm_matrix_L_kpoints
       TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_P_global
@@ -185,8 +181,6 @@ CONTAINS
       TYPE(dbcsr_p_type), DIMENSION(:, :), POINTER       :: mat_P_omega_kp
       TYPE(dbcsr_type), POINTER                          :: mat_work
       TYPE(cp_fm_type), DIMENSION(:), INTENT(IN)         :: mo_coeff
-      INTEGER, DIMENSION(:), INTENT(IN)                  :: homo
-      INTEGER, INTENT(IN)                                :: nmo
 
       CHARACTER(LEN=*), PARAMETER                        :: routineN = 'alloc_im_time'
 
@@ -200,11 +194,10 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      ALLOCATE (cfm_mo_coeff_occ(nspins), cfm_mo_coeff_virt(nspins))
+      ALLOCATE (cfm_mo_coeff(nspins))
 
       DO ispin = 1, SIZE(mo_coeff)
-         CALL create_occ_virt_mo_coeffs(cfm_mo_coeff_occ(ispin), cfm_mo_coeff_virt(ispin), mo_coeff(ispin), &
-                                        nmo, homo(ispin))
+         CALL create_mo_coeff(cfm_mo_coeff(ispin), mo_coeff(ispin))
       END DO
 
       num_3c_repl = SIZE(t_3c_O, 2)
@@ -362,50 +355,26 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param cfm_mo_coeff_occ ...
-!> \param cfm_mo_coeff_virt ...
+!> \param cfm_mo_coeff ...
 !> \param mo_coeff ...
-!> \param nmo ...
-!> \param homo ...
 ! **************************************************************************************************
-   SUBROUTINE create_occ_virt_mo_coeffs(cfm_mo_coeff_occ, cfm_mo_coeff_virt, mo_coeff, &
-                                        nmo, homo)
+   SUBROUTINE create_mo_coeff(cfm_mo_coeff, mo_coeff)
 
-      TYPE(cp_cfm_type), INTENT(OUT)                     :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), INTENT(OUT)                     :: cfm_mo_coeff
       TYPE(cp_fm_type), INTENT(IN)                       :: mo_coeff
-      INTEGER, INTENT(IN)                                :: nmo, homo
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'create_occ_virt_mo_coeffs'
+      CHARACTER(LEN=*), PARAMETER :: routineN = 'create_mo_coeff'
 
-      INTEGER                                            :: handle, icol_global, irow_global, nao
+      INTEGER                                            :: handle
 
       CALL timeset(routineN, handle)
 
-      CALL cp_fm_get_info(mo_coeff, nrow_global=nao)
-
-      CALL cp_cfm_create(cfm_mo_coeff_occ, mo_coeff%matrix_struct)
-      CALL cp_fm_to_cfm(msourcer=mo_coeff, mtarget=cfm_mo_coeff_occ)
-
-      ! set all virtual MO coeffs to zero
-      DO icol_global = homo + 1, nmo
-         DO irow_global = 1, nao
-            CALL cp_cfm_set_element(cfm_mo_coeff_occ, irow_global, icol_global, z_zero)
-         END DO
-      END DO
-
-      CALL cp_cfm_create(cfm_mo_coeff_virt, mo_coeff%matrix_struct)
-      CALL cp_fm_to_cfm(msourcer=mo_coeff, mtarget=cfm_mo_coeff_virt)
-
-      ! set all occupied MO coeffs to zero
-      DO icol_global = 1, homo
-         DO irow_global = 1, nao
-            CALL cp_cfm_set_element(cfm_mo_coeff_virt, irow_global, icol_global, z_zero)
-         END DO
-      END DO
+      CALL cp_cfm_create(cfm_mo_coeff, mo_coeff%matrix_struct)
+      CALL cp_fm_to_cfm(msourcer=mo_coeff, mtarget=cfm_mo_coeff)
 
       CALL timestop(handle)
 
-   END SUBROUTINE create_occ_virt_mo_coeffs
+   END SUBROUTINE create_mo_coeff
 
 ! **************************************************************************************************
 !> \brief ...
@@ -1042,8 +1011,7 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param cfm_mo_coeff_occ ...
-!> \param cfm_mo_coeff_virt ...
+!> \param cfm_mo_coeff ...
 !> \param index_to_cell_3c ...
 !> \param cell_to_index_3c ...
 !> \param do_ic_model ...
@@ -1071,7 +1039,7 @@ CONTAINS
 !> \param mat_work ...
 !> \param qs_env ...
 ! **************************************************************************************************
-   SUBROUTINE dealloc_im_time(cfm_mo_coeff_occ, cfm_mo_coeff_virt, index_to_cell_3c, &
+   SUBROUTINE dealloc_im_time(cfm_mo_coeff, index_to_cell_3c, &
                               cell_to_index_3c, do_ic_model, &
                               do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_ri_Sigma_x, &
                               has_mat_P_blocks, &
@@ -1082,7 +1050,7 @@ CONTAINS
                               t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                               mat_work, qs_env)
 
-      TYPE(cp_cfm_type), DIMENSION(:), INTENT(INOUT)     :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
+      TYPE(cp_cfm_type), DIMENSION(:), INTENT(INOUT)     :: cfm_mo_coeff
       INTEGER, ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: index_to_cell_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
@@ -1119,12 +1087,11 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      nspins = SIZE(cfm_mo_coeff_occ)
+      nspins = SIZE(cfm_mo_coeff)
       my_open_shell = (nspins == 2)
 
-      DO ispin = 1, SIZE(cfm_mo_coeff_occ)
-         CALL cp_cfm_release(cfm_mo_coeff_occ(ispin))
-         CALL cp_cfm_release(cfm_mo_coeff_virt(ispin))
+      DO ispin = 1, SIZE(cfm_mo_coeff)
+         CALL cp_cfm_release(cfm_mo_coeff(ispin))
       END DO
       CALL cp_fm_release(fm_mat_Minv_L_kpoints)
       CALL cp_fm_release(fm_mat_L_kpoints)

--- a/src/rpa_util.F
+++ b/src/rpa_util.F
@@ -20,7 +20,9 @@ MODULE rpa_util
    USE cp_cfm_types,                    ONLY: cp_cfm_create,&
                                               cp_cfm_release,&
                                               cp_cfm_set_all,&
-                                              cp_cfm_type
+                                              cp_cfm_set_element,&
+                                              cp_cfm_type,&
+                                              cp_fm_to_cfm
    USE cp_dbcsr_api,                    ONLY: &
         dbcsr_create, dbcsr_deallocate_matrix, dbcsr_filter, dbcsr_get_info, dbcsr_multiply, &
         dbcsr_p_type, dbcsr_release, dbcsr_set, dbcsr_type
@@ -34,9 +36,14 @@ MODULE rpa_util
    USE cp_fm_struct,                    ONLY: cp_fm_struct_create,&
                                               cp_fm_struct_release,&
                                               cp_fm_struct_type
-   USE cp_fm_types,                     ONLY: &
-        cp_fm_copy_general, cp_fm_create, cp_fm_get_info, cp_fm_release, cp_fm_set_all, &
-        cp_fm_set_element, cp_fm_to_fm, cp_fm_to_fm_submat_general, cp_fm_type
+   USE cp_fm_types,                     ONLY: cp_fm_copy_general,&
+                                              cp_fm_create,&
+                                              cp_fm_get_info,&
+                                              cp_fm_release,&
+                                              cp_fm_set_all,&
+                                              cp_fm_to_fm,&
+                                              cp_fm_to_fm_submat_general,&
+                                              cp_fm_type
    USE dbt_api,                         ONLY: dbt_destroy,&
                                               dbt_type
    USE dgemm_counter_types,             ONLY: dgemm_counter_start,&
@@ -81,8 +88,8 @@ CONTAINS
 !> \param num_integ_points ...
 !> \param nspins ...
 !> \param fm_mat_Q ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
+!> \param cfm_mo_coeff_occ ...
+!> \param cfm_mo_coeff_virt ...
 !> \param fm_matrix_Minv_L_kpoints ...
 !> \param fm_matrix_L_kpoints ...
 !> \param mat_P_global ...
@@ -124,7 +131,7 @@ CONTAINS
 !> \param nmo ...
 ! **************************************************************************************************
    SUBROUTINE alloc_im_time(qs_env, para_env, dimen_RI, dimen_RI_red, num_integ_points, nspins, &
-                            fm_mat_Q, fm_mo_coeff_occ, fm_mo_coeff_virt, &
+                            fm_mat_Q, cfm_mo_coeff_occ, cfm_mo_coeff_virt, &
                             fm_matrix_Minv_L_kpoints, fm_matrix_L_kpoints, mat_P_global, &
                             t_3c_O, matrix_s, kpoints, eps_filter_im_time, &
                             cut_memory, nkp, num_cells_dm, num_3c_repl, &
@@ -145,7 +152,7 @@ CONTAINS
       INTEGER, INTENT(IN)                                :: dimen_RI, dimen_RI_red, &
                                                             num_integ_points, nspins
       TYPE(cp_fm_type), INTENT(IN)                       :: fm_mat_Q
-      TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:)        :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      TYPE(cp_cfm_type), ALLOCATABLE, DIMENSION(:)       :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
       TYPE(cp_fm_type), ALLOCATABLE, DIMENSION(:, :)     :: fm_matrix_Minv_L_kpoints, &
                                                             fm_matrix_L_kpoints
       TYPE(dbcsr_p_type), INTENT(IN)                     :: mat_P_global
@@ -193,10 +200,10 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      ALLOCATE (fm_mo_coeff_occ(nspins), fm_mo_coeff_virt(nspins))
+      ALLOCATE (cfm_mo_coeff_occ(nspins), cfm_mo_coeff_virt(nspins))
 
       DO ispin = 1, SIZE(mo_coeff)
-         CALL create_occ_virt_mo_coeffs(fm_mo_coeff_occ(ispin), fm_mo_coeff_virt(ispin), mo_coeff(ispin), &
+         CALL create_occ_virt_mo_coeffs(cfm_mo_coeff_occ(ispin), cfm_mo_coeff_virt(ispin), mo_coeff(ispin), &
                                         nmo, homo(ispin))
       END DO
 
@@ -355,16 +362,16 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
+!> \param cfm_mo_coeff_occ ...
+!> \param cfm_mo_coeff_virt ...
 !> \param mo_coeff ...
 !> \param nmo ...
 !> \param homo ...
 ! **************************************************************************************************
-   SUBROUTINE create_occ_virt_mo_coeffs(fm_mo_coeff_occ, fm_mo_coeff_virt, mo_coeff, &
+   SUBROUTINE create_occ_virt_mo_coeffs(cfm_mo_coeff_occ, cfm_mo_coeff_virt, mo_coeff, &
                                         nmo, homo)
 
-      TYPE(cp_fm_type), INTENT(OUT)                      :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      TYPE(cp_cfm_type), INTENT(OUT)                     :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
       TYPE(cp_fm_type), INTENT(IN)                       :: mo_coeff
       INTEGER, INTENT(IN)                                :: nmo, homo
 
@@ -376,23 +383,23 @@ CONTAINS
 
       CALL cp_fm_get_info(mo_coeff, nrow_global=nao)
 
-      CALL cp_fm_create(fm_mo_coeff_occ, mo_coeff%matrix_struct)
-      CALL cp_fm_to_fm(mo_coeff, fm_mo_coeff_occ)
+      CALL cp_cfm_create(cfm_mo_coeff_occ, mo_coeff%matrix_struct)
+      CALL cp_fm_to_cfm(msourcer=mo_coeff, mtarget=cfm_mo_coeff_occ)
 
       ! set all virtual MO coeffs to zero
       DO icol_global = homo + 1, nmo
          DO irow_global = 1, nao
-            CALL cp_fm_set_element(fm_mo_coeff_occ, irow_global, icol_global, 0.0_dp)
+            CALL cp_cfm_set_element(cfm_mo_coeff_occ, irow_global, icol_global, z_zero)
          END DO
       END DO
 
-      CALL cp_fm_create(fm_mo_coeff_virt, mo_coeff%matrix_struct)
-      CALL cp_fm_to_fm(mo_coeff, fm_mo_coeff_virt)
+      CALL cp_cfm_create(cfm_mo_coeff_virt, mo_coeff%matrix_struct)
+      CALL cp_fm_to_cfm(msourcer=mo_coeff, mtarget=cfm_mo_coeff_virt)
 
       ! set all occupied MO coeffs to zero
       DO icol_global = 1, homo
          DO irow_global = 1, nao
-            CALL cp_fm_set_element(fm_mo_coeff_virt, irow_global, icol_global, 0.0_dp)
+            CALL cp_cfm_set_element(cfm_mo_coeff_virt, irow_global, icol_global, z_zero)
          END DO
       END DO
 
@@ -1035,8 +1042,8 @@ CONTAINS
 
 ! **************************************************************************************************
 !> \brief ...
-!> \param fm_mo_coeff_occ ...
-!> \param fm_mo_coeff_virt ...
+!> \param cfm_mo_coeff_occ ...
+!> \param cfm_mo_coeff_virt ...
 !> \param index_to_cell_3c ...
 !> \param cell_to_index_3c ...
 !> \param do_ic_model ...
@@ -1064,7 +1071,7 @@ CONTAINS
 !> \param mat_work ...
 !> \param qs_env ...
 ! **************************************************************************************************
-   SUBROUTINE dealloc_im_time(fm_mo_coeff_occ, fm_mo_coeff_virt, index_to_cell_3c, &
+   SUBROUTINE dealloc_im_time(cfm_mo_coeff_occ, cfm_mo_coeff_virt, index_to_cell_3c, &
                               cell_to_index_3c, do_ic_model, &
                               do_kpoints_cubic_RPA, do_kpoints_from_Gamma, do_ri_Sigma_x, &
                               has_mat_P_blocks, &
@@ -1075,7 +1082,7 @@ CONTAINS
                               t_3c_M, t_3c_O, t_3c_O_compressed, t_3c_O_ind, &
                               mat_work, qs_env)
 
-      TYPE(cp_fm_type), DIMENSION(:), INTENT(INOUT)      :: fm_mo_coeff_occ, fm_mo_coeff_virt
+      TYPE(cp_cfm_type), DIMENSION(:), INTENT(INOUT)     :: cfm_mo_coeff_occ, cfm_mo_coeff_virt
       INTEGER, ALLOCATABLE, DIMENSION(:, :), &
          INTENT(INOUT)                                   :: index_to_cell_3c
       INTEGER, ALLOCATABLE, DIMENSION(:, :, :), &
@@ -1112,12 +1119,12 @@ CONTAINS
 
       CALL timeset(routineN, handle)
 
-      nspins = SIZE(fm_mo_coeff_occ)
+      nspins = SIZE(cfm_mo_coeff_occ)
       my_open_shell = (nspins == 2)
 
-      DO ispin = 1, SIZE(fm_mo_coeff_occ)
-         CALL cp_fm_release(fm_mo_coeff_occ(ispin))
-         CALL cp_fm_release(fm_mo_coeff_virt(ispin))
+      DO ispin = 1, SIZE(cfm_mo_coeff_occ)
+         CALL cp_cfm_release(cfm_mo_coeff_occ(ispin))
+         CALL cp_cfm_release(cfm_mo_coeff_virt(ispin))
       END DO
       CALL cp_fm_release(fm_mat_Minv_L_kpoints)
       CALL cp_fm_release(fm_mat_L_kpoints)

--- a/src/rpa_util.F
+++ b/src/rpa_util.F
@@ -363,7 +363,7 @@ CONTAINS
       TYPE(cp_cfm_type), INTENT(OUT)                     :: cfm_mo_coeff
       TYPE(cp_fm_type), INTENT(IN)                       :: mo_coeff
 
-      CHARACTER(LEN=*), PARAMETER :: routineN = 'create_mo_coeff'
+      CHARACTER(LEN=*), PARAMETER                        :: routineN = 'create_mo_coeff'
 
       INTEGER                                            :: handle
 


### PR DESCRIPTION
This PR uses a single sector/time/cell DBCSR matrix set for occupied and virtual RPA imaginary-time propagators.
It removes persistent propagator work matrices and pre-split occupied/virtual MO coefficient copies, moves the Gamma-point construction into `rpa_im_time`, and keeps k-point density sources complex until real-space accumulation. It also fixes the minimum-image weight cache to distinguish k-points and avoids building unused spin channels.

Other duplicate implementations will be addressed in other PRs. 